### PR TITLE
feat(voice): Parler à sa vidéo — ElevenLabs Conversational AI

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,42 +1,5 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(git cherry-pick:*)",
-      "Bash(git reset:*)",
-      "Bash(grep:*)",
-      "Bash(git add:*)",
-      "Bash(git commit:*)",
-      "Bash(git push:*)",
-      "Bash(npx tsc:*)",
-      "Bash(npm run build:*)",
-      "Bash(npx vite build)",
-      "Bash(python -c:*)",
-      "Bash(python -m py_compile:*)",
-      "Bash(git pull:*)",
-      "Bash(git remote set-url:*)",
-      "Bash(git fetch:*)",
-      "Bash(gh repo create:*)",
-      "Bash(where:*)",
-      "Bash(curl:*)",
-      "Bash(winget install:*)",
-      "Bash(export PATH=\"$PATH:/c/Program Files/GitHub CLI\")",
-      "Bash(gh:*)",
-      "Bash(npm install:*)",
-      "Bash(xargs:*)",
-      "Bash(git submodule update:*)",
-      "Bash(git rm:*)",
-      "Bash(git merge:*)",
-      "Bash(railway status:*)",
-      "Bash(railway whoami:*)",
-      "Bash(test:*)",
-      "Bash(find:*)",
-      "Bash(file:*)",
-      "Bash(tr:*)",
-      "Bash(npx webpack:*)",
-      "WebSearch",
-      "WebFetch(domain:greasyfork.org)",
-      "Bash(done)",
-      "Bash(python3 -c \"import sys; sys.path.insert\\(0, ''.''\\); exec\\(open\\(''main.py''\\).read\\(\\).split\\(''if __name__''\\)[0]\\)\")"
-    ]
+    "allow": []
   }
 }

--- a/backend/alembic/versions/004_add_voice_tables.py
+++ b/backend/alembic/versions/004_add_voice_tables.py
@@ -1,0 +1,66 @@
+"""Add voice_sessions, voice_quotas tables and users.voice_bonus_seconds column
+
+Revision ID: 004_add_voice_tables
+Revises: 003_add_transcript_cache
+Create Date: 2026-03-23
+
+Voice conversation feature: ElevenLabs agent sessions, per-user monthly quotas,
+and bonus seconds tracking.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '004_add_voice_tables'
+down_revision: Union[str, None] = '003_add_transcript_cache'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- voice_sessions ---
+    op.create_table(
+        'voice_sessions',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('summary_id', sa.Integer, sa.ForeignKey('summaries.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('elevenlabs_agent_id', sa.String(100), nullable=True),
+        sa.Column('elevenlabs_conversation_id', sa.String(100), nullable=True),
+        sa.Column('started_at', sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column('ended_at', sa.DateTime, nullable=True),
+        sa.Column('duration_seconds', sa.Integer, server_default='0'),
+        sa.Column('status', sa.String(20), nullable=False, server_default='pending'),
+        sa.Column('conversation_transcript', sa.Text, nullable=True),
+        sa.Column('language', sa.String(5), server_default='fr'),
+        sa.Column('platform', sa.String(20), server_default='web'),
+    )
+
+    op.create_index('ix_voice_sessions_user_id', 'voice_sessions', ['user_id'])
+    op.create_index('ix_voice_sessions_summary_id', 'voice_sessions', ['summary_id'])
+    op.create_index('ix_voice_sessions_status', 'voice_sessions', ['status'])
+    op.create_index('ix_voice_sessions_elevenlabs_conversation_id', 'voice_sessions', ['elevenlabs_conversation_id'])
+    op.create_index('ix_voice_sessions_user_started', 'voice_sessions', ['user_id', 'started_at'])
+
+    # --- voice_quotas ---
+    op.create_table(
+        'voice_quotas',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('year', sa.Integer, nullable=False),
+        sa.Column('month', sa.Integer, nullable=False),
+        sa.Column('seconds_used', sa.Integer, nullable=False, server_default='0'),
+        sa.Column('seconds_limit', sa.Integer, nullable=False),
+        sa.Column('sessions_count', sa.Integer, nullable=False, server_default='0'),
+        sa.UniqueConstraint('user_id', 'year', 'month', name='uq_voice_quotas_user_year_month'),
+    )
+
+    # --- users.voice_bonus_seconds ---
+    op.add_column('users', sa.Column('voice_bonus_seconds', sa.Integer, server_default='0'))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'voice_bonus_seconds')
+    op.drop_table('voice_quotas')
+    # Indexes are dropped automatically with the table
+    op.drop_table('voice_sessions')

--- a/backend/src/admin/router.py
+++ b/backend/src/admin/router.py
@@ -12,8 +12,8 @@ from typing import Optional, List
 from datetime import datetime, date, timedelta
 
 from db.database import (
-    get_session, User, Summary, CreditTransaction, 
-    PlaylistAnalysis, AdminLog
+    get_session, User, Summary, CreditTransaction,
+    PlaylistAnalysis, AdminLog, VoiceSession, VoiceQuota
 )
 from auth.dependencies import get_current_admin
 from core.config import PLAN_LIMITS
@@ -499,3 +499,99 @@ async def reset_monthly_credits(
     await session.commit()
     
     return {"success": True, "users_updated": count}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎙️ VOICE CHAT STATS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.get("/voice-stats")
+async def get_voice_stats(
+    admin: User = Depends(get_current_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    """Statistiques d'utilisation du voice chat."""
+    now = datetime.now()
+    current_year = now.year
+    current_month_num = now.month
+    current_month = now.strftime("%Y-%m")
+
+    # Total minutes ce mois (depuis VoiceSession)
+    total_seconds_result = await session.execute(
+        select(func.coalesce(func.sum(VoiceSession.duration_seconds), 0)).where(
+            func.extract("year", VoiceSession.started_at) == current_year,
+            func.extract("month", VoiceSession.started_at) == current_month_num,
+        )
+    )
+    total_seconds = total_seconds_result.scalar() or 0
+    total_minutes = round(total_seconds / 60, 2)
+
+    # Nombre d'utilisateurs actifs voice ce mois
+    active_users_result = await session.execute(
+        select(func.count(func.distinct(VoiceSession.user_id))).where(
+            func.extract("year", VoiceSession.started_at) == current_year,
+            func.extract("month", VoiceSession.started_at) == current_month_num,
+        )
+    )
+    active_users = active_users_result.scalar() or 0
+
+    # Nombre de sessions ce mois
+    total_sessions_result = await session.execute(
+        select(func.count(VoiceSession.id)).where(
+            func.extract("year", VoiceSession.started_at) == current_year,
+            func.extract("month", VoiceSession.started_at) == current_month_num,
+        )
+    )
+    total_sessions = total_sessions_result.scalar() or 0
+
+    # Moyenne minutes/user
+    avg_minutes = round(total_minutes / active_users, 2) if active_users > 0 else 0.0
+
+    # Nombre de quotas atteints (seconds_used >= seconds_limit)
+    quota_reached_result = await session.execute(
+        select(func.count(VoiceQuota.id)).where(
+            VoiceQuota.year == current_year,
+            VoiceQuota.month == current_month_num,
+            VoiceQuota.seconds_used >= VoiceQuota.seconds_limit,
+        )
+    )
+    quota_reached = quota_reached_result.scalar() or 0
+
+    # Stats par plan
+    plan_stats_result = await session.execute(
+        select(
+            User.plan,
+            func.count(func.distinct(VoiceSession.user_id)).label("users"),
+            func.coalesce(func.sum(VoiceSession.duration_seconds), 0).label("seconds"),
+        )
+        .join(User, VoiceSession.user_id == User.id)
+        .where(
+            func.extract("year", VoiceSession.started_at) == current_year,
+            func.extract("month", VoiceSession.started_at) == current_month_num,
+        )
+        .group_by(User.plan)
+    )
+    plan_rows = plan_stats_result.all()
+
+    by_plan = {}
+    for row in plan_rows:
+        plan_name = row.plan or "free"
+        plan_users = row.users
+        plan_seconds = row.seconds
+        plan_minutes = round(plan_seconds / 60, 2)
+        by_plan[plan_name] = {
+            "users": plan_users,
+            "minutes": plan_minutes,
+            "avg_minutes_per_user": round(plan_minutes / plan_users, 2) if plan_users > 0 else 0.0,
+        }
+
+    return {
+        "month": current_month,
+        "total_voice_minutes": total_minutes,
+        "total_voice_cost_estimated": round(total_minutes * 0.12, 2),
+        "active_voice_users": active_users,
+        "total_sessions": total_sessions,
+        "avg_minutes_per_user": avg_minutes,
+        "quota_reached_count": quota_reached,
+        "by_plan": by_plan,
+    }

--- a/backend/src/billing/router.py
+++ b/backend/src/billing/router.py
@@ -1193,8 +1193,15 @@ async def stripe_health():
 
 async def handle_checkout_completed(session: AsyncSession, data: dict):
     """Gère la complétion d'un checkout"""
-    user_id = data.get("metadata", {}).get("user_id")
-    plan = data.get("metadata", {}).get("plan")
+    metadata = data.get("metadata", {})
+
+    # ── Voice addon (one-time payment) ────────────────────────────────
+    if metadata.get("type") == "voice_addon":
+        await _handle_voice_addon_checkout(session, data, metadata)
+        return
+
+    user_id = metadata.get("user_id")
+    plan = metadata.get("plan")
     customer_id = data.get("customer")
     subscription_id = data.get("subscription")
 
@@ -1268,6 +1275,61 @@ async def handle_checkout_completed(session: AsyncSession, data: dict):
         )
     except Exception as e:
         logger.info(f"📧 Payment success email error: {e}")
+
+
+async def _handle_voice_addon_checkout(
+    session: AsyncSession, data: dict, metadata: dict
+):
+    """Handle a completed voice add-on one-time payment."""
+    minutes = int(metadata.get("minutes", 0))
+    user_id_str = metadata.get("user_id", "0")
+    pack_id = metadata.get("pack_id", "unknown")
+
+    try:
+        user_id = int(user_id_str)
+    except (ValueError, TypeError):
+        logger.warning("Voice addon: invalid user_id in metadata: %s", user_id_str)
+        return
+
+    if minutes <= 0 or user_id <= 0:
+        logger.warning("Voice addon: invalid minutes=%s or user_id=%s", minutes, user_id)
+        return
+
+    # DB-level idempotency: check if this payment was already processed
+    payment_id = data.get("payment_intent") or data.get("id")
+    if payment_id:
+        existing = await session.execute(
+            select(CreditTransaction).where(CreditTransaction.stripe_payment_id == payment_id)
+        )
+        if existing.scalar_one_or_none():
+            logger.info("Voice addon checkout %s already processed — skipping", payment_id)
+            return
+
+    user = await session.get(User, user_id)
+    if not user:
+        logger.warning("Voice addon: user %s not found", user_id)
+        return
+
+    # Add bonus voice seconds
+    user.voice_bonus_seconds = (user.voice_bonus_seconds or 0) + (minutes * 60)
+
+    # Record transaction for idempotency + audit trail
+    transaction = CreditTransaction(
+        user_id=user.id,
+        amount=0,
+        balance_after=user.credits or 0,
+        transaction_type="voice_addon",
+        type="voice_addon",
+        stripe_payment_id=payment_id,
+        description=f"Voice pack: {pack_id} (+{minutes}min)",
+    )
+    session.add(transaction)
+
+    await session.commit()
+    logger.info(
+        "Voice addon: +%dmin for user %s (pack=%s, total_bonus=%ds)",
+        minutes, user_id, pack_id, user.voice_bonus_seconds,
+    )
 
 
 async def handle_subscription_created(session: AsyncSession, data: dict):

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -108,6 +108,10 @@ class _DeepSightSettings(BaseSettings):
     # -- TTS --
     TTS_PROVIDER: str = "openai"
     ELEVENLABS_API_KEY: str = ""
+    ELEVENLABS_AGENT_TEMPLATE_ID: str = ""
+    ELEVENLABS_WEBHOOK_SECRET: str = ""
+    ELEVENLABS_VOICE_ID: str = ""
+    ELEVENLABS_MODEL_ID: str = "eleven_flash_v2_5"
 
     # -- Legal --
     LEGAL_OWNER_NAME: str = "LEPARC Maxime Bertrand"
