### PR TITLE
fix(auth): Auto-verify users when Resend is not configured + improve …

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -152,7 +152,20 @@ if FRONTEND_URL not in ALLOWED_ORIGINS:
     ALLOWED_ORIGINS.append(FRONTEND_URL)
 
 # Ajouter les origines de développement mobile (Expo)
-MOBILE_DEV_ORIGINS = ["http://localhost:8081", "http://127.0.0.1:8081"]
+# Expo peut utiliser différents ports selon la configuration
+MOBILE_DEV_ORIGINS = [
+    "http://localhost:8081",
+    "http://127.0.0.1:8081",
+    "http://localhost:8082",
+    "http://localhost:19000",
+    "http://localhost:19001",
+    "http://localhost:19002",
+    "http://localhost:19006",  # Expo web
+    "http://127.0.0.1:19000",
+    "http://127.0.0.1:19006",
+    "exp://localhost:8081",
+    "exp://127.0.0.1:8081",
+]
 for origin in MOBILE_DEV_ORIGINS:
     if origin not in ALLOWED_ORIGINS:
         ALLOWED_ORIGINS.append(origin)

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -26,9 +26,17 @@ type LoginScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, '
 export const LoginScreen: React.FC = () => {
   const { colors } = useTheme();
   const { t } = useLanguage();
-  const { login, loginWithGoogle, isLoading, error, clearError } = useAuth();
+  const { login, loginWithGoogle, isLoading, error, clearError, pendingVerificationEmail, clearPendingVerification } = useAuth();
   const navigation = useNavigation<LoginScreenNavigationProp>();
   const insets = useSafeAreaInsets();
+
+  // Navigate to verification if email needs verification
+  useEffect(() => {
+    if (pendingVerificationEmail) {
+      navigation.navigate('VerifyEmail', { email: pendingVerificationEmail });
+      clearPendingVerification();
+    }
+  }, [pendingVerificationEmail, navigation, clearPendingVerification]);
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/mobile/src/screens/VerifyEmailScreen.tsx
+++ b/mobile/src/screens/VerifyEmailScreen.tsx
@@ -25,7 +25,7 @@ const CODE_LENGTH = 6;
 
 export const VerifyEmailScreen: React.FC = () => {
   const { colors } = useTheme();
-  const { verifyEmail, isLoading, error, clearError } = useAuth();
+  const { verifyEmail, resendVerificationCode, isLoading, error, clearError } = useAuth();
   const navigation = useNavigation<VerifyEmailNavigationProp>();
   const route = useRoute<VerifyEmailRouteProp>();
   const insets = useSafeAreaInsets();
@@ -74,13 +74,15 @@ export const VerifyEmailScreen: React.FC = () => {
     setIsResending(true);
     clearError();
 
-    // Note: Using a simple timeout as there's no dedicated resend endpoint
-    // In production, this should call a resend verification email API
-    setTimeout(() => {
-      setIsResending(false);
+    try {
+      await resendVerificationCode(email);
       setCountdown(60);
       setCode('');
-    }, 1500);
+    } catch (err) {
+      // Error handled by AuthContext
+    } finally {
+      setIsResending(false);
+    }
   };
 
   const handleBackToLogin = () => {

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -30,10 +30,19 @@ export class ApiError extends Error {
   constructor(
     message: string,
     public status: number,
-    public code?: string
+    public code?: string,
+    public detail?: string
   ) {
     super(message);
     this.name = 'ApiError';
+  }
+
+  // Helper to check if this is an email verification required error
+  get isEmailNotVerified(): boolean {
+    return this.status === 403 && (
+      this.code === 'EMAIL_NOT_VERIFIED' ||
+      this.detail === 'EMAIL_NOT_VERIFIED'
+    );
   }
 }
 
@@ -174,9 +183,10 @@ const request = async <T>(
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
       throw new ApiError(
-        errorData.message || errorData.error || 'Request failed',
+        errorData.message || errorData.detail || errorData.error || 'Request failed',
         response.status,
-        errorData.code
+        errorData.code || errorData.detail,
+        errorData.detail
       );
     }
 


### PR DESCRIPTION
…mobile error handling

Backend changes:
- Auto-verify users on registration when RESEND_API_KEY is not set
- Auto-verify existing users on login if Resend not configured
- Add more Expo dev ports to CORS (8082, 19000-19006)

Mobile changes:
- Add isEmailNotVerified helper to ApiError class
- Handle EMAIL_NOT_VERIFIED (403) error and redirect to verification
- Add pendingVerificationEmail state and resendVerificationCode method
- LoginScreen now navigates to VerifyEmail when email needs verification
- VerifyEmailScreen uses actual API for resending verification code

https://claude.ai/code/session_01DABRPPVXJfUsrWzPRz57ok