### PR TITLE
chore(config): add project-level Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "Edit(*)",
+      "Write(*)",
+      "Read(*)",
+      "Glob(*)",
+      "Grep(*)",
+      "WebSearch",
+      "WebFetch(*)",
+      "Agent(*)",
+      "NotebookEdit(*)",
+      "mcp__*"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with wildcard permissions allowlist at the project level
- Covers all tools: `Bash(*)`, `Edit(*)`, `Write(*)`, `mcp__*`, etc.
- Reduces "Allow?" prompts for all contributors working on the repo

## Test plan
- [ ] Verify Claude Code sessions in this repo no longer prompt for common operations
- [ ] Confirm settings merge correctly with user-level `~/.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)