### PR TITLE
feat(mobile): Auto-search videos when discovery modal opens

### DIFF
--- a/mobile/src/components/VideoDiscoveryModal.tsx
+++ b/mobile/src/components/VideoDiscoveryModal.tsx
@@ -36,6 +36,7 @@ interface VideoDiscoveryModalProps {
   onSelectVideo: (videoId: string, videoUrl: string) => void;
   onSelectMultiple?: (videos: DiscoveredVideo[]) => void;
   allowMultiSelect?: boolean;
+  initialQuery?: string;
 }
 
 type SortOption = 'quality' | 'views' | 'date' | 'academic';
@@ -46,6 +47,7 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
   onSelectVideo,
   onSelectMultiple,
   allowMultiSelect = false,
+  initialQuery = '',
 }) => {
   const { colors, isDark } = useTheme();
   const { language } = useLanguage();
@@ -104,6 +106,13 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
       return () => clearTimeout(debounce);
     }
   }, [searchQuery, sortBy, visible]);
+
+  // Auto-populate search query when modal opens with initialQuery
+  useEffect(() => {
+    if (visible && initialQuery && initialQuery.trim()) {
+      setSearchQuery(initialQuery);
+    }
+  }, [visible, initialQuery]);
 
   const handleSelectVideo = (video: DiscoveredVideo) => {
     Haptics.selectionAsync();

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -66,6 +66,7 @@ export const DashboardScreen: React.FC = () => {
     category: string;
     language: string;
     deepResearch: boolean;
+    searchQuery: string;
   } | null>(null);
 
   const loadRecentAnalyses = useCallback(async () => {
@@ -154,6 +155,7 @@ export const DashboardScreen: React.FC = () => {
           category: data.category,
           language: data.language || 'fr',
           deepResearch: data.deepResearch || false,
+          searchQuery: data.value, // Pass the search query to pre-fill the modal
         });
         setShowDiscoveryModal(true);
         setIsAnalyzing(false);
@@ -403,6 +405,7 @@ export const DashboardScreen: React.FC = () => {
           setPendingSearchData(null);
         }}
         onSelectVideo={handleVideoSelect}
+        initialQuery={pendingSearchData?.searchQuery}
       />
     </View>
   );


### PR DESCRIPTION
Pass the search query from SmartInputBar to VideoDiscoveryModal via initialQuery prop, enabling automatic video search when the modal opens from search mode. This provides a smoother UX where users see results immediately.

https://claude.ai/code/session_0172mjyj32ELmX6cGnA8TdcH