### PR TITLE
fix: Apply mobile fixes to monorepo structure

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -11,6 +11,7 @@ import { AuthProvider } from './src/contexts/AuthContext';
 import { ThemeProvider, useTheme } from './src/contexts/ThemeContext';
 import { AppNavigator } from './src/navigation/AppNavigator';
 import { DoodleBackground } from './src/components/backgrounds';
+import { ErrorBoundary } from './src/components/common';
 import { QUERY_CONFIG } from './src/constants/config';
 import { Colors } from './src/constants/theme';
 
@@ -85,11 +86,19 @@ export default function App() {
     <GestureHandlerRootView style={styles.container} onLayout={onLayoutRootView}>
       <SafeAreaProvider>
         <QueryClientProvider client={queryClient}>
-          <ThemeProvider>
-            <AuthProvider>
-              <AppContent />
-            </AuthProvider>
-          </ThemeProvider>
+          <ErrorBoundary
+            onError={(error, errorInfo) => {
+              // Log error to console in development
+              console.error('App Error:', error, errorInfo);
+              // In production, you would send this to an error tracking service
+            }}
+          >
+            <ThemeProvider>
+              <AuthProvider>
+                <AppContent />
+              </AuthProvider>
+            </ThemeProvider>
+          </ErrorBoundary>
         </QueryClientProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/mobile/src/constants/config.ts
+++ b/mobile/src/constants/config.ts
@@ -2,7 +2,14 @@
 export const API_BASE_URL = 'https://deep-sight-backend-v3-production.up.railway.app';
 
 // Google OAuth Configuration
+// Web Client ID (used for Expo Go and web)
 export const GOOGLE_CLIENT_ID = '763654536492-8hkdd3n31tqeodnhcak6ef8asu4v287j.apps.googleusercontent.com';
+// Android Client ID (for standalone builds - create in Google Cloud Console)
+export const GOOGLE_ANDROID_CLIENT_ID = '763654536492-8hkdd3n31tqeodnhcak6ef8asu4v287j.apps.googleusercontent.com';
+// iOS Client ID (for standalone builds - create in Google Cloud Console)
+export const GOOGLE_IOS_CLIENT_ID = '763654536492-8hkdd3n31tqeodnhcak6ef8asu4v287j.apps.googleusercontent.com';
+// Expo Client ID (same as web for Expo Go)
+export const GOOGLE_EXPO_CLIENT_ID = GOOGLE_CLIENT_ID;
 
 // App Configuration
 export const APP_NAME = 'Deep Sight';

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -13,8 +13,9 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, CompositeNavigationProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import * as Haptics from 'expo-haptics';
 import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
@@ -25,7 +26,11 @@ import { ANALYSIS_MODES, ANALYSIS_CATEGORIES, AI_MODELS } from '../constants/con
 import { isValidYouTubeUrl, formatCredits } from '../utils/formatters';
 import type { RootStackParamList, MainTabParamList, AnalysisSummary } from '../types';
 
-type DashboardNavigationProp = NativeStackNavigationProp<RootStackParamList, 'MainTabs'>;
+// Composite type for navigating to both tab screens and stack screens
+type DashboardNavigationProp = CompositeNavigationProp<
+  BottomTabNavigationProp<MainTabParamList, 'Dashboard'>,
+  NativeStackNavigationProp<RootStackParamList>
+>;
 
 export const DashboardScreen: React.FC = () => {
   const { colors } = useTheme();
@@ -285,7 +290,7 @@ export const DashboardScreen: React.FC = () => {
               <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
                 Analyses récentes
               </Text>
-              <TouchableOpacity onPress={() => (navigation as any).navigate('History')}>
+              <TouchableOpacity onPress={() => navigation.navigate('History')}>
                 <Text style={[styles.seeAllText, { color: colors.accentPrimary }]}>
                   Voir tout
                 </Text>

--- a/mobile/src/screens/HistoryScreen.tsx
+++ b/mobile/src/screens/HistoryScreen.tsx
@@ -11,16 +11,21 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, CompositeNavigationProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import * as Haptics from 'expo-haptics';
 import { useTheme } from '../contexts/ThemeContext';
 import { historyApi } from '../services/api';
 import { Header, VideoCard, EmptyState } from '../components';
 import { Spacing, Typography, BorderRadius } from '../constants/theme';
-import type { RootStackParamList, AnalysisSummary, HistoryFilters } from '../types';
+import type { RootStackParamList, MainTabParamList, AnalysisSummary, HistoryFilters } from '../types';
 
-type HistoryNavigationProp = NativeStackNavigationProp<RootStackParamList, 'MainTabs'>;
+// Composite type for navigating to both tab screens and stack screens
+type HistoryNavigationProp = CompositeNavigationProp<
+  BottomTabNavigationProp<MainTabParamList, 'History'>,
+  NativeStackNavigationProp<RootStackParamList>
+>;
 
 export const HistoryScreen: React.FC = () => {
   const { colors } = useTheme();
@@ -147,7 +152,7 @@ export const HistoryScreen: React.FC = () => {
             : 'Analysez votre première vidéo YouTube pour commencer'
         }
         actionLabel={!showFavoritesOnly && !searchQuery ? 'Analyser une vidéo' : undefined}
-        onAction={!showFavoritesOnly && !searchQuery ? () => (navigation as any).navigate('Dashboard') : undefined}
+        onAction={!showFavoritesOnly && !searchQuery ? () => navigation.navigate('Dashboard') : undefined}
       />
     );
   };

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -228,13 +228,12 @@ export interface ConceptEdge {
   label?: string;
 }
 
-// Quiz Types
+// Quiz Types (matches API response and QuizComponent)
 export interface QuizQuestion {
-  id: string;
   question: string;
   options: string[];
-  correctAnswer: number;
-  explanation?: string;
+  correct: number;
+  explanation: string;
 }
 
 export interface QuizResult {


### PR DESCRIPTION
Originally from PR #5 (claude/deep-sight-mobile-app-cDwC3), adapted for new paths:

- Fix Google OAuth with platform-specific client IDs (web, android, ios, expo)
- Implement settings persistence with AsyncStorage (mode, model, language)
- Add real API calls for account management (save, password change, delete)
- Enable Tournesol API integration for ethical video scoring
- Fix QuizQuestion type to match API response (correct instead of correctAnswer)
- Add ErrorBoundary wrapper in App.tsx for crash resilience
- Fix navigation types using CompositeNavigationProp (remove all 'as any' casts)

Files updated (9):
- mobile/App.tsx
- mobile/src/components/tournesol/TournesolWidget.tsx
- mobile/src/constants/config.ts
- mobile/src/contexts/AuthContext.tsx
- mobile/src/screens/AccountScreen.tsx
- mobile/src/screens/DashboardScreen.tsx
- mobile/src/screens/HistoryScreen.tsx
- mobile/src/screens/SettingsScreen.tsx
- mobile/src/types/index.ts