### PR TITLE
feat: Prioritize history keywords over local words in Le Saviez-Vous …

### DIFF
--- a/frontend/src/contexts/LoadingWordContext.tsx
+++ b/frontend/src/contexts/LoadingWordContext.tsx
@@ -308,22 +308,22 @@ export const LoadingWordProvider: React.FC<{ children: ReactNode }> = ({ childre
     setIsTimerActive(false);
   }, []);
 
-  // Fetch initial au montage
+  // Fetch initial au montage — PRIORITÉ ABSOLUE À L'HISTORIQUE
   useEffect(() => {
     isMountedRef.current = true;
 
-    // Afficher immédiatement un mot local pendant le chargement
-    useLocalFallback();
-
-    // Puis essayer de récupérer les mots de l'historique
+    // NE PAS afficher de mot local immédiatement
+    // Attendre fetchWord() pour avoir l'historique en priorité
     fetchWord();
 
-    // Démarrer le timer automatiquement (historique prioritaire, fallback local)
+    // Timer: toujours vérifier l'historique d'abord
     const timer = setInterval(() => {
       if (historyKeywordsCache.length > 0) {
+        // Utiliser l'historique en priorité
         useHistoryWord();
       } else {
-        useLocalFallback();
+        // Re-fetch pour vérifier si nouvel historique disponible
+        fetchWord();
       }
     }, REFRESH_INTERVAL);
 


### PR DESCRIPTION
…widget

- Remove immediate local word display on mount
- Wait for history fetch before showing any word
- Timer now re-fetches history instead of falling back to local
- Local words only shown when user has NO analysis history