### PR TITLE
fix(deploy): copy backend/static/ into Docker image (unblocks /static-share)

### DIFF
--- a/deploy/hetzner/Dockerfile
+++ b/deploy/hetzner/Dockerfile
@@ -31,6 +31,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src/ ./src/
 
+# Static assets served via FastAPI mounts (e.g. /static-share for public share pages).
+# Without this COPY, isdir() checks in main.py fail silently and mounts never activate.
+COPY static/ ./static/
+
 WORKDIR /app/src
 
 EXPOSE 8080


### PR DESCRIPTION
## Root cause (latent bug since 2026-04-17)

`backend/src/main.py:1119-1129` mounts `/static-share` only when the directory exists:

\`\`\`python
_SHARE_STATIC_DIR = os.path.join(os.path.dirname(__file__), \"..\", \"static\", \"share\")
if os.path.isdir(_SHARE_STATIC_DIR):
    app.mount(\"/static-share\", StaticFiles(directory=_SHARE_STATIC_DIR), name=\"share-static\")
\`\`\`

The Hetzner Dockerfile only copies \`src/\`:

\`\`\`dockerfile
COPY src/ ./src/
\`\`\`

Result: `/app/static/share/` does not exist in the production container, the `isdir()` check returns `False`, the mount is **never registered**, and every asset under `/static-share/*` returns **404**.

This affected `share.css`, `og-bg.png`, and (after PR #114) `favicon.png` and `logo-mark.svg`. The whole shared analysis page UX has been broken since the share feature shipped — every public share page loads with no styling and broken images.

## Verified on the prod container

\`\`\`
$ ssh hetzner 'docker exec repo-backend-1 ls /app/static/'
ls: cannot access '/app/static/': No such file or directory
\`\`\`

And startup logs never emit `🎨 Share static files mounted at /static-share`.

## Fix

Add a single \`COPY static/ ./static/\` line in the Dockerfile, right after \`COPY src/\`. The build context is already \`backend/\`, so the local \`backend/static/\` tree (\`share.css\`, \`og-bg.png\`, \`favicon.png\`, \`logo-mark.svg\`) lands at \`/app/static/\` in the image.

## Test plan

- [x] Dockerfile diff: +4 lines, no other changes
- [ ] After merge: GitHub Actions \`deploy-backend.yml\` rebuilds and redeploys
- [ ] After deploy: \`curl -I https://api.deepsightsynthesis.com/static-share/favicon.png\` → 200 image/png
- [ ] After deploy: \`curl -I https://api.deepsightsynthesis.com/static-share/logo-mark.svg\` → 200 image/svg+xml
- [ ] After deploy: \`curl -I https://api.deepsightsynthesis.com/static-share/share.css\` → 200 text/css
- [ ] After deploy: \`docker logs repo-backend-1 | grep '🎨 Share static'\` → mount confirmed

## Scope

Strictly the Dockerfile. No code change, no template change, no asset change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)