### PR TITLE
fix(images): retry Mistral Vision 429 rate limits

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -4461,6 +4461,68 @@ async def analyze_images(
     )
 
 
+async def _mistral_vision_request(
+    api_key: str,
+    messages: list,
+    model: str = "mistral-small-2603",
+    max_tokens: int = 4000,
+    temperature: float = 0.1,
+    response_format: Optional[Dict] = None,
+    timeout: float = 120.0,
+    max_retries: int = 3,
+) -> Optional[str]:
+    """
+    Appel Mistral Vision avec retry automatique sur 429 (rate limit).
+    Retourne le contenu texte de la réponse, ou None en cas d'échec.
+    """
+    import httpx as httpx_client
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if response_format:
+        payload["response_format"] = response_format
+
+    for attempt in range(max_retries):
+        try:
+            async with httpx_client.AsyncClient(timeout=timeout) as client:
+                response = await client.post(
+                    "https://api.mistral.ai/v1/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+
+                if response.status_code == 200:
+                    return response.json()["choices"][0]["message"]["content"].strip()
+
+                if response.status_code == 429:
+                    wait = 2 ** attempt + 1  # 2s, 3s, 5s
+                    logger.warning(f"[MISTRAL_VISION] Rate limited (429), retry {attempt + 1}/{max_retries} in {wait}s")
+                    import asyncio
+                    await asyncio.sleep(wait)
+                    continue
+
+                logger.error(f"[MISTRAL_VISION] Error {response.status_code}: {response.text[:200]}")
+                return None
+
+        except Exception as e:
+            logger.error(f"[MISTRAL_VISION] Request error (attempt {attempt + 1}): {e}")
+            if attempt < max_retries - 1:
+                import asyncio
+                await asyncio.sleep(2)
+                continue
+            return None
+
+    logger.error(f"[MISTRAL_VISION] All {max_retries} retries exhausted")
+    return None
+
+
 async def _detect_video_screenshot(
     image: Any,
     api_key: str,
@@ -4499,32 +4561,23 @@ async def _detect_video_screenshot(
     )
 
     try:
-        async with httpx_client.AsyncClient(timeout=30.0) as client:
-            response = await client.post(
-                "https://api.mistral.ai/v1/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": "mistral-small-2603",
-                    "messages": [
-                        {"role": "user", "content": [
-                            {"type": "image_url", "image_url": data_uri},
-                            {"type": "text", "text": detection_prompt},
-                        ]},
-                    ],
-                    "max_tokens": 300,
-                    "temperature": 0.0,
-                    "response_format": {"type": "json_object"},
-                },
-            )
+        text = await _mistral_vision_request(
+            api_key=api_key,
+            messages=[
+                {"role": "user", "content": [
+                    {"type": "image_url", "image_url": data_uri},
+                    {"type": "text", "text": detection_prompt},
+                ]},
+            ],
+            max_tokens=300,
+            temperature=0.0,
+            response_format={"type": "json_object"},
+            timeout=30.0,
+            max_retries=3,
+        )
 
-            if response.status_code != 200:
-                logger.warning(f"[SCREENSHOT_DETECT] Mistral error: {response.status_code}")
-                return None
-
-            text = response.json()["choices"][0]["message"]["content"].strip()
+        if not text:
+            return None
 
             # Parser le JSON
             import json as json_module
@@ -4825,29 +4878,21 @@ async def _analyze_images_background(
             f"Réponds en {'français' if lang == 'fr' else 'anglais'}."
         )
 
-        import httpx as httpx_client
-        async with httpx_client.AsyncClient(timeout=120.0) as client:
-            response = await client.post(
-                "https://api.mistral.ai/v1/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": vision_model,
-                    "messages": [
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": content},
-                    ],
-                    "max_tokens": 6000,
-                    "temperature": 0.1,
-                },
-            )
+        vision_result = await _mistral_vision_request(
+            api_key=api_key,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": content},
+            ],
+            model=vision_model,
+            max_tokens=6000,
+            temperature=0.1,
+            timeout=120.0,
+            max_retries=3,
+        )
 
-            if response.status_code != 200:
-                raise Exception(f"Mistral Vision error: {response.status_code} - {response.text[:300]}")
-
-            vision_result = response.json()["choices"][0]["message"]["content"].strip()
+        if not vision_result:
+            raise Exception("Mistral Vision: échec après 3 tentatives (rate limit ou erreur)")
 
         print(f"📸 [IMAGES] Vision analysis complete: {len(vision_result)} chars", flush=True)
 


### PR DESCRIPTION
Ajoute retry automatique (3 tentatives, backoff exponentiel) sur les erreurs 429 de Mistral Vision.