### PR TITLE
feat: 48 commits — thumbnails R2, extension cross-browser, voice agent, plans avril 2026

### DIFF
--- a/backend/src/images/screenshot_detection.py
+++ b/backend/src/images/screenshot_detection.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
-from core.config import BRAVE_SEARCH_API_KEY, get_mistral_key
+from core.config import BRAVE_SEARCH_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -55,36 +55,96 @@ BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
 
 # Browser noise keywords to filter from OCR
 BROWSER_NOISE_KEYWORDS = [
-    "connexion", "chrome", "edge", "firefox", "copilot", "bing", "google.com",
-    "nouvel onglet", "new tab", "favoris", "bookmarks", "translate", "extensions",
-    "paramètres", "settings", "téléchargements", "downloads", "historique",
-    "http://", "https://", ".com/", ".fr/", "www.", "://", "\\|",
+    "connexion",
+    "chrome",
+    "edge",
+    "firefox",
+    "copilot",
+    "bing",
+    "google.com",
+    "nouvel onglet",
+    "new tab",
+    "favoris",
+    "bookmarks",
+    "translate",
+    "extensions",
+    "paramètres",
+    "settings",
+    "téléchargements",
+    "downloads",
+    "historique",
+    "http://",
+    "https://",
+    ".com/",
+    ".fr/",
+    "www.",
+    "://",
+    "\\|",
 ]
 
 # Platform indicator words
 YOUTUBE_INDICATORS = [
-    "youtube", "subscribe", "s'abonner", "views", "vues", "shorts",
-    "j'aime", "dislike", "partager", "enregistrer", "save",
-    "playlist", "regarder plus tard", "watch later", "abonnés", "subscribers",
+    "youtube",
+    "subscribe",
+    "s'abonner",
+    "views",
+    "vues",
+    "shorts",
+    "j'aime",
+    "dislike",
+    "partager",
+    "enregistrer",
+    "save",
+    "playlist",
+    "regarder plus tard",
+    "watch later",
+    "abonnés",
+    "subscribers",
 ]
 
 TIKTOK_INDICATORS = [
-    "tiktok", "pour toi", "for you", "fyp", "following",
-    "suivre", "likes", "duet", "stitch", "son original",
-    "original sound", "partager", "répondre", "discover", "créer",
+    "tiktok",
+    "pour toi",
+    "for you",
+    "fyp",
+    "following",
+    "suivre",
+    "likes",
+    "duet",
+    "stitch",
+    "son original",
+    "original sound",
+    "partager",
+    "répondre",
+    "discover",
+    "créer",
 ]
 
 # UI words to filter from title candidates
 UI_WORDS = [
-    "subscribe", "s'abonner", "views", "vues", "likes", "share",
-    "partager", "follow", "j'aime", "enregistrer", "save",
-    "clip", "remix", "thanks", "merci", "download",
+    "subscribe",
+    "s'abonner",
+    "views",
+    "vues",
+    "likes",
+    "share",
+    "partager",
+    "follow",
+    "j'aime",
+    "enregistrer",
+    "save",
+    "clip",
+    "remix",
+    "thanks",
+    "merci",
+    "download",
 ]
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Public API
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 async def detect_video_screenshot(
     image: Any,
@@ -137,7 +197,10 @@ async def detect_video_screenshot(
 
         logger.info(
             "[SCREENSHOT_DETECT] Detected %s: url='%s' title='%s' channel='%s'",
-            platform, video_url, video_title, channel,
+            platform,
+            video_url,
+            video_title,
+            channel,
         )
 
         return {
@@ -198,18 +261,20 @@ async def detect_video_screenshot_vision(
                     },
                     json={
                         "model": model,
-                        "messages": [{
-                            "role": "user",
-                            "content": [
-                                {
-                                    "type": "image_url",
-                                    "image_url": {
-                                        "url": f"data:{image.mime_type};base64,{b64_data}",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": f"data:{image.mime_type};base64,{b64_data}",
+                                        },
                                     },
-                                },
-                                {"type": "text", "text": prompt_text},
-                            ],
-                        }],
+                                    {"type": "text", "text": prompt_text},
+                                ],
+                            }
+                        ],
                         "max_tokens": 150,
                         "temperature": 0.0,
                     },
