### PR TITLE
fix(frontend): fix crash Safari mobile

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,6 @@ import { BrowserRouter as Router, Routes, Route, Navigate, Outlet, useLocation }
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAuth } from "./hooks/useAuth";
 import { AuthProvider } from "./contexts/AuthContext";
-import { ThemeProvider } from "./contexts/ThemeContext";
 import { LanguageProvider } from "./contexts/LanguageContext";
 import { LoadingWordProvider } from "./contexts/LoadingWordContext";
 import { PrivateRoute } from "./components/PrivateRoute";
@@ -351,11 +350,10 @@ const AppRoutes = () => {
   const auth = useAuth();
 
   return (
-    <ThemeProvider>
-      <LanguageProvider>
-        <LoadingWordProvider>
-          <AuthProvider value={auth}>
-            <Router>
+    <LanguageProvider>
+      <LoadingWordProvider>
+        <AuthProvider value={auth}>
+          <Router>
             {/* ♿ Skip Link pour l'accessibilité */}
             <SkipLink targetId="main-content" />
             
@@ -578,7 +576,6 @@ const AppRoutes = () => {
           </AuthProvider>
         </LoadingWordProvider>
       </LanguageProvider>
-    </ThemeProvider>
   );
 };
 

--- a/frontend/src/components/CookieBanner.tsx
+++ b/frontend/src/components/CookieBanner.tsx
@@ -44,7 +44,9 @@ function getStoredConsent(): CookiePreferences | null {
 }
 
 function storeConsent(prefs: CookiePreferences): void {
-  localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(prefs));
+  try {
+    localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(prefs));
+  } catch { /* Safari private mode */ }
 }
 
 /** Vérifie si l'utilisateur a donné son consentement analytics */

--- a/frontend/src/hooks/usePWA.ts
+++ b/frontend/src/hooks/usePWA.ts
@@ -189,7 +189,7 @@ export function usePWA(): PWAState & PWAActions {
   // Réinitialiser l'état dismissed
   const resetDismissed = useCallback(() => {
     setInstallDismissed(false);
-    localStorage.removeItem('pwa-install-dismissed');
+    try { localStorage.removeItem('pwa-install-dismissed'); } catch { /* Safari private */ }
   }, []);
 
   // Vérifier si l'utilisateur a déjà refusé récemment


### PR DESCRIPTION
## Summary
- Remove duplicate ThemeProvider in App.tsx (already wrapped in main.tsx)
- Add try/catch around localStorage calls in CookieBanner and usePWA for Safari private mode

## Test plan
- [ ] Open deepsightsynthesis.com on mobile Safari
- [ ] Verify no crash / error boundary screen