### PR TITLE
feat(definitions): Add anti-hallucination rules and Wikipedia sources…

### DIFF
--- a/frontend/src/components/LoadingWord.tsx
+++ b/frontend/src/components/LoadingWord.tsx
@@ -292,16 +292,16 @@ export const LoadingWordWidget: React.FC<LoadingWordProps> = ({
           </div>
 
           <div className="flex items-center gap-3">
-            {/* Wiki link (seulement pour les mots locaux) */}
-            {displayedWord.wikiUrl && displayedWord.source === 'local' && (
+            {/* Wiki link - affiché pour tous les mots avec une URL */}
+            {displayedWord.wikiUrl && (
               <a
                 href={displayedWord.wikiUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs text-text-tertiary hover:text-accent-primary transition-colors"
-                title="Wikipedia"
+                title="Source"
               >
-                🔗 Wiki
+                🔗 {displayedWord.wikiUrl.includes('wikipedia') ? 'Wiki' : 'Source'}
               </a>
             )}
 

--- a/frontend/src/contexts/LoadingWordContext.tsx
+++ b/frontend/src/contexts/LoadingWordContext.tsx
@@ -38,9 +38,12 @@ interface HistoryKeyword {
   video_id: string | null;
   category: string | null;
   created_at: string | null;
-  // NOUVEAU: Définitions générées par IA (Mistral)
+  // Définitions générées par IA (Mistral)
   definition: string | null;
   short_definition: string | null;
+  // Source Wikipedia ou alternative
+  wiki_url: string | null;
+  confidence: string | null;
 }
 
 interface LoadingWordContextType {
@@ -111,6 +114,7 @@ function convertHistoryKeyword(keyword: HistoryKeyword): LoadingWord {
     summaryId: keyword.summary_id,
     videoTitle: keyword.video_title || undefined,
     videoId: keyword.video_id || undefined,
+    wikiUrl: keyword.wiki_url || undefined,
   };
 }
 


### PR DESCRIPTION
… to "Le Saviez-Vous" prompts

- Add explicit anti-hallucination instructions to all definition prompts
- Require Wikipedia URLs (FR/EN) as primary source with fallback alternatives
- Add wiki_url and confidence fields to KeywordItem, ConceptDefinition, EnrichedDefinition
- Update frontend HistoryKeyword interface to include wiki_url
- Display wiki/source links for all words (not just local fallback)
- Prompts now instruct AI to return null for uncertain terms
- System prompts updated to emphasize factual verification

https://claude.ai/code/session_01UVrdaBw4xcrttUWe6wFBuF