### PR TITLE
fix(db): use ssl='require' instead of SSLContext for Railway proxy

### DIFF
--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -73,11 +73,8 @@ if DATABASE_URL.startswith("postgresql"):
 
     # Configurer SSL pour asyncpg via connect_args
     if _use_ssl:
-        import ssl
-        ssl_context = ssl.create_default_context()
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-        _engine_kwargs["connect_args"] = {"ssl": ssl_context}
+        # Utiliser ssl="require" pour Railway proxy (plus simple que SSLContext)
+        _engine_kwargs["connect_args"] = {"ssl": "require"}
 
 engine = create_async_engine(DATABASE_URL, **_engine_kwargs)
 


### PR DESCRIPTION
SSLContext was causing connection reset errors. asyncpg supports ssl='require' which is simpler and works better with Railway's proxy.

https://claude.ai/code/session_01KNaXRUtSPkaeXXAUF5iNwc