@@ -358,7 +362,9 @@ PLAN_LIMITS: Dict[str, Dict[str, Any]] = {
         "academic_papers_per_analysis": 3,
         "bibliography_export": False,
         "academic_full_text": False,
-        "blocked_features": ["playlists", "export_csv", "export_excel", "batch_api", "tts", "deep_research"],
+        "voice_chat_enabled": False,
+        "voice_monthly_minutes": 0,
+        "blocked_features": ["playlists", "export_csv", "export_excel", "batch_api", "tts", "deep_research", "voice_chat"],
         "upgrade_prompt": {
             "fr": "Passez \u00e0 Starter pour d\u00e9bloquer plus d'analyses et de fonctionnalit\u00e9s !",
             "en": "Upgrade to Starter to unlock more analyses and features!"
@@ -388,6 +394,8 @@ PLAN_LIMITS: Dict[str, Dict[str, Any]] = {
         "academic_papers_per_analysis": 15,
         "bibliography_export": True,
         "academic_full_text": False,
+        "voice_chat_enabled": True,
+        "voice_monthly_minutes": 15,
         "blocked_features": ["playlists", "batch_api", "deep_research"],
         "upgrade_prompt": {
             "fr": "Passez \u00e0 Pro pour les playlists et le chat illimit\u00e9 !",
@@ -419,6 +427,8 @@ PLAN_LIMITS: Dict[str, Dict[str, Any]] = {
         "academic_papers_per_analysis": 30,
         "bibliography_export": True,
         "academic_full_text": True,
+        "voice_chat_enabled": True,
+        "voice_monthly_minutes": 45,
         "blocked_features": ["batch_api", "deep_research"],
         "upgrade_prompt": {
             "fr": "Passez \u00e0 Expert pour la recherche approfondie et l'API !",
@@ -450,6 +460,8 @@ PLAN_LIMITS: Dict[str, Dict[str, Any]] = {
         "academic_papers_per_analysis": 50,
         "bibliography_export": True,
         "academic_full_text": True,
+        "voice_chat_enabled": True,
+        "voice_monthly_minutes": 45,
         "blocked_features": [],
         "upgrade_prompt": {
             "fr": "Vous avez le plan Expert, toutes les fonctionnalit\u00e9s sont d\u00e9bloqu\u00e9es !",
@@ -480,6 +492,8 @@ PLAN_LIMITS: Dict[str, Dict[str, Any]] = {
         "academic_papers_per_analysis": 100,
         "bibliography_export": True,
         "academic_full_text": True,
+        "voice_chat_enabled": True,
+        "voice_monthly_minutes": -1,
         "blocked_features": [],
         "upgrade_prompt": {
             "fr": "Compte administrateur - acc\u00e8s illimit\u00e9",
@@ -514,6 +528,26 @@ R2_CONFIG = {
     "BUCKET": _settings.R2_BUCKET_NAME,
     "PUBLIC_DOMAIN": _settings.R2_PUBLIC_DOMAIN,
     "ENABLED": _settings.R2_ENABLED,
+}
+
+# =============================================================================
+# VOICE CHAT LIMITS
+# =============================================================================
+
+VOICE_LIMITS: Dict[str, Dict[str, Any]] = {
+    "free":      {"enabled": False, "monthly_minutes": 0,   "max_session_minutes": 0},
+    "etudiant":  {"enabled": True,  "monthly_minutes": 5,   "max_session_minutes": 10},
+    "starter":   {"enabled": True,  "monthly_minutes": 15,  "max_session_minutes": 10},
+    "pro":       {"enabled": True,  "monthly_minutes": 45,  "max_session_minutes": 10},
+}
+
+VOICE_CHAT_CONFIG: Dict[str, Any] = {
+    "max_session_duration_seconds": 600,
+    "min_billable_seconds": 5,
+    "silence_timeout_seconds": 30,
+    "quota_warning_thresholds": [50, 80, 95, 100],
+    "grace_period_seconds": 15,
+    "max_sessions_per_day": 50,
 }
 
 # =============================================================================

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -151,10 +151,13 @@ class User(Base):
     api_key_created_at = Column(DateTime)
     api_key_last_used = Column(DateTime)
     
+    # Voice
+    voice_bonus_seconds = Column(Integer, default=0)
+
     # Timestamps
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
-    
+
     # Relations
     summaries = relationship("Summary", back_populates="user", cascade="all, delete-orphan")
     chat_messages = relationship("ChatMessage", back_populates="user", cascade="all, delete-orphan")
@@ -660,6 +663,54 @@ class SharedAnalysis(Base):
     __table_args__ = (
         Index('idx_shared_analyses_token', 'share_token'),
         Index('idx_shared_analyses_user_video', 'user_id', 'video_id'),
+    )
+
+
+class VoiceSession(Base):
+    """🎙️ Sessions de conversation vocale avec l'IA (ElevenLabs)"""
+    __tablename__ = "voice_sessions"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(__import__('uuid').uuid4()))
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    summary_id = Column(Integer, ForeignKey("summaries.id", ondelete="CASCADE"), nullable=False, index=True)
+
+    # ElevenLabs
+    elevenlabs_agent_id = Column(String(100), nullable=True)
+    elevenlabs_conversation_id = Column(String(100), nullable=True, index=True)
+
+    # Timing
+    started_at = Column(DateTime, default=func.now(), nullable=False)
+    ended_at = Column(DateTime, nullable=True)
+    duration_seconds = Column(Integer, default=0)
+
+    # Status: pending, active, completed, failed, timeout
+    status = Column(String(20), default="pending", nullable=False, index=True)
+
+    # Contenu
+    conversation_transcript = Column(Text, nullable=True)
+    language = Column(String(5), default="fr")
+    platform = Column(String(20), default="web")
+
+    # Relations
+    user = relationship("User")
+    summary = relationship("Summary")
+
+
+class VoiceQuota(Base):
+    """🎙️ Quotas mensuels de conversation vocale"""
+    __tablename__ = "voice_quotas"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    year = Column(Integer, nullable=False)
+    month = Column(Integer, nullable=False)
+    seconds_used = Column(Integer, default=0)
+    seconds_limit = Column(Integer, nullable=False)
+    sessions_count = Column(Integer, default=0)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "year", "month", name="uq_voice_quota_user_month"),
+        Index("ix_voice_quota_user_period", "user_id", "year", "month"),
     )
 
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -270,6 +270,14 @@ except ImportError as e:
     VIDEO_CACHE_AVAILABLE = False
     print(f"⚠️ Video content cache not available: {e}", flush=True)
 
+# 🎙️ Voice chat router (ElevenLabs Conversational AI)
+try:
+    from voice.router import router as voice_router
+    VOICE_ROUTER_AVAILABLE = True
+except ImportError as e:
+    VOICE_ROUTER_AVAILABLE = False
+    print(f"⚠️ Voice router not available: {e}", flush=True)
+
 # Global video cache instance
 _video_cache: "VideoContentCacheService | None" = None
 
@@ -769,6 +777,11 @@ if HEALTH_V1_ROUTER_AVAILABLE:
 if VIDEO_CACHE_AVAILABLE:
     app.include_router(cache_router, tags=["Video Cache"])
     print("💾 Video cache router loaded (GET /api/v1/cache/video/{platform}/{video_id}, GET /api/v1/cache/stats)", flush=True)
+
+# 🎙️ Voice chat router
+if VOICE_ROUTER_AVAILABLE:
+    app.include_router(voice_router, prefix="/api/voice", tags=["Voice"])
+    print("🎙️ Voice router loaded (GET /api/voice/quota, POST /api/voice/session, POST /api/voice/webhook)", flush=True)
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ENDPOINTS DE BASE

--- a/backend/src/voice/__init__.py
+++ b/backend/src/voice/__init__.py
@@ -1,0 +1,1 @@
+# Voice chat module

--- a/backend/src/voice/elevenlabs.py
+++ b/backend/src/voice/elevenlabs.py
@@ -1,0 +1,322 @@
+"""
+ElevenLabs Conversational AI Client — DeepSight Voice Chat
+Phase 2 kickstart — API client for agent creation and signed URL generation.
+
+Uses the ElevenLabs Conversational AI API:
+https://elevenlabs.io/docs/api-reference/conversational-ai
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+
+from core.logging import logger
+
+
+class ElevenLabsClient:
+    """Async client for the ElevenLabs Conversational AI API."""
+
+    BASE_URL = "https://api.elevenlabs.io/v1"
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+        self._client = httpx.AsyncClient(
+            base_url=self.BASE_URL,
+            headers={"xi-api-key": api_key},
+            timeout=30.0,
+        )
+
+    async def __aenter__(self) -> "ElevenLabsClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    # ------------------------------------------------------------------
+    # Agent lifecycle
+    # ------------------------------------------------------------------
+
+    async def create_conversation_agent(
+        self,
+        system_prompt: str,
+        tools: list[dict],
+        voice_id: str,
+        first_message: Optional[str] = None,
+        language: str = "fr",
+    ) -> str:
+        """Create a conversational AI agent and return its agent_id.
+
+        Raises:
+            ValueError: on 401 (invalid API key).
+            httpx.HTTPStatusError: on 429 (rate limit) or 5xx.
+        """
+        body: dict = {
+            "conversation_config": {
+                "agent": {
+                    "prompt": {"prompt": system_prompt},
+                    "first_message": first_message,
+                    "language": language,
+                },
+                "tts": {
+                    "voice_id": voice_id,
+                    "model_id": "eleven_flash_v2_5",
+                },
+            },
+            "tools": tools,
+        }
+
+        logger.info(
+            "elevenlabs.create_agent",
+            extra={"voice_id": voice_id, "language": language},
+        )
+
+        response = await self._client.post("/convai/agents/create", json=body)
+
+        if response.status_code == 401:
+            raise ValueError("ElevenLabs API key is invalid or expired")
+        if response.status_code == 429:
+            raise httpx.HTTPStatusError(
+                "ElevenLabs rate limit exceeded — retry later",
+                request=response.request,
+                response=response,
+            )
+        response.raise_for_status()
+
+        data = response.json()
+        agent_id: str = data["agent_id"]
+        logger.info("elevenlabs.agent_created", extra={"agent_id": agent_id})
+        return agent_id
+
+    async def get_signed_url(self, agent_id: str) -> tuple[str, str]:
+        """Get a signed WebSocket URL for a conversation session.
+
+        Returns:
+            (signed_url, expires_at_iso)
+        """
+        logger.info("elevenlabs.get_signed_url", extra={"agent_id": agent_id})
+
+        response = await self._client.get(
+            "/convai/conversation/get-signed-url",
+            params={"agent_id": agent_id},
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        return data["signed_url"], data.get("expires_at", "")
+
+    async def delete_agent(self, agent_id: str) -> bool:
+        """Delete a conversational AI agent. Returns True on success, False otherwise."""
+        logger.info("elevenlabs.delete_agent", extra={"agent_id": agent_id})
+        try:
+            response = await self._client.delete(f"/convai/agents/{agent_id}")
+            if response.is_success:
+                logger.info("elevenlabs.agent_deleted", extra={"agent_id": agent_id})
+                return True
+            logger.warning(
+                "elevenlabs.delete_agent_failed",
+                extra={"agent_id": agent_id, "status": response.status_code},
+            )
+            return False
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "elevenlabs.delete_agent_error",
+                extra={"agent_id": agent_id, "error": str(exc)},
+            )
+            return False
+
+    # ------------------------------------------------------------------
+    # Prompt & tool builders (static)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def build_system_prompt(
+        video_title: str,
+        channel_name: str,
+        duration: str,
+        summary_content: str,
+        language: str = "fr",
+    ) -> str:
+        """Build the system prompt injected into the ElevenLabs agent."""
+
+        if language == "fr":
+            return (
+                "Tu es l'assistant vocal DeepSight. Tu aides l'utilisateur "
+                "à comprendre une vidéo YouTube.\n\n"
+                "## Vidéo\n"
+                f"Titre : {video_title}\n"
+                f"Chaîne : {channel_name}\n"
+                f"Durée : {duration}\n\n"
+                "## Résumé\n"
+                f"{summary_content}\n\n"
+                "## Règles\n"
+                "- Réponses courtes (2-4 phrases) sauf si on te demande de détailler\n"
+                "- N'invente JAMAIS de contenu — utilise les tools pour vérifier\n"
+                "- Si hors sujet → ramène vers la vidéo\n"
+                "- Utilise search_in_transcript pour les citations exactes\n"
+                "- Utilise get_sources pour les questions de fiabilité\n"
+                "- Si \"interroge-moi\" → utilise get_flashcards\n"
+                "- Ton naturel, expert mais accessible"
+            )
+
+        # English fallback
+        return (
+            "You are the DeepSight voice assistant. You help the user "
+            "understand a YouTube video.\n\n"
+            "## Video\n"
+            f"Title: {video_title}\n"
+            f"Channel: {channel_name}\n"
+            f"Duration: {duration}\n\n"
+            "## Summary\n"
+            f"{summary_content}\n\n"
+            "## Rules\n"
+            "- Keep answers short (2-4 sentences) unless asked to elaborate\n"
+            "- NEVER make up content — use tools to verify\n"
+            "- If off-topic → steer back to the video\n"
+            "- Use search_in_transcript for exact quotes\n"
+            "- Use get_sources for reliability questions\n"
+            '- If "quiz me" → use get_flashcards\n'
+            "- Natural tone, expert but approachable"
+        )
+
+    @staticmethod
+    def build_tools_config(webhook_base_url: str, api_token: str) -> list[dict]:
+        """Return the ElevenLabs server-tool definitions (webhook format).
+
+        Each tool calls back into the DeepSight API with the user's JWT.
+        """
+        auth_header = {"Authorization": f"Bearer {api_token}"}
+
+        return [
+            {
+                "type": "webhook",
+                "name": "search_in_transcript",
+                "description": (
+                    "Search the video transcript for an exact passage or keyword. "
+                    "Returns matching excerpts with timestamps."
+                ),
+                "api_schema": {
+                    "url": f"{webhook_base_url}/api/voice/tools/search-transcript",
+                    "method": "POST",
+                    "headers": auth_header,
+                },
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The search query (keyword or phrase)",
+                        },
+                        "summary_id": {
+                            "type": "string",
+                            "description": "The analysis / summary ID",
+                        },
+                    },
+                    "required": ["query", "summary_id"],
+                },
+            },
+            {
+                "type": "webhook",
+                "name": "get_analysis_section",
+                "description": (
+                    "Retrieve a specific section of the video analysis "
+                    "(e.g. key_points, arguments, conclusion)."
+                ),
+                "api_schema": {
+                    "url": f"{webhook_base_url}/api/voice/tools/analysis-section",
+                    "method": "POST",
+                    "headers": auth_header,
+                },
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "section": {
+                            "type": "string",
+                            "description": "Section name (key_points, arguments, conclusion, context, etc.)",
+                        },
+                        "summary_id": {
+                            "type": "string",
+                            "description": "The analysis / summary ID",
+                        },
+                    },
+                    "required": ["section", "summary_id"],
+                },
+            },
+            {
+                "type": "webhook",
+                "name": "get_sources",
+                "description": (
+                    "Get fact-check sources and reliability information "
+                    "for the claims made in the video."
+                ),
+                "api_schema": {
+                    "url": f"{webhook_base_url}/api/voice/tools/sources",
+                    "method": "POST",
+                    "headers": auth_header,
+                },
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "claim": {
+                            "type": "string",
+                            "description": "The specific claim to verify (optional, returns all if omitted)",
+                        },
+                        "summary_id": {
+                            "type": "string",
+                            "description": "The analysis / summary ID",
+                        },
+                    },
+                    "required": ["summary_id"],
+                },
+            },
+            {
+                "type": "webhook",
+                "name": "get_flashcards",
+                "description": (
+                    "Get study flashcards generated from the video analysis. "
+                    "Use when the user wants to be quizzed or review key concepts."
+                ),
+                "api_schema": {
+                    "url": f"{webhook_base_url}/api/voice/tools/flashcards",
+                    "method": "POST",
+                    "headers": auth_header,
+                },
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "summary_id": {
+                            "type": "string",
+                            "description": "The analysis / summary ID",
+                        },
+                        "count": {
+                            "type": "integer",
+                            "description": "Number of flashcards to return (default 5)",
+                        },
+                    },
+                    "required": ["summary_id"],
+                },
+            },
+        ]
+
+
+# =========================================================================
+# Module-level factory
+# =========================================================================
+
+
+def get_elevenlabs_client() -> ElevenLabsClient:
+    """Instantiate an ElevenLabsClient using the project-wide settings."""
+    from core.config import get_elevenlabs_key
+
+    api_key = get_elevenlabs_key()
+    if not api_key:
+        raise ValueError(
+            "ELEVENLABS_API_KEY is not configured — "
+            "set it in .env or environment variables"
+        )
+    return ElevenLabsClient(api_key=api_key)

--- a/backend/src/voice/quota.py
+++ b/backend/src/voice/quota.py
@@ -1,0 +1,183 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎙️ VOICE QUOTA SERVICE — Gestion des quotas de conversation vocale               ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import logging
+from datetime import datetime, date
+from calendar import monthrange
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from db.database import VoiceQuota, User
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# 🎙️ VOICE LIMITS PAR PLAN
+# =============================================================================
+
+VOICE_LIMITS = {
+    "free":      {"enabled": False, "monthly_minutes": 0,   "max_session_minutes": 0},
+    "etudiant":  {"enabled": True,  "monthly_minutes": 5,   "max_session_minutes": 10},
+    "starter":   {"enabled": True,  "monthly_minutes": 15,  "max_session_minutes": 10},
+    "pro":       {"enabled": True,  "monthly_minutes": 45,  "max_session_minutes": 10},
+}
+
+WARNING_THRESHOLDS = [50, 80, 95, 100]
+
+
+# =============================================================================
+# 📊 FONCTIONS DE GESTION DES QUOTAS
+# =============================================================================
+
+async def get_or_create_voice_quota(
+    user_id: int, plan: str, db: AsyncSession
+) -> VoiceQuota:
+    """Récupère ou crée le quota vocal pour le mois en cours."""
+    now = datetime.now()
+    year = now.year
+    month = now.month
+
+    result = await db.execute(
+        select(VoiceQuota).where(
+            VoiceQuota.user_id == user_id,
+            VoiceQuota.year == year,
+            VoiceQuota.month == month,
+        )
+    )
+    quota = result.scalars().first()
+
+    if quota is None:
+        limits = VOICE_LIMITS.get(plan, VOICE_LIMITS["free"])
+        seconds_limit = limits["monthly_minutes"] * 60
+
+        quota = VoiceQuota(
+            user_id=user_id,
+            year=year,
+            month=month,
+            seconds_used=0,
+            seconds_limit=seconds_limit,
+            sessions_count=0,
+        )
+        db.add(quota)
+        await db.flush()
+        logger.info(
+            "Created voice quota for user %d (%s): %d seconds",
+            user_id, plan, seconds_limit,
+        )
+
+    return quota
+
+
+async def check_voice_quota(
+    user_id: int, plan: str, db: AsyncSession
+) -> dict:
+    """Vérifie le quota vocal et retourne l'état détaillé."""
+    quota = await get_or_create_voice_quota(user_id, plan, db)
+
+    # Charger le user pour voice_bonus_seconds
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalars().first()
+    bonus_seconds = user.voice_bonus_seconds if user else 0
+
+    total_limit = quota.seconds_limit + bonus_seconds
+    seconds_remaining = total_limit - quota.seconds_used
+    seconds_remaining = max(seconds_remaining, 0)
+
+    # Calculer le pourcentage utilisé
+    if total_limit > 0:
+        pct_used = (quota.seconds_used / total_limit) * 100
+    else:
+        pct_used = 100.0 if quota.seconds_used > 0 else 0.0
+
+    # Déterminer le warning_level : le plus grand seuil dépassé
+    warning_level = None
+    for threshold in WARNING_THRESHOLDS:
+        if pct_used >= threshold:
+            warning_level = threshold
+
+    return {
+        "can_use": seconds_remaining > 0,
+        "seconds_remaining": seconds_remaining,
+        "seconds_used": quota.seconds_used,
+        "seconds_limit": quota.seconds_limit,
+        "bonus_seconds": bonus_seconds,
+        "warning_level": warning_level,
+    }
+
+
+async def deduct_voice_usage(
+    user_id: int, duration_seconds: int, db: AsyncSession
+) -> float:
+    """Déduit l'usage vocal du quota. Minimum 5 secondes facturées.
+
+    Retourne les minutes déduites.
+    """
+    duration_seconds = max(duration_seconds, 5)
+
+    # Récupérer le user pour connaître le plan
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalars().first()
+    if not user:
+        raise ValueError(f"User {user_id} not found")
+
+    plan = user.plan or "free"
+    quota = await get_or_create_voice_quota(user_id, plan, db)
+
+    # Mettre à jour le quota
+    quota.seconds_used += duration_seconds
+    quota.sessions_count += 1
+
+    # Si dépassement du quota plan, déduire du bonus
+    overage = quota.seconds_used - quota.seconds_limit
+    if overage > 0 and user.voice_bonus_seconds > 0:
+        deduct_from_bonus = min(overage, user.voice_bonus_seconds)
+        user.voice_bonus_seconds -= deduct_from_bonus
+        logger.info(
+            "User %d exceeded plan quota by %ds, deducted %ds from bonus (remaining: %ds)",
+            user_id, overage, deduct_from_bonus, user.voice_bonus_seconds,
+        )
+
+    await db.commit()
+
+    minutes_deducted = duration_seconds / 60
+    logger.info(
+        "Deducted %.2f min voice usage for user %d (total used: %ds/%ds)",
+        minutes_deducted, user_id, quota.seconds_used, quota.seconds_limit,
+    )
+    return minutes_deducted
+
+
+async def get_voice_quota_info(
+    user_id: int, plan: str, db: AsyncSession
+) -> dict:
+    """Retourne les informations complètes du quota vocal."""
+    quota = await get_or_create_voice_quota(user_id, plan, db)
+    limits = VOICE_LIMITS.get(plan, VOICE_LIMITS["free"])
+
+    # Calculer la date de reset (1er du mois prochain)
+    now = datetime.now()
+    year = now.year
+    month = now.month
+    if month == 12:
+        reset_date = date(year + 1, 1, 1)
+    else:
+        reset_date = date(year, month + 1, 1)
+
+    total_seconds_remaining = max(quota.seconds_limit - quota.seconds_used, 0)
+    minutes_remaining = total_seconds_remaining / 60
+
+    return {
+        "plan": plan,
+        "voice_enabled": limits["enabled"],
+        "seconds_used": quota.seconds_used,
+        "seconds_limit": quota.seconds_limit,
+        "minutes_remaining": round(minutes_remaining, 2),
+        "max_session_minutes": limits["max_session_minutes"],
+        "sessions_this_month": quota.sessions_count,
+        "reset_date": reset_date.isoformat(),
+    }

--- a/backend/src/voice/quota.py
+++ b/backend/src/voice/quota.py
@@ -168,7 +168,10 @@ async def get_voice_quota_info(
     else:
         reset_date = date(year, month + 1, 1)
 
-    total_seconds_remaining = max(quota.seconds_limit - quota.seconds_used, 0)
+    user = await db.get(User, user_id)
+    bonus = user.voice_bonus_seconds if user else 0
+    total_available = quota.seconds_limit + bonus
+    total_seconds_remaining = max(total_available - quota.seconds_used, 0)
     minutes_remaining = total_seconds_remaining / 60
 
     return {

--- a/backend/src/voice/quota.py
+++ b/backend/src/voice/quota.py
@@ -6,7 +6,6 @@
 
 import logging
 from datetime import datetime, date
-from calendar import monthrange
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -9,16 +9,22 @@ Endpoints:
   GET  /history/{summary_id}/{session_id}/transcript — Session transcript
 """
 
+import hashlib
+import hmac
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from db.database import get_session, VoiceSession, Summary, User
 from auth.dependencies import get_current_user
-from core.config import VOICE_LIMITS, VOICE_CHAT_CONFIG
+from core.config import (
+    VOICE_LIMITS,
+    VOICE_CHAT_CONFIG,
+    APP_URL,
+)
 
 from voice.schemas import (
     VoiceSessionRequest,
@@ -35,6 +41,7 @@ from voice.quota import (
     deduct_voice_usage,
     get_or_create_voice_quota,
 )
+from voice.elevenlabs import ElevenLabsClient, get_elevenlabs_client
 
 logger = logging.getLogger(__name__)
 
@@ -129,14 +136,119 @@ async def create_voice_session(
         },
     )
 
-    # TODO: Phase 2 — Generate signed URL via ElevenLabs Conversational AI API
-    signed_url = "TODO_ELEVENLABS_INTEGRATION"
+    # Generate signed URL via ElevenLabs Conversational AI API
+    try:
+        # Load video context for the system prompt
+        video_title = summary.video_title or "Vidéo sans titre"
+        channel_name = summary.video_channel or "Chaîne inconnue"
+        duration_secs = summary.video_duration or 0
+        duration_str = f"{duration_secs // 60}min{duration_secs % 60:02d}s" if duration_secs else "inconnue"
+        summary_content = summary.summary_content or ""
+
+        # Truncate summary to avoid prompt overflow (keep first ~3000 chars)
+        if len(summary_content) > 3000:
+            summary_content = summary_content[:3000] + "\n\n[… résumé tronqué]"
+
+        language = request.language or "fr"
+
+        system_prompt = ElevenLabsClient.build_system_prompt(
+            video_title=video_title,
+            channel_name=channel_name,
+            duration=duration_str,
+            summary_content=summary_content,
+            language=language,
+        )
+
+        # Build webhook tools — use APP_URL as the base for tool callbacks
+        webhook_base_url = APP_URL.rstrip("/")
+        tools_config = ElevenLabsClient.build_tools_config(
+            webhook_base_url=webhook_base_url,
+            api_token=str(request.summary_id),  # Session context for tool calls
+        )
+
+        # Get voice ID from config
+        from core.config import _settings
+        voice_id = _settings.ELEVENLABS_VOICE_ID or "21m00Tcm4TlvDq8ikWAM"  # Default: Rachel
+
+        first_message = (
+            f"Salut ! Je suis prêt à discuter de la vidéo « {video_title} ». "
+            "Qu'est-ce que tu veux savoir ?"
+        ) if language == "fr" else (
+            f"Hi! I'm ready to discuss the video \"{video_title}\". "
+            "What would you like to know?"
+        )
+
+        async with get_elevenlabs_client() as client:
+            # Create the agent
+            agent_id = await client.create_conversation_agent(
+                system_prompt=system_prompt,
+                tools=tools_config,
+                voice_id=voice_id,
+                first_message=first_message,
+                language=language,
+            )
+
+            # Get the signed WebSocket URL
+            signed_url, expires_at_iso = await client.get_signed_url(agent_id)
+
+        # Update session with agent_id
+        voice_session.elevenlabs_agent_id = agent_id
+        voice_session.status = "active"
+        await db.commit()
+
+        logger.info(
+            "Voice session started with ElevenLabs",
+            extra={
+                "session_id": voice_session.id,
+                "agent_id": agent_id,
+            },
+        )
+
+    except ValueError as exc:
+        # Invalid API key or missing config
+        logger.error("ElevenLabs config error: %s", exc)
+        voice_session.status = "error"
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "voice_service_unavailable",
+                "message": "Voice service is not configured properly. Please try again later.",
+            },
+        )
+    except Exception as exc:
+        logger.error("ElevenLabs API error: %s", exc, exc_info=True)
+        voice_session.status = "error"
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "voice_service_error",
+                "message": "Voice service is temporarily unavailable. Please try again later.",
+            },
+        )
+
+    # Parse expires_at from ISO string, fallback to +10min
+    try:
+        from datetime import timedelta
+        if expires_at_iso:
+            expires_at = datetime.fromisoformat(expires_at_iso.replace("Z", "+00:00"))
+        else:
+            expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+    except (ValueError, TypeError):
+        from datetime import timedelta
+        expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+
+    # Compute quota remaining
+    max_session_minutes = plan_limits.get("max_session_minutes", 10)
+    quota_remaining_minutes = quota_info.get("minutes_remaining", 0.0) if isinstance(quota_info, dict) else 0.0
 
     return VoiceSessionResponse(
         session_id=voice_session.id,
         signed_url=signed_url,
-        status=voice_session.status,
-        started_at=voice_session.started_at,
+        expires_at=expires_at,
+        quota_remaining_minutes=quota_remaining_minutes,
+        max_session_minutes=max_session_minutes,
     )
 
 
@@ -146,24 +258,81 @@ async def create_voice_session(
 
 @router.post("/webhook", response_model=WebhookAckResponse)
 async def voice_webhook(
-    payload: VoiceWebhookPayload,
+    request: Request,
     db: AsyncSession = Depends(get_session),
 ):
     """
     Receive ElevenLabs webhook after a voice conversation ends.
     Public endpoint — no Bearer auth required.
+    HMAC-SHA256 signature verification protects against spoofing.
     """
-    # TODO: Phase 2 — Verify HMAC signature from ElevenLabs
+    # ── HMAC signature verification ──────────────────────────────────────
+    from core.config import _settings
+    webhook_secret = _settings.ELEVENLABS_WEBHOOK_SECRET
 
-    # Find the voice session by elevenlabs_conversation_id or metadata session_id
+    raw_body = await request.body()
+
+    if webhook_secret:
+        signature_header = request.headers.get("X-ElevenLabs-Signature", "")
+        if not signature_header:
+            logger.warning("Voice webhook: missing X-ElevenLabs-Signature header")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={
+                    "code": "invalid_signature",
+                    "message": "Missing webhook signature.",
+                },
+            )
+
+        expected = hmac.new(
+            webhook_secret.encode("utf-8"),
+            raw_body,
+            hashlib.sha256,
+        ).hexdigest()
+
+        if not hmac.compare_digest(expected, signature_header):
+            logger.warning("Voice webhook: HMAC signature mismatch")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={
+                    "code": "invalid_signature",
+                    "message": "Invalid webhook signature.",
+                },
+            )
+    else:
+        logger.debug("Voice webhook: HMAC verification skipped (no secret configured)")
+
+    # ── Parse payload ────────────────────────────────────────────────────
+    import json
+    try:
+        body = json.loads(raw_body)
+    except (json.JSONDecodeError, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_payload",
+                "message": "Invalid JSON payload.",
+            },
+        )
+
+    payload = VoiceWebhookPayload(**body)
+
+    # Find the voice session by conversation_id or metadata session_id
     session_query = None
-    if payload.elevenlabs_conversation_id:
+    if payload.conversation_id:
         session_query = select(VoiceSession).where(
-            VoiceSession.elevenlabs_conversation_id == payload.elevenlabs_conversation_id
+            VoiceSession.elevenlabs_conversation_id == payload.conversation_id
         )
     elif payload.metadata and payload.metadata.get("session_id"):
         session_query = select(VoiceSession).where(
-            VoiceSession.id == int(payload.metadata["session_id"])
+            VoiceSession.id == payload.metadata["session_id"]
+        )
+
+    # Also try matching by agent_id if conversation_id didn't match
+    if session_query is None and payload.agent_id:
+        session_query = select(VoiceSession).where(
+            VoiceSession.elevenlabs_agent_id == payload.agent_id,
+            VoiceSession.status == "active",
         )
 
     if session_query is None:
@@ -171,7 +340,7 @@ async def voice_webhook(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "code": "missing_session_identifier",
-                "message": "No conversation_id or session_id provided in webhook payload.",
+                "message": "No conversation_id, agent_id, or session_id provided in webhook payload.",
             },
         )
 
@@ -188,15 +357,17 @@ async def voice_webhook(
         )
 
     # Update session with webhook data
+    voice_session.elevenlabs_conversation_id = payload.conversation_id
     voice_session.duration_seconds = payload.duration_seconds
     voice_session.status = payload.status or "completed"
     voice_session.ended_at = datetime.now(timezone.utc)
-    if payload.conversation_transcript:
-        voice_session.conversation_transcript = payload.conversation_transcript
+    if payload.transcript:
+        voice_session.conversation_transcript = payload.transcript
 
     await db.commit()
 
     # Deduct voice usage
+    minutes_deducted = (payload.duration_seconds or 0) / 60.0
     await deduct_voice_usage(
         voice_session.user_id,
         duration_seconds=payload.duration_seconds or 0,
@@ -207,12 +378,17 @@ async def voice_webhook(
         "Voice webhook processed",
         extra={
             "session_id": voice_session.id,
+            "conversation_id": payload.conversation_id,
             "duration": payload.duration_seconds,
             "status": voice_session.status,
         },
     )
 
-    return WebhookAckResponse(status="ok", session_id=voice_session.id)
+    return WebhookAckResponse(
+        status="ok",
+        session_id=voice_session.id,
+        minutes_deducted=round(minutes_deducted, 2),
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -233,7 +409,8 @@ async def get_voice_history(
             Summary.user_id == current_user.id,
         )
     )
-    if not result.scalar_one_or_none():
+    summary = result.scalar_one_or_none()
+    if not summary:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
@@ -253,7 +430,28 @@ async def get_voice_history(
     )
     sessions = result.scalars().all()
 
-    return VoiceHistoryResponse(sessions=sessions)
+    # Build session summaries
+    from voice.schemas import VoiceSessionSummary
+    session_summaries = [
+        VoiceSessionSummary(
+            session_id=s.id,
+            started_at=s.started_at,
+            ended_at=s.ended_at,
+            duration_seconds=s.duration_seconds or 0,
+            status=s.status or "unknown",
+            has_transcript=bool(s.conversation_transcript),
+        )
+        for s in sessions
+    ]
+
+    total_seconds = sum(s.duration_seconds or 0 for s in sessions)
+
+    return VoiceHistoryResponse(
+        summary_id=summary_id,
+        video_title=summary.video_title or "Vidéo sans titre",
+        sessions=session_summaries,
+        total_minutes=round(total_seconds / 60.0, 2),
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -266,7 +464,7 @@ async def get_voice_history(
 )
 async def get_voice_transcript(
     summary_id: int,
-    session_id: int,
+    session_id: str,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ):
@@ -317,6 +515,8 @@ async def get_voice_transcript(
 
     return VoiceTranscriptResponse(
         session_id=voice_session.id,
+        summary_id=summary_id,
+        started_at=voice_session.started_at,
+        duration_seconds=voice_session.duration_seconds or 0,
         transcript=voice_session.conversation_transcript,
-        duration_seconds=voice_session.duration_seconds,
     )

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -1,0 +1,322 @@
+"""
+Voice Chat Router — ElevenLabs Conversational AI Integration
+
+Endpoints:
+  GET  /quota                                    — Voice quota info
+  POST /session                                  — Create voice session
+  POST /webhook                                  — ElevenLabs webhook (public)
+  GET  /history/{summary_id}                     — Voice session history
+  GET  /history/{summary_id}/{session_id}/transcript — Session transcript
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from db.database import get_session, VoiceSession, Summary, User
+from auth.dependencies import get_current_user
+from core.config import VOICE_LIMITS, VOICE_CHAT_CONFIG
+
+from voice.schemas import (
+    VoiceSessionRequest,
+    VoiceSessionResponse,
+    VoiceQuotaResponse,
+    VoiceWebhookPayload,
+    WebhookAckResponse,
+    VoiceHistoryResponse,
+    VoiceTranscriptResponse,
+)
+from voice.quota import (
+    get_voice_quota_info,
+    check_voice_quota,
+    deduct_voice_usage,
+    get_or_create_voice_quota,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GET /quota — Voice quota info
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.get("/quota", response_model=VoiceQuotaResponse)
+async def get_voice_quota(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Return voice chat quota information for the current user."""
+    quota_info = await get_voice_quota_info(current_user.id, current_user.plan or "free", db)
+    return quota_info
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# POST /session — Create a voice session
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.post("/session", response_model=VoiceSessionResponse)
+async def create_voice_session(
+    request: VoiceSessionRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Create a new voice chat session linked to a video analysis."""
+    plan = current_user.plan or "free"
+
+    # Check plan has voice enabled
+    plan_limits = VOICE_LIMITS.get(plan, VOICE_LIMITS.get("free", {}))
+    if not plan_limits.get("enabled", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "voice_not_available",
+                "message": "Voice chat is not available on your current plan.",
+                "action": "upgrade",
+            },
+        )
+
+    # Verify summary ownership
+    result = await db.execute(
+        select(Summary).where(
+            Summary.id == request.summary_id,
+            Summary.user_id == current_user.id,
+        )
+    )
+    summary = result.scalar_one_or_none()
+    if not summary:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "summary_not_found",
+                "message": "Analysis not found or does not belong to you.",
+            },
+        )
+
+    # Check voice quota
+    can_use, quota_info = await check_voice_quota(current_user.id, plan, db)
+    if not can_use:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "code": "voice_quota_exceeded",
+                "message": "Voice chat quota exceeded for today.",
+                **quota_info,
+            },
+        )
+
+    # Create voice session in DB
+    voice_session = VoiceSession(
+        user_id=current_user.id,
+        summary_id=request.summary_id,
+        status="pending",
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(voice_session)
+    await db.commit()
+    await db.refresh(voice_session)
+
+    logger.info(
+        "Voice session created",
+        extra={
+            "user_id": current_user.id,
+            "summary_id": request.summary_id,
+            "session_id": voice_session.id,
+        },
+    )
+
+    # TODO: Phase 2 — Generate signed URL via ElevenLabs Conversational AI API
+    signed_url = "TODO_ELEVENLABS_INTEGRATION"
+
+    return VoiceSessionResponse(
+        session_id=voice_session.id,
+        signed_url=signed_url,
+        status=voice_session.status,
+        started_at=voice_session.started_at,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# POST /webhook — ElevenLabs webhook (public, no auth)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.post("/webhook", response_model=WebhookAckResponse)
+async def voice_webhook(
+    payload: VoiceWebhookPayload,
+    db: AsyncSession = Depends(get_session),
+):
+    """
+    Receive ElevenLabs webhook after a voice conversation ends.
+    Public endpoint — no Bearer auth required.
+    """
+    # TODO: Phase 2 — Verify HMAC signature from ElevenLabs
+
+    # Find the voice session by elevenlabs_conversation_id or metadata session_id
+    session_query = None
+    if payload.elevenlabs_conversation_id:
+        session_query = select(VoiceSession).where(
+            VoiceSession.elevenlabs_conversation_id == payload.elevenlabs_conversation_id
+        )
+    elif payload.metadata and payload.metadata.get("session_id"):
+        session_query = select(VoiceSession).where(
+            VoiceSession.id == int(payload.metadata["session_id"])
+        )
+
+    if session_query is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "missing_session_identifier",
+                "message": "No conversation_id or session_id provided in webhook payload.",
+            },
+        )
+
+    result = await db.execute(session_query)
+    voice_session = result.scalar_one_or_none()
+
+    if not voice_session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "session_not_found",
+                "message": "Voice session not found.",
+            },
+        )
+
+    # Update session with webhook data
+    voice_session.duration_seconds = payload.duration_seconds
+    voice_session.status = payload.status or "completed"
+    voice_session.ended_at = datetime.now(timezone.utc)
+    if payload.conversation_transcript:
+        voice_session.conversation_transcript = payload.conversation_transcript
+
+    await db.commit()
+
+    # Deduct voice usage
+    await deduct_voice_usage(
+        voice_session.user_id,
+        duration_seconds=payload.duration_seconds or 0,
+        db=db,
+    )
+
+    logger.info(
+        "Voice webhook processed",
+        extra={
+            "session_id": voice_session.id,
+            "duration": payload.duration_seconds,
+            "status": voice_session.status,
+        },
+    )
+
+    return WebhookAckResponse(status="ok", session_id=voice_session.id)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GET /history/{summary_id} — Voice session history
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.get("/history/{summary_id}", response_model=VoiceHistoryResponse)
+async def get_voice_history(
+    summary_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Get all voice sessions for a given analysis."""
+    # Verify summary ownership
+    result = await db.execute(
+        select(Summary).where(
+            Summary.id == summary_id,
+            Summary.user_id == current_user.id,
+        )
+    )
+    if not result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "summary_not_found",
+                "message": "Analysis not found or does not belong to you.",
+            },
+        )
+
+    # Query voice sessions
+    result = await db.execute(
+        select(VoiceSession)
+        .where(
+            VoiceSession.user_id == current_user.id,
+            VoiceSession.summary_id == summary_id,
+        )
+        .order_by(VoiceSession.started_at.desc())
+    )
+    sessions = result.scalars().all()
+
+    return VoiceHistoryResponse(sessions=sessions)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GET /history/{summary_id}/{session_id}/transcript — Session transcript
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.get(
+    "/history/{summary_id}/{session_id}/transcript",
+    response_model=VoiceTranscriptResponse,
+)
+async def get_voice_transcript(
+    summary_id: int,
+    session_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Get the transcript of a specific voice session."""
+    # Verify summary ownership
+    result = await db.execute(
+        select(Summary).where(
+            Summary.id == summary_id,
+            Summary.user_id == current_user.id,
+        )
+    )
+    if not result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "summary_not_found",
+                "message": "Analysis not found or does not belong to you.",
+            },
+        )
+
+    # Get the voice session
+    result = await db.execute(
+        select(VoiceSession).where(
+            VoiceSession.id == session_id,
+            VoiceSession.user_id == current_user.id,
+            VoiceSession.summary_id == summary_id,
+        )
+    )
+    voice_session = result.scalar_one_or_none()
+
+    if not voice_session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "session_not_found",
+                "message": "Voice session not found.",
+            },
+        )
+
+    if not voice_session.conversation_transcript:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "transcript_not_found",
+                "message": "No transcript available for this voice session.",
+            },
+        )
+
+    return VoiceTranscriptResponse(
+        session_id=voice_session.id,
+        transcript=voice_session.conversation_transcript,
+        duration_seconds=voice_session.duration_seconds,
+    )

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -30,6 +30,8 @@ from core.config import (
     get_stripe_key,
 )
 
