### PR TITLE
fix(images): fallback chain modèles Vision anti-429

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -4469,59 +4469,72 @@ async def _mistral_vision_request(
     temperature: float = 0.1,
     response_format: Optional[Dict] = None,
     timeout: float = 120.0,
-    max_retries: int = 5,
+    max_retries: int = 3,
+    fallback_models: Optional[list] = None,
 ) -> Optional[str]:
     """
-    Appel Mistral Vision avec retry automatique sur 429 (rate limit).
-    Backoff: 5s, 15s, 30s, 45s, 60s.
-    Retourne le contenu texte de la réponse, ou None en cas d'échec.
+    Appel Mistral Vision avec model fallback sur 429 (rate limit).
+
+    Stratégie : si le modèle principal est rate-limité, essayer les fallback models
+    immédiatement au lieu d'attendre. Chaque modèle a son propre rate limit.
     """
     import httpx as httpx_client
+    import asyncio
 
-    payload: Dict[str, Any] = {
-        "model": model,
-        "messages": messages,
-        "max_tokens": max_tokens,
-        "temperature": temperature,
-    }
-    if response_format:
-        payload["response_format"] = response_format
+    models_to_try = [model] + (fallback_models or [])
 
-    for attempt in range(max_retries):
-        try:
-            async with httpx_client.AsyncClient(timeout=timeout) as client:
-                response = await client.post(
-                    "https://api.mistral.ai/v1/chat/completions",
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json=payload,
-                )
+    for model_idx, current_model in enumerate(models_to_try):
+        for attempt in range(max_retries):
+            try:
+                payload: Dict[str, Any] = {
+                    "model": current_model,
+                    "messages": messages,
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                }
+                if response_format:
+                    payload["response_format"] = response_format
 
-                if response.status_code == 200:
-                    return response.json()["choices"][0]["message"]["content"].strip()
+                async with httpx_client.AsyncClient(timeout=timeout) as client:
+                    response = await client.post(
+                        "https://api.mistral.ai/v1/chat/completions",
+                        headers={
+                            "Authorization": f"Bearer {api_key}",
+                            "Content-Type": "application/json",
+                        },
+                        json=payload,
+                    )
 
-                if response.status_code == 429:
-                    wait_times = [5, 15, 30, 45, 60]
-                    wait = wait_times[min(attempt, len(wait_times) - 1)]
-                    logger.warning(f"[MISTRAL_VISION] Rate limited (429), retry {attempt + 1}/{max_retries} in {wait}s")
-                    import asyncio
-                    await asyncio.sleep(wait)
+                    if response.status_code == 200:
+                        if model_idx > 0:
+                            logger.info(f"[MISTRAL_VISION] Success with fallback model: {current_model}")
+                        return response.json()["choices"][0]["message"]["content"].strip()
+
+                    if response.status_code == 429:
+                        # Try next model immediately instead of waiting
+                        if model_idx < len(models_to_try) - 1:
+                            logger.warning(f"[MISTRAL_VISION] {current_model} rate-limited, trying {models_to_try[model_idx + 1]}")
+                            break  # Break inner retry loop → next model
+                        # Last model: wait and retry
+                        wait = min(5 * (attempt + 1), 20)
+                        logger.warning(f"[MISTRAL_VISION] {current_model} rate-limited, retry {attempt + 1}/{max_retries} in {wait}s")
+                        await asyncio.sleep(wait)
+                        continue
+
+                    logger.error(f"[MISTRAL_VISION] {current_model} error {response.status_code}: {response.text[:200]}")
+                    # Non-429 error: try next model
+                    if model_idx < len(models_to_try) - 1:
+                        break
+                    return None
+
+            except Exception as e:
+                logger.error(f"[MISTRAL_VISION] {current_model} request error: {e}")
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(2)
                     continue
+                break  # Try next model
 
-                logger.error(f"[MISTRAL_VISION] Error {response.status_code}: {response.text[:200]}")
-                return None
-
-        except Exception as e:
-            logger.error(f"[MISTRAL_VISION] Request error (attempt {attempt + 1}): {e}")
-            if attempt < max_retries - 1:
-                import asyncio
-                await asyncio.sleep(2)
-                continue
-            return None
-
-    logger.error(f"[MISTRAL_VISION] All {max_retries} retries exhausted (total wait ~2.5min)")
+    logger.error(f"[MISTRAL_VISION] All models exhausted: {models_to_try}")
     return None
 
 
@@ -4575,7 +4588,8 @@ async def _detect_video_screenshot(
             temperature=0.0,
             response_format={"type": "json_object"},
             timeout=30.0,
-            max_retries=1,  # Detection is a bonus — don't block on rate limits
+            max_retries=1,
+            fallback_models=["pixtral-large-2411", "mistral-medium-2508"],
         )
 
         if not text:
@@ -4890,7 +4904,8 @@ async def _analyze_images_background(
             max_tokens=6000,
             temperature=0.1,
             timeout=120.0,
-            max_retries=5,
+            max_retries=2,
+            fallback_models=["pixtral-large-2411", "mistral-medium-2508"],
         )
 
         if not vision_result:


### PR DESCRIPTION
Si mistral-small rate-limité → pixtral-large → mistral-medium. Switch immédiat, pas d'attente.