### PR TITLE
fix(extension): long sessions + fullscreen viewer + compact sidebar

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -341,7 +341,7 @@ GOOGLE_OAUTH_CONFIG = {
 JWT_CONFIG = {
     "SECRET_KEY": _settings.JWT_SECRET_KEY or _settings.ADMIN_SECRET_KEY,
     "ALGORITHM": "HS256",
-    "ACCESS_TOKEN_EXPIRE_MINUTES": 60,
+    "ACCESS_TOKEN_EXPIRE_MINUTES": 1440,  # 24h — long session UX for Chrome extension (was 60)
     "REFRESH_TOKEN_EXPIRE_DAYS": 30,
 }
 

--- a/extension/public/viewer.html
+++ b/extension/public/viewer.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DeepSight — Analyse complète</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
+    <link rel="stylesheet" href="design-tokens.css" />
+    <link rel="stylesheet" href="viewer.css" />
+  </head>
+  <body>
+    <div id="viewer-root"></div>
+    <script src="viewer.js"></script>
+  </body>
+</html>

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -11,6 +11,7 @@ import {
   clearStoredAuth,
   getStoredUser,
   addRecentAnalysis,
+  getTokenRefreshedAt,
 } from "./utils/storage";
 import { extractVideoId } from "./utils/video";
 import type {
@@ -46,6 +47,15 @@ async function apiRequest<T>(
     headers["Authorization"] = `Bearer ${accessToken}`;
   }
 
+  // Bug fix: proactive refresh if access_token is older than 20min
+  // to avoid 401 mid-request during long pollings.
+  const refreshedAt = await getTokenRefreshedAt();
+  if (accessToken && refreshedAt && Date.now() - refreshedAt > 20 * 60 * 1000) {
+    await tryRefreshToken();
+    const fresh = await getStoredTokens();
+    if (fresh.accessToken) headers["Authorization"] = `Bearer ${fresh.accessToken}`;
+  }
+
   const response = await fetch(`${API_BASE_URL}${endpoint}`, {
     ...options,
     headers,
@@ -66,6 +76,7 @@ async function apiRequest<T>(
       return retryResponse.json();
     }
     await clearStoredAuth();
+    console.warn("[DeepSight] Session expired, refresh failed. User needs to re-login.");
     throw new Error("SESSION_EXPIRED");
   }
 
@@ -81,7 +92,21 @@ async function apiRequest<T>(
 
 // ── Auth API ──
 
+let inflightRefresh: Promise<boolean> | null = null;
+
 async function tryRefreshToken(): Promise<boolean> {
+  if (inflightRefresh) return inflightRefresh;
+  inflightRefresh = (async () => {
+    try {
+      return await doRefreshToken();
+    } finally {
+      inflightRefresh = null;
+    }
+  })();
+  return inflightRefresh;
+}
+
+async function doRefreshToken(): Promise<boolean> {
   const { refreshToken } = await getStoredTokens();
   if (!refreshToken) {
     return false;
@@ -639,10 +664,16 @@ Browser.runtime.onInstalled.addListener(
   },
 );
 
+Browser.runtime.onStartup.addListener(async () => {
+  if (await isAuthenticated()) {
+    await tryRefreshToken();
+  }
+});
+
 // ── Alarms ──
 
 Browser.alarms.create("keepAlive", { periodInMinutes: 0.5 });
-Browser.alarms.create("refreshToken", { periodInMinutes: 50 }); // Refresh avant expiration (access_token = 60min)
+Browser.alarms.create("refreshToken", { periodInMinutes: 30 }); // Refresh toutes les 30min — grosse marge vs access_token 24h, + proactive refresh in-flight (20min)
 
 Browser.alarms.onAlarm.addListener(async (alarm: Alarms.Alarm) => {
   if (alarm.name === "refreshToken" && (await isAuthenticated())) {

--- a/extension/src/content/states/results.ts
+++ b/extension/src/content/states/results.ts
@@ -1,10 +1,10 @@
 // ── État: résultats d'analyse ──
 
+import Browser from "../../utils/browser-polyfill";
 import { WEBAPP_URL } from "../../utils/config";
 import { setWidgetBody } from "../widget";
 import {
   escapeHtml,
-  markdownToSafeHtml,
   markdownToFullHtml,
   parseAnalysisToSummary,
 } from "../../utils/sanitize";
@@ -151,7 +151,7 @@ function buildEcosystemBridge(summaryId: number): string {
 }
 
 export async function renderResultsState(opts: ResultsOptions): Promise<void> {
-  const { summary, userPlan, onChat } = opts;
+  const { summary, userPlan, onChat: _onChat } = opts;
   const parsed = parseAnalysisToSummary(summary.summary_content);
   const detailedHtml = processTimestamps(
     markdownToFullHtml(escapeHtml(summary.summary_content)),
@@ -201,10 +201,38 @@ export async function renderResultsState(opts: ResultsOptions): Promise<void> {
   const premiumHtml = buildPremiumTeasers(userPlan);
   const bridgeHtml = buildEcosystemBridge(summary.id);
 
+  // ── Detailed section HTML (collapsed under <details>) ──
+  const detailedSectionHtml = `
+    ${keyPointsHtml ? `<div class="ds-keypoints ds-stagger">${keyPointsHtml}</div>` : ""}
+    ${tagsHtml}
+    ${factCheckHtml}
+
+    <button class="ds-toggle-detail" id="ds-toggle-detail" type="button">
+      <span class="ds-toggle-text">Voir l'analyse détaillée</span>
+      <span class="ds-toggle-arrow">▼</span>
+    </button>
+    <div class="ds-detail-panel hidden" id="ds-detail-panel">
+      <div class="ds-detail-content">${detailedHtml}</div>
+    </div>
+
+    <div class="ds-share-actions">
+      <button class="ds-btn-outline" id="ds-copy-btn" type="button">📋 Copier</button>
+    </div>
+
+    ${suggestionsHtml}
+    <div class="ds-premium-teasers">${premiumHtml}</div>
+    ${bridgeHtml}
+
+    <div class="ds-card-footer">
+      <a href="${WEBAPP_URL}" target="_blank" rel="noreferrer">🌐 deepsightsynthesis.com</a>
+    </div>
+  `;
+
+  // ── Compact results HTML ──
   const html = `
-    <div class="ds-results-container">
+    <div class="ds-results-compact">
       <div class="ds-status-bar">
-        <span class="ds-done">✅ Analyse complète</span>
+        <span class="ds-done">✅ Analyse prête</span>
         <div class="ds-status-badges">
           <span class="ds-tag">${catIcon} ${escapeHtml(summary.category)}</span>
           <span class="ds-tag ${sc}">${si} ${summary.reliability_score}%</span>
@@ -223,47 +251,36 @@ export async function renderResultsState(opts: ResultsOptions): Promise<void> {
         </div>
       </div>
 
-      <div class="ds-verdict">
+      <div class="ds-verdict-compact">
         <div class="ds-summary-tts-row">
-          <p class="ds-verdict-text" style="flex:1;margin:0">${escapeHtml(parsed.verdict)}</p>
+          <p class="ds-verdict-text-compact" style="flex:1;margin:0">${escapeHtml(parsed.verdict)}</p>
           ${ttsBtn}
         </div>
       </div>
       ${ttsToolbar}
 
-      ${keyPointsHtml ? `<div class="ds-keypoints ds-stagger">${keyPointsHtml}</div>` : ""}
-      ${tagsHtml}
-      ${factCheckHtml}
-
-      <button class="ds-toggle-detail" id="ds-toggle-detail" type="button">
-        <span class="ds-toggle-text">Voir l'analyse détaillée</span>
-        <span class="ds-toggle-arrow">▼</span>
-      </button>
-      <div class="ds-detail-panel hidden" id="ds-detail-panel">
-        <div class="ds-detail-content">${detailedHtml}</div>
-      </div>
-
-      <div class="ds-share-actions">
-        <button class="ds-btn-outline" id="ds-copy-btn" type="button">📋 Copier</button>
-        <button class="ds-btn-outline" id="ds-share-btn" type="button">🔗 Partager</button>
-      </div>
-
-      <div class="ds-summary-actions">
-        <a href="${WEBAPP_URL}/summary/${summary.id}" target="_blank" rel="noreferrer" class="ds-btn-primary-link">
-          📖 Analyse complète sur DeepSight
-        </a>
-        <button class="ds-btn-secondary-action" id="ds-chat-btn" type="button">
-          💬 Chatter avec la vidéo
+      <div class="ds-compact-actions">
+        <button class="ds-btn-primary-xl" id="ds-open-fullscreen" type="button">
+          🔍 Voir l'analyse complète
         </button>
+        <button class="ds-btn-outline-xl" id="ds-share-btn" type="button">
+          🔗 Partager cette analyse
+        </button>
+        <a href="${WEBAPP_URL}/summary/${summary.id}" target="_blank" rel="noreferrer" class="ds-link-tertiary">
+          🌐 Ouvrir sur DeepSight Web ↗
+        </a>
       </div>
 
-      ${suggestionsHtml}
-      <div class="ds-premium-teasers">${premiumHtml}</div>
-      ${bridgeHtml}
+      <details class="ds-details-wrapper">
+        <summary class="ds-details-toggle">▸ Voir le détail ici</summary>
+        <div class="ds-details-body">
+          ${detailedSectionHtml}
+        </div>
+      </details>
 
-      <div class="ds-card-footer">
-        <a href="${WEBAPP_URL}" target="_blank" rel="noreferrer">🌐 deepsightsynthesis.com</a>
-      </div>
+      <button class="ds-btn-secondary-action" id="ds-chat-btn" type="button">
+        💬 Chatter avec la vidéo
+      </button>
     </div>
   `;
 
@@ -278,7 +295,13 @@ function bindResultsHandlers(
   opts: ResultsOptions,
   suggestions: string[],
 ): void {
-  // Toggle détail
+  // Open fullscreen viewer page
+  $id("ds-open-fullscreen")?.addEventListener("click", () => {
+    const viewerUrl = Browser.runtime.getURL(`viewer.html?id=${summary.id}`);
+    Browser.tabs.create({ url: viewerUrl });
+  });
+
+  // Toggle détail (inside <details>)
   $id("ds-toggle-detail")?.addEventListener("click", () => {
     const panel = $id("ds-detail-panel");
     const btn = $id("ds-toggle-detail");

--- a/extension/src/styles/viewer.css
+++ b/extension/src/styles/viewer.css
@@ -1,0 +1,531 @@
+/**
+ * DeepSight Extension — Viewer page styles
+ * Standalone fullscreen viewer for analysis details.
+ * Scoped tokens override design-tokens.css only on the viewer page
+ * because viewer.html is its own top-level tab.
+ */
+
+:root {
+  --bg-primary: #0a0a0f;
+  --bg-surface: #12121a;
+  --border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f5f5f7;
+  --text-secondary: #a1a1aa;
+  --text-muted: #71717a;
+  --accent-primary: #6366f1;
+  --accent-secondary: #8b5cf6;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --error: #ef4444;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family:
+    Inter,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ── Container ── */
+.viewer-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 32px 160px;
+  line-height: 1.6;
+}
+
+.viewer-loading,
+.viewer-error {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  text-align: center;
+  gap: 16px;
+}
+
+.viewer-loading p {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.viewer-spinner {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 3px solid rgba(99, 102, 241, 0.15);
+  border-top-color: var(--accent-primary);
+  animation: v-spin 0.8s linear infinite;
+}
+
+@keyframes v-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.viewer-error h1 {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 0 0 8px;
+}
+
+.viewer-error p {
+  color: var(--text-secondary);
+  margin: 0 0 24px;
+  max-width: 420px;
+}
+
+/* ── Header ── */
+.v-header {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 32px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.v-header-thumb {
+  width: 240px;
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+
+.v-header-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.v-header-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.v-header-title {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 0 0 8px;
+  line-height: 1.3;
+  color: var(--text-primary);
+}
+
+.v-header-channel {
+  color: var(--text-secondary);
+  font-size: 14px;
+  margin: 0 0 16px;
+}
+
+.v-header-badges {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.v-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.v-badge-score {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--success);
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+.v-badge-score.warn {
+  background: rgba(245, 158, 11, 0.1);
+  color: var(--warning);
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+.v-badge-score.low {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--error);
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+/* Reliability bar */
+.v-header-reliability {
+  margin-top: 4px;
+}
+
+.v-reliability-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.v-reliability-value {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.v-reliability-bar {
+  height: 4px;
+  background: var(--bg-surface);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.v-reliability-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Sections ── */
+.v-section {
+  margin-bottom: 40px;
+}
+
+.v-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: var(--text-muted);
+  margin: 0 0 16px;
+}
+
+/* ── Verdict ── */
+.v-verdict {
+  font-size: 20px;
+  line-height: 1.7;
+  color: var(--text-primary);
+  padding: 24px 28px;
+  background: linear-gradient(
+    135deg,
+    rgba(99, 102, 241, 0.06),
+    rgba(139, 92, 246, 0.06)
+  );
+  border-left: 3px solid var(--accent-primary);
+  border-radius: 0 12px 12px 0;
+}
+
+/* ── Key points ── */
+.v-kp-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.v-kp {
+  display: flex;
+  gap: 16px;
+  padding: 16px 20px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.v-kp:hover {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.v-kp-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.v-kp-text {
+  flex: 1;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+.v-kp-solid {
+  border-left: 3px solid var(--success);
+}
+
+.v-kp-weak {
+  border-left: 3px solid var(--warning);
+}
+
+.v-kp-default {
+  border-left: 3px solid var(--accent-primary);
+}
+
+/* ── Detailed markdown ── */
+.v-markdown h1,
+.v-markdown h2,
+.v-markdown h3 {
+  color: var(--text-primary);
+  margin: 32px 0 16px;
+  font-weight: 600;
+}
+
+.v-markdown h1 {
+  font-size: 24px;
+}
+
+.v-markdown h2 {
+  font-size: 20px;
+}
+
+.v-markdown h3 {
+  font-size: 17px;
+}
+
+.v-markdown p {
+  margin: 12px 0;
+  color: var(--text-primary);
+}
+
+.v-markdown ul,
+.v-markdown ol {
+  padding-left: 24px;
+  margin: 12px 0;
+}
+
+.v-markdown li {
+  margin: 6px 0;
+  color: var(--text-primary);
+}
+
+.v-markdown a {
+  color: var(--accent-primary);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border 0.15s;
+}
+
+.v-markdown a:hover {
+  border-bottom-color: var(--accent-primary);
+}
+
+.v-markdown code {
+  background: var(--bg-surface);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: "JetBrains Mono", Menlo, monospace;
+  font-size: 0.9em;
+}
+
+.v-markdown blockquote {
+  border-left: 3px solid var(--accent-primary);
+  padding: 8px 20px;
+  margin: 16px 0;
+  color: var(--text-secondary);
+  background: rgba(99, 102, 241, 0.04);
+  border-radius: 0 8px 8px 0;
+}
+
+.v-markdown hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 28px 0;
+}
+
+.v-timestamp {
+  display: inline-block;
+  padding: 1px 6px;
+  margin: 0 2px;
+  border-radius: 4px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent-primary);
+  font-family: "JetBrains Mono", Menlo, monospace;
+  font-size: 0.85em;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.v-timestamp:hover,
+.v-timestamp:focus-visible {
+  background: rgba(99, 102, 241, 0.22);
+  outline: none;
+}
+
+/* Inline epistemic markers inherited from sanitize.ts */
+.v-markdown .ds-marker {
+  display: inline-block;
+  padding: 1px 8px;
+  margin: 0 4px;
+  border-radius: 999px;
+  font-size: 0.8em;
+  font-weight: 500;
+}
+
+.v-markdown .ds-marker-solid {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--success);
+}
+
+.v-markdown .ds-marker-plausible {
+  background: rgba(59, 130, 246, 0.12);
+  color: #60a5fa;
+}
+
+.v-markdown .ds-marker-uncertain {
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--warning);
+}
+
+.v-markdown .ds-marker-weak {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--error);
+}
+
+/* ── Facts ── */
+.v-facts {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.v-fact {
+  display: flex;
+  gap: 12px;
+  padding: 14px 18px;
+  background: rgba(245, 158, 11, 0.06);
+  border: 1px solid rgba(245, 158, 11, 0.15);
+  border-radius: 10px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.v-fact-icon {
+  flex-shrink: 0;
+  font-size: 16px;
+  line-height: 1.4;
+}
+
+/* ── Action bar (sticky bottom) ── */
+.v-actions {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+  background: rgba(18, 18, 26, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  max-width: calc(100vw - 32px);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.v-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  border: none;
+  font-family: inherit;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.v-btn:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+.v-btn-primary {
+  background: linear-gradient(
+    135deg,
+    var(--accent-primary),
+    var(--accent-secondary)
+  );
+  color: white;
+}
+
+.v-btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.4);
+}
+
+.v-btn-secondary {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+}
+
+.v-btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .viewer-container {
+    padding: 32px 20px 160px;
+  }
+
+  .v-header {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .v-header-thumb {
+    width: 100%;
+  }
+
+  .v-header-title {
+    font-size: 20px;
+  }
+
+  .v-verdict {
+    font-size: 16px;
+    padding: 20px;
+  }
+
+  .v-actions {
+    bottom: 16px;
+    padding: 8px;
+    gap: 6px;
+  }
+
+  .v-btn {
+    padding: 9px 12px;
+    font-size: 12px;
+  }
+}

--- a/extension/src/styles/widget.css
+++ b/extension/src/styles/widget.css
@@ -1404,3 +1404,104 @@
 .ds-collapsed .ds-minimize-btn {
   display: none !important;
 }
+
+/* ══════════════════════════════════════════
+   COMPACT RESULTS MODE
+   ══════════════════════════════════════════ */
+.ds-results-compact {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.ds-verdict-compact {
+  padding: 12px 14px;
+  background: rgba(99, 102, 241, 0.04);
+  border-left: 3px solid var(--ds-accent-primary, #6366f1);
+  border-radius: 0 8px 8px 0;
+}
+.ds-verdict-text-compact {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--ds-text-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ds-compact-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 4px 0;
+}
+.ds-btn-primary-xl {
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: white;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  width: 100%;
+}
+.ds-btn-primary-xl:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.4);
+}
+.ds-btn-outline-xl {
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  background: transparent;
+  color: var(--ds-text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s;
+  width: 100%;
+}
+.ds-btn-outline-xl:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+.ds-link-tertiary {
+  display: block;
+  text-align: center;
+  font-size: 12px;
+  color: var(--ds-text-muted);
+  text-decoration: none;
+  padding: 6px 0;
+  transition: color 0.15s;
+}
+.ds-link-tertiary:hover {
+  color: var(--ds-accent-primary, #6366f1);
+}
+.ds-details-wrapper {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 0;
+  margin-top: 4px;
+}
+.ds-details-toggle {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: var(--ds-text-muted);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  transition: color 0.15s;
+}
+.ds-details-toggle::-webkit-details-marker { display: none; }
+.ds-details-toggle:hover { color: var(--ds-text-primary); }
+.ds-details-wrapper[open] .ds-details-toggle { color: var(--ds-text-primary); }
+.ds-details-body {
+  padding: 8px 14px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}

--- a/extension/src/utils/storage.ts
+++ b/extension/src/utils/storage.ts
@@ -28,8 +28,9 @@ export async function setStoredTokens(
   refreshToken: string,
 ): Promise<void> {
   // Bug #10: guard against undefined values
-  const payload: Record<string, string> = { accessToken };
+  const payload: Record<string, string | number> = { accessToken };
   if (refreshToken) payload.refreshToken = refreshToken;
+  payload.tokenRefreshedAt = Date.now();
   try {
     await Browser.storage.local.set(payload);
   } catch {
@@ -37,9 +38,18 @@ export async function setStoredTokens(
   }
 }
 
+export async function getTokenRefreshedAt(): Promise<number | null> {
+  try {
+    const data = (await Browser.storage.local.get("tokenRefreshedAt")) as { tokenRefreshedAt?: number };
+    return data.tokenRefreshedAt ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function clearStoredAuth(): Promise<void> {
   try {
-    await Browser.storage.local.remove(["accessToken", "refreshToken", "user"]);
+    await Browser.storage.local.remove(["accessToken", "refreshToken", "user", "tokenRefreshedAt"]);
   } catch {
     // Ignore errors on clear
   }

--- a/extension/src/viewer.tsx
+++ b/extension/src/viewer.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { ViewerApp } from "./viewer/ViewerApp";
+
+const params = new URLSearchParams(window.location.search);
+const summaryId = parseInt(params.get("id") || "0", 10);
+
+const rootEl = document.getElementById("viewer-root");
+if (rootEl) {
+  const root = createRoot(rootEl);
+  root.render(<ViewerApp summaryId={summaryId} />);
+}

--- a/extension/src/viewer/ViewerApp.tsx
+++ b/extension/src/viewer/ViewerApp.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from "react";
+import Browser from "../utils/browser-polyfill";
+import type { Summary, MessageResponse } from "../types";
+import { parseAnalysisToSummary } from "../utils/sanitize";
+import { ViewerHeader } from "./components/ViewerHeader";
+import { VerdictSection } from "./components/VerdictSection";
+import { KeyPointsSection } from "./components/KeyPointsSection";
+import { DetailedAnalysis } from "./components/DetailedAnalysis";
+import { FactCheckSection } from "./components/FactCheckSection";
+import { ActionBar } from "./components/ActionBar";
+
+interface Props {
+  summaryId: number;
+}
+
+export const ViewerApp: React.FC<Props> = ({ summaryId }) => {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!summaryId) {
+      setError("ID d'analyse manquant");
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    Browser.runtime
+      .sendMessage({
+        action: "GET_SUMMARY",
+        data: { summaryId },
+      })
+      .then((resp) => {
+        if (cancelled) return;
+        const response = resp as MessageResponse | undefined;
+        if (response?.success && response.summary) {
+          setSummary(response.summary as Summary);
+        } else {
+          setError(response?.error || "Analyse introuvable");
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError((e as Error).message);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [summaryId]);
+
+  if (loading) {
+    return (
+      <div className="viewer-loading">
+        <div className="viewer-spinner" aria-hidden="true" />
+        <p>Chargement de l'analyse…</p>
+      </div>
+    );
+  }
+
+  if (error || !summary) {
+    return (
+      <div className="viewer-error">
+        <h1>Analyse introuvable</h1>
+        <p>{error ?? "Aucune donnée retournée."}</p>
+        <button
+          type="button"
+          className="v-btn v-btn-primary"
+          onClick={() => window.close()}
+        >
+          Fermer
+        </button>
+      </div>
+    );
+  }
+
+  const parsed = parseAnalysisToSummary(summary.summary_content);
+
+  return (
+    <div className="viewer-container">
+      <ViewerHeader summary={summary} />
+      <VerdictSection verdict={parsed.verdict} />
+      <KeyPointsSection points={parsed.keyPoints} />
+      <FactCheckSection facts={summary.facts_to_verify ?? []} />
+      <DetailedAnalysis content={summary.summary_content} />
+      <ActionBar summary={summary} summaryId={summary.id} />
+    </div>
+  );
+};

--- a/extension/src/viewer/components/ActionBar.tsx
+++ b/extension/src/viewer/components/ActionBar.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useState } from "react";
+import Browser from "../../utils/browser-polyfill";
+import { WEBAPP_URL } from "../../utils/config";
+import type { Summary, MessageResponse } from "../../types";
+
+interface Props {
+  summary: Summary;
+  summaryId: number;
+}
+
+function extractVideoId(url: string | undefined): string | null {
+  if (!url) return null;
+  const yt = url.match(/[?&]v=([^&]+)/);
+  if (yt) return yt[1];
+  const ytShort = url.match(/youtu\.be\/([^?&]+)/);
+  if (ytShort) return ytShort[1];
+  const tt = url.match(/tiktok\.com\/[^/]+\/video\/(\d+)/);
+  if (tt) return tt[1];
+  return null;
+}
+
+export const ActionBar: React.FC<Props> = ({ summary, summaryId }) => {
+  const [shareLabel, setShareLabel] = useState<string | null>(null);
+
+  const videoId = extractVideoId(summary.video_url);
+
+  const handleShare = useCallback(async () => {
+    const fallbackUrl = `${WEBAPP_URL}/summary/${summaryId}`;
+    let shareUrl = fallbackUrl;
+
+    if (videoId) {
+      try {
+        const res = (await Browser.runtime.sendMessage({
+          action: "SHARE_ANALYSIS",
+          data: { videoId },
+        })) as MessageResponse | undefined;
+        if (res?.success && res.share_url) {
+          shareUrl = res.share_url;
+        }
+      } catch {
+        /* fallback */
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setShareLabel("Lien copié !");
+    } catch {
+      setShareLabel("Erreur de copie");
+    }
+    setTimeout(() => setShareLabel(null), 2200);
+  }, [videoId, summaryId]);
+
+  const handleOpenWeb = useCallback(() => {
+    Browser.tabs.create({ url: `${WEBAPP_URL}/summary/${summaryId}` });
+  }, [summaryId]);
+
+  const handleAnalyzeAnother = useCallback(() => {
+    Browser.tabs.create({ url: "https://www.youtube.com" });
+  }, []);
+
+  return (
+    <div className="v-actions" role="toolbar" aria-label="Actions">
+      <button
+        type="button"
+        className="v-btn v-btn-primary"
+        onClick={handleShare}
+      >
+        <span aria-hidden="true">{"\uD83D\uDD17"}</span>
+        <span>{shareLabel ?? "Partager cette analyse"}</span>
+      </button>
+      <button
+        type="button"
+        className="v-btn v-btn-secondary"
+        onClick={handleOpenWeb}
+      >
+        <span aria-hidden="true">{"\uD83C\uDF10"}</span>
+        <span>Ouvrir sur DeepSight Web</span>
+      </button>
+      <button
+        type="button"
+        className="v-btn v-btn-secondary"
+        onClick={handleAnalyzeAnother}
+      >
+        <span aria-hidden="true">{"\uD83C\uDFAC"}</span>
+        <span>Analyser une autre vidéo</span>
+      </button>
+    </div>
+  );
+};

--- a/extension/src/viewer/components/DetailedAnalysis.tsx
+++ b/extension/src/viewer/components/DetailedAnalysis.tsx
@@ -1,0 +1,37 @@
+import React, { useMemo } from "react";
+import { escapeHtml, markdownToFullHtml } from "../../utils/sanitize";
+
+interface Props {
+  content: string;
+}
+
+/**
+ * Replaces `[mm:ss]` or `[hh:mm:ss]` patterns with clickable timestamp spans
+ * in an already-sanitized HTML string. Uses a safe post-processing pass:
+ * we only match digit-only fragments already escaped by `escapeHtml`.
+ */
+function linkifyTimestamps(html: string): string {
+  return html.replace(
+    /\[((?:\d{1,2}:){1,2}\d{2})\]/g,
+    (_match, ts: string) =>
+      `<span class="v-timestamp" data-ts="${ts}" role="button" tabindex="0">${ts}</span>`,
+  );
+}
+
+export const DetailedAnalysis: React.FC<Props> = ({ content }) => {
+  const html = useMemo(() => {
+    if (!content) return "";
+    const escaped = escapeHtml(content);
+    const base = markdownToFullHtml(escaped);
+    return linkifyTimestamps(base);
+  }, [content]);
+
+  if (!html) return null;
+
+  return (
+    <section className="v-section">
+      <h2 className="v-section-title">Analyse détaillée</h2>
+      <div className="v-markdown" dangerouslySetInnerHTML={{ __html: html }} />
+    </section>
+  );
+};

--- a/extension/src/viewer/components/FactCheckSection.tsx
+++ b/extension/src/viewer/components/FactCheckSection.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface Props {
+  facts: string[];
+}
+
+export const FactCheckSection: React.FC<Props> = ({ facts }) => {
+  if (!facts || facts.length === 0) return null;
+
+  return (
+    <section className="v-section">
+      <h2 className="v-section-title">Faits à vérifier</h2>
+      <div className="v-facts">
+        {facts.map((fact, i) => (
+          <div key={i} className="v-fact">
+            <span className="v-fact-icon" aria-hidden="true">
+              {"\uD83D\uDD0D"}
+            </span>
+            <span className="v-fact-text">{fact}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/extension/src/viewer/components/KeyPointsSection.tsx
+++ b/extension/src/viewer/components/KeyPointsSection.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import type { KeyPoint } from "../../utils/sanitize";
+
+interface Props {
+  points: KeyPoint[];
+}
+
+function keyPointIcon(type: KeyPoint["type"]): string {
+  switch (type) {
+    case "solid":
+      return "\u2705";
+    case "weak":
+      return "\u26A0\uFE0F";
+    case "insight":
+      return "\u{1F4A1}";
+  }
+}
+
+function keyPointClass(type: KeyPoint["type"]): string {
+  switch (type) {
+    case "solid":
+      return "v-kp v-kp-solid";
+    case "weak":
+      return "v-kp v-kp-weak";
+    case "insight":
+      return "v-kp v-kp-default";
+  }
+}
+
+export const KeyPointsSection: React.FC<Props> = ({ points }) => {
+  if (!points || points.length === 0) return null;
+
+  return (
+    <section className="v-section">
+      <h2 className="v-section-title">Points clés</h2>
+      <div className="v-kp-list">
+        {points.map((kp, i) => (
+          <div key={i} className={keyPointClass(kp.type)}>
+            <span className="v-kp-icon" aria-hidden="true">
+              {keyPointIcon(kp.type)}
+            </span>
+            <span className="v-kp-text">{kp.text}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/extension/src/viewer/components/VerdictSection.tsx
+++ b/extension/src/viewer/components/VerdictSection.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface Props {
+  verdict: string;
+}
+
+export const VerdictSection: React.FC<Props> = ({ verdict }) => {
+  if (!verdict) return null;
+
+  return (
+    <section className="v-section v-section-verdict">
+      <h2 className="v-section-title">Verdict</h2>
+      <div className="v-verdict">{verdict}</div>
+    </section>
+  );
+};

--- a/extension/src/viewer/components/ViewerHeader.tsx
+++ b/extension/src/viewer/components/ViewerHeader.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import type { Summary } from "../../types";
+import { CATEGORY_ICONS } from "../../types";
+
+interface Props {
+  summary: Summary;
+}
+
+interface VideoRef {
+  id: string | null;
+  platform: "youtube" | "tiktok" | "unknown";
+}
+
+function extractVideoRef(url: string | undefined): VideoRef {
+  if (!url) return { id: null, platform: "unknown" };
+
+  const yt = url.match(/[?&]v=([^&]+)/);
+  if (yt) return { id: yt[1], platform: "youtube" };
+
+  const ytShort = url.match(/youtu\.be\/([^?&]+)/);
+  if (ytShort) return { id: ytShort[1], platform: "youtube" };
+
+  const tt = url.match(/tiktok\.com\/[^/]+\/video\/(\d+)/);
+  if (tt) return { id: tt[1], platform: "tiktok" };
+
+  return { id: null, platform: "unknown" };
+}
+
+function scoreBadgeClass(score: number): string {
+  if (score >= 80) return "v-badge v-badge-score";
+  if (score >= 60) return "v-badge v-badge-score warn";
+  return "v-badge v-badge-score low";
+}
+
+function scoreIcon(score: number): string {
+  if (score >= 80) return "\u2705";
+  if (score >= 60) return "\u26A0\uFE0F";
+  return "\u2753";
+}
+
+export const ViewerHeader: React.FC<Props> = ({ summary }) => {
+  const ref = extractVideoRef(summary.video_url);
+
+  const thumbnailUrl = (() => {
+    if (summary.thumbnail_url) return summary.thumbnail_url;
+    if (ref.platform === "youtube" && ref.id) {
+      return `https://img.youtube.com/vi/${ref.id}/maxresdefault.jpg`;
+    }
+    return null;
+  })();
+
+  const categoryIcon = CATEGORY_ICONS[summary.category] ?? "\u{1F4CB}";
+  const score = summary.reliability_score;
+
+  const reliabilityLabel =
+    score >= 80
+      ? "Source fiable"
+      : score >= 60
+        ? "Fiabilité modérée"
+        : "À vérifier";
+
+  const reliabilityColor =
+    score >= 80 ? "#10b981" : score >= 60 ? "#f59e0b" : "#ef4444";
+
+  return (
+    <header className="v-header">
+      {thumbnailUrl && (
+        <div className="v-header-thumb">
+          <img
+            src={thumbnailUrl}
+            alt={summary.video_title}
+            loading="lazy"
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).style.display = "none";
+            }}
+          />
+        </div>
+      )}
+      <div className="v-header-body">
+        <h1 className="v-header-title">{summary.video_title}</h1>
+        {summary.video_channel && (
+          <p className="v-header-channel">{summary.video_channel}</p>
+        )}
+        <div className="v-header-badges">
+          <span className="v-badge">
+            {categoryIcon} {summary.category}
+          </span>
+          <span className={scoreBadgeClass(score)}>
+            {scoreIcon(score)} {score}%
+          </span>
+          {summary.tournesol?.found &&
+            summary.tournesol.tournesol_score !== null && (
+              <span className="v-badge">
+                {"\uD83C\uDF3B"} Tournesol{" "}
+                {summary.tournesol.tournesol_score > 0 ? "+" : ""}
+                {Math.round(summary.tournesol.tournesol_score)}
+              </span>
+            )}
+        </div>
+        <div className="v-header-reliability">
+          <div className="v-reliability-label">
+            <span>Fiabilité — {reliabilityLabel}</span>
+            <span className="v-reliability-value">{score}%</span>
+          </div>
+          <div className="v-reliability-bar">
+            <div
+              className="v-reliability-fill"
+              style={{
+                width: `${Math.max(0, Math.min(100, score))}%`,
+                background: reliabilityColor,
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = (env, argv) => {
       authSync: "./src/authSync/index.ts",
       authSyncMain: "./src/authSyncMain/index.ts",
       popup: "./src/popup.tsx",
+      viewer: "./src/viewer.tsx",
     },
     output: {
       path: outputDir,
@@ -64,10 +65,12 @@ module.exports = (env, argv) => {
         patterns: [
           { from: `public/${manifestFile}`, to: "manifest.json" },
           { from: "public/popup.html", to: "popup.html" },
+          { from: "public/viewer.html", to: "viewer.html" },
           { from: "src/styles/design-tokens.css", to: "design-tokens.css" },
           { from: "src/styles/popup.css", to: "popup.css" },
           { from: "src/styles/content.css", to: "content.css" },
           { from: "src/styles/widget.css", to: "widget.css" },
+          { from: "src/styles/viewer.css", to: "viewer.css" },
           { from: "src/styles/tokens.css", to: "tokens.css" },
           { from: "icons", to: "icons" },
           {


### PR DESCRIPTION
## Summary

Two user-reported bugs on the DeepSight Chrome extension (sidebar injected on YouTube):

1. **SESSION_EXPIRED mid-analysis** — users were logged out in the middle of long polls.
2. **Analysis didn't display properly** — cramped 400px sidebar, dense rendering, dead-end UX.

## Fixes

### 1) Long, robust sessions

- **Backend** : `ACCESS_TOKEN_EXPIRE_MINUTES` 60 → **1440** (24h). Refresh_token stays 30d.
- **Extension `background.ts`** :
  - **Mutex** on `tryRefreshToken` (shared Promise) — kills the race condition that triggered SESSION_EXPIRED during `pollAnalysis` (which polls /videos/status every 2-8s for up to 30 min).
  - **Proactive refresh** in `apiRequest` when `tokenRefreshedAt > 20 min` old — long polls never reach the 401 path mid-burst.
  - **Alarm refresh** 50 → 30 min (larger safety margin vs MV3 service worker teardowns).
  - **`onStartup` listener** refreshes on SW cold start.
  - `console.warn` on SESSION_EXPIRED for future telemetry.
- **Extension `utils/storage.ts`** : stores `tokenRefreshedAt` timestamp + new `getTokenRefreshedAt()` helper + cleanup in `clearStoredAuth`.

### 2) Fullscreen viewer + compact sidebar

- **New module `extension/src/viewer/`** : standalone React app opened via `chrome.tabs.create({ url: chrome.runtime.getURL('viewer.html?id=X') })`. Fetches the summary via `chrome.runtime.sendMessage` and renders at 960px-centered with dark DeepSight design (thumbnail + score header, verdict highlight, keypoints cards, fact-check callouts, markdown body, sticky action bar).
- **Webpack** : new `viewer` entry + `viewer.html` + `viewer.css` copy patterns. Build produces `dist/viewer.{html,js,css}`.
- **Sidebar `results.ts`** refactored to **compact mode**:
  - Status bar, category + score badges, reliability bar, verdict clamped to 2 lines.
  - 3 vertical CTAs :
    - 🔍 *Voir l'analyse complète* (primary gradient → opens viewer.html)
    - 🔗 *Partager cette analyse* (outline → same onShare binding, integrates with the shareable-analysis feature from the other branch)
    - 🌐 *Ouvrir sur DeepSight Web* (tertiary link)
  - Dense rendering (keypoints, markdown, TTS, factcheck, suggestions, premium teasers, copy link) preserved inside a `<details>` expandable block.
- **Widget CSS** : new `COMPACT RESULTS MODE` block (~100 lines).

## Test plan

- [x] `npm run typecheck` in extension: 0 errors
- [x] `npm run build` in extension: OK, `dist/viewer.{html,js,css}` emitted
- [x] Backend `ACCESS_TOKEN_EXPIRE_MINUTES == 1440` verified
- [ ] After merge, rebuild extension + reload in `chrome://extensions`
- [ ] Start a fresh analysis on YouTube with the extension → complete without SESSION_EXPIRED
- [ ] Click "Voir l'analyse complète" on the compact sidebar → viewer opens in a new tab, loads the summary
- [ ] Click "Partager" → share link copied
- [ ] Click `<details>` → expanded view with full markdown/keypoints/TTS works

## Interaction with `feat/shareable-analysis`

Non-conflicting: the sharing branch produces the web share page (`/s/{token}`) consumed by the `Partager` button via the existing `/api/share` endpoint. This PR only wires up the sidebar button to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)