+from pydantic import BaseModel
+
 from voice.schemas import (
     VoiceSessionRequest,
     VoiceSessionResponse,
@@ -46,10 +48,15 @@ from voice.quota import (
     get_or_create_voice_quota,
 )
 from voice.elevenlabs import ElevenLabsClient, get_elevenlabs_client
+from voice.tools import search_in_transcript, get_analysis_section, get_sources, get_flashcards
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+class AddonCheckoutRequest(BaseModel):
+    pack_id: str
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -109,8 +116,8 @@ async def create_voice_session(
         )
 
     # Check voice quota
-    can_use, quota_info = await check_voice_quota(current_user.id, plan, db)
-    if not can_use:
+    quota_info = await check_voice_quota(current_user.id, plan, db)
+    if not quota_info["can_use"]:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail={
@@ -565,11 +572,12 @@ def _init_stripe() -> bool:
 
 @router.post("/addon/checkout")
 async def create_voice_addon_checkout(
-    pack_id: str,
+    request: AddonCheckoutRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ):
     """Crée une session Stripe Checkout pour l'achat d'un pack vocal."""
+    pack_id = request.pack_id
     # Validate pack_id
     pack = VOICE_ADDON_PACKS.get(pack_id)
     if not pack:
@@ -653,3 +661,46 @@ async def create_voice_addon_checkout(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"code": "stripe_error", "message": str(e)},
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# POST /tools/* — ElevenLabs webhook tool endpoints (public, no auth)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.post("/tools/search-transcript")
+async def tool_search_transcript(request: Request, db: AsyncSession = Depends(get_session)):
+    """ElevenLabs tool webhook: search in video transcript."""
+    body = await request.json()
+    summary_id = body.get("summary_id") or body.get("parameters", {}).get("summary_id")
+    query = body.get("query") or body.get("parameters", {}).get("query", "")
+    result = await search_in_transcript(summary_id, query, db)
+    return {"result": result}
+
+
+@router.post("/tools/analysis-section")
+async def tool_analysis_section(request: Request, db: AsyncSession = Depends(get_session)):
+    """ElevenLabs tool webhook: get a specific analysis section."""
+    body = await request.json()
+    summary_id = body.get("summary_id") or body.get("parameters", {}).get("summary_id")
+    section = body.get("section") or body.get("parameters", {}).get("section", "resume")
+    result = await get_analysis_section(summary_id, section, db)
+    return {"result": result}
+
+
+@router.post("/tools/sources")
+async def tool_sources(request: Request, db: AsyncSession = Depends(get_session)):
+    """ElevenLabs tool webhook: get sources and fact-check info."""
+    body = await request.json()
+    summary_id = body.get("summary_id") or body.get("parameters", {}).get("summary_id")
+    result = await get_sources(summary_id, db)
+    return {"result": result}
+
+
+@router.post("/tools/flashcards")
+async def tool_flashcards(request: Request, db: AsyncSession = Depends(get_session)):
+    """ElevenLabs tool webhook: get flashcards for a video."""
+    body = await request.json()
+    summary_id = body.get("summary_id") or body.get("parameters", {}).get("summary_id")
+    count = body.get("count") or body.get("parameters", {}).get("count", 5)
+    result = await get_flashcards(summary_id, int(count), db)
+    return {"result": result}

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -23,7 +23,6 @@ from db.database import get_session, VoiceSession, Summary, User
 from auth.dependencies import get_current_user
 from core.config import (
     VOICE_LIMITS,
-    VOICE_CHAT_CONFIG,
     APP_URL,
     STRIPE_CONFIG,
     FRONTEND_URL,
@@ -45,7 +44,6 @@ from voice.quota import (
     get_voice_quota_info,
     check_voice_quota,
     deduct_voice_usage,
-    get_or_create_voice_quota,
 )
 from voice.elevenlabs import ElevenLabsClient, get_elevenlabs_client
 from voice.tools import search_in_transcript, get_analysis_section, get_sources, get_flashcards

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -14,6 +14,7 @@ import hmac
 import logging
 from datetime import datetime, timezone
 
+import stripe
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -24,6 +25,9 @@ from core.config import (
     VOICE_LIMITS,
     VOICE_CHAT_CONFIG,
     APP_URL,
+    STRIPE_CONFIG,
+    FRONTEND_URL,
+    get_stripe_key,
 )
 
 from voice.schemas import (
@@ -520,3 +524,132 @@ async def get_voice_transcript(
         duration_seconds=voice_session.duration_seconds or 0,
         transcript=voice_session.conversation_transcript,
     )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GET /addon/packs — Available voice minute packs
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Pack definitions (id → {name, minutes, price_cents, currency})
+VOICE_ADDON_PACKS = {
+    "voice_10": {"name": "Pack Découverte", "minutes": 10, "price_cents": 199, "currency": "eur"},
+    "voice_30": {"name": "Pack Standard", "minutes": 30, "price_cents": 499, "currency": "eur"},
+    "voice_60": {"name": "Pack Pro", "minutes": 60, "price_cents": 899, "currency": "eur"},
+}
+
+
+@router.get("/addon/packs")
+async def get_voice_addon_packs(
+    current_user: User = Depends(get_current_user),
+):
+    """Retourne les packs de minutes vocales disponibles."""
+    packs = [
+        {"id": pack_id, **pack_info}
+        for pack_id, pack_info in VOICE_ADDON_PACKS.items()
+    ]
+    return {"packs": packs}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# POST /addon/checkout — Create Stripe checkout for voice pack
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _init_stripe() -> bool:
+    """Initialise Stripe avec la bonne clé."""
+    key = get_stripe_key()
+    if key:
+        stripe.api_key = key
+        return True
+    return False
+
+
+@router.post("/addon/checkout")
+async def create_voice_addon_checkout(
+    pack_id: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Crée une session Stripe Checkout pour l'achat d'un pack vocal."""
+    # Validate pack_id
+    pack = VOICE_ADDON_PACKS.get(pack_id)
+    if not pack:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_pack",
+                "message": f"Unknown voice pack: {pack_id}. Valid packs: {', '.join(VOICE_ADDON_PACKS.keys())}",
+            },
+        )
+
+    if not STRIPE_CONFIG.get("ENABLED"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "stripe_disabled", "message": "Stripe is not enabled."},
+        )
+
+    if not _init_stripe():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "stripe_not_configured", "message": "Stripe is not configured."},
+        )
+
+    # Create or retrieve Stripe customer
+    if current_user.stripe_customer_id:
+        customer_id = current_user.stripe_customer_id
+    else:
+        customer = stripe.Customer.create(
+            email=current_user.email,
+            name=current_user.username or current_user.email,
+            metadata={"user_id": str(current_user.id)},
+        )
+        customer_id = customer.id
+        current_user.stripe_customer_id = customer_id
+        await db.commit()
+
+    success_url = f"{FRONTEND_URL}/payment/success?session_id={{CHECKOUT_SESSION_ID}}&type=voice_addon&pack={pack_id}"
+    cancel_url = f"{FRONTEND_URL}/payment/cancel"
+
+    try:
+        checkout_session = stripe.checkout.Session.create(
+            customer=customer_id,
+            payment_method_types=["card"],
+            line_items=[{
+                "price_data": {
+                    "currency": pack["currency"],
+                    "unit_amount": pack["price_cents"],
+                    "product_data": {
+                        "name": f"DeepSight — {pack['name']}",
+                        "description": f"{pack['minutes']} minutes de chat vocal",
+                    },
+                },
+                "quantity": 1,
+            }],
+            mode="payment",
+            success_url=success_url,
+            cancel_url=cancel_url,
+            metadata={
+                "type": "voice_addon",
+                "minutes": str(pack["minutes"]),
+                "user_id": str(current_user.id),
+                "pack_id": pack_id,
+            },
+        )
+
+        logger.info(
+            "Voice addon checkout created",
+            extra={
+                "user_id": current_user.id,
+                "pack_id": pack_id,
+                "minutes": pack["minutes"],
+                "session_id": checkout_session.id,
+            },
+        )
+
+        return {"checkout_url": checkout_session.url, "session_id": checkout_session.id}
+
+    except stripe.error.StripeError as e:
+        logger.error("Stripe error creating voice addon checkout: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "stripe_error", "message": str(e)},
+        )

--- a/backend/src/voice/schemas.py
+++ b/backend/src/voice/schemas.py
@@ -1,0 +1,95 @@
+"""
+Voice Chat Schemas — Pydantic models for voice API endpoints.
+"""
+
+from datetime import datetime
+from typing import Optional, List
+
+from pydantic import BaseModel, Field
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# REQUEST SCHEMAS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class VoiceSessionRequest(BaseModel):
+    """Requete de creation de session voice chat."""
+    summary_id: int = Field(..., description="ID de l'analyse video")
+    language: str = Field(default="fr", description="Langue (fr, en)")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RESPONSE SCHEMAS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class VoiceSessionResponse(BaseModel):
+    """Reponse de creation de session voice chat."""
+    session_id: str
+    signed_url: str
+    expires_at: datetime
+    quota_remaining_minutes: float
+    max_session_minutes: int
+
+
+class VoiceQuotaResponse(BaseModel):
+    """Quota voice chat pour l'utilisateur."""
+    plan: str
+    voice_enabled: bool
+    seconds_used: int
+    seconds_limit: int
+    minutes_remaining: float
+    max_session_minutes: int
+    sessions_this_month: int
+    reset_date: str
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# WEBHOOK SCHEMAS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class VoiceWebhookPayload(BaseModel):
+    """Payload recu du provider voice (ElevenLabs)."""
+    conversation_id: str
+    agent_id: str
+    status: str
+    duration_seconds: int
+    transcript: Optional[str] = None
+    metadata: Optional[dict] = None
+
+
+class WebhookAckResponse(BaseModel):
+    """Reponse d'acquittement du webhook."""
+    status: str = "ok"
+    session_id: str
+    minutes_deducted: float
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HISTORY & TRANSCRIPT SCHEMAS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class VoiceSessionSummary(BaseModel):
+    """Resume d'une session voice chat."""
+    session_id: str
+    started_at: datetime
+    ended_at: Optional[datetime] = None
+    duration_seconds: int
+    status: str
+    has_transcript: bool
+
+
+class VoiceHistoryResponse(BaseModel):
+    """Historique des sessions voice pour une analyse."""
+    summary_id: int
+    video_title: str
+    sessions: List[VoiceSessionSummary]
+    total_minutes: float
+
+
+class VoiceTranscriptResponse(BaseModel):
+    """Transcript complet d'une session voice."""
+    session_id: str
+    summary_id: int
+    started_at: datetime
+    duration_seconds: int
+    transcript: str

--- a/backend/src/voice/tools.py
+++ b/backend/src/voice/tools.py
@@ -1,0 +1,392 @@
+"""
+Voice Agent Server Tools
+========================
+4 tools appelables par l'agent vocal ElevenLabs via webhook.
+Chaque fonction retourne un string formaté pour lecture vocale.
+"""
+
+import json
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from db.database import Summary, AcademicPaper
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helper : découpage en segments
+# ─────────────────────────────────────────────────────────────────────
+
+def split_into_segments(text: str, max_words: int = 200) -> list[str]:
+    """Découpe un texte en segments de *max_words* mots.
+
+    Essaie de couper aux fins de phrases (point suivi d'espace ou retour
+    à la ligne) pour ne jamais couper au milieu d'un mot.
+    """
+    if not text or not text.strip():
+        return []
+
+    words = text.split()
+    if len(words) <= max_words:
+        return [text.strip()]
+
+    segments: list[str] = []
+    current_words: list[str] = []
+
+    for word in words:
+        current_words.append(word)
+
+        if len(current_words) >= max_words:
+            chunk = " ".join(current_words)
+            # Cherche le dernier point suivi d'un espace ou fin de chaîne
+            cut = -1
+            for sep in [". ", ".\n", ".\r"]:
+                pos = chunk.rfind(sep)
+                if pos > len(chunk) // 3:  # pas trop tôt dans le chunk
+                    cut = pos + 1
+                    break
+
+            if cut > 0:
+                segments.append(chunk[:cut].strip())
+                remaining = chunk[cut:].strip()
+                current_words = remaining.split() if remaining else []
+            else:
+                segments.append(chunk.strip())
+                current_words = []
+
+    if current_words:
+        segments.append(" ".join(current_words).strip())
+
+    return [s for s in segments if s]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 1 : Recherche dans le transcript
+# ─────────────────────────────────────────────────────────────────────
+
+async def search_in_transcript(
+    summary_id: int,
+    query: str,
+    db: AsyncSession,
+) -> str:
+    """Recherche des passages pertinents dans le transcript de la vidéo."""
+    logger.info(
+        "search_in_transcript called",
+        extra={"summary_id": summary_id, "query": query},
+    )
+
+    try:
+        result = await db.execute(
+            select(Summary).where(Summary.id == summary_id)
+        )
+        summary = result.scalar_one_or_none()
+
+        if summary is None:
+            return "Analyse introuvable pour cet identifiant."
+
+        transcript = summary.transcript_context
+        if not transcript or not transcript.strip():
+            return "Aucun transcript disponible pour cette vidéo."
+
+        segments = split_into_segments(transcript, max_words=200)
+        if not segments:
+            return "Le transcript est vide."
+
+        query_words = set(query.lower().split())
+        if not query_words:
+            return "La requête de recherche est vide."
+
+        scored: list[tuple[float, int, str]] = []
+        for idx, segment in enumerate(segments):
+            segment_words = set(segment.lower().split())
+            intersection = query_words & segment_words
+            score = len(intersection) / len(query_words)
+            if score > 0.3:
+                scored.append((score, idx, segment))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        top = scored[:3]
+
+        if not top:
+            return (
+                f"Aucun passage trouvé dans le transcript pour la requête "
+                f"\"{query}\". Essayez avec d'autres mots-clés."
+            )
+
+        parts: list[str] = []
+        for score, idx, segment in top:
+            # Tronquer si trop long pour la lecture vocale
+            display = segment[:500] + "..." if len(segment) > 500 else segment
+            parts.append(f"[Segment {idx + 1}] {display}")
+
+        return "\n\n".join(parts)
+
+    except Exception as e:
+        logger.error("search_in_transcript error: %s", e, exc_info=True)
+        return "Une erreur est survenue lors de la recherche dans le transcript."
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 2 : Section de l'analyse
+# ─────────────────────────────────────────────────────────────────────
+
+_SECTION_KEYWORDS: dict[str, list[str]] = {
+    "resume": ["résumé", "summary", "vue d'ensemble", "overview"],
+    "points_cles": [
+        "points clés",
+        "key points",
+        "points essentiels",
+        "idées principales",
+    ],
+    "analyse_critique": [
+        "analyse critique",
+        "critical analysis",
+        "évaluation",
+        "limites",
+    ],
+    "contexte": ["contexte", "context", "background"],
+    "conclusion": ["conclusion", "en résumé", "takeaways"],
+}
+
+_VALID_SECTIONS = set(_SECTION_KEYWORDS.keys())
+
+
+async def get_analysis_section(
+    summary_id: int,
+    section: str,
+    db: AsyncSession,
+) -> str:
+    """Retourne une section spécifique de l'analyse markdown."""
+    logger.info(
+        "get_analysis_section called",
+        extra={"summary_id": summary_id, "section": section},
+    )
+
+    if section not in _VALID_SECTIONS:
+        return (
+            f"Section \"{section}\" inconnue. "
+            f"Sections disponibles : {', '.join(sorted(_VALID_SECTIONS))}."
+        )
+
+    try:
+        result = await db.execute(
+            select(Summary).where(Summary.id == summary_id)
+        )
+        summary = result.scalar_one_or_none()
+
+        if summary is None:
+            return "Analyse introuvable pour cet identifiant."
+
+        content = summary.summary_content
+        if not content or not content.strip():
+            return "Le contenu de l'analyse est vide."
+
+        # Parse markdown par headers ##
+        keywords = _SECTION_KEYWORDS[section]
+        lines = content.split("\n")
+        capturing = False
+        captured: list[str] = []
+
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("##"):
+                if capturing:
+                    # On a atteint le header suivant → stop
+                    break
+                header_text = stripped.lstrip("#").strip().lower()
+                if any(kw in header_text for kw in keywords):
+                    capturing = True
+                    continue  # ne pas inclure la ligne de header
+            elif capturing:
+                captured.append(line)
+
+        if not captured:
+            return (
+                f"Section \"{section}\" non trouvée dans l'analyse. "
+                "Le format de l'analyse ne contient peut-être pas cette section."
+            )
+
+        text = "\n".join(captured).strip()
+        return text if text else f"La section \"{section}\" est vide."
+
+    except Exception as e:
+        logger.error("get_analysis_section error: %s", e, exc_info=True)
+        return "Une erreur est survenue lors de la lecture de la section."
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 3 : Sources et fact-check
+# ─────────────────────────────────────────────────────────────────────
+
+async def get_sources(summary_id: int, db: AsyncSession) -> str:
+    """Récupère les sources, le fact-check et les papiers académiques."""
+    logger.info("get_sources called", extra={"summary_id": summary_id})
+
+    try:
+        result = await db.execute(
+            select(Summary).where(Summary.id == summary_id)
+        )
+        summary = result.scalar_one_or_none()
+
+        if summary is None:
+            return "Analyse introuvable pour cet identifiant."
+
+        parts: list[str] = []
+
+        # --- full_digest (JSON ou texte brut) ---
+        digest_data: dict = {}
+        if summary.full_digest:
+            try:
+                digest_data = json.loads(summary.full_digest)
+            except (json.JSONDecodeError, TypeError):
+                # full_digest est du texte brut
+                pass
+
+        # Sources depuis full_digest
+        sources_list = digest_data.get("sources", [])
+        if sources_list:
+            items = []
+            for src in sources_list:
+                if isinstance(src, dict):
+                    items.append(
+                        src.get("title") or src.get("url") or str(src)
+                    )
+                else:
+                    items.append(str(src))
+            parts.append("## Sources citées\n" + "\n".join(f"- {s}" for s in items))
+
+        # Fact-check depuis full_digest ou champ dédié
+        fact_check = digest_data.get("fact_check")
+        if not fact_check and summary.fact_check_result:
+            try:
+                fact_check = json.loads(summary.fact_check_result)
+            except (json.JSONDecodeError, TypeError):
+                fact_check = summary.fact_check_result
+
+        if fact_check:
+            if isinstance(fact_check, dict):
+                fc_text = json.dumps(fact_check, ensure_ascii=False, indent=2)
+            else:
+                fc_text = str(fact_check)
+            parts.append(f"## Fact-check\n{fc_text}")
+
+        # Score de fiabilité
+        rel_score = digest_data.get("reliability_score") or summary.reliability_score
+        if rel_score is not None:
+            parts.append(f"## Score fiabilité : {rel_score}/10")
+
+        # --- Papiers académiques ---
+        try:
+            papers_result = await db.execute(
+                select(AcademicPaper)
+                .where(AcademicPaper.summary_id == summary_id)
+                .order_by(AcademicPaper.relevance_score.desc())
+                .limit(5)
+            )
+            papers = papers_result.scalars().all()
+
+            if papers:
+                paper_lines = []
+                for p in papers:
+                    label = p.title or "Sans titre"
+                    source = p.source or "inconnu"
+                    paper_lines.append(f"- {label} ({source})")
+                parts.append(
+                    "## Papiers académiques\n" + "\n".join(paper_lines)
+                )
+        except Exception as e:
+            logger.warning("get_sources: academic papers query failed: %s", e)
+
+        if not parts:
+            return "Aucune source disponible pour cette vidéo."
+
+        return "\n\n".join(parts)
+
+    except Exception as e:
+        logger.error("get_sources error: %s", e, exc_info=True)
+        return "Une erreur est survenue lors de la récupération des sources."
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 4 : Flashcards
+# ─────────────────────────────────────────────────────────────────────
+
+async def get_flashcards(
+    summary_id: int,
+    count: int = 5,
+    db: AsyncSession = None,
+) -> str:
+    """Retourne les flashcards en cache pour une vidéo analysée.
+
+    Les flashcards sont générées par le study router et mises en cache
+    dans Redis (video_cache). On tente de les récupérer depuis le cache.
+    Si aucun cache n'est disponible, on indique à l'utilisateur de les
+    générer d'abord via l'interface.
+    """
+    logger.info(
+        "get_flashcards called",
+        extra={"summary_id": summary_id, "count": count},
+    )
+    count = min(count, 10)
+
+    try:
+        # On a besoin du summary pour récupérer video_id et platform
+        if db is None:
+            return "Aucune flashcard disponible (session DB manquante)."
+
+        result = await db.execute(
+            select(Summary).where(Summary.id == summary_id)
+        )
+        summary = result.scalar_one_or_none()
+
+        if summary is None:
+            return "Analyse introuvable pour cet identifiant."
+
+        video_id = summary.video_id
+        platform = summary.platform or "youtube"
+        lang = summary.lang or "fr"
+
+        # Tenter le cache Redis
+        flashcards_data: list[dict] | None = None
+        try:
+            from main import get_video_cache
+
+            vcache = get_video_cache()
+            if vcache is not None and video_id:
+                cached = await vcache.get_studio_content(
+                    platform, video_id, "flashcards", lang
+                )
+                if cached and cached.get("flashcards"):
+                    flashcards_data = cached["flashcards"]
+        except Exception as e:
+            logger.warning("get_flashcards: cache lookup failed: %s", e)
+
+        if not flashcards_data:
+            return (
+                "Aucune flashcard générée pour cette vidéo. "
+                "Génère-les d'abord depuis l'onglet Étude de l'application."
+            )
+
+        # Limiter au count demandé
+        cards = flashcards_data[:count]
+
+        parts: list[str] = []
+        for i, card in enumerate(cards, start=1):
+            question = card.get("question") or card.get("front", "")
+            answer = card.get("answer") or card.get("back", "")
+            if question and answer:
+                parts.append(
+                    f"**Question {i}** : {question}\n**Réponse** : {answer}"
+                )
+
+        if not parts:
+            return "Aucune flashcard exploitable trouvée pour cette vidéo."
+
+        return "\n\n".join(parts)
+
+    except Exception as e:
+        logger.error("get_flashcards error: %s", e, exc_info=True)
+        return "Une erreur est survenue lors de la récupération des flashcards."

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "deepsight-frontend",
       "version": "7.0.1",
       "dependencies": {
+        "@elevenlabs/client": "^0.15.2",
+        "@elevenlabs/react": "^0.14.3",
         "@sentry/react": "^8.0.0",
         "@supabase/supabase-js": "^2.57.4",
         "@tanstack/react-query": "^5.17.0",
@@ -415,6 +417,12 @@
       "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
       "license": "MIT"
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -529,6 +537,33 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@elevenlabs/client": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-0.15.2.tgz",
+      "integrity": "sha512-IKEs0OUHol9ZQ/gKBh5ThN5udRp6bnU70DxyRxprWop3zA8oYUdBa+LE+2tlWho9A4UKubD5UjvjCBJLh2cDVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/types": "0.6.1",
+        "livekit-client": "^2.11.4"
+      }
+    },
+    "node_modules/@elevenlabs/react": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/react/-/react-0.14.3.tgz",
+      "integrity": "sha512-nb+8pbbWGVCA/J7P8F5MckVYvKCOIi48I0chu5XkuAPOl4UPq4lw5RjrPQk10hDuoVtq7ccHl44F4652yh8hoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/client": "0.15.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@elevenlabs/types": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/types/-/types-0.6.1.tgz",
+      "integrity": "sha512-SNFrKWw5w/JHy9QGt3WWBj0kc71diPRuXHc/7/hdr46ghYz8mTPlFZJBmSPGwXQAfS29jxYXojEmBfKKfgoPCQ=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1206,6 +1241,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.44.0.tgz",
+      "integrity": "sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2833,6 +2883,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -5097,6 +5154,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5974,6 +6040,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6170,6 +6245,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/livekit-client": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.18.0.tgz",
+      "integrity": "sha512-wjH4y0rw5fnkPmmaxutPhD4XcAq6goQszS8lw9PEpGXVwiRE6sI/ZH+mOT/s8AHJnEC3tjmfiMZ4MQt8BlaWew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.44.0",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6198,6 +6293,19 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -14171,6 +14279,16 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -14209,6 +14327,21 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
+      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
       }
     },
     "node_modules/semver": {
@@ -14856,6 +14989,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -15362,6 +15504,19 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.4.tgz",
+      "integrity": "sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
     "ps": "node scripts/git-push-status.js"
   },
   "dependencies": {
+    "@elevenlabs/client": "^0.15.2",
+    "@elevenlabs/react": "^0.14.3",
     "@sentry/react": "^8.0.0",
     "@supabase/supabase-js": "^2.57.4",
     "@tanstack/react-query": "^5.17.0",

--- a/frontend/src/components/voice/VoiceAddonModal.tsx
+++ b/frontend/src/components/voice/VoiceAddonModal.tsx
@@ -1,0 +1,288 @@
+/**
+ * VoiceAddonModal — Purchase voice minute add-on packs via Stripe
+ * Displays 3 pack tiers with one-click checkout
+ */
+
+import React, { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Mic, Sparkles, ArrowRight, Loader2, Star, Zap } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from '../../hooks/useTranslation';
+
+interface VoiceAddonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentPlan: string;
+  minutesRemaining: number;
+}
+
+interface VoicePack {
+  id: string;
+  name_fr: string;
+  name_en: string;
+  minutes: number;
+  price: number; // in euros
+  badge_fr?: string;
+  badge_en?: string;
+  badgeColor?: string;
+}
+
+const VOICE_PACKS: VoicePack[] = [
+  {
+    id: 'voice_10',
+    name_fr: 'Pack Découverte',
+    name_en: 'Discovery Pack',
+    minutes: 10,
+    price: 1.99,
+  },
+  {
+    id: 'voice_30',
+    name_fr: 'Pack Standard',
+    name_en: 'Standard Pack',
+    minutes: 30,
+    price: 4.99,
+    badge_fr: 'Populaire',
+    badge_en: 'Popular',
+    badgeColor: 'indigo',
+  },
+  {
+    id: 'voice_60',
+    name_fr: 'Pack Pro',
+    name_en: 'Pro Pack',
+    minutes: 60,
+    price: 8.99,
+    badge_fr: 'Meilleur rapport',
+    badge_en: 'Best value',
+    badgeColor: 'emerald',
+  },
+];
+
+const API_URL = import.meta.env.VITE_API_URL || 'https://api.deepsightsynthesis.com';
+
+export const VoiceAddonModal: React.FC<VoiceAddonModalProps> = ({
+  isOpen,
+  onClose,
+  currentPlan,
+  minutesRemaining,
+}) => {
+  const [loadingPack, setLoadingPack] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { language } = useTranslation();
+
+  const tr = useCallback(
+    (fr: string, en: string) => (language === 'fr' ? fr : en),
+    [language]
+  );
+
+  const handlePurchase = async (pack: VoicePack) => {
+    setLoadingPack(pack.id);
+    setError(null);
+
+    try {
+      const token = localStorage.getItem('access_token');
+      const res = await fetch(`${API_URL}/api/voice/addon/checkout`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ pack_id: pack.id }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(
+          data?.detail || tr('Erreur lors de la création du paiement', 'Payment creation failed')
+        );
+      }
+
+      const data = await res.json();
+
+      if (data.checkout_url) {
+        window.location.href = data.checkout_url;
+      } else {
+        throw new Error(tr('URL de paiement manquante', 'Missing checkout URL'));
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : tr('Erreur inattendue', 'Unexpected error'));
+    } finally {
+      setLoadingPack(null);
+    }
+  };
+
+  const handleUpgrade = () => {
+    onClose();
+    navigate('/upgrade');
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          {/* Backdrop */}
+          <motion.div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            aria-hidden="true"
+          />
+
+          {/* Modal */}
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-label={tr('Acheter des minutes vocales', 'Buy voice minutes')}
+            className="relative w-full max-w-md bg-[#12121a]/95 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl overflow-hidden"
+            initial={{ scale: 0.9, opacity: 0, y: 20 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.9, opacity: 0, y: 20 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+          >
+            {/* Close button */}
+            <button
+              onClick={onClose}
+              className="absolute top-4 right-4 p-1.5 rounded-lg hover:bg-white/10 transition-colors text-white/40 hover:text-white z-10"
+              aria-label={tr('Fermer', 'Close')}
+            >
+              <X className="w-4 h-4" />
+            </button>
+
+            <div className="p-6 pt-8">
+              {/* Header */}
+              <div className="w-14 h-14 rounded-2xl bg-indigo-500/10 flex items-center justify-center mx-auto mb-4">
+                <Mic className="w-7 h-7 text-indigo-400" />
+              </div>
+
+              <h2 className="text-lg font-semibold text-white text-center mb-1">
+                {tr('Acheter des minutes vocales', 'Buy voice minutes')}
+              </h2>
+
+              <p className="text-white/50 text-sm text-center mb-6">
+                {tr(
+                  `Il vous reste ${minutesRemaining} minute${minutesRemaining !== 1 ? 's' : ''} ce mois`,
+                  `You have ${minutesRemaining} minute${minutesRemaining !== 1 ? 's' : ''} remaining this month`
+                )}
+              </p>
+
+              {/* Error */}
+              {error && (
+                <div className="mb-4 p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm text-center">
+                  {error}
+                </div>
+              )}
+
+              {/* Pack cards */}
+              <div className="space-y-3">
+                {VOICE_PACKS.map((pack) => {
+                  const isPopular = pack.badgeColor === 'indigo';
+                  const isBestValue = pack.badgeColor === 'emerald';
+                  const isLoading = loadingPack === pack.id;
+
+                  return (
+                    <div
+                      key={pack.id}
+                      className={`
+                        relative bg-white/5 rounded-xl p-4 transition-all duration-200
+                        ${isPopular
+                          ? 'border-2 border-indigo-500/50 shadow-lg shadow-indigo-500/5'
+                          : 'border border-white/10 hover:border-white/20'
+                        }
+                      `}
+                    >
+                      {/* Badge */}
+                      {pack.badge_fr && (
+                        <span
+                          className={`
+                            absolute -top-2.5 left-4 px-2.5 py-0.5 rounded-full text-xs font-medium
+                            ${isPopular
+                              ? 'bg-indigo-500 text-white'
+                              : 'bg-emerald-500 text-white'
+                            }
+                          `}
+                        >
+                          {isBestValue ? (
+                            <span className="flex items-center gap-1">
+                              <Zap className="w-3 h-3" />
+                              {tr(pack.badge_fr, pack.badge_en || '')}
+                            </span>
+                          ) : (
+                            <span className="flex items-center gap-1">
+                              <Star className="w-3 h-3" />
+                              {tr(pack.badge_fr, pack.badge_en || '')}
+                            </span>
+                          )}
+                        </span>
+                      )}
+
+                      <div className="flex items-center justify-between gap-4">
+                        <div className="min-w-0">
+                          <p className="text-white font-semibold text-sm">
+                            {tr(pack.name_fr, pack.name_en)}
+                          </p>
+                          <p className="text-2xl font-bold text-indigo-400 mt-0.5">
+                            {pack.minutes} <span className="text-sm font-normal text-white/40">min</span>
+                          </p>
+                          <p className="text-lg text-white/70 font-medium">
+                            {pack.price.toFixed(2)}&euro;
+                          </p>
+                        </div>
+
+                        <button
+                          onClick={() => handlePurchase(pack)}
+                          disabled={loadingPack !== null}
+                          className={`
+                            flex-shrink-0 flex items-center gap-2 px-5 py-2.5 rounded-xl font-medium text-sm transition-all duration-200
+                            ${isLoading
+                              ? 'bg-indigo-500/50 text-white/70 cursor-wait'
+                              : 'bg-indigo-500 hover:bg-indigo-600 text-white cursor-pointer active:scale-95'
+                            }
+                            disabled:opacity-50 disabled:cursor-not-allowed
+                          `}
+                          aria-label={tr(
+                            `Acheter ${pack.name_fr} - ${pack.minutes} minutes pour ${pack.price.toFixed(2)} euros`,
+                            `Buy ${pack.name_en} - ${pack.minutes} minutes for ${pack.price.toFixed(2)} euros`
+                          )}
+                        >
+                          {isLoading ? (
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                          ) : (
+                            tr('Acheter', 'Buy')
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Upgrade link */}
+              <button
+                onClick={handleUpgrade}
+                className="w-full mt-5 flex items-center justify-center gap-1.5 text-white/40 hover:text-indigo-400 text-xs transition-colors group"
+              >
+                <Sparkles className="w-3 h-3" />
+                <span>
+                  {tr(
+                    'Ou passez au plan supérieur pour plus de minutes incluses',
+                    'Or upgrade your plan for more included minutes'
+                  )}
+                </span>
+                <ArrowRight className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default VoiceAddonModal;

--- a/frontend/src/components/voice/VoiceAddonModal.tsx
+++ b/frontend/src/components/voice/VoiceAddonModal.tsx
@@ -61,7 +61,8 @@ const VOICE_PACKS: VoicePack[] = [
 export const VoiceAddonModal: React.FC<VoiceAddonModalProps> = ({
   isOpen,
   onClose,
-  currentPlan,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  currentPlan: _currentPlan,
   minutesRemaining,
 }) => {
   const [loadingPack, setLoadingPack] = useState<string | null>(null);

--- a/frontend/src/components/voice/VoiceAddonModal.tsx
+++ b/frontend/src/components/voice/VoiceAddonModal.tsx
@@ -8,6 +8,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { X, Mic, Sparkles, ArrowRight, Loader2, Star, Zap } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from '../../hooks/useTranslation';
+import { voiceApi } from '../../services/api';
 
 interface VoiceAddonModalProps {
   isOpen: boolean;
@@ -57,8 +58,6 @@ const VOICE_PACKS: VoicePack[] = [
   },
 ];
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://api.deepsightsynthesis.com';
-
 export const VoiceAddonModal: React.FC<VoiceAddonModalProps> = ({
   isOpen,
   onClose,
@@ -80,24 +79,7 @@ export const VoiceAddonModal: React.FC<VoiceAddonModalProps> = ({
     setError(null);
 
     try {
-      const token = localStorage.getItem('access_token');
-      const res = await fetch(`${API_URL}/api/voice/addon/checkout`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({ pack_id: pack.id }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json().catch(() => null);
-        throw new Error(
-          data?.detail || tr('Erreur lors de la création du paiement', 'Payment creation failed')
-        );
-      }
-
-      const data = await res.json();
+      const data = await voiceApi.createAddonCheckout(pack.id);
 
       if (data.checkout_url) {
         window.location.href = data.checkout_url;

--- a/frontend/src/components/voice/VoiceButton.tsx
+++ b/frontend/src/components/voice/VoiceButton.tsx
@@ -19,7 +19,7 @@ interface VoiceButtonProps {
   disabled?: boolean;
 }
 
-type VoiceState = 'idle' | 'locked' | 'active';
+type VoiceState = 'idle' | 'locked';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Animation variants
@@ -48,7 +48,8 @@ const pulseVariants: Variants = {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 const VoiceButton: React.FC<VoiceButtonProps> = ({
-  summaryId,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  summaryId: _summaryId,
   onOpen,
   disabled = false,
 }) => {
@@ -79,7 +80,6 @@ const VoiceButton: React.FC<VoiceButtonProps> = ({
   );
 
   const isLocked = state === 'locked';
-  const isActive = state === 'active';
 
   return (
     <motion.div
@@ -88,9 +88,7 @@ const VoiceButton: React.FC<VoiceButtonProps> = ({
       aria-label={
         isLocked
           ? 'Chat vocal — Disponible à partir du plan Étudiant'
-          : isActive
-            ? 'Chat vocal actif — cliquez pour fermer'
-            : 'Ouvrir le chat vocal'
+          : 'Ouvrir le chat vocal'
       }
       aria-disabled={isLocked || disabled}
       className={`
@@ -102,11 +100,9 @@ const VoiceButton: React.FC<VoiceButtonProps> = ({
         outline-none
         focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0f]
         ${
-          isActive
-            ? 'bg-gradient-to-br from-indigo-500 to-violet-500 border border-indigo-400/30'
-            : isLocked
-              ? 'bg-white/5 border border-white/10 cursor-not-allowed opacity-60'
-              : 'bg-white/5 border border-white/10 hover:bg-white/[0.08]'
+          isLocked
+            ? 'bg-white/5 border border-white/10 cursor-not-allowed opacity-60'
+            : 'bg-white/5 border border-white/10 hover:bg-white/[0.08]'
         }
         group
       `}
@@ -115,17 +111,13 @@ const VoiceButton: React.FC<VoiceButtonProps> = ({
       whileHover={!isLocked && !disabled ? { scale: 1.05 } : undefined}
       whileTap={!isLocked && !disabled ? { scale: 0.95 } : undefined}
       variants={pulseVariants}
-      animate={isActive ? 'active' : 'idle'}
+      animate="idle"
     >
       {/* Icon */}
       {isLocked ? (
         <Lock className="w-5 h-5 md:w-6 md:h-6 text-white/40" />
       ) : (
-        <Mic
-          className={`w-5 h-5 md:w-6 md:h-6 ${
-            isActive ? 'text-white' : 'text-white/60'
-          }`}
-        />
+        <Mic className="w-5 h-5 md:w-6 md:h-6 text-white/60" />
       )}
 
       {/* Locked tooltip */}

--- a/frontend/src/components/voice/VoiceButton.tsx
+++ b/frontend/src/components/voice/VoiceButton.tsx
@@ -1,0 +1,152 @@
+/**
+ * VoiceButton — Floating circular button for voice chat
+ * Fixed bottom-right, 3 states: idle / locked / active
+ */
+
+import React, { useCallback } from 'react';
+import { motion, type Variants } from 'framer-motion';
+import { Mic, Lock } from 'lucide-react';
+import { useAuth } from '../../hooks/useAuth';
+import { PLAN_LIMITS, normalizePlanId } from '../../config/planPrivileges';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface VoiceButtonProps {
+  summaryId: number;
+  onOpen: () => void;
+  disabled?: boolean;
+}
+
+type VoiceState = 'idle' | 'locked' | 'active';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Animation variants
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const pulseVariants: Variants = {
+  active: {
+    boxShadow: [
+      '0 0 0 0 rgba(99, 102, 241, 0)',
+      '0 0 20px 8px rgba(99, 102, 241, 0.35)',
+      '0 0 0 0 rgba(99, 102, 241, 0)',
+    ],
+    transition: {
+      duration: 2,
+      repeat: Infinity,
+      ease: 'easeInOut',
+    },
+  },
+  idle: {
+    boxShadow: '0 0 0 0 rgba(99, 102, 241, 0)',
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Component
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const VoiceButton: React.FC<VoiceButtonProps> = ({
+  summaryId,
+  onOpen,
+  disabled = false,
+}) => {
+  const { user } = useAuth();
+  const plan = normalizePlanId(user?.plan);
+  const voiceEnabled = PLAN_LIMITS[plan].voiceChatEnabled;
+
+  // Determine visual state
+  const state: VoiceState = disabled
+    ? 'idle'
+    : !voiceEnabled
+      ? 'locked'
+      : 'idle';
+
+  const handleClick = useCallback(() => {
+    if (state === 'locked' || disabled) return;
+    onOpen();
+  }, [state, disabled, onOpen]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleClick();
+      }
+    },
+    [handleClick],
+  );
+
+  const isLocked = state === 'locked';
+  const isActive = state === 'active';
+
+  return (
+    <motion.div
+      role="button"
+      tabIndex={0}
+      aria-label={
+        isLocked
+          ? 'Chat vocal — Disponible à partir du plan Étudiant'
+          : isActive
+            ? 'Chat vocal actif — cliquez pour fermer'
+            : 'Ouvrir le chat vocal'
+      }
+      aria-disabled={isLocked || disabled}
+      className={`
+        fixed bottom-6 right-6 z-40
+        flex items-center justify-center
+        rounded-full cursor-pointer
+        w-12 h-12 md:w-14 md:h-14
+        transition-colors duration-200
+        outline-none
+        focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0f]
+        ${
+          isActive
+            ? 'bg-gradient-to-br from-indigo-500 to-violet-500 border border-indigo-400/30'
+            : isLocked
+              ? 'bg-white/5 border border-white/10 cursor-not-allowed opacity-60'
+              : 'bg-white/5 border border-white/10 hover:bg-white/[0.08]'
+        }
+        group
+      `}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      whileHover={!isLocked && !disabled ? { scale: 1.05 } : undefined}
+      whileTap={!isLocked && !disabled ? { scale: 0.95 } : undefined}
+      variants={pulseVariants}
+      animate={isActive ? 'active' : 'idle'}
+    >
+      {/* Icon */}
+      {isLocked ? (
+        <Lock className="w-5 h-5 md:w-6 md:h-6 text-white/40" />
+      ) : (
+        <Mic
+          className={`w-5 h-5 md:w-6 md:h-6 ${
+            isActive ? 'text-white' : 'text-white/60'
+          }`}
+        />
+      )}
+
+      {/* Locked tooltip */}
+      {isLocked && (
+        <div
+          className="
+            absolute bottom-full right-0 mb-3
+            px-3 py-2 rounded-lg
+            bg-[#1a1a2e] border border-white/10
+            text-xs text-white/70 whitespace-nowrap
+            opacity-0 group-hover:opacity-100
+            transition-opacity duration-200
+            pointer-events-none
+          "
+        >
+          Disponible à partir du plan Étudiant
+          <div className="absolute top-full right-4 w-2 h-2 bg-[#1a1a2e] border-r border-b border-white/10 transform rotate-45 -translate-y-1" />
+        </div>
+      )}
+    </motion.div>
+  );
+};
+
+export default VoiceButton;

--- a/frontend/src/components/voice/VoiceModal.tsx
+++ b/frontend/src/components/voice/VoiceModal.tsx
@@ -1,0 +1,439 @@
+/**
+ * VoiceModal — Main voice conversation interface
+ * Full-screen modal with live transcript, status indicators, and controls
+ */
+
+import React, { useEffect, useRef, useId, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  X,
+  Mic,
+  MicOff,
+  Phone,
+  PhoneOff,
+  Loader2,
+  AlertCircle,
+  ArrowUpCircle,
+  RotateCcw,
+} from 'lucide-react';
+import { useTranslation } from '../../hooks/useTranslation';
+
+interface VoiceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  videoTitle: string;
+  channelName?: string;
+  /** Status de la conversation voice */
+  voiceStatus: 'idle' | 'connecting' | 'listening' | 'thinking' | 'speaking' | 'error' | 'quota_exceeded';
+  /** L'IA est en train de parler */
+  isSpeaking: boolean;
+  /** Messages de la conversation (transcript live) */
+  messages: Array<{ text: string; source: 'user' | 'ai' }>;
+  /** Timer en secondes */
+  elapsedSeconds: number;
+  /** Minutes restantes dans le quota */
+  remainingMinutes: number;
+  /** Callbacks */
+  onStart: () => void;
+  onStop: () => void;
+  onMuteToggle: () => void;
+  isMuted: boolean;
+  /** Erreur eventuelle */
+  error?: string;
+}
+
+/** Format seconds to MM:SS */
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+/** Pulsing microphone indicator */
+const PulsingMic: React.FC = () => (
+  <div className="relative flex items-center justify-center">
+    <motion.div
+      className="absolute w-20 h-20 rounded-full bg-green-500/20"
+      animate={{ scale: [1, 1.4, 1], opacity: [0.4, 0.1, 0.4] }}
+      transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+    />
+    <motion.div
+      className="absolute w-14 h-14 rounded-full bg-green-500/30"
+      animate={{ scale: [1, 1.2, 1], opacity: [0.6, 0.2, 0.6] }}
+      transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut', delay: 0.2 }}
+    />
+    <div className="w-10 h-10 rounded-full bg-green-500 flex items-center justify-center z-10">
+      <Mic className="w-5 h-5 text-white" />
+    </div>
+  </div>
+);
+
+/** Animated thinking dots */
+const ThinkingDots: React.FC = () => (
+  <div className="flex items-center gap-1.5">
+    {[0, 1, 2].map((i) => (
+      <motion.div
+        key={i}
+        className="w-2.5 h-2.5 rounded-full bg-indigo-400"
+        animate={{ y: [0, -8, 0], opacity: [0.4, 1, 0.4] }}
+        transition={{ duration: 0.8, repeat: Infinity, delay: i * 0.15, ease: 'easeInOut' }}
+      />
+    ))}
+  </div>
+);
+
+/** Sound wave bars for speaking state */
+const SoundWave: React.FC = () => (
+  <div className="flex items-center gap-1 h-10">
+    {[0, 1, 2, 3, 4, 5, 6].map((i) => (
+      <motion.div
+        key={i}
+        className="w-1 rounded-full bg-violet-400"
+        animate={{ height: [8, 24 + Math.random() * 16, 8] }}
+        transition={{
+          duration: 0.6 + Math.random() * 0.4,
+          repeat: Infinity,
+          delay: i * 0.08,
+          ease: 'easeInOut',
+        }}
+      />
+    ))}
+  </div>
+);
+
+export const VoiceModal: React.FC<VoiceModalProps> = ({
+  isOpen,
+  onClose,
+  videoTitle,
+  channelName,
+  voiceStatus,
+  isSpeaking: _isSpeaking,
+  messages,
+  elapsedSeconds,
+  remainingMinutes,
+  onStart,
+  onStop,
+  onMuteToggle,
+  isMuted,
+  error,
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const transcriptRef = useRef<HTMLDivElement>(null);
+  const previousActiveElement = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const descId = useId();
+  const { language } = useTranslation();
+
+  const tr = useCallback(
+    (fr: string, en: string) => (language === 'fr' ? fr : en),
+    [language]
+  );
+
+  const isActive = voiceStatus === 'listening' || voiceStatus === 'thinking' || voiceStatus === 'speaking';
+  const remainingFormatted = formatTime(remainingMinutes * 60);
+
+  // Body scroll lock + focus management
+  useEffect(() => {
+    if (isOpen) {
+      previousActiveElement.current = document.activeElement as HTMLElement;
+      document.body.style.overflow = 'hidden';
+      requestAnimationFrame(() => {
+        modalRef.current?.focus();
+      });
+    } else {
+      document.body.style.overflow = 'unset';
+      if (previousActiveElement.current) {
+        previousActiveElement.current.focus();
+      }
+    }
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  // Escape key + focus trap
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusable = modalRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
+    };
+    if (isOpen) {
+      window.addEventListener('keydown', handleKeyDown);
+      return () => window.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [isOpen, onClose]);
+
+  // Auto-scroll transcript
+  useEffect(() => {
+    if (transcriptRef.current) {
+      transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const renderCenterContent = () => {
+    switch (voiceStatus) {
+      case 'idle':
+        return (
+          <motion.button
+            onClick={onStart}
+            className="px-8 py-4 rounded-2xl bg-gradient-to-r from-indigo-500 to-violet-500 text-white font-semibold text-lg shadow-lg shadow-indigo-500/25 hover:shadow-indigo-500/40 transition-shadow focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0f]"
+            whileHover={{ scale: 1.03 }}
+            whileTap={{ scale: 0.97 }}
+          >
+            <div className="flex items-center gap-3">
+              <Phone className="w-5 h-5" />
+              {tr('Demarrer la conversation', 'Start conversation')}
+            </div>
+          </motion.button>
+        );
+
+      case 'connecting':
+        return (
+          <div className="flex flex-col items-center gap-4">
+            <Loader2 className="w-10 h-10 text-indigo-400 animate-spin" />
+            <p className="text-white/60 text-sm">
+              {tr('Connexion en cours...', 'Connecting...')}
+            </p>
+          </div>
+        );
+
+      case 'listening':
+        return (
+          <div className="flex flex-col items-center gap-4">
+            <PulsingMic />
+            <p className="text-green-400 text-sm font-medium">
+              {tr("A l'ecoute...", 'Listening...')}
+            </p>
+          </div>
+        );
+
+      case 'thinking':
+        return (
+          <div className="flex flex-col items-center gap-4">
+            <ThinkingDots />
+            <p className="text-indigo-300 text-sm">
+              {tr('Reflexion...', 'Thinking...')}
+            </p>
+          </div>
+        );
+
+      case 'speaking':
+        return (
+          <div className="flex flex-col items-center gap-4">
+            <SoundWave />
+            <p className="text-violet-300 text-sm font-medium">
+              {tr('DeepSight parle...', 'DeepSight is speaking...')}
+            </p>
+          </div>
+        );
+
+      case 'error':
+        return (
+          <div className="flex flex-col items-center gap-4 max-w-sm text-center">
+            <div className="w-12 h-12 rounded-full bg-red-500/10 border border-red-500/20 flex items-center justify-center">
+              <AlertCircle className="w-6 h-6 text-red-400" />
+            </div>
+            <p className="text-red-300 text-sm">
+              {error || tr('Une erreur est survenue', 'An error occurred')}
+            </p>
+            <button
+              onClick={onStart}
+              className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-white/5 border border-white/10 text-white/80 hover:bg-white/10 transition-colors text-sm focus-visible:ring-2 focus-visible:ring-indigo-400"
+            >
+              <RotateCcw className="w-4 h-4" />
+              {tr('Reessayer', 'Retry')}
+            </button>
+          </div>
+        );
+
+      case 'quota_exceeded':
+        return (
+          <div className="flex flex-col items-center gap-4 max-w-sm text-center">
+            <div className="w-12 h-12 rounded-full bg-amber-500/10 border border-amber-500/20 flex items-center justify-center">
+              <AlertCircle className="w-6 h-6 text-amber-400" />
+            </div>
+            <p className="text-amber-300 text-sm font-medium">
+              {tr('Quota de minutes epuise', 'Voice minutes quota exceeded')}
+            </p>
+            <p className="text-white/40 text-xs">
+              {tr(
+                'Passez au plan superieur pour continuer vos conversations vocales.',
+                'Upgrade your plan to continue voice conversations.'
+              )}
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-gradient-to-r from-indigo-500 to-violet-500 text-white font-medium text-sm hover:shadow-lg hover:shadow-indigo-500/25 transition-shadow focus-visible:ring-2 focus-visible:ring-indigo-400"
+              >
+                <ArrowUpCircle className="w-4 h-4" />
+                {tr('Passer au plan superieur', 'Upgrade plan')}
+              </button>
+            </div>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center"
+          role="presentation"
+        >
+          {/* Backdrop */}
+          <motion.div
+            className="absolute inset-0 bg-[#0a0a0f]/95 backdrop-blur-xl"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            aria-hidden="true"
+          />
+
+          {/* Dialog */}
+          <motion.div
+            ref={modalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={descId}
+            tabIndex={-1}
+            className="relative z-10 w-full h-full sm:h-auto sm:max-h-[90vh] sm:max-w-[720px] sm:mx-4 sm:rounded-2xl bg-white/5 backdrop-blur-xl border-0 sm:border sm:border-white/10 flex flex-col focus:outline-none overflow-hidden"
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 40 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p id={descId} className="sr-only">
+              {tr('Conversation vocale avec DeepSight', 'Voice conversation with DeepSight')}
+            </p>
+
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 py-4 border-b border-white/5 flex-shrink-0">
+              <div className="flex-1 min-w-0 pr-4">
+                <h2
+                  id={titleId}
+                  className="text-sm sm:text-base font-semibold text-white truncate"
+                  title={videoTitle}
+                >
+                  {videoTitle}
+                </h2>
+                {channelName && (
+                  <p className="text-xs text-white/40 mt-0.5 truncate">{channelName}</p>
+                )}
+              </div>
+              <button
+                onClick={onClose}
+                className="w-9 h-9 rounded-lg bg-white/5 border border-white/10 text-white/50 hover:text-white hover:bg-white/10 transition-all flex items-center justify-center flex-shrink-0 focus-visible:ring-2 focus-visible:ring-indigo-400"
+                aria-label={tr('Fermer', 'Close')}
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* Center — status zone */}
+            <div className="flex-1 flex flex-col items-center justify-center px-6 py-8 min-h-[200px]">
+              {renderCenterContent()}
+            </div>
+
+            {/* Transcript zone */}
+            {messages.length > 0 && (
+              <div
+                ref={transcriptRef}
+                className="mx-4 mb-3 max-h-[200px] overflow-y-auto rounded-xl bg-white/[0.03] border border-white/5 p-4 space-y-3 scroll-smooth"
+                aria-label={tr('Transcription de la conversation', 'Conversation transcript')}
+                role="log"
+                aria-live="polite"
+              >
+                {messages.map((msg, i) => (
+                  <div
+                    key={i}
+                    className={`flex ${msg.source === 'user' ? 'justify-end' : 'justify-start'}`}
+                  >
+                    <div
+                      className={`max-w-[80%] px-3.5 py-2 rounded-2xl text-sm leading-relaxed ${
+                        msg.source === 'user'
+                          ? 'bg-indigo-500/20 border border-indigo-500/20 text-indigo-100'
+                          : 'bg-white/5 border border-white/10 text-white/80'
+                      }`}
+                    >
+                      {msg.text}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Footer — controls */}
+            {isActive && (
+              <motion.div
+                className="flex items-center justify-between px-5 py-4 border-t border-white/5 flex-shrink-0"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.1 }}
+              >
+                {/* Mute toggle */}
+                <button
+                  onClick={onMuteToggle}
+                  className={`w-11 h-11 rounded-full flex items-center justify-center transition-all focus-visible:ring-2 focus-visible:ring-indigo-400 ${
+                    isMuted
+                      ? 'bg-red-500/15 border border-red-500/30 text-red-400 hover:bg-red-500/25'
+                      : 'bg-white/5 border border-white/10 text-white/60 hover:text-white hover:bg-white/10'
+                  }`}
+                  aria-label={isMuted ? tr('Reactiver le micro', 'Unmute microphone') : tr('Couper le micro', 'Mute microphone')}
+                >
+                  {isMuted ? <MicOff className="w-4.5 h-4.5" /> : <Mic className="w-4.5 h-4.5" />}
+                </button>
+
+                {/* Timer */}
+                <div className="flex flex-col items-center">
+                  <span className="text-white font-mono text-lg font-medium tabular-nums">
+                    {formatTime(elapsedSeconds)}
+                  </span>
+                  <span className="text-white/30 text-[10px] font-mono tabular-nums">
+                    / {remainingFormatted} {tr('restantes', 'remaining')}
+                  </span>
+                </div>
+
+                {/* End call */}
+                <button
+                  onClick={onStop}
+                  className="w-11 h-11 rounded-full bg-red-500/15 border border-red-500/30 text-red-400 hover:bg-red-500 hover:text-white hover:border-red-500 transition-all flex items-center justify-center focus-visible:ring-2 focus-visible:ring-red-400"
+                  aria-label={tr('Terminer la conversation', 'End conversation')}
+                >
+                  <PhoneOff className="w-4.5 h-4.5" />
+                </button>
+              </motion.div>
+            )}
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+};
+
+export default VoiceModal;

--- a/frontend/src/components/voice/VoiceQuotaBadge.tsx
+++ b/frontend/src/components/voice/VoiceQuotaBadge.tsx
@@ -1,0 +1,63 @@
+/**
+ * VoiceQuotaBadge — Compact quota indicator for voice chat modal.
+ * Displays minutes used / total with color-coded warning levels.
+ */
+
+import React from 'react';
+
+interface VoiceQuotaBadgeProps {
+  minutesUsed: number;
+  minutesTotal: number;
+  /** Warning threshold reached */
+  warningLevel?: 50 | 80 | 95 | 100 | null;
+}
+
+const formatTime = (minutes: number): string => {
+  const mins = Math.floor(minutes);
+  const secs = Math.round((minutes - mins) * 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+};
+
+const getColorClass = (level: VoiceQuotaBadgeProps['warningLevel']): string => {
+  switch (level) {
+    case 100:
+      return 'text-red-400 animate-pulse';
+    case 95:
+      return 'text-orange-400';
+    case 80:
+      return 'text-yellow-400';
+    default:
+      return 'text-white/60';
+  }
+};
+
+export const VoiceQuotaBadge: React.FC<VoiceQuotaBadgeProps> = React.memo(
+  ({ minutesUsed, minutesTotal, warningLevel = null }) => {
+    const colorClass = getColorClass(warningLevel);
+
+    return (
+      <div
+        className={`inline-flex items-center gap-1.5 bg-white/5 rounded-full px-3 py-1 ${colorClass}`}
+      >
+        {/* Clock icon */}
+        <svg
+          className="w-3 h-3 flex-shrink-0"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M8 4.5V8L10.5 9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        <span className="text-xs font-mono tabular-nums">
+          {formatTime(minutesUsed)} / {formatTime(minutesTotal)}
+        </span>
+      </div>
+    );
+  }
+);
+
+VoiceQuotaBadge.displayName = 'VoiceQuotaBadge';
+
+export default VoiceQuotaBadge;

--- a/frontend/src/components/voice/VoiceTranscript.tsx
+++ b/frontend/src/components/voice/VoiceTranscript.tsx
@@ -1,0 +1,72 @@
+/**
+ * VoiceTranscript — Scrollable conversation transcript for voice chat.
+ * Auto-scrolls to bottom on new messages, with live cursor animation.
+ */
+
+import React, { useRef, useEffect } from 'react';
+
+interface VoiceTranscriptProps {
+  messages: Array<{ text: string; source: 'user' | 'ai'; timestamp?: number }>;
+  isLive?: boolean;
+}
+
+export const VoiceTranscript: React.FC<VoiceTranscriptProps> = React.memo(
+  ({ messages, isLive = false }) => {
+    const bottomRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [messages]);
+
+    if (messages.length === 0) {
+      return (
+        <div className="flex items-center justify-center h-full min-h-[120px] p-4">
+          <p className="text-sm text-white/30 select-none">
+            La conversation apparaitra ici...
+          </p>
+        </div>
+      );
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    const showCursor = isLive && lastMessage?.source === 'ai';
+
+    return (
+      <div className="flex flex-col gap-3 p-4 max-h-[360px] overflow-y-auto">
+        {messages.map((msg, index) => {
+          const isUser = msg.source === 'user';
+          const isLastAi =
+            showCursor && index === messages.length - 1;
+
+          return (
+            <div
+              key={index}
+              className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
+            >
+              <div
+                className={`
+                  max-w-[80%] px-4 py-2.5 text-sm
+                  ${
+                    isUser
+                      ? 'bg-indigo-500/20 text-indigo-200 rounded-2xl rounded-br-sm'
+                      : 'bg-white/5 text-white/80 rounded-2xl rounded-bl-sm'
+                  }
+                `}
+              >
+                <span>{msg.text}</span>
+                {isLastAi && (
+                  <span className="inline-block w-[2px] h-[14px] ml-0.5 align-middle bg-white/60 animate-pulse" />
+                )}
+              </div>
+            </div>
+          );
+        })}
+        <div ref={bottomRef} />
+      </div>
+    );
+  }
+);
+
+VoiceTranscript.displayName = 'VoiceTranscript';
+
+export default VoiceTranscript;

--- a/frontend/src/components/voice/VoiceWaveform.tsx
+++ b/frontend/src/components/voice/VoiceWaveform.tsx
@@ -1,0 +1,139 @@
+/**
+ * VoiceWaveform — Real-time audio waveform visualization
+ *
+ * Displays animated vertical bars representing audio activity.
+ * Supports three modes: idle (minimal movement), user (natural speech),
+ * and ai (fluid, dynamic response).
+ */
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+
+interface VoiceWaveformProps {
+  /** Qui parle actuellement */
+  mode: 'user' | 'ai' | 'idle';
+  /** Intensité audio (0 à 1) — peut être simulée si pas de données réelles */
+  intensity?: number;
+  /** Couleur de l'onde */
+  color?: 'indigo' | 'violet' | 'cyan';
+  /** Taille */
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const BAR_COUNT = 20;
+
+const SIZE_CONFIG = {
+  sm: { maxHeight: 24, barWidth: 2, gap: 2 },
+  md: { maxHeight: 48, barWidth: 3, gap: 3 },
+  lg: { maxHeight: 80, barWidth: 4, gap: 4 },
+} as const;
+
+const COLOR_MAP = {
+  indigo: 'bg-indigo-500',
+  violet: 'bg-violet-500',
+  cyan: 'bg-cyan-500',
+} as const;
+
+const MIN_BAR_HEIGHT = 4;
+
+const VoiceWaveformInner: React.FC<VoiceWaveformProps> = ({
+  mode,
+  intensity = 0.5,
+  color = 'indigo',
+  size = 'md',
+}) => {
+  const [barHeights, setBarHeights] = useState<number[]>(() =>
+    Array(BAR_COUNT).fill(MIN_BAR_HEIGHT)
+  );
+  const rafRef = useRef<number | null>(null);
+  const lastUpdateRef = useRef<number>(0);
+
+  const clampedIntensity = Math.max(0, Math.min(1, intensity));
+  const config = SIZE_CONFIG[size];
+  const colorClass = COLOR_MAP[color];
+
+  const computeHeights = useCallback(
+    (timestamp: number) => {
+      // Throttle updates to ~100ms intervals for performance
+      if (timestamp - lastUpdateRef.current < 100) {
+        rafRef.current = requestAnimationFrame(computeHeights);
+        return;
+      }
+      lastUpdateRef.current = timestamp;
+
+      setBarHeights((prev) => {
+        const next = new Array<number>(BAR_COUNT);
+
+        for (let i = 0; i < BAR_COUNT; i++) {
+          if (mode === 'idle') {
+            // Subtle minimal movement around the minimum height
+            const jitter = Math.random() * 3;
+            next[i] = MIN_BAR_HEIGHT + jitter;
+          } else if (mode === 'user') {
+            // Natural speech: random heights scaled by intensity, with some
+            // smoothing from the previous value to avoid harsh jumps
+            const target =
+              MIN_BAR_HEIGHT +
+              Math.random() * (config.maxHeight - MIN_BAR_HEIGHT) * clampedIntensity * 0.7;
+            next[i] = prev[i] * 0.3 + target * 0.7;
+          } else {
+            // AI: fluid sine-based pattern with intensity scaling
+            const phase = (timestamp / 300 + i * 0.5) % (Math.PI * 2);
+            const sine = (Math.sin(phase) + 1) / 2; // 0-1
+            const noise = Math.random() * 0.2;
+            const factor = (sine + noise) * clampedIntensity;
+            next[i] =
+              MIN_BAR_HEIGHT +
+              factor * (config.maxHeight - MIN_BAR_HEIGHT) * 0.9;
+          }
+        }
+
+        return next;
+      });
+
+      rafRef.current = requestAnimationFrame(computeHeights);
+    },
+    [mode, clampedIntensity, config.maxHeight]
+  );
+
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(computeHeights);
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [computeHeights]);
+
+  return (
+    <div
+      className="flex items-center justify-center"
+      style={{
+        height: config.maxHeight,
+        gap: config.gap,
+      }}
+      role="img"
+      aria-label={
+        mode === 'idle'
+          ? 'Audio idle'
+          : mode === 'user'
+            ? 'User speaking'
+            : 'AI speaking'
+      }
+    >
+      {barHeights.map((height, index) => (
+        <div
+          key={index}
+          className={`rounded-full transition-all duration-100 ease-out ${colorClass}`}
+          style={{
+            width: config.barWidth,
+            height: Math.max(MIN_BAR_HEIGHT, Math.round(height)),
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export const VoiceWaveform = React.memo(VoiceWaveformInner);

--- a/frontend/src/components/voice/useVoiceChat.ts
+++ b/frontend/src/components/voice/useVoiceChat.ts
@@ -1,0 +1,367 @@
+/**
+ * useVoiceChat — Hook d'orchestration de conversation vocale
+ * Gère le cycle complet : micro → API session → ElevenLabs SDK → timer → cleanup
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { API_URL, getAccessToken } from '../../services/api';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface UseVoiceChatOptions {
+  summaryId: number;
+  onError?: (error: string) => void;
+}
+
+type VoiceChatStatus =
+  | 'idle'
+  | 'connecting'
+  | 'listening'
+  | 'thinking'
+  | 'speaking'
+  | 'error'
+  | 'quota_exceeded';
+
+interface VoiceChatMessage {
+  text: string;
+  source: 'user' | 'ai';
+}
+
+interface SessionResponse {
+  session_id: string;
+  signed_url: string;
+  quota_remaining_minutes: number;
+  max_session_minutes: number;
+}
+
+interface UseVoiceChatReturn {
+  /** Démarrer la conversation */
+  start: () => Promise<void>;
+  /** Arrêter la conversation */
+  stop: () => Promise<void>;
+  /** Toggle mute micro */
+  toggleMute: () => void;
+  /** Status de la connexion */
+  status: VoiceChatStatus;
+  /** L'IA est en train de parler */
+  isSpeaking: boolean;
+  /** Le micro est muted */
+  isMuted: boolean;
+  /** Messages de la conversation */
+  messages: VoiceChatMessage[];
+  /** Secondes écoulées dans la session */
+  elapsedSeconds: number;
+  /** Minutes restantes dans le quota */
+  remainingMinutes: number;
+  /** Erreur */
+  error: string | null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Erreurs françaises
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const ERROR_MESSAGES = {
+  MICROPHONE_DENIED: 'Accès au microphone refusé. Veuillez autoriser le micro dans les paramètres de votre navigateur.',
+  MICROPHONE_NOT_FOUND: 'Aucun microphone détecté. Veuillez brancher un micro et réessayer.',
+  MICROPHONE_GENERIC: 'Impossible d\'accéder au microphone. Vérifiez vos permissions.',
+  NETWORK: 'Erreur réseau. Vérifiez votre connexion internet et réessayez.',
+  API_DOWN: 'Le serveur est temporairement indisponible. Réessayez dans quelques instants.',
+  QUOTA_EXCEEDED: 'Quota de conversation vocale épuisé. Passez à un plan supérieur pour continuer.',
+  SESSION_FAILED: 'Impossible de démarrer la session vocale. Réessayez.',
+  SDK_LOAD_FAILED: 'Impossible de charger le module de conversation vocale.',
+  SESSION_TIMEOUT: 'Session terminée : durée maximale atteinte.',
+  UNKNOWN: 'Une erreur inattendue est survenue. Réessayez.',
+} as const;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hook
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function useVoiceChat({ summaryId, onError }: UseVoiceChatOptions): UseVoiceChatReturn {
+  const [status, setStatus] = useState<VoiceChatStatus>('idle');
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
+  const [messages, setMessages] = useState<VoiceChatMessage[]>([]);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [remainingMinutes, setRemainingMinutes] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  // Refs pour le cleanup
+  const conversationRef = useRef<unknown>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const maxSecondsRef = useRef<number>(0);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const isMountedRef = useRef(true);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const reportError = useCallback(
+    (msg: string) => {
+      setError(msg);
+      setStatus('error');
+      onError?.(msg);
+    },
+    [onError]
+  );
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const releaseMediaStream = useCallback(() => {
+    if (mediaStreamRef.current) {
+      mediaStreamRef.current.getTracks().forEach((track) => track.stop());
+      mediaStreamRef.current = null;
+    }
+  }, []);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // stop()
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const stop = useCallback(async () => {
+    stopTimer();
+
+    // End ElevenLabs session
+    if (conversationRef.current) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (conversationRef.current as any).endSession();
+      } catch {
+        // Ignorer les erreurs de fin de session
+      }
+      conversationRef.current = null;
+    }
+
+    releaseMediaStream();
+
+    if (isMountedRef.current) {
+      setStatus('idle');
+      setIsSpeaking(false);
+      setIsMuted(false);
+      setElapsedSeconds(0);
+    }
+  }, [stopTimer, releaseMediaStream]);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // start()
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const start = useCallback(async () => {
+    // Empêcher les démarrages multiples
+    if (status === 'connecting' || status === 'listening' || status === 'speaking') {
+      return;
+    }
+
+    setError(null);
+    setMessages([]);
+    setElapsedSeconds(0);
+    setStatus('connecting');
+
+    // 1. Demander l'accès micro
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaStreamRef.current = stream;
+    } catch (err: unknown) {
+      const mediaError = err as DOMException;
+      if (mediaError.name === 'NotAllowedError' || mediaError.name === 'PermissionDeniedError') {
+        reportError(ERROR_MESSAGES.MICROPHONE_DENIED);
+      } else if (mediaError.name === 'NotFoundError' || mediaError.name === 'DevicesNotFoundError') {
+        reportError(ERROR_MESSAGES.MICROPHONE_NOT_FOUND);
+      } else {
+        reportError(ERROR_MESSAGES.MICROPHONE_GENERIC);
+      }
+      return;
+    }
+
+    // 2. Créer la session via notre API
+    let sessionData: SessionResponse;
+    try {
+      const token = getAccessToken();
+      const response = await fetch(`${API_URL}/api/voice/session`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ summary_id: summaryId }),
+        credentials: 'include',
+      });
+
+      if (response.status === 403 || response.status === 429) {
+        releaseMediaStream();
+        setStatus('quota_exceeded');
+        setError(ERROR_MESSAGES.QUOTA_EXCEEDED);
+        onError?.(ERROR_MESSAGES.QUOTA_EXCEEDED);
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      sessionData = await response.json();
+      setRemainingMinutes(sessionData.quota_remaining_minutes);
+      maxSecondsRef.current = sessionData.max_session_minutes * 60;
+    } catch (err) {
+      releaseMediaStream();
+      if (err instanceof TypeError) {
+        // TypeError = network failure (fetch)
+        reportError(ERROR_MESSAGES.NETWORK);
+      } else {
+        reportError(ERROR_MESSAGES.SESSION_FAILED);
+      }
+      return;
+    }
+
+    // 3. Charger le SDK ElevenLabs et démarrer la session
+    try {
+      const { Conversation } = await import('@elevenlabs/client');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const conversation = await (Conversation as any).startSession({
+        signedUrl: sessionData.signed_url,
+        onConnect: () => {
+          if (isMountedRef.current) {
+            setStatus('listening');
+          }
+        },
+        onDisconnect: () => {
+          if (isMountedRef.current) {
+            stopTimer();
+            setStatus('idle');
+            setIsSpeaking(false);
+          }
+        },
+        onMessage: (message: { message: string; source: 'user' | 'ai' }) => {
+          if (isMountedRef.current) {
+            setMessages((prev) => [
+              ...prev,
+              { text: message.message, source: message.source },
+            ]);
+          }
+        },
+        onError: (err: Error | string) => {
+          if (isMountedRef.current) {
+            const msg = typeof err === 'string' ? err : err.message || ERROR_MESSAGES.UNKNOWN;
+            reportError(msg);
+          }
+        },
+        onStatusChange: (statusInfo: { status: string }) => {
+          if (!isMountedRef.current) return;
+          switch (statusInfo.status) {
+            case 'speaking':
+              setIsSpeaking(true);
+              setStatus('speaking');
+              break;
+            case 'listening':
+              setIsSpeaking(false);
+              setStatus('listening');
+              break;
+            case 'thinking':
+            case 'processing':
+              setIsSpeaking(false);
+              setStatus('thinking');
+              break;
+          }
+        },
+      });
+
+      conversationRef.current = conversation;
+
+      // 4. Démarrer le timer
+      timerRef.current = setInterval(() => {
+        if (!isMountedRef.current) return;
+        setElapsedSeconds((prev) => {
+          const next = prev + 1;
+          // Auto-stop si durée max atteinte
+          if (maxSecondsRef.current > 0 && next >= maxSecondsRef.current) {
+            stop();
+            setError(ERROR_MESSAGES.SESSION_TIMEOUT);
+          }
+          return next;
+        });
+      }, 1000);
+    } catch {
+      releaseMediaStream();
+      reportError(ERROR_MESSAGES.SDK_LOAD_FAILED);
+    }
+  }, [status, summaryId, onError, reportError, releaseMediaStream, stopTimer, stop]);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // toggleMute()
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const toggleMute = useCallback(() => {
+    if (!conversationRef.current) return;
+
+    const nextMuted = !isMuted;
+
+    // Mute/unmute via le SDK ElevenLabs
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const conv = conversationRef.current as any;
+      if (typeof conv.setVolume === 'function') {
+        // Certaines versions du SDK utilisent setVolume pour le micro input
+        conv.setVolume({ inputVolume: nextMuted ? 0 : 1 });
+      }
+    } catch {
+      // Fallback : mute via le MediaStream directement
+    }
+
+    // Fallback robuste : mute directement les tracks audio du micro
+    if (mediaStreamRef.current) {
+      mediaStreamRef.current.getAudioTracks().forEach((track) => {
+        track.enabled = !nextMuted;
+      });
+    }
+
+    setIsMuted(nextMuted);
+  }, [isMuted]);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Cleanup on unmount
+  // ─────────────────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      stopTimer();
+      releaseMediaStream();
+
+      // Fin de session ElevenLabs
+      if (conversationRef.current) {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (conversationRef.current as any).endSession();
+        } catch {
+          // Ignorer
+        }
+        conversationRef.current = null;
+      }
+    };
+  }, [stopTimer, releaseMediaStream]);
+
+  return {
+    start,
+    stop,
+    toggleMute,
+    status,
+    isSpeaking,
+    isMuted,
+    messages,
+    elapsedSeconds,
+    remainingMinutes,
+    error,
+  };
+}

--- a/frontend/src/components/voice/voiceAnalytics.ts
+++ b/frontend/src/components/voice/voiceAnalytics.ts
@@ -1,0 +1,96 @@
+/**
+ * Voice Chat Analytics — PostHog tracking events
+ *
+ * Utilise le service analytics centralisé (PostHog) pour tracker
+ * les interactions voice chat : sessions, quotas, upgrades, erreurs.
+ *
+ * Usage :
+ *   import { VoiceAnalytics } from './voiceAnalytics';
+ *   VoiceAnalytics.trackStarted({ plan: 'pro', platform: 'web', summaryId: 42, language: 'fr' });
+ */
+
+import { analytics } from '../../services/analytics';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Event names (type-safe constants)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const VoiceAnalyticsEvents = {
+  STARTED: 'voice_chat_started',
+  ENDED: 'voice_chat_ended',
+  QUOTA_WARNING: 'voice_chat_quota_warning',
+  QUOTA_REACHED: 'voice_chat_quota_reached',
+  ADDON_PURCHASED: 'voice_chat_addon_purchased',
+  UPGRADE_CLICKED: 'voice_chat_upgrade_clicked',
+  ERROR: 'voice_chat_error',
+} as const;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Typed event helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const VoiceAnalytics = {
+  /** Debut de session voice */
+  trackStarted(data: { plan: string; platform: string; summaryId: number; language: string }) {
+    analytics.capture(VoiceAnalyticsEvents.STARTED, {
+      plan: data.plan,
+      platform: data.platform,
+      summary_id: data.summaryId,
+      language: data.language,
+    });
+  },
+
+  /** Fin de session voice */
+  trackEnded(data: { durationSeconds: number; plan: string; platform: string; summaryId: number }) {
+    analytics.capture(VoiceAnalyticsEvents.ENDED, {
+      duration_seconds: data.durationSeconds,
+      plan: data.plan,
+      platform: data.platform,
+      summary_id: data.summaryId,
+    });
+  },
+
+  /** Alerte quota (80%, 90%, etc.) */
+  trackQuotaWarning(data: { percentUsed: number; plan: string; remainingSeconds: number }) {
+    analytics.capture(VoiceAnalyticsEvents.QUOTA_WARNING, {
+      percent_used: data.percentUsed,
+      plan: data.plan,
+      remaining_seconds: data.remainingSeconds,
+    });
+  },
+
+  /** Quota atteint — session bloquee */
+  trackQuotaReached(data: { plan: string; totalSecondsUsed: number }) {
+    analytics.capture(VoiceAnalyticsEvents.QUOTA_REACHED, {
+      plan: data.plan,
+      total_seconds_used: data.totalSecondsUsed,
+    });
+  },
+
+  /** Add-on minutes achete */
+  trackAddonPurchased(data: { packMinutes: number; priceCents: number; plan: string }) {
+    analytics.capture(VoiceAnalyticsEvents.ADDON_PURCHASED, {
+      pack_minutes: data.packMinutes,
+      price_cents: data.priceCents,
+      plan: data.plan,
+    });
+  },
+
+  /** CTA upgrade clique depuis voice chat */
+  trackUpgradeClicked(data: { currentPlan: string; targetPlan?: string; trigger: string }) {
+    analytics.capture(VoiceAnalyticsEvents.UPGRADE_CLICKED, {
+      current_plan: data.currentPlan,
+      target_plan: data.targetPlan ?? null,
+      trigger: data.trigger,
+    });
+  },
+
+  /** Erreur technique (micro, WebSocket, STT, etc.) */
+  trackError(data: { errorType: string; plan: string; platform: string }) {
+    analytics.capture(VoiceAnalyticsEvents.ERROR, {
+      error_type: data.errorType,
+      plan: data.plan,
+      platform: data.platform,
+    });
+  },
+};

--- a/frontend/src/config/planPrivileges.ts
+++ b/frontend/src/config/planPrivileges.ts
@@ -44,6 +44,10 @@ export interface PlanLimits {
   academicSearch: boolean;          // Recherche de sources académiques
   academicPapersPerAnalysis: number; // Nombre max de papiers (backend contrôle aussi)
   bibliographyExport: boolean;      // Export bibliographie (BibTeX, APA, etc.)
+
+  // Voice Chat
+  voiceChatEnabled: boolean;        // Activer le chat vocal
+  voiceChatMonthlyMinutes: number;  // Minutes mensuelles, 0 = désactivé
 }
 
 export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
@@ -70,6 +74,8 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     academicSearch: true,
     academicPapersPerAnalysis: 3,
     bibliographyExport: false,
+    voiceChatEnabled: false,
+    voiceChatMonthlyMinutes: 0,
   },
 
   etudiant: {
@@ -95,6 +101,8 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     academicSearch: true,
     academicPapersPerAnalysis: 10,
     bibliographyExport: true,
+    voiceChatEnabled: true,
+    voiceChatMonthlyMinutes: 5,
   },
 
   starter: {
@@ -120,6 +128,8 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     academicSearch: true,
     academicPapersPerAnalysis: 20,
     bibliographyExport: true,
+    voiceChatEnabled: true,
+    voiceChatMonthlyMinutes: 15,
   },
 
   pro: {
@@ -145,6 +155,8 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     academicSearch: true,
     academicPapersPerAnalysis: 50,
     bibliographyExport: true,
+    voiceChatEnabled: true,
+    voiceChatMonthlyMinutes: 45,
   },
 };
 
@@ -164,13 +176,14 @@ export interface PlanFeatures {
   prioritySupport: boolean;
   academicSearch: boolean;
   bibliographyExport: boolean;
+  voiceChat: boolean;
 }
 
 export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
-  free: { flashcards: false, mindmap: false, webSearch: false, playlists: false, exportPdf: false, exportMarkdown: false, ttsAudio: false, apiAccess: false, prioritySupport: false, academicSearch: true, bibliographyExport: false },
-  etudiant: { flashcards: true, mindmap: true, webSearch: false, playlists: false, exportPdf: false, exportMarkdown: true, ttsAudio: true, apiAccess: false, prioritySupport: false, academicSearch: true, bibliographyExport: true },
-  starter: { flashcards: true, mindmap: true, webSearch: true, playlists: false, exportPdf: false, exportMarkdown: true, ttsAudio: false, apiAccess: false, prioritySupport: false, academicSearch: true, bibliographyExport: true },
-  pro: { flashcards: true, mindmap: true, webSearch: true, playlists: true, exportPdf: true, exportMarkdown: true, ttsAudio: true, apiAccess: false, prioritySupport: true, academicSearch: true, bibliographyExport: true },
+  free: { flashcards: false, mindmap: false, webSearch: false, playlists: false, exportPdf: false, exportMarkdown: false, ttsAudio: false, apiAccess: false, prioritySupport: false, academicSearch: true, bibliographyExport: false, voiceChat: false },
+  etudiant: { flashcards: true, mindmap: true, webSearch: false, playlists: false, exportPdf: false, exportMarkdown: true, ttsAudio: true, apiAccess: false, prioritySupport: false, academicSearch: true, bibliographyExport: true, voiceChat: true },
+  starter: { flashcards: true, mindmap: true, webSearch: true, playlists: false, exportPdf: false, exportMarkdown: true, ttsAudio: false, apiAccess: false, prioritySupport: false, academicSearch: true, bibliographyExport: true, voiceChat: true },
+  pro: { flashcards: true, mindmap: true, webSearch: true, playlists: true, exportPdf: true, exportMarkdown: true, ttsAudio: true, apiAccess: false, prioritySupport: true, academicSearch: true, bibliographyExport: true, voiceChat: true },
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -52,6 +52,10 @@ import { CustomizationPanel } from "../components/analysis/CustomizationPanel";
 import { AnalysisCustomization, DEFAULT_CUSTOMIZATION, customizationToApiParams } from "../types/analysis";
 // 📊 AnalysisHub — Panel intelligent à onglets
 import { AnalysisHub } from "../components/AnalysisHub";
+// 🎙️ Voice Chat
+import VoiceButton from "../components/voice/VoiceButton";
+import { VoiceModal } from "../components/voice/VoiceModal";
+import { useVoiceChat } from "../components/voice/useVoiceChat";
 
 interface ChatMessage {
   id: string;
@@ -155,6 +159,10 @@ export const DashboardPage: React.FC = () => {
 
   // 🆕 État pour détection de playlist
   const [playlistDetected, setPlaylistDetected] = useState(false);
+
+  // 🎙️ Voice Chat
+  const [isVoiceModalOpen, setIsVoiceModalOpen] = useState(false);
+  const voiceChat = useVoiceChat({ summaryId: selectedSummary?.id ?? 0 });
 
   // 🕐 États Freshness & Fact-Check LITE
   const [reliabilityData, setReliabilityData] = useState<ReliabilityResult | null>(null);
@@ -1344,6 +1352,35 @@ export const DashboardPage: React.FC = () => {
           transform: scale(0.8);
         }
       `}</style>
+
+      {/* 🎙️ Voice Chat */}
+      {selectedSummary && (
+        <>
+          <VoiceButton
+            summaryId={selectedSummary.id}
+            onOpen={() => setIsVoiceModalOpen(true)}
+          />
+          <VoiceModal
+            isOpen={isVoiceModalOpen}
+            onClose={() => {
+              setIsVoiceModalOpen(false);
+              voiceChat.stop();
+            }}
+            videoTitle={selectedSummary.video_title}
+            channelName={selectedSummary.video_channel}
+            voiceStatus={voiceChat.status}
+            isSpeaking={voiceChat.isSpeaking}
+            messages={voiceChat.messages}
+            elapsedSeconds={voiceChat.elapsedSeconds}
+            remainingMinutes={voiceChat.remainingMinutes}
+            onStart={voiceChat.start}
+            onStop={voiceChat.stop}
+            onMuteToggle={voiceChat.toggleMute}
+            isMuted={voiceChat.isMuted}
+            error={voiceChat.error ?? undefined}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1954,7 +1954,7 @@ export const shareApi = {
   async createShareLink(videoId: string): Promise<{ share_url: string; share_token: string }> {
     return request('/api/share', {
       method: 'POST',
-      body: JSON.stringify({ video_id: videoId }),
+      body: { video_id: videoId },
     });
   },
 
@@ -2029,7 +2029,7 @@ export const searchApi = {
   ): Promise<SemanticSearchResponse> {
     return request('/api/search/semantic', {
       method: 'POST',
-      body: JSON.stringify({ query, limit, category }),
+      body: { query, limit, category },
     });
   },
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2058,6 +2058,90 @@ export const videoCacheApi = {
   },
 };
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎙️ VOICE CHAT API — Sessions vocales temps réel
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface VoiceQuota {
+  plan: string;
+  voice_enabled: boolean;
+  seconds_used: number;
+  seconds_limit: number;
+  minutes_remaining: number;
+  max_session_minutes: number;
+  sessions_this_month: number;
+  reset_date: string;
+}
+
+export interface VoiceSession {
+  session_id: string;
+  signed_url: string;
+  expires_at: string;
+  quota_remaining_minutes: number;
+  max_session_minutes: number;
+}
+
+export interface VoiceSessionSummary {
+  session_id: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_seconds: number;
+  status: string;
+  has_transcript: boolean;
+}
+
+export interface VoiceHistoryResponse {
+  summary_id: number;
+  video_title: string;
+  sessions: VoiceSessionSummary[];
+  total_minutes: number;
+}
+
+export interface VoiceTranscript {
+  session_id: string;
+  summary_id: number;
+  started_at: string;
+  duration_seconds: number;
+  transcript: string;
+}
+
+export const voiceApi = {
+  /**
+   * 🎙️ Récupère le quota vocal de l'utilisateur
+   * Endpoint: GET /api/voice/quota
+   */
+  async getQuota(): Promise<VoiceQuota> {
+    return request('/api/voice/quota');
+  },
+
+  /**
+   * 🎙️ Crée une nouvelle session vocale
+   * Endpoint: POST /api/voice/session
+   */
+  async createSession(summaryId: number, language: string = 'fr'): Promise<VoiceSession> {
+    return request('/api/voice/session', {
+      method: 'POST',
+      body: { summary_id: summaryId, language },
+    });
+  },
+
+  /**
+   * 🎙️ Récupère l'historique des sessions vocales pour une analyse
+   * Endpoint: GET /api/voice/history/{summaryId}
+   */
+  async getHistory(summaryId: number): Promise<VoiceHistoryResponse> {
+    return request(`/api/voice/history/${summaryId}`);
+  },
+
+  /**
+   * 🎙️ Récupère le transcript d'une session vocale
+   * Endpoint: GET /api/voice/history/{summaryId}/{sessionId}/transcript
+   */
+  async getTranscript(summaryId: number, sessionId: string): Promise<VoiceTranscript> {
+    return request(`/api/voice/history/${summaryId}/${sessionId}/transcript`);
+  },
+};
+
 // Export par défaut
 export default {
   auth: authApi,
@@ -2078,4 +2162,5 @@ export default {
   trending: trendingApi,
   search: searchApi,
   videoCache: videoCacheApi,
+  voice: voiceApi,
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2140,6 +2140,17 @@ export const voiceApi = {
   async getTranscript(summaryId: number, sessionId: string): Promise<VoiceTranscript> {
     return request(`/api/voice/history/${summaryId}/${sessionId}/transcript`);
   },
+
+  /**
+   * 🎙️ Crée un checkout Stripe pour un pack de minutes vocales
+   * Endpoint: POST /api/voice/addon/checkout
+   */
+  async createAddonCheckout(packId: string): Promise<{ checkout_url: string }> {
+    return request('/api/voice/addon/checkout', {
+      method: 'POST',
+      body: { pack_id: packId },
+    });
+  },
 };
 
 // Export par défaut

--- a/frontend/src/store/analysisStore.ts
+++ b/frontend/src/store/analysisStore.ts
@@ -65,12 +65,26 @@ export interface AnalysisPreferences {
   webEnrich: boolean;
 }
 
-export type AnalysisStatus = 
-  | 'idle' 
-  | 'loading' 
-  | 'streaming' 
-  | 'complete' 
+export type AnalysisStatus =
+  | 'idle'
+  | 'loading'
+  | 'streaming'
+  | 'complete'
   | 'error';
+
+export type VoiceStatus = 'idle' | 'connecting' | 'active' | 'error';
+
+export interface VoiceQuota {
+  secondsUsed: number;
+  secondsLimit: number;
+  minutesRemaining: number;
+  warningLevel: number | null;
+}
+
+export interface VoiceMessage {
+  text: string;
+  source: 'user' | 'ai';
+}
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // 🔧 ANALYSIS STORE
@@ -102,6 +116,14 @@ interface AnalysisState {
   chatOpen: boolean;
   playerVisible: boolean;
   playerStartTime: number;
+
+  // Voice
+  voiceStatus: VoiceStatus;
+  voiceSessionId: string | null;
+  voiceQuota: VoiceQuota | null;
+  voiceMessages: VoiceMessage[];
+  voiceElapsedSeconds: number;
+  isMuted: boolean;
 }
 
 interface AnalysisActions {
@@ -135,6 +157,16 @@ interface AnalysisActions {
   // Preferences actions
   setPreferences: (prefs: Partial<AnalysisPreferences>) => void;
   resetPreferences: () => void;
+
+  // Voice actions
+  setVoiceStatus: (status: VoiceStatus) => void;
+  setVoiceSessionId: (id: string | null) => void;
+  setVoiceQuota: (quota: VoiceQuota | null) => void;
+  addVoiceMessage: (message: VoiceMessage) => void;
+  clearVoiceMessages: () => void;
+  setVoiceElapsedSeconds: (seconds: number) => void;
+  setIsMuted: (muted: boolean) => void;
+  resetVoiceState: () => void;
 }
 
 type AnalysisStore = AnalysisState & AnalysisActions;
@@ -168,6 +200,12 @@ const INITIAL_STATE: AnalysisState = {
   chatOpen: false,
   playerVisible: false,
   playerStartTime: 0,
+  voiceStatus: 'idle',
+  voiceSessionId: null,
+  voiceQuota: null,
+  voiceMessages: [],
+  voiceElapsedSeconds: 0,
+  isMuted: false,
 };
 
 export const useAnalysisStore = create<AnalysisStore>()(
@@ -380,6 +418,63 @@ export const useAnalysisStore = create<AnalysisStore>()(
             state.preferences = DEFAULT_PREFERENCES;
           });
         },
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // 🎙️ VOICE ACTIONS
+        // ═══════════════════════════════════════════════════════════════════════
+
+        setVoiceStatus: (status: VoiceStatus) => {
+          set((state) => {
+            state.voiceStatus = status;
+          });
+        },
+
+        setVoiceSessionId: (id: string | null) => {
+          set((state) => {
+            state.voiceSessionId = id;
+          });
+        },
+
+        setVoiceQuota: (quota: VoiceQuota | null) => {
+          set((state) => {
+            state.voiceQuota = quota;
+          });
+        },
+
+        addVoiceMessage: (message: VoiceMessage) => {
+          set((state) => {
+            state.voiceMessages.push(message);
+          });
+        },
+
+        clearVoiceMessages: () => {
+          set((state) => {
+            state.voiceMessages = [];
+          });
+        },
+
+        setVoiceElapsedSeconds: (seconds: number) => {
+          set((state) => {
+            state.voiceElapsedSeconds = seconds;
+          });
+        },
+
+        setIsMuted: (muted: boolean) => {
+          set((state) => {
+            state.isMuted = muted;
+          });
+        },
+
+        resetVoiceState: () => {
+          set((state) => {
+            state.voiceStatus = 'idle';
+            state.voiceSessionId = null;
+            state.voiceQuota = null;
+            state.voiceMessages = [];
+            state.voiceElapsedSeconds = 0;
+            state.isMuted = false;
+          });
+        },
       })),
       {
         name: 'deepsight-analysis-store',
@@ -424,8 +519,18 @@ export const useCanStartNewAnalysis = () => useAnalysisStore((state) =>
   state.status === 'idle' || state.status === 'complete' || state.status === 'error'
 );
 
-export const useFavoriteCount = () => useAnalysisStore((state) => 
+export const useFavoriteCount = () => useAnalysisStore((state) =>
   state.favoriteSummaries.length
+);
+
+// Voice selectors
+export const useVoiceStatus = () => useAnalysisStore((state) => state.voiceStatus);
+export const useVoiceMessages = () => useAnalysisStore((state) => state.voiceMessages);
+export const useVoiceQuota = () => useAnalysisStore((state) => state.voiceQuota);
+export const useVoiceElapsedSeconds = () => useAnalysisStore((state) => state.voiceElapsedSeconds);
+export const useIsMuted = () => useAnalysisStore((state) => state.isMuted);
+export const useIsVoiceActive = () => useAnalysisStore((state) =>
+  state.voiceStatus === 'active' || state.voiceStatus === 'connecting'
 );
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/frontend/src/store/analysisStore.ts
+++ b/frontend/src/store/analysisStore.ts
@@ -211,6 +211,7 @@ const INITIAL_STATE: AnalysisState = {
 export const useAnalysisStore = create<AnalysisStore>()(
   devtools(
     persist(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       immer((set, _get) => ({
         ...INITIAL_STATE,
 
@@ -218,6 +219,7 @@ export const useAnalysisStore = create<AnalysisStore>()(
         // 🎬 ANALYSIS ACTIONS
         // ═══════════════════════════════════════════════════════════════════════
         
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         startAnalysis: (_videoId: string) => {
           set((state) => {
             state.status = 'loading';

--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -34,6 +34,9 @@ import { ActionBar } from '@/components/analysis/ActionBar';
 import { QuickChatScreen } from '@/components/analysis/QuickChatScreen';
 import { DoodleBackground } from '@/components/ui/DoodleBackground';
 import { DeepSightSpinner } from '@/components/ui/DeepSightSpinner';
+import { VoiceButton } from '@/components/voice/VoiceButton';
+import { VoiceScreen } from '@/components/voice/VoiceScreen';
+import { useVoiceChat } from '@/components/voice/useVoiceChat';
 
 const TAB_LABELS = ['Résumé', 'Chat'] as const;
 const TAB_BAR_HEIGHT = 60;
@@ -62,6 +65,7 @@ export default function AnalysisDetailScreen() {
   );
   const [activeTab, setActiveTab] = useState(initialTabIndex);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isVoiceVisible, setIsVoiceVisible] = useState(false);
   const scrollY = useSharedValue(0);
   const tabIndicatorX = useSharedValue(initialTabIndex);
 
@@ -117,6 +121,7 @@ export default function AnalysisDetailScreen() {
   });
 
   const [isFavorite, setIsFavorite] = useState(summary?.isFavorite ?? false);
+  const voiceChat = useVoiceChat({ summaryId: id as string });
 
   React.useEffect(() => {
     if (summary) setIsFavorite(summary.isFavorite);
@@ -445,6 +450,36 @@ export default function AnalysisDetailScreen() {
             onFavoriteChange={setIsFavorite}
           />
         </View>
+      )}
+
+      {/* Voice Chat */}
+      {summary && (
+        <>
+          <VoiceButton
+            summaryId={id as string}
+            videoTitle={summary.title || 'Vidéo'}
+            onSessionStart={() => setIsVoiceVisible(true)}
+          />
+          <VoiceScreen
+            visible={isVoiceVisible}
+            onClose={() => {
+              setIsVoiceVisible(false);
+              voiceChat.stop();
+            }}
+            videoTitle={summary.title || 'Vidéo'}
+            channelName={summary.channel}
+            voiceStatus={voiceChat.status}
+            isSpeaking={voiceChat.isSpeaking}
+            messages={voiceChat.messages}
+            elapsedSeconds={voiceChat.elapsedSeconds}
+            remainingMinutes={voiceChat.remainingMinutes}
+            onStart={voiceChat.start}
+            onStop={voiceChat.stop}
+            onMuteToggle={voiceChat.toggleMute}
+            isMuted={voiceChat.isMuted}
+            error={voiceChat.error ?? undefined}
+          />
+        </>
       )}
 
       {/* ── MODE FULLSCREEN ──────────────────────────────── */}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,8 +8,11 @@
       "name": "deepsight-mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@elevenlabs/react-native": "^0.5.12",
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.8",
+        "@livekit/react-native": "^2.9.6",
+        "@livekit/react-native-webrtc": "^137.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.4.1",
         "@react-native-google-signin/google-signin": "^13.0.0",
@@ -45,6 +48,7 @@
         "expo-store-review": "^55.0.8",
         "expo-updates": "~29.0.16",
         "expo-web-browser": "~15.0.10",
+        "livekit-client": "^2.18.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -1579,6 +1583,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
@@ -1590,6 +1600,27 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/@elevenlabs/react-native": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/react-native/-/react-native-0.5.12.tgz",
+      "integrity": "sha512-QUdPNgIJUVrHfjlWq/Q5A652ptZoEk363p8xqY0zrlyX/OzSZtLZS/aN0pbWy3DOUteHU6yhqRcWU1/bMxVW7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/types": "0.6.1"
+      },
+      "peerDependencies": {
+        "@livekit/react-native": "^2.9.2",
+        "@livekit/react-native-webrtc": "^137.0.2",
+        "livekit-client": "^2.15.4",
+        "react": ">=17.0.0",
+        "react-native": ">=0.70.0"
+      }
+    },
+    "node_modules/@elevenlabs/types": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/types/-/types-0.6.1.tgz",
+      "integrity": "sha512-SNFrKWw5w/JHy9QGt3WWBj0kc71diPRuXHc/7/hdr46ghYz8mTPlFZJBmSPGwXQAfS29jxYXojEmBfKKfgoPCQ=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -2383,6 +2414,31 @@
         "excpretty": "build/cli.js"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@gorhom/bottom-sheet": {
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.8.tgz",
@@ -3175,6 +3231,173 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@livekit/components-core": {
+      "version": "0.12.13",
+      "resolved": "https://registry.npmjs.org/@livekit/components-core/-/components-core-0.12.13.tgz",
+      "integrity": "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@floating-ui/dom": "1.7.4",
+        "loglevel": "1.9.1",
+        "rxjs": "7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "livekit-client": "^2.17.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@livekit/components-core/node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.44.0.tgz",
+      "integrity": "sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@livekit/react-native": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native/-/react-native-2.9.6.tgz",
+      "integrity": "sha512-4DOFJ/OO4yftZbm90QnVMDjwFXqSw2hcruSVO2idgwFxylDmH6NN2e1rs5ZCQPsnqlfwuMGz8vNfuYt++G4C/A==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@livekit/components-react": "^2.9.17",
+        "@livekit/mutex": "^1.1.1",
+        "array.prototype.at": "^1.1.1",
+        "base64-js": "1.5.1",
+        "event-target-shim": "6.0.2",
+        "events": "^3.3.0",
+        "loglevel": "^1.8.0",
+        "promise.allsettled": "^1.0.5",
+        "react-native-url-polyfill": "^1.3.0",
+        "typed-emitter": "^2.1.0",
+        "web-streams-polyfill": "^4.1.0",
+        "well-known-symbols": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@livekit/react-native-webrtc": "^137.0.2",
+        "livekit-client": "^2.15.8",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc": {
+      "version": "137.0.2",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native-webrtc/-/react-native-webrtc-137.0.2.tgz",
+      "integrity": "sha512-0aXYATcBraOMDTteKzmfH5ICNHw8xFyMPHmhKg14+94fAGZ2hGjdHZUSkzL14+e508W486aIAmbXipuSQCCJgA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "debug": "4.3.4",
+        "event-target-shim": "6.0.2"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/@livekit/react-native/node_modules/@livekit/components-react": {
+      "version": "2.9.20",
+      "resolved": "https://registry.npmjs.org/@livekit/components-react/-/components-react-2.9.20.tgz",
+      "integrity": "sha512-hjkYOsJj9Jbghb7wM5cI8HoVisKeL6Zcy1VnRWTLm0sqVbto8GJp/17T4Udx85mCPY6Jgh8I1Cv0yVzgz7CQtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/components-core": "0.12.13",
+        "clsx": "2.1.1",
+        "events": "^3.3.0",
+        "jose": "^6.0.12",
+        "usehooks-ts": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0",
+        "livekit-client": "^2.17.2",
+        "react": ">=18",
+        "react-dom": ">=18",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "@livekit/krisp-noise-filter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@livekit/react-native/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3955,6 +4178,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -4528,7 +4758,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -4572,6 +4801,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.at": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.at/-/array.prototype.at-1.1.3.tgz",
+      "integrity": "sha512-TX4J1Uig4skvpOakrvP8q/uyhUj+ZDNmQoZpHf3MsKTrXcMHDPrgJlpv2nRJMfANrsmhg1JoOGrg3yOp209SWg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -4633,6 +4881,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array.prototype.map": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.8.tgz",
+      "integrity": "sha512-YocPM7bYYu2hXGxWpb5vwZ8cMeudNHYtYBcUDY4Z1GWa53qcnQMWSl25jeBHNzitjl9HW2AWW4ro/S/nftUaOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "es-object-atoms": "^1.0.0",
+        "is-string": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
@@ -4654,7 +4923,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -4695,7 +4963,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5400,6 +5667,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5813,7 +6089,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -5831,7 +6106,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -5849,7 +6123,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6304,7 +6577,6 @@
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
       "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -6369,6 +6641,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -6385,6 +6663,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-iterator-helpers": {
@@ -6431,7 +6729,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6447,7 +6744,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
       "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6460,7 +6756,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7",
@@ -6839,6 +7134,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/exec-async": {
@@ -8621,7 +8925,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
       "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -8642,7 +8945,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8747,7 +9049,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8851,7 +9152,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -8914,7 +9214,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8948,7 +9247,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.0"
@@ -9306,7 +9604,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9346,7 +9643,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -9370,7 +9666,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-function": "^1.0.0",
@@ -9390,7 +9685,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
@@ -9406,7 +9700,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9450,7 +9743,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9468,7 +9760,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9510,7 +9801,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -9577,7 +9867,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9606,7 +9895,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9628,7 +9916,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9689,7 +9976,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9702,7 +9988,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -9731,7 +10016,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9748,7 +10032,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9781,7 +10064,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9794,7 +10076,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -9810,7 +10091,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9839,7 +10119,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -9925,6 +10204,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iterate-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
+      "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/iterator.prototype": {
@@ -10846,6 +11147,15 @@
       "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==",
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11410,6 +11720,26 @@
         "uc.micro": "^1.0.1"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.18.0.tgz",
+      "integrity": "sha512-wjH4y0rw5fnkPmmaxutPhD4XcAq6goQszS8lw9PEpGXVwiRE6sI/ZH+mOT/s8AHJnEC3tjmfiMZ4MQt8BlaWew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.44.0",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -11533,6 +11863,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/loose-envify": {
@@ -12314,7 +12657,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12611,7 +12953,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.6",
@@ -13146,6 +13487,26 @@
         "asap": "~2.0.6"
       }
     },
+    "node_modules/promise.allsettled": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.7.tgz",
+      "integrity": "sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==",
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.map": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
+        "iterate-value": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -13567,6 +13928,18 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-url-polyfill": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
+      "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-web": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
@@ -13857,7 +14230,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -13904,7 +14276,6 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -14186,11 +14557,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
       "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -14230,7 +14609,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14294,6 +14672,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
+      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -14433,7 +14826,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -14449,7 +14841,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -14524,7 +14915,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14544,7 +14934,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14561,7 +14950,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14580,7 +14968,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14802,7 +15189,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14916,7 +15302,6 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
       "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -14938,7 +15323,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
       "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -14957,7 +15341,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -15461,7 +15844,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15476,7 +15858,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -15496,7 +15877,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -15518,7 +15898,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -15533,6 +15912,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typescript": {
@@ -15585,7 +15973,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15796,6 +16183,21 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
+      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/util": {
@@ -16095,11 +16497,51 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.2.0.tgz",
+      "integrity": "sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==",
+      "license": "MIT",
+      "workspaces": [
+        "test/benchmark-test",
+        "test/rollup-test",
+        "test/webpack-test"
+      ],
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.4.tgz",
+      "integrity": "sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
+    "node_modules/well-known-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-4.1.0.tgz",
+      "integrity": "sha512-lKhCpGfPkaJnPKyep1Uj44pNmyrdupYHtxci2ThUCC/Y0px44d9BWt2dbewDif4PwOqSI6KkCdwuL22CDUj4rw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.7",
+        "has-symbols": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
@@ -16183,7 +16625,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
@@ -16203,7 +16644,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -16231,7 +16671,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -24,8 +24,11 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@elevenlabs/react-native": "^0.5.12",
     "@expo/vector-icons": "^15.0.3",
     "@gorhom/bottom-sheet": "^5.2.8",
+    "@livekit/react-native": "^2.9.6",
+    "@livekit/react-native-webrtc": "^137.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-google-signin/google-signin": "^13.0.0",
@@ -61,6 +64,7 @@
     "expo-store-review": "^55.0.8",
     "expo-updates": "~29.0.16",
     "expo-web-browser": "~15.0.10",
+    "livekit-client": "^2.18.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/mobile/src/components/voice/VoiceButton.tsx
+++ b/mobile/src/components/voice/VoiceButton.tsx
@@ -1,0 +1,165 @@
+/**
+ * VoiceButton — FAB for voice chat with ElevenLabs
+ * Circular 56px button, gold accent, pulse animation, plan-gated
+ */
+
+import React, { useCallback } from 'react';
+import { Alert, Pressable, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSpring,
+  withDelay,
+  withSequence,
+  runOnJS,
+} from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
+import { useTheme } from '../../contexts/ThemeContext';
+import { useVoiceChatGate } from '../../contexts/PlanContext';
+import { palette } from '../../theme/colors';
+import { shadows } from '../../theme/shadows';
+
+interface VoiceButtonProps {
+  summaryId: string;
+  videoTitle: string;
+  onSessionStart?: () => void;
+  disabled?: boolean;
+}
+
+const BUTTON_SIZE = 56;
+const RING_SIZE = 72;
+
+export const VoiceButton: React.FC<VoiceButtonProps> = ({
+  summaryId,
+  videoTitle,
+  onSessionStart,
+  disabled = false,
+}) => {
+  const { colors } = useTheme();
+  const { enabled, requiresUpgrade } = useVoiceChatGate();
+
+  // Pulse ring animation
+  const ringScale = useSharedValue(1);
+  const ringOpacity = useSharedValue(0.5);
+
+  React.useEffect(() => {
+    ringScale.value = withRepeat(
+      withSequence(
+        withSpring(1.3, { damping: 8, stiffness: 80, mass: 0.8 }),
+        withSpring(1, { damping: 12, stiffness: 100, mass: 0.8 }),
+      ),
+      -1,
+      false,
+    );
+    ringOpacity.value = withRepeat(
+      withSequence(
+        withSpring(0.15, { damping: 10, stiffness: 60 }),
+        withSpring(0.5, { damping: 10, stiffness: 60 }),
+      ),
+      -1,
+      false,
+    );
+  }, [ringScale, ringOpacity]);
+
+  const ringAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: ringScale.value }],
+    opacity: ringOpacity.value,
+  }));
+
+  const handlePress = useCallback(() => {
+    if (disabled) return;
+
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+
+    if (requiresUpgrade) {
+      Alert.alert(
+        'Fonctionnalité Premium',
+        'Le chat vocal est disponible avec un abonnement supérieur. Mettez à niveau pour débloquer cette fonctionnalité.',
+        [
+          { text: 'Plus tard', style: 'cancel' },
+          { text: 'Voir les plans', style: 'default' },
+        ],
+      );
+      return;
+    }
+
+    onSessionStart?.();
+  }, [disabled, requiresUpgrade, onSessionStart]);
+
+  const iconName = requiresUpgrade ? 'lock-closed-outline' : 'mic-outline';
+  const buttonOpacity = disabled ? 0.5 : 1;
+  const glowShadow = shadows.glow(palette.gold);
+
+  return (
+    <View
+      style={styles.container}
+      pointerEvents={disabled ? 'none' : 'auto'}
+    >
+      {/* Pulse ring (only when feature is available) */}
+      {enabled && !disabled && (
+        <Animated.View
+          style={[
+            styles.ring,
+            { borderColor: palette.gold },
+            ringAnimatedStyle,
+          ]}
+        />
+      )}
+
+      <Pressable
+        onPress={handlePress}
+        disabled={disabled}
+        style={({ pressed }) => [
+          styles.button,
+          {
+            backgroundColor: palette.gold,
+            opacity: pressed ? buttonOpacity * 0.85 : buttonOpacity,
+            ...glowShadow,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={
+          requiresUpgrade
+            ? 'Chat vocal — plan premium requis'
+            : `Démarrer le chat vocal pour ${videoTitle}`
+        }
+        accessibilityHint={
+          requiresUpgrade
+            ? 'Appuyez pour voir les plans disponibles'
+            : 'Appuyez pour démarrer une conversation vocale avec l\'IA'
+        }
+      >
+        <Ionicons name={iconName} size={24} color={palette.white} />
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 24,
+    right: 16,
+    width: RING_SIZE,
+    height: RING_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 100,
+  },
+  ring: {
+    position: 'absolute',
+    width: RING_SIZE,
+    height: RING_SIZE,
+    borderRadius: RING_SIZE / 2,
+    borderWidth: 2,
+  },
+  button: {
+    width: BUTTON_SIZE,
+    height: BUTTON_SIZE,
+    borderRadius: BUTTON_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/src/components/voice/VoiceScreen.tsx
+++ b/mobile/src/components/voice/VoiceScreen.tsx
@@ -1,0 +1,710 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  Modal,
+  FlatList,
+  ActivityIndicator,
+  StyleSheet,
+  Platform,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withSpring,
+  withTiming,
+  withSequence,
+  withDelay,
+  FadeIn,
+  SlideInDown,
+  Easing,
+} from 'react-native-reanimated';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { useTheme } from '@/contexts/ThemeContext';
+import { sp, borderRadius } from '@/theme/spacing';
+import { fontFamily, fontSize } from '@/theme/typography';
+import { palette } from '@/theme/colors';
+import { duration } from '@/theme/animations';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface VoiceMessage {
+  text: string;
+  source: 'user' | 'ai';
+}
+
+interface VoiceScreenProps {
+  visible: boolean;
+  onClose: () => void;
+  videoTitle: string;
+  channelName?: string;
+  voiceStatus:
+    | 'idle'
+    | 'connecting'
+    | 'listening'
+    | 'thinking'
+    | 'speaking'
+    | 'error'
+    | 'quota_exceeded';
+  isSpeaking: boolean;
+  messages: VoiceMessage[];
+  elapsedSeconds: number;
+  remainingMinutes: number;
+  onStart: () => void;
+  onStop: () => void;
+  onMuteToggle: () => void;
+  isMuted: boolean;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatTime = (totalSeconds: number): string => {
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+};
+
+const formatMinutes = (minutes: number): string => {
+  const m = Math.floor(minutes);
+  const s = Math.round((minutes - m) * 60);
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+/** Pulsing circle animation for the "listening" state */
+const PulsingCircle: React.FC<{ color: string }> = ({ color }) => {
+  const scale = useSharedValue(1);
+  const opacity = useSharedValue(0.5);
+
+  useEffect(() => {
+    scale.value = withRepeat(
+      withSpring(1.3, { damping: 8, stiffness: 80, mass: 1 }),
+      -1,
+      true,
+    );
+    opacity.value = withRepeat(
+      withTiming(0.15, { duration: 1200, easing: Easing.inOut(Easing.ease) }),
+      -1,
+      true,
+    );
+  }, [scale, opacity]);
+
+  const ringStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+    opacity: opacity.value,
+  }));
+
+  const innerStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: 1 + (scale.value - 1) * 0.3 }],
+  }));
+
+  return (
+    <View style={styles.pulseContainer}>
+      <Animated.View style={[styles.pulseRingOuter, { borderColor: color }, ringStyle]} />
+      <Animated.View style={[styles.pulseRing, { borderColor: color }, ringStyle]} />
+      <Animated.View style={[styles.pulseCore, { backgroundColor: color }, innerStyle]}>
+        <Ionicons name="mic" size={36} color={palette.white} />
+      </Animated.View>
+    </View>
+  );
+};
+
+/** Three animated dots for "thinking" state */
+const ThinkingDots: React.FC<{ color: string }> = ({ color }) => {
+  const dot1 = useSharedValue(0);
+  const dot2 = useSharedValue(0);
+  const dot3 = useSharedValue(0);
+
+  useEffect(() => {
+    const bounce = (sv: Animated.SharedValue<number>, delay: number) => {
+      sv.value = withDelay(
+        delay,
+        withRepeat(
+          withSequence(
+            withTiming(-10, { duration: 300, easing: Easing.out(Easing.ease) }),
+            withTiming(0, { duration: 300, easing: Easing.in(Easing.ease) }),
+          ),
+          -1,
+          false,
+        ),
+      );
+    };
+    bounce(dot1, 0);
+    bounce(dot2, 150);
+    bounce(dot3, 300);
+  }, [dot1, dot2, dot3]);
+
+  const s1 = useAnimatedStyle(() => ({ transform: [{ translateY: dot1.value }] }));
+  const s2 = useAnimatedStyle(() => ({ transform: [{ translateY: dot2.value }] }));
+  const s3 = useAnimatedStyle(() => ({ transform: [{ translateY: dot3.value }] }));
+
+  return (
+    <View style={styles.dotsRow}>
+      <Animated.View style={[styles.dot, { backgroundColor: color }, s1]} />
+      <Animated.View style={[styles.dot, { backgroundColor: color }, s2]} />
+      <Animated.View style={[styles.dot, { backgroundColor: color }, s3]} />
+    </View>
+  );
+};
+
+/** Simple waveform placeholder for "speaking" state */
+const WaveformPlaceholder: React.FC<{ color: string }> = ({ color }) => {
+  const bars = [0.4, 0.7, 1, 0.6, 0.9, 0.5, 0.8, 0.3];
+
+  return (
+    <View style={styles.waveRow}>
+      {bars.map((h, i) => {
+        const barScale = useSharedValue(h);
+
+        useEffect(() => {
+          barScale.value = withDelay(
+            i * 80,
+            withRepeat(
+              withSequence(
+                withTiming(1, { duration: 400 + i * 40, easing: Easing.inOut(Easing.ease) }),
+                withTiming(h * 0.4, { duration: 400 + i * 40, easing: Easing.inOut(Easing.ease) }),
+              ),
+              -1,
+              true,
+            ),
+          );
+        }, [barScale, h, i]);
+
+        const barStyle = useAnimatedStyle(() => ({
+          transform: [{ scaleY: barScale.value }],
+        }));
+
+        return (
+          <Animated.View
+            key={i}
+            style={[styles.waveBar, { backgroundColor: color }, barStyle]}
+          />
+        );
+      })}
+    </View>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const VoiceScreen: React.FC<VoiceScreenProps> = ({
+  visible,
+  onClose,
+  videoTitle,
+  channelName,
+  voiceStatus,
+  isSpeaking: _isSpeaking,
+  messages,
+  elapsedSeconds,
+  remainingMinutes,
+  onStart,
+  onStop,
+  onMuteToggle,
+  isMuted,
+  error,
+}) => {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  // Haptic feedback on start / stop
+  const handleStart = useCallback(() => {
+    if (Platform.OS !== 'web') {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    }
+    onStart();
+  }, [onStart]);
+
+  const handleStop = useCallback(() => {
+    if (Platform.OS !== 'web') {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+    }
+    onStop();
+  }, [onStop]);
+
+  // Whether the session is active (not idle / not error states)
+  const isActive = voiceStatus !== 'idle' && voiceStatus !== 'error' && voiceStatus !== 'quota_exceeded';
+
+  // ------- Centre content by status -------
+  const renderCenter = () => {
+    switch (voiceStatus) {
+      case 'idle':
+        return (
+          <Pressable
+            onPress={handleStart}
+            style={({ pressed }) => [
+              styles.startButton,
+              { backgroundColor: colors.accentPrimary, opacity: pressed ? 0.85 : 1 },
+            ]}
+          >
+            <Ionicons name="mic" size={28} color={palette.white} />
+            <Text style={[styles.startText, { color: palette.white }]}>Démarrer</Text>
+          </Pressable>
+        );
+
+      case 'connecting':
+        return (
+          <View style={styles.centerColumn}>
+            <ActivityIndicator size="large" color={colors.accentPrimary} />
+            <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>
+              Connexion...
+            </Text>
+          </View>
+        );
+
+      case 'listening':
+        return (
+          <View style={styles.centerColumn}>
+            <PulsingCircle color={colors.accentPrimary} />
+            <Text style={[styles.statusLabel, { color: colors.textSecondary, marginTop: sp['2xl'] }]}>
+              À l'écoute...
+            </Text>
+          </View>
+        );
+
+      case 'thinking':
+        return (
+          <View style={styles.centerColumn}>
+            <ThinkingDots color={colors.accentPrimary} />
+            <Text style={[styles.statusLabel, { color: colors.textSecondary, marginTop: sp.xl }]}>
+              Réflexion...
+            </Text>
+          </View>
+        );
+
+      case 'speaking':
+        return (
+          <View style={styles.centerColumn}>
+            <WaveformPlaceholder color={colors.accentPrimary} />
+            <Text style={[styles.statusLabel, { color: colors.textSecondary, marginTop: sp.xl }]}>
+              DeepSight parle...
+            </Text>
+          </View>
+        );
+
+      case 'error':
+        return (
+          <View style={styles.centerColumn}>
+            <Ionicons name="alert-circle" size={48} color={palette.red} />
+            <Text style={[styles.errorText, { color: palette.red }]}>
+              {error || 'Une erreur est survenue'}
+            </Text>
+            <Pressable
+              onPress={handleStart}
+              style={({ pressed }) => [
+                styles.retryButton,
+                { borderColor: palette.red, opacity: pressed ? 0.7 : 1 },
+              ]}
+            >
+              <Text style={[styles.retryLabel, { color: palette.red }]}>Réessayer</Text>
+            </Pressable>
+          </View>
+        );
+
+      case 'quota_exceeded':
+        return (
+          <View style={styles.centerColumn}>
+            <Ionicons name="timer-outline" size={48} color={colors.accentWarning} />
+            <Text style={[styles.errorText, { color: colors.textPrimary }]}>
+              Quota de conversation vocale atteint
+            </Text>
+            <Pressable
+              onPress={onClose}
+              style={({ pressed }) => [
+                styles.upgradeButton,
+                { backgroundColor: colors.accentPrimary, opacity: pressed ? 0.85 : 1 },
+              ]}
+            >
+              <Text style={[styles.upgradeLabel, { color: palette.white }]}>
+                Passer au plan supérieur
+              </Text>
+            </Pressable>
+          </View>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  // ------- Transcript bubble renderer -------
+  const renderMessage = useCallback(
+    ({ item }: { item: VoiceMessage }) => {
+      const isUser = item.source === 'user';
+      return (
+        <View
+          style={[
+            styles.bubble,
+            isUser ? styles.bubbleUser : styles.bubbleAI,
+            {
+              backgroundColor: isUser ? colors.accentPrimary : colors.bgTertiary,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.bubbleText,
+              { color: isUser ? palette.white : colors.textPrimary },
+            ]}
+          >
+            {item.text}
+          </Text>
+        </View>
+      );
+    },
+    [colors],
+  );
+
+  const keyExtractor = useCallback(
+    (_item: VoiceMessage, index: number) => `voice-msg-${index}`,
+    [],
+  );
+
+  // ------- Timer display -------
+  const timerDisplay = useMemo(() => {
+    return `${formatTime(elapsedSeconds)} / ${formatMinutes(remainingMinutes)} restantes`;
+  }, [elapsedSeconds, remainingMinutes]);
+
+  // ------- Render -------
+  return (
+    <Modal
+      visible={visible}
+      animationType="none"
+      transparent
+      statusBarTranslucent
+      onRequestClose={onClose}
+    >
+      <Animated.View
+        entering={FadeIn.duration(duration.slow)}
+        style={[styles.root, { backgroundColor: colors.bgPrimary }]}
+      >
+        <Animated.View
+          entering={SlideInDown.duration(duration.slower).springify()}
+          style={[
+            styles.innerContainer,
+            {
+              paddingTop: insets.top + sp.sm,
+              paddingBottom: insets.bottom + sp.sm,
+            },
+          ]}
+        >
+          {/* ---- Header ---- */}
+          <View style={styles.header}>
+            <View style={styles.headerTitles}>
+              <Text
+                numberOfLines={1}
+                style={[styles.videoTitle, { color: colors.textPrimary }]}
+              >
+                {videoTitle}
+              </Text>
+              {channelName ? (
+                <Text
+                  numberOfLines={1}
+                  style={[styles.channelName, { color: colors.textTertiary }]}
+                >
+                  {channelName}
+                </Text>
+              ) : null}
+            </View>
+            <Pressable
+              onPress={onClose}
+              hitSlop={12}
+              style={({ pressed }) => [
+                styles.closeButton,
+                { backgroundColor: colors.bgTertiary, opacity: pressed ? 0.7 : 1 },
+              ]}
+            >
+              <Ionicons name="close" size={22} color={colors.textSecondary} />
+            </Pressable>
+          </View>
+
+          {/* ---- Centre ---- */}
+          <View style={styles.center}>{renderCenter()}</View>
+
+          {/* ---- Transcript ---- */}
+          {messages.length > 0 && (
+            <View style={styles.transcriptContainer}>
+              <FlatList
+                data={messages}
+                renderItem={renderMessage}
+                keyExtractor={keyExtractor}
+                inverted
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={styles.transcriptContent}
+              />
+            </View>
+          )}
+
+          {/* ---- Footer ---- */}
+          {isActive && (
+            <View style={[styles.footer, { borderTopColor: colors.border }]}>
+              {/* Mute button */}
+              <Pressable
+                onPress={onMuteToggle}
+                style={({ pressed }) => [
+                  styles.footerButton,
+                  {
+                    backgroundColor: isMuted ? colors.bgTertiary : colors.bgSecondary,
+                    opacity: pressed ? 0.7 : 1,
+                  },
+                ]}
+              >
+                <Ionicons
+                  name={isMuted ? 'mic-off' : 'mic'}
+                  size={24}
+                  color={isMuted ? palette.red : colors.textPrimary}
+                />
+              </Pressable>
+
+              {/* Timer */}
+              <Text style={[styles.timer, { color: colors.textSecondary }]}>
+                {timerDisplay}
+              </Text>
+
+              {/* End button */}
+              <Pressable
+                onPress={handleStop}
+                style={({ pressed }) => [
+                  styles.endButton,
+                  { opacity: pressed ? 0.8 : 1 },
+                ]}
+              >
+                <Ionicons name="stop" size={20} color={palette.white} />
+              </Pressable>
+            </View>
+          )}
+        </Animated.View>
+      </Animated.View>
+    </Modal>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  innerContainer: {
+    flex: 1,
+    paddingHorizontal: sp.lg,
+  },
+
+  // Header
+  header: {
+    height: 60,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  headerTitles: {
+    flex: 1,
+    marginRight: sp.md,
+  },
+  videoTitle: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+  },
+  channelName: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+    marginTop: 2,
+  },
+  closeButton: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // Centre
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  centerColumn: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  statusLabel: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.lg,
+    marginTop: sp.lg,
+  },
+
+  // Start button
+  startButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+    paddingVertical: sp.lg,
+    borderRadius: 40,
+    gap: sp.sm,
+  },
+  startText: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.lg,
+  },
+
+  // Error state
+  errorText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.base,
+    textAlign: 'center',
+    marginTop: sp.lg,
+    marginHorizontal: sp['3xl'],
+  },
+  retryButton: {
+    marginTop: sp.xl,
+    paddingHorizontal: sp['2xl'],
+    paddingVertical: sp.md,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1.5,
+  },
+  retryLabel: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+  },
+
+  // Quota exceeded
+  upgradeButton: {
+    marginTop: sp.xl,
+    paddingHorizontal: sp['2xl'],
+    paddingVertical: sp.md,
+    borderRadius: borderRadius.lg,
+  },
+  upgradeLabel: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+  },
+
+  // Pulse animation
+  pulseContainer: {
+    width: 140,
+    height: 140,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pulseRingOuter: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 70,
+    borderWidth: 1,
+  },
+  pulseRing: {
+    position: 'absolute',
+    top: 15,
+    left: 15,
+    right: 15,
+    bottom: 15,
+    borderRadius: 55,
+    borderWidth: 2,
+  },
+  pulseCore: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // Thinking dots
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 10,
+    alignItems: 'center',
+    height: 40,
+  },
+  dot: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+  },
+
+  // Waveform
+  waveRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    height: 60,
+  },
+  waveBar: {
+    width: 6,
+    height: 40,
+    borderRadius: 3,
+  },
+
+  // Transcript
+  transcriptContainer: {
+    maxHeight: 200,
+  },
+  transcriptContent: {
+    paddingVertical: sp.sm,
+    gap: sp.sm,
+  },
+  bubble: {
+    maxWidth: '80%',
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.sm,
+    borderRadius: borderRadius.lg,
+  },
+  bubbleUser: {
+    alignSelf: 'flex-end',
+    borderBottomRightRadius: borderRadius.sm,
+  },
+  bubbleAI: {
+    alignSelf: 'flex-start',
+    borderBottomLeftRadius: borderRadius.sm,
+  },
+  bubbleText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    lineHeight: fontSize.sm * 1.5,
+  },
+
+  // Footer
+  footer: {
+    height: 80,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: sp.sm,
+  },
+  footerButton: {
+    width: 48,
+    height: 48,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  timer: {
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.sm,
+  },
+  endButton: {
+    width: 48,
+    height: 48,
+    borderRadius: borderRadius.full,
+    backgroundColor: palette.red,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default VoiceScreen;

--- a/mobile/src/components/voice/VoiceScreen.tsx
+++ b/mobile/src/components/voice/VoiceScreen.tsx
@@ -159,40 +159,49 @@ const ThinkingDots: React.FC<{ color: string }> = ({ color }) => {
   );
 };
 
+/** Single animated bar — extracted to respect Rules of Hooks */
+const WaveformBar: React.FC<{ targetHeight: number; color: string; index: number }> = ({
+  targetHeight,
+  color,
+  index,
+}) => {
+  const barScale = useSharedValue(targetHeight);
+
+  useEffect(() => {
+    barScale.value = withDelay(
+      index * 80,
+      withRepeat(
+        withSequence(
+          withTiming(1, { duration: 400 + index * 40, easing: Easing.inOut(Easing.ease) }),
+          withTiming(targetHeight * 0.4, {
+            duration: 400 + index * 40,
+            easing: Easing.inOut(Easing.ease),
+          }),
+        ),
+        -1,
+        true,
+      ),
+    );
+  }, [barScale, targetHeight, index]);
+
+  const barStyle = useAnimatedStyle(() => ({
+    transform: [{ scaleY: barScale.value }],
+  }));
+
+  return (
+    <Animated.View style={[styles.waveBar, { backgroundColor: color }, barStyle]} />
+  );
+};
+
 /** Simple waveform placeholder for "speaking" state */
 const WaveformPlaceholder: React.FC<{ color: string }> = ({ color }) => {
   const bars = [0.4, 0.7, 1, 0.6, 0.9, 0.5, 0.8, 0.3];
 
   return (
     <View style={styles.waveRow}>
-      {bars.map((h, i) => {
-        const barScale = useSharedValue(h);
-
-        useEffect(() => {
-          barScale.value = withDelay(
-            i * 80,
-            withRepeat(
-              withSequence(
-                withTiming(1, { duration: 400 + i * 40, easing: Easing.inOut(Easing.ease) }),
-                withTiming(h * 0.4, { duration: 400 + i * 40, easing: Easing.inOut(Easing.ease) }),
-              ),
-              -1,
-              true,
-            ),
-          );
-        }, [barScale, h, i]);
-
-        const barStyle = useAnimatedStyle(() => ({
-          transform: [{ scaleY: barScale.value }],
-        }));
-
-        return (
-          <Animated.View
-            key={i}
-            style={[styles.waveBar, { backgroundColor: color }, barStyle]}
-          />
-        );
-      })}
+      {bars.map((h, i) => (
+        <WaveformBar key={i} targetHeight={h} color={color} index={i} />
+      ))}
     </View>
   );
 };

--- a/mobile/src/components/voice/useVoiceChat.ts
+++ b/mobile/src/components/voice/useVoiceChat.ts
@@ -1,0 +1,437 @@
+/**
+ * useVoiceChat — Hook d'orchestration de conversation vocale (React Native)
+ * Gère le cycle complet : permissions micro → API session → ElevenLabs → timer → cleanup
+ * Adapté du hook web avec gestion AppState, expo-av, et haptics.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { Audio } from 'expo-av';
+import * as Haptics from 'expo-haptics';
+import { voiceApi } from '../../services/api';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface UseVoiceChatOptions {
+  summaryId: string;
+  onError?: (error: string) => void;
+}
+
+type VoiceChatStatus =
+  | 'idle'
+  | 'connecting'
+  | 'listening'
+  | 'thinking'
+  | 'speaking'
+  | 'error'
+  | 'quota_exceeded';
+
+interface VoiceChatMessage {
+  text: string;
+  source: 'user' | 'ai';
+}
+
+interface SessionResponse {
+  session_id: string;
+  signed_url: string;
+  expires_at: string;
+  quota_remaining_minutes: number;
+  max_session_minutes: number;
+}
+
+interface UseVoiceChatReturn {
+  /** Démarrer la conversation */
+  start: () => Promise<void>;
+  /** Arrêter la conversation */
+  stop: () => Promise<void>;
+  /** Toggle mute micro */
+  toggleMute: () => void;
+  /** Status de la connexion */
+  status: VoiceChatStatus;
+  /** L'IA est en train de parler */
+  isSpeaking: boolean;
+  /** Le micro est muted */
+  isMuted: boolean;
+  /** Messages de la conversation */
+  messages: VoiceChatMessage[];
+  /** Secondes écoulées dans la session */
+  elapsedSeconds: number;
+  /** Minutes restantes dans le quota */
+  remainingMinutes: number;
+  /** Erreur */
+  error: string | null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Erreurs françaises (adaptées mobile)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const ERROR_MESSAGES = {
+  MICROPHONE_DENIED:
+    "Autorisez l'accès au micro dans les réglages de votre appareil.",
+  MICROPHONE_GENERIC:
+    "Impossible d'accéder au microphone. Vérifiez vos permissions.",
+  NETWORK: 'Vérifiez votre connexion internet et réessayez.',
+  QUOTA_EXCEEDED: 'Quota vocal épuisé. Passez à un plan supérieur pour continuer.',
+  SESSION_FAILED: 'Impossible de démarrer la session vocale. Réessayez.',
+  SDK_LOAD_FAILED: 'Impossible de charger le module de conversation vocale.',
+  SESSION_TIMEOUT: 'Session terminée : durée maximale atteinte.',
+  APP_BACKGROUNDED: 'Session arrêtée car l\'application est passée en arrière-plan.',
+  UNKNOWN: 'Une erreur inattendue est survenue. Réessayez.',
+} as const;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hook
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export function useVoiceChat({
+  summaryId,
+  onError,
+}: UseVoiceChatOptions): UseVoiceChatReturn {
+  const [status, setStatus] = useState<VoiceChatStatus>('idle');
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
+  const [messages, setMessages] = useState<VoiceChatMessage[]>([]);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [remainingMinutes, setRemainingMinutes] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  // Refs pour le cleanup
+  const conversationRef = useRef<unknown>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const maxSecondsRef = useRef<number>(0);
+  const isMountedRef = useRef(true);
+  const isActiveRef = useRef(false);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const reportError = useCallback(
+    (msg: string) => {
+      setError(msg);
+      setStatus('error');
+      onError?.(msg);
+    },
+    [onError],
+  );
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // stop()
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const stop = useCallback(async () => {
+    stopTimer();
+    isActiveRef.current = false;
+
+    // End ElevenLabs session
+    if (conversationRef.current) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (conversationRef.current as any).endSession();
+      } catch {
+        // Ignorer les erreurs de fin de session
+      }
+      conversationRef.current = null;
+    }
+
+    // Haptic feedback au stop
+    try {
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+    } catch {
+      // Haptics non disponibles (simulateur)
+    }
+
+    if (isMountedRef.current) {
+      setStatus('idle');
+      setIsSpeaking(false);
+      setIsMuted(false);
+      setElapsedSeconds(0);
+    }
+  }, [stopTimer]);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // start()
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const start = useCallback(async () => {
+    // Empêcher les démarrages multiples
+    if (
+      status === 'connecting' ||
+      status === 'listening' ||
+      status === 'speaking'
+    ) {
+      return;
+    }
+
+    setError(null);
+    setMessages([]);
+    setElapsedSeconds(0);
+    setStatus('connecting');
+
+    // 1. Demander la permission micro via expo-av
+    try {
+      const { granted } = await Audio.requestPermissionsAsync();
+      if (!granted) {
+        reportError(ERROR_MESSAGES.MICROPHONE_DENIED);
+        return;
+      }
+
+      // Configurer le mode audio pour l'enregistrement + lecture simultanée
+      await Audio.setAudioModeAsync({
+        allowsRecordingIOS: true,
+        playsInSilentModeIOS: true,
+        staysActiveInBackground: false,
+      });
+    } catch {
+      reportError(ERROR_MESSAGES.MICROPHONE_GENERIC);
+      return;
+    }
+
+    // 2. Créer la session via notre API
+    let sessionData: SessionResponse;
+    try {
+      const numericId = parseInt(summaryId, 10);
+      if (isNaN(numericId)) {
+        reportError(ERROR_MESSAGES.SESSION_FAILED);
+        return;
+      }
+
+      sessionData = await voiceApi.createSession(numericId, 'fr');
+      setRemainingMinutes(sessionData.quota_remaining_minutes);
+      maxSecondsRef.current = sessionData.max_session_minutes * 60;
+    } catch (err: unknown) {
+      // Vérifier si c'est une erreur de quota (403/429)
+      const apiError = err as { status?: number; message?: string };
+      if (apiError.status === 403 || apiError.status === 429) {
+        setStatus('quota_exceeded');
+        setError(ERROR_MESSAGES.QUOTA_EXCEEDED);
+        onError?.(ERROR_MESSAGES.QUOTA_EXCEEDED);
+        return;
+      }
+
+      // Erreur réseau vs autre
+      if (
+        err instanceof TypeError ||
+        (apiError.message && apiError.message.includes('network'))
+      ) {
+        reportError(ERROR_MESSAGES.NETWORK);
+      } else {
+        reportError(ERROR_MESSAGES.SESSION_FAILED);
+      }
+      return;
+    }
+
+    // 3. Charger le SDK ElevenLabs React Native et démarrer la session
+    try {
+      // TODO: Quand @elevenlabs/react-native sera installé, remplacer par :
+      // import { Conversation } from '@elevenlabs/react-native';
+      let Conversation: unknown;
+      try {
+        const elevenLabsModule = await import('@elevenlabs/react-native');
+        Conversation = (elevenLabsModule as { Conversation: unknown }).Conversation;
+      } catch {
+        // Fallback : tenter le client web (certaines API sont compatibles RN)
+        try {
+          const clientModule = await import('@elevenlabs/client');
+          Conversation = (clientModule as { Conversation: unknown }).Conversation;
+        } catch {
+          throw new Error('ElevenLabs SDK not available');
+        }
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const conversation = await (Conversation as any).startSession({
+        signedUrl: sessionData.signed_url,
+        onConnect: () => {
+          if (isMountedRef.current) {
+            setStatus('listening');
+          }
+        },
+        onDisconnect: () => {
+          if (isMountedRef.current) {
+            stopTimer();
+            isActiveRef.current = false;
+            setStatus('idle');
+            setIsSpeaking(false);
+          }
+        },
+        onMessage: (message: { message: string; source: 'user' | 'ai' }) => {
+          if (isMountedRef.current) {
+            setMessages((prev) => [
+              ...prev,
+              { text: message.message, source: message.source },
+            ]);
+          }
+        },
+        onError: (err: Error | string) => {
+          if (isMountedRef.current) {
+            const msg =
+              typeof err === 'string'
+                ? err
+                : err.message || ERROR_MESSAGES.UNKNOWN;
+            reportError(msg);
+          }
+        },
+        onStatusChange: (statusInfo: { status: string }) => {
+          if (!isMountedRef.current) return;
+          switch (statusInfo.status) {
+            case 'speaking':
+              setIsSpeaking(true);
+              setStatus('speaking');
+              break;
+            case 'listening':
+              setIsSpeaking(false);
+              setStatus('listening');
+              break;
+            case 'thinking':
+            case 'processing':
+              setIsSpeaking(false);
+              setStatus('thinking');
+              break;
+          }
+        },
+      });
+
+      conversationRef.current = conversation;
+      isActiveRef.current = true;
+
+      // Haptic feedback au start
+      try {
+        await Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success,
+        );
+      } catch {
+        // Haptics non disponibles (simulateur)
+      }
+
+      // 4. Démarrer le timer
+      timerRef.current = setInterval(() => {
+        if (!isMountedRef.current) return;
+        setElapsedSeconds((prev) => {
+          const next = prev + 1;
+          // Auto-stop si durée max atteinte
+          if (maxSecondsRef.current > 0 && next >= maxSecondsRef.current) {
+            stop();
+            setError(ERROR_MESSAGES.SESSION_TIMEOUT);
+          }
+          return next;
+        });
+      }, 1000);
+    } catch {
+      reportError(ERROR_MESSAGES.SDK_LOAD_FAILED);
+    }
+  }, [status, summaryId, onError, reportError, stopTimer, stop]);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // toggleMute()
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const toggleMute = useCallback(() => {
+    if (!conversationRef.current) return;
+
+    const nextMuted = !isMuted;
+
+    // Tenter de muter via le SDK ElevenLabs
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const conv = conversationRef.current as any;
+      if (typeof conv.setVolume === 'function') {
+        conv.setVolume({ inputVolume: nextMuted ? 0 : 1 });
+      }
+    } catch {
+      // Ignorer — le mute est géré côté état
+    }
+
+    // Haptic feedback au toggle
+    try {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    } catch {
+      // Haptics non disponibles
+    }
+
+    setIsMuted(nextMuted);
+  }, [isMuted]);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // AppState — auto-stop quand l'app passe en background
+  // ─────────────────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (
+        nextAppState === 'background' ||
+        nextAppState === 'inactive'
+      ) {
+        if (isActiveRef.current) {
+          stop();
+          if (isMountedRef.current) {
+            setError(ERROR_MESSAGES.APP_BACKGROUNDED);
+          }
+        }
+      }
+    };
+
+    const subscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange,
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [stop]);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Cleanup on unmount
+  // ─────────────────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      isActiveRef.current = false;
+      stopTimer();
+
+      // Fin de session ElevenLabs
+      if (conversationRef.current) {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (conversationRef.current as any).endSession();
+        } catch {
+          // Ignorer
+        }
+        conversationRef.current = null;
+      }
+
+      // Réinitialiser le mode audio
+      Audio.setAudioModeAsync({
+        allowsRecordingIOS: false,
+      }).catch(() => {
+        // Ignorer les erreurs de cleanup audio
+      });
+    };
+  }, [stopTimer]);
+
+  return {
+    start,
+    stop,
+    toggleMute,
+    status,
+    isSpeaking,
+    isMuted,
+    messages,
+    elapsedSeconds,
+    remainingMinutes,
+    error,
+  };
+}

--- a/mobile/src/components/voice/voiceAnalytics.ts
+++ b/mobile/src/components/voice/voiceAnalytics.ts
@@ -1,0 +1,96 @@
+/**
+ * Voice Chat Analytics — Tracking events pour mobile
+ *
+ * Utilise le service analytics mobile (batch upload vers backend)
+ * pour tracker les interactions voice chat : sessions, quotas, upgrades, erreurs.
+ *
+ * Usage :
+ *   import { VoiceAnalytics } from './voiceAnalytics';
+ *   VoiceAnalytics.trackStarted({ plan: 'pro', platform: 'mobile', summaryId: 42, language: 'fr' });
+ */
+
+import { analytics } from '../../services/analytics';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Event names (type-safe constants)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const VoiceAnalyticsEvents = {
+  STARTED: 'voice_chat_started',
+  ENDED: 'voice_chat_ended',
+  QUOTA_WARNING: 'voice_chat_quota_warning',
+  QUOTA_REACHED: 'voice_chat_quota_reached',
+  ADDON_PURCHASED: 'voice_chat_addon_purchased',
+  UPGRADE_CLICKED: 'voice_chat_upgrade_clicked',
+  ERROR: 'voice_chat_error',
+} as const;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Typed event helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const VoiceAnalytics = {
+  /** Debut de session voice */
+  trackStarted(data: { plan: string; platform: string; summaryId: number; language: string }) {
+    analytics.track('voice_chat_started' as any, {
+      plan: data.plan,
+      platform: data.platform,
+      summary_id: data.summaryId,
+      language: data.language,
+    });
+  },
+
+  /** Fin de session voice */
+  trackEnded(data: { durationSeconds: number; plan: string; platform: string; summaryId: number }) {
+    analytics.track('voice_chat_ended' as any, {
+      duration_seconds: data.durationSeconds,
+      plan: data.plan,
+      platform: data.platform,
+      summary_id: data.summaryId,
+    });
+  },
+
+  /** Alerte quota (80%, 90%, etc.) */
+  trackQuotaWarning(data: { percentUsed: number; plan: string; remainingSeconds: number }) {
+    analytics.track('voice_chat_quota_warning' as any, {
+      percent_used: data.percentUsed,
+      plan: data.plan,
+      remaining_seconds: data.remainingSeconds,
+    });
+  },
+
+  /** Quota atteint — session bloquee */
+  trackQuotaReached(data: { plan: string; totalSecondsUsed: number }) {
+    analytics.track('voice_chat_quota_reached' as any, {
+      plan: data.plan,
+      total_seconds_used: data.totalSecondsUsed,
+    });
+  },
+
+  /** Add-on minutes achete */
+  trackAddonPurchased(data: { packMinutes: number; priceCents: number; plan: string }) {
+    analytics.track('voice_chat_addon_purchased' as any, {
+      pack_minutes: data.packMinutes,
+      price_cents: data.priceCents,
+      plan: data.plan,
+    });
+  },
+
+  /** CTA upgrade clique depuis voice chat */
+  trackUpgradeClicked(data: { currentPlan: string; targetPlan?: string; trigger: string }) {
+    analytics.track('voice_chat_upgrade_clicked' as any, {
+      current_plan: data.currentPlan,
+      target_plan: data.targetPlan ?? null,
+      trigger: data.trigger,
+    });
+  },
+
+  /** Erreur technique (micro, WebSocket, STT, etc.) */
+  trackError(data: { errorType: string; plan: string; platform: string }) {
+    analytics.track('voice_chat_error' as any, {
+      error_type: data.errorType,
+      plan: data.plan,
+      platform: data.platform,
+    });
+  },
+};

--- a/mobile/src/contexts/PlanContext.tsx
+++ b/mobile/src/contexts/PlanContext.tsx
@@ -35,6 +35,8 @@ export interface PlanFeatures {
   webEnrichEnabled: boolean;
   academicSearchEnabled: boolean;
   ttsEnabled: boolean;
+  voiceChatEnabled: boolean;
+  voiceChatMonthlyMinutes: number;
   historyDays: number;
   apiAccess: boolean;
 }
@@ -64,6 +66,8 @@ function buildPlanFeatures(planId: PlanId): PlanFeatures {
     webEnrichEnabled: f.chatWebSearch,
     academicSearchEnabled: f.academicSearch,
     ttsEnabled: f.ttsAudio,
+    voiceChatEnabled: planId !== 'free',
+    voiceChatMonthlyMinutes: ({ free: 0, student: 5, starter: 15, pro: 45 } as Record<PlanId, number>)[planId],
     historyDays: l.historyDays,
     apiAccess: f.apiAccess,
   };
@@ -315,6 +319,16 @@ export const useFeatureGate = (feature: keyof PlanFeatures) => {
   return {
     ...checkFeature(feature),
     canUse: canUseFeature(feature),
+  };
+};
+
+// Hook for voice chat feature gating
+export const useVoiceChatGate = () => {
+  const { features } = usePlan();
+  return {
+    enabled: features.voiceChatEnabled,
+    monthlyMinutes: features.voiceChatMonthlyMinutes,
+    requiresUpgrade: !features.voiceChatEnabled,
   };
 };
 

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -1687,6 +1687,63 @@ export const shareApi = {
   },
 };
 
+// ============================================
+// Voice Chat API
+// ============================================
+export const voiceApi = {
+  async getQuota(): Promise<{
+    plan: string;
+    voice_enabled: boolean;
+    seconds_used: number;
+    seconds_limit: number;
+    minutes_remaining: number;
+    max_session_minutes: number;
+    sessions_this_month: number;
+    reset_date: string;
+  }> {
+    return request('/api/voice/quota');
+  },
+
+  async createSession(summaryId: number, language: string = 'fr'): Promise<{
+    session_id: string;
+    signed_url: string;
+    expires_at: string;
+    quota_remaining_minutes: number;
+    max_session_minutes: number;
+  }> {
+    return request('/api/voice/session', {
+      method: 'POST',
+      body: { summary_id: summaryId, language },
+    });
+  },
+
+  async getHistory(summaryId: number): Promise<{
+    summary_id: number;
+    video_title: string;
+    sessions: Array<{
+      session_id: string;
+      started_at: string;
+      ended_at: string | null;
+      duration_seconds: number;
+      status: string;
+      has_transcript: boolean;
+    }>;
+    total_minutes: number;
+  }> {
+    return request(`/api/voice/history/${summaryId}`);
+  },
+
+  async getTranscript(summaryId: number, sessionId: string): Promise<{
+    session_id: string;
+    summary_id: number;
+    started_at: string;
+    duration_seconds: number;
+    transcript: string;
+  }> {
+    return request(`/api/voice/history/${summaryId}/${sessionId}/transcript`);
+  },
+};
+
 export default {
   authApi,
   userApi,
@@ -1700,5 +1757,6 @@ export default {
   contactApi,
   notificationsApi,
   shareApi,
+  voiceApi,
   ApiError,
 };


### PR DESCRIPTION
## Summary

Nouvelle feature majeure **"Parler à sa vidéo"** — conversation vocale temps réel avec un agent IA qui connaît le contenu d'une vidéo analysée, propulsé par ElevenLabs Conversational AI.

### Backend (10 fichiers, ~1820 lignes)
- **Nouveau module `voice/`** : router (7 endpoints + 4 tool webhooks), schemas Pydantic, quota service, client ElevenLabs, 4 server tools
- **DB** : 2 nouvelles tables (VoiceSession, VoiceQuota) + migration Alembic + colonne User.voice_bonus_seconds
- **Config** : VOICE_LIMITS par plan (Étudiant 5min, Starter 15min, Pro 45min/mois), VOICE_CHAT_CONFIG
- **Stripe** : add-on checkout pour packs de minutes (10/30/60 min) + webhook handling idempotent
- **Admin** : endpoint /voice-stats avec breakdown par plan
- **Sécurité** : signed URL ElevenLabs, HMAC webhook verification, feature gating par plan

### Frontend Web (8 fichiers, ~1735 lignes)
- **6 composants React** : VoiceButton (FAB flottant), VoiceModal (7 états), VoiceWaveform (20 barres animées RAF), VoiceTranscript (auto-scroll), VoiceQuotaBadge, VoiceAddonModal (checkout Stripe)
- **Hook useVoiceChat** : orchestration complète (micro, ElevenLabs SDK, timer, auto-stop)
- **Zustand** : voice slice (6 champs state, 8 actions, 6 selectors)
- **API service** : 5 méthodes voiceApi
- **Intégration** : VoiceButton + VoiceModal dans DashboardPage
- **SDK** : @elevenlabs/react + @elevenlabs/client installés

### Mobile React Native (5 fichiers, ~1910 lignes)
- **VoiceButton** : FAB Reanimated pulse + haptics + plan gating
- **VoiceScreen** : modal plein écran, 7 états, SafeArea, FlatList transcript
- **Hook useVoiceChat** : expo-av permissions, AppState background handling, haptics
- **API service** : 4 méthodes voiceApi
- **Intégration** : dans analysis/[id].tsx
- **SDK** : @elevenlabs/react-native + LiveKit installés

### Analytics & Monitoring
- **PostHog** : 7 events types (web + mobile)
- **Admin** : dashboard voice-stats (minutes, coût estimé, adoption, par plan)

### Décisions d'architecture
- Plans avec accès : Étudiant+ (5/15/45 min/mois)
- Extension Chrome : Non (CTA vers web)
- Durée max session : 10 minutes
- Add-ons : 10min/1.99€, 30min/4.99€, 60min/8.99€
- LLM : intégré ElevenLabs (v1), Custom Mistral prévu (v2)
- Rollout : progressif Pro → Starter → Étudiant

## Test plan

- [ ] Configurer ELEVENLABS_API_KEY, ELEVENLABS_VOICE_ID dans .env
- [ ] Exécuter la migration Alembic (004_add_voice_tables)
- [ ] Tester GET /api/voice/quota (vérifier quotas par plan)
- [ ] Tester POST /api/voice/session (vérifier création agent + signed URL)
- [ ] Tester la conversation vocale E2E sur web (micro → ElevenLabs → réponse)
- [ ] Tester les 4 tools (search transcript, get section, sources, flashcards)
- [ ] Tester POST /api/voice/webhook (fin de session + décompte)
- [ ] Tester le feature gating (free = locked, étudiant+ = accessible)
- [ ] Tester l'achat d'un pack add-on via Stripe checkout
- [ ] Tester le VoiceButton sur mobile (permissions micro, haptics)
- [ ] Tester le VoiceScreen mobile (7 états, timer, auto-stop)
- [ ] Vérifier les events PostHog (voice_chat_started, ended, etc.)
- [ ] Vérifier le endpoint admin /voice-stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)