@@ -217,15 +282,23 @@ async def detect_video_screenshot_vision(
 
                 if response.status_code == 429:
                     wait = 15 if "pixtral" in model else 5
-                    logger.warning("[SCREENSHOT_VISION] %s rate-limited, retrying in %ds", model, wait)
+                    logger.warning(
+                        "[SCREENSHOT_VISION] %s rate-limited, retrying in %ds",
+                        model,
+                        wait,
+                    )
                     await asyncio.sleep(wait)
                     continue
                 if response.status_code != 200:
-                    logger.warning("[SCREENSHOT_VISION] %s error: %d", model, response.status_code)
+                    logger.warning(
+                        "[SCREENSHOT_VISION] %s error: %d", model, response.status_code
+                    )
                     continue
 
                 data = response.json()
-                answer = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+                answer = (
+                    data.get("choices", [{}])[0].get("message", {}).get("content", "")
+                )
                 logger.info("[SCREENSHOT_VISION] %s response: %s", model, answer[:200])
 
                 result = _parse_vision_response(answer, platform)
@@ -237,7 +310,9 @@ async def detect_video_screenshot_vision(
             continue
 
     # ── Fallback: Anthropic Claude Vision ──
-    result = await _claude_vision_screenshot(b64_data, image.mime_type, prompt_text, platform)
+    result = await _claude_vision_screenshot(
+        b64_data, image.mime_type, prompt_text, platform
+    )
     if result:
         return result
 
@@ -332,15 +407,21 @@ async def mistral_vision_request(
                             if model_idx > 0 or attempt > 0:
                                 logger.info(
                                     "[MISTRAL_VISION] Success with %s (attempt %d)",
-                                    current_model, attempt + 1,
+                                    current_model,
+                                    attempt + 1,
                                 )
                             return content.strip()
                     if response.status_code == 429:
-                        logger.warning("[MISTRAL_VISION] %s rate-limited, next model", current_model)
+                        logger.warning(
+                            "[MISTRAL_VISION] %s rate-limited, next model",
+                            current_model,
+                        )
                         break
                     logger.warning(
                         "[MISTRAL_VISION] %s error %d: %s",
-                        current_model, response.status_code, response.text[:200],
+                        current_model,
+                        response.status_code,
+                        response.text[:200],
                     )
                     break
             except Exception as e:
@@ -359,7 +440,8 @@ async def mistral_vision_request(
     for retry_idx, wait_secs in enumerate([20, 40, 60]):
         logger.info(
             "[VISION_FALLBACK] Retry %d/3 — waiting %ds for rate limit reset",
-            retry_idx + 1, wait_secs,
+            retry_idx + 1,
+            wait_secs,
         )
         await asyncio.sleep(wait_secs)
         try:
@@ -390,12 +472,22 @@ async def mistral_vision_request(
                         .get("content", "")
                     )
                     if content:
-                        logger.info("[VISION_FALLBACK] Retry %d success with %s", retry_idx + 1, retry_model)
+                        logger.info(
+                            "[VISION_FALLBACK] Retry %d success with %s",
+                            retry_idx + 1,
+                            retry_model,
+                        )
                         return content.strip()
                 if response.status_code == 429:
-                    logger.warning("[VISION_FALLBACK] Retry %d still rate-limited", retry_idx + 1)
+                    logger.warning(
+                        "[VISION_FALLBACK] Retry %d still rate-limited", retry_idx + 1
+                    )
                     continue
-                logger.warning("[VISION_FALLBACK] Retry %d error %d", retry_idx + 1, response.status_code)
+                logger.warning(
+                    "[VISION_FALLBACK] Retry %d error %d",
+                    retry_idx + 1,
+                    response.status_code,
+                )
         except Exception as e:
             logger.warning("[VISION_FALLBACK] Retry %d exception: %s", retry_idx + 1, e)
 
@@ -436,8 +528,7 @@ def is_garbage_query(query: str) -> bool:
 
     # Single "word" queries that look like garbled text
     if len(words) <= 2 and any(
-        len(w) > 5 and sum(c.isdigit() for c in w) > len(w) * 0.3
-        for w in words
+        len(w) > 5 and sum(c.isdigit() for c in w) > len(w) * 0.3 for w in words
     ):
         return True
 
@@ -453,6 +544,7 @@ def is_garbage_query(query: str) -> bool:
 # ═══════════════════════════════════════════════════════════════════════════════
 # Internal — OCR
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 def _clean_base64(data: str) -> str:
     """Strip data: URI prefix from base64 string."""
@@ -481,7 +573,9 @@ async def _call_mistral_ocr(data_uri: str, api_key: str) -> Optional[str]:
             )
 
             if response.status_code != 200:
-                logger.warning("[SCREENSHOT_DETECT] OCR API error: %d", response.status_code)
+                logger.warning(
+                    "[SCREENSHOT_DETECT] OCR API error: %d", response.status_code
+                )
                 return None
 
             ocr_data = response.json()
@@ -500,14 +594,15 @@ async def _call_mistral_ocr(data_uri: str, api_key: str) -> Optional[str]:
 # Internal — URL & Platform extraction
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
 def _extract_video_url(ocr_text: str) -> tuple[Optional[str], Optional[str]]:
     """Extract YouTube/TikTok URL from OCR text. Returns (url, platform)."""
     # YouTube URLs
     yt_patterns = [
-        r'(https?://(?:www\.)?youtube\.com/watch\?v=[A-Za-z0-9_-]+[^\s\)\"\']*)',
-        r'(https?://youtu\.be/[A-Za-z0-9_-]+[^\s\)\"\']*)',
-        r'(https?://(?:www\.)?youtube\.com/shorts/[A-Za-z0-9_-]+[^\s\)\"\']*)',
-        r'(youtube\.com/watch\?v=[A-Za-z0-9_-]+[^\s\)\"\']*)',
+        r"(https?://(?:www\.)?youtube\.com/watch\?v=[A-Za-z0-9_-]+[^\s\)\"\']*)",
+        r"(https?://youtu\.be/[A-Za-z0-9_-]+[^\s\)\"\']*)",
+        r"(https?://(?:www\.)?youtube\.com/shorts/[A-Za-z0-9_-]+[^\s\)\"\']*)",
+        r"(youtube\.com/watch\?v=[A-Za-z0-9_-]+[^\s\)\"\']*)",
     ]
     for pattern in yt_patterns:
         match = re.search(pattern, ocr_text)
@@ -520,9 +615,9 @@ def _extract_video_url(ocr_text: str) -> tuple[Optional[str], Optional[str]]:
 
     # TikTok URLs
     tt_patterns = [
-        r'(https?://(?:www\.)?tiktok\.com/@[\w.-]+/video/\d+[^\s\)\"\']*)',
-        r'(https?://vm\.tiktok\.com/[\w-]+[^\s\)\"\']*)',
-        r'(tiktok\.com/@[\w.-]+/video/\d+)',
+        r"(https?://(?:www\.)?tiktok\.com/@[\w.-]+/video/\d+[^\s\)\"\']*)",
+        r"(https?://vm\.tiktok\.com/[\w-]+[^\s\)\"\']*)",
+        r"(tiktok\.com/@[\w.-]+/video/\d+)",
     ]
     for pattern in tt_patterns:
         match = re.search(pattern, ocr_text)
@@ -558,6 +653,7 @@ def _detect_platform_from_text(ocr_text: str) -> Optional[str]:
 # ═══════════════════════════════════════════════════════════════════════════════
 # Internal — Title & Channel extraction
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 def _filter_browser_noise(ocr_text: str) -> list[str]:
     """Filter browser UI noise from OCR lines."""
@@ -625,6 +721,7 @@ def _extract_title(clean_lines: list[str]) -> Optional[str]:
 # Internal — Vision response parsing
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
 def _parse_vision_response(
     answer: str,
     platform: str,
@@ -646,7 +743,9 @@ def _parse_vision_response(
     # Extract video URL from Vision response
     video_url = None
     if url_text and url_text.upper() != "UNKNOWN":
-        yt_id_match = re.search(r"(?:v=|youtu\.be/|shorts/)([A-Za-z0-9_-]{11})", url_text)
+        yt_id_match = re.search(
+            r"(?:v=|youtu\.be/|shorts/)([A-Za-z0-9_-]{11})", url_text
+        )
         if yt_id_match:
             video_url = f"https://www.youtube.com/watch?v={yt_id_match.group(1)}"
         tt_match = re.search(r"(tiktok\.com/@[\w.-]+/video/\d+)", url_text)
@@ -665,7 +764,10 @@ def _parse_vision_response(
 
     logger.info(
         "[SCREENSHOT_VISION] Extracted: title='%s' channel='%s' url='%s' query='%s'",
-        title, channel, video_url, search_query,
+        title,
+        channel,
+        video_url,
+        search_query,
     )
 
     return {
@@ -681,6 +783,7 @@ def _parse_vision_response(
 # Internal — Claude Vision fallback
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
 def _get_anthropic_key() -> str:
     """Get Anthropic API key from environment."""
     return os.environ.get("ANTHROPIC_API_KEY", "")
@@ -695,7 +798,9 @@ async def _claude_vision_screenshot(
     """Call Claude Vision for screenshot title extraction."""
     anthropic_key = _get_anthropic_key()
     if not anthropic_key:
-        logger.info("[SCREENSHOT_VISION] No ANTHROPIC_API_KEY, skipping Claude fallback")
+        logger.info(
+            "[SCREENSHOT_VISION] No ANTHROPIC_API_KEY, skipping Claude fallback"
+        )
         return None
 
     try:
@@ -711,20 +816,22 @@ async def _claude_vision_screenshot(
                 json={
                     "model": "claude-sonnet-4-20250514",
                     "max_tokens": 150,
-                    "messages": [{
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "image",
-                                "source": {
-                                    "type": "base64",
-                                    "media_type": mime_type,
-                                    "data": b64_data,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": mime_type,
+                                        "data": b64_data,
+                                    },
                                 },
-                            },
-                            {"type": "text", "text": prompt_text},
-                        ],
-                    }],
+                                {"type": "text", "text": prompt_text},
+                            ],
+                        }
+                    ],
                 },
             )
 
@@ -739,7 +846,8 @@ async def _claude_vision_screenshot(
             else:
                 logger.warning(
                     "[SCREENSHOT_VISION] Claude error: %d %s",
-                    response.status_code, response.text[:200],
+                    response.status_code,
+                    response.text[:200],
                 )
     except Exception as e:
         logger.warning("[SCREENSHOT_VISION] Claude exception: %s", e)
@@ -790,10 +898,17 @@ async def _claude_vision_general(
                             logger.info("[VISION_FALLBACK] Claude Vision success!")
                             return answer.strip()
                     if resp.status_code == 429:
-                        logger.warning("[VISION_FALLBACK] Claude rate-limited, attempt %d/2", attempt + 1)
+                        logger.warning(
+                            "[VISION_FALLBACK] Claude rate-limited, attempt %d/2",
+                            attempt + 1,
+                        )
                         await asyncio.sleep(5)
                         continue
-                    logger.warning("[VISION_FALLBACK] Claude error %d: %s", resp.status_code, resp.text[:200])
+                    logger.warning(
+                        "[VISION_FALLBACK] Claude error %d: %s",
+                        resp.status_code,
+                        resp.text[:200],
+                    )
                     break
             except Exception as e:
                 logger.warning("[VISION_FALLBACK] Claude exception: %s", e)
@@ -837,12 +952,20 @@ def _convert_messages_to_anthropic(messages: list) -> list:
                     # Convert data URI to Anthropic image block
                     if url_str.startswith("data:"):
                         parts = url_str.split(",", 1)
-                        media_type = parts[0].replace("data:", "").replace(";base64", "")
+                        media_type = (
+                            parts[0].replace("data:", "").replace(";base64", "")
+                        )
                         b64 = parts[1] if len(parts) > 1 else ""
-                        claude_content.append({
-                            "type": "image",
-                            "source": {"type": "base64", "media_type": media_type, "data": b64},
-                        })
+                        claude_content.append(
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": media_type,
+                                    "data": b64,
+                                },
+                            }
+                        )
                     else:
                         claude_content.append({"type": "text", "text": "[Image URL]"})
                 else:
@@ -858,6 +981,7 @@ def _convert_messages_to_anthropic(messages: list) -> list:
 # ═══════════════════════════════════════════════════════════════════════════════
 # Internal — Video search (yt-dlp + Brave)
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 async def _ytdlp_search(query: str, search_prefix: str = "ytsearch5") -> Optional[str]:
     """Search YouTube via yt-dlp ytsearch."""
@@ -892,7 +1016,11 @@ async def _ytdlp_search(query: str, search_prefix: str = "ytsearch5") -> Optiona
                 video_id = video.get("id")
                 if video_id:
                     url = f"https://www.youtube.com/watch?v={video_id}"
-                    logger.info("[SCREENSHOT_SEARCH] Found YouTube: %s (%s)", url, video.get("title", "?"))
+                    logger.info(
+                        "[SCREENSHOT_SEARCH] Found YouTube: %s (%s)",
+                        url,
+                        video.get("title", "?"),
+                    )
                     return url
             except json_module.JSONDecodeError:
                 continue
@@ -937,7 +1065,9 @@ async def _ytdlp_search_tiktok(query: str) -> Optional[str]:
                 uploader = video.get("uploader_id") or video.get("uploader")
                 if video_id and uploader:
                     url = f"https://www.tiktok.com/@{uploader}/video/{video_id}"
-                    logger.info("[SCREENSHOT_SEARCH] Found TikTok (constructed): %s", url)
+                    logger.info(
+                        "[SCREENSHOT_SEARCH] Found TikTok (constructed): %s", url
+                    )
                     return url
             except json_module.JSONDecodeError:
                 continue

--- a/backend/src/storage/r2.py
+++ b/backend/src/storage/r2.py
@@ -25,6 +25,7 @@ THUMBNAIL_BASE_URL = os.environ.get("THUMBNAIL_BASE_URL", "")
 # Availability checks
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
 def _is_r2_credentials_set() -> bool:
     """Check if R2 S3-compatible credentials are configured (not CHANGEME)."""
     key = R2_CONFIG.get("ACCESS_KEY_ID", "")
@@ -44,6 +45,7 @@ def is_r2_available() -> bool:
 # ═══════════════════════════════════════════════════════════════════════════════
 # R2 client (only initialized when credentials exist)
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 @lru_cache(maxsize=1)
 def _get_r2_client():
@@ -69,6 +71,7 @@ def _get_r2_client():
 # Public URL builders
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
 def get_r2_public_url(key: str) -> str:
     """Build public URL for a stored thumbnail (R2 or local)."""
     if _is_r2_credentials_set():
@@ -85,6 +88,7 @@ def get_r2_public_url(key: str) -> str:
 # Upload (dual-mode: R2 or local)
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
 async def upload_to_r2(
     image_bytes: bytes,
     key: str,
@@ -98,7 +102,6 @@ async def upload_to_r2(
 
 async def _upload_r2(image_bytes: bytes, key: str, content_type: str) -> str:
     """Upload to Cloudflare R2 via boto3."""
-    from botocore.exceptions import ClientError
 
     client = _get_r2_client()
     await asyncio.to_thread(
@@ -132,6 +135,7 @@ def _write_file(path: Path, data: bytes) -> None:
 # ═══════════════════════════════════════════════════════════════════════════════
 # Exists check (dual-mode)
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 async def check_exists_r2(key: str) -> bool:
     """Check whether a thumbnail already exists (R2 or local)."""

--- a/backend/src/storage/thumbnail_generator.py
+++ b/backend/src/storage/thumbnail_generator.py
@@ -6,7 +6,6 @@ and uploads them to R2 for permanent storage.
 Reuses existing pipeline functions — no duplication.
 """
 
-import asyncio
 import json
 import logging
 from datetime import date
@@ -43,12 +42,17 @@ async def _check_ai_budget() -> bool:
     """Check if we haven't exceeded the daily AI thumbnail budget."""
     try:
         from core.cache import cache_service
-        if hasattr(cache_service, 'backend') and hasattr(cache_service.backend, 'redis'):
+
+        if hasattr(cache_service, "backend") and hasattr(
+            cache_service.backend, "redis"
+        ):
             redis = cache_service.backend.redis
             key = f"{_REDIS_COUNTER_PREFIX}:{date.today().isoformat()}"
             count = await redis.get(key)
             if count and int(count) >= DAILY_AI_THUMB_LIMIT:
-                logger.info(f"AI thumbnail budget exhausted ({count}/{DAILY_AI_THUMB_LIMIT})")
+                logger.info(
+                    f"AI thumbnail budget exhausted ({count}/{DAILY_AI_THUMB_LIMIT})"
+                )
                 return False
             return True
     except Exception:
@@ -60,7 +64,10 @@ async def _increment_ai_budget() -> None:
     """Increment the daily AI thumbnail counter."""
     try:
         from core.cache import cache_service
-        if hasattr(cache_service, 'backend') and hasattr(cache_service.backend, 'redis'):
+
+        if hasattr(cache_service, "backend") and hasattr(
+            cache_service.backend, "redis"
+        ):
             redis = cache_service.backend.redis
             key = f"{_REDIS_COUNTER_PREFIX}:{date.today().isoformat()}"
             await redis.incr(key)
@@ -110,14 +117,17 @@ async def _generate_text_thumbnail(title: str, category: str | None) -> Optional
         from images.keyword_images import (
             _stage2_generate_image,
             _post_process,
-            DEEPSIGHT_STYLE_SUFFIX,
         )
 
-        raw_image, model_used = await _stage2_generate_image(visual_prompt, premium=False)
+        raw_image, model_used = await _stage2_generate_image(
+            visual_prompt, premium=False
+        )
         webp_bytes = _post_process(raw_image)
 
         await _increment_ai_budget()
-        logger.info(f"AI thumbnail generated for '{title[:40]}' ({model_used}, {len(webp_bytes)}B)")
+        logger.info(
+            f"AI thumbnail generated for '{title[:40]}' ({model_used}, {len(webp_bytes)}B)"
+        )
         return webp_bytes
 
     except Exception as e:

--- a/backend/src/tournesol/trending_cache.py
+++ b/backend/src/tournesol/trending_cache.py
@@ -15,7 +15,7 @@
 import logging
 import random
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -51,6 +51,7 @@ CACHE_PREFIX = "trending:tournesol"
 # ═══════════════════════════════════════════════════════════════════════════════
 # Public API
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 async def get_cached_trending(
     language: str = "fr",
@@ -133,12 +134,15 @@ async def refresh_trending_cache() -> Dict[str, Any]:
                     lang_fetched += len(results)
                     logger.info(
                         "[TRENDING_CACHE] Cached %d results for lang=%s offset=%d",
-                        len(results), lang, offset,
+                        len(results),
+                        lang,
+                        offset,
                     )
                 else:
                     logger.warning(
                         "[TRENDING_CACHE] Empty response for lang=%s offset=%d",
-                        lang, offset,
+                        lang,
+                        offset,
                     )
                 stats["fetched"] += 1
 
@@ -146,7 +150,9 @@ async def refresh_trending_cache() -> Dict[str, Any]:
                 stats["errors"] += 1
                 logger.error(
                     "[TRENDING_CACHE] Error fetching lang=%s offset=%d: %s",
-                    lang, offset, e,
+                    lang,
+                    offset,
+                    e,
                 )
 
         if lang_fetched > 0:
@@ -155,7 +161,10 @@ async def refresh_trending_cache() -> Dict[str, Any]:
     elapsed = time.time() - start
     logger.info(
         "[TRENDING_CACHE] Refresh complete in %.1fs — cached=%d errors=%d languages=%s",
-        elapsed, stats["cached"], stats["errors"], stats["languages"],
+        elapsed,
+        stats["cached"],
+        stats["errors"],
+        stats["languages"],
     )
 
     return stats
@@ -176,7 +185,11 @@ async def get_cache_stats() -> Dict[str, Any]:
                 lang_total += count
                 age = int(time.time() - cached.get("_cached_at", 0))
                 if lang not in stats["languages"]:
-                    stats["languages"][lang] = {"results": 0, "buckets": 0, "max_age_s": 0}
+                    stats["languages"][lang] = {
+                        "results": 0,
+                        "buckets": 0,
+                        "max_age_s": 0,
+                    }
                 stats["languages"][lang]["results"] += count
                 stats["languages"][lang]["buckets"] += 1
                 stats["languages"][lang]["max_age_s"] = max(
@@ -190,6 +203,7 @@ async def get_cache_stats() -> Dict[str, Any]:
 # ═══════════════════════════════════════════════════════════════════════════════
 # Internal
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 def _snap_to_bucket(offset: int) -> int:
     """Snap an offset to the nearest pre-cached bucket."""

--- a/backend/src/trending/trending_precache.py
+++ b/backend/src/trending/trending_precache.py
@@ -27,14 +27,15 @@ logger = logging.getLogger("deepsight.trending_precache")
 # ═══════════════════════════════════════════════════════════════════════════════
 
 PRECACHE_COMBOS: list[tuple[str, str | None, int]] = [
-    ("30d", None, 20),   # Default / most common request
-    ("7d",  None, 20),   # Weekly view
+    ("30d", None, 20),  # Default / most common request
+    ("7d", None, 20),  # Weekly view
 ]
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Public API
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 async def refresh_deepsight_trending() -> Dict[str, Any]:
     """

--- a/extension/__tests__/components/Popup.test.tsx
+++ b/extension/__tests__/components/Popup.test.tsx
@@ -147,8 +147,8 @@ describe("App — rendering", () => {
       new Promise(() => {}),
     );
 
-    render(<App />);
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    const { container } = render(<App />);
+    expect(container.querySelector(".loading-view")).toBeTruthy();
   });
 });
 

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-
+    "ignoreDeprecations": "6.0",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/frontend/src/components/TrendingSection.tsx
+++ b/frontend/src/components/TrendingSection.tsx
@@ -173,7 +173,7 @@ const TrendingCard: React.FC<TrendingCardProps> = ({
       {/* Thumbnail */}
       <div className="relative aspect-video overflow-hidden">
         <ThumbnailImage
-          thumbnailUrl={video.thumbnail_url}
+          thumbnailUrl={video.thumbnail_url ?? undefined}
           videoId={video.video_id}
           title={video.title}
           className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"


### PR DESCRIPTION
## Résumé

Branche cumulative de 48 commits couvrant les 4 plateformes. Audit complet effectué localement (lint + typecheck + tests + builds), 3 régressions corrigées dans cette PR.

## Highlights par thème

### Backend
- **Thumbnails** : stockage R2 persistant + fallback filesystem VPS + composant `ThumbnailImage` unifié (cf. `120e364`, `942e3cb`, `bf04140`)
- **Screenshot detection** : extraction du pipeline dans module dédié `images/screenshot_detection.py` + endpoint `POST /detect` + `GET /supported` (cf. `a76c07e`, `e1c794c`)
- **Trending** : migration cache in-memory → Redis + APScheduler hourly pre-cache (cf. `9de0e34`, `782a665`)
- **Videos** : nouveau `duration_router.py` + `get_analysis_strategy()` API (cf. `70a956d`)
- **Plans avril 2026** : free / plus / pro (migration tests `test_plan_limits`, `test_plan_gates`, `test_voice`)

### Frontend
- **Landing page** : démo interactive avec analyse statique + chat statique + nouveau pricing (cf. `9dc896d`)
- **Compatibilité navigateurs** : browserslist élargi, target ES2018 (Chrome 63+, Firefox 58+, Safari 12+), `@supports` fallbacks pour glassmorphism, fix safe-area sans `env()`, fonts Latin subset
- **Bundle analysis** : tooling `rollup-plugin-visualizer`
- **Recovery** : patterns Firefox/Edge ajoutés au chunk error handler

### Mobile
- **Voice agent ElevenLabs** : intégration RN SDK + 3 suites de tests (`useVoiceChat`, `VoiceScreen`, `VoiceButton`)
- **Plans** : matrice plans étendue dans types extension
- **Scripts EAS** : `eas update` et preview ajoutés

### Extension Chrome
- **Cross-browser** : Manifest Firefox MV3 + Manifest Safari + adapter OAuth + abstraction API + webextension-polyfill (cf. `2658408`, `fc054fd`, `fbbc334`, `57cfe60`, `beb423f`, `c6c9c7e`)
- **Performance** : migration popup React → Preact (432KB → 85KB) (cf. `64580b3`)
- **Hardening** : détection coexistence avec autres extensions, theme detection résistant à Dark Reader, title extraction défensive, sidebar visibility check
- **i18n content scripts** : FR + EN

## Fixes apportés par l'audit (cette session)

| Commit | Scope | Description |
|--------|-------|-------------|
| `40b329e` | backend | Ruff format + remove unused imports sur les 5 nouveaux fichiers |
| `428139c` | frontend | `TrendingSection` : `thumbnail_url ?? undefined` (TS2322 régression de `120e364`) |
| `56f8cff` | extension | Test `Popup` loading view : assertion sur `.loading-view` au lieu du texte `Loading...` (markup migré vers DeepSightSpinner) |

## État de l'audit local

| Job | Résultat | Note |
|-----|----------|------|
| Backend ruff lint (fichiers branche) | ✅ All checks passed | 5 erreurs auto-corrigées |
| Backend ruff format (fichiers branche) | ✅ 5 files reformatted | |
| Backend pytest | ✅ **738 passed**, 6 skipped (integration) | +212 vs CLAUDE.md baseline |
| Frontend tsc | ✅ **276 erreurs** vs 294 sur main | nouvelle régression fixée, -18 net |
| Frontend ESLint | ⚠️ 305 errors vs 312 sur main | déjà cassé sur main, hors scope |
| Frontend vitest | ⚠️ 419/440 passing | **mêmes 21 tests cassés sur main** (planPrivileges + useVoiceChat), hors scope |
| Mobile tsc | ✅ 0 erreur | |
| Mobile jest | ✅ **202/202 individual tests** | 2 suites broken on main aussi (expo-audio import) |
| Extension tsc | ✅ exit 0 | warning TS5107 non bloquant |
| Extension jest | ✅ **107/107 passing** | (vs 0/0 sur main à cause TS5103) |
| Extension build chrome/firefox/safari | ✅ webpack 2 warnings (assets size) | |
| Frontend build vite | ✅ built in 52.73s | |

## Hors scope explicite

- ESLint frontend (305 erreurs préexistantes sur main)
- Tests frontend `planPrivileges.test.ts` et `useVoiceChat.test.ts` (déjà rouges sur main, pas introduits par cette branche)
- Tests mobile `DashboardCrash.test.tsx` et `AnalysisScreen.test.tsx` (échec de chargement `expo-audio` préexistant sur main)

## Test plan
- [x] Backend : pytest local 738/738
- [x] Frontend : tsc OK pour les fichiers de la branche, build production OK
- [x] Mobile : tsc OK, 202 tests individuels passent
- [x] Extension : 107 tests passent, builds Chrome/Firefox/Safari OK
- [ ] CI à vérifier après push (Backend CI, Frontend CI, Mobile CI, Extension CI, Gitleaks)

https://claude.ai/code/session_01DPsnN2p19FGS9PUAgg4GcT