### PR TITLE
fix(mobile): Remove Google Sign-In plugin for Expo Go compatibility

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -43,8 +43,7 @@
     "plugins": [
       "expo-font",
       "expo-secure-store",
-      "expo-audio",
-      "@react-native-google-signin/google-signin"
+      "expo-audio"
     ],
     "owner": "maximeadmin",
     "runtimeVersion": {


### PR DESCRIPTION
The native Google Sign-In plugin causes crashes in Expo Go since native modules are not available. Removed from plugins list to allow testing in Expo Go. The plugin should be re-added for EAS production builds.

https://claude.ai/code/session_0172mjyj32ELmX6cGnA8TdcH