### PR TITLE
fix(spinner): eliminate visible black square around logo

### DIFF
--- a/frontend/src/components/ui/DeepSightSpinner.tsx
+++ b/frontend/src/components/ui/DeepSightSpinner.tsx
@@ -54,9 +54,11 @@ export const DeepSightSpinner: React.FC<DeepSightSpinnerProps> = ({
     >
       <div 
         className="relative"
-        style={{ 
-          width: config.container, 
+        style={{
+          width: config.container,
           height: config.container,
+          borderRadius: '50%',
+          overflow: 'hidden',
         }}
       >
         {/* Flammes cosmiques - FIXES */}
@@ -68,6 +70,8 @@ export const DeepSightSpinner: React.FC<DeepSightSpinnerProps> = ({
             maskImage: `radial-gradient(circle at center, transparent 0%, transparent 38%, rgba(0,0,0,0.4) 45%, black 52%, black 100%)`,
             WebkitMaskImage: `radial-gradient(circle at center, transparent 0%, transparent 38%, rgba(0,0,0,0.4) 45%, black 52%, black 100%)`,
             zIndex: 1,
+            mixBlendMode: 'screen',
+            borderRadius: '50%',
           }}
         />
         


### PR DESCRIPTION
Use mix-blend-mode: screen on the cosmic flames image so black JPG
background becomes transparent against the page. Add border-radius: 50%
and overflow: hidden on the container as a safety clip.

https://claude.ai/code/session_01P4uNca7ZJE7X8J7CFcygUY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual tweaks to a UI spinner; primary risk is minor cross-browser rendering differences for `mix-blend-mode` and masking.
> 
> **Overview**
> Updates `DeepSightSpinner` to **hide the black rectangular JPG background** behind the spinner by applying `mix-blend-mode: screen` to the cosmic-flames image.
> 
> Adds circular clipping safeguards on the spinner container (`borderRadius: '50%'` + `overflow: 'hidden'`) and matches the image `borderRadius` to ensure no square edges bleed through.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7870337485768ca7511ada374abcb0782a6b1e85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->