### PR TITLE
fix(mobile): Add Android OAuth Client ID for native Google Sign-In

### DIFF
--- a/mobile/src/constants/config.ts
+++ b/mobile/src/constants/config.ts
@@ -5,7 +5,7 @@ export const API_BASE_URL = 'https://deep-sight-backend-v3-production.up.railway
 // Web Client ID (used for Expo Go and web)
 export const GOOGLE_CLIENT_ID = '763654536492-8hkdd3n31tqeodnhcak6ef8asu4v287j.apps.googleusercontent.com';
 // Android Client ID (for standalone builds - create in Google Cloud Console)
-export const GOOGLE_ANDROID_CLIENT_ID = '763654536492-8hkdd3n31tqeodnhcak6ef8asu4v287j.apps.googleusercontent.com';
+export const GOOGLE_ANDROID_CLIENT_ID = '763654536492-v1tod4emvrkcrl9j582o6fltpqdg3a6t.apps.googleusercontent.com';
 // iOS Client ID (for standalone builds - create in Google Cloud Console)
 export const GOOGLE_IOS_CLIENT_ID = '763654536492-riumsqb787nj8d3eq1nnhlo29qufc11h.apps.googleusercontent.com';
 // Expo Client ID (same as web for Expo Go)

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -5,14 +5,15 @@ import { authApi, ApiError } from '../services/api';
 import { tokenStorage, userStorage } from '../utils/storage';
 import {
   GOOGLE_CLIENT_ID,
-  GOOGLE_IOS_CLIENT_ID
+  GOOGLE_IOS_CLIENT_ID,
+  GOOGLE_ANDROID_CLIENT_ID
 } from '../constants/config';
 import type { User } from '../types';
 
 // Configure Google Sign-In on app start
 GoogleSignin.configure({
   webClientId: GOOGLE_CLIENT_ID,
-  iosClientId: GOOGLE_IOS_CLIENT_ID,
+  iosClientId: Platform.OS === 'ios' ? GOOGLE_IOS_CLIENT_ID : undefined,
   offlineAccess: true,
   scopes: ['profile', 'email'],
 });


### PR DESCRIPTION
- Update GOOGLE_ANDROID_CLIENT_ID with the correct Client ID from Google Cloud Console
- Import GOOGLE_ANDROID_CLIENT_ID in AuthContext.tsx
- Configure GoogleSignin with platform-specific Client IDs