### PR TITLE
Increase academic search results limit from 50 to 100

### DIFF
--- a/backend/src/academic/schemas.py
+++ b/backend/src/academic/schemas.py
@@ -57,7 +57,7 @@ class AcademicSearchRequest(BaseModel):
     """Request model for academic search"""
     keywords: List[str] = Field(..., min_length=1, description="Keywords to search for")
     summary_id: Optional[str] = None
-    limit: int = Field(default=10, ge=1, le=50)
+    limit: int = Field(default=10, ge=1, le=100)
     year_from: Optional[int] = None
     year_to: Optional[int] = None
     include_preprints: bool = True


### PR DESCRIPTION
## Summary
Increased the maximum limit for academic search results to allow users to retrieve more results per request.

## Changes
- Updated the `limit` field validation in `AcademicSearchRequest` schema
  - Changed maximum allowed value from 50 to 100
  - Default value remains at 10
  - Minimum value remains at 1

## Details
This change allows API consumers to request up to 100 academic search results in a single request, providing more flexibility for bulk data retrieval while maintaining reasonable API performance constraints.

https://claude.ai/code/session_01KNaXRUtSPkaeXXAUF5iNwc