### PR TITLE
fix(extension): widget YouTube nuclear restoration

### DIFF
--- a/extension/dist/authSync.js
+++ b/extension/dist/authSync.js
@@ -1,1 +1,579 @@
-(()=>{var e={815(e,r){var s,g;"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self&&self,s=function(e){"use strict";if(!(globalThis.chrome&&globalThis.chrome.runtime&&globalThis.chrome.runtime.id))throw new Error("This script should only be loaded in a browser extension.");if(globalThis.browser&&globalThis.browser.runtime&&globalThis.browser.runtime.id)e.exports=globalThis.browser;else{const r="The message port closed before a response was received.",s=e=>{const s={alarms:{clear:{minArgs:0,maxArgs:1},clearAll:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getAll:{minArgs:0,maxArgs:0}},bookmarks:{create:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},getChildren:{minArgs:1,maxArgs:1},getRecent:{minArgs:1,maxArgs:1},getSubTree:{minArgs:1,maxArgs:1},getTree:{minArgs:0,maxArgs:0},move:{minArgs:2,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeTree:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}},browserAction:{disable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},enable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},getBadgeBackgroundColor:{minArgs:1,maxArgs:1},getBadgeText:{minArgs:1,maxArgs:1},getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},openPopup:{minArgs:0,maxArgs:0},setBadgeBackgroundColor:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setBadgeText:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},browsingData:{remove:{minArgs:2,maxArgs:2},removeCache:{minArgs:1,maxArgs:1},removeCookies:{minArgs:1,maxArgs:1},removeDownloads:{minArgs:1,maxArgs:1},removeFormData:{minArgs:1,maxArgs:1},removeHistory:{minArgs:1,maxArgs:1},removeLocalStorage:{minArgs:1,maxArgs:1},removePasswords:{minArgs:1,maxArgs:1},removePluginData:{minArgs:1,maxArgs:1},settings:{minArgs:0,maxArgs:0}},commands:{getAll:{minArgs:0,maxArgs:0}},contextMenus:{remove:{minArgs:1,maxArgs:1},removeAll:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},cookies:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:1,maxArgs:1},getAllCookieStores:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},devtools:{inspectedWindow:{eval:{minArgs:1,maxArgs:2,singleCallbackArg:!1}},panels:{create:{minArgs:3,maxArgs:3,singleCallbackArg:!0},elements:{createSidebarPane:{minArgs:1,maxArgs:1}}}},downloads:{cancel:{minArgs:1,maxArgs:1},download:{minArgs:1,maxArgs:1},erase:{minArgs:1,maxArgs:1},getFileIcon:{minArgs:1,maxArgs:2},open:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},pause:{minArgs:1,maxArgs:1},removeFile:{minArgs:1,maxArgs:1},resume:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},extension:{isAllowedFileSchemeAccess:{minArgs:0,maxArgs:0},isAllowedIncognitoAccess:{minArgs:0,maxArgs:0}},history:{addUrl:{minArgs:1,maxArgs:1},deleteAll:{minArgs:0,maxArgs:0},deleteRange:{minArgs:1,maxArgs:1},deleteUrl:{minArgs:1,maxArgs:1},getVisits:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1}},i18n:{detectLanguage:{minArgs:1,maxArgs:1},getAcceptLanguages:{minArgs:0,maxArgs:0}},identity:{launchWebAuthFlow:{minArgs:1,maxArgs:1}},idle:{queryState:{minArgs:1,maxArgs:1}},management:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},getSelf:{minArgs:0,maxArgs:0},setEnabled:{minArgs:2,maxArgs:2},uninstallSelf:{minArgs:0,maxArgs:1}},notifications:{clear:{minArgs:1,maxArgs:1},create:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:0},getPermissionLevel:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},pageAction:{getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},hide:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},permissions:{contains:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},request:{minArgs:1,maxArgs:1}},runtime:{getBackgroundPage:{minArgs:0,maxArgs:0},getPlatformInfo:{minArgs:0,maxArgs:0},openOptionsPage:{minArgs:0,maxArgs:0},requestUpdateCheck:{minArgs:0,maxArgs:0},sendMessage:{minArgs:1,maxArgs:3},sendNativeMessage:{minArgs:2,maxArgs:2},setUninstallURL:{minArgs:1,maxArgs:1}},sessions:{getDevices:{minArgs:0,maxArgs:1},getRecentlyClosed:{minArgs:0,maxArgs:1},restore:{minArgs:0,maxArgs:1}},storage:{local:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},managed:{get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1}},sync:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}}},tabs:{captureVisibleTab:{minArgs:0,maxArgs:2},create:{minArgs:1,maxArgs:1},detectLanguage:{minArgs:0,maxArgs:1},discard:{minArgs:0,maxArgs:1},duplicate:{minArgs:1,maxArgs:1},executeScript:{minArgs:1,maxArgs:2},get:{minArgs:1,maxArgs:1},getCurrent:{minArgs:0,maxArgs:0},getZoom:{minArgs:0,maxArgs:1},getZoomSettings:{minArgs:0,maxArgs:1},goBack:{minArgs:0,maxArgs:1},goForward:{minArgs:0,maxArgs:1},highlight:{minArgs:1,maxArgs:1},insertCSS:{minArgs:1,maxArgs:2},move:{minArgs:2,maxArgs:2},query:{minArgs:1,maxArgs:1},reload:{minArgs:0,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeCSS:{minArgs:1,maxArgs:2},sendMessage:{minArgs:2,maxArgs:3},setZoom:{minArgs:1,maxArgs:2},setZoomSettings:{minArgs:1,maxArgs:2},update:{minArgs:1,maxArgs:2}},topSites:{get:{minArgs:0,maxArgs:0}},webNavigation:{getAllFrames:{minArgs:1,maxArgs:1},getFrame:{minArgs:1,maxArgs:1}},webRequest:{handlerBehaviorChanged:{minArgs:0,maxArgs:0}},windows:{create:{minArgs:0,maxArgs:1},get:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:1},getCurrent:{minArgs:0,maxArgs:1},getLastFocused:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}}};if(0===Object.keys(s).length)throw new Error("api-metadata.json has not been included in browser-polyfill");class g extends WeakMap{constructor(e,r=void 0){super(r),this.createItem=e}get(e){return this.has(e)||this.set(e,this.createItem(e)),super.get(e)}}const a=(r,s)=>(...g)=>{e.runtime.lastError?r.reject(new Error(e.runtime.lastError.message)):s.singleCallbackArg||g.length<=1&&!1!==s.singleCallbackArg?r.resolve(g[0]):r.resolve(g)},n=e=>1==e?"argument":"arguments",m=(e,r,s)=>new Proxy(r,{apply:(r,g,a)=>s.call(g,e,...a)});let t=Function.call.bind(Object.prototype.hasOwnProperty);const i=(e,r={},s={})=>{let g=Object.create(null),A={has:(r,s)=>s in e||s in g,get(A,o,l){if(o in g)return g[o];if(!(o in e))return;let c=e[o];if("function"==typeof c)if("function"==typeof r[o])c=m(e,e[o],r[o]);else if(t(s,o)){let r=((e,r)=>function(s,...g){if(g.length<r.minArgs)throw new Error(`Expected at least ${r.minArgs} ${n(r.minArgs)} for ${e}(), got ${g.length}`);if(g.length>r.maxArgs)throw new Error(`Expected at most ${r.maxArgs} ${n(r.maxArgs)} for ${e}(), got ${g.length}`);return new Promise((n,m)=>{if(r.fallbackToNoCallback)try{s[e](...g,a({resolve:n,reject:m},r))}catch(a){console.warn(`${e} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,a),s[e](...g),r.fallbackToNoCallback=!1,r.noCallback=!0,n()}else r.noCallback?(s[e](...g),n()):s[e](...g,a({resolve:n,reject:m},r))})})(o,s[o]);c=m(e,e[o],r)}else c=c.bind(e);else if("object"==typeof c&&null!==c&&(t(r,o)||t(s,o)))c=i(c,r[o],s[o]);else{if(!t(s,"*"))return Object.defineProperty(g,o,{configurable:!0,enumerable:!0,get:()=>e[o],set(r){e[o]=r}}),c;c=i(c,r[o],s["*"])}return g[o]=c,c},set:(r,s,a,n)=>(s in g?g[s]=a:e[s]=a,!0),defineProperty:(e,r,s)=>Reflect.defineProperty(g,r,s),deleteProperty:(e,r)=>Reflect.deleteProperty(g,r)},o=Object.create(e);return new Proxy(o,A)},A=e=>({addListener(r,s,...g){r.addListener(e.get(s),...g)},hasListener:(r,s)=>r.hasListener(e.get(s)),removeListener(r,s){r.removeListener(e.get(s))}}),o=new g(e=>"function"!=typeof e?e:function(r){const s=i(r,{},{getContent:{minArgs:0,maxArgs:0}});e(s)}),l=new g(e=>"function"!=typeof e?e:function(r,s,g){let a,n,m=!1,t=new Promise(e=>{a=function(r){m=!0,e(r)}});try{n=e(r,s,a)}catch(e){n=Promise.reject(e)}const i=!0!==n&&((A=n)&&"object"==typeof A&&"function"==typeof A.then);var A;if(!0!==n&&!i&&!m)return!1;return(i?n:t).then(e=>{g(e)},e=>{let r;r=e&&(e instanceof Error||"string"==typeof e.message)?e.message:"An unexpected error occurred",g({__mozWebExtensionPolyfillReject__:!0,message:r})}).catch(e=>{console.error("Failed to send onMessage rejected reply",e)}),!0}),c=({reject:s,resolve:g},a)=>{e.runtime.lastError?e.runtime.lastError.message===r?g():s(new Error(e.runtime.lastError.message)):a&&a.__mozWebExtensionPolyfillReject__?s(new Error(a.message)):g(a)},x=(e,r,s,...g)=>{if(g.length<r.minArgs)throw new Error(`Expected at least ${r.minArgs} ${n(r.minArgs)} for ${e}(), got ${g.length}`);if(g.length>r.maxArgs)throw new Error(`Expected at most ${r.maxArgs} ${n(r.maxArgs)} for ${e}(), got ${g.length}`);return new Promise((e,r)=>{const a=c.bind(null,{resolve:e,reject:r});g.push(a),s.sendMessage(...g)})},d={devtools:{network:{onRequestFinished:A(o)}},runtime:{onMessage:A(l),onMessageExternal:A(l),sendMessage:x.bind(null,"sendMessage",{minArgs:1,maxArgs:3})},tabs:{sendMessage:x.bind(null,"sendMessage",{minArgs:2,maxArgs:3})}},u={clear:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}};return s.privacy={network:{"*":u},services:{"*":u},websites:{"*":u}},i(e,d,s)};e.exports=s(chrome)}},void 0===(g=s.apply(r,[e]))||(e.exports=g)}},r={};function s(g){var a=r[g];if(void 0!==a)return a.exports;var n=r[g]={exports:{}};return e[g].call(n.exports,n,n.exports,s),n.exports}s.n=e=>{var r=e&&e.__esModule?()=>e.default:()=>e;return s.d(r,{a:r}),r},s.d=(e,r)=>{for(var g in r)s.o(r,g)&&!s.o(e,g)&&Object.defineProperty(e,g,{enumerable:!0,get:r[g]})},s.o=(e,r)=>Object.prototype.hasOwnProperty.call(e,r),(()=>{"use strict";var e=s(815);const r=s.n(e)(),g="https://www.deepsightsynthesis.com";window.addEventListener("message",async e=>{if(e.origin!==new URL(g).origin)return;const{type:s,payload:a}=e.data||{};if("DEEPSIGHT_AUTH_SUCCESS"===s)try{const e=await r.runtime.sendMessage({action:"SYNC_AUTH_FROM_WEBSITE",data:a});e?.success&&window.postMessage({type:"DEEPSIGHT_EXTENSION_AUTH_SYNCED"},g)}catch(e){console.error("[DeepSight Extension] Failed to sync auth:",e)}})})()})();
+(() => {
+  var e = {
+      815(e, r) {
+        var s, g;
+        ("undefined" != typeof globalThis
+          ? globalThis
+          : "undefined" != typeof self && self,
+          (s = function (e) {
+            "use strict";
+            if (
+              !(
+                globalThis.chrome &&
+                globalThis.chrome.runtime &&
+                globalThis.chrome.runtime.id
+              )
+            )
+              throw new Error(
+                "This script should only be loaded in a browser extension.",
+              );
+            if (
+              globalThis.browser &&
+              globalThis.browser.runtime &&
+              globalThis.browser.runtime.id
+            )
+              e.exports = globalThis.browser;
+            else {
+              const r =
+                  "The message port closed before a response was received.",
+                s = (e) => {
+                  const s = {
+                    alarms: {
+                      clear: { minArgs: 0, maxArgs: 1 },
+                      clearAll: { minArgs: 0, maxArgs: 0 },
+                      get: { minArgs: 0, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                    },
+                    bookmarks: {
+                      create: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getChildren: { minArgs: 1, maxArgs: 1 },
+                      getRecent: { minArgs: 1, maxArgs: 1 },
+                      getSubTree: { minArgs: 1, maxArgs: 1 },
+                      getTree: { minArgs: 0, maxArgs: 0 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeTree: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    browserAction: {
+                      disable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      enable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      getBadgeBackgroundColor: { minArgs: 1, maxArgs: 1 },
+                      getBadgeText: { minArgs: 1, maxArgs: 1 },
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      openPopup: { minArgs: 0, maxArgs: 0 },
+                      setBadgeBackgroundColor: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setBadgeText: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    browsingData: {
+                      remove: { minArgs: 2, maxArgs: 2 },
+                      removeCache: { minArgs: 1, maxArgs: 1 },
+                      removeCookies: { minArgs: 1, maxArgs: 1 },
+                      removeDownloads: { minArgs: 1, maxArgs: 1 },
+                      removeFormData: { minArgs: 1, maxArgs: 1 },
+                      removeHistory: { minArgs: 1, maxArgs: 1 },
+                      removeLocalStorage: { minArgs: 1, maxArgs: 1 },
+                      removePasswords: { minArgs: 1, maxArgs: 1 },
+                      removePluginData: { minArgs: 1, maxArgs: 1 },
+                      settings: { minArgs: 0, maxArgs: 0 },
+                    },
+                    commands: { getAll: { minArgs: 0, maxArgs: 0 } },
+                    contextMenus: {
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeAll: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    cookies: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 1, maxArgs: 1 },
+                      getAllCookieStores: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    },
+                    devtools: {
+                      inspectedWindow: {
+                        eval: { minArgs: 1, maxArgs: 2, singleCallbackArg: !1 },
+                      },
+                      panels: {
+                        create: {
+                          minArgs: 3,
+                          maxArgs: 3,
+                          singleCallbackArg: !0,
+                        },
+                        elements: {
+                          createSidebarPane: { minArgs: 1, maxArgs: 1 },
+                        },
+                      },
+                    },
+                    downloads: {
+                      cancel: { minArgs: 1, maxArgs: 1 },
+                      download: { minArgs: 1, maxArgs: 1 },
+                      erase: { minArgs: 1, maxArgs: 1 },
+                      getFileIcon: { minArgs: 1, maxArgs: 2 },
+                      open: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      pause: { minArgs: 1, maxArgs: 1 },
+                      removeFile: { minArgs: 1, maxArgs: 1 },
+                      resume: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    extension: {
+                      isAllowedFileSchemeAccess: { minArgs: 0, maxArgs: 0 },
+                      isAllowedIncognitoAccess: { minArgs: 0, maxArgs: 0 },
+                    },
+                    history: {
+                      addUrl: { minArgs: 1, maxArgs: 1 },
+                      deleteAll: { minArgs: 0, maxArgs: 0 },
+                      deleteRange: { minArgs: 1, maxArgs: 1 },
+                      deleteUrl: { minArgs: 1, maxArgs: 1 },
+                      getVisits: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                    },
+                    i18n: {
+                      detectLanguage: { minArgs: 1, maxArgs: 1 },
+                      getAcceptLanguages: { minArgs: 0, maxArgs: 0 },
+                    },
+                    identity: { launchWebAuthFlow: { minArgs: 1, maxArgs: 1 } },
+                    idle: { queryState: { minArgs: 1, maxArgs: 1 } },
+                    management: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getSelf: { minArgs: 0, maxArgs: 0 },
+                      setEnabled: { minArgs: 2, maxArgs: 2 },
+                      uninstallSelf: { minArgs: 0, maxArgs: 1 },
+                    },
+                    notifications: {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      create: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getPermissionLevel: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    pageAction: {
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      hide: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    permissions: {
+                      contains: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      request: { minArgs: 1, maxArgs: 1 },
+                    },
+                    runtime: {
+                      getBackgroundPage: { minArgs: 0, maxArgs: 0 },
+                      getPlatformInfo: { minArgs: 0, maxArgs: 0 },
+                      openOptionsPage: { minArgs: 0, maxArgs: 0 },
+                      requestUpdateCheck: { minArgs: 0, maxArgs: 0 },
+                      sendMessage: { minArgs: 1, maxArgs: 3 },
+                      sendNativeMessage: { minArgs: 2, maxArgs: 2 },
+                      setUninstallURL: { minArgs: 1, maxArgs: 1 },
+                    },
+                    sessions: {
+                      getDevices: { minArgs: 0, maxArgs: 1 },
+                      getRecentlyClosed: { minArgs: 0, maxArgs: 1 },
+                      restore: { minArgs: 0, maxArgs: 1 },
+                    },
+                    storage: {
+                      local: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                      managed: {
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                      },
+                      sync: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                    },
+                    tabs: {
+                      captureVisibleTab: { minArgs: 0, maxArgs: 2 },
+                      create: { minArgs: 1, maxArgs: 1 },
+                      detectLanguage: { minArgs: 0, maxArgs: 1 },
+                      discard: { minArgs: 0, maxArgs: 1 },
+                      duplicate: { minArgs: 1, maxArgs: 1 },
+                      executeScript: { minArgs: 1, maxArgs: 2 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 0 },
+                      getZoom: { minArgs: 0, maxArgs: 1 },
+                      getZoomSettings: { minArgs: 0, maxArgs: 1 },
+                      goBack: { minArgs: 0, maxArgs: 1 },
+                      goForward: { minArgs: 0, maxArgs: 1 },
+                      highlight: { minArgs: 1, maxArgs: 1 },
+                      insertCSS: { minArgs: 1, maxArgs: 2 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      query: { minArgs: 1, maxArgs: 1 },
+                      reload: { minArgs: 0, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeCSS: { minArgs: 1, maxArgs: 2 },
+                      sendMessage: { minArgs: 2, maxArgs: 3 },
+                      setZoom: { minArgs: 1, maxArgs: 2 },
+                      setZoomSettings: { minArgs: 1, maxArgs: 2 },
+                      update: { minArgs: 1, maxArgs: 2 },
+                    },
+                    topSites: { get: { minArgs: 0, maxArgs: 0 } },
+                    webNavigation: {
+                      getAllFrames: { minArgs: 1, maxArgs: 1 },
+                      getFrame: { minArgs: 1, maxArgs: 1 },
+                    },
+                    webRequest: {
+                      handlerBehaviorChanged: { minArgs: 0, maxArgs: 0 },
+                    },
+                    windows: {
+                      create: { minArgs: 0, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 1 },
+                      getLastFocused: { minArgs: 0, maxArgs: 1 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                  };
+                  if (0 === Object.keys(s).length)
+                    throw new Error(
+                      "api-metadata.json has not been included in browser-polyfill",
+                    );
+                  class g extends WeakMap {
+                    constructor(e, r = void 0) {
+                      (super(r), (this.createItem = e));
+                    }
+                    get(e) {
+                      return (
+                        this.has(e) || this.set(e, this.createItem(e)),
+                        super.get(e)
+                      );
+                    }
+                  }
+                  const a =
+                      (r, s) =>
+                      (...g) => {
+                        e.runtime.lastError
+                          ? r.reject(new Error(e.runtime.lastError.message))
+                          : s.singleCallbackArg ||
+                              (g.length <= 1 && !1 !== s.singleCallbackArg)
+                            ? r.resolve(g[0])
+                            : r.resolve(g);
+                      },
+                    n = (e) => (1 == e ? "argument" : "arguments"),
+                    m = (e, r, s) =>
+                      new Proxy(r, { apply: (r, g, a) => s.call(g, e, ...a) });
+                  let t = Function.call.bind(Object.prototype.hasOwnProperty);
+                  const i = (e, r = {}, s = {}) => {
+                      let g = Object.create(null),
+                        A = {
+                          has: (r, s) => s in e || s in g,
+                          get(A, o, l) {
+                            if (o in g) return g[o];
+                            if (!(o in e)) return;
+                            let c = e[o];
+                            if ("function" == typeof c)
+                              if ("function" == typeof r[o])
+                                c = m(e, e[o], r[o]);
+                              else if (t(s, o)) {
+                                let r = ((e, r) =>
+                                  function (s, ...g) {
+                                    if (g.length < r.minArgs)
+                                      throw new Error(
+                                        `Expected at least ${r.minArgs} ${n(r.minArgs)} for ${e}(), got ${g.length}`,
+                                      );
+                                    if (g.length > r.maxArgs)
+                                      throw new Error(
+                                        `Expected at most ${r.maxArgs} ${n(r.maxArgs)} for ${e}(), got ${g.length}`,
+                                      );
+                                    return new Promise((n, m) => {
+                                      if (r.fallbackToNoCallback)
+                                        try {
+                                          s[e](
+                                            ...g,
+                                            a({ resolve: n, reject: m }, r),
+                                          );
+                                        } catch (a) {
+                                          (console.warn(
+                                            `${e} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,
+                                            a,
+                                          ),
+                                            s[e](...g),
+                                            (r.fallbackToNoCallback = !1),
+                                            (r.noCallback = !0),
+                                            n());
+                                        }
+                                      else
+                                        r.noCallback
+                                          ? (s[e](...g), n())
+                                          : s[e](
+                                              ...g,
+                                              a({ resolve: n, reject: m }, r),
+                                            );
+                                    });
+                                  })(o, s[o]);
+                                c = m(e, e[o], r);
+                              } else c = c.bind(e);
+                            else if (
+                              "object" == typeof c &&
+                              null !== c &&
+                              (t(r, o) || t(s, o))
+                            )
+                              c = i(c, r[o], s[o]);
+                            else {
+                              if (!t(s, "*"))
+                                return (
+                                  Object.defineProperty(g, o, {
+                                    configurable: !0,
+                                    enumerable: !0,
+                                    get: () => e[o],
+                                    set(r) {
+                                      e[o] = r;
+                                    },
+                                  }),
+                                  c
+                                );
+                              c = i(c, r[o], s["*"]);
+                            }
+                            return ((g[o] = c), c);
+                          },
+                          set: (r, s, a, n) => (
+                            s in g ? (g[s] = a) : (e[s] = a),
+                            !0
+                          ),
+                          defineProperty: (e, r, s) =>
+                            Reflect.defineProperty(g, r, s),
+                          deleteProperty: (e, r) =>
+                            Reflect.deleteProperty(g, r),
+                        },
+                        o = Object.create(e);
+                      return new Proxy(o, A);
+                    },
+                    A = (e) => ({
+                      addListener(r, s, ...g) {
+                        r.addListener(e.get(s), ...g);
+                      },
+                      hasListener: (r, s) => r.hasListener(e.get(s)),
+                      removeListener(r, s) {
+                        r.removeListener(e.get(s));
+                      },
+                    }),
+                    o = new g((e) =>
+                      "function" != typeof e
+                        ? e
+                        : function (r) {
+                            const s = i(
+                              r,
+                              {},
+                              { getContent: { minArgs: 0, maxArgs: 0 } },
+                            );
+                            e(s);
+                          },
+                    ),
+                    l = new g((e) =>
+                      "function" != typeof e
+                        ? e
+                        : function (r, s, g) {
+                            let a,
+                              n,
+                              m = !1,
+                              t = new Promise((e) => {
+                                a = function (r) {
+                                  ((m = !0), e(r));
+                                };
+                              });
+                            try {
+                              n = e(r, s, a);
+                            } catch (e) {
+                              n = Promise.reject(e);
+                            }
+                            const i =
+                              !0 !== n &&
+                              (A = n) &&
+                              "object" == typeof A &&
+                              "function" == typeof A.then;
+                            var A;
+                            if (!0 !== n && !i && !m) return !1;
+                            return (
+                              (i ? n : t)
+                                .then(
+                                  (e) => {
+                                    g(e);
+                                  },
+                                  (e) => {
+                                    let r;
+                                    ((r =
+                                      e &&
+                                      (e instanceof Error ||
+                                        "string" == typeof e.message)
+                                        ? e.message
+                                        : "An unexpected error occurred"),
+                                      g({
+                                        __mozWebExtensionPolyfillReject__: !0,
+                                        message: r,
+                                      }));
+                                  },
+                                )
+                                .catch((e) => {
+                                  console.error(
+                                    "Failed to send onMessage rejected reply",
+                                    e,
+                                  );
+                                }),
+                              !0
+                            );
+                          },
+                    ),
+                    c = ({ reject: s, resolve: g }, a) => {
+                      e.runtime.lastError
+                        ? e.runtime.lastError.message === r
+                          ? g()
+                          : s(new Error(e.runtime.lastError.message))
+                        : a && a.__mozWebExtensionPolyfillReject__
+                          ? s(new Error(a.message))
+                          : g(a);
+                    },
+                    x = (e, r, s, ...g) => {
+                      if (g.length < r.minArgs)
+                        throw new Error(
+                          `Expected at least ${r.minArgs} ${n(r.minArgs)} for ${e}(), got ${g.length}`,
+                        );
+                      if (g.length > r.maxArgs)
+                        throw new Error(
+                          `Expected at most ${r.maxArgs} ${n(r.maxArgs)} for ${e}(), got ${g.length}`,
+                        );
+                      return new Promise((e, r) => {
+                        const a = c.bind(null, { resolve: e, reject: r });
+                        (g.push(a), s.sendMessage(...g));
+                      });
+                    },
+                    d = {
+                      devtools: { network: { onRequestFinished: A(o) } },
+                      runtime: {
+                        onMessage: A(l),
+                        onMessageExternal: A(l),
+                        sendMessage: x.bind(null, "sendMessage", {
+                          minArgs: 1,
+                          maxArgs: 3,
+                        }),
+                      },
+                      tabs: {
+                        sendMessage: x.bind(null, "sendMessage", {
+                          minArgs: 2,
+                          maxArgs: 3,
+                        }),
+                      },
+                    },
+                    u = {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    };
+                  return (
+                    (s.privacy = {
+                      network: { "*": u },
+                      services: { "*": u },
+                      websites: { "*": u },
+                    }),
+                    i(e, d, s)
+                  );
+                };
+              e.exports = s(chrome);
+            }
+          }),
+          void 0 === (g = s.apply(r, [e])) || (e.exports = g));
+      },
+    },
+    r = {};
+  function s(g) {
+    var a = r[g];
+    if (void 0 !== a) return a.exports;
+    var n = (r[g] = { exports: {} });
+    return (e[g].call(n.exports, n, n.exports, s), n.exports);
+  }
+  ((s.n = (e) => {
+    var r = e && e.__esModule ? () => e.default : () => e;
+    return (s.d(r, { a: r }), r);
+  }),
+    (s.d = (e, r) => {
+      for (var g in r)
+        s.o(r, g) &&
+          !s.o(e, g) &&
+          Object.defineProperty(e, g, { enumerable: !0, get: r[g] });
+    }),
+    (s.o = (e, r) => Object.prototype.hasOwnProperty.call(e, r)),
+    (() => {
+      "use strict";
+      var e = s(815);
+      const r = s.n(e)(),
+        g = "https://www.deepsightsynthesis.com";
+      window.addEventListener("message", async (e) => {
+        if (e.origin !== new URL(g).origin) return;
+        const { type: s, payload: a } = e.data || {};
+        if ("DEEPSIGHT_AUTH_SUCCESS" === s)
+          try {
+            const e = await r.runtime.sendMessage({
+              action: "SYNC_AUTH_FROM_WEBSITE",
+              data: a,
+            });
+            e?.success &&
+              window.postMessage(
+                { type: "DEEPSIGHT_EXTENSION_AUTH_SYNCED" },
+                g,
+              );
+          } catch (e) {
+            console.error("[DeepSight Extension] Failed to sync auth:", e);
+          }
+      });
+    })());
+})();

--- a/extension/dist/authSyncMain.js
+++ b/extension/dist/authSyncMain.js
@@ -1,1 +1,23 @@
-(()=>{"use strict";window.__DEEPSIGHT_EXTENSION_PRESENT__=!0,setTimeout(function(){try{const e=localStorage.getItem("accessToken"),o=localStorage.getItem("refreshToken"),t=localStorage.getItem("user");e&&o&&t&&window.postMessage({type:"DEEPSIGHT_AUTH_SUCCESS",payload:{accessToken:e,refreshToken:o,user:JSON.parse(t)}},window.location.origin)}catch(e){console.error("[DeepSight] Failed to read localStorage:",e)}},2e3)})();
+(() => {
+  "use strict";
+  ((window.__DEEPSIGHT_EXTENSION_PRESENT__ = !0),
+    setTimeout(function () {
+      try {
+        const e = localStorage.getItem("accessToken"),
+          o = localStorage.getItem("refreshToken"),
+          t = localStorage.getItem("user");
+        e &&
+          o &&
+          t &&
+          window.postMessage(
+            {
+              type: "DEEPSIGHT_AUTH_SUCCESS",
+              payload: { accessToken: e, refreshToken: o, user: JSON.parse(t) },
+            },
+            window.location.origin,
+          );
+      } catch (e) {
+        console.error("[DeepSight] Failed to read localStorage:", e);
+      }
+    }, 2e3));
+})();

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1,1 +1,1099 @@
-(()=>{var e={815(e,r){var s,t;"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self&&self,s=function(e){"use strict";if(!(globalThis.chrome&&globalThis.chrome.runtime&&globalThis.chrome.runtime.id))throw new Error("This script should only be loaded in a browser extension.");if(globalThis.browser&&globalThis.browser.runtime&&globalThis.browser.runtime.id)e.exports=globalThis.browser;else{const r="The message port closed before a response was received.",s=e=>{const s={alarms:{clear:{minArgs:0,maxArgs:1},clearAll:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getAll:{minArgs:0,maxArgs:0}},bookmarks:{create:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},getChildren:{minArgs:1,maxArgs:1},getRecent:{minArgs:1,maxArgs:1},getSubTree:{minArgs:1,maxArgs:1},getTree:{minArgs:0,maxArgs:0},move:{minArgs:2,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeTree:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}},browserAction:{disable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},enable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},getBadgeBackgroundColor:{minArgs:1,maxArgs:1},getBadgeText:{minArgs:1,maxArgs:1},getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},openPopup:{minArgs:0,maxArgs:0},setBadgeBackgroundColor:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setBadgeText:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},browsingData:{remove:{minArgs:2,maxArgs:2},removeCache:{minArgs:1,maxArgs:1},removeCookies:{minArgs:1,maxArgs:1},removeDownloads:{minArgs:1,maxArgs:1},removeFormData:{minArgs:1,maxArgs:1},removeHistory:{minArgs:1,maxArgs:1},removeLocalStorage:{minArgs:1,maxArgs:1},removePasswords:{minArgs:1,maxArgs:1},removePluginData:{minArgs:1,maxArgs:1},settings:{minArgs:0,maxArgs:0}},commands:{getAll:{minArgs:0,maxArgs:0}},contextMenus:{remove:{minArgs:1,maxArgs:1},removeAll:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},cookies:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:1,maxArgs:1},getAllCookieStores:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},devtools:{inspectedWindow:{eval:{minArgs:1,maxArgs:2,singleCallbackArg:!1}},panels:{create:{minArgs:3,maxArgs:3,singleCallbackArg:!0},elements:{createSidebarPane:{minArgs:1,maxArgs:1}}}},downloads:{cancel:{minArgs:1,maxArgs:1},download:{minArgs:1,maxArgs:1},erase:{minArgs:1,maxArgs:1},getFileIcon:{minArgs:1,maxArgs:2},open:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},pause:{minArgs:1,maxArgs:1},removeFile:{minArgs:1,maxArgs:1},resume:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},extension:{isAllowedFileSchemeAccess:{minArgs:0,maxArgs:0},isAllowedIncognitoAccess:{minArgs:0,maxArgs:0}},history:{addUrl:{minArgs:1,maxArgs:1},deleteAll:{minArgs:0,maxArgs:0},deleteRange:{minArgs:1,maxArgs:1},deleteUrl:{minArgs:1,maxArgs:1},getVisits:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1}},i18n:{detectLanguage:{minArgs:1,maxArgs:1},getAcceptLanguages:{minArgs:0,maxArgs:0}},identity:{launchWebAuthFlow:{minArgs:1,maxArgs:1}},idle:{queryState:{minArgs:1,maxArgs:1}},management:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},getSelf:{minArgs:0,maxArgs:0},setEnabled:{minArgs:2,maxArgs:2},uninstallSelf:{minArgs:0,maxArgs:1}},notifications:{clear:{minArgs:1,maxArgs:1},create:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:0},getPermissionLevel:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},pageAction:{getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},hide:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},permissions:{contains:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},request:{minArgs:1,maxArgs:1}},runtime:{getBackgroundPage:{minArgs:0,maxArgs:0},getPlatformInfo:{minArgs:0,maxArgs:0},openOptionsPage:{minArgs:0,maxArgs:0},requestUpdateCheck:{minArgs:0,maxArgs:0},sendMessage:{minArgs:1,maxArgs:3},sendNativeMessage:{minArgs:2,maxArgs:2},setUninstallURL:{minArgs:1,maxArgs:1}},sessions:{getDevices:{minArgs:0,maxArgs:1},getRecentlyClosed:{minArgs:0,maxArgs:1},restore:{minArgs:0,maxArgs:1}},storage:{local:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},managed:{get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1}},sync:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}}},tabs:{captureVisibleTab:{minArgs:0,maxArgs:2},create:{minArgs:1,maxArgs:1},detectLanguage:{minArgs:0,maxArgs:1},discard:{minArgs:0,maxArgs:1},duplicate:{minArgs:1,maxArgs:1},executeScript:{minArgs:1,maxArgs:2},get:{minArgs:1,maxArgs:1},getCurrent:{minArgs:0,maxArgs:0},getZoom:{minArgs:0,maxArgs:1},getZoomSettings:{minArgs:0,maxArgs:1},goBack:{minArgs:0,maxArgs:1},goForward:{minArgs:0,maxArgs:1},highlight:{minArgs:1,maxArgs:1},insertCSS:{minArgs:1,maxArgs:2},move:{minArgs:2,maxArgs:2},query:{minArgs:1,maxArgs:1},reload:{minArgs:0,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeCSS:{minArgs:1,maxArgs:2},sendMessage:{minArgs:2,maxArgs:3},setZoom:{minArgs:1,maxArgs:2},setZoomSettings:{minArgs:1,maxArgs:2},update:{minArgs:1,maxArgs:2}},topSites:{get:{minArgs:0,maxArgs:0}},webNavigation:{getAllFrames:{minArgs:1,maxArgs:1},getFrame:{minArgs:1,maxArgs:1}},webRequest:{handlerBehaviorChanged:{minArgs:0,maxArgs:0}},windows:{create:{minArgs:0,maxArgs:1},get:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:1},getCurrent:{minArgs:0,maxArgs:1},getLastFocused:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}}};if(0===Object.keys(s).length)throw new Error("api-metadata.json has not been included in browser-polyfill");class t extends WeakMap{constructor(e,r=void 0){super(r),this.createItem=e}get(e){return this.has(e)||this.set(e,this.createItem(e)),super.get(e)}}const a=(r,s)=>(...t)=>{e.runtime.lastError?r.reject(new Error(e.runtime.lastError.message)):s.singleCallbackArg||t.length<=1&&!1!==s.singleCallbackArg?r.resolve(t[0]):r.resolve(t)},n=e=>1==e?"argument":"arguments",o=(e,r,s)=>new Proxy(r,{apply:(r,t,a)=>s.call(t,e,...a)});let i=Function.call.bind(Object.prototype.hasOwnProperty);const c=(e,r={},s={})=>{let t=Object.create(null),g={has:(r,s)=>s in e||s in t,get(g,m,l){if(m in t)return t[m];if(!(m in e))return;let A=e[m];if("function"==typeof A)if("function"==typeof r[m])A=o(e,e[m],r[m]);else if(i(s,m)){let r=((e,r)=>function(s,...t){if(t.length<r.minArgs)throw new Error(`Expected at least ${r.minArgs} ${n(r.minArgs)} for ${e}(), got ${t.length}`);if(t.length>r.maxArgs)throw new Error(`Expected at most ${r.maxArgs} ${n(r.maxArgs)} for ${e}(), got ${t.length}`);return new Promise((n,o)=>{if(r.fallbackToNoCallback)try{s[e](...t,a({resolve:n,reject:o},r))}catch(a){console.warn(`${e} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,a),s[e](...t),r.fallbackToNoCallback=!1,r.noCallback=!0,n()}else r.noCallback?(s[e](...t),n()):s[e](...t,a({resolve:n,reject:o},r))})})(m,s[m]);A=o(e,e[m],r)}else A=A.bind(e);else if("object"==typeof A&&null!==A&&(i(r,m)||i(s,m)))A=c(A,r[m],s[m]);else{if(!i(s,"*"))return Object.defineProperty(t,m,{configurable:!0,enumerable:!0,get:()=>e[m],set(r){e[m]=r}}),A;A=c(A,r[m],s["*"])}return t[m]=A,A},set:(r,s,a,n)=>(s in t?t[s]=a:e[s]=a,!0),defineProperty:(e,r,s)=>Reflect.defineProperty(t,r,s),deleteProperty:(e,r)=>Reflect.deleteProperty(t,r)},m=Object.create(e);return new Proxy(m,g)},g=e=>({addListener(r,s,...t){r.addListener(e.get(s),...t)},hasListener:(r,s)=>r.hasListener(e.get(s)),removeListener(r,s){r.removeListener(e.get(s))}}),m=new t(e=>"function"!=typeof e?e:function(r){const s=c(r,{},{getContent:{minArgs:0,maxArgs:0}});e(s)}),l=new t(e=>"function"!=typeof e?e:function(r,s,t){let a,n,o=!1,i=new Promise(e=>{a=function(r){o=!0,e(r)}});try{n=e(r,s,a)}catch(e){n=Promise.reject(e)}const c=!0!==n&&((g=n)&&"object"==typeof g&&"function"==typeof g.then);var g;if(!0!==n&&!c&&!o)return!1;return(c?n:i).then(e=>{t(e)},e=>{let r;r=e&&(e instanceof Error||"string"==typeof e.message)?e.message:"An unexpected error occurred",t({__mozWebExtensionPolyfillReject__:!0,message:r})}).catch(e=>{console.error("Failed to send onMessage rejected reply",e)}),!0}),A=({reject:s,resolve:t},a)=>{e.runtime.lastError?e.runtime.lastError.message===r?t():s(new Error(e.runtime.lastError.message)):a&&a.__mozWebExtensionPolyfillReject__?s(new Error(a.message)):t(a)},u=(e,r,s,...t)=>{if(t.length<r.minArgs)throw new Error(`Expected at least ${r.minArgs} ${n(r.minArgs)} for ${e}(), got ${t.length}`);if(t.length>r.maxArgs)throw new Error(`Expected at most ${r.maxArgs} ${n(r.maxArgs)} for ${e}(), got ${t.length}`);return new Promise((e,r)=>{const a=A.bind(null,{resolve:e,reject:r});t.push(a),s.sendMessage(...t)})},d={devtools:{network:{onRequestFinished:g(m)}},runtime:{onMessage:g(l),onMessageExternal:g(l),sendMessage:u.bind(null,"sendMessage",{minArgs:1,maxArgs:3})},tabs:{sendMessage:u.bind(null,"sendMessage",{minArgs:2,maxArgs:3})}},h={clear:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}};return s.privacy={network:{"*":h},services:{"*":h},websites:{"*":h}},c(e,d,s)};e.exports=s(chrome)}},void 0===(t=s.apply(r,[e]))||(e.exports=t)}},r={};function s(t){var a=r[t];if(void 0!==a)return a.exports;var n=r[t]={exports:{}};return e[t].call(n.exports,n,n.exports,s),n.exports}s.n=e=>{var r=e&&e.__esModule?()=>e.default:()=>e;return s.d(r,{a:r}),r},s.d=(e,r)=>{for(var t in r)s.o(r,t)&&!s.o(e,t)&&Object.defineProperty(e,t,{enumerable:!0,get:r[t]})},s.o=(e,r)=>Object.prototype.hasOwnProperty.call(e,r),(()=>{"use strict";var e=s(815);const r=s.n(e)(),t="https://api.deepsightsynthesis.com/api";async function a(){try{const e=await r.storage.local.get(["accessToken","refreshToken"]);return{accessToken:e.accessToken||null,refreshToken:e.refreshToken||null}}catch{return{accessToken:null,refreshToken:null}}}async function n(e,s){const t={accessToken:e};s&&(t.refreshToken=s),t.tokenRefreshedAt=Date.now();try{await r.storage.local.set(t)}catch{}}async function o(){try{await r.storage.local.remove(["accessToken","refreshToken","user","tokenRefreshedAt"])}catch{}}async function i(){try{return(await r.storage.local.get(["user"])).user||null}catch{return null}}async function c(e){try{await r.storage.local.set({user:e})}catch{}}const g=[/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?\s]+)/,/youtube\.com\/shorts\/([^&?\s]+)/],m=[/tiktok\.com\/@[\w.-]+\/video\/(\d+)/i,/vm\.tiktok\.com\/([\w-]+)/i,/m\.tiktok\.com\/v\/(\d+)/i,/tiktok\.com\/t\/([\w-]+)/i,/tiktok\.com\/video\/(\d+)/i];const l="ds_crash_log";async function A(){try{const e=await chrome.storage.local.get(l),r=Array.isArray(e[l])?e[l]:[];return r.length>0&&await chrome.storage.local.set({[l]:[]}),r}catch{return[]}}async function u(e){if(0!==e.length)try{console.warn(`[DeepSight] ${e.length} previous crash(es) detected — will ship to Sentry in Phase 5`,e)}catch{}}async function d(e,s={}){const{accessToken:n}=await a(),i={"Content-Type":"application/json",...s.headers};n&&(i.Authorization=`Bearer ${n}`);const c=await async function(){try{return(await r.storage.local.get("tokenRefreshedAt")).tokenRefreshedAt??null}catch{return null}}();if(n&&c&&Date.now()-c>12e5){await f();const e=await a();e.accessToken&&(i.Authorization=`Bearer ${e.accessToken}`)}const g=await fetch(`${t}${e}`,{...s,headers:i});if(401===g.status){if(await f()){const{accessToken:r}=await a();i.Authorization=`Bearer ${r}`;const n=await fetch(`${t}${e}`,{...s,headers:i});if(!n.ok)throw new Error(`API Error: ${n.status}`);return n.json()}throw await o(),console.warn("[DeepSight] Session expired, refresh failed. User needs to re-login."),new Error("SESSION_EXPIRED")}if(!g.ok){const e=await g.json().catch(()=>({detail:"Unknown error"}));throw new Error(e.detail||`API Error: ${g.status}`)}return g.json()}let h=null;async function f(){return h||(h=(async()=>{try{return await async function(){const{refreshToken:e}=await a();if(!e)return!1;try{const r=await fetch(`${t}/auth/refresh`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({refresh_token:e})});if(!r.ok)return!1;const s=await r.json();if(!s.access_token)return!1;const a=s.refresh_token||e;return await n(s.access_token,a),await c(s.user),!0}catch{return!1}}()}finally{h=null}})(),h)}async function x(){const e=r.identity.getRedirectURL(),s=function(){const e=new Uint8Array(16);return crypto.getRandomValues(e),Array.from(e,e=>e.toString(16).padStart(2,"0")).join("")}(),a=`https://accounts.google.com/o/oauth2/v2/auth?client_id=${encodeURIComponent("763654536492-8hkdd3n31tqeodnhcak6ef8asu4v287j.apps.googleusercontent.com")}&redirect_uri=${encodeURIComponent(e)}&response_type=${encodeURIComponent("id_token token")}&scope=${encodeURIComponent("openid email profile")}&nonce=${encodeURIComponent(s)}&prompt=select_account`,o=await r.identity.launchWebAuthFlow({url:a,interactive:!0});if(!o)throw new Error("Google login cancelled");const i=new URLSearchParams(o.split("#")[1]).get("id_token");if(!i)throw new Error("No ID token received from Google");const g=await fetch(`${t}/auth/google/token`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({id_token:i,client_platform:"web"})});if(!g.ok){const e=await g.json().catch(()=>({detail:"Google login failed"}));throw new Error(e.detail||"Google login failed on server")}const m=await g.json();return await n(m.access_token,m.refresh_token),await c(m.user),m.user}async function w(e,r={}){return d("/videos/analyze",{method:"POST",body:JSON.stringify({url:e,mode:r.mode||"standard",lang:r.lang||"fr",category:r.category||"auto",model:r.model,force_refresh:r.force_refresh||!1})})}async function y(e){return d(`/videos/status/${e}`)}async function p(){const{accessToken:e}=await a();return!!e}async function k(e,s){switch(e.action){case"CHECK_AUTH":if(await p())try{return{authenticated:!0,user:await i()??void 0}}catch{return{authenticated:!1}}return{authenticated:!1};case"GET_USER":try{return{success:!0,user:await async function(){const e=await d("/auth/me");return await c(e),e}()}}catch(e){return{success:!1,error:e.message}}case"LOGIN":{const{email:r,password:s}=e.data;try{const e=await async function(e,r){const s=await fetch(`${t}/auth/login`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({email:e,password:r})});if(!s.ok){const e=await s.json().catch(()=>({detail:"Login failed"}));throw new Error(e.detail||"Login failed")}const a=await s.json();return await n(a.access_token,a.refresh_token),await c(a.user),a.user}(r,s);return{success:!0,user:e}}catch(e){return{success:!1,error:e.message}}}case"GOOGLE_LOGIN":try{return{success:!0,user:await x()}}catch(e){return{success:!1,error:e.message}}case"START_ANALYSIS":{const{url:r,options:s}=e.data;try{const{task_id:e}=await w(r,s);return{success:!0,result:{task_id:e}}}catch(e){return{success:!1,error:e.message}}}case"ANALYZE_VIDEO":{const{url:t,options:a}=e.data;try{const{task_id:e}=await w(t,a),n=await async function(e,s){const t=Date.now();let a=2e3;for(;Date.now()-t<18e5;){const n=await y(e);if("completed"===n.status||"failed"===n.status||"cancelled"===n.status)return n;void 0!==s&&r.tabs.sendMessage(s,{action:"ANALYSIS_PROGRESS",data:{taskId:e,progress:n.progress,message:n.message}}).catch(()=>{});const o=Date.now()-t;o>3e5?a=8e3:o>12e4?a=5e3:o>3e4&&(a=3e3),await new Promise(e=>setTimeout(e,a))}throw new Error("Analysis timeout — video may be too long")}(e,s);if("completed"===n.status&&n.result?.summary_id){const e=function(e){return function(e){for(const r of g){const s=e.match(r);if(s)return s[1]}return null}(e)||function(e){for(const r of m){const s=e.match(r);if(s)return s[1]}return null}(e)}(t);e&&await async function(e){const s=(await async function(){return(await r.storage.local.get(["recentAnalyses"])).recentAnalyses||[]}()).filter(r=>r.videoId!==e.videoId);s.unshift({...e,timestamp:Date.now()}),await r.storage.local.set({recentAnalyses:s.slice(0,20)})}({videoId:e,summaryId:n.result.summary_id,title:n.result.video_title||"Unknown"})}return{success:!0,result:n}}catch(e){return{success:!1,error:e.message}}}case"GET_TASK_STATUS":{const{taskId:r}=e.data;try{return{success:!0,status:await y(r)}}catch(e){return{success:!1,error:e.message}}}case"CANCEL_ANALYSIS":{const{taskId:r}=e.data;try{const e=await async function(e){return d(`/videos/cancel/${e}`,{method:"POST"})}(r);return{success:!0,result:e}}catch(e){return{success:!1,error:e.message}}}case"GET_SUMMARY":{const{summaryId:r}=e.data;try{const e=await async function(e){const r=await d(`/videos/summary/${e}`);if(r.video_url&&!r.tournesol)try{const e=r.video_url.match(/[?&]v=([^&]+)/),s=e?.[1];if(s){const e=await d(`/tournesol/video/${s}`);e.found&&e.data&&(r.tournesol={found:!0,tournesol_score:e.data.tournesol_score,n_comparisons:e.data.n_comparisons,n_contributors:e.data.n_contributors,criteria_scores:e.data.criteria_scores})}}catch{}return r}(r);return{success:!0,summary:e}}catch(e){return{success:!1,error:e.message}}}case"ASK_QUESTION":{const{summaryId:r,question:s,options:t}=e.data;try{const e=await async function(e,r,s={}){return d("/chat/ask",{method:"POST",body:JSON.stringify({question:r,summary_id:e,mode:s.mode||"standard",use_web_search:s.use_web_search||!1})})}(r,s,t);return{success:!0,result:e}}catch(e){return{success:!1,error:e.message}}}case"GET_CHAT_HISTORY":{const{summaryId:r}=e.data;try{const e=await async function(e){try{return(await d(`/chat/${e}/history`)).messages||[]}catch{return[]}}(r);return{success:!0,result:e}}catch(e){return{success:!1,error:e.message}}}case"GET_PLAN":try{return{success:!0,plan:await async function(){return d("/billing/my-plan?platform=extension")}()}}catch(e){return{success:!1,error:e.message}}case"SHARE_ANALYSIS":{const{videoId:r}=e.data;try{const e=await async function(e){return d("/share",{method:"POST",body:JSON.stringify({video_id:e})})}(r);return{success:!0,share_url:e.share_url}}catch(e){return{success:!1,error:e.message}}}case"QUICK_CHAT":{const{url:r,lang:s}=e.data;try{const e=await async function(e,r="fr"){return d("/videos/quick-chat",{method:"POST",body:JSON.stringify({url:e,lang:r})})}(r,s||"fr");return{success:!0,result:e}}catch(e){return{success:!1,error:e.message}}}case"LOGOUT":return await async function(){try{await d("/auth/logout",{method:"POST"})}catch{}await o()}(),{success:!0};case"OPEN_POPUP":return r.action.setBadgeText({text:"!"}),r.action.setBadgeBackgroundColor({color:"#6366f1"}),{success:!0};case"SYNC_AUTH_FROM_WEBSITE":{const{accessToken:s,refreshToken:t,user:a}=e.data;if(!s||"string"!=typeof s)return{success:!1,error:"Invalid accessToken"};if(!a||void 0===a.id||"string"!=typeof a.plan)return{success:!1,error:"Invalid user data"};try{return await n(s,t),await c(a),r.action.setBadgeText({text:""}),{success:!0}}catch(e){return{success:!1,error:e.message}}}default:return{error:"Unknown action"}}}r.runtime.onMessage.addListener((e,r,s)=>{const t=r.tab?.id;return k(e,t).then(s).catch(e=>s({error:e.message})),!0}),r.runtime.onInstalled.addListener(async e=>{try{const e=await A();await u(e)}catch{}"install"===e.reason&&(r.tabs.create({url:"https://www.deepsightsynthesis.com"}),r.storage.local.set({showYouTubeRecommendation:!0}))}),r.runtime.onStartup.addListener(async()=>{try{const e=await A();await u(e)}catch{}await p()&&await f()}),r.alarms.create("keepAlive",{periodInMinutes:.5}),r.alarms.create("refreshToken",{periodInMinutes:30}),r.alarms.onAlarm.addListener(async e=>{"refreshToken"===e.name&&await p()&&await f()}),r.storage.onChanged.addListener((e,s)=>{"local"===s&&e.accessToken&&(e.accessToken.newValue?r.action.setBadgeText({text:""}):(r.action.setBadgeText({text:"!"}),r.action.setBadgeBackgroundColor({color:"#ef4444"})))})})()})();
+(() => {
+  var e = {
+      815(e, r) {
+        var s, t;
+        ("undefined" != typeof globalThis
+          ? globalThis
+          : "undefined" != typeof self && self,
+          (s = function (e) {
+            "use strict";
+            if (
+              !(
+                globalThis.chrome &&
+                globalThis.chrome.runtime &&
+                globalThis.chrome.runtime.id
+              )
+            )
+              throw new Error(
+                "This script should only be loaded in a browser extension.",
+              );
+            if (
+              globalThis.browser &&
+              globalThis.browser.runtime &&
+              globalThis.browser.runtime.id
+            )
+              e.exports = globalThis.browser;
+            else {
+              const r =
+                  "The message port closed before a response was received.",
+                s = (e) => {
+                  const s = {
+                    alarms: {
+                      clear: { minArgs: 0, maxArgs: 1 },
+                      clearAll: { minArgs: 0, maxArgs: 0 },
+                      get: { minArgs: 0, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                    },
+                    bookmarks: {
+                      create: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getChildren: { minArgs: 1, maxArgs: 1 },
+                      getRecent: { minArgs: 1, maxArgs: 1 },
+                      getSubTree: { minArgs: 1, maxArgs: 1 },
+                      getTree: { minArgs: 0, maxArgs: 0 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeTree: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    browserAction: {
+                      disable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      enable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      getBadgeBackgroundColor: { minArgs: 1, maxArgs: 1 },
+                      getBadgeText: { minArgs: 1, maxArgs: 1 },
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      openPopup: { minArgs: 0, maxArgs: 0 },
+                      setBadgeBackgroundColor: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setBadgeText: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    browsingData: {
+                      remove: { minArgs: 2, maxArgs: 2 },
+                      removeCache: { minArgs: 1, maxArgs: 1 },
+                      removeCookies: { minArgs: 1, maxArgs: 1 },
+                      removeDownloads: { minArgs: 1, maxArgs: 1 },
+                      removeFormData: { minArgs: 1, maxArgs: 1 },
+                      removeHistory: { minArgs: 1, maxArgs: 1 },
+                      removeLocalStorage: { minArgs: 1, maxArgs: 1 },
+                      removePasswords: { minArgs: 1, maxArgs: 1 },
+                      removePluginData: { minArgs: 1, maxArgs: 1 },
+                      settings: { minArgs: 0, maxArgs: 0 },
+                    },
+                    commands: { getAll: { minArgs: 0, maxArgs: 0 } },
+                    contextMenus: {
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeAll: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    cookies: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 1, maxArgs: 1 },
+                      getAllCookieStores: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    },
+                    devtools: {
+                      inspectedWindow: {
+                        eval: { minArgs: 1, maxArgs: 2, singleCallbackArg: !1 },
+                      },
+                      panels: {
+                        create: {
+                          minArgs: 3,
+                          maxArgs: 3,
+                          singleCallbackArg: !0,
+                        },
+                        elements: {
+                          createSidebarPane: { minArgs: 1, maxArgs: 1 },
+                        },
+                      },
+                    },
+                    downloads: {
+                      cancel: { minArgs: 1, maxArgs: 1 },
+                      download: { minArgs: 1, maxArgs: 1 },
+                      erase: { minArgs: 1, maxArgs: 1 },
+                      getFileIcon: { minArgs: 1, maxArgs: 2 },
+                      open: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      pause: { minArgs: 1, maxArgs: 1 },
+                      removeFile: { minArgs: 1, maxArgs: 1 },
+                      resume: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    extension: {
+                      isAllowedFileSchemeAccess: { minArgs: 0, maxArgs: 0 },
+                      isAllowedIncognitoAccess: { minArgs: 0, maxArgs: 0 },
+                    },
+                    history: {
+                      addUrl: { minArgs: 1, maxArgs: 1 },
+                      deleteAll: { minArgs: 0, maxArgs: 0 },
+                      deleteRange: { minArgs: 1, maxArgs: 1 },
+                      deleteUrl: { minArgs: 1, maxArgs: 1 },
+                      getVisits: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                    },
+                    i18n: {
+                      detectLanguage: { minArgs: 1, maxArgs: 1 },
+                      getAcceptLanguages: { minArgs: 0, maxArgs: 0 },
+                    },
+                    identity: { launchWebAuthFlow: { minArgs: 1, maxArgs: 1 } },
+                    idle: { queryState: { minArgs: 1, maxArgs: 1 } },
+                    management: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getSelf: { minArgs: 0, maxArgs: 0 },
+                      setEnabled: { minArgs: 2, maxArgs: 2 },
+                      uninstallSelf: { minArgs: 0, maxArgs: 1 },
+                    },
+                    notifications: {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      create: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getPermissionLevel: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    pageAction: {
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      hide: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    permissions: {
+                      contains: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      request: { minArgs: 1, maxArgs: 1 },
+                    },
+                    runtime: {
+                      getBackgroundPage: { minArgs: 0, maxArgs: 0 },
+                      getPlatformInfo: { minArgs: 0, maxArgs: 0 },
+                      openOptionsPage: { minArgs: 0, maxArgs: 0 },
+                      requestUpdateCheck: { minArgs: 0, maxArgs: 0 },
+                      sendMessage: { minArgs: 1, maxArgs: 3 },
+                      sendNativeMessage: { minArgs: 2, maxArgs: 2 },
+                      setUninstallURL: { minArgs: 1, maxArgs: 1 },
+                    },
+                    sessions: {
+                      getDevices: { minArgs: 0, maxArgs: 1 },
+                      getRecentlyClosed: { minArgs: 0, maxArgs: 1 },
+                      restore: { minArgs: 0, maxArgs: 1 },
+                    },
+                    storage: {
+                      local: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                      managed: {
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                      },
+                      sync: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                    },
+                    tabs: {
+                      captureVisibleTab: { minArgs: 0, maxArgs: 2 },
+                      create: { minArgs: 1, maxArgs: 1 },
+                      detectLanguage: { minArgs: 0, maxArgs: 1 },
+                      discard: { minArgs: 0, maxArgs: 1 },
+                      duplicate: { minArgs: 1, maxArgs: 1 },
+                      executeScript: { minArgs: 1, maxArgs: 2 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 0 },
+                      getZoom: { minArgs: 0, maxArgs: 1 },
+                      getZoomSettings: { minArgs: 0, maxArgs: 1 },
+                      goBack: { minArgs: 0, maxArgs: 1 },
+                      goForward: { minArgs: 0, maxArgs: 1 },
+                      highlight: { minArgs: 1, maxArgs: 1 },
+                      insertCSS: { minArgs: 1, maxArgs: 2 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      query: { minArgs: 1, maxArgs: 1 },
+                      reload: { minArgs: 0, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeCSS: { minArgs: 1, maxArgs: 2 },
+                      sendMessage: { minArgs: 2, maxArgs: 3 },
+                      setZoom: { minArgs: 1, maxArgs: 2 },
+                      setZoomSettings: { minArgs: 1, maxArgs: 2 },
+                      update: { minArgs: 1, maxArgs: 2 },
+                    },
+                    topSites: { get: { minArgs: 0, maxArgs: 0 } },
+                    webNavigation: {
+                      getAllFrames: { minArgs: 1, maxArgs: 1 },
+                      getFrame: { minArgs: 1, maxArgs: 1 },
+                    },
+                    webRequest: {
+                      handlerBehaviorChanged: { minArgs: 0, maxArgs: 0 },
+                    },
+                    windows: {
+                      create: { minArgs: 0, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 1 },
+                      getLastFocused: { minArgs: 0, maxArgs: 1 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                  };
+                  if (0 === Object.keys(s).length)
+                    throw new Error(
+                      "api-metadata.json has not been included in browser-polyfill",
+                    );
+                  class t extends WeakMap {
+                    constructor(e, r = void 0) {
+                      (super(r), (this.createItem = e));
+                    }
+                    get(e) {
+                      return (
+                        this.has(e) || this.set(e, this.createItem(e)),
+                        super.get(e)
+                      );
+                    }
+                  }
+                  const a =
+                      (r, s) =>
+                      (...t) => {
+                        e.runtime.lastError
+                          ? r.reject(new Error(e.runtime.lastError.message))
+                          : s.singleCallbackArg ||
+                              (t.length <= 1 && !1 !== s.singleCallbackArg)
+                            ? r.resolve(t[0])
+                            : r.resolve(t);
+                      },
+                    n = (e) => (1 == e ? "argument" : "arguments"),
+                    o = (e, r, s) =>
+                      new Proxy(r, { apply: (r, t, a) => s.call(t, e, ...a) });
+                  let i = Function.call.bind(Object.prototype.hasOwnProperty);
+                  const c = (e, r = {}, s = {}) => {
+                      let t = Object.create(null),
+                        g = {
+                          has: (r, s) => s in e || s in t,
+                          get(g, m, l) {
+                            if (m in t) return t[m];
+                            if (!(m in e)) return;
+                            let A = e[m];
+                            if ("function" == typeof A)
+                              if ("function" == typeof r[m])
+                                A = o(e, e[m], r[m]);
+                              else if (i(s, m)) {
+                                let r = ((e, r) =>
+                                  function (s, ...t) {
+                                    if (t.length < r.minArgs)
+                                      throw new Error(
+                                        `Expected at least ${r.minArgs} ${n(r.minArgs)} for ${e}(), got ${t.length}`,
+                                      );
+                                    if (t.length > r.maxArgs)
+                                      throw new Error(
+                                        `Expected at most ${r.maxArgs} ${n(r.maxArgs)} for ${e}(), got ${t.length}`,
+                                      );
+                                    return new Promise((n, o) => {
+                                      if (r.fallbackToNoCallback)
+                                        try {
+                                          s[e](
+                                            ...t,
+                                            a({ resolve: n, reject: o }, r),
+                                          );
+                                        } catch (a) {
+                                          (console.warn(
+                                            `${e} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,
+                                            a,
+                                          ),
+                                            s[e](...t),
+                                            (r.fallbackToNoCallback = !1),
+                                            (r.noCallback = !0),
+                                            n());
+                                        }
+                                      else
+                                        r.noCallback
+                                          ? (s[e](...t), n())
+                                          : s[e](
+                                              ...t,
+                                              a({ resolve: n, reject: o }, r),
+                                            );
+                                    });
+                                  })(m, s[m]);
+                                A = o(e, e[m], r);
+                              } else A = A.bind(e);
+                            else if (
+                              "object" == typeof A &&
+                              null !== A &&
+                              (i(r, m) || i(s, m))
+                            )
+                              A = c(A, r[m], s[m]);
+                            else {
+                              if (!i(s, "*"))
+                                return (
+                                  Object.defineProperty(t, m, {
+                                    configurable: !0,
+                                    enumerable: !0,
+                                    get: () => e[m],
+                                    set(r) {
+                                      e[m] = r;
+                                    },
+                                  }),
+                                  A
+                                );
+                              A = c(A, r[m], s["*"]);
+                            }
+                            return ((t[m] = A), A);
+                          },
+                          set: (r, s, a, n) => (
+                            s in t ? (t[s] = a) : (e[s] = a),
+                            !0
+                          ),
+                          defineProperty: (e, r, s) =>
+                            Reflect.defineProperty(t, r, s),
+                          deleteProperty: (e, r) =>
+                            Reflect.deleteProperty(t, r),
+                        },
+                        m = Object.create(e);
+                      return new Proxy(m, g);
+                    },
+                    g = (e) => ({
+                      addListener(r, s, ...t) {
+                        r.addListener(e.get(s), ...t);
+                      },
+                      hasListener: (r, s) => r.hasListener(e.get(s)),
+                      removeListener(r, s) {
+                        r.removeListener(e.get(s));
+                      },
+                    }),
+                    m = new t((e) =>
+                      "function" != typeof e
+                        ? e
+                        : function (r) {
+                            const s = c(
+                              r,
+                              {},
+                              { getContent: { minArgs: 0, maxArgs: 0 } },
+                            );
+                            e(s);
+                          },
+                    ),
+                    l = new t((e) =>
+                      "function" != typeof e
+                        ? e
+                        : function (r, s, t) {
+                            let a,
+                              n,
+                              o = !1,
+                              i = new Promise((e) => {
+                                a = function (r) {
+                                  ((o = !0), e(r));
+                                };
+                              });
+                            try {
+                              n = e(r, s, a);
+                            } catch (e) {
+                              n = Promise.reject(e);
+                            }
+                            const c =
+                              !0 !== n &&
+                              (g = n) &&
+                              "object" == typeof g &&
+                              "function" == typeof g.then;
+                            var g;
+                            if (!0 !== n && !c && !o) return !1;
+                            return (
+                              (c ? n : i)
+                                .then(
+                                  (e) => {
+                                    t(e);
+                                  },
+                                  (e) => {
+                                    let r;
+                                    ((r =
+                                      e &&
+                                      (e instanceof Error ||
+                                        "string" == typeof e.message)
+                                        ? e.message
+                                        : "An unexpected error occurred"),
+                                      t({
+                                        __mozWebExtensionPolyfillReject__: !0,
+                                        message: r,
+                                      }));
+                                  },
+                                )
+                                .catch((e) => {
+                                  console.error(
+                                    "Failed to send onMessage rejected reply",
+                                    e,
+                                  );
+                                }),
+                              !0
+                            );
+                          },
+                    ),
+                    A = ({ reject: s, resolve: t }, a) => {
+                      e.runtime.lastError
+                        ? e.runtime.lastError.message === r
+                          ? t()
+                          : s(new Error(e.runtime.lastError.message))
+                        : a && a.__mozWebExtensionPolyfillReject__
+                          ? s(new Error(a.message))
+                          : t(a);
+                    },
+                    u = (e, r, s, ...t) => {
+                      if (t.length < r.minArgs)
+                        throw new Error(
+                          `Expected at least ${r.minArgs} ${n(r.minArgs)} for ${e}(), got ${t.length}`,
+                        );
+                      if (t.length > r.maxArgs)
+                        throw new Error(
+                          `Expected at most ${r.maxArgs} ${n(r.maxArgs)} for ${e}(), got ${t.length}`,
+                        );
+                      return new Promise((e, r) => {
+                        const a = A.bind(null, { resolve: e, reject: r });
+                        (t.push(a), s.sendMessage(...t));
+                      });
+                    },
+                    d = {
+                      devtools: { network: { onRequestFinished: g(m) } },
+                      runtime: {
+                        onMessage: g(l),
+                        onMessageExternal: g(l),
+                        sendMessage: u.bind(null, "sendMessage", {
+                          minArgs: 1,
+                          maxArgs: 3,
+                        }),
+                      },
+                      tabs: {
+                        sendMessage: u.bind(null, "sendMessage", {
+                          minArgs: 2,
+                          maxArgs: 3,
+                        }),
+                      },
+                    },
+                    h = {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    };
+                  return (
+                    (s.privacy = {
+                      network: { "*": h },
+                      services: { "*": h },
+                      websites: { "*": h },
+                    }),
+                    c(e, d, s)
+                  );
+                };
+              e.exports = s(chrome);
+            }
+          }),
+          void 0 === (t = s.apply(r, [e])) || (e.exports = t));
+      },
+    },
+    r = {};
+  function s(t) {
+    var a = r[t];
+    if (void 0 !== a) return a.exports;
+    var n = (r[t] = { exports: {} });
+    return (e[t].call(n.exports, n, n.exports, s), n.exports);
+  }
+  ((s.n = (e) => {
+    var r = e && e.__esModule ? () => e.default : () => e;
+    return (s.d(r, { a: r }), r);
+  }),
+    (s.d = (e, r) => {
+      for (var t in r)
+        s.o(r, t) &&
+          !s.o(e, t) &&
+          Object.defineProperty(e, t, { enumerable: !0, get: r[t] });
+    }),
+    (s.o = (e, r) => Object.prototype.hasOwnProperty.call(e, r)),
+    (() => {
+      "use strict";
+      var e = s(815);
+      const r = s.n(e)(),
+        t = "https://api.deepsightsynthesis.com/api";
+      async function a() {
+        try {
+          const e = await r.storage.local.get(["accessToken", "refreshToken"]);
+          return {
+            accessToken: e.accessToken || null,
+            refreshToken: e.refreshToken || null,
+          };
+        } catch {
+          return { accessToken: null, refreshToken: null };
+        }
+      }
+      async function n(e, s) {
+        const t = { accessToken: e };
+        (s && (t.refreshToken = s), (t.tokenRefreshedAt = Date.now()));
+        try {
+          await r.storage.local.set(t);
+        } catch {}
+      }
+      async function o() {
+        try {
+          await r.storage.local.remove([
+            "accessToken",
+            "refreshToken",
+            "user",
+            "tokenRefreshedAt",
+          ]);
+        } catch {}
+      }
+      async function i() {
+        try {
+          return (await r.storage.local.get(["user"])).user || null;
+        } catch {
+          return null;
+        }
+      }
+      async function c(e) {
+        try {
+          await r.storage.local.set({ user: e });
+        } catch {}
+      }
+      const g = [
+          /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?\s]+)/,
+          /youtube\.com\/shorts\/([^&?\s]+)/,
+        ],
+        m = [
+          /tiktok\.com\/@[\w.-]+\/video\/(\d+)/i,
+          /vm\.tiktok\.com\/([\w-]+)/i,
+          /m\.tiktok\.com\/v\/(\d+)/i,
+          /tiktok\.com\/t\/([\w-]+)/i,
+          /tiktok\.com\/video\/(\d+)/i,
+        ];
+      const l = "ds_crash_log";
+      async function A() {
+        try {
+          const e = await chrome.storage.local.get(l),
+            r = Array.isArray(e[l]) ? e[l] : [];
+          return (
+            r.length > 0 && (await chrome.storage.local.set({ [l]: [] })),
+            r
+          );
+        } catch {
+          return [];
+        }
+      }
+      async function u(e) {
+        if (0 !== e.length)
+          try {
+            console.warn(
+              `[DeepSight] ${e.length} previous crash(es) detected — will ship to Sentry in Phase 5`,
+              e,
+            );
+          } catch {}
+      }
+      async function d(e, s = {}) {
+        const { accessToken: n } = await a(),
+          i = { "Content-Type": "application/json", ...s.headers };
+        n && (i.Authorization = `Bearer ${n}`);
+        const c = await (async function () {
+          try {
+            return (
+              (await r.storage.local.get("tokenRefreshedAt"))
+                .tokenRefreshedAt ?? null
+            );
+          } catch {
+            return null;
+          }
+        })();
+        if (n && c && Date.now() - c > 12e5) {
+          await f();
+          const e = await a();
+          e.accessToken && (i.Authorization = `Bearer ${e.accessToken}`);
+        }
+        const g = await fetch(`${t}${e}`, { ...s, headers: i });
+        if (401 === g.status) {
+          if (await f()) {
+            const { accessToken: r } = await a();
+            i.Authorization = `Bearer ${r}`;
+            const n = await fetch(`${t}${e}`, { ...s, headers: i });
+            if (!n.ok) throw new Error(`API Error: ${n.status}`);
+            return n.json();
+          }
+          throw (
+            await o(),
+            console.warn(
+              "[DeepSight] Session expired, refresh failed. User needs to re-login.",
+            ),
+            new Error("SESSION_EXPIRED")
+          );
+        }
+        if (!g.ok) {
+          const e = await g.json().catch(() => ({ detail: "Unknown error" }));
+          throw new Error(e.detail || `API Error: ${g.status}`);
+        }
+        return g.json();
+      }
+      let h = null;
+      async function f() {
+        return (
+          h ||
+          ((h = (async () => {
+            try {
+              return await (async function () {
+                const { refreshToken: e } = await a();
+                if (!e) return !1;
+                try {
+                  const r = await fetch(`${t}/auth/refresh`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ refresh_token: e }),
+                  });
+                  if (!r.ok) return !1;
+                  const s = await r.json();
+                  if (!s.access_token) return !1;
+                  const a = s.refresh_token || e;
+                  return (await n(s.access_token, a), await c(s.user), !0);
+                } catch {
+                  return !1;
+                }
+              })();
+            } finally {
+              h = null;
+            }
+          })()),
+          h)
+        );
+      }
+      async function x() {
+        const e = r.identity.getRedirectURL(),
+          s = (function () {
+            const e = new Uint8Array(16);
+            return (
+              crypto.getRandomValues(e),
+              Array.from(e, (e) => e.toString(16).padStart(2, "0")).join("")
+            );
+          })(),
+          a = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${encodeURIComponent("763654536492-8hkdd3n31tqeodnhcak6ef8asu4v287j.apps.googleusercontent.com")}&redirect_uri=${encodeURIComponent(e)}&response_type=${encodeURIComponent("id_token token")}&scope=${encodeURIComponent("openid email profile")}&nonce=${encodeURIComponent(s)}&prompt=select_account`,
+          o = await r.identity.launchWebAuthFlow({ url: a, interactive: !0 });
+        if (!o) throw new Error("Google login cancelled");
+        const i = new URLSearchParams(o.split("#")[1]).get("id_token");
+        if (!i) throw new Error("No ID token received from Google");
+        const g = await fetch(`${t}/auth/google/token`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id_token: i, client_platform: "web" }),
+        });
+        if (!g.ok) {
+          const e = await g
+            .json()
+            .catch(() => ({ detail: "Google login failed" }));
+          throw new Error(e.detail || "Google login failed on server");
+        }
+        const m = await g.json();
+        return (
+          await n(m.access_token, m.refresh_token),
+          await c(m.user),
+          m.user
+        );
+      }
+      async function w(e, r = {}) {
+        return d("/videos/analyze", {
+          method: "POST",
+          body: JSON.stringify({
+            url: e,
+            mode: r.mode || "standard",
+            lang: r.lang || "fr",
+            category: r.category || "auto",
+            model: r.model,
+            force_refresh: r.force_refresh || !1,
+          }),
+        });
+      }
+      async function y(e) {
+        return d(`/videos/status/${e}`);
+      }
+      async function p() {
+        const { accessToken: e } = await a();
+        return !!e;
+      }
+      async function k(e, s) {
+        switch (e.action) {
+          case "CHECK_AUTH":
+            if (await p())
+              try {
+                return { authenticated: !0, user: (await i()) ?? void 0 };
+              } catch {
+                return { authenticated: !1 };
+              }
+            return { authenticated: !1 };
+          case "GET_USER":
+            try {
+              return {
+                success: !0,
+                user: await (async function () {
+                  const e = await d("/auth/me");
+                  return (await c(e), e);
+                })(),
+              };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          case "LOGIN": {
+            const { email: r, password: s } = e.data;
+            try {
+              const e = await (async function (e, r) {
+                const s = await fetch(`${t}/auth/login`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ email: e, password: r }),
+                });
+                if (!s.ok) {
+                  const e = await s
+                    .json()
+                    .catch(() => ({ detail: "Login failed" }));
+                  throw new Error(e.detail || "Login failed");
+                }
+                const a = await s.json();
+                return (
+                  await n(a.access_token, a.refresh_token),
+                  await c(a.user),
+                  a.user
+                );
+              })(r, s);
+              return { success: !0, user: e };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "GOOGLE_LOGIN":
+            try {
+              return { success: !0, user: await x() };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          case "START_ANALYSIS": {
+            const { url: r, options: s } = e.data;
+            try {
+              const { task_id: e } = await w(r, s);
+              return { success: !0, result: { task_id: e } };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "ANALYZE_VIDEO": {
+            const { url: t, options: a } = e.data;
+            try {
+              const { task_id: e } = await w(t, a),
+                n = await (async function (e, s) {
+                  const t = Date.now();
+                  let a = 2e3;
+                  for (; Date.now() - t < 18e5; ) {
+                    const n = await y(e);
+                    if (
+                      "completed" === n.status ||
+                      "failed" === n.status ||
+                      "cancelled" === n.status
+                    )
+                      return n;
+                    void 0 !== s &&
+                      r.tabs
+                        .sendMessage(s, {
+                          action: "ANALYSIS_PROGRESS",
+                          data: {
+                            taskId: e,
+                            progress: n.progress,
+                            message: n.message,
+                          },
+                        })
+                        .catch(() => {});
+                    const o = Date.now() - t;
+                    (o > 3e5
+                      ? (a = 8e3)
+                      : o > 12e4
+                        ? (a = 5e3)
+                        : o > 3e4 && (a = 3e3),
+                      await new Promise((e) => setTimeout(e, a)));
+                  }
+                  throw new Error("Analysis timeout — video may be too long");
+                })(e, s);
+              if ("completed" === n.status && n.result?.summary_id) {
+                const e = (function (e) {
+                  return (
+                    (function (e) {
+                      for (const r of g) {
+                        const s = e.match(r);
+                        if (s) return s[1];
+                      }
+                      return null;
+                    })(e) ||
+                    (function (e) {
+                      for (const r of m) {
+                        const s = e.match(r);
+                        if (s) return s[1];
+                      }
+                      return null;
+                    })(e)
+                  );
+                })(t);
+                e &&
+                  (await (async function (e) {
+                    const s = (
+                      await (async function () {
+                        return (
+                          (await r.storage.local.get(["recentAnalyses"]))
+                            .recentAnalyses || []
+                        );
+                      })()
+                    ).filter((r) => r.videoId !== e.videoId);
+                    (s.unshift({ ...e, timestamp: Date.now() }),
+                      await r.storage.local.set({
+                        recentAnalyses: s.slice(0, 20),
+                      }));
+                  })({
+                    videoId: e,
+                    summaryId: n.result.summary_id,
+                    title: n.result.video_title || "Unknown",
+                  }));
+              }
+              return { success: !0, result: n };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "GET_TASK_STATUS": {
+            const { taskId: r } = e.data;
+            try {
+              return { success: !0, status: await y(r) };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "CANCEL_ANALYSIS": {
+            const { taskId: r } = e.data;
+            try {
+              const e = await (async function (e) {
+                return d(`/videos/cancel/${e}`, { method: "POST" });
+              })(r);
+              return { success: !0, result: e };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "GET_SUMMARY": {
+            const { summaryId: r } = e.data;
+            try {
+              const e = await (async function (e) {
+                const r = await d(`/videos/summary/${e}`);
+                if (r.video_url && !r.tournesol)
+                  try {
+                    const e = r.video_url.match(/[?&]v=([^&]+)/),
+                      s = e?.[1];
+                    if (s) {
+                      const e = await d(`/tournesol/video/${s}`);
+                      e.found &&
+                        e.data &&
+                        (r.tournesol = {
+                          found: !0,
+                          tournesol_score: e.data.tournesol_score,
+                          n_comparisons: e.data.n_comparisons,
+                          n_contributors: e.data.n_contributors,
+                          criteria_scores: e.data.criteria_scores,
+                        });
+                    }
+                  } catch {}
+                return r;
+              })(r);
+              return { success: !0, summary: e };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "ASK_QUESTION": {
+            const { summaryId: r, question: s, options: t } = e.data;
+            try {
+              const e = await (async function (e, r, s = {}) {
+                return d("/chat/ask", {
+                  method: "POST",
+                  body: JSON.stringify({
+                    question: r,
+                    summary_id: e,
+                    mode: s.mode || "standard",
+                    use_web_search: s.use_web_search || !1,
+                  }),
+                });
+              })(r, s, t);
+              return { success: !0, result: e };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "GET_CHAT_HISTORY": {
+            const { summaryId: r } = e.data;
+            try {
+              const e = await (async function (e) {
+                try {
+                  return (await d(`/chat/${e}/history`)).messages || [];
+                } catch {
+                  return [];
+                }
+              })(r);
+              return { success: !0, result: e };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "GET_PLAN":
+            try {
+              return {
+                success: !0,
+                plan: await (async function () {
+                  return d("/billing/my-plan?platform=extension");
+                })(),
+              };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          case "SHARE_ANALYSIS": {
+            const { videoId: r } = e.data;
+            try {
+              const e = await (async function (e) {
+                return d("/share", {
+                  method: "POST",
+                  body: JSON.stringify({ video_id: e }),
+                });
+              })(r);
+              return { success: !0, share_url: e.share_url };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "QUICK_CHAT": {
+            const { url: r, lang: s } = e.data;
+            try {
+              const e = await (async function (e, r = "fr") {
+                return d("/videos/quick-chat", {
+                  method: "POST",
+                  body: JSON.stringify({ url: e, lang: r }),
+                });
+              })(r, s || "fr");
+              return { success: !0, result: e };
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          case "LOGOUT":
+            return (
+              await (async function () {
+                try {
+                  await d("/auth/logout", { method: "POST" });
+                } catch {}
+                await o();
+              })(),
+              { success: !0 }
+            );
+          case "OPEN_POPUP":
+            return (
+              r.action.setBadgeText({ text: "!" }),
+              r.action.setBadgeBackgroundColor({ color: "#6366f1" }),
+              { success: !0 }
+            );
+          case "SYNC_AUTH_FROM_WEBSITE": {
+            const { accessToken: s, refreshToken: t, user: a } = e.data;
+            if (!s || "string" != typeof s)
+              return { success: !1, error: "Invalid accessToken" };
+            if (!a || void 0 === a.id || "string" != typeof a.plan)
+              return { success: !1, error: "Invalid user data" };
+            try {
+              return (
+                await n(s, t),
+                await c(a),
+                r.action.setBadgeText({ text: "" }),
+                { success: !0 }
+              );
+            } catch (e) {
+              return { success: !1, error: e.message };
+            }
+          }
+          default:
+            return { error: "Unknown action" };
+        }
+      }
+      (r.runtime.onMessage.addListener((e, r, s) => {
+        const t = r.tab?.id;
+        return (
+          k(e, t)
+            .then(s)
+            .catch((e) => s({ error: e.message })),
+          !0
+        );
+      }),
+        r.runtime.onInstalled.addListener(async (e) => {
+          try {
+            const e = await A();
+            await u(e);
+          } catch {}
+          "install" === e.reason &&
+            (r.tabs.create({ url: "https://www.deepsightsynthesis.com" }),
+            r.storage.local.set({ showYouTubeRecommendation: !0 }));
+        }),
+        r.runtime.onStartup.addListener(async () => {
+          try {
+            const e = await A();
+            await u(e);
+          } catch {}
+          (await p()) && (await f());
+        }),
+        r.alarms.create("keepAlive", { periodInMinutes: 0.5 }),
+        r.alarms.create("refreshToken", { periodInMinutes: 30 }),
+        r.alarms.onAlarm.addListener(async (e) => {
+          "refreshToken" === e.name && (await p()) && (await f());
+        }),
+        r.storage.onChanged.addListener((e, s) => {
+          "local" === s &&
+            e.accessToken &&
+            (e.accessToken.newValue
+              ? r.action.setBadgeText({ text: "" })
+              : (r.action.setBadgeText({ text: "!" }),
+                r.action.setBadgeBackgroundColor({ color: "#ef4444" })));
+        }));
+    })());
+})();

--- a/extension/dist/content.js
+++ b/extension/dist/content.js
@@ -1,1 +1,2468 @@
-(()=>{var n={40(n,t,e){"use strict";e.d(t,{$id:()=>a,JF:()=>i,PM:()=>s,gC:()=>o});let r=null;function s(n){if(r&&r!==n){const t=r.host,e=n?.host;if(t&&t.isConnected&&t!==e)try{t.remove()}catch{}}r=n}function a(n){return r?.getElementById(n)??null}function i(n){return r?.querySelector(n)??null}function o(n){return r?r.querySelectorAll(n):document.createDocumentFragment().querySelectorAll(n)}},815(n,t){var e,r;"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self&&self,e=function(n){"use strict";if(!(globalThis.chrome&&globalThis.chrome.runtime&&globalThis.chrome.runtime.id))throw new Error("This script should only be loaded in a browser extension.");if(globalThis.browser&&globalThis.browser.runtime&&globalThis.browser.runtime.id)n.exports=globalThis.browser;else{const t="The message port closed before a response was received.",e=n=>{const e={alarms:{clear:{minArgs:0,maxArgs:1},clearAll:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getAll:{minArgs:0,maxArgs:0}},bookmarks:{create:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},getChildren:{minArgs:1,maxArgs:1},getRecent:{minArgs:1,maxArgs:1},getSubTree:{minArgs:1,maxArgs:1},getTree:{minArgs:0,maxArgs:0},move:{minArgs:2,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeTree:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}},browserAction:{disable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},enable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},getBadgeBackgroundColor:{minArgs:1,maxArgs:1},getBadgeText:{minArgs:1,maxArgs:1},getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},openPopup:{minArgs:0,maxArgs:0},setBadgeBackgroundColor:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setBadgeText:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},browsingData:{remove:{minArgs:2,maxArgs:2},removeCache:{minArgs:1,maxArgs:1},removeCookies:{minArgs:1,maxArgs:1},removeDownloads:{minArgs:1,maxArgs:1},removeFormData:{minArgs:1,maxArgs:1},removeHistory:{minArgs:1,maxArgs:1},removeLocalStorage:{minArgs:1,maxArgs:1},removePasswords:{minArgs:1,maxArgs:1},removePluginData:{minArgs:1,maxArgs:1},settings:{minArgs:0,maxArgs:0}},commands:{getAll:{minArgs:0,maxArgs:0}},contextMenus:{remove:{minArgs:1,maxArgs:1},removeAll:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},cookies:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:1,maxArgs:1},getAllCookieStores:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},devtools:{inspectedWindow:{eval:{minArgs:1,maxArgs:2,singleCallbackArg:!1}},panels:{create:{minArgs:3,maxArgs:3,singleCallbackArg:!0},elements:{createSidebarPane:{minArgs:1,maxArgs:1}}}},downloads:{cancel:{minArgs:1,maxArgs:1},download:{minArgs:1,maxArgs:1},erase:{minArgs:1,maxArgs:1},getFileIcon:{minArgs:1,maxArgs:2},open:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},pause:{minArgs:1,maxArgs:1},removeFile:{minArgs:1,maxArgs:1},resume:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},extension:{isAllowedFileSchemeAccess:{minArgs:0,maxArgs:0},isAllowedIncognitoAccess:{minArgs:0,maxArgs:0}},history:{addUrl:{minArgs:1,maxArgs:1},deleteAll:{minArgs:0,maxArgs:0},deleteRange:{minArgs:1,maxArgs:1},deleteUrl:{minArgs:1,maxArgs:1},getVisits:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1}},i18n:{detectLanguage:{minArgs:1,maxArgs:1},getAcceptLanguages:{minArgs:0,maxArgs:0}},identity:{launchWebAuthFlow:{minArgs:1,maxArgs:1}},idle:{queryState:{minArgs:1,maxArgs:1}},management:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},getSelf:{minArgs:0,maxArgs:0},setEnabled:{minArgs:2,maxArgs:2},uninstallSelf:{minArgs:0,maxArgs:1}},notifications:{clear:{minArgs:1,maxArgs:1},create:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:0},getPermissionLevel:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},pageAction:{getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},hide:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},permissions:{contains:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},request:{minArgs:1,maxArgs:1}},runtime:{getBackgroundPage:{minArgs:0,maxArgs:0},getPlatformInfo:{minArgs:0,maxArgs:0},openOptionsPage:{minArgs:0,maxArgs:0},requestUpdateCheck:{minArgs:0,maxArgs:0},sendMessage:{minArgs:1,maxArgs:3},sendNativeMessage:{minArgs:2,maxArgs:2},setUninstallURL:{minArgs:1,maxArgs:1}},sessions:{getDevices:{minArgs:0,maxArgs:1},getRecentlyClosed:{minArgs:0,maxArgs:1},restore:{minArgs:0,maxArgs:1}},storage:{local:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},managed:{get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1}},sync:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}}},tabs:{captureVisibleTab:{minArgs:0,maxArgs:2},create:{minArgs:1,maxArgs:1},detectLanguage:{minArgs:0,maxArgs:1},discard:{minArgs:0,maxArgs:1},duplicate:{minArgs:1,maxArgs:1},executeScript:{minArgs:1,maxArgs:2},get:{minArgs:1,maxArgs:1},getCurrent:{minArgs:0,maxArgs:0},getZoom:{minArgs:0,maxArgs:1},getZoomSettings:{minArgs:0,maxArgs:1},goBack:{minArgs:0,maxArgs:1},goForward:{minArgs:0,maxArgs:1},highlight:{minArgs:1,maxArgs:1},insertCSS:{minArgs:1,maxArgs:2},move:{minArgs:2,maxArgs:2},query:{minArgs:1,maxArgs:1},reload:{minArgs:0,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeCSS:{minArgs:1,maxArgs:2},sendMessage:{minArgs:2,maxArgs:3},setZoom:{minArgs:1,maxArgs:2},setZoomSettings:{minArgs:1,maxArgs:2},update:{minArgs:1,maxArgs:2}},topSites:{get:{minArgs:0,maxArgs:0}},webNavigation:{getAllFrames:{minArgs:1,maxArgs:1},getFrame:{minArgs:1,maxArgs:1}},webRequest:{handlerBehaviorChanged:{minArgs:0,maxArgs:0}},windows:{create:{minArgs:0,maxArgs:1},get:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:1},getCurrent:{minArgs:0,maxArgs:1},getLastFocused:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}}};if(0===Object.keys(e).length)throw new Error("api-metadata.json has not been included in browser-polyfill");class r extends WeakMap{constructor(n,t=void 0){super(t),this.createItem=n}get(n){return this.has(n)||this.set(n,this.createItem(n)),super.get(n)}}const s=(t,e)=>(...r)=>{n.runtime.lastError?t.reject(new Error(n.runtime.lastError.message)):e.singleCallbackArg||r.length<=1&&!1!==e.singleCallbackArg?t.resolve(r[0]):t.resolve(r)},a=n=>1==n?"argument":"arguments",i=(n,t,e)=>new Proxy(t,{apply:(t,r,s)=>e.call(r,n,...s)});let o=Function.call.bind(Object.prototype.hasOwnProperty);const d=(n,t={},e={})=>{let r=Object.create(null),l={has:(t,e)=>e in n||e in r,get(l,c,p){if(c in r)return r[c];if(!(c in n))return;let m=n[c];if("function"==typeof m)if("function"==typeof t[c])m=i(n,n[c],t[c]);else if(o(e,c)){let t=((n,t)=>function(e,...r){if(r.length<t.minArgs)throw new Error(`Expected at least ${t.minArgs} ${a(t.minArgs)} for ${n}(), got ${r.length}`);if(r.length>t.maxArgs)throw new Error(`Expected at most ${t.maxArgs} ${a(t.maxArgs)} for ${n}(), got ${r.length}`);return new Promise((a,i)=>{if(t.fallbackToNoCallback)try{e[n](...r,s({resolve:a,reject:i},t))}catch(s){console.warn(`${n} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,s),e[n](...r),t.fallbackToNoCallback=!1,t.noCallback=!0,a()}else t.noCallback?(e[n](...r),a()):e[n](...r,s({resolve:a,reject:i},t))})})(c,e[c]);m=i(n,n[c],t)}else m=m.bind(n);else if("object"==typeof m&&null!==m&&(o(t,c)||o(e,c)))m=d(m,t[c],e[c]);else{if(!o(e,"*"))return Object.defineProperty(r,c,{configurable:!0,enumerable:!0,get:()=>n[c],set(t){n[c]=t}}),m;m=d(m,t[c],e["*"])}return r[c]=m,m},set:(t,e,s,a)=>(e in r?r[e]=s:n[e]=s,!0),defineProperty:(n,t,e)=>Reflect.defineProperty(r,t,e),deleteProperty:(n,t)=>Reflect.deleteProperty(r,t)},c=Object.create(n);return new Proxy(c,l)},l=n=>({addListener(t,e,...r){t.addListener(n.get(e),...r)},hasListener:(t,e)=>t.hasListener(n.get(e)),removeListener(t,e){t.removeListener(n.get(e))}}),c=new r(n=>"function"!=typeof n?n:function(t){const e=d(t,{},{getContent:{minArgs:0,maxArgs:0}});n(e)}),p=new r(n=>"function"!=typeof n?n:function(t,e,r){let s,a,i=!1,o=new Promise(n=>{s=function(t){i=!0,n(t)}});try{a=n(t,e,s)}catch(n){a=Promise.reject(n)}const d=!0!==a&&((l=a)&&"object"==typeof l&&"function"==typeof l.then);var l;if(!0!==a&&!d&&!i)return!1;return(d?a:o).then(n=>{r(n)},n=>{let t;t=n&&(n instanceof Error||"string"==typeof n.message)?n.message:"An unexpected error occurred",r({__mozWebExtensionPolyfillReject__:!0,message:t})}).catch(n=>{console.error("Failed to send onMessage rejected reply",n)}),!0}),m=({reject:e,resolve:r},s)=>{n.runtime.lastError?n.runtime.lastError.message===t?r():e(new Error(n.runtime.lastError.message)):s&&s.__mozWebExtensionPolyfillReject__?e(new Error(s.message)):r(s)},g=(n,t,e,...r)=>{if(r.length<t.minArgs)throw new Error(`Expected at least ${t.minArgs} ${a(t.minArgs)} for ${n}(), got ${r.length}`);if(r.length>t.maxArgs)throw new Error(`Expected at most ${t.maxArgs} ${a(t.maxArgs)} for ${n}(), got ${r.length}`);return new Promise((n,t)=>{const s=m.bind(null,{resolve:n,reject:t});r.push(s),e.sendMessage(...r)})},u={devtools:{network:{onRequestFinished:l(c)}},runtime:{onMessage:l(p),onMessageExternal:l(p),sendMessage:g.bind(null,"sendMessage",{minArgs:1,maxArgs:3})},tabs:{sendMessage:g.bind(null,"sendMessage",{minArgs:2,maxArgs:3})}},x={clear:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}};return e.privacy={network:{"*":x},services:{"*":x},websites:{"*":x}},d(n,u,e)};n.exports=e(chrome)}},void 0===(r=e.apply(t,[n]))||(n.exports=r)}},t={};function e(r){var s=t[r];if(void 0!==s)return s.exports;var a=t[r]={exports:{}};return n[r].call(a.exports,a,a.exports,e),a.exports}e.n=n=>{var t=n&&n.__esModule?()=>n.default:()=>n;return e.d(t,{a:t}),t},e.d=(n,t)=>{for(var r in t)e.o(t,r)&&!e.o(n,r)&&Object.defineProperty(n,r,{enumerable:!0,get:t[r]})},e.o=(n,t)=>Object.prototype.hasOwnProperty.call(n,t),(()=>{"use strict";var n=e(815);const t=e.n(n)(),r=[/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?\s]+)/,/youtube\.com\/shorts\/([^&?\s]+)/],s=[/tiktok\.com\/@[\w.-]+\/video\/(\d+)/i,/vm\.tiktok\.com\/([\w-]+)/i,/m\.tiktok\.com\/v\/(\d+)/i,/tiktok\.com\/t\/([\w-]+)/i,/tiktok\.com\/video\/(\d+)/i];const a="https://www.deepsightsynthesis.com";var i=e(40);const o=[1,1.5,2,3],d={free:0,decouverte:0,plus:1,pro:2,expert:2,etudiant:1,student:1,starter:1};let l={isPlaying:!1,isLoading:!1,isPaused:!1,currentText:"",currentTime:0,duration:0,speed:1,language:"fr",gender:"female"},c=null,p=null,m=null,g=null;function u(){t.storage.local.set({tts_speed:l.speed,tts_lang:l.language,tts_gender:l.gender})}async function x(){const n=await async function(){try{return(await t.storage.local.get(["user"])).user||null}catch{return null}}();return(d[n?.plan||"free"]??0)>=1}function b(){c&&(c.pause(),c.removeAttribute("src"),c=null),p&&(URL.revokeObjectURL(p),p=null)}function f(){m?.abort(),m=null,b(),g=null,l.isPlaying=!1,l.isPaused=!1,l.isLoading=!1,l.currentText="",l.currentTime=0,l.duration=0,w()}function h(){c&&(c.paused?(c.play().catch(()=>{}),l.isPaused=!1,l.isPlaying=!0):(c.pause(),l.isPaused=!0,l.isPlaying=!1),w())}function v(){const n=o.indexOf(l.speed);l.speed=o[(n+1)%o.length],c&&(c.playbackRate=l.speed),u(),w()}function y(n){return!isFinite(n)||isNaN(n)?"0:00":`${Math.floor(n/60)}:${Math.floor(n%60).toString().padStart(2,"0")}`}function w(){(0,i.gC)(".ds-tts-btn").forEach(n=>{const t=n,e=t.dataset.ttsId;t.dataset.ttsText,g===e&&(l.isPlaying||l.isPaused||l.isLoading)?(t.classList.add("ds-tts-active"),t.innerHTML=function(n){return`\n    <span class="ds-tts-play-icon">${l.isLoading?'<svg class="ds-tts-spinner" width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" opacity="0.3"/><path d="M12 2a10 10 0 0 1 10 10" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>':l.isPlaying?"⏸️":"▶️"}</span>\n    <div class="ds-tts-progress" id="${n}-progress">\n      <div class="ds-tts-progress-fill" id="${n}-progress-fill" style="width:${l.duration>0?l.currentTime/l.duration*100:0}%"></div>\n    </div>\n    <span class="ds-tts-time" id="${n}-time">${y(l.currentTime)}/${y(l.duration)}</span>\n    <span class="ds-tts-stop" title="Stop">⏹️</span>\n    <span class="ds-tts-speed" title="Vitesse">${l.speed}x</span>\n  `}(e||""),function(n){const t=n.querySelector(".ds-tts-play-icon"),e=n.querySelector(".ds-tts-stop"),r=n.querySelector(".ds-tts-speed"),s=n.querySelector(".ds-tts-progress");t?.addEventListener("click",n=>{n.stopPropagation(),h()}),e?.addEventListener("click",n=>{n.stopPropagation(),f()}),r?.addEventListener("click",n=>{n.stopPropagation(),v()}),s?.addEventListener("click",n=>{if(n.stopPropagation(),!c||!l.duration)return;const t=s.getBoundingClientRect(),e=(n.clientX-t.left)/t.width;c.currentTime=e*l.duration})}(t)):(t.classList.remove("ds-tts-active"),t.innerHTML='<span class="ds-tts-icon">🔊</span>')})}t.storage.local.get(["tts_speed","tts_lang","tts_gender"]).then(n=>{n.tts_speed&&(l.speed=n.tts_speed),n.tts_lang&&(l.language=n.tts_lang),n.tts_gender&&(l.gender=n.tts_gender)});let A=0;function k(n,t="sm"){return`<button class="ds-tts-btn ${"md"===t?"ds-tts-btn-md":""}" data-tts-id="${"ds-tts-"+ ++A}" data-tts-text="${n.replace(/"/g,"&quot;").replace(/'/g,"&#39;")}" type="button" title="Écouter"><span class="ds-tts-icon">🔊</span></button>`}function E(){(0,i.gC)(".ds-tts-btn:not([data-bound])").forEach(n=>{const e=n;e.setAttribute("data-bound","1"),e.classList.contains("ds-tts-locked")||e.addEventListener("click",n=>{n.stopPropagation();const r=e.dataset.ttsText||"",s=e.dataset.ttsId||"";r&&s&&async function(n,e){if(n?.trim())if(l.currentText!==n||!l.isPlaying&&!l.isPaused){f(),g=e,l.isLoading=!0,l.currentText=n,w(),m=new AbortController;try{const e=await async function(){try{const n=await t.storage.local.get(["accessToken","refreshToken"]);return{accessToken:n.accessToken||null,refreshToken:n.refreshToken||null}}catch{return{accessToken:null,refreshToken:null}}}();if(!e.accessToken)throw new Error("Auth required");const r=await fetch("https://api.deepsightsynthesis.com/api/tts",{method:"POST",headers:{Authorization:`Bearer ${e.accessToken}`,"Content-Type":"application/json"},body:JSON.stringify({text:n,language:l.language,gender:l.gender,speed:l.speed,strip_questions:!0}),signal:m.signal});if(m.signal.aborted)return;if(403===r.status)throw new Error("TTS réservé aux abonnés Étudiant+");if(!r.ok)throw new Error(`TTS erreur (${r.status})`);const s=await r.blob();if(0===s.size)throw new Error("Audio vide");if(m.signal.aborted)return;b(),p=URL.createObjectURL(s),c=new Audio(p),c.playbackRate=l.speed,c.onloadedmetadata=()=>{l.duration=c.duration,w()},c.ontimeupdate=()=>{l.currentTime=c.currentTime,function(){if(!g)return;const n=(0,i.$id)(`${g}-progress-fill`),t=(0,i.$id)(`${g}-time`);n&&l.duration>0&&(n.style.width=l.currentTime/l.duration*100+"%"),t&&(t.textContent=`${y(l.currentTime)}/${y(l.duration)}`)}()},c.onended=()=>{l.isPlaying=!1,l.isPaused=!1,l.currentTime=0,g=null,w()},c.onerror=()=>f(),await c.play(),l.isPlaying=!0,l.isPaused=!1,l.isLoading=!1,w()}catch(n){if(n instanceof DOMException&&"AbortError"===n.name)return;console.warn("[DeepSight TTS]",n),b(),l.isLoading=!1,l.isPlaying=!1,l.currentText="",g=null,w()}}else l.isPaused?h():f()}(r,s)})})}let $=null;function T(){const n={darkReader:C(),adBlocker:S(),enhancerForYoutube:!!document.querySelector('[class*="enhancer-for-youtube"]')||!!document.getElementById("efyt-not-interest"),sponsorBlock:!!document.querySelector(".sponsorSkipButton")||!!document.getElementById("sponsorblock-bar")||!!document.querySelector('[class*="sponsorBlock"]'),returnYoutubeDislike:!!document.getElementById("return-youtube-dislike")||!!document.querySelector('[class*="ryd-"]')};return $=n,n}function C(){const n=document.documentElement;return!!(n.hasAttribute("data-darkreader-mode")||n.hasAttribute("data-darkreader-scheme")||document.querySelector('meta[name="darkreader"]')||document.querySelector("style.darkreader"))}function S(){const n=document.getElementById("secondary");return!!n&&("none"!==getComputedStyle(n).display&&null===n.offsetParent)}function I(){const n=window.location.href;return n.includes("youtube.com/watch")||n.includes("tiktok.com/")}function L(){return function(n){for(const t of r){const e=n.match(t);if(e)return e[1]}return null}(n=window.location.href)||function(n){for(const t of s){const e=n.match(t);if(e)return e[1]}return null}(n);var n}function z(){const n=document.documentElement;if("true"===n.getAttribute("dark")||n.hasAttribute("dark"))return"dark";if(window.matchMedia("(prefers-color-scheme: dark)").matches)return"dark";if(!($||T()).darkReader){const t=getComputedStyle(n).getPropertyValue("--yt-spec-base-background").trim();if(t.includes("#0f")||t.includes("#18")||t.includes("#21"))return"dark";const e=getComputedStyle(document.body).backgroundColor;if(e.includes("rgb(15,")||e.includes("rgb(24,")||e.includes("rgb(33,"))return"dark"}return"light"}let P=null;function M(){P&&(P(),P=null)}const _='/* ============================================================\n   DeepSight Widget — Scoped Design Tokens (--ds-* prefix)\n   Maps to design-tokens.css values for Shadow DOM isolation.\n   ============================================================ */\n\n/* FIX-WHITE-WIDGET: split `:host` and `:root` into separate rules.\n   Some browsers treat the combined `:host, :root { ... }` selector list\n   as invalid inside a Shadow DOM (`:root` doesn\'t match anything in\n   shadow scope), which can drop the entire rule and leave CSS vars\n   undefined — producing a transparent/white widget. */\n:host,\n:root,\n.ds-widget {\n  /* === Text === */\n  --ds-text-primary: #f5f0e8;\n  --ds-text-secondary: #b5a89b;\n  --ds-text-muted: #7a7068;\n  --ds-text-inverse: #0a0a0f;\n\n  /* === Font (system stack — no @import possible in closed Shadow DOM) === */\n  --ds-font-family:\n    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;\n  --ds-font-display: Georgia, "Times New Roman", serif;\n  --ds-font-mono: ui-monospace, "Cascadia Code", "Fira Code", monospace;\n\n  /* === Font sizes === */\n  --ds-text-xs: 11px;\n  --ds-text-sm: 13px;\n  --ds-text-md: 15px;\n  --ds-text-lg: 18px;\n\n  /* === Font weights === */\n  --ds-weight-normal: 400;\n  --ds-weight-medium: 500;\n  --ds-weight-semi: 600;\n  --ds-weight-bold: 700;\n\n  /* === Line heights === */\n  --ds-leading-tight: 1.3;\n  --ds-leading-normal: 1.5;\n  --ds-leading-relaxed: 1.6;\n\n  /* === Border radius === */\n  --ds-radius-xs: 4px;\n  --ds-radius-sm: 6px;\n  --ds-radius-md: 10px;\n  --ds-radius-lg: 14px;\n  --ds-radius-card: 14px;\n  --ds-radius-pill: 9999px;\n  --ds-radius-input: 8px;\n\n  /* === Borders === */\n  --ds-border: rgba(200, 144, 58, 0.08);\n  --ds-border-hover: rgba(200, 144, 58, 0.2);\n  --ds-border-focus: rgba(200, 144, 58, 0.4);\n  --ds-border-gold: rgba(200, 144, 58, 0.3);\n\n  /* === Gold accents === */\n  --ds-gold-mid: #c8903a;\n  --ds-gold-gradient: linear-gradient(135deg, #c8903a, #e5b86a);\n\n  /* === Glassmorphism === */\n  --ds-glass-bg: rgba(10, 10, 15, 0.85);\n  --ds-glass-border: rgba(200, 144, 58, 0.06);\n\n  /* === Status colors === */\n  --ds-success: #10b981;\n  --ds-success-bg: rgba(16, 185, 129, 0.1);\n  --ds-warning: #f59e0b;\n  --ds-warning-bg: rgba(245, 158, 11, 0.1);\n  --ds-error: #ef4444;\n  --ds-error-bg: rgba(239, 68, 68, 0.1);\n  --ds-info: #3b82f6;\n  --ds-info-bg: rgba(59, 130, 246, 0.1);\n\n  /* === Transitions === */\n  --ds-transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);\n  --ds-transition-normal: 200ms cubic-bezier(0.4, 0, 0.2, 1);\n  --ds-transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);\n\n  /* === Z-index === */\n  --ds-z-widget: 9999;\n\n  /* === Plan badge colors === */\n  --ds-plan-free: #9ca3af;\n  --ds-plan-decouverte: #9ca3af;\n  --ds-plan-student: #3b82f6;\n  --ds-plan-etudiant: #3b82f6;\n  --ds-plan-starter: #8b5cf6;\n  --ds-plan-plus: #8b5cf6;\n  --ds-plan-pro: #c8903a;\n  --ds-plan-expert: #c8903a;\n}\n\n/* ── Keyframes (ds-* prefixed for Shadow DOM isolation) ── */\n\n@keyframes ds-slideIn {\n  from {\n    transform: translateX(100%);\n    opacity: 0;\n  }\n  to {\n    transform: translateX(0);\n    opacity: 1;\n  }\n}\n\n@keyframes ds-fadeIn {\n  from {\n    opacity: 0;\n  }\n  to {\n    opacity: 1;\n  }\n}\n\n@keyframes ds-glow-pulse {\n  0%,\n  100% {\n    box-shadow: 0 0 20px rgba(200, 144, 58, 0.15);\n  }\n  50% {\n    box-shadow: 0 0 30px rgba(200, 144, 58, 0.3);\n  }\n}\n\n@keyframes ds-spin {\n  from {\n    transform: rotate(0deg);\n  }\n  to {\n    transform: rotate(360deg);\n  }\n}\n\n@keyframes ds-phraseOut {\n  from {\n    opacity: 1;\n    transform: translateY(0);\n  }\n  to {\n    opacity: 0;\n    transform: translateY(-6px);\n  }\n}\n\n@keyframes ds-phraseIn {\n  from {\n    opacity: 0;\n    transform: translateY(6px);\n  }\n  to {\n    opacity: 1;\n    transform: translateY(0);\n  }\n}\n',j='/* ============================================================\n   DeepSight Extension — Widget YouTube (content script)\n   Remplace l\'ancien content.css\n   Glassmorphism & Premium Glow Effects — V4.2\n   ============================================================ */\n\n/* Tokens loaded inline since Shadow DOM isolates from page CSS */\n\n/* ══════════════════════════════════════════\n   WIDGET CONTAINER — PREMIUM GLASSMORPHISM\n══════════════════════════════════════════ */\n\n#deepsight-card.ds-widget {\n  all: initial;\n  /* FIX-WHITE-WIDGET: hardcoded background + color so the widget renders\n     correctly even if CSS custom properties fail to resolve in the\n     closed Shadow DOM context. var() fallbacks are kept for theming. */\n  font-family: var(\n    --ds-font-family,\n    -apple-system,\n    BlinkMacSystemFont,\n    "Segoe UI",\n    system-ui,\n    sans-serif\n  ) !important;\n  font-size: var(--ds-text-sm, 13px) !important;\n  color: var(--ds-text-primary, #f5f0e8) !important;\n  background: var(--ds-glass-bg, rgba(10, 10, 15, 0.95)) !important;\n  border: 1px solid rgba(200, 144, 58, 0.15) !important;\n  border-radius: var(--ds-radius-card, 14px) !important;\n  backdrop-filter: blur(24px) saturate(150%) !important;\n  -webkit-backdrop-filter: blur(24px) saturate(150%) !important;\n  box-shadow:\n    0 8px 32px rgba(0, 0, 0, 0.4),\n    0 0 20px rgba(200, 144, 58, 0.05) !important;\n  width: 100% !important;\n  max-width: 420px !important;\n  overflow: hidden !important;\n  position: relative !important;\n  z-index: var(--ds-z-widget, 9999) !important;\n  margin-bottom: 12px !important;\n  box-sizing: border-box !important;\n  animation: ds-slideIn 300ms cubic-bezier(0.4, 0, 0.2, 1) forwards !important;\n}\n\n#deepsight-card.ds-widget * {\n  box-sizing: border-box !important;\n  font-family: var(--ds-font-family) !important;\n}\n\n/* FIX-WHITE-WIDGET: `.light` class neutralized — produces same dark output\n   as default to prevent unreadable white-text-on-white widget. */\n#deepsight-card.ds-widget.light {\n  background: var(--ds-glass-bg) !important;\n  border-color: rgba(200, 144, 58, 0.06) !important;\n  color: var(--ds-text-primary) !important;\n  box-shadow:\n    0 8px 32px rgba(0, 0, 0, 0.4),\n    0 0 20px rgba(200, 144, 58, 0.05) !important;\n}\n\n/* Hard fallback on host element. */\n:host {\n  color-scheme: dark;\n}\n\n/* ══════════════════════════════════════════\n   HEADER — GOLDEN ACCENT LINE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-card-header {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  padding: 10px 14px !important;\n  border-bottom: 2px solid transparent !important;\n  background: linear-gradient(\n    90deg,\n    rgba(255, 255, 255, 0.03),\n    rgba(200, 144, 58, 0.02)\n  ) !important;\n  background-clip: padding-box !important;\n  position: relative !important;\n}\n\n.ds-widget .ds-card-header::after {\n  content: "" !important;\n  position: absolute !important;\n  bottom: -2px !important;\n  left: 0 !important;\n  right: 0 !important;\n  height: 2px !important;\n  background: linear-gradient(\n    90deg,\n    rgba(200, 144, 58, 0.3),\n    rgba(200, 144, 58, 0.1)\n  ) !important;\n}\n\n.ds-widget .ds-card-logo {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  font-weight: var(--ds-weight-semi) !important;\n  font-size: var(--ds-text-md) !important;\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-card-logo span {\n  background: var(--ds-gold-gradient) !important;\n  -webkit-background-clip: text !important;\n  -webkit-text-fill-color: transparent !important;\n  background-clip: text !important;\n}\n\n.ds-widget .ds-card-badge {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  background: rgba(255, 255, 255, 0.06) !important;\n  padding: 2px 7px !important;\n  border-radius: var(--ds-radius-pill) !important;\n  border: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-header-actions {\n  display: flex !important;\n  align-items: center !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-minimize-btn {\n  all: unset !important;\n  cursor: pointer !important;\n  color: var(--ds-text-muted) !important;\n  padding: 4px !important;\n  border-radius: 4px !important;\n  font-size: 16px !important;\n  line-height: 1 !important;\n  transition: color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-minimize-btn:hover {\n  color: var(--ds-text-primary) !important;\n}\n\n/* ══════════════════════════════════════════\n   BODY\n══════════════════════════════════════════ */\n\n.ds-widget .ds-card-body {\n  padding: 14px !important;\n  max-height: 480px !important;\n  overflow-y: auto !important;\n  scrollbar-width: thin !important;\n  scrollbar-color: rgba(255, 255, 255, 0.15) transparent !important;\n}\n\n.ds-widget .ds-card-body::-webkit-scrollbar {\n  width: 4px;\n}\n.ds-widget .ds-card-body::-webkit-scrollbar-track {\n  background: transparent;\n}\n.ds-widget .ds-card-body::-webkit-scrollbar-thumb {\n  background: rgba(255, 255, 255, 0.15);\n  border-radius: 2px;\n}\n\n/* Loading state */\n.ds-widget .ds-loading {\n  display: flex !important;\n  flex-direction: column !important;\n  align-items: center !important;\n  justify-content: center !important;\n  padding: 32px 16px !important;\n  gap: 12px !important;\n}\n\n.ds-widget .ds-loading-text {\n  color: var(--ds-text-muted) !important;\n  font-size: var(--ds-text-sm) !important;\n}\n\n/* ══════════════════════════════════════════\n   LOGIN STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-login-container {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 12px !important;\n}\n\n/* FIX-WHITE-WIDGET: generic button base + ds-btn-primary (used by login).\n   Both classes were referenced in HTML but had no CSS — login submit button\n   rendered as raw HTML. */\n.ds-widget .ds-btn {\n  all: unset !important;\n  box-sizing: border-box !important;\n  display: inline-flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 8px !important;\n  width: 100% !important;\n  padding: 10px !important;\n  border-radius: var(--ds-radius-md) !important;\n  cursor: pointer !important;\n  font-family: var(--ds-font-family) !important;\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-medium) !important;\n  text-align: center !important;\n  transition: all var(--ds-transition-fast) !important;\n  user-select: none !important;\n}\n\n.ds-widget .ds-btn:disabled {\n  opacity: 0.5 !important;\n  cursor: not-allowed !important;\n}\n\n.ds-widget .ds-btn-primary {\n  background: var(--ds-gold-gradient) !important;\n  color: #0b0f19 !important;\n  border: none !important;\n  font-weight: var(--ds-weight-semi) !important;\n  box-shadow: 0 4px 14px rgba(200, 144, 58, 0.2) !important;\n}\n\n.ds-widget .ds-btn-primary:hover:not(:disabled) {\n  filter: brightness(1.1) !important;\n  box-shadow: 0 6px 20px rgba(200, 144, 58, 0.3) !important;\n}\n\n.ds-widget .ds-login-headline,\n.ds-widget .ds-subtitle {\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-normal) !important;\n  color: var(--ds-text-secondary) !important;\n  margin: 0 0 4px !important;\n  line-height: var(--ds-leading-relaxed) !important;\n}\n\n.ds-widget .ds-login-sub {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  margin-bottom: 8px !important;\n  line-height: var(--ds-leading-relaxed) !important;\n}\n\n/* FIX-WHITE-WIDGET: `.ds-divider` is what login.ts actually renders. */\n.ds-widget .ds-divider {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  color: var(--ds-text-muted) !important;\n  font-size: var(--ds-text-xs) !important;\n  margin: 4px 0 !important;\n}\n\n.ds-widget .ds-divider::before,\n.ds-widget .ds-divider::after {\n  content: "" !important;\n  flex: 1 !important;\n  height: 1px !important;\n  background: var(--ds-border) !important;\n}\n\n.ds-widget .ds-divider span {\n  text-transform: uppercase !important;\n  letter-spacing: 0.05em !important;\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-btn-google {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 8px !important;\n  width: 100% !important;\n  padding: 10px !important;\n  background: #fff !important;\n  border: 1px solid #dadce0 !important;\n  border-radius: var(--ds-radius-md) !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-medium) !important;\n  color: #3c4043 !important;\n  transition: background var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-btn-google:hover {\n  background: #f8f9fa !important;\n}\n\n.ds-widget .ds-divider-text {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  color: var(--ds-text-muted) !important;\n  font-size: var(--ds-text-xs) !important;\n}\n\n.ds-widget .ds-divider-text::before,\n.ds-widget .ds-divider-text::after {\n  content: "" !important;\n  flex: 1 !important;\n  height: 1px !important;\n  background: var(--ds-border) !important;\n}\n\n.ds-widget .ds-login-form {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-login-form input {\n  all: unset !important;\n  display: block !important;\n  width: 100% !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-input) !important;\n  padding: 9px 12px !important;\n  font-size: var(--ds-text-sm) !important;\n  color: var(--ds-text-primary) !important;\n  box-sizing: border-box !important;\n  transition: border-color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-login-form input:focus {\n  border-color: var(--ds-border-focus) !important;\n}\n\n.ds-widget .ds-login-form input::placeholder {\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-error-msg {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-error) !important;\n  background: var(--ds-error-bg) !important;\n  border-radius: var(--ds-radius-sm) !important;\n  padding: 6px 10px !important;\n}\n\n.ds-widget .ds-error-msg.hidden {\n  display: none !important;\n}\n\n/* ══════════════════════════════════════════\n   READY STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-ready-container {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 10px !important;\n}\n\n.ds-widget .ds-user-bar {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  padding: 8px 10px !important;\n  background: rgba(255, 255, 255, 0.04) !important;\n  border-radius: var(--ds-radius-md) !important;\n  border: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-user-name {\n  font-weight: var(--ds-weight-medium) !important;\n  font-size: var(--ds-text-sm) !important;\n  flex: 1 !important;\n  overflow: hidden !important;\n  text-overflow: ellipsis !important;\n  white-space: nowrap !important;\n}\n\n.ds-widget .ds-user-credits {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-btn-analyze {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 8px !important;\n  width: 100% !important;\n  padding: 12px !important;\n  background: linear-gradient(135deg, #c8903a, #9b6b4a) !important;\n  background-size: 200% 200% !important;\n  animation: ds-gradient-shift 8s ease infinite !important;\n  border: none !important;\n  border-radius: var(--ds-radius-md) !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-md) !important;\n  font-weight: var(--ds-weight-semi) !important;\n  color: #0b0f19 !important;\n  box-shadow: 0 4px 15px rgba(200, 144, 58, 0.25) !important;\n  transition: all var(--ds-transition-normal) !important;\n}\n\n.ds-widget .ds-btn-analyze:hover:not(:disabled) {\n  transform: translateY(-1px) !important;\n  box-shadow: 0 0 25px rgba(200, 144, 58, 0.35) !important;\n}\n\n.ds-widget .ds-btn-analyze:disabled {\n  opacity: 0.5 !important;\n  cursor: not-allowed !important;\n  transform: none !important;\n}\n\n.ds-widget .ds-btn-quickchat {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 8px !important;\n  width: 100% !important;\n  padding: 10px !important;\n  background: transparent !important;\n  border: 1px solid var(--ds-border-gold) !important;\n  border-radius: var(--ds-radius-md) !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-medium) !important;\n  color: var(--ds-gold-mid) !important;\n  box-shadow: 0 0 12px rgba(200, 144, 58, 0.1) !important;\n  transition: all var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-btn-quickchat:hover:not(:disabled) {\n  background: rgba(200, 144, 58, 0.1) !important;\n  box-shadow: 0 0 20px rgba(200, 144, 58, 0.2) !important;\n  transform: translateY(-1px) !important;\n}\n\n.ds-widget .ds-options-row {\n  display: flex !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-select {\n  all: unset !important;\n  flex: 1 !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-md) !important;\n  padding: 7px 10px !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-primary) !important;\n  cursor: pointer !important;\n  display: block !important;\n}\n\n/* ══════════════════════════════════════════\n   ANALYZING STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-analyzing-container {\n  display: flex !important;\n  flex-direction: column !important;\n  align-items: center !important;\n  gap: 14px !important;\n  padding: 20px 4px 8px !important;\n  text-align: center !important;\n}\n\n/* Spinner wrapper avec glow radial */\n.ds-widget .ds-spinner-wrapper {\n  position: relative !important;\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n}\n\n.ds-widget .ds-spinner-wrapper::before {\n  content: "" !important;\n  position: absolute !important;\n  width: 110px !important;\n  height: 110px !important;\n  border-radius: 50% !important;\n  background: radial-gradient(\n    circle,\n    rgba(91, 141, 184, 0.22) 0%,\n    rgba(196, 147, 90, 0.15) 40%,\n    rgba(107, 67, 128, 0.1) 70%,\n    transparent 100%\n  ) !important;\n  animation: ds-glow-pulse 2.5s ease-in-out infinite !important;\n  pointer-events: none !important;\n}\n\n/* Header : titre + timer */\n.ds-widget .ds-analyzing-header {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  width: 100% !important;\n}\n\n.ds-widget .ds-analyzing-title {\n  font-size: 12px !important;\n  color: var(--ds-text-secondary) !important;\n  font-weight: 600 !important;\n  letter-spacing: 0.02em !important;\n}\n\n.ds-widget .ds-timer {\n  font-size: 10px !important;\n  color: var(--ds-text-muted) !important;\n  background: rgba(255, 255, 255, 0.06) !important;\n  border: 1px solid rgba(255, 255, 255, 0.1) !important;\n  border-radius: 4px !important;\n  padding: 2px 6px !important;\n  font-variant-numeric: tabular-nums !important;\n  letter-spacing: 0.05em !important;\n}\n\n/* Barre de progression — 6px avec glow doré */\n.ds-widget .ds-progress {\n  width: 100% !important;\n  height: 6px !important;\n  background: rgba(255, 255, 255, 0.08) !important;\n  border-radius: 3px !important;\n  overflow: hidden !important;\n  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2) !important;\n}\n\n.ds-widget .ds-progress-bar {\n  height: 100% !important;\n  background: linear-gradient(90deg, #3b82f6, #c8903a, #9b6b4a) !important;\n  background-size: 200% 100% !important;\n  border-radius: 3px !important;\n  transition: width 600ms ease !important;\n  min-width: 4px !important;\n  animation: ds-gradient-shift 3s ease infinite !important;\n  box-shadow: 0 0 8px rgba(200, 144, 58, 0.3) !important;\n}\n\n/* Footer : phrase dynamique + pourcentage */\n.ds-widget .ds-progress-footer {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  width: 100% !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-phrase-container {\n  flex: 1 !important;\n  text-align: left !important;\n  overflow: hidden !important;\n  min-height: 16px !important;\n}\n\n.ds-widget .ds-phrase-container.ds-phrase-out .ds-phrase-text {\n  animation: ds-phraseOut 250ms ease forwards !important;\n}\n\n.ds-widget .ds-phrase-container.ds-phrase-in .ds-phrase-text {\n  animation: ds-phraseIn 300ms ease forwards !important;\n}\n\n.ds-widget .ds-phrase-text {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  display: block !important;\n  white-space: nowrap !important;\n  overflow: hidden !important;\n  text-overflow: ellipsis !important;\n}\n\n.ds-widget .ds-progress-pct {\n  font-size: 10px !important;\n  color: var(--ds-text-muted) !important;\n  font-variant-numeric: tabular-nums !important;\n  white-space: nowrap !important;\n  flex-shrink: 0 !important;\n}\n\n/* Steps avec icônes et connecteur vertical */\n.ds-widget .ds-analyzing-steps {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 0 !important;\n  width: 100% !important;\n  font-size: var(--ds-text-xs) !important;\n}\n\n.ds-widget .ds-step {\n  display: flex !important;\n  align-items: flex-start !important;\n  gap: 10px !important;\n  color: var(--ds-text-muted) !important;\n  padding: 2px 0 !important;\n}\n\n.ds-widget .ds-step-left {\n  display: flex !important;\n  flex-direction: column !important;\n  align-items: center !important;\n  flex-shrink: 0 !important;\n  width: 16px !important;\n}\n\n.ds-widget .ds-step-icon {\n  width: 16px !important;\n  height: 16px !important;\n  border-radius: 50% !important;\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  flex-shrink: 0 !important;\n  background: rgba(255, 255, 255, 0.06) !important;\n  border: 1px solid rgba(255, 255, 255, 0.12) !important;\n  transition: all 200ms ease !important;\n}\n\n.ds-widget .ds-step-icon-active {\n  background: rgba(91, 141, 184, 0.2) !important;\n  border-color: rgba(91, 141, 184, 0.5) !important;\n  box-shadow: 0 0 8px rgba(91, 141, 184, 0.3) !important;\n}\n\n.ds-widget .ds-step-icon-done {\n  background: rgba(34, 197, 94, 0.15) !important;\n  border-color: rgba(34, 197, 94, 0.5) !important;\n  color: #22c55e !important;\n}\n\n.ds-widget .ds-step-dot {\n  width: 6px !important;\n  height: 6px !important;\n  border-radius: 50% !important;\n  background: currentColor !important;\n  display: block !important;\n}\n\n.ds-widget .ds-step-connector {\n  width: 1px !important;\n  height: 10px !important;\n  background: rgba(255, 255, 255, 0.1) !important;\n  margin-top: 2px !important;\n}\n\n.ds-widget .ds-step-label {\n  line-height: 16px !important;\n  padding-bottom: 8px !important;\n}\n\n.ds-widget .ds-step.ds-step-active {\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-step.ds-step-active .ds-step-connector {\n  background: rgba(91, 141, 184, 0.3) !important;\n}\n\n.ds-widget .ds-step.ds-step-done {\n  color: var(--ds-success) !important;\n}\n\n.ds-widget .ds-step.ds-step-done .ds-step-connector {\n  background: rgba(34, 197, 94, 0.3) !important;\n}\n\n/* ══════════════════════════════════════════\n   RESULTS STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-results-container {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 12px !important;\n  animation: ds-fadeIn 300ms ease forwards !important;\n}\n\n.ds-widget .ds-status-bar {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  flex-wrap: wrap !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-done {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-success) !important;\n  font-weight: var(--ds-weight-medium) !important;\n}\n\n.ds-widget .ds-status-badges {\n  display: flex !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-tag {\n  font-size: var(--ds-text-xs) !important;\n  padding: 2px 8px !important;\n  border-radius: var(--ds-radius-pill) !important;\n  background: rgba(255, 255, 255, 0.07) !important;\n  border: 1px solid var(--ds-border) !important;\n  color: var(--ds-text-secondary) !important;\n}\n\n.ds-widget .ds-tag.ds-score-high {\n  color: var(--ds-success) !important;\n  border-color: rgba(76, 175, 80, 0.3) !important;\n}\n.ds-widget .ds-tag.ds-score-mid {\n  color: var(--ds-warning) !important;\n  border-color: rgba(255, 152, 0, 0.3) !important;\n}\n.ds-widget .ds-tag.ds-score-low {\n  color: var(--ds-error) !important;\n  border-color: rgba(239, 68, 68, 0.3) !important;\n}\n\n.ds-widget .ds-reliability-bar {\n  background: rgba(255, 255, 255, 0.05) !important;\n  border-radius: var(--ds-radius-md) !important;\n  padding: 10px !important;\n  border: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-reliability-header {\n  display: flex !important;\n  justify-content: space-between !important;\n  margin-bottom: 8px !important;\n  font-size: var(--ds-text-xs) !important;\n}\n\n.ds-widget .ds-verdict {\n  font-size: var(--ds-text-sm) !important;\n  line-height: var(--ds-leading-relaxed) !important;\n  color: var(--ds-text-secondary) !important;\n  padding: 10px !important;\n  background: rgba(255, 255, 255, 0.03) !important;\n  border-radius: var(--ds-radius-md) !important;\n  border-left: 3px solid var(--ds-gold-mid) !important;\n}\n\n.ds-widget .ds-keypoints {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-kp {\n  display: flex !important;\n  align-items: flex-start !important;\n  gap: 8px !important;\n  font-size: var(--ds-text-xs) !important;\n  line-height: var(--ds-leading-relaxed) !important;\n}\n\n.ds-widget .ds-kp-icon {\n  font-size: 12px !important;\n  flex-shrink: 0 !important;\n  margin-top: 1px !important;\n}\n.ds-widget .ds-kp-text {\n  color: var(--ds-text-secondary) !important;\n}\n.ds-widget .ds-kp-solid .ds-kp-icon {\n  color: var(--ds-success) !important;\n}\n.ds-widget .ds-kp-weak .ds-kp-icon {\n  color: var(--ds-warning) !important;\n}\n.ds-widget .ds-kp-insight .ds-kp-icon {\n  color: var(--ds-info) !important;\n}\n\n.ds-widget .ds-tags {\n  display: flex !important;\n  flex-wrap: wrap !important;\n  gap: 4px !important;\n}\n\n.ds-widget .ds-tag-pill {\n  font-size: var(--ds-text-xs) !important;\n  padding: 2px 8px !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border-radius: var(--ds-radius-pill) !important;\n  border: 1px solid var(--ds-border) !important;\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-toggle-detail {\n  all: unset !important;\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  width: 100% !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  padding: 6px 0 !important;\n  border-bottom: 1px solid var(--ds-border) !important;\n  transition: color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-toggle-detail:hover {\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-detail-panel {\n  font-size: var(--ds-text-xs) !important;\n  line-height: var(--ds-leading-relaxed) !important;\n  color: var(--ds-text-secondary) !important;\n}\n\n.ds-widget .ds-detail-panel.hidden {\n  display: none !important;\n}\n\n.ds-widget .ds-detail-content {\n  padding-top: 8px !important;\n}\n\n.ds-widget .ds-share-actions {\n  display: flex !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-btn-outline {\n  flex: 1 !important;\n  padding: 7px 10px !important;\n  background: transparent !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-sm) !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-secondary) !important;\n  cursor: pointer !important;\n  text-align: center !important;\n  transition:\n    border-color var(--ds-transition-fast),\n    color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-btn-outline:hover {\n  border-color: var(--ds-border-hover) !important;\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-summary-actions {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-btn-primary-link {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 6px !important;\n  width: 100% !important;\n  padding: 10px !important;\n  background: var(--ds-gold-gradient) !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-medium) !important;\n  color: #0b0f19 !important;\n  text-decoration: none !important;\n  text-align: center !important;\n  transition: filter var(--ds-transition-normal) !important;\n}\n\n.ds-widget .ds-btn-primary-link:hover {\n  filter: brightness(1.08) !important;\n}\n\n.ds-widget .ds-btn-secondary-action {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 6px !important;\n  width: 100% !important;\n  padding: 9px !important;\n  background: transparent !important;\n  border: 1px solid var(--ds-border-gold) !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-sm) !important;\n  color: var(--ds-gold-mid) !important;\n  cursor: pointer !important;\n  transition: background var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-btn-secondary-action:hover {\n  background: rgba(200, 144, 58, 0.1) !important;\n}\n\n/* ══════════════════════════════════════════\n   FACT-CHECK\n══════════════════════════════════════════ */\n\n.ds-widget .ds-factcheck-list {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-fc-item {\n  display: flex !important;\n  align-items: flex-start !important;\n  gap: 8px !important;\n  padding: 8px 10px !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-xs) !important;\n  border-left: 2px solid transparent !important;\n  border-right: 1px solid transparent !important;\n  border-top: 1px solid transparent !important;\n  border-bottom: 1px solid transparent !important;\n}\n\n.ds-widget .ds-fc-verified {\n  background: var(--ds-success-bg) !important;\n  border-left-color: #10b981 !important;\n  border-right-color: rgba(76, 175, 80, 0.25) !important;\n  border-top-color: rgba(76, 175, 80, 0.25) !important;\n  border-bottom-color: rgba(76, 175, 80, 0.25) !important;\n}\n.ds-widget .ds-fc-uncertain {\n  background: var(--ds-warning-bg) !important;\n  border-left-color: #f59e0b !important;\n  border-right-color: rgba(255, 152, 0, 0.25) !important;\n  border-top-color: rgba(255, 152, 0, 0.25) !important;\n  border-bottom-color: rgba(255, 152, 0, 0.25) !important;\n}\n.ds-widget .ds-fc-contested {\n  background: var(--ds-error-bg) !important;\n  border-left-color: #ef4444 !important;\n  border-right-color: rgba(239, 68, 68, 0.25) !important;\n  border-top-color: rgba(239, 68, 68, 0.25) !important;\n  border-bottom-color: rgba(239, 68, 68, 0.25) !important;\n}\n\n.ds-widget .ds-fc-icon {\n  flex-shrink: 0 !important;\n}\n.ds-widget .ds-fc-text {\n  flex: 1 !important;\n  line-height: var(--ds-leading-relaxed) !important;\n  color: var(--ds-text-secondary) !important;\n}\n\n/* ══════════════════════════════════════════\n   TOURNESOL BADGE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-tournesol-badge {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  padding: 8px 10px !important;\n  background: rgba(255, 193, 7, 0.08) !important;\n  border: 1px solid rgba(255, 193, 7, 0.2) !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-xs) !important;\n}\n\n.ds-widget .ds-tournesol-icon {\n  font-size: 16px !important;\n}\n\n.ds-widget .ds-tournesol-info {\n  flex: 1 !important;\n}\n\n.ds-widget .ds-tournesol-score {\n  font-weight: var(--ds-weight-bold) !important;\n  font-size: var(--ds-text-md) !important;\n  color: #ffc107 !important;\n}\n\n/* ══════════════════════════════════════════\n   CHAT STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-chat-container {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 10px !important;\n}\n\n.ds-widget .ds-chat-messages {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 8px !important;\n  max-height: 280px !important;\n  overflow-y: auto !important;\n  scrollbar-width: thin !important;\n  scrollbar-color: rgba(255, 255, 255, 0.15) transparent !important;\n}\n\n.ds-widget .ds-chat-msg {\n  padding: 9px 12px !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-xs) !important;\n  line-height: var(--ds-leading-relaxed) !important;\n  max-width: 90% !important;\n}\n\n.ds-widget .ds-chat-msg-user {\n  background: rgba(200, 144, 58, 0.15) !important;\n  border: 1px solid var(--ds-border-gold) !important;\n  color: var(--ds-text-primary) !important;\n  align-self: flex-end !important;\n  box-shadow: 0 2px 8px rgba(200, 144, 58, 0.1) !important;\n}\n\n.ds-widget .ds-chat-msg-assistant {\n  background: rgba(255, 255, 255, 0.05) !important;\n  backdrop-filter: blur(12px) !important;\n  -webkit-backdrop-filter: blur(12px) !important;\n  border: 1px solid rgba(200, 144, 58, 0.06) !important;\n  color: var(--ds-text-secondary) !important;\n  align-self: flex-start !important;\n  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2) !important;\n}\n\n.ds-widget .ds-chat-suggestions {\n  display: flex !important;\n  flex-wrap: wrap !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-chat-suggestion {\n  all: unset !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-xs) !important;\n  padding: 5px 10px !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-pill) !important;\n  color: var(--ds-text-secondary) !important;\n  transition: all var(--ds-transition-fast) !important;\n  display: inline-block !important;\n}\n\n.ds-widget .ds-chat-suggestion:hover {\n  background: rgba(200, 144, 58, 0.1) !important;\n  border-color: var(--ds-border-gold) !important;\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-chat-input-row {\n  display: flex !important;\n  gap: 6px !important;\n  align-items: flex-end !important;\n}\n\n.ds-widget .ds-chat-input {\n  all: unset !important;\n  flex: 1 !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-input) !important;\n  padding: 8px 12px !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-primary) !important;\n  display: block !important;\n  transition: border-color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-chat-input:focus {\n  border-color: var(--ds-border-focus) !important;\n}\n.ds-widget .ds-chat-input::placeholder {\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-chat-send-btn {\n  all: unset !important;\n  cursor: pointer !important;\n  width: 32px !important;\n  height: 32px !important;\n  background: var(--ds-gold-gradient) !important;\n  border-radius: var(--ds-radius-sm) !important;\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  color: #0b0f19 !important;\n  font-size: 14px !important;\n  transition: filter var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-chat-send-btn:hover:not(:disabled) {\n  filter: brightness(1.1) !important;\n}\n.ds-widget .ds-chat-send-btn:disabled {\n  opacity: 0.45 !important;\n  cursor: not-allowed !important;\n}\n\n/* ══════════════════════════════════════════\n   PREMIUM TEASERS\n══════════════════════════════════════════ */\n\n.ds-widget .ds-teasers-section {\n  padding: 10px !important;\n  background: rgba(255, 255, 255, 0.03) !important;\n  border-radius: var(--ds-radius-md) !important;\n  border: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-teasers-title {\n  font-size: var(--ds-text-xs) !important;\n  font-weight: var(--ds-weight-semi) !important;\n  color: var(--ds-text-secondary) !important;\n  margin-bottom: 8px !important;\n}\n\n.ds-widget .ds-teasers-grid {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 4px !important;\n}\n\n.ds-widget .ds-teaser-item {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  padding: 6px 8px !important;\n  border-radius: var(--ds-radius-sm) !important;\n  text-decoration: none !important;\n  color: var(--ds-text-muted) !important;\n  font-size: var(--ds-text-xs) !important;\n  transition: background var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-teaser-item:hover {\n  background: rgba(255, 255, 255, 0.06) !important;\n}\n.ds-widget .ds-teaser-label {\n  flex: 1 !important;\n}\n.ds-widget .ds-teaser-lock {\n  font-size: 10px !important;\n  color: var(--ds-text-muted) !important;\n}\n.ds-widget .ds-teaser-price {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-gold-mid) !important;\n}\n\n.ds-widget .ds-teasers-all {\n  display: block !important;\n  text-align: center !important;\n  margin-top: 8px !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-gold-mid) !important;\n  text-decoration: none !important;\n}\n\n/* ══════════════════════════════════════════\n   ECOSYSTEM BRIDGE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-ecosystem-bridge {\n  display: flex !important;\n  flex-wrap: wrap !important;\n  gap: 6px !important;\n  padding-top: 10px !important;\n  border-top: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-bridge-link {\n  display: flex !important;\n  align-items: center !important;\n  gap: 5px !important;\n  padding: 5px 10px !important;\n  background: rgba(255, 255, 255, 0.04) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-pill) !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  text-decoration: none !important;\n  transition: all var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-bridge-link:hover {\n  background: rgba(255, 255, 255, 0.08) !important;\n  color: var(--ds-text-primary) !important;\n  border-color: var(--ds-border-hover) !important;\n}\n\n.ds-widget .ds-bridge-link.ds-bridge-upgrade {\n  background: rgba(200, 144, 58, 0.1) !important;\n  border-color: var(--ds-border-gold) !important;\n  color: var(--ds-gold-mid) !important;\n}\n\n/* ══════════════════════════════════════════\n   FOOTER\n══════════════════════════════════════════ */\n\n.ds-widget .ds-card-footer {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  padding: 8px 14px !important;\n  border-top: 1px solid var(--ds-border) !important;\n  background: rgba(255, 255, 255, 0.02) !important;\n}\n\n.ds-widget .ds-card-footer a,\n.ds-widget .ds-link-btn {\n  all: unset !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  text-decoration: none !important;\n  transition: color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-card-footer a:hover,\n.ds-widget .ds-link-btn:hover {\n  color: var(--ds-text-secondary) !important;\n}\n\n.ds-widget .ds-card-legal {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  padding: 4px 14px 8px !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-card-legal a {\n  color: var(--ds-text-muted) !important;\n  text-decoration: none !important;\n}\n\n.ds-widget .ds-card-legal a:hover {\n  text-decoration: underline !important;\n}\n\n/* ══════════════════════════════════════════\n   PLAN BADGE IN USER BAR\n══════════════════════════════════════════ */\n\n.ds-widget [class*="ds-user-plan"] {\n  font-size: var(--ds-text-xs) !important;\n  padding: 1px 7px !important;\n  border-radius: var(--ds-radius-pill) !important;\n  font-weight: var(--ds-weight-medium) !important;\n}\n\n.ds-widget .ds-plan-free {\n  background: rgba(107, 114, 128, 0.2) !important;\n  color: var(--ds-plan-free) !important;\n}\n.ds-widget .ds-plan-etudiant,\n.ds-widget .ds-plan-student {\n  background: rgba(59, 130, 246, 0.15) !important;\n  color: var(--ds-plan-student) !important;\n}\n.ds-widget .ds-plan-starter {\n  background: rgba(139, 92, 246, 0.15) !important;\n  color: var(--ds-plan-starter) !important;\n}\n.ds-widget .ds-plan-pro {\n  background: rgba(200, 144, 58, 0.15) !important;\n  color: var(--ds-plan-pro) !important;\n}\n\n/* ══════════════════════════════════════════\n   TIKTOK FLOATING CARD (overlay)\n══════════════════════════════════════════ */\n\n#deepsight-card.ds-widget.ds-tiktok-float {\n  position: fixed !important;\n  bottom: 80px !important;\n  right: 16px !important;\n  width: 340px !important;\n  max-height: 520px !important;\n  z-index: var(--ds-z-widget) !important;\n}\n\n/* ═══════════════════════════════════════════════════════════════════════════════\n   🔊 TTS — Text-to-Speech Controls\n   ═══════════════════════════════════════════════════════════════════════════════ */\n\n/* Base TTS button — idle state (compact play icon) */\n.ds-tts-btn {\n  display: inline-flex;\n  align-items: center;\n  justify-content: center;\n  width: 26px;\n  height: 26px;\n  border-radius: 6px;\n  border: 1px solid rgba(255, 255, 255, 0.08);\n  background: rgba(255, 255, 255, 0.06);\n  color: rgba(255, 255, 255, 0.5);\n  cursor: pointer;\n  transition: all 0.2s ease;\n  flex-shrink: 0;\n  font-size: 12px;\n  padding: 0;\n  vertical-align: middle;\n}\n\n.ds-tts-btn:hover {\n  color: #06b6d4;\n  background: rgba(6, 182, 212, 0.15);\n  border-color: rgba(6, 182, 212, 0.3);\n}\n\n.ds-tts-btn-md {\n  width: 30px;\n  height: 30px;\n  font-size: 14px;\n}\n\n/* Locked state */\n.ds-tts-locked {\n  color: rgba(255, 255, 255, 0.25);\n  cursor: not-allowed;\n}\n.ds-tts-locked:hover {\n  color: rgba(255, 255, 255, 0.35);\n  background: rgba(255, 255, 255, 0.06);\n  border-color: rgba(255, 255, 255, 0.08);\n}\n\n.ds-tts-icon {\n  font-size: 12px;\n  line-height: 1;\n}\n\n/* Active player state — expanded inline mini-player */\n.ds-tts-btn.ds-tts-active {\n  width: auto;\n  min-width: 180px;\n  gap: 6px;\n  padding: 4px 8px;\n  background: rgba(6, 182, 212, 0.08);\n  border-color: rgba(6, 182, 212, 0.25);\n}\n\n.ds-tts-play-icon {\n  cursor: pointer;\n  font-size: 13px;\n  flex-shrink: 0;\n  transition: opacity 0.2s;\n}\n.ds-tts-play-icon:hover {\n  opacity: 0.7;\n}\n\n/* Loading spinner */\n.ds-tts-spinner {\n  animation: ds-spin 0.8s linear infinite;\n  color: #06b6d4;\n}\n\n/* Progress bar */\n.ds-tts-progress {\n  flex: 1;\n  min-width: 40px;\n  height: 4px;\n  background: rgba(255, 255, 255, 0.1);\n  border-radius: 2px;\n  cursor: pointer;\n  position: relative;\n}\n\n.ds-tts-progress-fill {\n  height: 100%;\n  background: #06b6d4;\n  border-radius: 2px;\n  transition: width 0.1s linear;\n}\n\n.ds-tts-time {\n  font-size: 9px;\n  font-family: monospace;\n  color: rgba(255, 255, 255, 0.4);\n  white-space: nowrap;\n}\n\n.ds-tts-stop {\n  cursor: pointer;\n  font-size: 11px;\n  opacity: 0.5;\n  transition: opacity 0.2s;\n}\n.ds-tts-stop:hover {\n  opacity: 1;\n  color: #ef4444;\n}\n\n.ds-tts-speed {\n  cursor: pointer;\n  font-size: 10px;\n  font-family: monospace;\n  color: #06b6d4;\n  background: rgba(6, 182, 212, 0.1);\n  padding: 1px 4px;\n  border-radius: 3px;\n  transition: background 0.2s;\n}\n.ds-tts-speed:hover {\n  background: rgba(6, 182, 212, 0.2);\n}\n\n/* TTS Toolbar — settings bar */\n.ds-tts-toolbar {\n  display: flex;\n  align-items: center;\n  gap: 6px;\n  padding: 4px 8px;\n  background: rgba(255, 255, 255, 0.03);\n  border-radius: 6px;\n  border: 1px solid rgba(255, 255, 255, 0.06);\n  margin-top: 6px;\n}\n\n.ds-tts-toolbar-label {\n  font-size: 10px;\n  color: rgba(255, 255, 255, 0.4);\n  margin-right: 2px;\n}\n\n.ds-tts-toolbar-btn {\n  font-size: 12px;\n  padding: 2px 6px;\n  border-radius: 4px;\n  border: none;\n  background: rgba(255, 255, 255, 0.06);\n  color: rgba(255, 255, 255, 0.5);\n  cursor: pointer;\n  transition: all 0.2s;\n}\n.ds-tts-toolbar-btn:hover {\n  background: rgba(255, 255, 255, 0.1);\n  color: rgba(255, 255, 255, 0.7);\n}\n\n/* TTS button in summary header row */\n.ds-summary-tts-row {\n  display: flex;\n  align-items: center;\n  gap: 8px;\n  margin-bottom: 6px;\n}\n\n/* ══════════════════════════════════════════\n   PREMIUM GRADIENT ANIMATIONS\n══════════════════════════════════════════ */\n\n@keyframes ds-gradient-shift {\n  0% {\n    background-position: 0% 50%;\n  }\n  50% {\n    background-position: 100% 50%;\n  }\n  100% {\n    background-position: 0% 50%;\n  }\n}\n\n/* ══════════════════════════════════════════\n   COLLAPSED STATE (minimize persistent)\n══════════════════════════════════════════ */\n\n#deepsight-card.ds-widget.ds-collapsed {\n  width: 44px !important;\n  max-width: 44px !important;\n  height: 44px !important;\n  border-radius: 50% !important;\n  overflow: hidden !important;\n  cursor: pointer !important;\n}\n\n.ds-collapsed .ds-card-body,\n.ds-collapsed .ds-card-logo span,\n.ds-collapsed .ds-card-badge,\n.ds-collapsed .ds-minimize-btn {\n  display: none !important;\n}\n\n/* ══════════════════════════════════════════\n   COMPACT RESULTS MODE\n   ══════════════════════════════════════════ */\n.ds-results-compact {\n  display: flex;\n  flex-direction: column;\n  gap: 12px;\n}\n.ds-verdict-compact {\n  padding: 12px 14px;\n  background: rgba(99, 102, 241, 0.04);\n  border-left: 3px solid var(--ds-accent-primary, #6366f1);\n  border-radius: 0 8px 8px 0;\n}\n.ds-verdict-text-compact {\n  font-size: 13px;\n  line-height: 1.55;\n  color: var(--ds-text-primary);\n  display: -webkit-box;\n  -webkit-line-clamp: 2;\n  -webkit-box-orient: vertical;\n  overflow: hidden;\n  text-overflow: ellipsis;\n}\n.ds-compact-actions {\n  display: flex;\n  flex-direction: column;\n  gap: 8px;\n  margin: 4px 0;\n}\n.ds-btn-primary-xl {\n  padding: 12px 16px;\n  font-size: 14px;\n  font-weight: 600;\n  background: linear-gradient(135deg, #6366f1, #8b5cf6);\n  color: white;\n  border: none;\n  border-radius: 10px;\n  cursor: pointer;\n  transition:\n    transform 0.2s,\n    box-shadow 0.2s;\n  width: 100%;\n}\n.ds-btn-primary-xl:hover {\n  transform: translateY(-1px);\n  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.4);\n}\n.ds-btn-outline-xl {\n  padding: 10px 16px;\n  font-size: 13px;\n  font-weight: 500;\n  background: transparent;\n  color: var(--ds-text-primary);\n  border: 1px solid rgba(255, 255, 255, 0.15);\n  border-radius: 10px;\n  cursor: pointer;\n  transition: all 0.2s;\n  width: 100%;\n}\n.ds-btn-outline-xl:hover {\n  background: rgba(255, 255, 255, 0.05);\n  border-color: rgba(255, 255, 255, 0.25);\n}\n.ds-link-tertiary {\n  display: block;\n  text-align: center;\n  font-size: 12px;\n  color: var(--ds-text-muted);\n  text-decoration: none;\n  padding: 6px 0;\n  transition: color 0.15s;\n}\n.ds-link-tertiary:hover {\n  color: var(--ds-accent-primary, #6366f1);\n}\n.ds-details-wrapper {\n  border: 1px solid rgba(255, 255, 255, 0.08);\n  border-radius: 8px;\n  background: rgba(255, 255, 255, 0.02);\n  padding: 0;\n  margin-top: 4px;\n}\n.ds-details-toggle {\n  padding: 10px 14px;\n  font-size: 12px;\n  color: var(--ds-text-muted);\n  cursor: pointer;\n  list-style: none;\n  user-select: none;\n  transition: color 0.15s;\n}\n.ds-details-toggle::-webkit-details-marker {\n  display: none;\n}\n.ds-details-toggle:hover {\n  color: var(--ds-text-primary);\n}\n.ds-details-wrapper[open] .ds-details-toggle {\n  color: var(--ds-text-primary);\n}\n.ds-details-body {\n  padding: 8px 14px 12px;\n  border-top: 1px solid rgba(255, 255, 255, 0.05);\n  display: flex;\n  flex-direction: column;\n  gap: 12px;\n}\n',R="/* DeepSight Content Script Styles — Premium Glassmorphism V4.2 */\n\n/* ══════════════════════════════════════════\n   INJECTED CARD CONTAINER\n══════════════════════════════════════════ */\n\n.deepsight-injected-card {\n  backdrop-filter: blur(24px) saturate(150%) !important;\n  -webkit-backdrop-filter: blur(24px) saturate(150%) !important;\n  border: 1px solid rgba(200, 144, 58, 0.06) !important;\n  border-radius: 10px !important;\n  box-shadow:\n    0 8px 32px rgba(0, 0, 0, 0.4),\n    0 0 20px rgba(200, 144, 58, 0.05) !important;\n  background: var(--ds-glass-bg, rgba(10, 10, 15, 0.5)) !important;\n}\n\n/* Light theme variant */\n.deepsight-injected-card.light {\n  background: rgba(255, 255, 255, 0.85) !important;\n  border-color: rgba(166, 120, 40, 0.08) !important;\n  box-shadow:\n    0 8px 32px rgba(0, 0, 0, 0.15),\n    0 0 20px rgba(200, 144, 58, 0.04) !important;\n}\n\n/* ══════════════════════════════════════════\n   GOUVERNAIL SPINNER — PREMIUM ANIMATION\n══════════════════════════════════════════ */\n\n.ds-gouvernail-spinner {\n  display: inline-flex;\n  align-items: center;\n  justify-content: center;\n  animation: ds-gouvernail-spin 2s linear infinite;\n  filter: drop-shadow(0 0 4px rgba(200, 144, 58, 0.3));\n}\n\n.ds-gouvernail-spinner-sm {\n  width: 18px;\n  height: 18px;\n  animation: ds-gouvernail-spin 2s linear infinite;\n  filter: drop-shadow(0 0 3px rgba(200, 144, 58, 0.25));\n}\n\n.ds-gouvernail-spinner svg {\n  width: 100%;\n  height: 100%;\n  color: #c8903a;\n}\n\n@keyframes ds-gouvernail-spin {\n  from {\n    transform: rotate(0deg);\n  }\n  to {\n    transform: rotate(360deg);\n  }\n}\n\n/* ══════════════════════════════════════════\n   LOADING STATE — ENHANCED VISUAL\n══════════════════════════════════════════ */\n\n.ds-loading {\n  display: flex;\n  flex-direction: column;\n  align-items: center;\n  justify-content: center;\n  gap: 12px;\n  padding: 20px 0;\n}\n\n.ds-loading-text {\n  color: rgba(255, 255, 255, 0.7);\n  font-size: 14px;\n  margin: 0;\n  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);\n}\n\n/* ══════════════════════════════════════════\n   PREMIUM GRADIENT ANIMATIONS\n══════════════════════════════════════════ */\n\n@keyframes ds-gradient-shift {\n  0% {\n    background-position: 0% 50%;\n  }\n  50% {\n    background-position: 100% 50%;\n  }\n  100% {\n    background-position: 0% 50%;\n  }\n}\n",O="deepsight-card",N="deepsight-host",D=[{selector:"#secondary-inner",position:"prepend"},{selector:"#secondary",position:"prepend"},{selector:"ytd-watch-next-secondary-results-renderer",position:"prepend"},{selector:"#below",position:"prepend"},{selector:"ytd-watch-metadata",position:"afterend"}],q=['[class*="DivBrowserModeContainer"]','[class*="DivVideoDetailContainer"]',"#app","body"];function B(n){const t=getComputedStyle(n);return n.offsetHeight>0&&n.offsetWidth>50&&"none"!==t.display&&"hidden"!==t.visibility&&"0"!==t.opacity}let F=!1;function U(){document.getElementById(N)?.remove()}function H(){return(0,i.$id)(O)}function G(n){const t=W();t&&(t.innerHTML=n)}function W(){return(0,i.JF)(`#${O} .ds-card-body`)}function Q(){const n=H(),t=(0,i.$id)("ds-minimize-btn");n&&(n.classList.add("ds-collapsed"),t&&(t.textContent="+"))}const V=["#secondary-inner","#secondary","ytd-watch-next-secondary-results-renderer","#below","ytd-watch-metadata"];function Y(){for(const n of V){const t=document.querySelector(n);if(t instanceof HTMLElement&&B(t))return!0}return!1}let K=null;function X(){K?.disconnect(),K=null}function Z(){if(document.fullscreenElement)return"fullscreen";const n=document.querySelector("ytd-watch-flexy");return n?.hasAttribute("theater")?"theater":"default"}let J=null,nn=null;function tn(){J?.disconnect(),J=null,nn&&document.removeEventListener("fullscreenchange",nn),nn=null}function en(n){const t=document.createElement("div");return t.textContent=n,t.innerHTML}const rn={résumé:"📝",summary:"📝",synthèse:"📝",introduction:"🎬",contexte:"🌍",context:"🌍",analyse:"🔬",analysis:"🔬","points clés":"🎯","key points":"🎯","points forts":"💪",strengths:"💪","points faibles":"⚠️",weaknesses:"⚠️",limites:"⚠️",conclusion:"🏁",recommandations:"💡",recommendations:"💡",sources:"📚",références:"📚",references:"📚","fact-check":"🔍",vérification:"🔍",arguments:"⚖️",méthodologie:"🧪",methodology:"🧪",données:"📊",data:"📊",statistiques:"📊",opinion:"💬",avis:"💬",biais:"🎭",bias:"🎭",nuances:"🎨",perspectives:"👁️",timeline:"📅",chronologie:"📅",définitions:"📖",glossaire:"📖"};function sn(n){const t=n.toLowerCase().trim();for(const[n,e]of Object.entries(rn))if(t.includes(n))return e;return"📌"}function an(n){return n.replace(/`([^`]+)`/g,'<code class="ds-md-code">$1</code>').replace(/\*\*(.+?)\*\*/g,"<strong>$1</strong>").replace(/\*(.+?)\*/g,"<em>$1</em>").replace(/\[?(SOLIDE|SOLID)\]?/g,'<span class="ds-marker ds-marker-solid">✅ Établi</span>').replace(/\[?(PLAUSIBLE)\]?/g,'<span class="ds-marker ds-marker-plausible">🔵 Probable</span>').replace(/\[?(INCERTAIN|UNCERTAIN)\]?/g,'<span class="ds-marker ds-marker-uncertain">🟡 Incertain</span>').replace(/\[?(A VERIFIER|À VÉRIFIER|TO VERIFY|QUESTIONABLE|WEAK)\]?/g,'<span class="ds-marker ds-marker-weak">🔴 À vérifier</span>')}function on(n){return n.replace(/\*\*(.+?)\*\*/g,"$1").replace(/\*(.+?)\*/g,"$1").replace(/`([^`]+)`/g,"$1").replace(/#{1,6}\s+/g,"").replace(/\[([^\]]+)\]\([^)]+\)/g,"$1").replace(/^>\s+/gm,"").replace(/\n+/g," ").trim()}function dn(n,t){if(n.length<=t)return n;const e=n.substring(0,t),r=e.lastIndexOf(" ");return(r>.6*t?e.substring(0,r):e)+"..."}function ln(n){G(`\n    <div class="ds-login-container">\n      <p class="ds-subtitle">Analysez cette vidéo avec l'IA</p>\n\n      <button class="ds-btn ds-btn-google" id="ds-google-login" type="button">\n        <svg width="16" height="16" viewBox="0 0 24 24">\n          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>\n          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>\n          <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>\n          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>\n        </svg>\n        Connexion avec Google\n      </button>\n\n      <div class="ds-divider"><span>ou</span></div>\n\n      <form id="ds-login-form" class="ds-login-form">\n        <input type="email" id="ds-email" placeholder="Email" required autocomplete="email" />\n        <input type="password" id="ds-password" placeholder="Mot de passe" required autocomplete="current-password" />\n        <div id="ds-login-error" class="ds-error-msg hidden"></div>\n        <button type="submit" class="ds-btn ds-btn-primary" id="ds-login-btn">Connexion</button>\n      </form>\n\n      <div class="ds-card-footer">\n        <a href="${a}/register" target="_blank" rel="noreferrer">Créer un compte</a>\n        <span>·</span>\n        <a href="${a}" target="_blank" rel="noreferrer">deepsightsynthesis.com</a>\n      </div>\n    </div>\n  `),(0,i.$id)("ds-google-login")?.addEventListener("click",async()=>{const e=(0,i.$id)("ds-google-login");e&&(e.disabled=!0,e.innerHTML='<svg class="ds-gouvernail-spinner ds-gouvernail-spinner-sm" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" width="14" height="14"><circle cx="24" cy="24" r="20" opacity="0.3"/><circle cx="24" cy="24" r="3"/><line x1="24" y1="4" x2="24" y2="11"/></svg> Connexion...');try{const r=await t.runtime.sendMessage({action:"GOOGLE_LOGIN"});r?.success&&r.user?n():(cn(r?.error||"Connexion Google échouée"),e&&(e.disabled=!1,e.textContent="Connexion avec Google"))}catch(n){cn(n.message),e&&(e.disabled=!1,e.textContent="Connexion avec Google")}}),(0,i.$id)("ds-login-form")?.addEventListener("submit",async e=>{e.preventDefault();const r=(0,i.$id)("ds-email").value,s=(0,i.$id)("ds-password").value,a=(0,i.$id)("ds-login-btn");a&&(a.disabled=!0,a.textContent="Connexion...");try{const e=await t.runtime.sendMessage({action:"LOGIN",data:{email:r,password:s}});e?.success&&e.user?n():(cn(e?.error||"Connexion échouée"),a&&(a.disabled=!1,a.textContent="Connexion"))}catch(n){cn(en(n.message)),a&&(a.disabled=!1,a.textContent="Connexion")}})}function cn(n){const t=(0,i.$id)("ds-login-error");t&&(t.textContent=n,t.classList.remove("hidden"))}const pn={fr:{credits:"crédits",analyzeButton:"Analyser cette vidéo",quickChatButton:"Quick Chat IA",logout:"Déconnexion",preparing:"Préparation...",loading:"Chargement...",startingAnalysis:"Démarrage de l'analyse...",askQuestion:"Posez une question sur cette vidéo",webSearchUsed:"Recherche web utilisée",backToResults:"Retour aux résultats",responding:"En train de répondre...",chatError:"Erreur de chat"},en:{credits:"credits",analyzeButton:"Analyze this video",quickChatButton:"Quick AI Chat",logout:"Log out",preparing:"Preparing...",loading:"Loading...",startingAnalysis:"Starting analysis...",askQuestion:"Ask a question about this video",webSearchUsed:"Web search used",backToResults:"Back to results",responding:"Responding...",chatError:"Chat error"}};function mn(){return pn.fr}function gn(n){const{user:t,tournesol:e,onAnalyze:r,onQuickChat:s,onLogout:o}=n;G(`\n    <div class="ds-ready-container">\n      <div class="ds-user-bar">\n        <span class="ds-user-name">${en(t.username)}</span>\n        <span class="ds-user-plan ds-plan-${en(t.plan)}">${en(t.plan)}</span>\n        <span class="ds-user-credits">${t.credits} ${mn().credits}</span>\n      </div>\n      ${function(n){if(!n?.found||null===n.tournesol_score)return"";const t=Math.round(n.tournesol_score);return`<div class="ds-tournesol-badge" style="font-size:10px;color:${t>=50?"var(--ds-success)":t>=0?"var(--ds-warning)":"var(--ds-error)"};margin-top:${document.querySelector('tournesol-entity-context, [class*="tournesol"], #tournesol-rate')?"32px":"4px"}">🌻 Tournesol: ${t>0?"+":""}${t}</div>`}(e)}\n\n      <button class="ds-btn ds-btn-analyze" id="ds-analyze-btn" type="button">\n        🚀 ${mn().analyzeButton}\n      </button>\n\n      <button class="ds-btn ds-btn-quickchat" id="ds-quickchat-btn" type="button">\n        💬 ${mn().quickChatButton}\n      </button>\n\n      <div class="ds-options-row">\n        <select id="ds-mode" class="ds-select" title="Mode d'analyse">\n          <option value="standard">📋 Standard</option>\n          <option value="accessible">📖 Accessible</option>\n        </select>\n        <select id="ds-lang" class="ds-select" title="Langue">\n          <option value="fr">🇫🇷 FR</option>\n          <option value="en">🇬🇧 EN</option>\n          <option value="es">🇪🇸 ES</option>\n          <option value="de">🇩🇪 DE</option>\n        </select>\n      </div>\n\n      <div class="ds-card-footer">\n        <a href="${a}" target="_blank" rel="noreferrer">🌐 deepsightsynthesis.com</a>\n        <button id="ds-logout" class="ds-link-btn" type="button">${mn().logout}</button>\n      </div>\n    </div>\n  `),(0,i.$id)("ds-analyze-btn")?.addEventListener("click",()=>{const n=(0,i.$id)("ds-mode").value,t=(0,i.$id)("ds-lang").value;r(n,t)}),(0,i.$id)("ds-quickchat-btn")?.addEventListener("click",async()=>{const n=(0,i.$id)("ds-quickchat-btn"),t=(0,i.$id)("ds-lang")?.value||"fr";n&&(n.disabled=!0,n.innerHTML=`<svg class="ds-gouvernail-spinner ds-gouvernail-spinner-sm" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" width="14" height="14"><circle cx="24" cy="24" r="20" opacity="0.3"/><circle cx="24" cy="24" r="3"/><line x1="24" y1="4" x2="24" y2="11"/></svg> ${mn().preparing}`),s(t)}),(0,i.$id)("ds-logout")?.addEventListener("click",o)}const un={tech:["Quelles sont les principales technologies mentionnées ?","Quels sont les risques évoqués ?","Comment cela s'applique-t-il concrètement ?","Quelles alternatives sont proposées ?"],science:["Quelles sont les preuves scientifiques citées ?","Y a-t-il des biais dans cette étude ?","Qui sont les chercheurs impliqués ?","Quelles sont les limites de cette recherche ?"],education:["Quels sont les points clés à retenir ?","Comment appliquer ces concepts ?","Y a-t-il des exercices pratiques suggérés ?","Quelles ressources complémentaires sont recommandées ?"],news:["Quels sont les faits vérifiables ?","Quelles sources sont citées ?","Y a-t-il des éléments de contexte importants ?","Quels sont les différents points de vue ?"],default:["Quel est le message principal de cette vidéo ?","Quels sont les points les plus importants ?","Y a-t-il des éléments à vérifier ?","Que recommande l'auteur ?"]};let xn=!1;function bn(n,t){return(un[n]??un.default).slice(0,t)}function fn(n,t,e){if(xn)return;const r=(0,i.$id)(n);r&&(xn=!0,r.querySelectorAll(".ds-chat-suggestion").forEach(n=>{const r=parseInt(n.dataset.index??"0",10);n.addEventListener("click",()=>{xn=!1,t[r]&&e(t[r])})}),xn=!1)}const hn={free:0,decouverte:0,plus:1,pro:2,expert:2,etudiant:1,student:1,starter:1},vn={tech:"💻",science:"🔬",education:"📚",news:"📰",entertainment:"🎬",gaming:"🎮",music:"🎵",sports:"⚽",business:"💼",lifestyle:"🌟",other:"📋"};async function yn(n){const{summary:e,userPlan:r,onChat:s}=n,o={verdict:function(n){const t=[/#+\s*(?:Conclusion|Verdict|Synthèse|Résumé|Summary|En résumé|Final Assessment|Overall Assessment)[^\n]*\n([\s\S]*?)(?=\n#|\n---|\n\*{3,}|$)/i,/\*\*(?:Conclusion|Verdict|Synthèse|En résumé|Summary)\*\*[:\s]*([\s\S]*?)(?=\n\n|\n#|\n---|\n\*{3,}|$)/i];for(const e of t){const t=n.match(e);if(t&&t[1]){const n=on(t[1]).trim();if(n.length>20)return dn(n,200)}}const e=n.split(/\n\n+/).filter(n=>{const t=n.trim();return t.length>30&&!t.startsWith("#")&&!t.startsWith("-")&&!t.startsWith("*")});return e.length>0?dn(on(e[e.length-1]),200):"Analysis complete. See detailed view for full results."}(m=e.summary_content),keyPoints:function(n){const t=[],e=n.split("\n"),r=[/\b(?:SOLIDE|SOLID)\b/i,/\u2705\s*\*\*/,/\u2705/],s=[/\b(?:A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK|INCERTAIN|UNCERTAIN)\b/i,/\u26A0\uFE0F\s*\*\*/,/\u2753/,/\u26A0/],a=[/\b(?:PLAUSIBLE)\b/i,/\uD83D\uDCA1/];for(const n of e){const e=n.replace(/^[\s\-*]+/,"").trim();if(e.length<10)continue;let i=null;if(r.some(t=>t.test(n))?i="solid":s.some(t=>t.test(n))?i="weak":a.some(t=>t.test(n))&&(i="insight"),i&&t.filter(n=>n.type===i).length<2){const n=on(e).replace(/\b(?:SOLIDE|SOLID|PLAUSIBLE|INCERTAIN|UNCERTAIN|A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK)\b\s*[:—\-–]?\s*/gi,"").replace(/^[✅⚠️❓💡🔍🔬]\s*/u,"").trim();n.length>10&&t.push({type:i,text:dn(n,120)})}if(t.length>=4)break}if(t.length<2){const e=/#+\s*(?:Points?\s+(?:forts?|clés?|faibles?)|Key\s+(?:Points?|Findings?|Takeaways?)|Strengths?|Weaknesses?|Main\s+Points?)[^\n]*\n([\s\S]*?)(?=\n#|$)/gi;let r;for(;null!==(r=e.exec(n))&&t.length<4;){const n=r[1].match(/^[\s]*[-*]\s+(.+)$/gm);if(n)for(const e of n.slice(0,4-t.length)){const n=on(e.replace(/^[\s]*[-*]\s+/,""));n.length>10&&!t.some(t=>t.text===dn(n,120))&&t.push({type:"insight",text:dn(n,120)})}}}return t.slice(0,4)}(m),tags:function(n){const t=[],e=n.match(/#+\s*(?:Tags?|Thèmes?|Themes?|Topics?|Catégories?|Categories?)[^\n]*\n([\s\S]*?)(?=\n#|$)/i);if(e){const n=e[1].match(/[-*]\s+(.+)/g);if(n)for(const e of n.slice(0,3)){const n=on(e.replace(/^[-*]\s+/,"")).trim();n.length>0&&n.length<30&&t.push(n)}}if(0===t.length){const e=n.match(/^#{2,3}\s+(.+)$/gm);if(e){const n=/^(?:Conclusion|Summary|Résumé|Synthèse|Introduction|Verdict|Analysis|Points?\s+(?:clés?|forts?|faibles?)|Key\s+(?:Points?|Findings?)|Strengths?|Weaknesses?|Overview)/i;for(const r of e){const e=on(r.replace(/^#{2,3}\s+/,"")).trim();if(e.length>2&&e.length<35&&!n.test(e)&&(t.push(e),t.length>=3))break}}}return t.slice(0,3)}(m)},d=function(n){const t=n.split("\n"),e=[];let r=!1,s=!1;for(let n=0;n<t.length;n++){let a=t[n];if(/^-{3,}$/.test(a.trim())||/^\*{3,}$/.test(a.trim())){r&&(e.push("</ul>"),r=!1),s&&(e.push("</ol>"),s=!1),e.push('<hr class="ds-md-hr">');continue}const i=a.match(/^(#{1,4})\s+(.+)$/);if(i){r&&(e.push("</ul>"),r=!1),s&&(e.push("</ol>"),s=!1);const n=i[1].length,t=i[2],a=n<=2?sn(t):"",o=an(t),d=a?`${a}&nbsp;&nbsp;`:"";e.push(`<h${n} class="ds-md-h${n}">${d}${o}</h${n}>`);continue}if(a.startsWith("&gt; ")||"&gt;"===a){r&&(e.push("</ul>"),r=!1),s&&(e.push("</ol>"),s=!1);const n=an(a.replace(/^&gt;\s?/,""));e.push(`<blockquote class="ds-md-blockquote">${n}</blockquote>`);continue}const o=a.match(/^(\s*)[-*]\s+(.+)$/);if(o){s&&(e.push("</ol>"),s=!1),r||(e.push('<ul class="ds-md-ul">'),r=!0),e.push(`<li>${an(o[2])}</li>`);continue}const d=a.match(/^(\s*)\d+\.\s+(.+)$/);d?(r&&(e.push("</ul>"),r=!1),s||(e.push('<ol class="ds-md-ol">'),s=!0),e.push(`<li>${an(d[2])}</li>`)):(r&&(e.push("</ul>"),r=!1),s&&(e.push("</ol>"),s=!1),""!==a.trim()?e.push(`<p class="ds-md-p">${an(a)}</p>`):e.push('<div class="ds-md-spacer"></div>'))}return r&&e.push("</ul>"),s&&e.push("</ol>"),e.join("\n")}(en(e.summary_content)).replace(/\[(\d{1,2}:\d{2}(?::\d{2})?)\]/g,(n,t)=>`<a href="#" class="ds-timestamp" data-time="${function(n){const t=n.split(":").map(Number);return 3===t.length?3600*t[0]+60*t[1]+t[2]:60*t[0]+t[1]}(t)}">[${t}]</a>`),c=vn[e.category]??"📋",p=(g=e.reliability_score)>=80?"ds-score-high":g>=60?"ds-score-mid":"ds-score-low";var m,g;const b=function(n){return n>=80?"✅":n>=60?"⚠️":"❓"}(e.reliability_score),f=await x(),h=f?k(o.verdict||e.summary_content.slice(0,2e3),"md"):'<button class="ds-tts-btn ds-tts-locked" type="button" title="Lecture vocale — Plan Étudiant+"><span class="ds-tts-icon">🔒</span></button>',y=f?`\n    <div class="ds-tts-toolbar">\n      <span class="ds-tts-toolbar-label">🔊 Voix</span>\n      <button class="ds-tts-toolbar-btn" id="ds-tts-lang" title="Langue">${"fr"===l.language?"🇫🇷":"🇬🇧"}</button>\n      <button class="ds-tts-toolbar-btn" id="ds-tts-gender" title="Genre">${"female"===l.gender?"♀":"♂"}</button>\n      <button class="ds-tts-toolbar-btn" id="ds-tts-speed-global" title="Vitesse">${l.speed}x</button>\n    </div>\n  `:"",w=o.keyPoints.map(n=>{return`<div class="ds-kp ds-kp-${n.type}">\n      <span class="ds-kp-icon">${t=n.type,"solid"===t?"✅":"weak"===t?"⚠️":"💡"}</span>\n      <span class="ds-kp-text">${en(n.text)}</span>\n    </div>`;var t}).join(""),A=o.tags.length>0?`<div class="ds-tags">${o.tags.map(n=>`<span class="ds-tag-pill">${en(n)}</span>`).join("")}</div>`:"",$=(e.facts_to_verify??[]).filter(n=>n.trim().length>0).map(n=>({text:n.trim(),icon:"🔍"})),T=$.length>0?`<div style="margin-top:8px">${function(n,t=3){return 0===n.length?"":`<div class="ds-factcheck-list">${n.slice(0,t).map(n=>`<div class="ds-fact-item"><span class="ds-fact-icon">${n.icon}</span><span class="ds-fact-text">${n.text}</span></div>`).join("")}</div>`}($,2)}</div>`:"",C=bn(e.category,4),S=function(n){return 0===n.length?"":`<div class="ds-chat-suggestions" id="ds-results-suggestions">${n.map((n,t)=>`<button class="ds-chat-suggestion" data-index="${t}" type="button">${n}</button>`).join("")}</div>`}(C),I=function(n){const t=hn[n]??0,e=[{icon:"🃏",label:"Flashcards IA",minPlan:"pro",price:"5,99€"},{icon:"🧠",label:"Carte mentale",minPlan:"pro",price:"5,99€"},{icon:"🌐",label:"Recherche web IA",minPlan:"pro",price:"5,99€"},{icon:"📦",label:"Export PDF/DOCX",minPlan:"pro",price:"5,99€"}].filter(n=>(hn[n.minPlan]??0)>t);return 0===e.length?`<div class="ds-teaser-pro-cta"><span>📱 Révisez sur mobile —</span><a href="${a}/mobile" target="_blank" rel="noreferrer" class="ds-teaser-link">Télécharger l'app</a></div>`:`\n    <div class="ds-teasers-section">\n      <div class="ds-teasers-title">✨ Débloquez plus</div>\n      <div class="ds-teasers-grid">${e.slice(0,3).map(n=>`\n    <a href="${a}/upgrade" target="_blank" rel="noreferrer" class="ds-teaser-item" title="Dès ${n.price}/mois">\n      <span class="ds-teaser-icon">${n.icon}</span>\n      <span class="ds-teaser-label">${n.label}</span>\n      <span class="ds-teaser-lock">🔒</span>\n      <span class="ds-teaser-price">${n.price}/m</span>\n    </a>\n  `).join("")}</div>\n      <a href="${a}/upgrade" target="_blank" rel="noreferrer" class="ds-teasers-all">Voir tous les plans →</a>\n    </div>\n  `}(r);var L;const z=`\n    ${w?`<div class="ds-keypoints ds-stagger">${w}</div>`:""}\n    ${A}\n    ${T}\n\n    <button class="ds-toggle-detail" id="ds-toggle-detail" type="button">\n      <span class="ds-toggle-text">Voir l'analyse détaillée</span>\n      <span class="ds-toggle-arrow">▼</span>\n    </button>\n    <div class="ds-detail-panel hidden" id="ds-detail-panel">\n      <div class="ds-detail-content">${d}</div>\n    </div>\n\n    <div class="ds-share-actions">\n      <button class="ds-btn-outline" id="ds-copy-btn" type="button">📋 Copier</button>\n    </div>\n\n    ${S}\n    <div class="ds-premium-teasers">${I}</div>\n    ${L=e.id,`\n    <div class="ds-ecosystem-bridge">\n      <a href="${a}/summary/${L}" target="_blank" rel="noreferrer" class="ds-bridge-link" title="Voir l'analyse complète sur le web">\n        🌐 Web\n      </a>\n      <a href="https://apps.apple.com/app/deepsight/id6744066498" target="_blank" rel="noreferrer" class="ds-bridge-link" title="App iOS">\n        🍎 iOS\n      </a>\n      <a href="https://play.google.com/store/apps/details?id=com.deepsight.app" target="_blank" rel="noreferrer" class="ds-bridge-link" title="App Android">\n        🤖 Android\n      </a>\n      <a href="${a}/upgrade" target="_blank" rel="noreferrer" class="ds-bridge-link ds-bridge-upgrade">\n        ⚡ Upgrade\n      </a>\n    </div>\n  `}\n\n    <div class="ds-card-footer">\n      <a href="${a}" target="_blank" rel="noreferrer">🌐 deepsightsynthesis.com</a>\n    </div>\n  `;G(`\n    <div class="ds-results-compact">\n      <div class="ds-status-bar">\n        <span class="ds-done">✅ Analyse prête</span>\n        <div class="ds-status-badges">\n          <span class="ds-tag">${c} ${en(e.category)}</span>\n          <span class="ds-tag ${p}">${b} ${e.reliability_score}%</span>\n        </div>\n      </div>\n\n      <div class="ds-reliability-bar">\n        <div class="ds-reliability-header">\n          <span style="color:var(--ds-text-muted)">Fiabilité</span>\n          <span class="${p}" style="font-weight:600">${e.reliability_score}/100</span>\n        </div>\n        <div class="ds-progress" style="height:6px">\n          <div class="ds-progress-bar ds-fill-bar" data-score="${p.replace("ds-score-","")}"\n               style="width:${e.reliability_score}%;background:${e.reliability_score>=80?"var(--ds-success)":e.reliability_score>=60?"var(--ds-warning)":"var(--ds-error)"}">\n          </div>\n        </div>\n      </div>\n\n      <div class="ds-verdict-compact">\n        <div class="ds-summary-tts-row">\n          <p class="ds-verdict-text-compact" style="flex:1;margin:0">${en(o.verdict)}</p>\n          ${h}\n        </div>\n      </div>\n      ${y}\n\n      <div class="ds-compact-actions">\n        <button class="ds-btn-primary-xl" id="ds-open-fullscreen" type="button">\n          🔍 Voir l'analyse complète\n        </button>\n        <button class="ds-btn-outline-xl" id="ds-share-btn" type="button">\n          🔗 Partager cette analyse\n        </button>\n        <a href="${a}/summary/${e.id}" target="_blank" rel="noreferrer" class="ds-link-tertiary">\n          🌐 Ouvrir sur DeepSight Web ↗\n        </a>\n      </div>\n\n      <details class="ds-details-wrapper">\n        <summary class="ds-details-toggle">▸ Voir le détail ici</summary>\n        <div class="ds-details-body">\n          ${z}\n        </div>\n      </details>\n\n      <button class="ds-btn-secondary-action" id="ds-chat-btn" type="button">\n        💬 Chatter avec la vidéo\n      </button>\n    </div>\n  `),function(n,e,r){(0,i.$id)("ds-open-fullscreen")?.addEventListener("click",()=>{const e=t.runtime.getURL(`viewer.html?id=${n.id}`);t.tabs.create({url:e})}),(0,i.$id)("ds-toggle-detail")?.addEventListener("click",()=>{const n=(0,i.$id)("ds-detail-panel"),t=(0,i.$id)("ds-toggle-detail");if(!n||!t)return;const e=n.classList.contains("hidden");n.classList.toggle("hidden");const r=t.querySelector(".ds-toggle-arrow"),s=t.querySelector(".ds-toggle-text");r&&(r.textContent=e?"▲":"▼"),s&&(s.textContent=e?"Masquer l'analyse":"Voir l'analyse détaillée")}),(0,i.gC)(".ds-timestamp").forEach(n=>{n.addEventListener("click",t=>{t.preventDefault();const e=parseInt(n.dataset.time??"0",10),r=document.querySelector("video");r&&(r.currentTime=e,r.play())})}),(0,i.$id)("ds-chat-btn")?.addEventListener("click",()=>{e.onChat(n.id,n.video_title)}),fn("ds-results-suggestions",r,t=>{e.onChat(n.id,n.video_title),setTimeout(()=>{const n=(0,i.$id)("ds-chat-input");n&&(n.value=t,(0,i.$id)("ds-chat-send")?.click())},100)}),(0,i.$id)("ds-copy-btn")?.addEventListener("click",e.onCopyLink),(0,i.$id)("ds-share-btn")?.addEventListener("click",e.onShare)}(e,n,C),E(),f&&((0,i.$id)("ds-tts-lang")?.addEventListener("click",()=>{l.language="fr"===l.language?"en":"fr",u();const n=(0,i.$id)("ds-tts-lang");n&&(n.textContent="fr"===l.language?"🇫🇷":"🇬🇧")}),(0,i.$id)("ds-tts-gender")?.addEventListener("click",()=>{l.gender="female"===l.gender?"male":"female",u();const n=(0,i.$id)("ds-tts-gender");n&&(n.textContent="female"===l.gender?"♀":"♂")}),(0,i.$id)("ds-tts-speed-global")?.addEventListener("click",()=>{v();const n=(0,i.$id)("ds-tts-speed-global");n&&(n.textContent=`${l.speed}x`)}))}let wn=!1;function An(n){return`<div class="ds-chat-msg ${"user"===n.role?"ds-chat-msg-user":"ds-chat-msg-assistant"}">${"assistant"===n.role?en(n.content).replace(/\*\*(.*?)\*\*/g,"<strong>$1</strong>").replace(/\*(.*?)\*/g,"<em>$1</em>").replace(/\n/g,"<br>"):en(n.content)}${n.web_search_used?`<span style="font-size:10px;color:var(--ds-info);display:block;margin-top:3px">🌐 ${mn().webSearchUsed}</span>`:""}${"assistant"===n.role&&n.content.length>20?`<div style="margin-top:4px">${wn?k(n.content):'<button class="ds-tts-btn ds-tts-locked" type="button" title="Lecture vocale — Plan Étudiant+"><span class="ds-tts-icon">🔒</span></button>'}</div>`:""}</div>`}function kn(n){const t=(0,i.$id)("ds-chat-messages");if(!t)return;const e=t.querySelector('[style*="text-align:center"]');e?.remove();const r=document.createElement("div");r.innerHTML=An(n);const s=r.firstElementChild;s&&t.appendChild(s),En()}function En(){requestAnimationFrame(()=>{const n=(0,i.$id)("ds-chat-messages");n&&(n.scrollTop=n.scrollHeight)})}function $n(n){const t=(0,i.$id)("ds-chat-input"),e=(0,i.$id)("ds-chat-send");t&&(t.disabled=n),e&&(e.disabled=n,e.innerHTML=n?'<svg class="ds-gouvernail-spinner ds-gouvernail-spinner-sm" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" width="14" height="14"><circle cx="24" cy="24" r="20" opacity="0.3"/><circle cx="24" cy="24" r="3"/><line x1="24" y1="4" x2="24" y2="11"/></svg>':"➤")}async function Tn(n){const e=(0,i.$id)("ds-chat-input");if(!e)return;const r=e.value.trim();if(!r)return;e.value="",$n(!0),(0,i.$id)("ds-chat-suggestions")?.remove(),kn({role:"user",content:r});const s=(0,i.$id)("ds-chat-messages"),a=`ds-loading-${Date.now()}`;if(s){const n=document.createElement("div");n.id=a,n.className="ds-chat-msg ds-chat-msg-assistant",n.innerHTML='<svg class="ds-gouvernail-spinner ds-gouvernail-spinner-sm" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" width="14" height="14"><circle cx="24" cy="24" r="20" opacity="0.3"/><circle cx="24" cy="24" r="3"/><line x1="24" y1="4" x2="24" y2="11"/></svg> En train de répondre...',s.appendChild(n),En()}try{const e=await t.runtime.sendMessage({action:"ASK_QUESTION",data:{summaryId:n,question:r,options:{}}});if((0,i.$id)(a)?.remove(),!e?.success)throw new Error(e?.error||"Erreur de chat");const s=e.result;kn({role:"assistant",content:s.response,web_search_used:s.web_search_used}),E()}catch(n){(0,i.$id)(a)?.remove(),kn({role:"assistant",content:`❌ ${n.message}`})}finally{$n(!1),(0,i.$id)("ds-chat-input")?.focus()}}const Cn="ds_crash_log";let Sn=[];function In(n,t){Sn.push({step:n,detail:t,t:Date.now()}),Sn.length>100&&(Sn=Sn.slice(-100));try{void 0!==t?console.log("[DeepSight-boot]",n,t):console.log("[DeepSight-boot]",n)}catch{}}async function Ln(n,t){const e=n instanceof Error?n:new Error(String(n)),r={message:e.message||"Unknown error",stack:e.stack,context:t,steps:Sn.map(n=>n.step),timestamp:Date.now(),url:"undefined"!=typeof location&&location.href?location.href:"",userAgent:"undefined"!=typeof navigator&&navigator.userAgent?navigator.userAgent:""};try{const n=await chrome.storage.local.get(Cn),t=[...Array.isArray(n[Cn])?n[Cn]:[],r].slice(-20);await chrome.storage.local.set({[Cn]:t})}catch(n){try{console.error("[DeepSight-crash]",r,n)}catch{}}}const zn={state:"login",videoId:null,currentTaskId:null,user:null,planInfo:null,summary:null,tournesol:null,injected:!1,injectionAttempts:0};function Pn(){try{if(zn.injected&&H())return void In("inject:skip-already-injected");if(zn.injectionAttempts>30)return void In("inject:max-attempts-reached");zn.injectionAttempts++,In("inject:attempt",{n:zn.injectionAttempts});const r=function(){const n=window.location.hostname;return n.includes("youtube.com")||n.includes("youtu.be")?"youtube":n.includes("tiktok.com")?"tiktok":null}(),s="tiktok"===r;In("inject:platform-theme",{platform:r,theme:z()});const a=function(n,t){let e,r;try{e=document.createElement("div")}catch{return null}e.id=N,e.style.cssText="all:initial;display:block;width:100%;max-width:420px;margin-bottom:12px;",t&&(e.style.cssText="all:initial;position:fixed;bottom:20px;right:20px;width:360px;max-height:80vh;z-index:2147483646;");try{r=e.attachShadow({mode:"closed"})}catch{return null}(0,i.PM)(r);const s=n=>{n.stopPropagation()};e.addEventListener("keydown",s),e.addEventListener("keyup",s),e.addEventListener("keypress",s);const a=document.createElement("style");a.textContent=[_,j,R].join("\n\n"),r.appendChild(a);const o=document.createElement("div");return o.id=O,o.className="ds-widget deepsight-card dark",t&&(o.classList.add("deepsight-card-floating"),o.style.cssText="overflow-y:auto;box-shadow:0 8px 32px rgba(0,0,0,0.5);border-radius:12px;"),r.appendChild(o),e}(0,s);if(!a){In("inject:createWidgetShell-returned-null");const n=zn.injectionAttempts<=10?300:1e3;return void setTimeout(Pn,n)}const o=H();if(o){o.innerHTML=`\n    <div class="ds-card-header">\n      <div class="ds-card-logo">${function(n=22){return`<img src="${t.runtime.getURL("assets/deepsight-logo-cosmic.png")}" alt="DeepSight" width="${n}" height="${n}" style="object-fit:contain;border-radius:50%;" />`}(22)}<span>Deep Sight</span></div>\n      <div style="display:flex;align-items:center;gap:4px">\n        <span class="ds-card-badge">AI</span>\n        <button class="ds-minimize-btn" id="ds-minimize-btn" type="button" title="Réduire">−</button>\n      </div>\n    </div>\n  `;const r=(n=()=>{In("skeleton:retry-clicked"),zn.injected=!1,zn.injectionAttempts=0,U(),Pn()},{html:'\n    <div class="ds-card-body">\n      <div class="ds-loading" style="padding:16px;text-align:center">\n        <div style="color:var(--ds-gold-mid);font-size:24px;margin-bottom:8px">⏳</div>\n        <p class="ds-loading-text" style="color:var(--ds-text-secondary);font-size:12px;margin:0 0 12px">\n          Chargement de DeepSight…\n        </p>\n        <button\n          type="button"\n          id="ds-skeleton-retry"\n          class="ds-btn ds-btn-primary"\n          style="font-size:11px;padding:6px 12px;display:none"\n        >\n          Réessayer\n        </button>\n      </div>\n    </div>\n  ',bind:()=>{Promise.resolve().then(e.bind(e,40)).then(({$id:t})=>{setTimeout(()=>{const e=t("ds-skeleton-retry");e&&!e.hasAttribute("data-bound")&&(e.setAttribute("data-bound","1"),e.style.display="inline-block",e.addEventListener("click",n))},1e4)}).catch(()=>{})}}),s=document.createElement("div");s.innerHTML=r.html;const a=s.firstElementChild;a&&o.appendChild(a),r.bind(),In("inject:widget-populated-with-skeleton")}else In("inject:widgetCard-null");const d=function(n,t){const e=document.getElementById(N);if(e&&e!==n&&e.remove(),F=!1,t){for(const t of q)if(document.querySelector(t))return document.body.appendChild(n),!0;return!1}for(const{selector:t,position:e}of D){const r=document.querySelector(t);if(r instanceof HTMLElement&&B(r))return"prepend"===e?r.insertBefore(n,r.firstChild):r.parentElement?.insertBefore(n,r.nextSibling),!0}return F=!0,n.style.cssText="all:initial;position:fixed;bottom:20px;right:20px;width:380px;max-height:80vh;z-index:2147483646;",document.body.appendChild(n),!0}(a,s);if(In("inject:injectWidget-result",{success:d}),d)zn.injected=!0,zn.injectionAttempts=0,function(){const n=(0,i.$id)("ds-minimize-btn"),e=H();n&&e&&(t.storage.local.get(["ds_minimized"]).then(n=>{n.ds_minimized&&Q()}),n.addEventListener("click",()=>{e.classList.contains("ds-collapsed")?(function(){const n=H(),t=(0,i.$id)("ds-minimize-btn");n&&(n.classList.remove("ds-collapsed"),t&&(t.textContent="−"))}(),t.storage.local.set({ds_minimized:!1})):(Q(),t.storage.local.set({ds_minimized:!0}))}))}(),function(n){M();const t=new MutationObserver(()=>{n(z())});t.observe(document.documentElement,{attributes:!0,attributeFilter:["dark","class"]});const e=window.matchMedia("(prefers-color-scheme: dark)"),r=()=>{n(z())};e.addEventListener("change",r),P=()=>{e.removeEventListener("change",r),t.disconnect()}}(()=>{const n=H();n&&!n.classList.contains("dark")&&(n.classList.remove("light"),n.classList.add("dark"))}),function(){X();const n=document.querySelector("ytd-watch-flexy")||document.querySelector("#content");n&&(K=new MutationObserver(()=>{document.getElementById("deepsight-host")||(In("observer:widget-detached"),zn.injected=!1,Pn())}),K.observe(n,{childList:!0,subtree:!1}))}(),function(n){tn();const t=document.querySelector("ytd-watch-flexy");t&&(J=new MutationObserver(()=>n(Z())),J.observe(t,{attributes:!0,attributeFilter:["theater"]})),nn=()=>n(Z()),document.addEventListener("fullscreenchange",nn)}(n=>{const t=document.getElementById("deepsight-host");t&&("fullscreen"===n?t.style.display="none":"theater"===n?(t.style.cssText="all:initial;position:fixed;bottom:20px;right:20px;width:380px;max-height:80vh;z-index:2147483646;",t.style.display=""):t.style.cssText="all:initial;display:block;width:100%;max-width:420px;margin-bottom:12px;")}),In("inject:success-calling-initCard"),Mn();else{const n=15e3;if(500*zn.injectionAttempts>=n)In("inject:budget-exceeded-force-floating"),zn.injected=!1,setTimeout(Pn,1e3);else{const n=zn.injectionAttempts<=10?300:1e3;setTimeout(Pn,n)}}}catch(n){In("inject:caught-error",{message:n.message}),Ln(n,{step:"tryInjectWidget",attempt:zn.injectionAttempts}),zn.injectionAttempts<3&&setTimeout(Pn,1e3)}var n}async function Mn(){try{const r=await(n=t.runtime.sendMessage({action:"CHECK_AUTH"}),e={authenticated:!1},new Promise(t=>{let r=!1;const s=setTimeout(()=>{r||(r=!0,t(e))},5e3);n.then(n=>{r||(r=!0,clearTimeout(s),t(n))},()=>{r||(r=!0,clearTimeout(s),t(e))})}));if(In("initCard:auth-checked",{authenticated:!!r?.authenticated}),!r?.authenticated)return zn.state="login",zn.user=null,void ln(()=>Mn());zn.user=r.user??null,t.runtime.sendMessage({action:"GET_PLAN"}).then(n=>{const t=n;t?.success&&(zn.planInfo=t.plan??null)}).catch(()=>{}),zn.videoId&&async function(n){try{const e=await t.runtime.sendMessage({action:"GET_TOURNESOL",data:{videoId:n}});return e?.success&&e.data?e.data:null}catch{return null}}(zn.videoId).then(n=>{zn.tournesol=n,"ready"===zn.state&&zn.user&&gn({user:{username:zn.user.username,plan:zn.user.plan,credits:zn.user.credits},tournesol:zn.tournesol,videoTitle:_n(),onAnalyze:(n,t)=>Rn(n,t),onQuickChat:n=>On(n),onLogout:Bn})}).catch(()=>{}),zn.state="ready",gn({user:{username:zn.user.username,plan:zn.user.plan,credits:zn.user.credits},tournesol:zn.tournesol,videoTitle:_n(),onAnalyze:(n,t)=>Rn(n,t),onQuickChat:n=>On(n),onLogout:Bn})}catch(n){Fn(`Erreur d'initialisation: ${n.message}`)}var n,e}function _n(){const n=document.querySelector('meta[property="og:title"]');if(n instanceof HTMLMetaElement&&n.content)return n.content;const t=document.querySelector('meta[name="title"]');if(t instanceof HTMLMetaElement&&t.content)return t.content;const e=document.querySelector("ytd-watch-metadata h1 yt-formatted-string")??document.querySelector("h1.title yt-formatted-string")??document.querySelector("h1.title");if(e?.textContent?.trim())return e.textContent.trim();return document.title.replace(/\s*[-–—]\s*YouTube\s*$/,"").trim()||""}function jn(){zn.currentTaskId&&t.runtime.sendMessage({action:"CANCEL_ANALYSIS",data:{taskId:zn.currentTaskId}}).catch(()=>{}),zn.state="ready",zn.currentTaskId=null,zn.user&&gn({user:{username:zn.user.username,plan:zn.user.plan,credits:zn.user.credits},tournesol:zn.tournesol,videoTitle:_n(),onAnalyze:Rn,onQuickChat:On,onLogout:Bn})}async function Rn(n,e){if(!zn.videoId)return;zn.state="analyzing",zn.currentTaskId=null,function(n,t,e){if(G(`\n    <div class="ds-analyzing-container">\n      <div class="ds-loading" style="text-align:center;padding:16px 0">\n        \n    <div class="ds-gouvernail-spinner" style="width:48px;height:48px;">\n      <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">\n        <circle cx="24" cy="24" r="20" opacity="0.3"/>\n        <circle cx="24" cy="24" r="3"/>\n        <line x1="24" y1="4" x2="24" y2="11"/>\n        <line x1="38.1" y1="9.9" x2="33.2" y2="14.8"/>\n        <line x1="44" y1="24" x2="37" y2="24"/>\n        <line x1="38.1" y1="38.1" x2="33.2" y2="33.2"/>\n        <line x1="24" y1="44" x2="24" y2="37"/>\n        <line x1="9.9" y1="38.1" x2="14.8" y2="33.2"/>\n        <line x1="4" y1="24" x2="11" y2="24"/>\n        <line x1="9.9" y1="9.9" x2="14.8" y2="14.8"/>\n      </svg>\n    </div>\n        <p class="ds-loading-text" id="ds-progress-text">${en("Démarrage de l'analyse...")}</p>\n      </div>\n      <div class="ds-progress" style="margin:8px 0">\n        <div class="ds-progress-bar" id="ds-progress-bar" style="width:0%"></div>\n      </div>\n      <button id="ds-cancel-btn" style="\n        display:block;margin:12px auto 0;padding:6px 16px;\n        background:transparent;border:1px solid rgba(255,255,255,0.15);\n        border-radius:8px;color:rgba(255,255,255,0.5);font-size:12px;\n        cursor:pointer;transition:all 0.2s;\n      ">Annuler</button>\n    </div>\n  `),e){const n=W(),t=n?.querySelector("#ds-cancel-btn");t&&(t.addEventListener("click",e),t.addEventListener("mouseenter",()=>{t.style.color="#ef4444",t.style.borderColor="rgba(239,68,68,0.3)",t.style.background="rgba(239,68,68,0.1)"}),t.addEventListener("mouseleave",()=>{t.style.color="rgba(255,255,255,0.5)",t.style.borderColor="rgba(255,255,255,0.15)",t.style.background="transparent"}))}}(0,0,jn);const r=window.location.href;try{const s=await t.runtime.sendMessage({action:"ANALYZE_VIDEO",data:{url:r,options:{mode:n,lang:e,category:"auto"}}});if(!s?.success)throw new Error(s?.error||"Analyse échouée");const a=s.result;if("completed"===a.status&&a.result?.summary_id)await async function(n){const e=await t.runtime.sendMessage({action:"GET_SUMMARY",data:{summaryId:n}});if(!e?.success)throw new Error(e?.error||"Récupération analyse échouée");zn.summary=e.summary,zn.state="results",zn.videoId&&await async function(n){const e=(await async function(){return(await t.storage.local.get(["recentAnalyses"])).recentAnalyses||[]}()).filter(t=>t.videoId!==n.videoId);e.unshift({...n,timestamp:Date.now()}),await t.storage.local.set({recentAnalyses:e.slice(0,20)})}({videoId:zn.videoId,summaryId:zn.summary.id,title:zn.summary.video_title}),await yn({summary:zn.summary,userPlan:zn.user?.plan??"free",onChat:Nn,onCopyLink:Dn,onShare:qn})}(a.result.summary_id);else if("failed"===a.status)throw new Error(a.error??"Analyse échouée")}catch(n){zn.state="ready",Fn(n.message),setTimeout(()=>{zn.user&&gn({user:{username:zn.user.username,plan:zn.user.plan,credits:zn.user.credits},tournesol:zn.tournesol,videoTitle:_n(),onAnalyze:Rn,onQuickChat:On,onLogout:Bn})},3e3)}}async function On(n){try{const e=await t.runtime.sendMessage({action:"QUICK_CHAT",data:{url:window.location.href,lang:n}});if(!e?.success)throw new Error(e?.error||"Quick Chat échoué");const r=e.result;Nn(r.summary_id,r.video_title)}catch(n){Fn(n.message);const t=(0,i.$id)("ds-quickchat-btn");t&&(t.disabled=!1,t.innerHTML="💬 Quick Chat IA")}}async function Nn(n,e){zn.state="chat";let r=[];try{const e=await t.runtime.sendMessage({action:"GET_CHAT_HISTORY",data:{summaryId:n}});e?.success&&Array.isArray(e.result)&&(r=e.result)}catch{}await async function(n){const{summaryId:t,videoTitle:e,category:r="default",messages:s=[],onBack:o}=n,d=bn(r,4);wn=await x();const l=s.map(An).join("");G(`\n    <div class="ds-chat-container ds-animate-fadeIn">\n      ${o?`<button class="ds-link-btn" id="ds-chat-back" type="button" style="font-size:11px;margin-bottom:4px">← ${mn().backToResults}</button>`:""}\n      <div style="font-size:11px;color:var(--ds-text-muted);margin-bottom:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${en(e)}">\n        💬 Chat — ${en(e)}\n      </div>\n\n      <div class="ds-chat-messages" id="ds-chat-messages">\n        ${l||`<div style="text-align:center;color:var(--ds-text-muted);font-size:11px;padding:16px 0">${mn().askQuestion}</div>`}\n      </div>\n\n      ${0===s.length?`\n        <div class="ds-chat-suggestions" id="ds-chat-suggestions">\n          ${d.map((n,t)=>`<button class="ds-chat-suggestion" data-index="${t}" type="button">${en(n)}</button>`).join("")}\n        </div>\n      `:""}\n\n      <div class="ds-chat-input-row">\n        <input\n          type="text"\n          id="ds-chat-input"\n          class="ds-chat-input"\n          placeholder="Posez une question..."\n          autocomplete="off"\n          maxlength="500"\n        />\n        <button class="ds-chat-send-btn" id="ds-chat-send" type="button" title="Envoyer">➤</button>\n      </div>\n\n      <div class="ds-card-footer" style="margin-top:6px">\n        <a href="${a}/summary/${t}" target="_blank" rel="noreferrer" style="font-size:11px">\n          📖 Voir l'analyse complète\n        </a>\n        <span style="font-size:11px;color:var(--ds-text-muted)">Alt+C pour ouvrir</span>\n      </div>\n    </div>\n  `),function(n,t,e){e&&(0,i.$id)("ds-chat-back")?.addEventListener("click",e),fn("ds-chat-suggestions",t,t=>{const e=(0,i.$id)("ds-chat-input");e&&(e.value=t,Tn(n))});const r=(0,i.$id)("ds-chat-input"),s=(0,i.$id)("ds-chat-send");s?.addEventListener("click",()=>Tn(n)),r?.addEventListener("keydown",t=>{"Enter"!==t.key||t.shiftKey||(t.preventDefault(),Tn(n))})}(t,d,o),E(),En()}({summaryId:n,videoTitle:e,category:zn.summary?.category??"default",messages:r,onBack:zn.summary?()=>{zn.state="results",yn({summary:zn.summary,userPlan:zn.user?.plan??"free",onChat:Nn,onCopyLink:Dn,onShare:qn})}:void 0})}async function Dn(){if(!zn.summary)return;const n=(0,i.$id)("ds-copy-btn");if(!n)return;let e=`${a}/summary/${zn.summary.id}`;try{const n=await t.runtime.sendMessage({action:"SHARE_ANALYSIS",data:{videoId:zn.videoId}});n?.success&&n.share_url&&(e=n.share_url)}catch{}const r=["🎯 DeepSight — Analyse IA","",`📹 ${zn.summary.video_title}`,`🏷️ Catégorie: ${zn.summary.category}`,`📊 Fiabilité: ${zn.summary.reliability_score}%`,"",`🔗 ${e}`,"—","deepsightsynthesis.com"].join("\n");try{await navigator.clipboard.writeText(r),n.textContent="✅ Copié!",setTimeout(()=>{n.textContent="📋 Copier"},2e3)}catch{n.textContent="❌ Échec",setTimeout(()=>{n.textContent="📋 Copier"},2e3)}}async function qn(){if(!zn.summary)return;const n=(0,i.$id)("ds-share-btn");if(n)try{const e=await t.runtime.sendMessage({action:"SHARE_ANALYSIS",data:{videoId:zn.videoId}}),r=e?.success?e.share_url:`${a}/summary/${zn.summary.id}`;await navigator.clipboard.writeText(r),n.textContent="✅ Lien copié!",setTimeout(()=>{n.textContent="🔗 Partager"},2e3)}catch{n.textContent="❌ Échec",setTimeout(()=>{n.textContent="🔗 Partager"},2e3)}}async function Bn(){await t.runtime.sendMessage({action:"LOGOUT"}),zn.user=null,zn.planInfo=null,zn.summary=null,zn.tournesol=null,zn.state="login",ln(()=>Mn())}function Fn(n){const t=W();if(!t)return;const e="undefined"!=typeof navigator&&!navigator.onLine,r=document.createElement("div");if(r.style.cssText="padding:8px 12px;background:var(--ds-error-bg);border-radius:8px;font-size:11px;color:var(--ds-error);margin-top:8px;display:flex;flex-direction:column;gap:6px",r.textContent=e?"📡 Hors ligne — vérifiez votre connexion":`❌ ${n}`,e){const n=document.createElement("button");n.type="button",n.textContent="Réessayer",n.style.cssText="padding:4px 8px;border-radius:4px;background:var(--ds-gold-mid);color:#0a0a0f;border:none;font-size:10px;cursor:pointer;align-self:flex-start",n.addEventListener("click",()=>{Mn()}),r.appendChild(n)}t.appendChild(r)}async function Un(n){f(),X(),tn(),M(),$=null,T(),zn.videoId=n,zn.summary=null,zn.tournesol=null,zn.state="login",zn.injected=!1,zn.injectionAttempts=0,U(),n&&I()&&setTimeout(Pn,800)}function Hn(){try{if(In("bootstrap:start",{url:location.href,readyState:document.readyState}),!I())return void In("bootstrap:not-video-page");if(zn.videoId=L(),!zn.videoId)return void In("bootstrap:no-video-id");In("bootstrap:video-id",{videoId:zn.videoId}),T(),In("bootstrap:anchor-ready",{ready:Y()}),setTimeout(Pn,1e3),function(n){let t=L();function e(){const e=L();e!==t&&(t=e,setTimeout(()=>n(e),500))}const r=history.pushState;history.pushState=function(...n){r.apply(history,n),e()},window.addEventListener("popstate",e),document.addEventListener("yt-navigate-finish",e),document.addEventListener("yt-page-data-updated",e)}(Un),In("bootstrap:ready")}catch(n){In("bootstrap:caught-error",{message:n.message}),Ln(n,{step:"bootstrap"})}}t.runtime.onMessage.addListener(n=>{const t=n;if("ANALYSIS_PROGRESS"===t.action){const{taskId:n,progress:e,message:r}=t.data;return"analyzing"===zn.state&&(zn.currentTaskId=n,function(n,t){const e=W();if(!e)return;const r=e.querySelector("#ds-progress-bar"),s=e.querySelector("#ds-progress-text");r&&(r.style.width=`${t}%`),s&&(s.textContent=n)}(r,e)),Promise.resolve({success:!0})}return"TOGGLE_WIDGET"===t.action?(H()?U():Pn(),Promise.resolve({success:!0})):"START_ANALYSIS_FROM_COMMAND"===t.action?("ready"===zn.state&&Rn("standard","fr"),Promise.resolve({success:!0})):"OPEN_CHAT_FROM_COMMAND"===t.action?("results"===zn.state&&zn.summary&&Nn(zn.summary.id,zn.summary.video_title),Promise.resolve({success:!0})):void 0}),window.addEventListener("error",n=>{n.error&&Ln(n.error,{source:"window.onerror"})}),window.addEventListener("unhandledrejection",n=>{Ln(n.reason,{source:"unhandledrejection"})}),"undefined"!=typeof window&&window.addEventListener("online",()=>{In("network:online-retry"),"login"!==zn.state&&"ready"!==zn.state||Mn()}),"loading"===document.readyState?document.addEventListener("DOMContentLoaded",Hn):Hn()})()})();
+(() => {
+  var n = {
+      40(n, t, e) {
+        "use strict";
+        e.d(t, { $id: () => a, JF: () => i, PM: () => s, gC: () => o });
+        let r = null;
+        function s(n) {
+          if (r && r !== n) {
+            const t = r.host,
+              e = n?.host;
+            if (t && t.isConnected && t !== e)
+              try {
+                t.remove();
+              } catch {}
+          }
+          r = n;
+        }
+        function a(n) {
+          return r?.getElementById(n) ?? null;
+        }
+        function i(n) {
+          return r?.querySelector(n) ?? null;
+        }
+        function o(n) {
+          return r
+            ? r.querySelectorAll(n)
+            : document.createDocumentFragment().querySelectorAll(n);
+        }
+      },
+      815(n, t) {
+        var e, r;
+        ("undefined" != typeof globalThis
+          ? globalThis
+          : "undefined" != typeof self && self,
+          (e = function (n) {
+            "use strict";
+            if (
+              !(
+                globalThis.chrome &&
+                globalThis.chrome.runtime &&
+                globalThis.chrome.runtime.id
+              )
+            )
+              throw new Error(
+                "This script should only be loaded in a browser extension.",
+              );
+            if (
+              globalThis.browser &&
+              globalThis.browser.runtime &&
+              globalThis.browser.runtime.id
+            )
+              n.exports = globalThis.browser;
+            else {
+              const t =
+                  "The message port closed before a response was received.",
+                e = (n) => {
+                  const e = {
+                    alarms: {
+                      clear: { minArgs: 0, maxArgs: 1 },
+                      clearAll: { minArgs: 0, maxArgs: 0 },
+                      get: { minArgs: 0, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                    },
+                    bookmarks: {
+                      create: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getChildren: { minArgs: 1, maxArgs: 1 },
+                      getRecent: { minArgs: 1, maxArgs: 1 },
+                      getSubTree: { minArgs: 1, maxArgs: 1 },
+                      getTree: { minArgs: 0, maxArgs: 0 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeTree: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    browserAction: {
+                      disable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      enable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      getBadgeBackgroundColor: { minArgs: 1, maxArgs: 1 },
+                      getBadgeText: { minArgs: 1, maxArgs: 1 },
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      openPopup: { minArgs: 0, maxArgs: 0 },
+                      setBadgeBackgroundColor: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setBadgeText: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    browsingData: {
+                      remove: { minArgs: 2, maxArgs: 2 },
+                      removeCache: { minArgs: 1, maxArgs: 1 },
+                      removeCookies: { minArgs: 1, maxArgs: 1 },
+                      removeDownloads: { minArgs: 1, maxArgs: 1 },
+                      removeFormData: { minArgs: 1, maxArgs: 1 },
+                      removeHistory: { minArgs: 1, maxArgs: 1 },
+                      removeLocalStorage: { minArgs: 1, maxArgs: 1 },
+                      removePasswords: { minArgs: 1, maxArgs: 1 },
+                      removePluginData: { minArgs: 1, maxArgs: 1 },
+                      settings: { minArgs: 0, maxArgs: 0 },
+                    },
+                    commands: { getAll: { minArgs: 0, maxArgs: 0 } },
+                    contextMenus: {
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeAll: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    cookies: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 1, maxArgs: 1 },
+                      getAllCookieStores: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    },
+                    devtools: {
+                      inspectedWindow: {
+                        eval: { minArgs: 1, maxArgs: 2, singleCallbackArg: !1 },
+                      },
+                      panels: {
+                        create: {
+                          minArgs: 3,
+                          maxArgs: 3,
+                          singleCallbackArg: !0,
+                        },
+                        elements: {
+                          createSidebarPane: { minArgs: 1, maxArgs: 1 },
+                        },
+                      },
+                    },
+                    downloads: {
+                      cancel: { minArgs: 1, maxArgs: 1 },
+                      download: { minArgs: 1, maxArgs: 1 },
+                      erase: { minArgs: 1, maxArgs: 1 },
+                      getFileIcon: { minArgs: 1, maxArgs: 2 },
+                      open: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      pause: { minArgs: 1, maxArgs: 1 },
+                      removeFile: { minArgs: 1, maxArgs: 1 },
+                      resume: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    extension: {
+                      isAllowedFileSchemeAccess: { minArgs: 0, maxArgs: 0 },
+                      isAllowedIncognitoAccess: { minArgs: 0, maxArgs: 0 },
+                    },
+                    history: {
+                      addUrl: { minArgs: 1, maxArgs: 1 },
+                      deleteAll: { minArgs: 0, maxArgs: 0 },
+                      deleteRange: { minArgs: 1, maxArgs: 1 },
+                      deleteUrl: { minArgs: 1, maxArgs: 1 },
+                      getVisits: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                    },
+                    i18n: {
+                      detectLanguage: { minArgs: 1, maxArgs: 1 },
+                      getAcceptLanguages: { minArgs: 0, maxArgs: 0 },
+                    },
+                    identity: { launchWebAuthFlow: { minArgs: 1, maxArgs: 1 } },
+                    idle: { queryState: { minArgs: 1, maxArgs: 1 } },
+                    management: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getSelf: { minArgs: 0, maxArgs: 0 },
+                      setEnabled: { minArgs: 2, maxArgs: 2 },
+                      uninstallSelf: { minArgs: 0, maxArgs: 1 },
+                    },
+                    notifications: {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      create: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getPermissionLevel: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    pageAction: {
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      hide: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    permissions: {
+                      contains: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      request: { minArgs: 1, maxArgs: 1 },
+                    },
+                    runtime: {
+                      getBackgroundPage: { minArgs: 0, maxArgs: 0 },
+                      getPlatformInfo: { minArgs: 0, maxArgs: 0 },
+                      openOptionsPage: { minArgs: 0, maxArgs: 0 },
+                      requestUpdateCheck: { minArgs: 0, maxArgs: 0 },
+                      sendMessage: { minArgs: 1, maxArgs: 3 },
+                      sendNativeMessage: { minArgs: 2, maxArgs: 2 },
+                      setUninstallURL: { minArgs: 1, maxArgs: 1 },
+                    },
+                    sessions: {
+                      getDevices: { minArgs: 0, maxArgs: 1 },
+                      getRecentlyClosed: { minArgs: 0, maxArgs: 1 },
+                      restore: { minArgs: 0, maxArgs: 1 },
+                    },
+                    storage: {
+                      local: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                      managed: {
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                      },
+                      sync: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                    },
+                    tabs: {
+                      captureVisibleTab: { minArgs: 0, maxArgs: 2 },
+                      create: { minArgs: 1, maxArgs: 1 },
+                      detectLanguage: { minArgs: 0, maxArgs: 1 },
+                      discard: { minArgs: 0, maxArgs: 1 },
+                      duplicate: { minArgs: 1, maxArgs: 1 },
+                      executeScript: { minArgs: 1, maxArgs: 2 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 0 },
+                      getZoom: { minArgs: 0, maxArgs: 1 },
+                      getZoomSettings: { minArgs: 0, maxArgs: 1 },
+                      goBack: { minArgs: 0, maxArgs: 1 },
+                      goForward: { minArgs: 0, maxArgs: 1 },
+                      highlight: { minArgs: 1, maxArgs: 1 },
+                      insertCSS: { minArgs: 1, maxArgs: 2 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      query: { minArgs: 1, maxArgs: 1 },
+                      reload: { minArgs: 0, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeCSS: { minArgs: 1, maxArgs: 2 },
+                      sendMessage: { minArgs: 2, maxArgs: 3 },
+                      setZoom: { minArgs: 1, maxArgs: 2 },
+                      setZoomSettings: { minArgs: 1, maxArgs: 2 },
+                      update: { minArgs: 1, maxArgs: 2 },
+                    },
+                    topSites: { get: { minArgs: 0, maxArgs: 0 } },
+                    webNavigation: {
+                      getAllFrames: { minArgs: 1, maxArgs: 1 },
+                      getFrame: { minArgs: 1, maxArgs: 1 },
+                    },
+                    webRequest: {
+                      handlerBehaviorChanged: { minArgs: 0, maxArgs: 0 },
+                    },
+                    windows: {
+                      create: { minArgs: 0, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 1 },
+                      getLastFocused: { minArgs: 0, maxArgs: 1 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                  };
+                  if (0 === Object.keys(e).length)
+                    throw new Error(
+                      "api-metadata.json has not been included in browser-polyfill",
+                    );
+                  class r extends WeakMap {
+                    constructor(n, t = void 0) {
+                      (super(t), (this.createItem = n));
+                    }
+                    get(n) {
+                      return (
+                        this.has(n) || this.set(n, this.createItem(n)),
+                        super.get(n)
+                      );
+                    }
+                  }
+                  const s =
+                      (t, e) =>
+                      (...r) => {
+                        n.runtime.lastError
+                          ? t.reject(new Error(n.runtime.lastError.message))
+                          : e.singleCallbackArg ||
+                              (r.length <= 1 && !1 !== e.singleCallbackArg)
+                            ? t.resolve(r[0])
+                            : t.resolve(r);
+                      },
+                    a = (n) => (1 == n ? "argument" : "arguments"),
+                    i = (n, t, e) =>
+                      new Proxy(t, { apply: (t, r, s) => e.call(r, n, ...s) });
+                  let o = Function.call.bind(Object.prototype.hasOwnProperty);
+                  const d = (n, t = {}, e = {}) => {
+                      let r = Object.create(null),
+                        l = {
+                          has: (t, e) => e in n || e in r,
+                          get(l, c, p) {
+                            if (c in r) return r[c];
+                            if (!(c in n)) return;
+                            let m = n[c];
+                            if ("function" == typeof m)
+                              if ("function" == typeof t[c])
+                                m = i(n, n[c], t[c]);
+                              else if (o(e, c)) {
+                                let t = ((n, t) =>
+                                  function (e, ...r) {
+                                    if (r.length < t.minArgs)
+                                      throw new Error(
+                                        `Expected at least ${t.minArgs} ${a(t.minArgs)} for ${n}(), got ${r.length}`,
+                                      );
+                                    if (r.length > t.maxArgs)
+                                      throw new Error(
+                                        `Expected at most ${t.maxArgs} ${a(t.maxArgs)} for ${n}(), got ${r.length}`,
+                                      );
+                                    return new Promise((a, i) => {
+                                      if (t.fallbackToNoCallback)
+                                        try {
+                                          e[n](
+                                            ...r,
+                                            s({ resolve: a, reject: i }, t),
+                                          );
+                                        } catch (s) {
+                                          (console.warn(
+                                            `${n} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,
+                                            s,
+                                          ),
+                                            e[n](...r),
+                                            (t.fallbackToNoCallback = !1),
+                                            (t.noCallback = !0),
+                                            a());
+                                        }
+                                      else
+                                        t.noCallback
+                                          ? (e[n](...r), a())
+                                          : e[n](
+                                              ...r,
+                                              s({ resolve: a, reject: i }, t),
+                                            );
+                                    });
+                                  })(c, e[c]);
+                                m = i(n, n[c], t);
+                              } else m = m.bind(n);
+                            else if (
+                              "object" == typeof m &&
+                              null !== m &&
+                              (o(t, c) || o(e, c))
+                            )
+                              m = d(m, t[c], e[c]);
+                            else {
+                              if (!o(e, "*"))
+                                return (
+                                  Object.defineProperty(r, c, {
+                                    configurable: !0,
+                                    enumerable: !0,
+                                    get: () => n[c],
+                                    set(t) {
+                                      n[c] = t;
+                                    },
+                                  }),
+                                  m
+                                );
+                              m = d(m, t[c], e["*"]);
+                            }
+                            return ((r[c] = m), m);
+                          },
+                          set: (t, e, s, a) => (
+                            e in r ? (r[e] = s) : (n[e] = s),
+                            !0
+                          ),
+                          defineProperty: (n, t, e) =>
+                            Reflect.defineProperty(r, t, e),
+                          deleteProperty: (n, t) =>
+                            Reflect.deleteProperty(r, t),
+                        },
+                        c = Object.create(n);
+                      return new Proxy(c, l);
+                    },
+                    l = (n) => ({
+                      addListener(t, e, ...r) {
+                        t.addListener(n.get(e), ...r);
+                      },
+                      hasListener: (t, e) => t.hasListener(n.get(e)),
+                      removeListener(t, e) {
+                        t.removeListener(n.get(e));
+                      },
+                    }),
+                    c = new r((n) =>
+                      "function" != typeof n
+                        ? n
+                        : function (t) {
+                            const e = d(
+                              t,
+                              {},
+                              { getContent: { minArgs: 0, maxArgs: 0 } },
+                            );
+                            n(e);
+                          },
+                    ),
+                    p = new r((n) =>
+                      "function" != typeof n
+                        ? n
+                        : function (t, e, r) {
+                            let s,
+                              a,
+                              i = !1,
+                              o = new Promise((n) => {
+                                s = function (t) {
+                                  ((i = !0), n(t));
+                                };
+                              });
+                            try {
+                              a = n(t, e, s);
+                            } catch (n) {
+                              a = Promise.reject(n);
+                            }
+                            const d =
+                              !0 !== a &&
+                              (l = a) &&
+                              "object" == typeof l &&
+                              "function" == typeof l.then;
+                            var l;
+                            if (!0 !== a && !d && !i) return !1;
+                            return (
+                              (d ? a : o)
+                                .then(
+                                  (n) => {
+                                    r(n);
+                                  },
+                                  (n) => {
+                                    let t;
+                                    ((t =
+                                      n &&
+                                      (n instanceof Error ||
+                                        "string" == typeof n.message)
+                                        ? n.message
+                                        : "An unexpected error occurred"),
+                                      r({
+                                        __mozWebExtensionPolyfillReject__: !0,
+                                        message: t,
+                                      }));
+                                  },
+                                )
+                                .catch((n) => {
+                                  console.error(
+                                    "Failed to send onMessage rejected reply",
+                                    n,
+                                  );
+                                }),
+                              !0
+                            );
+                          },
+                    ),
+                    m = ({ reject: e, resolve: r }, s) => {
+                      n.runtime.lastError
+                        ? n.runtime.lastError.message === t
+                          ? r()
+                          : e(new Error(n.runtime.lastError.message))
+                        : s && s.__mozWebExtensionPolyfillReject__
+                          ? e(new Error(s.message))
+                          : r(s);
+                    },
+                    g = (n, t, e, ...r) => {
+                      if (r.length < t.minArgs)
+                        throw new Error(
+                          `Expected at least ${t.minArgs} ${a(t.minArgs)} for ${n}(), got ${r.length}`,
+                        );
+                      if (r.length > t.maxArgs)
+                        throw new Error(
+                          `Expected at most ${t.maxArgs} ${a(t.maxArgs)} for ${n}(), got ${r.length}`,
+                        );
+                      return new Promise((n, t) => {
+                        const s = m.bind(null, { resolve: n, reject: t });
+                        (r.push(s), e.sendMessage(...r));
+                      });
+                    },
+                    u = {
+                      devtools: { network: { onRequestFinished: l(c) } },
+                      runtime: {
+                        onMessage: l(p),
+                        onMessageExternal: l(p),
+                        sendMessage: g.bind(null, "sendMessage", {
+                          minArgs: 1,
+                          maxArgs: 3,
+                        }),
+                      },
+                      tabs: {
+                        sendMessage: g.bind(null, "sendMessage", {
+                          minArgs: 2,
+                          maxArgs: 3,
+                        }),
+                      },
+                    },
+                    b = {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    };
+                  return (
+                    (e.privacy = {
+                      network: { "*": b },
+                      services: { "*": b },
+                      websites: { "*": b },
+                    }),
+                    d(n, u, e)
+                  );
+                };
+              n.exports = e(chrome);
+            }
+          }),
+          void 0 === (r = e.apply(t, [n])) || (n.exports = r));
+      },
+    },
+    t = {};
+  function e(r) {
+    var s = t[r];
+    if (void 0 !== s) return s.exports;
+    var a = (t[r] = { exports: {} });
+    return (n[r].call(a.exports, a, a.exports, e), a.exports);
+  }
+  ((e.n = (n) => {
+    var t = n && n.__esModule ? () => n.default : () => n;
+    return (e.d(t, { a: t }), t);
+  }),
+    (e.d = (n, t) => {
+      for (var r in t)
+        e.o(t, r) &&
+          !e.o(n, r) &&
+          Object.defineProperty(n, r, { enumerable: !0, get: t[r] });
+    }),
+    (e.o = (n, t) => Object.prototype.hasOwnProperty.call(n, t)),
+    (() => {
+      "use strict";
+      var n = e(815);
+      const t = e.n(n)(),
+        r = [
+          /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?\s]+)/,
+          /youtube\.com\/shorts\/([^&?\s]+)/,
+        ],
+        s = [
+          /tiktok\.com\/@[\w.-]+\/video\/(\d+)/i,
+          /vm\.tiktok\.com\/([\w-]+)/i,
+          /m\.tiktok\.com\/v\/(\d+)/i,
+          /tiktok\.com\/t\/([\w-]+)/i,
+          /tiktok\.com\/video\/(\d+)/i,
+        ];
+      const a = "https://www.deepsightsynthesis.com";
+      var i = e(40);
+      const o = [1, 1.5, 2, 3],
+        d = {
+          free: 0,
+          decouverte: 0,
+          plus: 1,
+          pro: 2,
+          expert: 2,
+          etudiant: 1,
+          student: 1,
+          starter: 1,
+        };
+      let l = {
+          isPlaying: !1,
+          isLoading: !1,
+          isPaused: !1,
+          currentText: "",
+          currentTime: 0,
+          duration: 0,
+          speed: 1,
+          language: "fr",
+          gender: "female",
+        },
+        c = null,
+        p = null,
+        m = null,
+        g = null;
+      function u() {
+        t.storage.local.set({
+          tts_speed: l.speed,
+          tts_lang: l.language,
+          tts_gender: l.gender,
+        });
+      }
+      async function b() {
+        const n = await (async function () {
+          try {
+            return (await t.storage.local.get(["user"])).user || null;
+          } catch {
+            return null;
+          }
+        })();
+        return (d[n?.plan || "free"] ?? 0) >= 1;
+      }
+      function x() {
+        (c && (c.pause(), c.removeAttribute("src"), (c = null)),
+          p && (URL.revokeObjectURL(p), (p = null)));
+      }
+      function f() {
+        (m?.abort(),
+          (m = null),
+          x(),
+          (g = null),
+          (l.isPlaying = !1),
+          (l.isPaused = !1),
+          (l.isLoading = !1),
+          (l.currentText = ""),
+          (l.currentTime = 0),
+          (l.duration = 0),
+          w());
+      }
+      function h() {
+        c &&
+          (c.paused
+            ? (c.play().catch(() => {}), (l.isPaused = !1), (l.isPlaying = !0))
+            : (c.pause(), (l.isPaused = !0), (l.isPlaying = !1)),
+          w());
+      }
+      function v() {
+        const n = o.indexOf(l.speed);
+        ((l.speed = o[(n + 1) % o.length]),
+          c && (c.playbackRate = l.speed),
+          u(),
+          w());
+      }
+      function y(n) {
+        return !isFinite(n) || isNaN(n)
+          ? "0:00"
+          : `${Math.floor(n / 60)}:${Math.floor(n % 60)
+              .toString()
+              .padStart(2, "0")}`;
+      }
+      function w() {
+        (0, i.gC)(".ds-tts-btn").forEach((n) => {
+          const t = n,
+            e = t.dataset.ttsId;
+          (t.dataset.ttsText,
+            g === e && (l.isPlaying || l.isPaused || l.isLoading)
+              ? (t.classList.add("ds-tts-active"),
+                (t.innerHTML = (function (n) {
+                  return `\n    <span class="ds-tts-play-icon">${l.isLoading ? '<svg class="ds-tts-spinner" width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" opacity="0.3"/><path d="M12 2a10 10 0 0 1 10 10" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>' : l.isPlaying ? "⏸️" : "▶️"}</span>\n    <div class="ds-tts-progress" id="${n}-progress">\n      <div class="ds-tts-progress-fill" id="${n}-progress-fill" style="width:${l.duration > 0 ? (l.currentTime / l.duration) * 100 : 0}%"></div>\n    </div>\n    <span class="ds-tts-time" id="${n}-time">${y(l.currentTime)}/${y(l.duration)}</span>\n    <span class="ds-tts-stop" title="Stop">⏹️</span>\n    <span class="ds-tts-speed" title="Vitesse">${l.speed}x</span>\n  `;
+                })(e || "")),
+                (function (n) {
+                  const t = n.querySelector(".ds-tts-play-icon"),
+                    e = n.querySelector(".ds-tts-stop"),
+                    r = n.querySelector(".ds-tts-speed"),
+                    s = n.querySelector(".ds-tts-progress");
+                  (t?.addEventListener("click", (n) => {
+                    (n.stopPropagation(), h());
+                  }),
+                    e?.addEventListener("click", (n) => {
+                      (n.stopPropagation(), f());
+                    }),
+                    r?.addEventListener("click", (n) => {
+                      (n.stopPropagation(), v());
+                    }),
+                    s?.addEventListener("click", (n) => {
+                      if ((n.stopPropagation(), !c || !l.duration)) return;
+                      const t = s.getBoundingClientRect(),
+                        e = (n.clientX - t.left) / t.width;
+                      c.currentTime = e * l.duration;
+                    }));
+                })(t))
+              : (t.classList.remove("ds-tts-active"),
+                (t.innerHTML = '<span class="ds-tts-icon">🔊</span>')));
+        });
+      }
+      t.storage.local.get(["tts_speed", "tts_lang", "tts_gender"]).then((n) => {
+        (n.tts_speed && (l.speed = n.tts_speed),
+          n.tts_lang && (l.language = n.tts_lang),
+          n.tts_gender && (l.gender = n.tts_gender));
+      });
+      let A = 0;
+      function k(n, t = "sm") {
+        return `<button class="ds-tts-btn ${"md" === t ? "ds-tts-btn-md" : ""}" data-tts-id="${"ds-tts-" + ++A}" data-tts-text="${n.replace(/"/g, "&quot;").replace(/'/g, "&#39;")}" type="button" title="Écouter"><span class="ds-tts-icon">🔊</span></button>`;
+      }
+      function E() {
+        (0, i.gC)(".ds-tts-btn:not([data-bound])").forEach((n) => {
+          const e = n;
+          (e.setAttribute("data-bound", "1"),
+            e.classList.contains("ds-tts-locked") ||
+              e.addEventListener("click", (n) => {
+                n.stopPropagation();
+                const r = e.dataset.ttsText || "",
+                  s = e.dataset.ttsId || "";
+                r &&
+                  s &&
+                  (async function (n, e) {
+                    if (n?.trim())
+                      if (
+                        l.currentText !== n ||
+                        (!l.isPlaying && !l.isPaused)
+                      ) {
+                        (f(),
+                          (g = e),
+                          (l.isLoading = !0),
+                          (l.currentText = n),
+                          w(),
+                          (m = new AbortController()));
+                        try {
+                          const e = await (async function () {
+                            try {
+                              const n = await t.storage.local.get([
+                                "accessToken",
+                                "refreshToken",
+                              ]);
+                              return {
+                                accessToken: n.accessToken || null,
+                                refreshToken: n.refreshToken || null,
+                              };
+                            } catch {
+                              return { accessToken: null, refreshToken: null };
+                            }
+                          })();
+                          if (!e.accessToken) throw new Error("Auth required");
+                          const r = await fetch(
+                            "https://api.deepsightsynthesis.com/api/tts",
+                            {
+                              method: "POST",
+                              headers: {
+                                Authorization: `Bearer ${e.accessToken}`,
+                                "Content-Type": "application/json",
+                              },
+                              body: JSON.stringify({
+                                text: n,
+                                language: l.language,
+                                gender: l.gender,
+                                speed: l.speed,
+                                strip_questions: !0,
+                              }),
+                              signal: m.signal,
+                            },
+                          );
+                          if (m.signal.aborted) return;
+                          if (403 === r.status)
+                            throw new Error(
+                              "TTS réservé aux abonnés Étudiant+",
+                            );
+                          if (!r.ok)
+                            throw new Error(`TTS erreur (${r.status})`);
+                          const s = await r.blob();
+                          if (0 === s.size) throw new Error("Audio vide");
+                          if (m.signal.aborted) return;
+                          (x(),
+                            (p = URL.createObjectURL(s)),
+                            (c = new Audio(p)),
+                            (c.playbackRate = l.speed),
+                            (c.onloadedmetadata = () => {
+                              ((l.duration = c.duration), w());
+                            }),
+                            (c.ontimeupdate = () => {
+                              ((l.currentTime = c.currentTime),
+                                (function () {
+                                  if (!g) return;
+                                  const n = (0, i.$id)(`${g}-progress-fill`),
+                                    t = (0, i.$id)(`${g}-time`);
+                                  (n &&
+                                    l.duration > 0 &&
+                                    (n.style.width =
+                                      (l.currentTime / l.duration) * 100 + "%"),
+                                    t &&
+                                      (t.textContent = `${y(l.currentTime)}/${y(l.duration)}`));
+                                })());
+                            }),
+                            (c.onended = () => {
+                              ((l.isPlaying = !1),
+                                (l.isPaused = !1),
+                                (l.currentTime = 0),
+                                (g = null),
+                                w());
+                            }),
+                            (c.onerror = () => f()),
+                            await c.play(),
+                            (l.isPlaying = !0),
+                            (l.isPaused = !1),
+                            (l.isLoading = !1),
+                            w());
+                        } catch (n) {
+                          if (
+                            n instanceof DOMException &&
+                            "AbortError" === n.name
+                          )
+                            return;
+                          (console.warn("[DeepSight TTS]", n),
+                            x(),
+                            (l.isLoading = !1),
+                            (l.isPlaying = !1),
+                            (l.currentText = ""),
+                            (g = null),
+                            w());
+                        }
+                      } else l.isPaused ? h() : f();
+                  })(r, s);
+              }));
+        });
+      }
+      let T = null;
+      function $() {
+        const n = {
+          darkReader: C(),
+          adBlocker: S(),
+          enhancerForYoutube:
+            !!document.querySelector('[class*="enhancer-for-youtube"]') ||
+            !!document.getElementById("efyt-not-interest"),
+          sponsorBlock:
+            !!document.querySelector(".sponsorSkipButton") ||
+            !!document.getElementById("sponsorblock-bar") ||
+            !!document.querySelector('[class*="sponsorBlock"]'),
+          returnYoutubeDislike:
+            !!document.getElementById("return-youtube-dislike") ||
+            !!document.querySelector('[class*="ryd-"]'),
+        };
+        return ((T = n), n);
+      }
+      function C() {
+        const n = document.documentElement;
+        return !!(
+          n.hasAttribute("data-darkreader-mode") ||
+          n.hasAttribute("data-darkreader-scheme") ||
+          document.querySelector('meta[name="darkreader"]') ||
+          document.querySelector("style.darkreader")
+        );
+      }
+      function S() {
+        const n = document.getElementById("secondary");
+        return (
+          !!n &&
+          "none" !== getComputedStyle(n).display &&
+          null === n.offsetParent
+        );
+      }
+      function I() {
+        const n = window.location.href;
+        return n.includes("youtube.com/watch") || n.includes("tiktok.com/");
+      }
+      function L() {
+        return (
+          (function (n) {
+            for (const t of r) {
+              const e = n.match(t);
+              if (e) return e[1];
+            }
+            return null;
+          })((n = window.location.href)) ||
+          (function (n) {
+            for (const t of s) {
+              const e = n.match(t);
+              if (e) return e[1];
+            }
+            return null;
+          })(n)
+        );
+        var n;
+      }
+      function z() {
+        const n = document.documentElement;
+        if ("true" === n.getAttribute("dark") || n.hasAttribute("dark"))
+          return "dark";
+        if (window.matchMedia("(prefers-color-scheme: dark)").matches)
+          return "dark";
+        if (!(T || $()).darkReader) {
+          const t = getComputedStyle(n)
+            .getPropertyValue("--yt-spec-base-background")
+            .trim();
+          if (t.includes("#0f") || t.includes("#18") || t.includes("#21"))
+            return "dark";
+          const e = getComputedStyle(document.body).backgroundColor;
+          if (
+            e.includes("rgb(15,") ||
+            e.includes("rgb(24,") ||
+            e.includes("rgb(33,")
+          )
+            return "dark";
+        }
+        return "light";
+      }
+      let P = null;
+      function M() {
+        P && (P(), (P = null));
+      }
+      const _ =
+          '/* ============================================================\n   DeepSight Widget — Scoped Design Tokens (--ds-* prefix)\n   Maps to design-tokens.css values for Shadow DOM isolation.\n   ============================================================ */\n\n/* FIX-WHITE-WIDGET: split `:host` and `:root` into separate rules.\n   Some browsers treat the combined `:host, :root { ... }` selector list\n   as invalid inside a Shadow DOM (`:root` doesn\'t match anything in\n   shadow scope), which can drop the entire rule and leave CSS vars\n   undefined — producing a transparent/white widget. */\n:host,\n:root,\n.ds-widget {\n  /* === Text === */\n  --ds-text-primary: #f5f0e8;\n  --ds-text-secondary: #b5a89b;\n  --ds-text-muted: #7a7068;\n  --ds-text-inverse: #0a0a0f;\n\n  /* === Font (system stack — no @import possible in closed Shadow DOM) === */\n  --ds-font-family:\n    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;\n  --ds-font-display: Georgia, "Times New Roman", serif;\n  --ds-font-mono: ui-monospace, "Cascadia Code", "Fira Code", monospace;\n\n  /* === Font sizes === */\n  --ds-text-xs: 11px;\n  --ds-text-sm: 13px;\n  --ds-text-md: 15px;\n  --ds-text-lg: 18px;\n\n  /* === Font weights === */\n  --ds-weight-normal: 400;\n  --ds-weight-medium: 500;\n  --ds-weight-semi: 600;\n  --ds-weight-bold: 700;\n\n  /* === Line heights === */\n  --ds-leading-tight: 1.3;\n  --ds-leading-normal: 1.5;\n  --ds-leading-relaxed: 1.6;\n\n  /* === Border radius === */\n  --ds-radius-xs: 4px;\n  --ds-radius-sm: 6px;\n  --ds-radius-md: 10px;\n  --ds-radius-lg: 14px;\n  --ds-radius-card: 14px;\n  --ds-radius-pill: 9999px;\n  --ds-radius-input: 8px;\n\n  /* === Borders === */\n  --ds-border: rgba(200, 144, 58, 0.08);\n  --ds-border-hover: rgba(200, 144, 58, 0.2);\n  --ds-border-focus: rgba(200, 144, 58, 0.4);\n  --ds-border-gold: rgba(200, 144, 58, 0.3);\n\n  /* === Gold accents === */\n  --ds-gold-mid: #c8903a;\n  --ds-gold-gradient: linear-gradient(135deg, #c8903a, #e5b86a);\n\n  /* === Glassmorphism === */\n  --ds-glass-bg: rgba(10, 10, 15, 0.85);\n  --ds-glass-border: rgba(200, 144, 58, 0.06);\n\n  /* === Status colors === */\n  --ds-success: #10b981;\n  --ds-success-bg: rgba(16, 185, 129, 0.1);\n  --ds-warning: #f59e0b;\n  --ds-warning-bg: rgba(245, 158, 11, 0.1);\n  --ds-error: #ef4444;\n  --ds-error-bg: rgba(239, 68, 68, 0.1);\n  --ds-info: #3b82f6;\n  --ds-info-bg: rgba(59, 130, 246, 0.1);\n\n  /* === Transitions === */\n  --ds-transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);\n  --ds-transition-normal: 200ms cubic-bezier(0.4, 0, 0.2, 1);\n  --ds-transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);\n\n  /* === Z-index === */\n  --ds-z-widget: 9999;\n\n  /* === Plan badge colors === */\n  --ds-plan-free: #9ca3af;\n  --ds-plan-decouverte: #9ca3af;\n  --ds-plan-student: #3b82f6;\n  --ds-plan-etudiant: #3b82f6;\n  --ds-plan-starter: #8b5cf6;\n  --ds-plan-plus: #8b5cf6;\n  --ds-plan-pro: #c8903a;\n  --ds-plan-expert: #c8903a;\n}\n\n/* ── Keyframes (ds-* prefixed for Shadow DOM isolation) ── */\n\n@keyframes ds-slideIn {\n  from {\n    transform: translateX(100%);\n    opacity: 0;\n  }\n  to {\n    transform: translateX(0);\n    opacity: 1;\n  }\n}\n\n@keyframes ds-fadeIn {\n  from {\n    opacity: 0;\n  }\n  to {\n    opacity: 1;\n  }\n}\n\n@keyframes ds-glow-pulse {\n  0%,\n  100% {\n    box-shadow: 0 0 20px rgba(200, 144, 58, 0.15);\n  }\n  50% {\n    box-shadow: 0 0 30px rgba(200, 144, 58, 0.3);\n  }\n}\n\n@keyframes ds-spin {\n  from {\n    transform: rotate(0deg);\n  }\n  to {\n    transform: rotate(360deg);\n  }\n}\n\n@keyframes ds-phraseOut {\n  from {\n    opacity: 1;\n    transform: translateY(0);\n  }\n  to {\n    opacity: 0;\n    transform: translateY(-6px);\n  }\n}\n\n@keyframes ds-phraseIn {\n  from {\n    opacity: 0;\n    transform: translateY(6px);\n  }\n  to {\n    opacity: 1;\n    transform: translateY(0);\n  }\n}\n',
+        j =
+          '/* ============================================================\n   DeepSight Extension — Widget YouTube (content script)\n   Remplace l\'ancien content.css\n   Glassmorphism & Premium Glow Effects — V4.2\n   ============================================================ */\n\n/* Tokens loaded inline since Shadow DOM isolates from page CSS */\n\n/* ══════════════════════════════════════════\n   NUCLEAR FIX-WHITE-WIDGET — Always dark, no var() dependency\n   These rules MUST come first and use literal values so the widget\n   is dark even if CSS variables, theme detection, or `.light` class\n   ever leak through. Solid #0a0a0f beats any backdrop-filter weirdness.\n══════════════════════════════════════════ */\n\n:host {\n  color-scheme: dark !important;\n  background-color: #0a0a0f !important;\n}\n\n#deepsight-card,\n#deepsight-card.ds-widget,\n#deepsight-card.ds-widget.dark,\n#deepsight-card.ds-widget.light {\n  background-color: #0a0a0f !important;\n  background-image: none !important;\n  color: #f5f0e8 !important;\n}\n\n/* ══════════════════════════════════════════\n   WIDGET CONTAINER — PREMIUM GLASSMORPHISM\n══════════════════════════════════════════ */\n\n#deepsight-card.ds-widget {\n  all: initial;\n  /* FIX-WHITE-WIDGET: solid hex background — NO var(), NO rgba alpha,\n     NO glass-bg. backdrop-filter could make a 0.85 alpha look near-white\n     on a light page. Solid #0a0a0f is always dark. */\n  font-family: var(\n    --ds-font-family,\n    -apple-system,\n    BlinkMacSystemFont,\n    "Segoe UI",\n    system-ui,\n    sans-serif\n  ) !important;\n  font-size: var(--ds-text-sm, 13px) !important;\n  color: #f5f0e8 !important;\n  background-color: #0a0a0f !important;\n  background-image: none !important;\n  border: 1px solid rgba(200, 144, 58, 0.15) !important;\n  border-radius: var(--ds-radius-card, 14px) !important;\n  box-shadow:\n    0 8px 32px rgba(0, 0, 0, 0.4),\n    0 0 20px rgba(200, 144, 58, 0.05) !important;\n  width: 100% !important;\n  max-width: 420px !important;\n  overflow: hidden !important;\n  position: relative !important;\n  z-index: var(--ds-z-widget, 9999) !important;\n  margin-bottom: 12px !important;\n  box-sizing: border-box !important;\n  animation: ds-slideIn 300ms cubic-bezier(0.4, 0, 0.2, 1) forwards !important;\n}\n\n#deepsight-card.ds-widget * {\n  box-sizing: border-box !important;\n  font-family: var(--ds-font-family) !important;\n}\n\n/* FIX-WHITE-WIDGET: `.light` class fully neutralized — identical to default\n   dark rendering. Solid hex, no var(). */\n#deepsight-card.ds-widget.light {\n  background-color: #0a0a0f !important;\n  background-image: none !important;\n  border-color: rgba(200, 144, 58, 0.15) !important;\n  color: #f5f0e8 !important;\n  box-shadow:\n    0 8px 32px rgba(0, 0, 0, 0.4),\n    0 0 20px rgba(200, 144, 58, 0.05) !important;\n}\n\n/* ══════════════════════════════════════════\n   HEADER — GOLDEN ACCENT LINE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-card-header {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  padding: 10px 14px !important;\n  border-bottom: 2px solid transparent !important;\n  background: linear-gradient(\n    90deg,\n    rgba(255, 255, 255, 0.03),\n    rgba(200, 144, 58, 0.02)\n  ) !important;\n  background-clip: padding-box !important;\n  position: relative !important;\n}\n\n.ds-widget .ds-card-header::after {\n  content: "" !important;\n  position: absolute !important;\n  bottom: -2px !important;\n  left: 0 !important;\n  right: 0 !important;\n  height: 2px !important;\n  background: linear-gradient(\n    90deg,\n    rgba(200, 144, 58, 0.3),\n    rgba(200, 144, 58, 0.1)\n  ) !important;\n}\n\n.ds-widget .ds-card-logo {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  font-weight: var(--ds-weight-semi) !important;\n  font-size: var(--ds-text-md) !important;\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-card-logo span {\n  background: var(--ds-gold-gradient) !important;\n  -webkit-background-clip: text !important;\n  -webkit-text-fill-color: transparent !important;\n  background-clip: text !important;\n}\n\n.ds-widget .ds-card-badge {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  background: rgba(255, 255, 255, 0.06) !important;\n  padding: 2px 7px !important;\n  border-radius: var(--ds-radius-pill) !important;\n  border: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-header-actions {\n  display: flex !important;\n  align-items: center !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-minimize-btn {\n  all: unset !important;\n  cursor: pointer !important;\n  color: var(--ds-text-muted) !important;\n  padding: 4px !important;\n  border-radius: 4px !important;\n  font-size: 16px !important;\n  line-height: 1 !important;\n  transition: color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-minimize-btn:hover {\n  color: var(--ds-text-primary) !important;\n}\n\n/* ══════════════════════════════════════════\n   BODY\n══════════════════════════════════════════ */\n\n.ds-widget .ds-card-body {\n  padding: 14px !important;\n  max-height: 480px !important;\n  overflow-y: auto !important;\n  scrollbar-width: thin !important;\n  scrollbar-color: rgba(255, 255, 255, 0.15) transparent !important;\n}\n\n.ds-widget .ds-card-body::-webkit-scrollbar {\n  width: 4px;\n}\n.ds-widget .ds-card-body::-webkit-scrollbar-track {\n  background: transparent;\n}\n.ds-widget .ds-card-body::-webkit-scrollbar-thumb {\n  background: rgba(255, 255, 255, 0.15);\n  border-radius: 2px;\n}\n\n/* Loading state */\n.ds-widget .ds-loading {\n  display: flex !important;\n  flex-direction: column !important;\n  align-items: center !important;\n  justify-content: center !important;\n  padding: 32px 16px !important;\n  gap: 12px !important;\n}\n\n.ds-widget .ds-loading-text {\n  color: var(--ds-text-muted) !important;\n  font-size: var(--ds-text-sm) !important;\n}\n\n/* ══════════════════════════════════════════\n   LOGIN STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-login-container {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 12px !important;\n}\n\n/* FIX-WHITE-WIDGET: generic button base + ds-btn-primary (used by login).\n   Both classes were referenced in HTML but had no CSS — login submit button\n   rendered as raw HTML. */\n.ds-widget .ds-btn {\n  all: unset !important;\n  box-sizing: border-box !important;\n  display: inline-flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 8px !important;\n  width: 100% !important;\n  padding: 10px !important;\n  border-radius: var(--ds-radius-md) !important;\n  cursor: pointer !important;\n  font-family: var(--ds-font-family) !important;\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-medium) !important;\n  text-align: center !important;\n  transition: all var(--ds-transition-fast) !important;\n  user-select: none !important;\n}\n\n.ds-widget .ds-btn:disabled {\n  opacity: 0.5 !important;\n  cursor: not-allowed !important;\n}\n\n.ds-widget .ds-btn-primary {\n  background: var(--ds-gold-gradient) !important;\n  color: #0b0f19 !important;\n  border: none !important;\n  font-weight: var(--ds-weight-semi) !important;\n  box-shadow: 0 4px 14px rgba(200, 144, 58, 0.2) !important;\n}\n\n.ds-widget .ds-btn-primary:hover:not(:disabled) {\n  filter: brightness(1.1) !important;\n  box-shadow: 0 6px 20px rgba(200, 144, 58, 0.3) !important;\n}\n\n.ds-widget .ds-login-headline,\n.ds-widget .ds-subtitle {\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-normal) !important;\n  color: var(--ds-text-secondary) !important;\n  margin: 0 0 4px !important;\n  line-height: var(--ds-leading-relaxed) !important;\n}\n\n.ds-widget .ds-login-sub {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  margin-bottom: 8px !important;\n  line-height: var(--ds-leading-relaxed) !important;\n}\n\n/* FIX-WHITE-WIDGET: `.ds-divider` is what login.ts actually renders. */\n.ds-widget .ds-divider {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  color: var(--ds-text-muted) !important;\n  font-size: var(--ds-text-xs) !important;\n  margin: 4px 0 !important;\n}\n\n.ds-widget .ds-divider::before,\n.ds-widget .ds-divider::after {\n  content: "" !important;\n  flex: 1 !important;\n  height: 1px !important;\n  background: var(--ds-border) !important;\n}\n\n.ds-widget .ds-divider span {\n  text-transform: uppercase !important;\n  letter-spacing: 0.05em !important;\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-btn-google {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 8px !important;\n  width: 100% !important;\n  padding: 10px !important;\n  background: #fff !important;\n  border: 1px solid #dadce0 !important;\n  border-radius: var(--ds-radius-md) !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-medium) !important;\n  color: #3c4043 !important;\n  transition: background var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-btn-google:hover {\n  background: #f8f9fa !important;\n}\n\n.ds-widget .ds-divider-text {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  color: var(--ds-text-muted) !important;\n  font-size: var(--ds-text-xs) !important;\n}\n\n.ds-widget .ds-divider-text::before,\n.ds-widget .ds-divider-text::after {\n  content: "" !important;\n  flex: 1 !important;\n  height: 1px !important;\n  background: var(--ds-border) !important;\n}\n\n.ds-widget .ds-login-form {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-login-form input {\n  all: unset !important;\n  display: block !important;\n  width: 100% !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-input) !important;\n  padding: 9px 12px !important;\n  font-size: var(--ds-text-sm) !important;\n  color: var(--ds-text-primary) !important;\n  box-sizing: border-box !important;\n  transition: border-color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-login-form input:focus {\n  border-color: var(--ds-border-focus) !important;\n}\n\n.ds-widget .ds-login-form input::placeholder {\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-error-msg {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-error) !important;\n  background: var(--ds-error-bg) !important;\n  border-radius: var(--ds-radius-sm) !important;\n  padding: 6px 10px !important;\n}\n\n.ds-widget .ds-error-msg.hidden {\n  display: none !important;\n}\n\n/* ══════════════════════════════════════════\n   READY STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-ready-container {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 10px !important;\n}\n\n.ds-widget .ds-user-bar {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  padding: 8px 10px !important;\n  background: rgba(255, 255, 255, 0.04) !important;\n  border-radius: var(--ds-radius-md) !important;\n  border: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-user-name {\n  font-weight: var(--ds-weight-medium) !important;\n  font-size: var(--ds-text-sm) !important;\n  flex: 1 !important;\n  overflow: hidden !important;\n  text-overflow: ellipsis !important;\n  white-space: nowrap !important;\n}\n\n.ds-widget .ds-user-credits {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-btn-analyze {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 8px !important;\n  width: 100% !important;\n  padding: 12px !important;\n  background: linear-gradient(135deg, #c8903a, #9b6b4a) !important;\n  background-size: 200% 200% !important;\n  animation: ds-gradient-shift 8s ease infinite !important;\n  border: none !important;\n  border-radius: var(--ds-radius-md) !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-md) !important;\n  font-weight: var(--ds-weight-semi) !important;\n  color: #0b0f19 !important;\n  box-shadow: 0 4px 15px rgba(200, 144, 58, 0.25) !important;\n  transition: all var(--ds-transition-normal) !important;\n}\n\n.ds-widget .ds-btn-analyze:hover:not(:disabled) {\n  transform: translateY(-1px) !important;\n  box-shadow: 0 0 25px rgba(200, 144, 58, 0.35) !important;\n}\n\n.ds-widget .ds-btn-analyze:disabled {\n  opacity: 0.5 !important;\n  cursor: not-allowed !important;\n  transform: none !important;\n}\n\n.ds-widget .ds-btn-quickchat {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 8px !important;\n  width: 100% !important;\n  padding: 10px !important;\n  background: transparent !important;\n  border: 1px solid var(--ds-border-gold) !important;\n  border-radius: var(--ds-radius-md) !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-medium) !important;\n  color: var(--ds-gold-mid) !important;\n  box-shadow: 0 0 12px rgba(200, 144, 58, 0.1) !important;\n  transition: all var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-btn-quickchat:hover:not(:disabled) {\n  background: rgba(200, 144, 58, 0.1) !important;\n  box-shadow: 0 0 20px rgba(200, 144, 58, 0.2) !important;\n  transform: translateY(-1px) !important;\n}\n\n.ds-widget .ds-options-row {\n  display: flex !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-select {\n  all: unset !important;\n  flex: 1 !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-md) !important;\n  padding: 7px 10px !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-primary) !important;\n  cursor: pointer !important;\n  display: block !important;\n}\n\n/* ══════════════════════════════════════════\n   ANALYZING STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-analyzing-container {\n  display: flex !important;\n  flex-direction: column !important;\n  align-items: center !important;\n  gap: 14px !important;\n  padding: 20px 4px 8px !important;\n  text-align: center !important;\n}\n\n/* Spinner wrapper avec glow radial */\n.ds-widget .ds-spinner-wrapper {\n  position: relative !important;\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n}\n\n.ds-widget .ds-spinner-wrapper::before {\n  content: "" !important;\n  position: absolute !important;\n  width: 110px !important;\n  height: 110px !important;\n  border-radius: 50% !important;\n  background: radial-gradient(\n    circle,\n    rgba(91, 141, 184, 0.22) 0%,\n    rgba(196, 147, 90, 0.15) 40%,\n    rgba(107, 67, 128, 0.1) 70%,\n    transparent 100%\n  ) !important;\n  animation: ds-glow-pulse 2.5s ease-in-out infinite !important;\n  pointer-events: none !important;\n}\n\n/* Header : titre + timer */\n.ds-widget .ds-analyzing-header {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  width: 100% !important;\n}\n\n.ds-widget .ds-analyzing-title {\n  font-size: 12px !important;\n  color: var(--ds-text-secondary) !important;\n  font-weight: 600 !important;\n  letter-spacing: 0.02em !important;\n}\n\n.ds-widget .ds-timer {\n  font-size: 10px !important;\n  color: var(--ds-text-muted) !important;\n  background: rgba(255, 255, 255, 0.06) !important;\n  border: 1px solid rgba(255, 255, 255, 0.1) !important;\n  border-radius: 4px !important;\n  padding: 2px 6px !important;\n  font-variant-numeric: tabular-nums !important;\n  letter-spacing: 0.05em !important;\n}\n\n/* Barre de progression — 6px avec glow doré */\n.ds-widget .ds-progress {\n  width: 100% !important;\n  height: 6px !important;\n  background: rgba(255, 255, 255, 0.08) !important;\n  border-radius: 3px !important;\n  overflow: hidden !important;\n  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2) !important;\n}\n\n.ds-widget .ds-progress-bar {\n  height: 100% !important;\n  background: linear-gradient(90deg, #3b82f6, #c8903a, #9b6b4a) !important;\n  background-size: 200% 100% !important;\n  border-radius: 3px !important;\n  transition: width 600ms ease !important;\n  min-width: 4px !important;\n  animation: ds-gradient-shift 3s ease infinite !important;\n  box-shadow: 0 0 8px rgba(200, 144, 58, 0.3) !important;\n}\n\n/* Footer : phrase dynamique + pourcentage */\n.ds-widget .ds-progress-footer {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  width: 100% !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-phrase-container {\n  flex: 1 !important;\n  text-align: left !important;\n  overflow: hidden !important;\n  min-height: 16px !important;\n}\n\n.ds-widget .ds-phrase-container.ds-phrase-out .ds-phrase-text {\n  animation: ds-phraseOut 250ms ease forwards !important;\n}\n\n.ds-widget .ds-phrase-container.ds-phrase-in .ds-phrase-text {\n  animation: ds-phraseIn 300ms ease forwards !important;\n}\n\n.ds-widget .ds-phrase-text {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  display: block !important;\n  white-space: nowrap !important;\n  overflow: hidden !important;\n  text-overflow: ellipsis !important;\n}\n\n.ds-widget .ds-progress-pct {\n  font-size: 10px !important;\n  color: var(--ds-text-muted) !important;\n  font-variant-numeric: tabular-nums !important;\n  white-space: nowrap !important;\n  flex-shrink: 0 !important;\n}\n\n/* Steps avec icônes et connecteur vertical */\n.ds-widget .ds-analyzing-steps {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 0 !important;\n  width: 100% !important;\n  font-size: var(--ds-text-xs) !important;\n}\n\n.ds-widget .ds-step {\n  display: flex !important;\n  align-items: flex-start !important;\n  gap: 10px !important;\n  color: var(--ds-text-muted) !important;\n  padding: 2px 0 !important;\n}\n\n.ds-widget .ds-step-left {\n  display: flex !important;\n  flex-direction: column !important;\n  align-items: center !important;\n  flex-shrink: 0 !important;\n  width: 16px !important;\n}\n\n.ds-widget .ds-step-icon {\n  width: 16px !important;\n  height: 16px !important;\n  border-radius: 50% !important;\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  flex-shrink: 0 !important;\n  background: rgba(255, 255, 255, 0.06) !important;\n  border: 1px solid rgba(255, 255, 255, 0.12) !important;\n  transition: all 200ms ease !important;\n}\n\n.ds-widget .ds-step-icon-active {\n  background: rgba(91, 141, 184, 0.2) !important;\n  border-color: rgba(91, 141, 184, 0.5) !important;\n  box-shadow: 0 0 8px rgba(91, 141, 184, 0.3) !important;\n}\n\n.ds-widget .ds-step-icon-done {\n  background: rgba(34, 197, 94, 0.15) !important;\n  border-color: rgba(34, 197, 94, 0.5) !important;\n  color: #22c55e !important;\n}\n\n.ds-widget .ds-step-dot {\n  width: 6px !important;\n  height: 6px !important;\n  border-radius: 50% !important;\n  background: currentColor !important;\n  display: block !important;\n}\n\n.ds-widget .ds-step-connector {\n  width: 1px !important;\n  height: 10px !important;\n  background: rgba(255, 255, 255, 0.1) !important;\n  margin-top: 2px !important;\n}\n\n.ds-widget .ds-step-label {\n  line-height: 16px !important;\n  padding-bottom: 8px !important;\n}\n\n.ds-widget .ds-step.ds-step-active {\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-step.ds-step-active .ds-step-connector {\n  background: rgba(91, 141, 184, 0.3) !important;\n}\n\n.ds-widget .ds-step.ds-step-done {\n  color: var(--ds-success) !important;\n}\n\n.ds-widget .ds-step.ds-step-done .ds-step-connector {\n  background: rgba(34, 197, 94, 0.3) !important;\n}\n\n/* ══════════════════════════════════════════\n   RESULTS STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-results-container {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 12px !important;\n  animation: ds-fadeIn 300ms ease forwards !important;\n}\n\n.ds-widget .ds-status-bar {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  flex-wrap: wrap !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-done {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-success) !important;\n  font-weight: var(--ds-weight-medium) !important;\n}\n\n.ds-widget .ds-status-badges {\n  display: flex !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-tag {\n  font-size: var(--ds-text-xs) !important;\n  padding: 2px 8px !important;\n  border-radius: var(--ds-radius-pill) !important;\n  background: rgba(255, 255, 255, 0.07) !important;\n  border: 1px solid var(--ds-border) !important;\n  color: var(--ds-text-secondary) !important;\n}\n\n.ds-widget .ds-tag.ds-score-high {\n  color: var(--ds-success) !important;\n  border-color: rgba(76, 175, 80, 0.3) !important;\n}\n.ds-widget .ds-tag.ds-score-mid {\n  color: var(--ds-warning) !important;\n  border-color: rgba(255, 152, 0, 0.3) !important;\n}\n.ds-widget .ds-tag.ds-score-low {\n  color: var(--ds-error) !important;\n  border-color: rgba(239, 68, 68, 0.3) !important;\n}\n\n.ds-widget .ds-reliability-bar {\n  background: rgba(255, 255, 255, 0.05) !important;\n  border-radius: var(--ds-radius-md) !important;\n  padding: 10px !important;\n  border: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-reliability-header {\n  display: flex !important;\n  justify-content: space-between !important;\n  margin-bottom: 8px !important;\n  font-size: var(--ds-text-xs) !important;\n}\n\n.ds-widget .ds-verdict {\n  font-size: var(--ds-text-sm) !important;\n  line-height: var(--ds-leading-relaxed) !important;\n  color: var(--ds-text-secondary) !important;\n  padding: 10px !important;\n  background: rgba(255, 255, 255, 0.03) !important;\n  border-radius: var(--ds-radius-md) !important;\n  border-left: 3px solid var(--ds-gold-mid) !important;\n}\n\n.ds-widget .ds-keypoints {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-kp {\n  display: flex !important;\n  align-items: flex-start !important;\n  gap: 8px !important;\n  font-size: var(--ds-text-xs) !important;\n  line-height: var(--ds-leading-relaxed) !important;\n}\n\n.ds-widget .ds-kp-icon {\n  font-size: 12px !important;\n  flex-shrink: 0 !important;\n  margin-top: 1px !important;\n}\n.ds-widget .ds-kp-text {\n  color: var(--ds-text-secondary) !important;\n}\n.ds-widget .ds-kp-solid .ds-kp-icon {\n  color: var(--ds-success) !important;\n}\n.ds-widget .ds-kp-weak .ds-kp-icon {\n  color: var(--ds-warning) !important;\n}\n.ds-widget .ds-kp-insight .ds-kp-icon {\n  color: var(--ds-info) !important;\n}\n\n.ds-widget .ds-tags {\n  display: flex !important;\n  flex-wrap: wrap !important;\n  gap: 4px !important;\n}\n\n.ds-widget .ds-tag-pill {\n  font-size: var(--ds-text-xs) !important;\n  padding: 2px 8px !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border-radius: var(--ds-radius-pill) !important;\n  border: 1px solid var(--ds-border) !important;\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-toggle-detail {\n  all: unset !important;\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  width: 100% !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  padding: 6px 0 !important;\n  border-bottom: 1px solid var(--ds-border) !important;\n  transition: color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-toggle-detail:hover {\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-detail-panel {\n  font-size: var(--ds-text-xs) !important;\n  line-height: var(--ds-leading-relaxed) !important;\n  color: var(--ds-text-secondary) !important;\n}\n\n.ds-widget .ds-detail-panel.hidden {\n  display: none !important;\n}\n\n.ds-widget .ds-detail-content {\n  padding-top: 8px !important;\n}\n\n.ds-widget .ds-share-actions {\n  display: flex !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-btn-outline {\n  flex: 1 !important;\n  padding: 7px 10px !important;\n  background: transparent !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-sm) !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-secondary) !important;\n  cursor: pointer !important;\n  text-align: center !important;\n  transition:\n    border-color var(--ds-transition-fast),\n    color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-btn-outline:hover {\n  border-color: var(--ds-border-hover) !important;\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-summary-actions {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 8px !important;\n}\n\n.ds-widget .ds-btn-primary-link {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 6px !important;\n  width: 100% !important;\n  padding: 10px !important;\n  background: var(--ds-gold-gradient) !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-sm) !important;\n  font-weight: var(--ds-weight-medium) !important;\n  color: #0b0f19 !important;\n  text-decoration: none !important;\n  text-align: center !important;\n  transition: filter var(--ds-transition-normal) !important;\n}\n\n.ds-widget .ds-btn-primary-link:hover {\n  filter: brightness(1.08) !important;\n}\n\n.ds-widget .ds-btn-secondary-action {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  gap: 6px !important;\n  width: 100% !important;\n  padding: 9px !important;\n  background: transparent !important;\n  border: 1px solid var(--ds-border-gold) !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-sm) !important;\n  color: var(--ds-gold-mid) !important;\n  cursor: pointer !important;\n  transition: background var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-btn-secondary-action:hover {\n  background: rgba(200, 144, 58, 0.1) !important;\n}\n\n/* ══════════════════════════════════════════\n   FACT-CHECK\n══════════════════════════════════════════ */\n\n.ds-widget .ds-factcheck-list {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-fc-item {\n  display: flex !important;\n  align-items: flex-start !important;\n  gap: 8px !important;\n  padding: 8px 10px !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-xs) !important;\n  border-left: 2px solid transparent !important;\n  border-right: 1px solid transparent !important;\n  border-top: 1px solid transparent !important;\n  border-bottom: 1px solid transparent !important;\n}\n\n.ds-widget .ds-fc-verified {\n  background: var(--ds-success-bg) !important;\n  border-left-color: #10b981 !important;\n  border-right-color: rgba(76, 175, 80, 0.25) !important;\n  border-top-color: rgba(76, 175, 80, 0.25) !important;\n  border-bottom-color: rgba(76, 175, 80, 0.25) !important;\n}\n.ds-widget .ds-fc-uncertain {\n  background: var(--ds-warning-bg) !important;\n  border-left-color: #f59e0b !important;\n  border-right-color: rgba(255, 152, 0, 0.25) !important;\n  border-top-color: rgba(255, 152, 0, 0.25) !important;\n  border-bottom-color: rgba(255, 152, 0, 0.25) !important;\n}\n.ds-widget .ds-fc-contested {\n  background: var(--ds-error-bg) !important;\n  border-left-color: #ef4444 !important;\n  border-right-color: rgba(239, 68, 68, 0.25) !important;\n  border-top-color: rgba(239, 68, 68, 0.25) !important;\n  border-bottom-color: rgba(239, 68, 68, 0.25) !important;\n}\n\n.ds-widget .ds-fc-icon {\n  flex-shrink: 0 !important;\n}\n.ds-widget .ds-fc-text {\n  flex: 1 !important;\n  line-height: var(--ds-leading-relaxed) !important;\n  color: var(--ds-text-secondary) !important;\n}\n\n/* ══════════════════════════════════════════\n   TOURNESOL BADGE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-tournesol-badge {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  padding: 8px 10px !important;\n  background: rgba(255, 193, 7, 0.08) !important;\n  border: 1px solid rgba(255, 193, 7, 0.2) !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-xs) !important;\n}\n\n.ds-widget .ds-tournesol-icon {\n  font-size: 16px !important;\n}\n\n.ds-widget .ds-tournesol-info {\n  flex: 1 !important;\n}\n\n.ds-widget .ds-tournesol-score {\n  font-weight: var(--ds-weight-bold) !important;\n  font-size: var(--ds-text-md) !important;\n  color: #ffc107 !important;\n}\n\n/* ══════════════════════════════════════════\n   CHAT STATE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-chat-container {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 10px !important;\n}\n\n.ds-widget .ds-chat-messages {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 8px !important;\n  max-height: 280px !important;\n  overflow-y: auto !important;\n  scrollbar-width: thin !important;\n  scrollbar-color: rgba(255, 255, 255, 0.15) transparent !important;\n}\n\n.ds-widget .ds-chat-msg {\n  padding: 9px 12px !important;\n  border-radius: var(--ds-radius-md) !important;\n  font-size: var(--ds-text-xs) !important;\n  line-height: var(--ds-leading-relaxed) !important;\n  max-width: 90% !important;\n}\n\n.ds-widget .ds-chat-msg-user {\n  background: rgba(200, 144, 58, 0.15) !important;\n  border: 1px solid var(--ds-border-gold) !important;\n  color: var(--ds-text-primary) !important;\n  align-self: flex-end !important;\n  box-shadow: 0 2px 8px rgba(200, 144, 58, 0.1) !important;\n}\n\n.ds-widget .ds-chat-msg-assistant {\n  background: rgba(255, 255, 255, 0.05) !important;\n  backdrop-filter: blur(12px) !important;\n  -webkit-backdrop-filter: blur(12px) !important;\n  border: 1px solid rgba(200, 144, 58, 0.06) !important;\n  color: var(--ds-text-secondary) !important;\n  align-self: flex-start !important;\n  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2) !important;\n}\n\n.ds-widget .ds-chat-suggestions {\n  display: flex !important;\n  flex-wrap: wrap !important;\n  gap: 6px !important;\n}\n\n.ds-widget .ds-chat-suggestion {\n  all: unset !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-xs) !important;\n  padding: 5px 10px !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-pill) !important;\n  color: var(--ds-text-secondary) !important;\n  transition: all var(--ds-transition-fast) !important;\n  display: inline-block !important;\n}\n\n.ds-widget .ds-chat-suggestion:hover {\n  background: rgba(200, 144, 58, 0.1) !important;\n  border-color: var(--ds-border-gold) !important;\n  color: var(--ds-text-primary) !important;\n}\n\n.ds-widget .ds-chat-input-row {\n  display: flex !important;\n  gap: 6px !important;\n  align-items: flex-end !important;\n}\n\n.ds-widget .ds-chat-input {\n  all: unset !important;\n  flex: 1 !important;\n  background: rgba(255, 255, 255, 0.05) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-input) !important;\n  padding: 8px 12px !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-primary) !important;\n  display: block !important;\n  transition: border-color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-chat-input:focus {\n  border-color: var(--ds-border-focus) !important;\n}\n.ds-widget .ds-chat-input::placeholder {\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-chat-send-btn {\n  all: unset !important;\n  cursor: pointer !important;\n  width: 32px !important;\n  height: 32px !important;\n  background: var(--ds-gold-gradient) !important;\n  border-radius: var(--ds-radius-sm) !important;\n  display: flex !important;\n  align-items: center !important;\n  justify-content: center !important;\n  color: #0b0f19 !important;\n  font-size: 14px !important;\n  transition: filter var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-chat-send-btn:hover:not(:disabled) {\n  filter: brightness(1.1) !important;\n}\n.ds-widget .ds-chat-send-btn:disabled {\n  opacity: 0.45 !important;\n  cursor: not-allowed !important;\n}\n\n/* ══════════════════════════════════════════\n   PREMIUM TEASERS\n══════════════════════════════════════════ */\n\n.ds-widget .ds-teasers-section {\n  padding: 10px !important;\n  background: rgba(255, 255, 255, 0.03) !important;\n  border-radius: var(--ds-radius-md) !important;\n  border: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-teasers-title {\n  font-size: var(--ds-text-xs) !important;\n  font-weight: var(--ds-weight-semi) !important;\n  color: var(--ds-text-secondary) !important;\n  margin-bottom: 8px !important;\n}\n\n.ds-widget .ds-teasers-grid {\n  display: flex !important;\n  flex-direction: column !important;\n  gap: 4px !important;\n}\n\n.ds-widget .ds-teaser-item {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  padding: 6px 8px !important;\n  border-radius: var(--ds-radius-sm) !important;\n  text-decoration: none !important;\n  color: var(--ds-text-muted) !important;\n  font-size: var(--ds-text-xs) !important;\n  transition: background var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-teaser-item:hover {\n  background: rgba(255, 255, 255, 0.06) !important;\n}\n.ds-widget .ds-teaser-label {\n  flex: 1 !important;\n}\n.ds-widget .ds-teaser-lock {\n  font-size: 10px !important;\n  color: var(--ds-text-muted) !important;\n}\n.ds-widget .ds-teaser-price {\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-gold-mid) !important;\n}\n\n.ds-widget .ds-teasers-all {\n  display: block !important;\n  text-align: center !important;\n  margin-top: 8px !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-gold-mid) !important;\n  text-decoration: none !important;\n}\n\n/* ══════════════════════════════════════════\n   ECOSYSTEM BRIDGE\n══════════════════════════════════════════ */\n\n.ds-widget .ds-ecosystem-bridge {\n  display: flex !important;\n  flex-wrap: wrap !important;\n  gap: 6px !important;\n  padding-top: 10px !important;\n  border-top: 1px solid var(--ds-border) !important;\n}\n\n.ds-widget .ds-bridge-link {\n  display: flex !important;\n  align-items: center !important;\n  gap: 5px !important;\n  padding: 5px 10px !important;\n  background: rgba(255, 255, 255, 0.04) !important;\n  border: 1px solid var(--ds-border) !important;\n  border-radius: var(--ds-radius-pill) !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  text-decoration: none !important;\n  transition: all var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-bridge-link:hover {\n  background: rgba(255, 255, 255, 0.08) !important;\n  color: var(--ds-text-primary) !important;\n  border-color: var(--ds-border-hover) !important;\n}\n\n.ds-widget .ds-bridge-link.ds-bridge-upgrade {\n  background: rgba(200, 144, 58, 0.1) !important;\n  border-color: var(--ds-border-gold) !important;\n  color: var(--ds-gold-mid) !important;\n}\n\n/* ══════════════════════════════════════════\n   FOOTER\n══════════════════════════════════════════ */\n\n.ds-widget .ds-card-footer {\n  display: flex !important;\n  align-items: center !important;\n  justify-content: space-between !important;\n  padding: 8px 14px !important;\n  border-top: 1px solid var(--ds-border) !important;\n  background: rgba(255, 255, 255, 0.02) !important;\n}\n\n.ds-widget .ds-card-footer a,\n.ds-widget .ds-link-btn {\n  all: unset !important;\n  cursor: pointer !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n  text-decoration: none !important;\n  transition: color var(--ds-transition-fast) !important;\n}\n\n.ds-widget .ds-card-footer a:hover,\n.ds-widget .ds-link-btn:hover {\n  color: var(--ds-text-secondary) !important;\n}\n\n.ds-widget .ds-card-legal {\n  display: flex !important;\n  align-items: center !important;\n  gap: 8px !important;\n  padding: 4px 14px 8px !important;\n  font-size: var(--ds-text-xs) !important;\n  color: var(--ds-text-muted) !important;\n}\n\n.ds-widget .ds-card-legal a {\n  color: var(--ds-text-muted) !important;\n  text-decoration: none !important;\n}\n\n.ds-widget .ds-card-legal a:hover {\n  text-decoration: underline !important;\n}\n\n/* ══════════════════════════════════════════\n   PLAN BADGE IN USER BAR\n══════════════════════════════════════════ */\n\n.ds-widget [class*="ds-user-plan"] {\n  font-size: var(--ds-text-xs) !important;\n  padding: 1px 7px !important;\n  border-radius: var(--ds-radius-pill) !important;\n  font-weight: var(--ds-weight-medium) !important;\n}\n\n.ds-widget .ds-plan-free {\n  background: rgba(107, 114, 128, 0.2) !important;\n  color: var(--ds-plan-free) !important;\n}\n.ds-widget .ds-plan-etudiant,\n.ds-widget .ds-plan-student {\n  background: rgba(59, 130, 246, 0.15) !important;\n  color: var(--ds-plan-student) !important;\n}\n.ds-widget .ds-plan-starter {\n  background: rgba(139, 92, 246, 0.15) !important;\n  color: var(--ds-plan-starter) !important;\n}\n.ds-widget .ds-plan-pro {\n  background: rgba(200, 144, 58, 0.15) !important;\n  color: var(--ds-plan-pro) !important;\n}\n\n/* ══════════════════════════════════════════\n   TIKTOK FLOATING CARD (overlay)\n══════════════════════════════════════════ */\n\n#deepsight-card.ds-widget.ds-tiktok-float {\n  position: fixed !important;\n  bottom: 80px !important;\n  right: 16px !important;\n  width: 340px !important;\n  max-height: 520px !important;\n  z-index: var(--ds-z-widget) !important;\n}\n\n/* ═══════════════════════════════════════════════════════════════════════════════\n   🔊 TTS — Text-to-Speech Controls\n   ═══════════════════════════════════════════════════════════════════════════════ */\n\n/* Base TTS button — idle state (compact play icon) */\n.ds-tts-btn {\n  display: inline-flex;\n  align-items: center;\n  justify-content: center;\n  width: 26px;\n  height: 26px;\n  border-radius: 6px;\n  border: 1px solid rgba(255, 255, 255, 0.08);\n  background: rgba(255, 255, 255, 0.06);\n  color: rgba(255, 255, 255, 0.5);\n  cursor: pointer;\n  transition: all 0.2s ease;\n  flex-shrink: 0;\n  font-size: 12px;\n  padding: 0;\n  vertical-align: middle;\n}\n\n.ds-tts-btn:hover {\n  color: #06b6d4;\n  background: rgba(6, 182, 212, 0.15);\n  border-color: rgba(6, 182, 212, 0.3);\n}\n\n.ds-tts-btn-md {\n  width: 30px;\n  height: 30px;\n  font-size: 14px;\n}\n\n/* Locked state */\n.ds-tts-locked {\n  color: rgba(255, 255, 255, 0.25);\n  cursor: not-allowed;\n}\n.ds-tts-locked:hover {\n  color: rgba(255, 255, 255, 0.35);\n  background: rgba(255, 255, 255, 0.06);\n  border-color: rgba(255, 255, 255, 0.08);\n}\n\n.ds-tts-icon {\n  font-size: 12px;\n  line-height: 1;\n}\n\n/* Active player state — expanded inline mini-player */\n.ds-tts-btn.ds-tts-active {\n  width: auto;\n  min-width: 180px;\n  gap: 6px;\n  padding: 4px 8px;\n  background: rgba(6, 182, 212, 0.08);\n  border-color: rgba(6, 182, 212, 0.25);\n}\n\n.ds-tts-play-icon {\n  cursor: pointer;\n  font-size: 13px;\n  flex-shrink: 0;\n  transition: opacity 0.2s;\n}\n.ds-tts-play-icon:hover {\n  opacity: 0.7;\n}\n\n/* Loading spinner */\n.ds-tts-spinner {\n  animation: ds-spin 0.8s linear infinite;\n  color: #06b6d4;\n}\n\n/* Progress bar */\n.ds-tts-progress {\n  flex: 1;\n  min-width: 40px;\n  height: 4px;\n  background: rgba(255, 255, 255, 0.1);\n  border-radius: 2px;\n  cursor: pointer;\n  position: relative;\n}\n\n.ds-tts-progress-fill {\n  height: 100%;\n  background: #06b6d4;\n  border-radius: 2px;\n  transition: width 0.1s linear;\n}\n\n.ds-tts-time {\n  font-size: 9px;\n  font-family: monospace;\n  color: rgba(255, 255, 255, 0.4);\n  white-space: nowrap;\n}\n\n.ds-tts-stop {\n  cursor: pointer;\n  font-size: 11px;\n  opacity: 0.5;\n  transition: opacity 0.2s;\n}\n.ds-tts-stop:hover {\n  opacity: 1;\n  color: #ef4444;\n}\n\n.ds-tts-speed {\n  cursor: pointer;\n  font-size: 10px;\n  font-family: monospace;\n  color: #06b6d4;\n  background: rgba(6, 182, 212, 0.1);\n  padding: 1px 4px;\n  border-radius: 3px;\n  transition: background 0.2s;\n}\n.ds-tts-speed:hover {\n  background: rgba(6, 182, 212, 0.2);\n}\n\n/* TTS Toolbar — settings bar */\n.ds-tts-toolbar {\n  display: flex;\n  align-items: center;\n  gap: 6px;\n  padding: 4px 8px;\n  background: rgba(255, 255, 255, 0.03);\n  border-radius: 6px;\n  border: 1px solid rgba(255, 255, 255, 0.06);\n  margin-top: 6px;\n}\n\n.ds-tts-toolbar-label {\n  font-size: 10px;\n  color: rgba(255, 255, 255, 0.4);\n  margin-right: 2px;\n}\n\n.ds-tts-toolbar-btn {\n  font-size: 12px;\n  padding: 2px 6px;\n  border-radius: 4px;\n  border: none;\n  background: rgba(255, 255, 255, 0.06);\n  color: rgba(255, 255, 255, 0.5);\n  cursor: pointer;\n  transition: all 0.2s;\n}\n.ds-tts-toolbar-btn:hover {\n  background: rgba(255, 255, 255, 0.1);\n  color: rgba(255, 255, 255, 0.7);\n}\n\n/* TTS button in summary header row */\n.ds-summary-tts-row {\n  display: flex;\n  align-items: center;\n  gap: 8px;\n  margin-bottom: 6px;\n}\n\n/* ══════════════════════════════════════════\n   PREMIUM GRADIENT ANIMATIONS\n══════════════════════════════════════════ */\n\n@keyframes ds-gradient-shift {\n  0% {\n    background-position: 0% 50%;\n  }\n  50% {\n    background-position: 100% 50%;\n  }\n  100% {\n    background-position: 0% 50%;\n  }\n}\n\n/* ══════════════════════════════════════════\n   COLLAPSED STATE (minimize persistent)\n══════════════════════════════════════════ */\n\n#deepsight-card.ds-widget.ds-collapsed {\n  width: 44px !important;\n  max-width: 44px !important;\n  height: 44px !important;\n  border-radius: 50% !important;\n  overflow: hidden !important;\n  cursor: pointer !important;\n}\n\n.ds-collapsed .ds-card-body,\n.ds-collapsed .ds-card-logo span,\n.ds-collapsed .ds-card-badge,\n.ds-collapsed .ds-minimize-btn {\n  display: none !important;\n}\n\n/* ══════════════════════════════════════════\n   COMPACT RESULTS MODE\n   ══════════════════════════════════════════ */\n.ds-results-compact {\n  display: flex;\n  flex-direction: column;\n  gap: 12px;\n}\n.ds-verdict-compact {\n  padding: 12px 14px;\n  background: rgba(99, 102, 241, 0.04);\n  border-left: 3px solid var(--ds-accent-primary, #6366f1);\n  border-radius: 0 8px 8px 0;\n}\n.ds-verdict-text-compact {\n  font-size: 13px;\n  line-height: 1.55;\n  color: var(--ds-text-primary);\n  display: -webkit-box;\n  -webkit-line-clamp: 2;\n  -webkit-box-orient: vertical;\n  overflow: hidden;\n  text-overflow: ellipsis;\n}\n.ds-compact-actions {\n  display: flex;\n  flex-direction: column;\n  gap: 8px;\n  margin: 4px 0;\n}\n.ds-btn-primary-xl {\n  padding: 12px 16px;\n  font-size: 14px;\n  font-weight: 600;\n  background: linear-gradient(135deg, #6366f1, #8b5cf6);\n  color: white;\n  border: none;\n  border-radius: 10px;\n  cursor: pointer;\n  transition:\n    transform 0.2s,\n    box-shadow 0.2s;\n  width: 100%;\n}\n.ds-btn-primary-xl:hover {\n  transform: translateY(-1px);\n  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.4);\n}\n.ds-btn-outline-xl {\n  padding: 10px 16px;\n  font-size: 13px;\n  font-weight: 500;\n  background: transparent;\n  color: var(--ds-text-primary);\n  border: 1px solid rgba(255, 255, 255, 0.15);\n  border-radius: 10px;\n  cursor: pointer;\n  transition: all 0.2s;\n  width: 100%;\n}\n.ds-btn-outline-xl:hover {\n  background: rgba(255, 255, 255, 0.05);\n  border-color: rgba(255, 255, 255, 0.25);\n}\n.ds-link-tertiary {\n  display: block;\n  text-align: center;\n  font-size: 12px;\n  color: var(--ds-text-muted);\n  text-decoration: none;\n  padding: 6px 0;\n  transition: color 0.15s;\n}\n.ds-link-tertiary:hover {\n  color: var(--ds-accent-primary, #6366f1);\n}\n.ds-details-wrapper {\n  border: 1px solid rgba(255, 255, 255, 0.08);\n  border-radius: 8px;\n  background: rgba(255, 255, 255, 0.02);\n  padding: 0;\n  margin-top: 4px;\n}\n.ds-details-toggle {\n  padding: 10px 14px;\n  font-size: 12px;\n  color: var(--ds-text-muted);\n  cursor: pointer;\n  list-style: none;\n  user-select: none;\n  transition: color 0.15s;\n}\n.ds-details-toggle::-webkit-details-marker {\n  display: none;\n}\n.ds-details-toggle:hover {\n  color: var(--ds-text-primary);\n}\n.ds-details-wrapper[open] .ds-details-toggle {\n  color: var(--ds-text-primary);\n}\n.ds-details-body {\n  padding: 8px 14px 12px;\n  border-top: 1px solid rgba(255, 255, 255, 0.05);\n  display: flex;\n  flex-direction: column;\n  gap: 12px;\n}\n',
+        R =
+          "/* DeepSight Content Script Styles — Premium Glassmorphism V4.2 */\n\n/* ══════════════════════════════════════════\n   INJECTED CARD CONTAINER\n══════════════════════════════════════════ */\n\n.deepsight-injected-card {\n  backdrop-filter: blur(24px) saturate(150%) !important;\n  -webkit-backdrop-filter: blur(24px) saturate(150%) !important;\n  border: 1px solid rgba(200, 144, 58, 0.06) !important;\n  border-radius: 10px !important;\n  box-shadow:\n    0 8px 32px rgba(0, 0, 0, 0.4),\n    0 0 20px rgba(200, 144, 58, 0.05) !important;\n  background: var(--ds-glass-bg, rgba(10, 10, 15, 0.5)) !important;\n}\n\n/* Light theme variant */\n.deepsight-injected-card.light {\n  background: rgba(255, 255, 255, 0.85) !important;\n  border-color: rgba(166, 120, 40, 0.08) !important;\n  box-shadow:\n    0 8px 32px rgba(0, 0, 0, 0.15),\n    0 0 20px rgba(200, 144, 58, 0.04) !important;\n}\n\n/* ══════════════════════════════════════════\n   GOUVERNAIL SPINNER — PREMIUM ANIMATION\n══════════════════════════════════════════ */\n\n.ds-gouvernail-spinner {\n  display: inline-flex;\n  align-items: center;\n  justify-content: center;\n  animation: ds-gouvernail-spin 2s linear infinite;\n  filter: drop-shadow(0 0 4px rgba(200, 144, 58, 0.3));\n}\n\n.ds-gouvernail-spinner-sm {\n  width: 18px;\n  height: 18px;\n  animation: ds-gouvernail-spin 2s linear infinite;\n  filter: drop-shadow(0 0 3px rgba(200, 144, 58, 0.25));\n}\n\n.ds-gouvernail-spinner svg {\n  width: 100%;\n  height: 100%;\n  color: #c8903a;\n}\n\n@keyframes ds-gouvernail-spin {\n  from {\n    transform: rotate(0deg);\n  }\n  to {\n    transform: rotate(360deg);\n  }\n}\n\n/* ══════════════════════════════════════════\n   LOADING STATE — ENHANCED VISUAL\n══════════════════════════════════════════ */\n\n.ds-loading {\n  display: flex;\n  flex-direction: column;\n  align-items: center;\n  justify-content: center;\n  gap: 12px;\n  padding: 20px 0;\n}\n\n.ds-loading-text {\n  color: rgba(255, 255, 255, 0.7);\n  font-size: 14px;\n  margin: 0;\n  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);\n}\n\n/* ══════════════════════════════════════════\n   PREMIUM GRADIENT ANIMATIONS\n══════════════════════════════════════════ */\n\n@keyframes ds-gradient-shift {\n  0% {\n    background-position: 0% 50%;\n  }\n  50% {\n    background-position: 100% 50%;\n  }\n  100% {\n    background-position: 0% 50%;\n  }\n}\n",
+        O = "deepsight-card",
+        N = "deepsight-host",
+        D = [
+          { selector: "#secondary-inner", position: "prepend" },
+          { selector: "#secondary", position: "prepend" },
+          {
+            selector: "ytd-watch-next-secondary-results-renderer",
+            position: "prepend",
+          },
+          { selector: "#below", position: "prepend" },
+          { selector: "ytd-watch-metadata", position: "afterend" },
+        ],
+        q = [
+          '[class*="DivBrowserModeContainer"]',
+          '[class*="DivVideoDetailContainer"]',
+          "#app",
+          "body",
+        ];
+      function B(n) {
+        const t = getComputedStyle(n);
+        return (
+          n.offsetHeight > 0 &&
+          n.offsetWidth > 50 &&
+          "none" !== t.display &&
+          "hidden" !== t.visibility &&
+          "0" !== t.opacity
+        );
+      }
+      let F = !1;
+      function U() {
+        document.getElementById(N)?.remove();
+      }
+      function H() {
+        return (0, i.$id)(O);
+      }
+      function G(n) {
+        const t = W();
+        t && (t.innerHTML = n);
+      }
+      function W() {
+        return (0, i.JF)(`#${O} .ds-card-body`);
+      }
+      function Q() {
+        const n = H(),
+          t = (0, i.$id)("ds-minimize-btn");
+        n && (n.classList.add("ds-collapsed"), t && (t.textContent = "+"));
+      }
+      const V = [
+        "#secondary-inner",
+        "#secondary",
+        "ytd-watch-next-secondary-results-renderer",
+        "#below",
+        "ytd-watch-metadata",
+      ];
+      function Y() {
+        for (const n of V) {
+          const t = document.querySelector(n);
+          if (t instanceof HTMLElement && B(t)) return !0;
+        }
+        return !1;
+      }
+      let K = null;
+      function X() {
+        (K?.disconnect(), (K = null));
+      }
+      function Z() {
+        if (document.fullscreenElement) return "fullscreen";
+        const n = document.querySelector("ytd-watch-flexy");
+        return n?.hasAttribute("theater") ? "theater" : "default";
+      }
+      let J = null,
+        nn = null;
+      function tn() {
+        (J?.disconnect(),
+          (J = null),
+          nn && document.removeEventListener("fullscreenchange", nn),
+          (nn = null));
+      }
+      function en(n) {
+        const t = document.createElement("div");
+        return ((t.textContent = n), t.innerHTML);
+      }
+      const rn = {
+        résumé: "📝",
+        summary: "📝",
+        synthèse: "📝",
+        introduction: "🎬",
+        contexte: "🌍",
+        context: "🌍",
+        analyse: "🔬",
+        analysis: "🔬",
+        "points clés": "🎯",
+        "key points": "🎯",
+        "points forts": "💪",
+        strengths: "💪",
+        "points faibles": "⚠️",
+        weaknesses: "⚠️",
+        limites: "⚠️",
+        conclusion: "🏁",
+        recommandations: "💡",
+        recommendations: "💡",
+        sources: "📚",
+        références: "📚",
+        references: "📚",
+        "fact-check": "🔍",
+        vérification: "🔍",
+        arguments: "⚖️",
+        méthodologie: "🧪",
+        methodology: "🧪",
+        données: "📊",
+        data: "📊",
+        statistiques: "📊",
+        opinion: "💬",
+        avis: "💬",
+        biais: "🎭",
+        bias: "🎭",
+        nuances: "🎨",
+        perspectives: "👁️",
+        timeline: "📅",
+        chronologie: "📅",
+        définitions: "📖",
+        glossaire: "📖",
+      };
+      function sn(n) {
+        const t = n.toLowerCase().trim();
+        for (const [n, e] of Object.entries(rn)) if (t.includes(n)) return e;
+        return "📌";
+      }
+      function an(n) {
+        return n
+          .replace(/`([^`]+)`/g, '<code class="ds-md-code">$1</code>')
+          .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+          .replace(/\*(.+?)\*/g, "<em>$1</em>")
+          .replace(
+            /\[?(SOLIDE|SOLID)\]?/g,
+            '<span class="ds-marker ds-marker-solid">✅ Établi</span>',
+          )
+          .replace(
+            /\[?(PLAUSIBLE)\]?/g,
+            '<span class="ds-marker ds-marker-plausible">🔵 Probable</span>',
+          )
+          .replace(
+            /\[?(INCERTAIN|UNCERTAIN)\]?/g,
+            '<span class="ds-marker ds-marker-uncertain">🟡 Incertain</span>',
+          )
+          .replace(
+            /\[?(A VERIFIER|À VÉRIFIER|TO VERIFY|QUESTIONABLE|WEAK)\]?/g,
+            '<span class="ds-marker ds-marker-weak">🔴 À vérifier</span>',
+          );
+      }
+      function on(n) {
+        return n
+          .replace(/\*\*(.+?)\*\*/g, "$1")
+          .replace(/\*(.+?)\*/g, "$1")
+          .replace(/`([^`]+)`/g, "$1")
+          .replace(/#{1,6}\s+/g, "")
+          .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+          .replace(/^>\s+/gm, "")
+          .replace(/\n+/g, " ")
+          .trim();
+      }
+      function dn(n, t) {
+        if (n.length <= t) return n;
+        const e = n.substring(0, t),
+          r = e.lastIndexOf(" ");
+        return (r > 0.6 * t ? e.substring(0, r) : e) + "...";
+      }
+      function ln(n) {
+        (G(
+          `\n    <div class="ds-login-container">\n      <p class="ds-subtitle">Analysez cette vidéo avec l'IA</p>\n\n      <button class="ds-btn ds-btn-google" id="ds-google-login" type="button">\n        <svg width="16" height="16" viewBox="0 0 24 24">\n          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>\n          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>\n          <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>\n          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>\n        </svg>\n        Connexion avec Google\n      </button>\n\n      <div class="ds-divider"><span>ou</span></div>\n\n      <form id="ds-login-form" class="ds-login-form">\n        <input type="email" id="ds-email" placeholder="Email" required autocomplete="email" />\n        <input type="password" id="ds-password" placeholder="Mot de passe" required autocomplete="current-password" />\n        <div id="ds-login-error" class="ds-error-msg hidden"></div>\n        <button type="submit" class="ds-btn ds-btn-primary" id="ds-login-btn">Connexion</button>\n      </form>\n\n      <div class="ds-card-footer">\n        <a href="${a}/register" target="_blank" rel="noreferrer">Créer un compte</a>\n        <span>·</span>\n        <a href="${a}" target="_blank" rel="noreferrer">deepsightsynthesis.com</a>\n      </div>\n    </div>\n  `,
+        ),
+          (0, i.$id)("ds-google-login")?.addEventListener("click", async () => {
+            const e = (0, i.$id)("ds-google-login");
+            e &&
+              ((e.disabled = !0),
+              (e.innerHTML =
+                '<svg class="ds-gouvernail-spinner ds-gouvernail-spinner-sm" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" width="14" height="14"><circle cx="24" cy="24" r="20" opacity="0.3"/><circle cx="24" cy="24" r="3"/><line x1="24" y1="4" x2="24" y2="11"/></svg> Connexion...'));
+            try {
+              const r = await t.runtime.sendMessage({ action: "GOOGLE_LOGIN" });
+              r?.success && r.user
+                ? n()
+                : (cn(r?.error || "Connexion Google échouée"),
+                  e &&
+                    ((e.disabled = !1),
+                    (e.textContent = "Connexion avec Google")));
+            } catch (n) {
+              (cn(n.message),
+                e &&
+                  ((e.disabled = !1),
+                  (e.textContent = "Connexion avec Google")));
+            }
+          }),
+          (0, i.$id)("ds-login-form")?.addEventListener("submit", async (e) => {
+            e.preventDefault();
+            const r = (0, i.$id)("ds-email").value,
+              s = (0, i.$id)("ds-password").value,
+              a = (0, i.$id)("ds-login-btn");
+            a && ((a.disabled = !0), (a.textContent = "Connexion..."));
+            try {
+              const e = await t.runtime.sendMessage({
+                action: "LOGIN",
+                data: { email: r, password: s },
+              });
+              e?.success && e.user
+                ? n()
+                : (cn(e?.error || "Connexion échouée"),
+                  a && ((a.disabled = !1), (a.textContent = "Connexion")));
+            } catch (n) {
+              (cn(en(n.message)),
+                a && ((a.disabled = !1), (a.textContent = "Connexion")));
+            }
+          }));
+      }
+      function cn(n) {
+        const t = (0, i.$id)("ds-login-error");
+        t && ((t.textContent = n), t.classList.remove("hidden"));
+      }
+      const pn = {
+        fr: {
+          credits: "crédits",
+          analyzeButton: "Analyser cette vidéo",
+          quickChatButton: "Quick Chat IA",
+          logout: "Déconnexion",
+          preparing: "Préparation...",
+          loading: "Chargement...",
+          startingAnalysis: "Démarrage de l'analyse...",
+          askQuestion: "Posez une question sur cette vidéo",
+          webSearchUsed: "Recherche web utilisée",
+          backToResults: "Retour aux résultats",
+          responding: "En train de répondre...",
+          chatError: "Erreur de chat",
+        },
+        en: {
+          credits: "credits",
+          analyzeButton: "Analyze this video",
+          quickChatButton: "Quick AI Chat",
+          logout: "Log out",
+          preparing: "Preparing...",
+          loading: "Loading...",
+          startingAnalysis: "Starting analysis...",
+          askQuestion: "Ask a question about this video",
+          webSearchUsed: "Web search used",
+          backToResults: "Back to results",
+          responding: "Responding...",
+          chatError: "Chat error",
+        },
+      };
+      function mn() {
+        return pn.fr;
+      }
+      function gn(n) {
+        const {
+          user: t,
+          tournesol: e,
+          onAnalyze: r,
+          onQuickChat: s,
+          onLogout: o,
+        } = n;
+        (G(
+          `\n    <div class="ds-ready-container">\n      <div class="ds-user-bar">\n        <span class="ds-user-name">${en(t.username)}</span>\n        <span class="ds-user-plan ds-plan-${en(t.plan)}">${en(t.plan)}</span>\n        <span class="ds-user-credits">${t.credits} ${mn().credits}</span>\n      </div>\n      ${(function (
+            n,
+          ) {
+            if (!n?.found || null === n.tournesol_score) return "";
+            const t = Math.round(n.tournesol_score);
+            return `<div class="ds-tournesol-badge" style="font-size:10px;color:${t >= 50 ? "var(--ds-success)" : t >= 0 ? "var(--ds-warning)" : "var(--ds-error)"};margin-top:${document.querySelector('tournesol-entity-context, [class*="tournesol"], #tournesol-rate') ? "32px" : "4px"}">🌻 Tournesol: ${t > 0 ? "+" : ""}${t}</div>`;
+          })(
+            e,
+          )}\n\n      <button class="ds-btn ds-btn-analyze" id="ds-analyze-btn" type="button">\n        🚀 ${mn().analyzeButton}\n      </button>\n\n      <button class="ds-btn ds-btn-quickchat" id="ds-quickchat-btn" type="button">\n        💬 ${mn().quickChatButton}\n      </button>\n\n      <div class="ds-options-row">\n        <select id="ds-mode" class="ds-select" title="Mode d'analyse">\n          <option value="standard">📋 Standard</option>\n          <option value="accessible">📖 Accessible</option>\n        </select>\n        <select id="ds-lang" class="ds-select" title="Langue">\n          <option value="fr">🇫🇷 FR</option>\n          <option value="en">🇬🇧 EN</option>\n          <option value="es">🇪🇸 ES</option>\n          <option value="de">🇩🇪 DE</option>\n        </select>\n      </div>\n\n      <div class="ds-card-footer">\n        <a href="${a}" target="_blank" rel="noreferrer">🌐 deepsightsynthesis.com</a>\n        <button id="ds-logout" class="ds-link-btn" type="button">${mn().logout}</button>\n      </div>\n    </div>\n  `,
+        ),
+          (0, i.$id)("ds-analyze-btn")?.addEventListener("click", () => {
+            const n = (0, i.$id)("ds-mode").value,
+              t = (0, i.$id)("ds-lang").value;
+            r(n, t);
+          }),
+          (0, i.$id)("ds-quickchat-btn")?.addEventListener(
+            "click",
+            async () => {
+              const n = (0, i.$id)("ds-quickchat-btn"),
+                t = (0, i.$id)("ds-lang")?.value || "fr";
+              (n &&
+                ((n.disabled = !0),
+                (n.innerHTML = `<svg class="ds-gouvernail-spinner ds-gouvernail-spinner-sm" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" width="14" height="14"><circle cx="24" cy="24" r="20" opacity="0.3"/><circle cx="24" cy="24" r="3"/><line x1="24" y1="4" x2="24" y2="11"/></svg> ${mn().preparing}`)),
+                s(t));
+            },
+          ),
+          (0, i.$id)("ds-logout")?.addEventListener("click", o));
+      }
+      const un = {
+        tech: [
+          "Quelles sont les principales technologies mentionnées ?",
+          "Quels sont les risques évoqués ?",
+          "Comment cela s'applique-t-il concrètement ?",
+          "Quelles alternatives sont proposées ?",
+        ],
+        science: [
+          "Quelles sont les preuves scientifiques citées ?",
+          "Y a-t-il des biais dans cette étude ?",
+          "Qui sont les chercheurs impliqués ?",
+          "Quelles sont les limites de cette recherche ?",
+        ],
+        education: [
+          "Quels sont les points clés à retenir ?",
+          "Comment appliquer ces concepts ?",
+          "Y a-t-il des exercices pratiques suggérés ?",
+          "Quelles ressources complémentaires sont recommandées ?",
+        ],
+        news: [
+          "Quels sont les faits vérifiables ?",
+          "Quelles sources sont citées ?",
+          "Y a-t-il des éléments de contexte importants ?",
+          "Quels sont les différents points de vue ?",
+        ],
+        default: [
+          "Quel est le message principal de cette vidéo ?",
+          "Quels sont les points les plus importants ?",
+          "Y a-t-il des éléments à vérifier ?",
+          "Que recommande l'auteur ?",
+        ],
+      };
+      let bn = !1;
+      function xn(n, t) {
+        return (un[n] ?? un.default).slice(0, t);
+      }
+      function fn(n, t, e) {
+        if (bn) return;
+        const r = (0, i.$id)(n);
+        r &&
+          ((bn = !0),
+          r.querySelectorAll(".ds-chat-suggestion").forEach((n) => {
+            const r = parseInt(n.dataset.index ?? "0", 10);
+            n.addEventListener("click", () => {
+              ((bn = !1), t[r] && e(t[r]));
+            });
+          }),
+          (bn = !1));
+      }
+      const hn = {
+          free: 0,
+          decouverte: 0,
+          plus: 1,
+          pro: 2,
+          expert: 2,
+          etudiant: 1,
+          student: 1,
+          starter: 1,
+        },
+        vn = {
+          tech: "💻",
+          science: "🔬",
+          education: "📚",
+          news: "📰",
+          entertainment: "🎬",
+          gaming: "🎮",
+          music: "🎵",
+          sports: "⚽",
+          business: "💼",
+          lifestyle: "🌟",
+          other: "📋",
+        };
+      async function yn(n) {
+        const { summary: e, userPlan: r, onChat: s } = n,
+          o = {
+            verdict: (function (n) {
+              const t = [
+                /#+\s*(?:Conclusion|Verdict|Synthèse|Résumé|Summary|En résumé|Final Assessment|Overall Assessment)[^\n]*\n([\s\S]*?)(?=\n#|\n---|\n\*{3,}|$)/i,
+                /\*\*(?:Conclusion|Verdict|Synthèse|En résumé|Summary)\*\*[:\s]*([\s\S]*?)(?=\n\n|\n#|\n---|\n\*{3,}|$)/i,
+              ];
+              for (const e of t) {
+                const t = n.match(e);
+                if (t && t[1]) {
+                  const n = on(t[1]).trim();
+                  if (n.length > 20) return dn(n, 200);
+                }
+              }
+              const e = n.split(/\n\n+/).filter((n) => {
+                const t = n.trim();
+                return (
+                  t.length > 30 &&
+                  !t.startsWith("#") &&
+                  !t.startsWith("-") &&
+                  !t.startsWith("*")
+                );
+              });
+              return e.length > 0
+                ? dn(on(e[e.length - 1]), 200)
+                : "Analysis complete. See detailed view for full results.";
+            })((m = e.summary_content)),
+            keyPoints: (function (n) {
+              const t = [],
+                e = n.split("\n"),
+                r = [/\b(?:SOLIDE|SOLID)\b/i, /\u2705\s*\*\*/, /\u2705/],
+                s = [
+                  /\b(?:A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK|INCERTAIN|UNCERTAIN)\b/i,
+                  /\u26A0\uFE0F\s*\*\*/,
+                  /\u2753/,
+                  /\u26A0/,
+                ],
+                a = [/\b(?:PLAUSIBLE)\b/i, /\uD83D\uDCA1/];
+              for (const n of e) {
+                const e = n.replace(/^[\s\-*]+/, "").trim();
+                if (e.length < 10) continue;
+                let i = null;
+                if (
+                  (r.some((t) => t.test(n))
+                    ? (i = "solid")
+                    : s.some((t) => t.test(n))
+                      ? (i = "weak")
+                      : a.some((t) => t.test(n)) && (i = "insight"),
+                  i && t.filter((n) => n.type === i).length < 2)
+                ) {
+                  const n = on(e)
+                    .replace(
+                      /\b(?:SOLIDE|SOLID|PLAUSIBLE|INCERTAIN|UNCERTAIN|A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK)\b\s*[:—\-–]?\s*/gi,
+                      "",
+                    )
+                    .replace(/^[✅⚠️❓💡🔍🔬]\s*/u, "")
+                    .trim();
+                  n.length > 10 && t.push({ type: i, text: dn(n, 120) });
+                }
+                if (t.length >= 4) break;
+              }
+              if (t.length < 2) {
+                const e =
+                  /#+\s*(?:Points?\s+(?:forts?|clés?|faibles?)|Key\s+(?:Points?|Findings?|Takeaways?)|Strengths?|Weaknesses?|Main\s+Points?)[^\n]*\n([\s\S]*?)(?=\n#|$)/gi;
+                let r;
+                for (; null !== (r = e.exec(n)) && t.length < 4; ) {
+                  const n = r[1].match(/^[\s]*[-*]\s+(.+)$/gm);
+                  if (n)
+                    for (const e of n.slice(0, 4 - t.length)) {
+                      const n = on(e.replace(/^[\s]*[-*]\s+/, ""));
+                      n.length > 10 &&
+                        !t.some((t) => t.text === dn(n, 120)) &&
+                        t.push({ type: "insight", text: dn(n, 120) });
+                    }
+                }
+              }
+              return t.slice(0, 4);
+            })(m),
+            tags: (function (n) {
+              const t = [],
+                e = n.match(
+                  /#+\s*(?:Tags?|Thèmes?|Themes?|Topics?|Catégories?|Categories?)[^\n]*\n([\s\S]*?)(?=\n#|$)/i,
+                );
+              if (e) {
+                const n = e[1].match(/[-*]\s+(.+)/g);
+                if (n)
+                  for (const e of n.slice(0, 3)) {
+                    const n = on(e.replace(/^[-*]\s+/, "")).trim();
+                    n.length > 0 && n.length < 30 && t.push(n);
+                  }
+              }
+              if (0 === t.length) {
+                const e = n.match(/^#{2,3}\s+(.+)$/gm);
+                if (e) {
+                  const n =
+                    /^(?:Conclusion|Summary|Résumé|Synthèse|Introduction|Verdict|Analysis|Points?\s+(?:clés?|forts?|faibles?)|Key\s+(?:Points?|Findings?)|Strengths?|Weaknesses?|Overview)/i;
+                  for (const r of e) {
+                    const e = on(r.replace(/^#{2,3}\s+/, "")).trim();
+                    if (
+                      e.length > 2 &&
+                      e.length < 35 &&
+                      !n.test(e) &&
+                      (t.push(e), t.length >= 3)
+                    )
+                      break;
+                  }
+                }
+              }
+              return t.slice(0, 3);
+            })(m),
+          },
+          d = (function (n) {
+            const t = n.split("\n"),
+              e = [];
+            let r = !1,
+              s = !1;
+            for (let n = 0; n < t.length; n++) {
+              let a = t[n];
+              if (/^-{3,}$/.test(a.trim()) || /^\*{3,}$/.test(a.trim())) {
+                (r && (e.push("</ul>"), (r = !1)),
+                  s && (e.push("</ol>"), (s = !1)),
+                  e.push('<hr class="ds-md-hr">'));
+                continue;
+              }
+              const i = a.match(/^(#{1,4})\s+(.+)$/);
+              if (i) {
+                (r && (e.push("</ul>"), (r = !1)),
+                  s && (e.push("</ol>"), (s = !1)));
+                const n = i[1].length,
+                  t = i[2],
+                  a = n <= 2 ? sn(t) : "",
+                  o = an(t),
+                  d = a ? `${a}&nbsp;&nbsp;` : "";
+                e.push(`<h${n} class="ds-md-h${n}">${d}${o}</h${n}>`);
+                continue;
+              }
+              if (a.startsWith("&gt; ") || "&gt;" === a) {
+                (r && (e.push("</ul>"), (r = !1)),
+                  s && (e.push("</ol>"), (s = !1)));
+                const n = an(a.replace(/^&gt;\s?/, ""));
+                e.push(
+                  `<blockquote class="ds-md-blockquote">${n}</blockquote>`,
+                );
+                continue;
+              }
+              const o = a.match(/^(\s*)[-*]\s+(.+)$/);
+              if (o) {
+                (s && (e.push("</ol>"), (s = !1)),
+                  r || (e.push('<ul class="ds-md-ul">'), (r = !0)),
+                  e.push(`<li>${an(o[2])}</li>`));
+                continue;
+              }
+              const d = a.match(/^(\s*)\d+\.\s+(.+)$/);
+              d
+                ? (r && (e.push("</ul>"), (r = !1)),
+                  s || (e.push('<ol class="ds-md-ol">'), (s = !0)),
+                  e.push(`<li>${an(d[2])}</li>`))
+                : (r && (e.push("</ul>"), (r = !1)),
+                  s && (e.push("</ol>"), (s = !1)),
+                  "" !== a.trim()
+                    ? e.push(`<p class="ds-md-p">${an(a)}</p>`)
+                    : e.push('<div class="ds-md-spacer"></div>'));
+            }
+            return (r && e.push("</ul>"), s && e.push("</ol>"), e.join("\n"));
+          })(en(e.summary_content)).replace(
+            /\[(\d{1,2}:\d{2}(?::\d{2})?)\]/g,
+            (n, t) =>
+              `<a href="#" class="ds-timestamp" data-time="${(function (n) {
+                const t = n.split(":").map(Number);
+                return 3 === t.length
+                  ? 3600 * t[0] + 60 * t[1] + t[2]
+                  : 60 * t[0] + t[1];
+              })(t)}">[${t}]</a>`,
+          ),
+          c = vn[e.category] ?? "📋",
+          p =
+            (g = e.reliability_score) >= 80
+              ? "ds-score-high"
+              : g >= 60
+                ? "ds-score-mid"
+                : "ds-score-low";
+        var m, g;
+        const x = (function (n) {
+            return n >= 80 ? "✅" : n >= 60 ? "⚠️" : "❓";
+          })(e.reliability_score),
+          f = await b(),
+          h = f
+            ? k(o.verdict || e.summary_content.slice(0, 2e3), "md")
+            : '<button class="ds-tts-btn ds-tts-locked" type="button" title="Lecture vocale — Plan Étudiant+"><span class="ds-tts-icon">🔒</span></button>',
+          y = f
+            ? `\n    <div class="ds-tts-toolbar">\n      <span class="ds-tts-toolbar-label">🔊 Voix</span>\n      <button class="ds-tts-toolbar-btn" id="ds-tts-lang" title="Langue">${"fr" === l.language ? "🇫🇷" : "🇬🇧"}</button>\n      <button class="ds-tts-toolbar-btn" id="ds-tts-gender" title="Genre">${"female" === l.gender ? "♀" : "♂"}</button>\n      <button class="ds-tts-toolbar-btn" id="ds-tts-speed-global" title="Vitesse">${l.speed}x</button>\n    </div>\n  `
+            : "",
+          w = o.keyPoints
+            .map((n) => {
+              return `<div class="ds-kp ds-kp-${n.type}">\n      <span class="ds-kp-icon">${((t = n.type), "solid" === t ? "✅" : "weak" === t ? "⚠️" : "💡")}</span>\n      <span class="ds-kp-text">${en(n.text)}</span>\n    </div>`;
+              var t;
+            })
+            .join(""),
+          A =
+            o.tags.length > 0
+              ? `<div class="ds-tags">${o.tags.map((n) => `<span class="ds-tag-pill">${en(n)}</span>`).join("")}</div>`
+              : "",
+          T = (e.facts_to_verify ?? [])
+            .filter((n) => n.trim().length > 0)
+            .map((n) => ({ text: n.trim(), icon: "🔍" })),
+          $ =
+            T.length > 0
+              ? `<div style="margin-top:8px">${(function (n, t = 3) {
+                  return 0 === n.length
+                    ? ""
+                    : `<div class="ds-factcheck-list">${n
+                        .slice(0, t)
+                        .map(
+                          (n) =>
+                            `<div class="ds-fact-item"><span class="ds-fact-icon">${n.icon}</span><span class="ds-fact-text">${n.text}</span></div>`,
+                        )
+                        .join("")}</div>`;
+                })(T, 2)}</div>`
+              : "",
+          C = xn(e.category, 4),
+          S = (function (n) {
+            return 0 === n.length
+              ? ""
+              : `<div class="ds-chat-suggestions" id="ds-results-suggestions">${n.map((n, t) => `<button class="ds-chat-suggestion" data-index="${t}" type="button">${n}</button>`).join("")}</div>`;
+          })(C),
+          I = (function (n) {
+            const t = hn[n] ?? 0,
+              e = [
+                {
+                  icon: "🃏",
+                  label: "Flashcards IA",
+                  minPlan: "pro",
+                  price: "5,99€",
+                },
+                {
+                  icon: "🧠",
+                  label: "Carte mentale",
+                  minPlan: "pro",
+                  price: "5,99€",
+                },
+                {
+                  icon: "🌐",
+                  label: "Recherche web IA",
+                  minPlan: "pro",
+                  price: "5,99€",
+                },
+                {
+                  icon: "📦",
+                  label: "Export PDF/DOCX",
+                  minPlan: "pro",
+                  price: "5,99€",
+                },
+              ].filter((n) => (hn[n.minPlan] ?? 0) > t);
+            return 0 === e.length
+              ? `<div class="ds-teaser-pro-cta"><span>📱 Révisez sur mobile —</span><a href="${a}/mobile" target="_blank" rel="noreferrer" class="ds-teaser-link">Télécharger l'app</a></div>`
+              : `\n    <div class="ds-teasers-section">\n      <div class="ds-teasers-title">✨ Débloquez plus</div>\n      <div class="ds-teasers-grid">${e
+                  .slice(0, 3)
+                  .map(
+                    (n) =>
+                      `\n    <a href="${a}/upgrade" target="_blank" rel="noreferrer" class="ds-teaser-item" title="Dès ${n.price}/mois">\n      <span class="ds-teaser-icon">${n.icon}</span>\n      <span class="ds-teaser-label">${n.label}</span>\n      <span class="ds-teaser-lock">🔒</span>\n      <span class="ds-teaser-price">${n.price}/m</span>\n    </a>\n  `,
+                  )
+                  .join(
+                    "",
+                  )}</div>\n      <a href="${a}/upgrade" target="_blank" rel="noreferrer" class="ds-teasers-all">Voir tous les plans →</a>\n    </div>\n  `;
+          })(r);
+        var L;
+        const z = `\n    ${w ? `<div class="ds-keypoints ds-stagger">${w}</div>` : ""}\n    ${A}\n    ${$}\n\n    <button class="ds-toggle-detail" id="ds-toggle-detail" type="button">\n      <span class="ds-toggle-text">Voir l'analyse détaillée</span>\n      <span class="ds-toggle-arrow">▼</span>\n    </button>\n    <div class="ds-detail-panel hidden" id="ds-detail-panel">\n      <div class="ds-detail-content">${d}</div>\n    </div>\n\n    <div class="ds-share-actions">\n      <button class="ds-btn-outline" id="ds-copy-btn" type="button">📋 Copier</button>\n    </div>\n\n    ${S}\n    <div class="ds-premium-teasers">${I}</div>\n    ${((L = e.id), `\n    <div class="ds-ecosystem-bridge">\n      <a href="${a}/summary/${L}" target="_blank" rel="noreferrer" class="ds-bridge-link" title="Voir l'analyse complète sur le web">\n        🌐 Web\n      </a>\n      <a href="https://apps.apple.com/app/deepsight/id6744066498" target="_blank" rel="noreferrer" class="ds-bridge-link" title="App iOS">\n        🍎 iOS\n      </a>\n      <a href="https://play.google.com/store/apps/details?id=com.deepsight.app" target="_blank" rel="noreferrer" class="ds-bridge-link" title="App Android">\n        🤖 Android\n      </a>\n      <a href="${a}/upgrade" target="_blank" rel="noreferrer" class="ds-bridge-link ds-bridge-upgrade">\n        ⚡ Upgrade\n      </a>\n    </div>\n  `)}\n\n    <div class="ds-card-footer">\n      <a href="${a}" target="_blank" rel="noreferrer">🌐 deepsightsynthesis.com</a>\n    </div>\n  `;
+        (G(
+          `\n    <div class="ds-results-compact">\n      <div class="ds-status-bar">\n        <span class="ds-done">✅ Analyse prête</span>\n        <div class="ds-status-badges">\n          <span class="ds-tag">${c} ${en(e.category)}</span>\n          <span class="ds-tag ${p}">${x} ${e.reliability_score}%</span>\n        </div>\n      </div>\n\n      <div class="ds-reliability-bar">\n        <div class="ds-reliability-header">\n          <span style="color:var(--ds-text-muted)">Fiabilité</span>\n          <span class="${p}" style="font-weight:600">${e.reliability_score}/100</span>\n        </div>\n        <div class="ds-progress" style="height:6px">\n          <div class="ds-progress-bar ds-fill-bar" data-score="${p.replace("ds-score-", "")}"\n               style="width:${e.reliability_score}%;background:${e.reliability_score >= 80 ? "var(--ds-success)" : e.reliability_score >= 60 ? "var(--ds-warning)" : "var(--ds-error)"}">\n          </div>\n        </div>\n      </div>\n\n      <div class="ds-verdict-compact">\n        <div class="ds-summary-tts-row">\n          <p class="ds-verdict-text-compact" style="flex:1;margin:0">${en(o.verdict)}</p>\n          ${h}\n        </div>\n      </div>\n      ${y}\n\n      <div class="ds-compact-actions">\n        <button class="ds-btn-primary-xl" id="ds-open-fullscreen" type="button">\n          🔍 Voir l'analyse complète\n        </button>\n        <button class="ds-btn-outline-xl" id="ds-share-btn" type="button">\n          🔗 Partager cette analyse\n        </button>\n        <a href="${a}/summary/${e.id}" target="_blank" rel="noreferrer" class="ds-link-tertiary">\n          🌐 Ouvrir sur DeepSight Web ↗\n        </a>\n      </div>\n\n      <details class="ds-details-wrapper">\n        <summary class="ds-details-toggle">▸ Voir le détail ici</summary>\n        <div class="ds-details-body">\n          ${z}\n        </div>\n      </details>\n\n      <button class="ds-btn-secondary-action" id="ds-chat-btn" type="button">\n        💬 Chatter avec la vidéo\n      </button>\n    </div>\n  `,
+        ),
+          (function (n, e, r) {
+            ((0, i.$id)("ds-open-fullscreen")?.addEventListener("click", () => {
+              const e = t.runtime.getURL(`viewer.html?id=${n.id}`);
+              t.tabs.create({ url: e });
+            }),
+              (0, i.$id)("ds-toggle-detail")?.addEventListener("click", () => {
+                const n = (0, i.$id)("ds-detail-panel"),
+                  t = (0, i.$id)("ds-toggle-detail");
+                if (!n || !t) return;
+                const e = n.classList.contains("hidden");
+                n.classList.toggle("hidden");
+                const r = t.querySelector(".ds-toggle-arrow"),
+                  s = t.querySelector(".ds-toggle-text");
+                (r && (r.textContent = e ? "▲" : "▼"),
+                  s &&
+                    (s.textContent = e
+                      ? "Masquer l'analyse"
+                      : "Voir l'analyse détaillée"));
+              }),
+              (0, i.gC)(".ds-timestamp").forEach((n) => {
+                n.addEventListener("click", (t) => {
+                  t.preventDefault();
+                  const e = parseInt(n.dataset.time ?? "0", 10),
+                    r = document.querySelector("video");
+                  r && ((r.currentTime = e), r.play());
+                });
+              }),
+              (0, i.$id)("ds-chat-btn")?.addEventListener("click", () => {
+                e.onChat(n.id, n.video_title);
+              }),
+              fn("ds-results-suggestions", r, (t) => {
+                (e.onChat(n.id, n.video_title),
+                  setTimeout(() => {
+                    const n = (0, i.$id)("ds-chat-input");
+                    n && ((n.value = t), (0, i.$id)("ds-chat-send")?.click());
+                  }, 100));
+              }),
+              (0, i.$id)("ds-copy-btn")?.addEventListener(
+                "click",
+                e.onCopyLink,
+              ),
+              (0, i.$id)("ds-share-btn")?.addEventListener("click", e.onShare));
+          })(e, n, C),
+          E(),
+          f &&
+            ((0, i.$id)("ds-tts-lang")?.addEventListener("click", () => {
+              ((l.language = "fr" === l.language ? "en" : "fr"), u());
+              const n = (0, i.$id)("ds-tts-lang");
+              n && (n.textContent = "fr" === l.language ? "🇫🇷" : "🇬🇧");
+            }),
+            (0, i.$id)("ds-tts-gender")?.addEventListener("click", () => {
+              ((l.gender = "female" === l.gender ? "male" : "female"), u());
+              const n = (0, i.$id)("ds-tts-gender");
+              n && (n.textContent = "female" === l.gender ? "♀" : "♂");
+            }),
+            (0, i.$id)("ds-tts-speed-global")?.addEventListener("click", () => {
+              v();
+              const n = (0, i.$id)("ds-tts-speed-global");
+              n && (n.textContent = `${l.speed}x`);
+            })));
+      }
+      let wn = !1;
+      function An(n) {
+        return `<div class="ds-chat-msg ${"user" === n.role ? "ds-chat-msg-user" : "ds-chat-msg-assistant"}">${
+          "assistant" === n.role
+            ? en(n.content)
+                .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
+                .replace(/\*(.*?)\*/g, "<em>$1</em>")
+                .replace(/\n/g, "<br>")
+            : en(n.content)
+        }${n.web_search_used ? `<span style="font-size:10px;color:var(--ds-info);display:block;margin-top:3px">🌐 ${mn().webSearchUsed}</span>` : ""}${"assistant" === n.role && n.content.length > 20 ? `<div style="margin-top:4px">${wn ? k(n.content) : '<button class="ds-tts-btn ds-tts-locked" type="button" title="Lecture vocale — Plan Étudiant+"><span class="ds-tts-icon">🔒</span></button>'}</div>` : ""}</div>`;
+      }
+      function kn(n) {
+        const t = (0, i.$id)("ds-chat-messages");
+        if (!t) return;
+        const e = t.querySelector('[style*="text-align:center"]');
+        e?.remove();
+        const r = document.createElement("div");
+        r.innerHTML = An(n);
+        const s = r.firstElementChild;
+        (s && t.appendChild(s), En());
+      }
+      function En() {
+        requestAnimationFrame(() => {
+          const n = (0, i.$id)("ds-chat-messages");
+          n && (n.scrollTop = n.scrollHeight);
+        });
+      }
+      function Tn(n) {
+        const t = (0, i.$id)("ds-chat-input"),
+          e = (0, i.$id)("ds-chat-send");
+        (t && (t.disabled = n),
+          e &&
+            ((e.disabled = n),
+            (e.innerHTML = n
+              ? '<svg class="ds-gouvernail-spinner ds-gouvernail-spinner-sm" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" width="14" height="14"><circle cx="24" cy="24" r="20" opacity="0.3"/><circle cx="24" cy="24" r="3"/><line x1="24" y1="4" x2="24" y2="11"/></svg>'
+              : "➤")));
+      }
+      async function $n(n) {
+        const e = (0, i.$id)("ds-chat-input");
+        if (!e) return;
+        const r = e.value.trim();
+        if (!r) return;
+        ((e.value = ""),
+          Tn(!0),
+          (0, i.$id)("ds-chat-suggestions")?.remove(),
+          kn({ role: "user", content: r }));
+        const s = (0, i.$id)("ds-chat-messages"),
+          a = `ds-loading-${Date.now()}`;
+        if (s) {
+          const n = document.createElement("div");
+          ((n.id = a),
+            (n.className = "ds-chat-msg ds-chat-msg-assistant"),
+            (n.innerHTML =
+              '<svg class="ds-gouvernail-spinner ds-gouvernail-spinner-sm" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" width="14" height="14"><circle cx="24" cy="24" r="20" opacity="0.3"/><circle cx="24" cy="24" r="3"/><line x1="24" y1="4" x2="24" y2="11"/></svg> En train de répondre...'),
+            s.appendChild(n),
+            En());
+        }
+        try {
+          const e = await t.runtime.sendMessage({
+            action: "ASK_QUESTION",
+            data: { summaryId: n, question: r, options: {} },
+          });
+          if (((0, i.$id)(a)?.remove(), !e?.success))
+            throw new Error(e?.error || "Erreur de chat");
+          const s = e.result;
+          (kn({
+            role: "assistant",
+            content: s.response,
+            web_search_used: s.web_search_used,
+          }),
+            E());
+        } catch (n) {
+          ((0, i.$id)(a)?.remove(),
+            kn({ role: "assistant", content: `❌ ${n.message}` }));
+        } finally {
+          (Tn(!1), (0, i.$id)("ds-chat-input")?.focus());
+        }
+      }
+      const Cn = "ds_crash_log";
+      let Sn = [];
+      function In(n, t) {
+        (Sn.push({ step: n, detail: t, t: Date.now() }),
+          Sn.length > 100 && (Sn = Sn.slice(-100)));
+        try {
+          void 0 !== t
+            ? console.log("[DeepSight-boot]", n, t)
+            : console.log("[DeepSight-boot]", n);
+        } catch {}
+      }
+      async function Ln(n, t) {
+        const e = n instanceof Error ? n : new Error(String(n)),
+          r = {
+            message: e.message || "Unknown error",
+            stack: e.stack,
+            context: t,
+            steps: Sn.map((n) => n.step),
+            timestamp: Date.now(),
+            url:
+              "undefined" != typeof location && location.href
+                ? location.href
+                : "",
+            userAgent:
+              "undefined" != typeof navigator && navigator.userAgent
+                ? navigator.userAgent
+                : "",
+          };
+        try {
+          const n = await chrome.storage.local.get(Cn),
+            t = [...(Array.isArray(n[Cn]) ? n[Cn] : []), r].slice(-20);
+          await chrome.storage.local.set({ [Cn]: t });
+        } catch (n) {
+          try {
+            console.error("[DeepSight-crash]", r, n);
+          } catch {}
+        }
+      }
+      const zn = {
+        state: "login",
+        videoId: null,
+        currentTaskId: null,
+        user: null,
+        planInfo: null,
+        summary: null,
+        tournesol: null,
+        injected: !1,
+        injectionAttempts: 0,
+      };
+      function Pn() {
+        try {
+          if (zn.injected && H())
+            return void In("inject:skip-already-injected");
+          if (zn.injectionAttempts > 30)
+            return void In("inject:max-attempts-reached");
+          (zn.injectionAttempts++,
+            In("inject:attempt", { n: zn.injectionAttempts }));
+          const r = (function () {
+              const n = window.location.hostname;
+              return n.includes("youtube.com") || n.includes("youtu.be")
+                ? "youtube"
+                : n.includes("tiktok.com")
+                  ? "tiktok"
+                  : null;
+            })(),
+            s = "tiktok" === r;
+          In("inject:platform-theme", { platform: r, theme: z() });
+          const a = (function (n, t) {
+            let e, r;
+            try {
+              e = document.createElement("div");
+            } catch {
+              return null;
+            }
+            ((e.id = N),
+              (e.style.cssText =
+                "all:initial;display:block;width:100%;max-width:420px;margin-bottom:12px;background-color:#0a0a0f;color-scheme:dark;"),
+              t &&
+                (e.style.cssText =
+                  "all:initial;position:fixed;bottom:20px;right:20px;width:360px;max-height:80vh;z-index:2147483646;background-color:#0a0a0f;color-scheme:dark;"));
+            try {
+              r = e.attachShadow({ mode: "closed" });
+            } catch {
+              return null;
+            }
+            (0, i.PM)(r);
+            const s = (n) => {
+              n.stopPropagation();
+            };
+            (e.addEventListener("keydown", s),
+              e.addEventListener("keyup", s),
+              e.addEventListener("keypress", s));
+            const a = document.createElement("style");
+            ((a.textContent = [_, j, R].join("\n\n")), r.appendChild(a));
+            const o = document.createElement("div");
+            return (
+              (o.id = O),
+              (o.className = "ds-widget deepsight-card dark"),
+              (o.style.backgroundColor = "#0a0a0f"),
+              (o.style.color = "#f5f0e8"),
+              t &&
+                (o.classList.add("deepsight-card-floating"),
+                (o.style.cssText =
+                  "overflow-y:auto;box-shadow:0 8px 32px rgba(0,0,0,0.5);border-radius:12px;background-color:#0a0a0f;color:#f5f0e8;")),
+              r.appendChild(o),
+              e
+            );
+          })(0, s);
+          if (!a) {
+            In("inject:createWidgetShell-returned-null");
+            const n = zn.injectionAttempts <= 10 ? 300 : 1e3;
+            return void setTimeout(Pn, n);
+          }
+          const o = H();
+          if (o) {
+            o.innerHTML = `\n    <div class="ds-card-header">\n      <div class="ds-card-logo">${(function (
+              n = 22,
+            ) {
+              return `<img src="${t.runtime.getURL("assets/deepsight-logo-cosmic.png")}" alt="DeepSight" width="${n}" height="${n}" style="object-fit:contain;border-radius:50%;" />`;
+            })(
+              22,
+            )}<span>Deep Sight</span></div>\n      <div style="display:flex;align-items:center;gap:4px">\n        <span class="ds-card-badge">AI</span>\n        <button class="ds-minimize-btn" id="ds-minimize-btn" type="button" title="Réduire">−</button>\n      </div>\n    </div>\n  `;
+            const r =
+                ((n = () => {
+                  (In("skeleton:retry-clicked"),
+                    (zn.injected = !1),
+                    (zn.injectionAttempts = 0),
+                    U(),
+                    Pn());
+                }),
+                {
+                  html: '\n    <div class="ds-card-body">\n      <div class="ds-loading" style="padding:16px;text-align:center">\n        <div style="color:var(--ds-gold-mid);font-size:24px;margin-bottom:8px">⏳</div>\n        <p class="ds-loading-text" style="color:var(--ds-text-secondary);font-size:12px;margin:0 0 12px">\n          Chargement de DeepSight…\n        </p>\n        <button\n          type="button"\n          id="ds-skeleton-retry"\n          class="ds-btn ds-btn-primary"\n          style="font-size:11px;padding:6px 12px;display:none"\n        >\n          Réessayer\n        </button>\n      </div>\n    </div>\n  ',
+                  bind: () => {
+                    Promise.resolve()
+                      .then(e.bind(e, 40))
+                      .then(({ $id: t }) => {
+                        setTimeout(() => {
+                          const e = t("ds-skeleton-retry");
+                          e &&
+                            !e.hasAttribute("data-bound") &&
+                            (e.setAttribute("data-bound", "1"),
+                            (e.style.display = "inline-block"),
+                            e.addEventListener("click", n));
+                        }, 1e4);
+                      })
+                      .catch(() => {});
+                  },
+                }),
+              s = document.createElement("div");
+            s.innerHTML = r.html;
+            const a = s.firstElementChild;
+            (a && o.appendChild(a),
+              r.bind(),
+              In("inject:widget-populated-with-skeleton"));
+          } else In("inject:widgetCard-null");
+          const d = (function (n, t) {
+            const e = document.getElementById(N);
+            if ((e && e !== n && e.remove(), (F = !1), t)) {
+              for (const t of q)
+                if (document.querySelector(t))
+                  return (document.body.appendChild(n), !0);
+              return !1;
+            }
+            for (const { selector: t, position: e } of D) {
+              const r = document.querySelector(t);
+              if (r instanceof HTMLElement && B(r))
+                return (
+                  "prepend" === e
+                    ? r.insertBefore(n, r.firstChild)
+                    : r.parentElement?.insertBefore(n, r.nextSibling),
+                  !0
+                );
+            }
+            return (
+              (F = !0),
+              (n.style.cssText =
+                "all:initial;position:fixed;bottom:20px;right:20px;width:380px;max-height:80vh;z-index:2147483646;"),
+              document.body.appendChild(n),
+              !0
+            );
+          })(a, s);
+          if ((In("inject:injectWidget-result", { success: d }), d))
+            ((zn.injected = !0),
+              (zn.injectionAttempts = 0),
+              (function () {
+                const n = (0, i.$id)("ds-minimize-btn"),
+                  e = H();
+                n &&
+                  e &&
+                  (t.storage.local.get(["ds_minimized"]).then((n) => {
+                    n.ds_minimized && Q();
+                  }),
+                  n.addEventListener("click", () => {
+                    e.classList.contains("ds-collapsed")
+                      ? ((function () {
+                          const n = H(),
+                            t = (0, i.$id)("ds-minimize-btn");
+                          n &&
+                            (n.classList.remove("ds-collapsed"),
+                            t && (t.textContent = "−"));
+                        })(),
+                        t.storage.local.set({ ds_minimized: !1 }))
+                      : (Q(), t.storage.local.set({ ds_minimized: !0 }));
+                  }));
+              })(),
+              (function (n) {
+                M();
+                const t = new MutationObserver(() => {
+                  n(z());
+                });
+                t.observe(document.documentElement, {
+                  attributes: !0,
+                  attributeFilter: ["dark", "class"],
+                });
+                const e = window.matchMedia("(prefers-color-scheme: dark)"),
+                  r = () => {
+                    n(z());
+                  };
+                (e.addEventListener("change", r),
+                  (P = () => {
+                    (e.removeEventListener("change", r), t.disconnect());
+                  }));
+              })(() => {
+                const n = H();
+                n &&
+                  !n.classList.contains("dark") &&
+                  (n.classList.remove("light"), n.classList.add("dark"));
+              }),
+              (function () {
+                X();
+                const n =
+                  document.querySelector("ytd-watch-flexy") ||
+                  document.querySelector("#content");
+                n &&
+                  ((K = new MutationObserver(() => {
+                    document.getElementById("deepsight-host") ||
+                      (In("observer:widget-detached"),
+                      (zn.injected = !1),
+                      Pn());
+                  })),
+                  K.observe(n, { childList: !0, subtree: !1 }));
+              })(),
+              (function (n) {
+                tn();
+                const t = document.querySelector("ytd-watch-flexy");
+                (t &&
+                  ((J = new MutationObserver(() => n(Z()))),
+                  J.observe(t, {
+                    attributes: !0,
+                    attributeFilter: ["theater"],
+                  })),
+                  (nn = () => n(Z())),
+                  document.addEventListener("fullscreenchange", nn));
+              })((n) => {
+                const t = document.getElementById("deepsight-host");
+                t &&
+                  ("fullscreen" === n
+                    ? (t.style.display = "none")
+                    : "theater" === n
+                      ? ((t.style.cssText =
+                          "all:initial;position:fixed;bottom:20px;right:20px;width:380px;max-height:80vh;z-index:2147483646;"),
+                        (t.style.display = ""))
+                      : (t.style.cssText =
+                          "all:initial;display:block;width:100%;max-width:420px;margin-bottom:12px;"));
+              }),
+              In("inject:success-calling-initCard"),
+              Mn());
+          else {
+            const n = 15e3;
+            if (500 * zn.injectionAttempts >= n)
+              (In("inject:budget-exceeded-force-floating"),
+                (zn.injected = !1),
+                setTimeout(Pn, 1e3));
+            else {
+              const n = zn.injectionAttempts <= 10 ? 300 : 1e3;
+              setTimeout(Pn, n);
+            }
+          }
+        } catch (n) {
+          (In("inject:caught-error", { message: n.message }),
+            Ln(n, { step: "tryInjectWidget", attempt: zn.injectionAttempts }),
+            zn.injectionAttempts < 3 && setTimeout(Pn, 1e3));
+        }
+        var n;
+      }
+      async function Mn() {
+        try {
+          const r = await ((n = t.runtime.sendMessage({
+            action: "CHECK_AUTH",
+          })),
+          (e = { authenticated: !1 }),
+          new Promise((t) => {
+            let r = !1;
+            const s = setTimeout(() => {
+              r || ((r = !0), t(e));
+            }, 5e3);
+            n.then(
+              (n) => {
+                r || ((r = !0), clearTimeout(s), t(n));
+              },
+              () => {
+                r || ((r = !0), clearTimeout(s), t(e));
+              },
+            );
+          }));
+          if (
+            (In("initCard:auth-checked", { authenticated: !!r?.authenticated }),
+            !r?.authenticated)
+          )
+            return (
+              (zn.state = "login"),
+              (zn.user = null),
+              void ln(() => Mn())
+            );
+          ((zn.user = r.user ?? null),
+            t.runtime
+              .sendMessage({ action: "GET_PLAN" })
+              .then((n) => {
+                const t = n;
+                t?.success && (zn.planInfo = t.plan ?? null);
+              })
+              .catch(() => {}),
+            zn.videoId &&
+              (async function (n) {
+                try {
+                  const e = await t.runtime.sendMessage({
+                    action: "GET_TOURNESOL",
+                    data: { videoId: n },
+                  });
+                  return e?.success && e.data ? e.data : null;
+                } catch {
+                  return null;
+                }
+              })(zn.videoId)
+                .then((n) => {
+                  ((zn.tournesol = n),
+                    "ready" === zn.state &&
+                      zn.user &&
+                      gn({
+                        user: {
+                          username: zn.user.username,
+                          plan: zn.user.plan,
+                          credits: zn.user.credits,
+                        },
+                        tournesol: zn.tournesol,
+                        videoTitle: _n(),
+                        onAnalyze: (n, t) => Rn(n, t),
+                        onQuickChat: (n) => On(n),
+                        onLogout: Bn,
+                      }));
+                })
+                .catch(() => {}),
+            (zn.state = "ready"),
+            gn({
+              user: {
+                username: zn.user.username,
+                plan: zn.user.plan,
+                credits: zn.user.credits,
+              },
+              tournesol: zn.tournesol,
+              videoTitle: _n(),
+              onAnalyze: (n, t) => Rn(n, t),
+              onQuickChat: (n) => On(n),
+              onLogout: Bn,
+            }));
+        } catch (n) {
+          Fn(`Erreur d'initialisation: ${n.message}`);
+        }
+        var n, e;
+      }
+      function _n() {
+        const n = document.querySelector('meta[property="og:title"]');
+        if (n instanceof HTMLMetaElement && n.content) return n.content;
+        const t = document.querySelector('meta[name="title"]');
+        if (t instanceof HTMLMetaElement && t.content) return t.content;
+        const e =
+          document.querySelector("ytd-watch-metadata h1 yt-formatted-string") ??
+          document.querySelector("h1.title yt-formatted-string") ??
+          document.querySelector("h1.title");
+        if (e?.textContent?.trim()) return e.textContent.trim();
+        return (
+          document.title.replace(/\s*[-–—]\s*YouTube\s*$/, "").trim() || ""
+        );
+      }
+      function jn() {
+        (zn.currentTaskId &&
+          t.runtime
+            .sendMessage({
+              action: "CANCEL_ANALYSIS",
+              data: { taskId: zn.currentTaskId },
+            })
+            .catch(() => {}),
+          (zn.state = "ready"),
+          (zn.currentTaskId = null),
+          zn.user &&
+            gn({
+              user: {
+                username: zn.user.username,
+                plan: zn.user.plan,
+                credits: zn.user.credits,
+              },
+              tournesol: zn.tournesol,
+              videoTitle: _n(),
+              onAnalyze: Rn,
+              onQuickChat: On,
+              onLogout: Bn,
+            }));
+      }
+      async function Rn(n, e) {
+        if (!zn.videoId) return;
+        ((zn.state = "analyzing"),
+          (zn.currentTaskId = null),
+          (function (n, t, e) {
+            if (
+              (G(
+                `\n    <div class="ds-analyzing-container">\n      <div class="ds-loading" style="text-align:center;padding:16px 0">\n        \n    <div class="ds-gouvernail-spinner" style="width:48px;height:48px;">\n      <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">\n        <circle cx="24" cy="24" r="20" opacity="0.3"/>\n        <circle cx="24" cy="24" r="3"/>\n        <line x1="24" y1="4" x2="24" y2="11"/>\n        <line x1="38.1" y1="9.9" x2="33.2" y2="14.8"/>\n        <line x1="44" y1="24" x2="37" y2="24"/>\n        <line x1="38.1" y1="38.1" x2="33.2" y2="33.2"/>\n        <line x1="24" y1="44" x2="24" y2="37"/>\n        <line x1="9.9" y1="38.1" x2="14.8" y2="33.2"/>\n        <line x1="4" y1="24" x2="11" y2="24"/>\n        <line x1="9.9" y1="9.9" x2="14.8" y2="14.8"/>\n      </svg>\n    </div>\n        <p class="ds-loading-text" id="ds-progress-text">${en("Démarrage de l'analyse...")}</p>\n      </div>\n      <div class="ds-progress" style="margin:8px 0">\n        <div class="ds-progress-bar" id="ds-progress-bar" style="width:0%"></div>\n      </div>\n      <button id="ds-cancel-btn" style="\n        display:block;margin:12px auto 0;padding:6px 16px;\n        background:transparent;border:1px solid rgba(255,255,255,0.15);\n        border-radius:8px;color:rgba(255,255,255,0.5);font-size:12px;\n        cursor:pointer;transition:all 0.2s;\n      ">Annuler</button>\n    </div>\n  `,
+              ),
+              e)
+            ) {
+              const n = W(),
+                t = n?.querySelector("#ds-cancel-btn");
+              t &&
+                (t.addEventListener("click", e),
+                t.addEventListener("mouseenter", () => {
+                  ((t.style.color = "#ef4444"),
+                    (t.style.borderColor = "rgba(239,68,68,0.3)"),
+                    (t.style.background = "rgba(239,68,68,0.1)"));
+                }),
+                t.addEventListener("mouseleave", () => {
+                  ((t.style.color = "rgba(255,255,255,0.5)"),
+                    (t.style.borderColor = "rgba(255,255,255,0.15)"),
+                    (t.style.background = "transparent"));
+                }));
+            }
+          })(0, 0, jn));
+        const r = window.location.href;
+        try {
+          const s = await t.runtime.sendMessage({
+            action: "ANALYZE_VIDEO",
+            data: { url: r, options: { mode: n, lang: e, category: "auto" } },
+          });
+          if (!s?.success) throw new Error(s?.error || "Analyse échouée");
+          const a = s.result;
+          if ("completed" === a.status && a.result?.summary_id)
+            await (async function (n) {
+              const e = await t.runtime.sendMessage({
+                action: "GET_SUMMARY",
+                data: { summaryId: n },
+              });
+              if (!e?.success)
+                throw new Error(e?.error || "Récupération analyse échouée");
+              ((zn.summary = e.summary),
+                (zn.state = "results"),
+                zn.videoId &&
+                  (await (async function (n) {
+                    const e = (
+                      await (async function () {
+                        return (
+                          (await t.storage.local.get(["recentAnalyses"]))
+                            .recentAnalyses || []
+                        );
+                      })()
+                    ).filter((t) => t.videoId !== n.videoId);
+                    (e.unshift({ ...n, timestamp: Date.now() }),
+                      await t.storage.local.set({
+                        recentAnalyses: e.slice(0, 20),
+                      }));
+                  })({
+                    videoId: zn.videoId,
+                    summaryId: zn.summary.id,
+                    title: zn.summary.video_title,
+                  })),
+                await yn({
+                  summary: zn.summary,
+                  userPlan: zn.user?.plan ?? "free",
+                  onChat: Nn,
+                  onCopyLink: Dn,
+                  onShare: qn,
+                }));
+            })(a.result.summary_id);
+          else if ("failed" === a.status)
+            throw new Error(a.error ?? "Analyse échouée");
+        } catch (n) {
+          ((zn.state = "ready"),
+            Fn(n.message),
+            setTimeout(() => {
+              zn.user &&
+                gn({
+                  user: {
+                    username: zn.user.username,
+                    plan: zn.user.plan,
+                    credits: zn.user.credits,
+                  },
+                  tournesol: zn.tournesol,
+                  videoTitle: _n(),
+                  onAnalyze: Rn,
+                  onQuickChat: On,
+                  onLogout: Bn,
+                });
+            }, 3e3));
+        }
+      }
+      async function On(n) {
+        try {
+          const e = await t.runtime.sendMessage({
+            action: "QUICK_CHAT",
+            data: { url: window.location.href, lang: n },
+          });
+          if (!e?.success) throw new Error(e?.error || "Quick Chat échoué");
+          const r = e.result;
+          Nn(r.summary_id, r.video_title);
+        } catch (n) {
+          Fn(n.message);
+          const t = (0, i.$id)("ds-quickchat-btn");
+          t && ((t.disabled = !1), (t.innerHTML = "💬 Quick Chat IA"));
+        }
+      }
+      async function Nn(n, e) {
+        zn.state = "chat";
+        let r = [];
+        try {
+          const e = await t.runtime.sendMessage({
+            action: "GET_CHAT_HISTORY",
+            data: { summaryId: n },
+          });
+          e?.success && Array.isArray(e.result) && (r = e.result);
+        } catch {}
+        await (async function (n) {
+          const {
+              summaryId: t,
+              videoTitle: e,
+              category: r = "default",
+              messages: s = [],
+              onBack: o,
+            } = n,
+            d = xn(r, 4);
+          wn = await b();
+          const l = s.map(An).join("");
+          (G(
+            `\n    <div class="ds-chat-container ds-animate-fadeIn">\n      ${o ? `<button class="ds-link-btn" id="ds-chat-back" type="button" style="font-size:11px;margin-bottom:4px">← ${mn().backToResults}</button>` : ""}\n      <div style="font-size:11px;color:var(--ds-text-muted);margin-bottom:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${en(e)}">\n        💬 Chat — ${en(e)}\n      </div>\n\n      <div class="ds-chat-messages" id="ds-chat-messages">\n        ${l || `<div style="text-align:center;color:var(--ds-text-muted);font-size:11px;padding:16px 0">${mn().askQuestion}</div>`}\n      </div>\n\n      ${0 === s.length ? `\n        <div class="ds-chat-suggestions" id="ds-chat-suggestions">\n          ${d.map((n, t) => `<button class="ds-chat-suggestion" data-index="${t}" type="button">${en(n)}</button>`).join("")}\n        </div>\n      ` : ""}\n\n      <div class="ds-chat-input-row">\n        <input\n          type="text"\n          id="ds-chat-input"\n          class="ds-chat-input"\n          placeholder="Posez une question..."\n          autocomplete="off"\n          maxlength="500"\n        />\n        <button class="ds-chat-send-btn" id="ds-chat-send" type="button" title="Envoyer">➤</button>\n      </div>\n\n      <div class="ds-card-footer" style="margin-top:6px">\n        <a href="${a}/summary/${t}" target="_blank" rel="noreferrer" style="font-size:11px">\n          📖 Voir l'analyse complète\n        </a>\n        <span style="font-size:11px;color:var(--ds-text-muted)">Alt+C pour ouvrir</span>\n      </div>\n    </div>\n  `,
+          ),
+            (function (n, t, e) {
+              (e && (0, i.$id)("ds-chat-back")?.addEventListener("click", e),
+                fn("ds-chat-suggestions", t, (t) => {
+                  const e = (0, i.$id)("ds-chat-input");
+                  e && ((e.value = t), $n(n));
+                }));
+              const r = (0, i.$id)("ds-chat-input"),
+                s = (0, i.$id)("ds-chat-send");
+              (s?.addEventListener("click", () => $n(n)),
+                r?.addEventListener("keydown", (t) => {
+                  "Enter" !== t.key ||
+                    t.shiftKey ||
+                    (t.preventDefault(), $n(n));
+                }));
+            })(t, d, o),
+            E(),
+            En());
+        })({
+          summaryId: n,
+          videoTitle: e,
+          category: zn.summary?.category ?? "default",
+          messages: r,
+          onBack: zn.summary
+            ? () => {
+                ((zn.state = "results"),
+                  yn({
+                    summary: zn.summary,
+                    userPlan: zn.user?.plan ?? "free",
+                    onChat: Nn,
+                    onCopyLink: Dn,
+                    onShare: qn,
+                  }));
+              }
+            : void 0,
+        });
+      }
+      async function Dn() {
+        if (!zn.summary) return;
+        const n = (0, i.$id)("ds-copy-btn");
+        if (!n) return;
+        let e = `${a}/summary/${zn.summary.id}`;
+        try {
+          const n = await t.runtime.sendMessage({
+            action: "SHARE_ANALYSIS",
+            data: { videoId: zn.videoId },
+          });
+          n?.success && n.share_url && (e = n.share_url);
+        } catch {}
+        const r = [
+          "🎯 DeepSight — Analyse IA",
+          "",
+          `📹 ${zn.summary.video_title}`,
+          `🏷️ Catégorie: ${zn.summary.category}`,
+          `📊 Fiabilité: ${zn.summary.reliability_score}%`,
+          "",
+          `🔗 ${e}`,
+          "—",
+          "deepsightsynthesis.com",
+        ].join("\n");
+        try {
+          (await navigator.clipboard.writeText(r),
+            (n.textContent = "✅ Copié!"),
+            setTimeout(() => {
+              n.textContent = "📋 Copier";
+            }, 2e3));
+        } catch {
+          ((n.textContent = "❌ Échec"),
+            setTimeout(() => {
+              n.textContent = "📋 Copier";
+            }, 2e3));
+        }
+      }
+      async function qn() {
+        if (!zn.summary) return;
+        const n = (0, i.$id)("ds-share-btn");
+        if (n)
+          try {
+            const e = await t.runtime.sendMessage({
+                action: "SHARE_ANALYSIS",
+                data: { videoId: zn.videoId },
+              }),
+              r = e?.success ? e.share_url : `${a}/summary/${zn.summary.id}`;
+            (await navigator.clipboard.writeText(r),
+              (n.textContent = "✅ Lien copié!"),
+              setTimeout(() => {
+                n.textContent = "🔗 Partager";
+              }, 2e3));
+          } catch {
+            ((n.textContent = "❌ Échec"),
+              setTimeout(() => {
+                n.textContent = "🔗 Partager";
+              }, 2e3));
+          }
+      }
+      async function Bn() {
+        (await t.runtime.sendMessage({ action: "LOGOUT" }),
+          (zn.user = null),
+          (zn.planInfo = null),
+          (zn.summary = null),
+          (zn.tournesol = null),
+          (zn.state = "login"),
+          ln(() => Mn()));
+      }
+      function Fn(n) {
+        const t = W();
+        if (!t) return;
+        const e = "undefined" != typeof navigator && !navigator.onLine,
+          r = document.createElement("div");
+        if (
+          ((r.style.cssText =
+            "padding:8px 12px;background:var(--ds-error-bg);border-radius:8px;font-size:11px;color:var(--ds-error);margin-top:8px;display:flex;flex-direction:column;gap:6px"),
+          (r.textContent = e
+            ? "📡 Hors ligne — vérifiez votre connexion"
+            : `❌ ${n}`),
+          e)
+        ) {
+          const n = document.createElement("button");
+          ((n.type = "button"),
+            (n.textContent = "Réessayer"),
+            (n.style.cssText =
+              "padding:4px 8px;border-radius:4px;background:var(--ds-gold-mid);color:#0a0a0f;border:none;font-size:10px;cursor:pointer;align-self:flex-start"),
+            n.addEventListener("click", () => {
+              Mn();
+            }),
+            r.appendChild(n));
+        }
+        t.appendChild(r);
+      }
+      async function Un(n) {
+        (f(),
+          X(),
+          tn(),
+          M(),
+          (T = null),
+          $(),
+          (zn.videoId = n),
+          (zn.summary = null),
+          (zn.tournesol = null),
+          (zn.state = "login"),
+          (zn.injected = !1),
+          (zn.injectionAttempts = 0),
+          U(),
+          n && I() && setTimeout(Pn, 800));
+      }
+      function Hn() {
+        try {
+          if (
+            (In("bootstrap:start", {
+              url: location.href,
+              readyState: document.readyState,
+            }),
+            !I())
+          )
+            return void In("bootstrap:not-video-page");
+          if (((zn.videoId = L()), !zn.videoId))
+            return void In("bootstrap:no-video-id");
+          (In("bootstrap:video-id", { videoId: zn.videoId }),
+            $(),
+            In("bootstrap:anchor-ready", { ready: Y() }),
+            setTimeout(Pn, 1e3),
+            (function (n) {
+              let t = L();
+              function e() {
+                const e = L();
+                e !== t && ((t = e), setTimeout(() => n(e), 500));
+              }
+              const r = history.pushState;
+              ((history.pushState = function (...n) {
+                (r.apply(history, n), e());
+              }),
+                window.addEventListener("popstate", e),
+                document.addEventListener("yt-navigate-finish", e),
+                document.addEventListener("yt-page-data-updated", e));
+            })(Un),
+            In("bootstrap:ready"));
+        } catch (n) {
+          (In("bootstrap:caught-error", { message: n.message }),
+            Ln(n, { step: "bootstrap" }));
+        }
+      }
+      (t.runtime.onMessage.addListener((n) => {
+        const t = n;
+        if ("ANALYSIS_PROGRESS" === t.action) {
+          const { taskId: n, progress: e, message: r } = t.data;
+          return (
+            "analyzing" === zn.state &&
+              ((zn.currentTaskId = n),
+              (function (n, t) {
+                const e = W();
+                if (!e) return;
+                const r = e.querySelector("#ds-progress-bar"),
+                  s = e.querySelector("#ds-progress-text");
+                (r && (r.style.width = `${t}%`), s && (s.textContent = n));
+              })(r, e)),
+            Promise.resolve({ success: !0 })
+          );
+        }
+        return "TOGGLE_WIDGET" === t.action
+          ? (H() ? U() : Pn(), Promise.resolve({ success: !0 }))
+          : "START_ANALYSIS_FROM_COMMAND" === t.action
+            ? ("ready" === zn.state && Rn("standard", "fr"),
+              Promise.resolve({ success: !0 }))
+            : "OPEN_CHAT_FROM_COMMAND" === t.action
+              ? ("results" === zn.state &&
+                  zn.summary &&
+                  Nn(zn.summary.id, zn.summary.video_title),
+                Promise.resolve({ success: !0 }))
+              : void 0;
+      }),
+        window.addEventListener("error", (n) => {
+          n.error && Ln(n.error, { source: "window.onerror" });
+        }),
+        window.addEventListener("unhandledrejection", (n) => {
+          Ln(n.reason, { source: "unhandledrejection" });
+        }),
+        "undefined" != typeof window &&
+          window.addEventListener("online", () => {
+            (In("network:online-retry"),
+              ("login" !== zn.state && "ready" !== zn.state) || Mn());
+          }),
+        "loading" === document.readyState
+          ? document.addEventListener("DOMContentLoaded", Hn)
+          : Hn());
+    })());
+})();

--- a/extension/dist/popup.js
+++ b/extension/dist/popup.js
@@ -1,1 +1,4647 @@
-(()=>{var e={815(e,t){var n,s;"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self&&self,n=function(e){"use strict";if(!(globalThis.chrome&&globalThis.chrome.runtime&&globalThis.chrome.runtime.id))throw new Error("This script should only be loaded in a browser extension.");if(globalThis.browser&&globalThis.browser.runtime&&globalThis.browser.runtime.id)e.exports=globalThis.browser;else{const t="The message port closed before a response was received.",n=e=>{const n={alarms:{clear:{minArgs:0,maxArgs:1},clearAll:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getAll:{minArgs:0,maxArgs:0}},bookmarks:{create:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},getChildren:{minArgs:1,maxArgs:1},getRecent:{minArgs:1,maxArgs:1},getSubTree:{minArgs:1,maxArgs:1},getTree:{minArgs:0,maxArgs:0},move:{minArgs:2,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeTree:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}},browserAction:{disable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},enable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},getBadgeBackgroundColor:{minArgs:1,maxArgs:1},getBadgeText:{minArgs:1,maxArgs:1},getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},openPopup:{minArgs:0,maxArgs:0},setBadgeBackgroundColor:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setBadgeText:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},browsingData:{remove:{minArgs:2,maxArgs:2},removeCache:{minArgs:1,maxArgs:1},removeCookies:{minArgs:1,maxArgs:1},removeDownloads:{minArgs:1,maxArgs:1},removeFormData:{minArgs:1,maxArgs:1},removeHistory:{minArgs:1,maxArgs:1},removeLocalStorage:{minArgs:1,maxArgs:1},removePasswords:{minArgs:1,maxArgs:1},removePluginData:{minArgs:1,maxArgs:1},settings:{minArgs:0,maxArgs:0}},commands:{getAll:{minArgs:0,maxArgs:0}},contextMenus:{remove:{minArgs:1,maxArgs:1},removeAll:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},cookies:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:1,maxArgs:1},getAllCookieStores:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},devtools:{inspectedWindow:{eval:{minArgs:1,maxArgs:2,singleCallbackArg:!1}},panels:{create:{minArgs:3,maxArgs:3,singleCallbackArg:!0},elements:{createSidebarPane:{minArgs:1,maxArgs:1}}}},downloads:{cancel:{minArgs:1,maxArgs:1},download:{minArgs:1,maxArgs:1},erase:{minArgs:1,maxArgs:1},getFileIcon:{minArgs:1,maxArgs:2},open:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},pause:{minArgs:1,maxArgs:1},removeFile:{minArgs:1,maxArgs:1},resume:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},extension:{isAllowedFileSchemeAccess:{minArgs:0,maxArgs:0},isAllowedIncognitoAccess:{minArgs:0,maxArgs:0}},history:{addUrl:{minArgs:1,maxArgs:1},deleteAll:{minArgs:0,maxArgs:0},deleteRange:{minArgs:1,maxArgs:1},deleteUrl:{minArgs:1,maxArgs:1},getVisits:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1}},i18n:{detectLanguage:{minArgs:1,maxArgs:1},getAcceptLanguages:{minArgs:0,maxArgs:0}},identity:{launchWebAuthFlow:{minArgs:1,maxArgs:1}},idle:{queryState:{minArgs:1,maxArgs:1}},management:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},getSelf:{minArgs:0,maxArgs:0},setEnabled:{minArgs:2,maxArgs:2},uninstallSelf:{minArgs:0,maxArgs:1}},notifications:{clear:{minArgs:1,maxArgs:1},create:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:0},getPermissionLevel:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},pageAction:{getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},hide:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},permissions:{contains:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},request:{minArgs:1,maxArgs:1}},runtime:{getBackgroundPage:{minArgs:0,maxArgs:0},getPlatformInfo:{minArgs:0,maxArgs:0},openOptionsPage:{minArgs:0,maxArgs:0},requestUpdateCheck:{minArgs:0,maxArgs:0},sendMessage:{minArgs:1,maxArgs:3},sendNativeMessage:{minArgs:2,maxArgs:2},setUninstallURL:{minArgs:1,maxArgs:1}},sessions:{getDevices:{minArgs:0,maxArgs:1},getRecentlyClosed:{minArgs:0,maxArgs:1},restore:{minArgs:0,maxArgs:1}},storage:{local:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},managed:{get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1}},sync:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}}},tabs:{captureVisibleTab:{minArgs:0,maxArgs:2},create:{minArgs:1,maxArgs:1},detectLanguage:{minArgs:0,maxArgs:1},discard:{minArgs:0,maxArgs:1},duplicate:{minArgs:1,maxArgs:1},executeScript:{minArgs:1,maxArgs:2},get:{minArgs:1,maxArgs:1},getCurrent:{minArgs:0,maxArgs:0},getZoom:{minArgs:0,maxArgs:1},getZoomSettings:{minArgs:0,maxArgs:1},goBack:{minArgs:0,maxArgs:1},goForward:{minArgs:0,maxArgs:1},highlight:{minArgs:1,maxArgs:1},insertCSS:{minArgs:1,maxArgs:2},move:{minArgs:2,maxArgs:2},query:{minArgs:1,maxArgs:1},reload:{minArgs:0,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeCSS:{minArgs:1,maxArgs:2},sendMessage:{minArgs:2,maxArgs:3},setZoom:{minArgs:1,maxArgs:2},setZoomSettings:{minArgs:1,maxArgs:2},update:{minArgs:1,maxArgs:2}},topSites:{get:{minArgs:0,maxArgs:0}},webNavigation:{getAllFrames:{minArgs:1,maxArgs:1},getFrame:{minArgs:1,maxArgs:1}},webRequest:{handlerBehaviorChanged:{minArgs:0,maxArgs:0}},windows:{create:{minArgs:0,maxArgs:1},get:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:1},getCurrent:{minArgs:0,maxArgs:1},getLastFocused:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}}};if(0===Object.keys(n).length)throw new Error("api-metadata.json has not been included in browser-polyfill");class s extends WeakMap{constructor(e,t=void 0){super(t),this.createItem=e}get(e){return this.has(e)||this.set(e,this.createItem(e)),super.get(e)}}const a=(t,n)=>(...s)=>{e.runtime.lastError?t.reject(new Error(e.runtime.lastError.message)):n.singleCallbackArg||s.length<=1&&!1!==n.singleCallbackArg?t.resolve(s[0]):t.resolve(s)},r=e=>1==e?"argument":"arguments",i=(e,t,n)=>new Proxy(t,{apply:(t,s,a)=>n.call(s,e,...a)});let o=Function.call.bind(Object.prototype.hasOwnProperty);const l=(e,t={},n={})=>{let s=Object.create(null),c={has:(t,n)=>n in e||n in s,get(c,d,u){if(d in s)return s[d];if(!(d in e))return;let m=e[d];if("function"==typeof m)if("function"==typeof t[d])m=i(e,e[d],t[d]);else if(o(n,d)){let t=((e,t)=>function(n,...s){if(s.length<t.minArgs)throw new Error(`Expected at least ${t.minArgs} ${r(t.minArgs)} for ${e}(), got ${s.length}`);if(s.length>t.maxArgs)throw new Error(`Expected at most ${t.maxArgs} ${r(t.maxArgs)} for ${e}(), got ${s.length}`);return new Promise((r,i)=>{if(t.fallbackToNoCallback)try{n[e](...s,a({resolve:r,reject:i},t))}catch(a){console.warn(`${e} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,a),n[e](...s),t.fallbackToNoCallback=!1,t.noCallback=!0,r()}else t.noCallback?(n[e](...s),r()):n[e](...s,a({resolve:r,reject:i},t))})})(d,n[d]);m=i(e,e[d],t)}else m=m.bind(e);else if("object"==typeof m&&null!==m&&(o(t,d)||o(n,d)))m=l(m,t[d],n[d]);else{if(!o(n,"*"))return Object.defineProperty(s,d,{configurable:!0,enumerable:!0,get:()=>e[d],set(t){e[d]=t}}),m;m=l(m,t[d],n["*"])}return s[d]=m,m},set:(t,n,a,r)=>(n in s?s[n]=a:e[n]=a,!0),defineProperty:(e,t,n)=>Reflect.defineProperty(s,t,n),deleteProperty:(e,t)=>Reflect.deleteProperty(s,t)},d=Object.create(e);return new Proxy(d,c)},c=e=>({addListener(t,n,...s){t.addListener(e.get(n),...s)},hasListener:(t,n)=>t.hasListener(e.get(n)),removeListener(t,n){t.removeListener(e.get(n))}}),d=new s(e=>"function"!=typeof e?e:function(t){const n=l(t,{},{getContent:{minArgs:0,maxArgs:0}});e(n)}),u=new s(e=>"function"!=typeof e?e:function(t,n,s){let a,r,i=!1,o=new Promise(e=>{a=function(t){i=!0,e(t)}});try{r=e(t,n,a)}catch(e){r=Promise.reject(e)}const l=!0!==r&&((c=r)&&"object"==typeof c&&"function"==typeof c.then);var c;if(!0!==r&&!l&&!i)return!1;return(l?r:o).then(e=>{s(e)},e=>{let t;t=e&&(e instanceof Error||"string"==typeof e.message)?e.message:"An unexpected error occurred",s({__mozWebExtensionPolyfillReject__:!0,message:t})}).catch(e=>{console.error("Failed to send onMessage rejected reply",e)}),!0}),m=({reject:n,resolve:s},a)=>{e.runtime.lastError?e.runtime.lastError.message===t?s():n(new Error(e.runtime.lastError.message)):a&&a.__mozWebExtensionPolyfillReject__?n(new Error(a.message)):s(a)},g=(e,t,n,...s)=>{if(s.length<t.minArgs)throw new Error(`Expected at least ${t.minArgs} ${r(t.minArgs)} for ${e}(), got ${s.length}`);if(s.length>t.maxArgs)throw new Error(`Expected at most ${t.maxArgs} ${r(t.maxArgs)} for ${e}(), got ${s.length}`);return new Promise((e,t)=>{const a=m.bind(null,{resolve:e,reject:t});s.push(a),n.sendMessage(...s)})},p={devtools:{network:{onRequestFinished:c(d)}},runtime:{onMessage:c(u),onMessageExternal:c(u),sendMessage:g.bind(null,"sendMessage",{minArgs:1,maxArgs:3})},tabs:{sendMessage:g.bind(null,"sendMessage",{minArgs:2,maxArgs:3})}},h={clear:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}};return n.privacy={network:{"*":h},services:{"*":h},websites:{"*":h}},l(e,p,n)};e.exports=n(chrome)}},void 0===(s=n.apply(t,[e]))||(e.exports=s)}},t={};function n(s){var a=t[s];if(void 0!==a)return a.exports;var r=t[s]={exports:{}};return e[s].call(r.exports,r,r.exports,n),r.exports}n.n=e=>{var t=e&&e.__esModule?()=>e.default:()=>e;return n.d(t,{a:t}),t},n.d=(e,t)=>{for(var s in t)n.o(t,s)&&!n.o(e,s)&&Object.defineProperty(e,s,{enumerable:!0,get:t[s]})},n.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),(()=>{"use strict";var e,t,s,a,r,i,o,l,c,d,u,m,g,p,h={},_=[],f=/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,y=Array.isArray;function v(e,t){for(var n in t)e[n]=t[n];return e}function b(e){e&&e.parentNode&&e.parentNode.removeChild(e)}function A(t,n,s){var a,r,i,o={};for(i in n)"key"==i?a=n[i]:"ref"==i?r=n[i]:o[i]=n[i];if(arguments.length>2&&(o.children=arguments.length>3?e.call(arguments,2):s),"function"==typeof t&&null!=t.defaultProps)for(i in t.defaultProps)void 0===o[i]&&(o[i]=t.defaultProps[i]);return x(t,o,a,r,null)}function x(e,n,a,r,i){var o={type:e,props:n,key:a,ref:r,__k:null,__:null,__b:0,__e:null,__c:null,constructor:void 0,__v:null==i?++s:i,__i:-1,__u:0};return null==i&&null!=t.vnode&&t.vnode(o),o}function k(e){return e.children}function w(e,t){this.props=e,this.context=t}function N(e,t){if(null==t)return e.__?N(e.__,e.__i+1):null;for(var n;t<e.__k.length;t++)if(null!=(n=e.__k[t])&&null!=n.__e)return n.__e;return"function"==typeof e.type?N(e):null}function C(e){if(e.__P&&e.__d){var n=e.__v,s=n.__e,a=[],r=[],i=v({},n);i.__v=n.__v+1,t.vnode&&t.vnode(i),R(e.__P,i,n,e.__n,e.__P.namespaceURI,32&n.__u?[s]:null,a,null==s?N(n):s,!!(32&n.__u),r),i.__v=n.__v,i.__.__k[i.__i]=i,U(a,i,r),n.__e=n.__=null,i.__e!=s&&S(i)}}function S(e){if(null!=(e=e.__)&&null!=e.__c)return e.__e=e.__c.base=null,e.__k.some(function(t){if(null!=t&&null!=t.__e)return e.__e=e.__c.base=t.__e}),S(e)}function P(e){(!e.__d&&(e.__d=!0)&&a.push(e)&&!z.__r++||r!=t.debounceRendering)&&((r=t.debounceRendering)||i)(z)}function z(){try{for(var e,t=1;a.length;)a.length>t&&a.sort(o),e=a.shift(),t=a.length,C(e)}finally{a.length=z.__r=0}}function M(e,t,n,s,a,r,i,o,l,c,d){var u,m,g,p,f,y,v,b=s&&s.__k||_,A=t.length;for(l=T(n,t,b,l,A),u=0;u<A;u++)null!=(g=n.__k[u])&&(m=-1!=g.__i&&b[g.__i]||h,g.__i=u,y=R(e,g,m,a,r,i,o,l,c,d),p=g.__e,g.ref&&m.ref!=g.ref&&(m.ref&&q(m.ref,null,g),d.push(g.ref,g.__c||p,g)),null==f&&null!=p&&(f=p),(v=!!(4&g.__u))||m.__k===g.__k?(l=E(g,l,e,v),v&&m.__e&&(m.__e=null)):"function"==typeof g.type&&void 0!==y?l=y:p&&(l=p.nextSibling),g.__u&=-7);return n.__e=f,l}function T(e,t,n,s,a){var r,i,o,l,c,d=n.length,u=d,m=0;for(e.__k=new Array(a),r=0;r<a;r++)null!=(i=t[r])&&"boolean"!=typeof i&&"function"!=typeof i?("string"==typeof i||"number"==typeof i||"bigint"==typeof i||i.constructor==String?i=e.__k[r]=x(null,i,null,null,null):y(i)?i=e.__k[r]=x(k,{children:i},null,null,null):void 0===i.constructor&&i.__b>0?i=e.__k[r]=x(i.type,i.props,i.key,i.ref?i.ref:null,i.__v):e.__k[r]=i,l=r+m,i.__=e,i.__b=e.__b+1,o=null,-1!=(c=i.__i=I(i,n,l,u))&&(u--,(o=n[c])&&(o.__u|=2)),null==o||null==o.__v?(-1==c&&(a>d?m--:a<d&&m++),"function"!=typeof i.type&&(i.__u|=4)):c!=l&&(c==l-1?m--:c==l+1?m++:(c>l?m--:m++,i.__u|=4))):e.__k[r]=null;if(u)for(r=0;r<d;r++)null!=(o=n[r])&&!(2&o.__u)&&(o.__e==s&&(s=N(o)),H(o,o));return s}function E(e,t,n,s){var a,r;if("function"==typeof e.type){for(a=e.__k,r=0;a&&r<a.length;r++)a[r]&&(a[r].__=e,t=E(a[r],t,n,s));return t}e.__e!=t&&(s&&(t&&e.type&&!t.parentNode&&(t=N(e)),n.insertBefore(e.__e,t||null)),t=e.__e);do{t=t&&t.nextSibling}while(null!=t&&8==t.nodeType);return t}function $(e,t){return t=t||[],null==e||"boolean"==typeof e||(y(e)?e.some(function(e){$(e,t)}):t.push(e)),t}function I(e,t,n,s){var a,r,i,o=e.key,l=e.type,c=t[n],d=null!=c&&!(2&c.__u);if(null===c&&null==o||d&&o==c.key&&l==c.type)return n;if(s>(d?1:0))for(a=n-1,r=n+1;a>=0||r<t.length;)if(null!=(c=t[i=a>=0?a--:r++])&&!(2&c.__u)&&o==c.key&&l==c.type)return i;return-1}function L(e,t,n){"-"==t[0]?e.setProperty(t,null==n?"":n):e[t]=null==n?"":"number"!=typeof n||f.test(t)?n:n+"px"}function D(e,t,n,s,a){var r,i;e:if("style"==t)if("string"==typeof n)e.style.cssText=n;else{if("string"==typeof s&&(e.style.cssText=s=""),s)for(t in s)n&&t in n||L(e.style,t,"");if(n)for(t in n)s&&n[t]==s[t]||L(e.style,t,n[t])}else if("o"==t[0]&&"n"==t[1])r=t!=(t=t.replace(u,"$1")),i=t.toLowerCase(),t=i in e||"onFocusOut"==t||"onFocusIn"==t?i.slice(2):t.slice(2),e.l||(e.l={}),e.l[t+r]=n,n?s?n[d]=s[d]:(n[d]=m,e.addEventListener(t,r?p:g,r)):e.removeEventListener(t,r?p:g,r);else{if("http://www.w3.org/2000/svg"==a)t=t.replace(/xlink(H|:h)/,"h").replace(/sName$/,"s");else if("width"!=t&&"height"!=t&&"href"!=t&&"list"!=t&&"form"!=t&&"tabIndex"!=t&&"download"!=t&&"rowSpan"!=t&&"colSpan"!=t&&"role"!=t&&"popover"!=t&&t in e)try{e[t]=null==n?"":n;break e}catch(e){}"function"==typeof n||(null==n||!1===n&&"-"!=t[4]?e.removeAttribute(t):e.setAttribute(t,"popover"==t&&1==n?"":n))}}function F(e){return function(n){if(this.l){var s=this.l[n.type+e];if(null==n[c])n[c]=m++;else if(n[c]<s[d])return;return s(t.event?t.event(n):n)}}}function R(e,n,s,a,r,i,o,l,c,d){var u,m,g,p,h,f,A,x,N,C,S,P,z,T,E,$=n.type;if(void 0!==n.constructor)return null;128&s.__u&&(c=!!(32&s.__u),i=[l=n.__e=s.__e]),(u=t.__b)&&u(n);e:if("function"==typeof $)try{if(x=n.props,N=$.prototype&&$.prototype.render,C=(u=$.contextType)&&a[u.__c],S=u?C?C.props.value:u.__:a,s.__c?A=(m=n.__c=s.__c).__=m.__E:(N?n.__c=m=new $(x,S):(n.__c=m=new w(x,S),m.constructor=$,m.render=W),C&&C.sub(m),m.state||(m.state={}),m.__n=a,g=m.__d=!0,m.__h=[],m._sb=[]),N&&null==m.__s&&(m.__s=m.state),N&&null!=$.getDerivedStateFromProps&&(m.__s==m.state&&(m.__s=v({},m.__s)),v(m.__s,$.getDerivedStateFromProps(x,m.__s))),p=m.props,h=m.state,m.__v=n,g)N&&null==$.getDerivedStateFromProps&&null!=m.componentWillMount&&m.componentWillMount(),N&&null!=m.componentDidMount&&m.__h.push(m.componentDidMount);else{if(N&&null==$.getDerivedStateFromProps&&x!==p&&null!=m.componentWillReceiveProps&&m.componentWillReceiveProps(x,S),n.__v==s.__v||!m.__e&&null!=m.shouldComponentUpdate&&!1===m.shouldComponentUpdate(x,m.__s,S)){n.__v!=s.__v&&(m.props=x,m.state=m.__s,m.__d=!1),n.__e=s.__e,n.__k=s.__k,n.__k.some(function(e){e&&(e.__=n)}),_.push.apply(m.__h,m._sb),m._sb=[],m.__h.length&&o.push(m);break e}null!=m.componentWillUpdate&&m.componentWillUpdate(x,m.__s,S),N&&null!=m.componentDidUpdate&&m.__h.push(function(){m.componentDidUpdate(p,h,f)})}if(m.context=S,m.props=x,m.__P=e,m.__e=!1,P=t.__r,z=0,N)m.state=m.__s,m.__d=!1,P&&P(n),u=m.render(m.props,m.state,m.context),_.push.apply(m.__h,m._sb),m._sb=[];else do{m.__d=!1,P&&P(n),u=m.render(m.props,m.state,m.context),m.state=m.__s}while(m.__d&&++z<25);m.state=m.__s,null!=m.getChildContext&&(a=v(v({},a),m.getChildContext())),N&&!g&&null!=m.getSnapshotBeforeUpdate&&(f=m.getSnapshotBeforeUpdate(p,h)),T=null!=u&&u.type===k&&null==u.key?O(u.props.children):u,l=M(e,y(T)?T:[T],n,s,a,r,i,o,l,c,d),m.base=n.__e,n.__u&=-161,m.__h.length&&o.push(m),A&&(m.__E=m.__=null)}catch(e){if(n.__v=null,c||null!=i)if(e.then){for(n.__u|=c?160:128;l&&8==l.nodeType&&l.nextSibling;)l=l.nextSibling;i[i.indexOf(l)]=null,n.__e=l}else{for(E=i.length;E--;)b(i[E]);B(n)}else n.__e=s.__e,n.__k=s.__k,e.then||B(n);t.__e(e,n,s)}else null==i&&n.__v==s.__v?(n.__k=s.__k,n.__e=s.__e):l=n.__e=V(s.__e,n,s,a,r,i,o,c,d);return(u=t.diffed)&&u(n),128&n.__u?void 0:l}function B(e){e&&(e.__c&&(e.__c.__e=!0),e.__k&&e.__k.some(B))}function U(e,n,s){for(var a=0;a<s.length;a++)q(s[a],s[++a],s[++a]);t.__c&&t.__c(n,e),e.some(function(n){try{e=n.__h,n.__h=[],e.some(function(e){e.call(n)})}catch(e){t.__e(e,n.__v)}})}function O(e){return"object"!=typeof e||null==e||e.__b>0?e:y(e)?e.map(O):v({},e)}function V(n,s,a,r,i,o,l,c,d){var u,m,g,p,_,f,v,A=a.props||h,x=s.props,k=s.type;if("svg"==k?i="http://www.w3.org/2000/svg":"math"==k?i="http://www.w3.org/1998/Math/MathML":i||(i="http://www.w3.org/1999/xhtml"),null!=o)for(u=0;u<o.length;u++)if((_=o[u])&&"setAttribute"in _==!!k&&(k?_.localName==k:3==_.nodeType)){n=_,o[u]=null;break}if(null==n){if(null==k)return document.createTextNode(x);n=document.createElementNS(i,k,x.is&&x),c&&(t.__m&&t.__m(s,o),c=!1),o=null}if(null==k)A===x||c&&n.data==x||(n.data=x);else{if(o=o&&e.call(n.childNodes),!c&&null!=o)for(A={},u=0;u<n.attributes.length;u++)A[(_=n.attributes[u]).name]=_.value;for(u in A)_=A[u],"dangerouslySetInnerHTML"==u?g=_:"children"==u||u in x||"value"==u&&"defaultValue"in x||"checked"==u&&"defaultChecked"in x||D(n,u,null,_,i);for(u in x)_=x[u],"children"==u?p=_:"dangerouslySetInnerHTML"==u?m=_:"value"==u?f=_:"checked"==u?v=_:c&&"function"!=typeof _||A[u]===_||D(n,u,_,A[u],i);if(m)c||g&&(m.__html==g.__html||m.__html==n.innerHTML)||(n.innerHTML=m.__html),s.__k=[];else if(g&&(n.innerHTML=""),M("template"==s.type?n.content:n,y(p)?p:[p],s,a,r,"foreignObject"==k?"http://www.w3.org/1999/xhtml":i,o,l,o?o[0]:a.__k&&N(a,0),c,d),null!=o)for(u=o.length;u--;)b(o[u]);c||(u="value","progress"==k&&null==f?n.removeAttribute("value"):null!=f&&(f!==n[u]||"progress"==k&&!f||"option"==k&&f!=A[u])&&D(n,u,f,A[u],i),u="checked",null!=v&&v!=n[u]&&D(n,u,v,A[u],i))}return n}function q(e,n,s){try{if("function"==typeof e){var a="function"==typeof e.__u;a&&e.__u(),a&&null==n||(e.__u=e(n))}else e.current=n}catch(e){t.__e(e,s)}}function H(e,n,s){var a,r;if(t.unmount&&t.unmount(e),(a=e.ref)&&(a.current&&a.current!=e.__e||q(a,null,n)),null!=(a=e.__c)){if(a.componentWillUnmount)try{a.componentWillUnmount()}catch(e){t.__e(e,n)}a.base=a.__P=null}if(a=e.__k)for(r=0;r<a.length;r++)a[r]&&H(a[r],n,s||"function"!=typeof e.type);s||b(e.__e),e.__c=e.__=e.__e=void 0}function W(e,t,n){return this.constructor(e,n)}function j(n,s,a){var r,i,o,l;s==document&&(s=document.documentElement),t.__&&t.__(n,s),i=(r="function"==typeof a)?null:a&&a.__k||s.__k,o=[],l=[],R(s,n=(!r&&a||s).__k=A(k,null,[n]),i||h,h,s.namespaceURI,!r&&a?[a]:i?null:s.firstChild?e.call(s.childNodes):null,o,!r&&a?a:i?i.__e:s.firstChild,r,l),U(o,n,l)}e=_.slice,t={__e:function(e,t,n,s){for(var a,r,i;t=t.__;)if((a=t.__c)&&!a.__)try{if((r=a.constructor)&&null!=r.getDerivedStateFromError&&(a.setState(r.getDerivedStateFromError(e)),i=a.__d),null!=a.componentDidCatch&&(a.componentDidCatch(e,s||{}),i=a.__d),i)return a.__E=a}catch(t){e=t}throw e}},s=0,w.prototype.setState=function(e,t){var n;n=null!=this.__s&&this.__s!=this.state?this.__s:this.__s=v({},this.state),"function"==typeof e&&(e=e(v({},n),this.props)),e&&v(n,e),null!=e&&this.__v&&(t&&this._sb.push(t),P(this))},w.prototype.forceUpdate=function(e){this.__v&&(this.__e=!0,e&&this.__h.push(e),P(this))},w.prototype.render=k,a=[],i="function"==typeof Promise?Promise.prototype.then.bind(Promise.resolve()):setTimeout,o=function(e,t){return e.__v.__b-t.__v.__b},z.__r=0,l=Math.random().toString(8),c="__d"+l,d="__a"+l,u=/(PointerCapture)$|Capture$/i,m=0,g=F(!1),p=F(!0);var G,Y,K,Q,X=0,Z=[],J=t,ee=J.__b,te=J.__r,ne=J.diffed,se=J.__c,ae=J.unmount,re=J.__;function ie(e,t){J.__h&&J.__h(Y,e,X||t),X=0;var n=Y.__H||(Y.__H={__:[],__h:[]});return e>=n.__.length&&n.__.push({}),n.__[e]}function oe(e){return X=1,function(e,t,n){var s=ie(G++,2);if(s.t=e,!s.__c&&(s.__=[n?n(t):ye(void 0,t),function(e){var t=s.__N?s.__N[0]:s.__[0],n=s.t(t,e);t!==n&&(s.__N=[n,s.__[1]],s.__c.setState({}))}],s.__c=Y,!Y.__f)){var a=function(e,t,n){if(!s.__c.__H)return!0;var a=s.__c.__H.__.filter(function(e){return e.__c});if(a.every(function(e){return!e.__N}))return!r||r.call(this,e,t,n);var i=s.__c.props!==e;return a.some(function(e){if(e.__N){var t=e.__[0];e.__=e.__N,e.__N=void 0,t!==e.__[0]&&(i=!0)}}),r&&r.call(this,e,t,n)||i};Y.__f=!0;var r=Y.shouldComponentUpdate,i=Y.componentWillUpdate;Y.componentWillUpdate=function(e,t,n){if(this.__e){var s=r;r=void 0,a(e,t,n),r=s}i&&i.call(this,e,t,n)},Y.shouldComponentUpdate=a}return s.__N||s.__}(ye,e)}function le(e,t){var n=ie(G++,3);!J.__s&&fe(n.__H,t)&&(n.__=e,n.u=t,Y.__H.__h.push(n))}function ce(e){return X=5,de(function(){return{current:e}},[])}function de(e,t){var n=ie(G++,7);return fe(n.__H,t)&&(n.__=e(),n.__H=t,n.__h=e),n.__}function ue(e,t){return X=8,de(function(){return e},t)}function me(){for(var e;e=Z.shift();){var t=e.__H;if(e.__P&&t)try{t.__h.some(he),t.__h.some(_e),t.__h=[]}catch(n){t.__h=[],J.__e(n,e.__v)}}}J.__b=function(e){Y=null,ee&&ee(e)},J.__=function(e,t){e&&t.__k&&t.__k.__m&&(e.__m=t.__k.__m),re&&re(e,t)},J.__r=function(e){te&&te(e),G=0;var t=(Y=e.__c).__H;t&&(K===Y?(t.__h=[],Y.__h=[],t.__.some(function(e){e.__N&&(e.__=e.__N),e.u=e.__N=void 0})):(t.__h.some(he),t.__h.some(_e),t.__h=[],G=0)),K=Y},J.diffed=function(e){ne&&ne(e);var t=e.__c;t&&t.__H&&(t.__H.__h.length&&(1!==Z.push(t)&&Q===J.requestAnimationFrame||((Q=J.requestAnimationFrame)||pe)(me)),t.__H.__.some(function(e){e.u&&(e.__H=e.u),e.u=void 0})),K=Y=null},J.__c=function(e,t){t.some(function(e){try{e.__h.some(he),e.__h=e.__h.filter(function(e){return!e.__||_e(e)})}catch(n){t.some(function(e){e.__h&&(e.__h=[])}),t=[],J.__e(n,e.__v)}}),se&&se(e,t)},J.unmount=function(e){ae&&ae(e);var t,n=e.__c;n&&n.__H&&(n.__H.__.some(function(e){try{he(e)}catch(e){t=e}}),n.__H=void 0,t&&J.__e(t,n.__v))};var ge="function"==typeof requestAnimationFrame;function pe(e){var t,n=function(){clearTimeout(s),ge&&cancelAnimationFrame(t),setTimeout(e)},s=setTimeout(n,35);ge&&(t=requestAnimationFrame(n))}function he(e){var t=Y,n=e.__c;"function"==typeof n&&(e.__c=void 0,n()),Y=t}function _e(e){var t=Y;e.__c=e.__(),Y=t}function fe(e,t){return!e||e.length!==t.length||t.some(function(t,n){return t!==e[n]})}function ye(e,t){return"function"==typeof t?t(e):t}function ve(e,t){for(var n in e)if("__source"!==n&&!(n in t))return!0;for(var s in t)if("__source"!==s&&e[s]!==t[s])return!0;return!1}function be(e,t){this.props=e,this.context=t}(be.prototype=new w).isPureReactComponent=!0,be.prototype.shouldComponentUpdate=function(e,t){return ve(this.props,e)||ve(this.state,t)};var Ae=t.__b;t.__b=function(e){e.type&&e.type.__f&&e.ref&&(e.props.ref=e.ref,e.ref=null),Ae&&Ae(e)},"undefined"!=typeof Symbol&&Symbol.for&&Symbol.for("react.forward_ref");var xe=t.__e;t.__e=function(e,t,n,s){if(e.then)for(var a,r=t;r=r.__;)if((a=r.__c)&&a.__c)return null==t.__e&&(t.__e=n.__e,t.__k=n.__k),a.__c(e,t);xe(e,t,n,s)};var ke=t.unmount;function we(e,t,n){return e&&(e.__c&&e.__c.__H&&(e.__c.__H.__.forEach(function(e){"function"==typeof e.__c&&e.__c()}),e.__c.__H=null),null!=(e=function(e,t){for(var n in t)e[n]=t[n];return e}({},e)).__c&&(e.__c.__P===n&&(e.__c.__P=t),e.__c.__e=!0,e.__c=null),e.__k=e.__k&&e.__k.map(function(e){return we(e,t,n)})),e}function Ne(e,t,n){return e&&n&&(e.__v=null,e.__k=e.__k&&e.__k.map(function(e){return Ne(e,t,n)}),e.__c&&e.__c.__P===t&&(e.__e&&n.appendChild(e.__e),e.__c.__e=!0,e.__c.__P=n)),e}function Ce(){this.__u=0,this.o=null,this.__b=null}function Se(e){var t=e.__&&e.__.__c;return t&&t.__a&&t.__a(e)}function Pe(){this.i=null,this.l=null}t.unmount=function(e){var t=e.__c;t&&(t.__z=!0),t&&t.__R&&t.__R(),t&&32&e.__u&&(e.type=null),ke&&ke(e)},(Ce.prototype=new w).__c=function(e,t){var n=t.__c,s=this;null==s.o&&(s.o=[]),s.o.push(n);var a=Se(s.__v),r=!1,i=function(){r||s.__z||(r=!0,n.__R=null,a?a(l):l())};n.__R=i;var o=n.__P;n.__P=null;var l=function(){if(! --s.__u){if(s.state.__a){var e=s.state.__a;s.__v.__k[0]=Ne(e,e.__c.__P,e.__c.__O)}var t;for(s.setState({__a:s.__b=null});t=s.o.pop();)t.__P=o,t.forceUpdate()}};s.__u++||32&t.__u||s.setState({__a:s.__b=s.__v.__k[0]}),e.then(i,i)},Ce.prototype.componentWillUnmount=function(){this.o=[]},Ce.prototype.render=function(e,t){if(this.__b){if(this.__v.__k){var n=document.createElement("div"),s=this.__v.__k[0].__c;this.__v.__k[0]=we(this.__b,n,s.__O=s.__P)}this.__b=null}var a=t.__a&&A(k,null,e.fallback);return a&&(a.__u&=-33),[A(k,null,t.__a?null:e.children),a]};var ze=function(e,t,n){if(++n[1]===n[0]&&e.l.delete(t),e.props.revealOrder&&("t"!==e.props.revealOrder[0]||!e.l.size))for(n=e.i;n;){for(;n.length>3;)n.pop()();if(n[1]<n[0])break;e.i=n=n[2]}};(Pe.prototype=new w).__a=function(e){var t=this,n=Se(t.__v),s=t.l.get(e);return s[0]++,function(a){var r=function(){t.props.revealOrder?(s.push(a),ze(t,e,s)):a()};n?n(r):r()}},Pe.prototype.render=function(e){this.i=null,this.l=new Map;var t=$(e.children);e.revealOrder&&"b"===e.revealOrder[0]&&t.reverse();for(var n=t.length;n--;)this.l.set(t[n],this.i=[1,0,this.i]);return e.children},Pe.prototype.componentDidUpdate=Pe.prototype.componentDidMount=function(){var e=this;this.l.forEach(function(t,n){ze(e,n,t)})};var Me="undefined"!=typeof Symbol&&Symbol.for&&Symbol.for("react.element")||60103,Te=/^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/,Ee=/^on(Ani|Tra|Tou|BeforeInp|Compo)/,$e=/[A-Z0-9]/g,Ie="undefined"!=typeof document,Le=function(e){return("undefined"!=typeof Symbol&&"symbol"==typeof Symbol()?/fil|che|rad/:/fil|che|ra/).test(e)};w.prototype.isReactComponent=!0,["componentWillMount","componentWillReceiveProps","componentWillUpdate"].forEach(function(e){Object.defineProperty(w.prototype,e,{configurable:!0,get:function(){return this["UNSAFE_"+e]},set:function(t){Object.defineProperty(this,e,{configurable:!0,writable:!0,value:t})}})});var De=t.event;t.event=function(e){return De&&(e=De(e)),e.persist=function(){},e.isPropagationStopped=function(){return this.cancelBubble},e.isDefaultPrevented=function(){return this.defaultPrevented},e.nativeEvent=e};var Fe={configurable:!0,get:function(){return this.class}},Re=t.vnode;t.vnode=function(e){"string"==typeof e.type&&function(e){var t=e.props,n=e.type,s={},a=-1==n.indexOf("-");for(var r in t){var i=t[r];if(!("value"===r&&"defaultValue"in t&&null==i||Ie&&"children"===r&&"noscript"===n||"class"===r||"className"===r)){var o=r.toLowerCase();"defaultValue"===r&&"value"in t&&null==t.value?r="value":"download"===r&&!0===i?i="":"translate"===o&&"no"===i?i=!1:"o"===o[0]&&"n"===o[1]?"ondoubleclick"===o?r="ondblclick":"onchange"!==o||"input"!==n&&"textarea"!==n||Le(t.type)?"onfocus"===o?r="onfocusin":"onblur"===o?r="onfocusout":Ee.test(r)&&(r=o):o=r="oninput":a&&Te.test(r)?r=r.replace($e,"-$&").toLowerCase():null===i&&(i=void 0),"oninput"===o&&s[r=o]&&(r="oninputCapture"),s[r]=i}}"select"==n&&(s.multiple&&Array.isArray(s.value)&&(s.value=$(t.children).forEach(function(e){e.props.selected=-1!=s.value.indexOf(e.props.value)})),null!=s.defaultValue&&(s.value=$(t.children).forEach(function(e){e.props.selected=s.multiple?-1!=s.defaultValue.indexOf(e.props.value):s.defaultValue==e.props.value}))),t.class&&!t.className?(s.class=t.class,Object.defineProperty(s,"className",Fe)):t.className&&(s.class=s.className=t.className),e.props=s}(e),e.$$typeof=Me,Re&&Re(e)};var Be=t.__r;t.__r=function(e){Be&&Be(e),e.__c};var Ue=t.diffed;t.diffed=function(e){Ue&&Ue(e);var t=e.props,n=e.__e;null!=n&&"textarea"===e.type&&"value"in t&&t.value!==n.value&&(n.value=null==t.value?"":t.value)};var Oe=0;function Ve(e,n,s,a,r,i){n||(n={});var o,l,c=n;if("ref"in c)for(l in c={},n)"ref"==l?o=n[l]:c[l]=n[l];var d={type:e,props:c,key:s,ref:o,__k:null,__:null,__b:0,__e:null,__c:null,constructor:void 0,__v:--Oe,__i:-1,__u:0,__source:r,__self:i};if("function"==typeof e&&(o=e.defaultProps))for(l in o)void 0===c[l]&&(c[l]=o[l]);return t.vnode&&t.vnode(d),d}Array.isArray;var qe=n(815);const He=n.n(qe)(),We=({size:e=20,className:t})=>Ve("svg",{width:e,height:e,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeLinejoin:"round",className:t,children:Ve("path",{d:"M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"})}),je=({size:e=20,className:t})=>Ve("svg",{width:e,height:e,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeLinejoin:"round",className:t,children:[Ve("line",{x1:"22",y1:"2",x2:"11",y2:"13"}),Ve("polygon",{points:"22 2 15 22 11 13 2 9 22 2"})]}),Ge=({size:e=20,className:t})=>Ve("svg",{width:e,height:e,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeLinejoin:"round",className:t,children:[Ve("line",{x1:"19",y1:"12",x2:"5",y2:"12"}),Ve("polyline",{points:"12 19 5 12 12 5"})]}),Ye=({size:e=20,className:t})=>Ve("svg",{width:e,height:e,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeLinejoin:"round",className:t,children:[Ve("path",{d:"M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"}),Ve("polyline",{points:"16 17 21 12 16 7"}),Ve("line",{x1:"21",y1:"12",x2:"9",y2:"12"})]}),Ke=({size:e=20,className:t})=>Ve("svg",{width:e,height:e,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeLinejoin:"round",className:t,children:[Ve("path",{d:"M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"}),Ve("polyline",{points:"15 3 21 3 21 9"}),Ve("line",{x1:"10",y1:"14",x2:"21",y2:"3"})]}),Qe=({size:e=16,className:t})=>Ve("svg",{width:e,height:e,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeLinejoin:"round",className:t,children:Ve("polyline",{points:"6 9 12 15 18 9"})}),Xe=({size:e=16,className:t})=>Ve("svg",{width:e,height:e,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeLinejoin:"round",className:t,children:Ve("polyline",{points:"18 15 12 9 6 15"})}),Ze=({size:e=20,className:t})=>Ve("svg",{width:e,height:e,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeLinejoin:"round",className:t,children:[Ve("circle",{cx:"18",cy:"5",r:"3"}),Ve("circle",{cx:"6",cy:"12",r:"3"}),Ve("circle",{cx:"18",cy:"19",r:"3"}),Ve("line",{x1:"8.59",y1:"13.51",x2:"15.42",y2:"17.49"}),Ve("line",{x1:"15.41",y1:"6.51",x2:"8.59",y2:"10.49"})]}),Je=()=>Ve("svg",{width:"18",height:"18",viewBox:"0 0 24 24",children:[Ve("path",{fill:"#4285F4",d:"M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"}),Ve("path",{fill:"#34A853",d:"M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"}),Ve("path",{fill:"#FBBC05",d:"M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"}),Ve("path",{fill:"#EA4335",d:"M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"})]}),et={play:"M5 3l14 9-14 9V3z",camera:"M23 7l-7 5 7 5V7zM14 5H3a2 2 0 00-2 2v10a2 2 0 002 2h11a2 2 0 002-2V7a2 2 0 00-2-2z",headphones:"M3 18v-6a9 9 0 0118 0v6",youtube:"M22.54 6.42A2.78 2.78 0 0020.6 4.42C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 00-1.94 2A29 29 0 001 11.75a29 29 0 00.46 5.33A2.78 2.78 0 003.4 19c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 001.94-2 29 29 0 00.46-5.25 29 29 0 00-.46-5.33z",waveform:"M2 12c2-3 4-3 6 0s4 3 6 0 4-3 6 0",book:"M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2zm20 0h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z",lightbulb:"M9 18h6M10 22h4M12 2a6 6 0 00-6 6c0 2 1 3.5 2.5 5 .5.5 1 1.5 1 2.5V17h5v-1.5c0-1 .5-2 1-2.5 1.5-1.5 2.5-3 2.5-5a6 6 0 00-6-6z",brain:"M12 4c-2 0-3.5 1-4 2.5-.5-1-2-1.5-3-.5S3.5 8 4 9c-1 .5-1.5 2-.5 3s2 1.5 3 1c.5 1.5 2 2.5 4 2.5s3.5-1 4-2.5c1 .5 2 0 3-1s.5-2.5-.5-3c.5-1 0-2.5-1-3.5s-2.5 0-3 .5C15.5 5 14 4 12 4z",graduation:"M22 10l-10-5L2 10l10 5zm-16 2v5c0 2 2.7 3 6 3s6-1 6-3v-5",sparkles:"M12 3v2m0 14v2m9-9h-2M5 12H3m15.4-6.4l-1.4 1.4M7 17l-1.4 1.4m12.8 0L17 17M7 7L5.6 5.6",lightning:"M13 2L3 14h9l-1 8 10-12h-9z",robot:"M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1v1a2 2 0 01-2 2H5a2 2 0 01-2-2v-1H2a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2z",search:"M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z",globe:"M12 2a10 10 0 100 20 10 10 0 000-20zM2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z",star:"M12 2l2.4 7.4h7.6l-6 4.6 2.4 7.4-6.4-4.8-6.4 4.8 2.4-7.4-6-4.6h7.6z",heart:"M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z",sparkle4pt:"M12 2l1.5 4.5L18 8l-4.5 1.5L12 14l-1.5-4.5L6 8l4.5-1.5z",crown:"M2 17l3-7 4 4 3-9 3 9 4-4 3 7z",diamond:"M12 2l10 10-10 10L2 12z",code:"M16 18l6-6-6-6M8 6l-6 6 6 6",shield:"M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"},tt=Object.values(et),nt=({name:e,size:t=24,color:n="currentColor",strokeWidth:s=1.5,className:a="",style:r})=>{const i=et[e];return i?Ve("svg",{width:t,height:t,viewBox:"0 0 24 24",fill:"none",stroke:n,strokeWidth:s,strokeLinecap:"round",strokeLinejoin:"round",className:`doodle-icon ${a}`,style:r,"aria-hidden":"true",children:Ve("path",{d:i})}):null},st={xs:{container:24,wheel:22},sm:{container:40,wheel:36},md:{container:64,wheel:58},lg:{container:96,wheel:88}},at={slow:8,normal:5,fast:2},rt=[{src:"platforms/youtube-icon-red.png",alt:"YouTube",size:18,position:{top:-8,left:"50%"},delay:0},{src:"platforms/tiktok-note-white.png",alt:"TikTok",size:16,position:{top:"50%",right:-8},delay:.5},{src:"platforms/mistral-m-orange.svg",alt:"Mistral",size:16,position:{bottom:-8,left:"50%"},delay:1},{src:"platforms/tournesol-logo.png",alt:"Tournesol",size:16,position:{top:"50%",left:-8},delay:1.5}],it=({size:e="md",className:t="",label:n="Chargement...",showLabel:s=!1,speed:a="normal",showLogos:r=!1})=>{const{container:i,wheel:o}=st[e],l=at[a],c=i>=36,d=r&&i>=64,u=He.runtime.getURL("assets/spinner-cosmic.jpg"),m=He.runtime.getURL("assets/spinner-wheel.jpg"),g=d?i+40:i;return Ve("div",{className:`ds-spinner-wrapper ${t}`,role:"status","aria-label":n,style:{display:"inline-flex",flexDirection:"column",alignItems:"center",justifyContent:"center",gap:8},children:[Ve("div",{style:{position:"relative",display:"flex",alignItems:"center",justifyContent:"center",width:g,height:g},children:[d&&rt.map((e,t)=>{const n=He.runtime.getURL(e.src),s=g/2,a=g/2,r=i/2+14,o=(90*t-90)*(Math.PI/180),l=s+Math.cos(o)*r-e.size/2,c=a+Math.sin(o)*r-e.size/2;return Ve("img",{src:n,alt:e.alt,style:{position:"absolute",width:e.size,height:e.size,left:l,top:c,objectFit:"contain",zIndex:20,filter:"drop-shadow(0 0 6px rgba(200,144,58,0.4))",animation:`logoPulse 3s ease-in-out ${e.delay}s infinite`}},e.alt)}),c&&Ve("img",{src:u,alt:"","aria-hidden":"true",style:{position:"absolute",width:i,height:i,left:d?20:0,top:d?20:0,objectFit:"cover",maskImage:"radial-gradient(circle at center, transparent 0%, transparent 38%, rgba(0,0,0,0.4) 45%, black 52%, black 100%)",WebkitMaskImage:"radial-gradient(circle at center, transparent 0%, transparent 38%, rgba(0,0,0,0.4) 45%, black 52%, black 100%)",zIndex:1,mixBlendMode:"screen",borderRadius:"50%",animation:"colorCycle 12s ease-in-out infinite"}}),Ve("img",{src:m,alt:"","aria-hidden":"true",style:{width:o,height:o,position:"relative",zIndex:10,mixBlendMode:"screen",opacity:.85,filter:"brightness(1.2) contrast(1.25) saturate(1.1)",animation:`gouvernailSpin ${l}s linear infinite`,willChange:"transform"}})]}),s&&Ve("span",{style:{fontSize:13,color:"var(--text-tertiary)",animation:"glowPulse 2s ease-in-out infinite"},children:n}),Ve("span",{style:{position:"absolute",width:1,height:1,padding:0,margin:-1,overflow:"hidden",clip:"rect(0,0,0,0)",border:0},children:n})]})},ot={fr:JSON.parse('{"common":{"login":"Se connecter","logout":"Déconnexion","back":"Retour","retry":"Réessayer","send":"Envoyer","hide":"Masquer","error":"Erreur","viewPlans":"Voir les plans","allPlans":"Tous les plans","createAccount":"Créer un compte","unlock":"Débloquer","analyses":"analyses","credits":"crédits"},"login":{"tagline":"Ne subissez plus vos vidéos — interrogez-les.","badgeFr":"IA Française","badgeEu":"Données en Europe","googleLoading":"Connexion Google...","googleButton":"Continuer avec Google","divider":"ou","emailPlaceholder":"Adresse e-mail","passwordPlaceholder":"Mot de passe","loginLoading":"Connexion...","guestButton":"Essayer sans compte (3 analyses gratuites)","privacy":"Confidentialité","terms":"CGU"},"plans":{"free":"Gratuit","pro":"Pro","expert":"Expert","etudiant":"Pro","student":"Pro","starter":"Pro","equipe":"Expert","team":"Expert"},"upsell":{"free":{"label":"Pro","feature":"30 analyses + Cartes mentales + Web Search","price":"5,99€"},"pro":{"label":"Expert","feature":"100 analyses + Mistral Large + Playlists 20 vidéos","price":"14,99€"}},"analysis":{"noVideo":"Ouvre une vidéo YouTube ou TikTok pour l\'analyser","analyzeButton":"Analyser cette vidéo","starting":"Démarrage de l\'analyse...","processing":"Traitement en cours...","failed":"Analyse échouée","startFailed":"Impossible de démarrer l\'analyse","recent":"Analyses récentes","quotaExceeded":"Quota atteint","quotaExceededText":"Passez au plan supérieur","mode":"Mode","language":"Langue","quickChatButton":"Quick Chat IA","quickChatPreparing":"Préparation du chat...","modes":{"standard":"Standard","accessible":"Accessible","expert":"Expert"},"languages":{"fr":"Français","en":"English","es":"Español","de":"Deutsch"}},"guest":{"banner":"Mode découverte — 3 analyses gratuites sans compte","exhaustedText":"Créez un compte gratuit pour sauvegarder vos analyses et en faire plus"},"credits":{"critical":"Plus que {count} crédits —","recharge":"Recharger","remaining":"{count} crédits restants","low":"cr."},"mistral":{"badge":"Propulsé par Mistral AI"},"synthesis":{"complete":"Analyse complète","fullAnalysis":"Analyse complète","chat":"Chat","share":"Partager","showDetail":"Voir l\'analyse détaillée","hideDetail":"Masquer l\'analyse détaillée","printPdf":"Imprimer / PDF","reliable":"Fiable","toVerify":"À vérifier","unreliable":"Peu fiable","generatingDef":"Définition en cours de génération...","shareTitle":"Synthèse DeepSight","verdict":"Verdict","keyPoints":"Points Clés","concepts":"Concepts","tags":"Tags","generatedBy":"Généré par","analysisDesc":"Analyse IA de vidéos YouTube & TikTok","euBadge":"IA 100% Européenne propulsée par Mistral AI"},"features":{"flashcards":"Flashcards","flashcardsDesc":"Révisez avec des cartes mémoire générées par l\'IA","mindMaps":"Cartes mentales","mindMapsDesc":"Visualisez les idées clés sous forme de carte","webSearch":"Recherche web","webSearchDesc":"Enrichissez l\'analyse avec des sources externes","exports":"Exports","exportsDesc":"Téléchargez en PDF, DOCX ou Markdown","playlists":"Playlists","playlistsDesc":"Analysez des playlists entières en un clic","mobileDesc":"Accédez à DeepSight sur mobile","fromPrice":"dès {price}"},"chat":{"welcome":"Pose une question sur cette vidéo.","sessionExpired":"Session expirée","reconnect":"Se reconnecter","webSearchEnable":"Activer recherche web","webSearchDisable":"Désactiver recherche web","webSearchLocked":"Recherche web — plan payant requis","inputPlaceholder":"Pose une question...","expiredPlaceholder":"Session expirée...","webEnriched":"Enrichi par le web","unavailable":"Réponse indisponible","suggestions":["Quels sont les points clés ?","Résume en 3 phrases","Y a-t-il des biais ?","Quelles sources sont citées ?"]},"widget":{"analyze":"Analyser cette vidéo","quickChat":"Quick Chat IA","back":"← Retour","minimize":"Réduire","expand":"Agrandir","analyzing":"Analyse en cours...","analysisComplete":"Analyse complète","reliability":"Fiabilité","verdict":"Verdict","keyPoints":"Points clés","seeDetail":"Voir l\'analyse détaillée","hideDetail":"Masquer","chatWith":"Chatter avec la vidéo","openFull":"Analyse complète sur DeepSight","copy":"Copier","share":"Partager","copied":"Copié!","tournesolScore":"Score Tournesol"},"panel":{"synthesis":"Synthèse","chat":"Chat","factcheck":"Faits","tournesol":"Tournesol","study":"Étude","noVideo":"Aucune vidéo détectée","noVideoSub":"Naviguez sur YouTube ou TikTok pour analyser une vidéo.","notAnalyzed":"Vidéo non analysée","notAnalyzedSub":"Lancez l\'analyse depuis le widget YouTube.","loading":"Chargement..."},"bridge":{"title":"Retrouvez cette analyse sur","web":"Application Web","ios":"App iOS","android":"App Android","upgrade":"Passer Pro"},"teaser":{"unlockMore":"Débloquez plus","flashcards":"Flashcards IA","mindmap":"Carte mentale","webSearch":"Recherche web IA","export":"Export PDF/DOCX","playlists":"Playlists entières","seeAllPlans":"Voir tous les plans →","reviewMobile":"Révisez vos flashcards sur mobile","downloadApp":"Télécharger l\'app"},"ytRecommend":{"title":"Essayez DeepSight sur YouTube !","subtitle":"Naviguez vers une vidéo pour l\'analyser avec l\'IA","dismiss":"Fermer"},"onboarding":{"welcome":"Bienvenue sur DeepSight !","step1":"Ouvrez une vidéo YouTube","step2":"Cliquez sur \'Analyser\'","step3":"Lisez la synthèse IA","shortcuts":"Raccourcis clavier","shortcutWidget":"Alt+D — Toggle widget","shortcutAnalyze":"Alt+A — Analyser","shortcutChat":"Alt+C — Chat","shortcutPanel":"Alt+S — Side Panel"},"results":{"backToAnalysis":"Nouvelle analyse"},"promos":{"free":[{"text":"30 analyses/mois + Cartes mentales + Web Search — dès 5,99€/mois","cta":"Passer à Pro"},{"text":"Seulement 5 analyses/mois ? Passez à 30 avec Pro","cta":"Upgrade →"},{"text":"Quota limité ? Débloquez 30 analyses et toutes les fonctionnalités Pro","cta":"Voir les plans"}],"pro":[{"text":"100 analyses/mois + Mistral Large + Playlists 20 vidéos — Expert","cta":"Passer à Expert"},{"text":"DeepSight sur mobile — révisez vos flashcards partout","cta":"Télécharger"}],"expert":[{"text":"Gérez vos playlists et exports sur deepsightsynthesis.com","cta":"Ouvrir"}]}}'),en:JSON.parse('{"common":{"login":"Log in","logout":"Log out","back":"Back","retry":"Retry","send":"Send","hide":"Hide","error":"Error","viewPlans":"View plans","allPlans":"All plans","createAccount":"Create account","unlock":"Unlock","analyses":"analyses","credits":"credits"},"login":{"tagline":"Stop enduring your videos — question them.","badgeFr":"French AI","badgeEu":"Data in Europe","googleLoading":"Google login...","googleButton":"Continue with Google","divider":"or","emailPlaceholder":"Email address","passwordPlaceholder":"Password","loginLoading":"Logging in...","guestButton":"Try without an account (3 free analyses)","privacy":"Privacy","terms":"Terms"},"plans":{"free":"Free","pro":"Pro","expert":"Expert","etudiant":"Pro","student":"Pro","starter":"Pro","equipe":"Expert","team":"Expert"},"upsell":{"free":{"label":"Pro","feature":"30 analyses + Mind maps + Web Search","price":"€5.99"},"pro":{"label":"Expert","feature":"100 analyses + Mistral Large + 20-video playlists","price":"€14.99"}},"analysis":{"noVideo":"Open a YouTube or TikTok video to analyze it","analyzeButton":"Analyze this video","starting":"Starting analysis...","processing":"Processing...","failed":"Analysis failed","startFailed":"Could not start analysis","recent":"Recent analyses","quotaExceeded":"Quota reached","quotaExceededText":"Upgrade to a higher plan","mode":"Mode","language":"Language","quickChatButton":"Quick AI Chat","quickChatPreparing":"Preparing chat...","modes":{"standard":"Standard","accessible":"Accessible","expert":"Expert"},"languages":{"fr":"Français","en":"English","es":"Español","de":"Deutsch"}},"guest":{"banner":"Discovery mode — 3 free analyses without an account","exhaustedText":"Create a free account to save your analyses and do more"},"credits":{"critical":"Only {count} credits left —","recharge":"Top up","remaining":"{count} credits remaining","low":"cr."},"mistral":{"badge":"Powered by Mistral AI"},"synthesis":{"complete":"Analysis complete","fullAnalysis":"Full analysis","chat":"Chat","share":"Share","showDetail":"Show detailed analysis","hideDetail":"Hide detailed analysis","printPdf":"Print / PDF","reliable":"Reliable","toVerify":"To verify","unreliable":"Unreliable","generatingDef":"Generating definition...","shareTitle":"DeepSight Synthesis","verdict":"Verdict","keyPoints":"Key Points","concepts":"Concepts","tags":"Tags","generatedBy":"Generated by","analysisDesc":"AI analysis of YouTube & TikTok videos","euBadge":"100% European AI powered by Mistral AI"},"features":{"flashcards":"Flashcards","flashcardsDesc":"Study with AI-generated memory cards","mindMaps":"Mind maps","mindMapsDesc":"Visualize key ideas as a mind map","webSearch":"Web search","webSearchDesc":"Enrich analysis with external sources","exports":"Exports","exportsDesc":"Download as PDF, DOCX or Markdown","playlists":"Playlists","playlistsDesc":"Analyze entire playlists in one click","mobileDesc":"Access DeepSight on mobile","fromPrice":"from {price}"},"chat":{"welcome":"Ask a question about this video.","sessionExpired":"Session expired","reconnect":"Reconnect","webSearchEnable":"Enable web search","webSearchDisable":"Disable web search","webSearchLocked":"Web search — paid plan required","inputPlaceholder":"Ask a question...","expiredPlaceholder":"Session expired...","webEnriched":"Enriched by the web","unavailable":"Response unavailable","suggestions":["What are the key points?","Summarize in 3 sentences","Are there any biases?","What sources are cited?"]},"widget":{"analyze":"Analyze this video","quickChat":"Quick AI Chat","back":"← Back","minimize":"Minimize","expand":"Expand","analyzing":"Analyzing...","analysisComplete":"Analysis complete","reliability":"Reliability","verdict":"Verdict","keyPoints":"Key points","seeDetail":"See detailed analysis","hideDetail":"Hide","chatWith":"Chat with this video","openFull":"Full analysis on DeepSight","copy":"Copy","share":"Share","copied":"Copied!","tournesolScore":"Tournesol score"},"panel":{"synthesis":"Analysis","chat":"Chat","factcheck":"Facts","tournesol":"Tournesol","study":"Study","noVideo":"No video detected","noVideoSub":"Go to YouTube or TikTok to analyze a video.","notAnalyzed":"Video not yet analyzed","notAnalyzedSub":"Launch analysis from the YouTube widget.","loading":"Loading..."},"bridge":{"title":"Find this analysis on","web":"Web App","ios":"iOS App","android":"Android App","upgrade":"Go Pro"},"teaser":{"unlockMore":"Unlock more","flashcards":"AI Flashcards","mindmap":"Mind map","webSearch":"AI Web search","export":"PDF/DOCX Export","playlists":"Full playlists","seeAllPlans":"See all plans →","reviewMobile":"Study flashcards on mobile","downloadApp":"Download the app"},"ytRecommend":{"title":"Try DeepSight on YouTube!","subtitle":"Navigate to a video to analyze it with AI","dismiss":"Close"},"onboarding":{"welcome":"Welcome to DeepSight!","step1":"Open a YouTube video","step2":"Click \'Analyze\'","step3":"Read the AI synthesis","shortcuts":"Keyboard shortcuts","shortcutWidget":"Alt+D — Toggle widget","shortcutAnalyze":"Alt+A — Analyze","shortcutChat":"Alt+C — Chat","shortcutPanel":"Alt+S — Side Panel"},"results":{"backToAnalysis":"New analysis"},"promos":{"free":[{"text":"30 analyses/month + Mind maps + Web Search — from €5.99/mo","cta":"Upgrade to Pro"},{"text":"Only 5 analyses/month? Get 30 with Pro","cta":"Upgrade →"},{"text":"Limited quota? Unlock 30 analyses and all Pro features","cta":"View plans"}],"pro":[{"text":"100 analyses/month + Mistral Large + 20-video playlists — Expert","cta":"Upgrade to Expert"},{"text":"DeepSight on mobile — study your flashcards anywhere","cta":"Download"}],"expert":[{"text":"Manage your playlists and exports on deepsightsynthesis.com","cta":"Open"}]}}')},lt="ds_language";function ct(){const[e,t]=oe("fr");le(()=>{He.storage.sync.get([lt]).then(e=>{const n=e[lt];"en"!==n&&"fr"!==n||t(n)})},[]);const n=ue(e=>{t(e),He.storage.sync.set({[lt]:e})},[]);return{t:ot[e],language:e,setLanguage:n}}const dt=({onLogin:e,onGoogleLogin:t,onGuestMode:n,error:s})=>{const{t:a,language:r,setLanguage:i}=ct(),[o,l]=oe(""),[c,d]=oe(""),[u,m]=oe(!1),[g,p]=oe(!1),[h,_]=oe(null),f=h||s;return Ve("div",{className:"login-view",children:[Ve(nt,{name:"sparkles",size:32,className:"doodle-decoration",style:{top:20,left:16,transform:"rotate(-15deg)"}}),Ve(nt,{name:"brain",size:28,className:"doodle-decoration",style:{top:60,right:20,transform:"rotate(10deg)"}}),Ve(nt,{name:"lightning",size:24,className:"doodle-decoration",style:{bottom:80,left:24,transform:"rotate(-25deg)"}}),Ve(nt,{name:"star",size:20,className:"doodle-decoration",style:{bottom:120,right:30,transform:"rotate(20deg)"}}),Ve("div",{className:"login-lang-toggle",children:[Ve("button",{className:"login-lang-btn "+("fr"===r?"login-lang-active":""),onClick:()=>i("fr"),children:"FR"}),Ve("button",{className:"login-lang-btn "+("en"===r?"login-lang-active":""),onClick:()=>i("en"),children:"EN"})]}),Ve("div",{className:"login-hero",children:Ve(it,{size:"lg",speed:"slow",showLogos:!0})}),Ve("div",{className:"login-logo",children:Ve("h1",{children:"DeepSight"})}),Ve("p",{className:"login-tagline",children:a.login.tagline}),Ve("div",{className:"login-platforms",children:[Ve("img",{src:He.runtime.getURL("platforms/youtube-icon-red.png"),alt:"YouTube",className:"login-platform-logo",style:{height:20,width:"auto"}}),Ve("span",{className:"login-platform-sep"}),Ve("img",{src:He.runtime.getURL("platforms/tiktok-note-white.png"),alt:"TikTok",className:"login-platform-logo",style:{height:18,width:"auto"}}),Ve("span",{className:"login-platform-sep"}),Ve("img",{src:He.runtime.getURL("platforms/mistral-m-orange.svg"),alt:"Mistral",className:"login-platform-logo",style:{height:18,width:"auto"}}),Ve("span",{className:"login-platform-sep"}),Ve("img",{src:He.runtime.getURL("platforms/tournesol-logo.png"),alt:"Tournesol",className:"login-platform-logo",style:{height:16,width:"auto"}})]}),Ve("div",{className:"login-badges",children:[Ve("span",{className:"login-badge",children:[Ve("span",{className:"login-badge-flag",children:"🇫🇷"})," ",a.login.badgeFr]}),Ve("span",{className:"login-badge",children:[Ve("span",{className:"login-badge-flag",children:"🇪🇺"})," ",a.login.badgeEu]})]}),Ve("button",{className:"btn-google",onClick:async function(){p(!0),_(null);try{await t()}catch(e){_(e.message)}finally{p(!1)}},disabled:g||u,children:g?a.login.googleLoading:Ve(k,{children:[Ve(Je,{})," ",a.login.googleButton]})}),Ve("div",{className:"login-divider",children:a.login.divider}),Ve("form",{className:"login-form",onSubmit:async function(t){if(t.preventDefault(),o&&c){m(!0),_(null);try{await e(o,c)}catch(e){_(e.message)}finally{m(!1)}}},children:[Ve("input",{type:"email",placeholder:a.login.emailPlaceholder,value:o,onChange:e=>l(e.target.value),required:!0,disabled:u}),Ve("input",{type:"password",placeholder:a.login.passwordPlaceholder,value:c,onChange:e=>d(e.target.value),required:!0,disabled:u}),f&&Ve("div",{className:"login-error",children:f}),Ve("button",{type:"submit",className:"btn-login",disabled:u||!o||!c,children:u?a.login.loginLoading:a.common.login})]}),Ve("button",{className:"btn-guest",onClick:n,children:a.login.guestButton}),Ve("div",{className:"login-footer",children:[Ve("a",{href:"https://www.deepsightsynthesis.com/register",target:"_blank",rel:"noreferrer",children:a.common.createAccount}),Ve("span",{children:"·"}),Ve("a",{href:"https://www.deepsightsynthesis.com",target:"_blank",rel:"noreferrer",children:"deepsightsynthesis.com"})]}),Ve("div",{className:"login-legal",children:[Ve("a",{href:"https://www.deepsightsynthesis.com/legal/privacy",target:"_blank",rel:"noreferrer",children:a.login.privacy}),Ve("span",{children:"·"}),Ve("a",{href:"https://www.deepsightsynthesis.com/legal/cgu",target:"_blank",rel:"noreferrer",children:a.login.terms})]})]})},ut=[/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?\s]+)/,/youtube\.com\/shorts\/([^&?\s]+)/],mt=[/tiktok\.com\/@[\w.-]+\/video\/(\d+)/i,/vm\.tiktok\.com\/([\w-]+)/i,/m\.tiktok\.com\/v\/(\d+)/i,/tiktok\.com\/t\/([\w-]+)/i,/tiktok\.com\/video\/(\d+)/i];function gt(e){return function(e){return ut.some(t=>t.test(e))}(e)?"youtube":function(e){return mt.some(t=>t.test(e))}(e)?"tiktok":null}async function pt(){return(await He.storage.local.get(["recentAnalyses"])).recentAnalyses||[]}async function ht(){return(await He.storage.local.get(["deepsight_free_analyses"])).deepsight_free_analyses||0}const _t="https://www.deepsightsynthesis.com",ft={tech:"💻",science:"🔬",education:"📚",news:"📰",entertainment:"🎬",gaming:"🎮",music:"🎵",sports:"⚽",business:"💼",lifestyle:"🌟",other:"📋"};function yt(e){const t=document.createElement("div");return t.textContent=e,t.innerHTML}function vt(e){const t=e.split("\n"),n=[];let s=!1,a=!1;for(let e=0;e<t.length;e++){let r=t[e];if(/^-{3,}$/.test(r.trim())||/^\*{3,}$/.test(r.trim())){s&&(n.push("</ul>"),s=!1),a&&(n.push("</ol>"),a=!1),n.push('<hr class="ds-md-hr">');continue}const i=r.match(/^(#{1,4})\s+(.+)$/);if(i){s&&(n.push("</ul>"),s=!1),a&&(n.push("</ol>"),a=!1);const e=i[1].length,t=i[2],r=e<=2?At(t):"",o=xt(t),l=r?`${r}&nbsp;&nbsp;`:"";n.push(`<h${e} class="ds-md-h${e}">${l}${o}</h${e}>`);continue}if(r.startsWith("&gt; ")||"&gt;"===r){s&&(n.push("</ul>"),s=!1),a&&(n.push("</ol>"),a=!1);const e=xt(r.replace(/^&gt;\s?/,""));n.push(`<blockquote class="ds-md-blockquote">${e}</blockquote>`);continue}const o=r.match(/^(\s*)[-*]\s+(.+)$/);if(o){a&&(n.push("</ol>"),a=!1),s||(n.push('<ul class="ds-md-ul">'),s=!0),n.push(`<li>${xt(o[2])}</li>`);continue}const l=r.match(/^(\s*)\d+\.\s+(.+)$/);l?(s&&(n.push("</ul>"),s=!1),a||(n.push('<ol class="ds-md-ol">'),a=!0),n.push(`<li>${xt(l[2])}</li>`)):(s&&(n.push("</ul>"),s=!1),a&&(n.push("</ol>"),a=!1),""!==r.trim()?n.push(`<p class="ds-md-p">${xt(r)}</p>`):n.push('<div class="ds-md-spacer"></div>'))}return s&&n.push("</ul>"),a&&n.push("</ol>"),n.join("\n")}const bt={résumé:"📝",summary:"📝",synthèse:"📝",introduction:"🎬",contexte:"🌍",context:"🌍",analyse:"🔬",analysis:"🔬","points clés":"🎯","key points":"🎯","points forts":"💪",strengths:"💪","points faibles":"⚠️",weaknesses:"⚠️",limites:"⚠️",conclusion:"🏁",recommandations:"💡",recommendations:"💡",sources:"📚",références:"📚",references:"📚","fact-check":"🔍",vérification:"🔍",arguments:"⚖️",méthodologie:"🧪",methodology:"🧪",données:"📊",data:"📊",statistiques:"📊",opinion:"💬",avis:"💬",biais:"🎭",bias:"🎭",nuances:"🎨",perspectives:"👁️",timeline:"📅",chronologie:"📅",définitions:"📖",glossaire:"📖"};function At(e){const t=e.toLowerCase().trim();for(const[e,n]of Object.entries(bt))if(t.includes(e))return n;return"📌"}function xt(e){return e.replace(/`([^`]+)`/g,'<code class="ds-md-code">$1</code>').replace(/\*\*(.+?)\*\*/g,"<strong>$1</strong>").replace(/\*(.+?)\*/g,"<em>$1</em>").replace(/\[?(SOLIDE|SOLID)\]?/g,'<span class="ds-marker ds-marker-solid">✅ Établi</span>').replace(/\[?(PLAUSIBLE)\]?/g,'<span class="ds-marker ds-marker-plausible">🔵 Probable</span>').replace(/\[?(INCERTAIN|UNCERTAIN)\]?/g,'<span class="ds-marker ds-marker-uncertain">🟡 Incertain</span>').replace(/\[?(A VERIFIER|À VÉRIFIER|TO VERIFY|QUESTIONABLE|WEAK)\]?/g,'<span class="ds-marker ds-marker-weak">🔴 À vérifier</span>')}function kt(e){return e.replace(/\*\*(.+?)\*\*/g,"$1").replace(/\*(.+?)\*/g,"$1").replace(/`([^`]+)`/g,"$1").replace(/#{1,6}\s+/g,"").replace(/\[([^\]]+)\]\([^)]+\)/g,"$1").replace(/^>\s+/gm,"").replace(/\n+/g," ").trim()}function wt(e,t){if(e.length<=t)return e;const n=e.substring(0,t),s=n.lastIndexOf(" ");return(s>.6*t?n.substring(0,s):n)+"..."}function Nt(e){switch(e){case"solid":return"✅";case"weak":return"⚠️";case"insight":return"💡"}}function Ct(e){switch(e){case"solid":return"keypoint-solid";case"weak":return"keypoint-weak";case"insight":return"keypoint-insight"}}const St=[{key:"flashcards",icon:"🗂️",doodleName:"book",labelKey:"flashcards",hash:"#flashcards",minPlan:"pro",price:"5,99€"},{key:"mind_maps",icon:"🧠",doodleName:"brain",labelKey:"mindMaps",hash:"#mindmap",minPlan:"pro",price:"5,99€"},{key:"web_search",icon:"🌐",doodleName:"globe",labelKey:"webSearch",hash:"#websearch",minPlan:"pro",price:"5,99€"},{key:"exports",icon:"📤",doodleName:"code",labelKey:"exports",hash:"#export",minPlan:"pro",price:"5,99€"},{key:"playlists",icon:"🎬",doodleName:"camera",labelKey:"playlists",hash:"#playlists",minPlan:"pro",price:"5,99€"}],Pt=({summary:e,summaryId:t,planInfo:n,onOpenChat:s})=>{const{t:a,language:r}=ct(),[i,o]=oe(!1),l=function(e){const t=function(e){const t=[/#+\s*(?:Conclusion|Verdict|Synthèse|Résumé|Summary|En résumé|Final Assessment|Overall Assessment)[^\n]*\n([\s\S]*?)(?=\n#|\n---|\n\*{3,}|$)/i,/\*\*(?:Conclusion|Verdict|Synthèse|En résumé|Summary)\*\*[:\s]*([\s\S]*?)(?=\n\n|\n#|\n---|\n\*{3,}|$)/i];for(const n of t){const t=e.match(n);if(t&&t[1]){const e=kt(t[1]).trim();if(e.length>20)return wt(e,200)}}const n=e.split(/\n\n+/).filter(e=>{const t=e.trim();return t.length>30&&!t.startsWith("#")&&!t.startsWith("-")&&!t.startsWith("*")});return n.length>0?wt(kt(n[n.length-1]),200):"Analysis complete. See detailed view for full results."}(e),n=function(e){const t=[],n=e.split("\n"),s=[/\b(?:SOLIDE|SOLID)\b/i,/\u2705\s*\*\*/,/\u2705/],a=[/\b(?:A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK|INCERTAIN|UNCERTAIN)\b/i,/\u26A0\uFE0F\s*\*\*/,/\u2753/,/\u26A0/],r=[/\b(?:PLAUSIBLE)\b/i,/\uD83D\uDCA1/];for(const e of n){const n=e.replace(/^[\s\-*]+/,"").trim();if(n.length<10)continue;let i=null;if(s.some(t=>t.test(e))?i="solid":a.some(t=>t.test(e))?i="weak":r.some(t=>t.test(e))&&(i="insight"),i&&t.filter(e=>e.type===i).length<2){const e=kt(n).replace(/\b(?:SOLIDE|SOLID|PLAUSIBLE|INCERTAIN|UNCERTAIN|A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK)\b\s*[:—\-–]?\s*/gi,"").replace(/^[✅⚠️❓💡🔍🔬]\s*/u,"").trim();e.length>10&&t.push({type:i,text:wt(e,120)})}if(t.length>=4)break}if(t.length<2){const n=/#+\s*(?:Points?\s+(?:forts?|clés?|faibles?)|Key\s+(?:Points?|Findings?|Takeaways?)|Strengths?|Weaknesses?|Main\s+Points?)[^\n]*\n([\s\S]*?)(?=\n#|$)/gi;let s;for(;null!==(s=n.exec(e))&&t.length<4;){const e=s[1].match(/^[\s]*[-*]\s+(.+)$/gm);if(e)for(const n of e.slice(0,4-t.length)){const e=kt(n.replace(/^[\s]*[-*]\s+/,""));e.length>10&&!t.some(t=>t.text===wt(e,120))&&t.push({type:"insight",text:wt(e,120)})}}}return t.slice(0,4)}(e),s=function(e){const t=[],n=e.match(/#+\s*(?:Tags?|Thèmes?|Themes?|Topics?|Catégories?|Categories?)[^\n]*\n([\s\S]*?)(?=\n#|$)/i);if(n){const e=n[1].match(/[-*]\s+(.+)/g);if(e)for(const n of e.slice(0,3)){const e=kt(n.replace(/^[-*]\s+/,"")).trim();e.length>0&&e.length<30&&t.push(e)}}if(0===t.length){const n=e.match(/^#{2,3}\s+(.+)$/gm);if(n){const e=/^(?:Conclusion|Summary|Résumé|Synthèse|Introduction|Verdict|Analysis|Points?\s+(?:clés?|forts?|faibles?)|Key\s+(?:Points?|Findings?)|Strengths?|Weaknesses?|Overview)/i;for(const s of n){const n=kt(s.replace(/^#{2,3}\s+/,"")).trim();if(n.length>2&&n.length<35&&!e.test(n)&&(t.push(n),t.length>=3))break}}}return t.slice(0,3)}(e);return{verdict:t,keyPoints:n,tags:s}}(e.summary_content),c=ft[e.category]||"📋",d=e.reliability_score,u=d>=80?"score-high":d>=60?"score-mid":"score-low",m=d>=80?"✅":d>=60?"⚠️":"❓",g=vt(yt(e.summary_content)),p=St.map(e=>({cta:e,available:n?.features?.[e.key]??!1}));return Ve("div",{className:"synthesis",children:[Ve("div",{className:"synthesis-header",children:[Ve("span",{className:"synthesis-done",children:["✅"," ",a.synthesis.complete]}),Ve("div",{className:"synthesis-badges",children:[Ve("span",{className:"synthesis-badge",children:[c," ",e.category]}),Ve("span",{className:`synthesis-badge ${u}`,children:[m," ",d,"%"]})]})]}),Ve("div",{className:"synthesis-platforms",children:[Ve("img",{src:He.runtime.getURL("platforms/youtube-icon-red.png"),alt:"YouTube",style:{height:16}}),Ve("span",{className:"synthesis-platform-sep"}),Ve("img",{src:He.runtime.getURL("platforms/tiktok-note-white.png"),alt:"TikTok",style:{height:14}}),Ve("span",{className:"synthesis-platform-sep"}),Ve("img",{src:He.runtime.getURL("platforms/mistral-logo-white.png"),alt:"Mistral AI",style:{height:12,opacity:.7}}),Ve("span",{className:"synthesis-platform-sep"}),Ve("img",{src:He.runtime.getURL("platforms/tournesol-logo.png"),alt:"Tournesol",style:{height:13,opacity:.8}})]}),e.tournesol?.found&&null!==e.tournesol.tournesol_score&&Ve("a",{href:`https://tournesol.app/entities/yt:${e.video_url?.match(/[?&]v=([^&]+)/)?.[1]||""}`,target:"_blank",rel:"noreferrer",className:"tournesol-badge",title:`Score Tournesol: ${e.tournesol.tournesol_score} | ${e.tournesol.n_contributors} contributeurs | ${e.tournesol.n_comparisons} comparaisons`,style:{background:e.tournesol.tournesol_score>=50?"rgba(34,197,94,0.12)":e.tournesol.tournesol_score>=20?"rgba(234,179,8,0.12)":"var(--bg-secondary)",border:"1px solid "+(e.tournesol.tournesol_score>=50?"rgba(34,197,94,0.25)":e.tournesol.tournesol_score>=20?"rgba(234,179,8,0.25)":"var(--border-default)")},children:[Ve("span",{style:{fontSize:"14px"},children:"🌻"}),Ve("span",{style:{fontWeight:600,color:"var(--text-primary)"},children:["Tournesol: ",e.tournesol.tournesol_score>0?"+":"",Math.round(e.tournesol.tournesol_score)]}),Ve("span",{style:{opacity:.6,fontSize:"11px",color:"var(--text-tertiary)"},children:["(",e.tournesol.n_contributors," votes)"]})]}),Ve("div",{className:"synthesis-verdict",children:Ve("p",{children:l.verdict})}),l.keyPoints.length>0&&Ve("div",{className:"synthesis-keypoints",children:l.keyPoints.map((e,t)=>Ve("div",{className:`keypoint ${Ct(e.type)}`,children:[Ve("span",{className:"keypoint-icon",children:Nt(e.type)}),Ve("span",{className:"keypoint-text",children:e.text})]},t))}),l.tags.length>0&&Ve("div",{className:"synthesis-tags",children:l.tags.map((e,t)=>Ve("span",{className:"tag-pill",children:e},t))}),e.concepts&&e.concepts.length>0&&Ve("div",{className:"synthesis-concepts",children:e.concepts.slice(0,3).map((e,t)=>Ve("div",{className:"concept-item",children:[Ve("div",{className:"concept-name",children:e.name}),Ve("div",{className:"concept-def",children:e.definition||a.synthesis.generatingDef})]},t))}),Ve("button",{className:"toggle-detail",onClick:()=>o(!i),children:[Ve("span",{children:i?a.synthesis.hideDetail:a.synthesis.showDetail}),Ve(i?Xe:Qe,{size:14})]}),i&&Ve("div",{className:"detail-panel",dangerouslySetInnerHTML:{__html:g}}),Ve("div",{className:"synthesis-actions",children:[Ve("a",{href:`${_t}/summary/${t}`,target:"_blank",rel:"noreferrer",className:"btn-action btn-action-primary",children:[Ve(Ke,{size:14})," ",a.synthesis.fullAnalysis]}),Ve("button",{className:"btn-action btn-action-secondary",onClick:s,children:[Ve(We,{size:14})," ",a.synthesis.chat]}),Ve("button",{className:"btn-action btn-action-secondary",onClick:()=>{const t=d>=80?a.synthesis.reliable:d>=60?a.synthesis.toVerify:a.synthesis.unreliable,n=function(e,t,n,s,a,r){const i=n>=80?"#22c55e":n>=60?"#eab308":"#ef4444",o="fr"===r?"fr-FR":"en-US",l=new Date(e.created_at).toLocaleDateString(o,{day:"numeric",month:"long",year:"numeric"}),c=t.keyPoints.map(e=>`<div style="display:flex;gap:10px;padding:12px 16px;border-radius:10px;background:rgba(200,144,58,0.06);border:1px solid rgba(200,144,58,0.1);margin-bottom:8px">\n      <span style="font-size:16px;flex-shrink:0">${"solid"===e.type?"✅":"weak"===e.type?"⚠️":"💡"}</span>\n      <span style="color:#F5F0E8;font-size:14px;line-height:1.6">${e.text}</span>\n    </div>`).join(""),d=t.tags.map(e=>`<span style="display:inline-block;padding:4px 12px;border-radius:20px;background:rgba(200,144,58,0.12);color:#C8903A;font-size:12px;font-weight:500">${e}</span>`).join(" "),u=(e.concepts||[]).slice(0,5).map(e=>`<div style="padding:14px 18px;border-radius:12px;background:rgba(155,107,74,0.08);border:1px solid rgba(155,107,74,0.15)">\n      <div style="font-weight:600;color:#9B6B4A;font-size:14px;margin-bottom:4px;font-family:'Cormorant Garamond',serif">${e.name}</div>\n      <div style="color:#B5A89B;font-size:13px;line-height:1.5">${e.definition||a.synthesis.generatingDef}</div>\n    </div>`).join("");return`<!DOCTYPE html>\n<html lang="${r}">\n<head>\n  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n  <title>${e.video_title} — ${a.synthesis.shareTitle}</title>\n  <link rel="preconnect" href="https://fonts.googleapis.com">\n  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">\n  <style>\n    *{margin:0;padding:0;box-sizing:border-box}\n    body{font-family:'DM Sans',system-ui,sans-serif;background:#0a0a0f;color:#F5F0E8;min-height:100vh}\n    .page{max-width:720px;margin:0 auto;padding:40px 24px 60px}\n    .header{text-align:center;margin-bottom:32px}\n    .logo{display:inline-flex;align-items:center;gap:8px;font-size:13px;font-weight:600;color:#C8903A;letter-spacing:0.5px;text-transform:uppercase;margin-bottom:16px;font-family:'Cormorant Garamond',serif}\n    .video-title{font-size:22px;font-weight:700;line-height:1.35;color:#F5F0E8;margin-bottom:8px;font-family:'Cormorant Garamond',serif}\n    .video-meta{display:flex;align-items:center;justify-content:center;gap:16px;font-size:13px;color:#7A7068;flex-wrap:wrap}\n    .score-badge{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:20px;font-weight:600;font-size:13px;background:${i}15;color:${i}}\n    .section{margin-top:28px}\n    .section-title{font-size:15px;font-weight:600;color:#B5A89B;text-transform:uppercase;letter-spacing:0.8px;margin-bottom:14px;display:flex;align-items:center;gap:8px;font-family:'Cormorant Garamond',serif}\n    .verdict{padding:20px 24px;border-radius:14px;background:rgba(200,144,58,0.06);border:1px solid rgba(200,144,58,0.12);border-left:3px solid #C8903A;font-size:15px;line-height:1.7;color:#F5F0E8}\n    .concepts-grid{display:grid;gap:10px}\n    .tags{display:flex;flex-wrap:wrap;gap:8px}\n    .footer{margin-top:40px;padding-top:20px;border-top:1px solid rgba(200,144,58,0.08);text-align:center;color:#45455a;font-size:12px}\n    .footer a{color:#C8903A;text-decoration:none}\n    .footer a:hover{text-decoration:underline}\n    .btn-print{display:inline-flex;align-items:center;gap:6px;padding:10px 20px;border-radius:10px;background:linear-gradient(135deg,#C8903A,#D4A054);color:#0a0a0f;font-size:13px;font-weight:600;cursor:pointer;border:none;font-family:inherit;transition:all 0.2s}\n    .btn-print:hover{transform:translateY(-1px);box-shadow:0 4px 20px rgba(200,144,58,0.35)}\n    .actions{text-align:center;margin-top:28px;display:flex;gap:12px;justify-content:center}\n    @media print{\n      body{background:white;color:#1a1a1a}\n      .verdict{background:#faf7f2;border-color:#e2e8f0}\n      .score-badge{background:#f0fdf4}\n      .actions,.btn-print{display:none!important}\n      .section-title{color:#64748b}\n      .footer{color:#94a3b8}\n    }\n  </style>\n</head>\n<body>\n  <div class="page">\n    <div class="header">\n      <div class="logo">DeepSight Synthesis</div>\n      <h1 class="video-title">${e.video_title}</h1>\n      <div class="video-meta">\n        <span>${e.video_channel}</span>\n        <span>${e.category}</span>\n        <span>${l}</span>\n        <span class="score-badge">${n}% — ${s}</span>\n      </div>\n    </div>\n\n    <div class="section">\n      <div class="section-title">${a.synthesis.verdict}</div>\n      <div class="verdict">${t.verdict}</div>\n    </div>\n\n    ${t.keyPoints.length>0?`\n    <div class="section">\n      <div class="section-title">${a.synthesis.keyPoints}</div>\n      ${c}\n    </div>`:""}\n\n    ${(e.concepts||[]).length>0?`\n    <div class="section">\n      <div class="section-title">${a.synthesis.concepts}</div>\n      <div class="concepts-grid">${u}</div>\n    </div>`:""}\n\n    ${t.tags.length>0?`\n    <div class="section">\n      <div class="section-title">${a.synthesis.tags}</div>\n      <div class="tags">${d}</div>\n    </div>`:""}\n\n    <div class="actions">\n      <button class="btn-print" onclick="window.print()">${a.synthesis.printPdf}</button>\n    </div>\n\n    <div class="footer">\n      <p>${a.synthesis.generatedBy} <a href="https://www.deepsightsynthesis.com" target="_blank">DeepSight</a> — ${a.synthesis.analysisDesc}</p>\n      <p style="margin-top:4px">🇫🇷🇪🇺 ${a.synthesis.euBadge}</p>\n    </div>\n  </div>\n</body>\n</html>`}(e,l,d,t,a,r),s=new Blob([n],{type:"text/html"}),i=URL.createObjectURL(s);He.tabs.create({url:i})},title:a.synthesis.share,children:[Ve(Ze,{size:14})," ",a.synthesis.share]})]}),Ve("div",{className:"feature-ctas",children:[p.map(({cta:e,available:n})=>Ve("button",n?{className:"feature-cta feature-cta-available",onClick:()=>He.tabs.create({url:`${_t}/summary/${t}${e.hash}`}),children:[Ve("span",{className:"feature-cta-icon",children:Ve(nt,{name:e.doodleName,size:16,color:"var(--accent-primary)"})}),Ve("span",{className:"feature-cta-label",children:a.features[e.labelKey]}),Ve("span",{className:"feature-cta-arrow",children:"↗"})]}:{className:"feature-cta feature-cta-locked",onClick:()=>He.tabs.create({url:`${_t}/upgrade`}),children:[Ve("span",{className:"feature-cta-icon",children:Ve(nt,{name:e.doodleName,size:16,color:"var(--text-muted)"})}),Ve("span",{className:"feature-cta-label",children:a.features[e.labelKey]}),Ve("span",{className:"feature-cta-price",children:a.features.fromPrice.replace("{price}",e.price)})]},e.key)),Ve("a",{href:`${_t}/upgrade`,target:"_blank",rel:"noreferrer",className:"feature-cta-all-plans",onClick:e=>{e.preventDefault(),He.tabs.create({url:`${_t}/upgrade`})},children:[a.common.allPlans," ","↗"]})]})]})};function zt(e){return e.replace(/\[\[([^\]]+)\]\]/g,"$1").trim()}const Mt=["plus","pro","starter","student","etudiant","expert","team","equipe"],Tt=({summaryId:e,videoTitle:t,onClose:n,onSessionExpired:s,userPlan:a})=>{const{t:r}=ct(),[i,o]=oe([]),[l,c]=oe(""),[d,u]=oe(!1),[m,g]=oe(!0),[p,h]=oe(!1),[_,f]=oe(!1),y=ce(null),v=!!(b=a)&&Mt.includes(b.toLowerCase());var b;const A=r.chat.suggestions;async function x(t,n){const s=t||l.trim();if(!s||d)return;t||c(""),o(e=>[...e,{role:"user",content:s}]),u(!0);const a={};(n||v&&_)&&(a.use_web_search=!0);try{const t=await He.runtime.sendMessage({action:"ASK_QUESTION",data:{summaryId:e,question:s,options:a}});if(t.success){const e=t.result;o(t=>[...t,{role:"assistant",content:e.response,web_search_used:e.web_search_used}])}else{const e=t.error||"";e.includes("SESSION_EXPIRED")?h(!0):o(t=>[...t,{role:"assistant",content:`${r.common.error} : ${e||r.chat.unavailable}`}])}}catch(e){const t=e.message||"";t.includes("SESSION_EXPIRED")?h(!0):o(e=>[...e,{role:"assistant",content:`${r.common.error} : ${t}`}])}finally{u(!1)}}function k(e){x(zt(e))}le(()=>{!async function(){try{const t=await He.runtime.sendMessage({action:"GET_CHAT_HISTORY",data:{summaryId:e}});t.success&&Array.isArray(t.result)&&o(t.result)}catch{}finally{g(!1)}}()},[e]),le(()=>{y.current&&(y.current.scrollTop=y.current.scrollHeight)},[i,d]);const w=t.length>30?t.substring(0,30)+"...":t;return Ve("div",{className:"chat-view",children:[Ve("div",{className:"chat-header",children:[Ve("button",{className:"icon-btn",onClick:n,title:r.common.back,children:Ve(Ge,{size:18})}),Ve("span",{className:"chat-header-title",children:[r.synthesis.chat," : « ",w," »"]})]}),Ve("div",{className:"chat-messages",ref:y,children:[m?Ve("div",{className:"chat-welcome",children:Ve(it,{size:"xs",speed:"fast"})}):0===i.length?Ve("div",{className:"chat-welcome",children:[Ve(nt,{name:"robot",size:32,color:"var(--accent-primary)",style:{opacity:.6}}),Ve("p",{children:r.chat.welcome}),Ve("div",{className:"chat-suggestions",children:A.map((e,t)=>Ve("button",{className:"chat-suggestion-btn",onClick:()=>{x(e)},disabled:d||p,children:[Ve("span",{className:"chat-suggestion-arrow",children:"→"}),e]},t))})]}):i.map((e,t)=>Ve(Et,{msg:e,onQuestionClick:k,webEnrichedLabel:r.chat.webEnriched},t)),d&&Ve("div",{className:"chat-typing",children:[Ve("div",{className:"chat-typing-dot"}),Ve("div",{className:"chat-typing-dot"}),Ve("div",{className:"chat-typing-dot"})]})]}),p&&Ve("div",{className:"chat-session-expired",children:[Ve("span",{children:["🔒"," ",r.chat.sessionExpired]}),Ve("button",{className:"chat-reconnect-btn",onClick:()=>{s?s():n()},children:r.chat.reconnect})]}),Ve("div",{className:"chat-input-area",children:[Ve("button",{className:"chat-ws-toggle "+(_&&v?"chat-ws-active":""),onClick:()=>{v&&f(!_)},title:v?_?r.chat.webSearchDisable:r.chat.webSearchEnable:r.chat.webSearchLocked,style:{opacity:v?1:.4},children:Ve(nt,{name:"globe",size:14,color:_&&v?"var(--accent-primary)":"var(--text-muted)"})}),Ve("input",{type:"text",className:"chat-input",value:l,onChange:e=>c(e.target.value),onKeyDown:function(e){"Enter"!==e.key||e.shiftKey||(e.preventDefault(),x())},placeholder:p?r.chat.expiredPlaceholder:r.chat.inputPlaceholder,disabled:d||p,autoFocus:!0}),Ve("button",{className:"chat-send-btn",onClick:()=>x(),disabled:!l.trim()||d||p,title:r.common.send,children:Ve(je,{size:16})})]})]})},Et=({msg:e,onQuestionClick:t,webEnrichedLabel:n})=>{const s=de(()=>"user"===e.role?{text:e.content,questions:[]}:function(e){const t=/\[ask:\s*([^\]]+)\]/g,n=[];let s;for(;null!==(s=t.exec(e));){const e=s[1].trim();e&&n.push(e)}return{text:e.replace(t,"").trim(),questions:n}}(e.content),[e.content,e.role]);return Ve("div",{className:`chat-msg chat-msg-${e.role}`,children:"assistant"===e.role?Ve(k,{children:[e.web_search_used&&Ve("div",{className:"chat-web-badge",children:[Ve(nt,{name:"globe",size:12,color:"var(--accent-primary)",style:{display:"inline-block",verticalAlign:"middle",marginRight:4}}),n]}),Ve("div",{className:"chat-md-content",dangerouslySetInnerHTML:{__html:vt(yt(s.text))}}),s.questions.length>0&&Ve("div",{className:"chat-ask-pills",children:s.questions.map((e,n)=>Ve("button",{className:"chat-ask-pill",onClick:()=>t(e),children:[Ve("span",{className:"chat-ask-arrow",children:"→"}),zt(e)]},n))})]}):e.content})},$t="linear-gradient(135deg, rgba(200,144,58,0.15), rgba(155,107,74,0.15))",It="linear-gradient(135deg, rgba(200,144,58,0.2), rgba(200,144,58,0.08))",Lt=[{id:"free-flashcards",textKey:0,url:`${_t}/upgrade`,gradient:It},{id:"free-mindmap",textKey:1,url:`${_t}/upgrade`,gradient:"linear-gradient(135deg, rgba(155,107,74,0.15), rgba(200,144,58,0.1))"},{id:"free-quota",textKey:2,url:`${_t}/upgrade`,gradient:$t}],Dt=[{id:"pro-mobile",textKey:0,url:`${_t}/mobile`,gradient:$t},{id:"pro-web",textKey:1,url:_t,gradient:It}];function Ft(e){switch(e){case"plus":case"pro":case"expert":case"etudiant":case"student":case"starter":return"pro";default:return"free"}}const Rt=({planInfo:e})=>{const{t}=ct(),[n,s]=oe(0),[a,r]=oe(!1),i=Ft(e?.plan_id),o=(l=e?.plan_id,"pro"===Ft(l)?Dt:Lt);var l;const c=t.promos[i];if(le(()=>{He.storage.local.get(["promoDismissedAt"]).then(e=>{e.promoDismissedAt&&(Date.now()-e.promoDismissedAt>864e5?He.storage.local.remove(["promoDismissedAt"]):r(!0))})},[]),le(()=>{if(a||o.length<=1)return;const e=setInterval(()=>{s(e=>(e+1)%o.length)},8e3);return()=>clearInterval(e)},[a,o.length]),le(()=>{s(0)},[e?.plan_id]),a||0===o.length)return null;const d=n%o.length,u=o[d],m=c[d]||c[0],g=["sparkle4pt","star","crown"];return Ve("div",{className:"promo-banner",style:{background:u.gradient,borderTop:"1px solid var(--border-accent)"},children:[Ve("div",{className:"promo-content",children:[Ve("div",{style:{display:"flex",alignItems:"center",gap:8},children:[Ve(nt,{name:g[d%g.length],size:16,color:"var(--accent-primary)"}),Ve("span",{className:"promo-text",style:{color:"var(--text-primary)"},children:m.text})]}),Ve("a",{href:u.url,target:"_blank",rel:"noreferrer",className:"promo-cta",style:{color:"var(--accent-primary)"},onClick:e=>{e.preventDefault(),He.tabs.create({url:u.url})},children:[m.cta," →"]})]}),Ve("button",{className:"promo-close",onClick:()=>{r(!0),He.storage.local.set({promoDismissedAt:Date.now()})},title:t.common.hide,style:{background:"var(--accent-primary-muted)",color:"var(--accent-primary)"},children:"×"})]})},Bt=({user:e,planInfo:t,isGuest:n,onLogout:s,onLoginRedirect:a,onError:r})=>{const{t:i,language:o}=ct(),[l,c]=oe(null),[d,u]=oe(e?.default_mode||"standard"),[m,g]=oe(e?.default_lang||"fr"),[p,h]=oe({phase:"idle"}),[_,f]=oe([]),[y,v]=oe(!1),[b,A]=oe(!1),[x,w]=oe(!1),[N,C]=oe(!1),S=ce(null);async function P(){const e=await pt();f(e)}le(()=>{n&&ht().then(e=>{e>=3&&A(!0)})},[n]),le(()=>{He.storage.local.get("showYouTubeRecommendation").then(e=>{e.showYouTubeRecommendation&&C(!0)})},[]),le(()=>(He.tabs.query({active:!0,currentWindow:!0}).then(e=>{const t=e[0]?.url||"",n=function(e){return function(e){for(const t of ut){const n=e.match(t);if(n)return n[1]}return null}(e)||function(e){for(const t of mt){const n=e.match(t);if(n)return n[1]}return null}(e)}(t);if(n){const s="tiktok"===gt(t)?"TikTok Video":"YouTube Video";c({url:t,videoId:n,title:e[0]?.title||s})}}),n||P(),()=>{S.current&&clearInterval(S.current)}),[n]);const z=!!t&&t.analyses_this_month>=t.monthly_analyses,M=t?t.monthly_analyses-t.analyses_this_month:null,T=!!(t&&t.monthly_analyses>0)&&null!==M&&M/t.monthly_analyses<.2,E=t?.credits_monthly||e?.credits_monthly||0,$=t?.credits??e?.credits??0,I=E>0&&$/E<.3,L=E>0&&$/E<.1,D=t?.plan_id||e?.plan||"free",F=i.upsell[D]||null,R=ue(async()=>{if(l){w(!0);try{const e=await He.runtime.sendMessage({action:"QUICK_CHAT",data:{url:l.url,lang:m}});if(!e.success)throw new Error(e.error||"Quick Chat failed");const t=e.result;He.tabs.create({url:`${_t}/chat?summary=${t.summary_id}`})}catch(e){r(e.message)}finally{w(!1)}}},[l,m,r]),B=ue(async()=>{if(l){if(n&&await ht()>=3)return void A(!0);h({phase:"analyzing",progress:0,message:i.analysis.starting});try{const e=await He.runtime.sendMessage({action:"START_ANALYSIS",data:{url:l.url,options:{mode:d,lang:m}}});if(!e.success)return void h({phase:"error",message:e.error||i.analysis.startFailed});const t=e.result.task_id;S.current=setInterval(async()=>{try{const e=await He.runtime.sendMessage({action:"GET_TASK_STATUS",data:{taskId:t}});if(!e.success||!e.status)return;const s=e.status;if("completed"===s.status&&s.result?.summary_id){S.current&&clearInterval(S.current),n&&(await async function(){const e=await ht()+1;return await He.storage.local.set({deepsight_free_analyses:e}),e}(),A(!0)),await async function(e){const t=(await pt()).filter(t=>t.videoId!==e.videoId);t.unshift({...e,timestamp:Date.now()}),await He.storage.local.set({recentAnalyses:t.slice(0,20)})}({videoId:l.videoId,summaryId:s.result.summary_id,title:s.result.video_title||l.title});const e=await He.runtime.sendMessage({action:"GET_SUMMARY",data:{summaryId:s.result.summary_id}});e.success&&e.summary&&(h({phase:"complete",summaryId:s.result.summary_id,summary:e.summary}),P())}else"failed"===s.status?(S.current&&clearInterval(S.current),h({phase:"error",message:s.error||i.analysis.failed})):h({phase:"analyzing",progress:s.progress||0,message:s.message||i.analysis.processing})}catch{}},2500)}catch(e){h({phase:"error",message:e.message})}}},[l,d,m,n,i]);if(y&&"complete"===p.phase)return Ve(Tt,{summaryId:p.summaryId,videoTitle:p.summary.video_title,onClose:()=>v(!1),onSessionExpired:s,userPlan:t?.plan_id||e?.plan||"free"});const U=t?i.plans[t.plan_id]||t.plan_name:null,O=!e||"free"===e.plan;return Ve("div",{className:"main-view",children:[Ve("div",{className:"main-header",children:[Ve("div",{className:"main-header-left",children:[Ve(it,{size:"xs",speed:"slow"}),Ve("h1",n?{children:"DeepSight"}:O?{children:["DeepSight ",U||i.plans.free]}:{children:["DeepSight ",U]})]}),Ve("div",{className:"main-header-actions",children:[Ve("button",{className:"btn-open-webapp",onClick:()=>He.tabs.create({url:_t}),title:"Ouvrir DeepSight",children:[Ve(Ke,{size:12})," Web"]}),Ve("button",n?{className:"btn-header-login",onClick:a,children:i.common.login}:{className:"icon-btn icon-btn-danger",onClick:s,title:i.common.logout,children:Ve(Ye,{size:16})})]})]}),!n&&e&&Ve("div",{className:"user-bar",children:[Ve("span",{className:`plan-badge plan-${e.plan}`,children:i.plans[e.plan]||e.plan}),Ve("span",t?{className:"user-quota "+(T?"quota-warning":""),children:[t.analyses_this_month,"/",t.monthly_analyses," ",i.common.analyses]}:{className:"user-credits",children:[e.credits," ",i.common.credits]}),I&&Ve("span",{className:"credits-urgency "+(L?"credits-critical":"credits-low"),title:i.credits.remaining.replace("{count}",String($)),children:[L?"🚨":"⚠️"," ",$," ",i.credits.low]})]}),!n&&L&&Ve("div",{className:"credits-banner-critical",children:[Ve("span",{children:[i.credits.critical.replace("{count}",String($))," "]}),Ve("a",{href:`${_t}/upgrade`,onClick:e=>{e.preventDefault(),He.tabs.create({url:`${_t}/upgrade`})},children:[i.credits.recharge," ","↗"]})]}),n&&Ve("div",{className:"guest-banner",children:Ve("span",{children:i.guest.banner})}),N&&Ve("div",{className:"yt-recommend-banner",children:[Ve("div",{className:"yt-recommend-content",children:[Ve("img",{src:He.runtime.getURL("platforms/youtube-icon-red.png"),alt:"YouTube",style:{height:18,width:"auto",flexShrink:0}}),Ve("div",{className:"yt-recommend-text",children:[Ve("span",{className:"yt-recommend-title",children:i.ytRecommend.title}),Ve("span",{className:"yt-recommend-subtitle",children:i.ytRecommend.subtitle})]})]}),Ve("button",{className:"yt-recommend-dismiss",onClick:()=>{C(!1),He.storage.local.remove("showYouTubeRecommendation")},title:i.ytRecommend.dismiss,children:"✕"})]}),Ve("div",{className:"main-content",children:[l?(()=>{const e="tiktok"===gt(l.url),t=e?null:`https://img.youtube.com/vi/${l.videoId}/mqdefault.jpg`,n=e?`tiktok.com/video/${l.videoId}`:`youtube.com/watch?v=${l.videoId}`;return Ve("div",{className:"video-status-card",children:[t?Ve("img",{src:t,alt:"",className:"video-thumbnail",onError:e=>{e.target.style.display="none"}}):Ve("div",{className:"video-thumbnail",style:{display:"flex",alignItems:"center",justifyContent:"center",background:"rgba(200,144,58,0.1)"},children:Ve(nt,{name:"waveform",size:20,color:"var(--accent-primary)"})}),Ve("div",{className:"video-status-body",children:[Ve("span",{className:"video-status-title",children:l.title.length>52?l.title.substring(0,52)+"…":l.title}),Ve("span",{className:"video-status-url",children:n})]}),Ve("div",{className:"video-live-dot",title:"Video detected"})]})})():Ve("div",{className:"video-status",children:[Ve("div",{className:"video-status-icon",children:Ve(nt,{name:"play",size:16,color:"var(--text-muted)"})}),Ve("span",{className:"video-status-text video-status-none",children:i.analysis.noVideo})]}),l&&"idle"===p.phase&&Ve(k,{children:!n&&z?Ve("div",{className:"quota-exceeded",children:[Ve("p",{className:"quota-exceeded-text",children:[i.analysis.quotaExceeded," (",t?.analyses_this_month,"/",t?.monthly_analyses,") — ",i.analysis.quotaExceededText]}),Ve("button",{className:"analyze-btn analyze-btn-disabled btn-shimmer",disabled:!0,children:i.analysis.analyzeButton}),Ve("button",{className:"quickchat-btn",onClick:R,disabled:x,children:x?i.analysis.quickChatPreparing:i.analysis.quickChatButton}),Ve("a",{href:`${_t}/upgrade`,target:"_blank",rel:"noreferrer",className:"btn-upgrade-cta",onClick:e=>{e.preventDefault(),He.tabs.create({url:`${_t}/upgrade`})},children:[i.common.viewPlans," ","↗"]})]}):n&&b?Ve("div",{className:"guest-exhausted",children:[Ve("p",{className:"guest-exhausted-text",children:i.guest.exhaustedText}),Ve("button",{className:"btn-create-account",onClick:()=>He.tabs.create({url:`${_t}/register`}),children:[i.common.createAccount," ","↗"]})]}):Ve(k,{children:[Ve("div",{className:"selectors-row",children:[Ve("div",{className:"ds-select-wrapper",children:[Ve("label",{children:i.analysis.mode}),Ve("select",{className:"ds-select",value:d,onChange:e=>u(e.target.value),children:[Ve("option",{value:"standard",children:i.analysis.modes.standard}),Ve("option",{value:"accessible",children:i.analysis.modes.accessible})]})]}),Ve("div",{className:"ds-select-wrapper",children:[Ve("label",{children:i.analysis.language}),Ve("select",{className:"ds-select",value:m,onChange:e=>g(e.target.value),children:[Ve("option",{value:"fr",children:i.analysis.languages.fr}),Ve("option",{value:"en",children:i.analysis.languages.en}),Ve("option",{value:"es",children:i.analysis.languages.es}),Ve("option",{value:"de",children:i.analysis.languages.de})]})]})]}),Ve("button",{className:"quickchat-btn",onClick:R,disabled:!l||x,children:x?i.analysis.quickChatPreparing:i.analysis.quickChatButton}),Ve("button",{className:"analyze-btn btn-shimmer",onClick:B,style:{animation:"float 3s ease-in-out infinite"},children:i.analysis.analyzeButton}),Ve("div",{className:"mistral-badge",children:[Ve("span",{children:"🇫🇷"}),Ve("span",{children:i.mistral.badge})]})]})}),"analyzing"===p.phase&&Ve("div",{className:"progress-container",children:[Ve("div",{style:{display:"flex",justifyContent:"center",marginBottom:8},children:Ve(it,{size:"sm",speed:"fast"})}),Ve("div",{className:"progress-bar",children:Ve("div",{className:"progress-fill",style:{width:`${p.progress}%`}})}),Ve("p",{className:"progress-text",children:p.message})]}),"error"===p.phase&&Ve("div",{style:{textAlign:"center",padding:"12px"},children:[Ve("p",{style:{color:"var(--error)",fontSize:"13px",marginBottom:"8px"},children:p.message}),Ve("button",{className:"analyze-btn btn-shimmer",onClick:()=>h({phase:"idle"}),style:{height:"40px",fontSize:"13px",animation:"float 3s ease-in-out infinite"},children:i.common.retry})]}),"complete"===p.phase&&Ve(k,{children:[Ve(Pt,{summary:p.summary,summaryId:p.summaryId,planInfo:t,onOpenChat:()=>v(!0)}),!n&&F&&"pro"!==D&&Ve("div",{className:"post-analysis-upsell",children:[Ve("div",{className:"upsell-content",children:[Ve(nt,{name:"sparkle4pt",size:18,color:"var(--accent-primary)"}),Ve("div",{className:"upsell-text",children:[Ve("span",{className:"upsell-headline",children:F.feature}),Ve("span",{className:"upsell-sub",children:["Plan ",F.label," — ",F.price,"/","fr"===o?"mois":"mo"]})]})]}),Ve("a",{href:`${_t}/upgrade`,className:"upsell-btn",onClick:e=>{e.preventDefault(),He.tabs.create({url:`${_t}/upgrade`})},children:[i.common.unlock," ","↗"]})]}),n&&Ve("div",{className:"guest-post-analysis",children:[Ve("p",{children:i.guest.exhaustedText}),Ve("button",{className:"btn-create-account",onClick:()=>He.tabs.create({url:`${_t}/register`}),children:[i.common.createAccount," ","↗"]})]})]}),!n&&"idle"===p.phase&&_.length>0&&Ve("div",{className:"recent-section",children:[Ve("h3",{children:i.analysis.recent}),Ve("div",{className:"recent-list",children:_.slice(0,5).map(e=>{return Ve("a",{href:`${_t}/summary/${e.summaryId}`,target:"_blank",rel:"noreferrer",className:"recent-item",children:["tiktok"===e.platform?Ve("div",{style:{width:48,height:36,display:"flex",alignItems:"center",justifyContent:"center",background:"rgba(200,144,58,0.1)",borderRadius:4,flexShrink:0},children:Ve(nt,{name:"waveform",size:16,color:"var(--accent-primary)"})}):Ve("img",{src:(t=e.videoId,`https://img.youtube.com/vi/${t}/default.jpg`||""),alt:"",loading:"lazy"}),Ve("span",{className:"recent-title",children:e.title})]},e.videoId);var t})})]})]}),Ve(Rt,{planInfo:t})]})},Ut=["M6 4h4v16H6zm8 0h4v16h-4z","M8 7c0-2 1-3 2-3s2 1 2 3v10c0 2-1 3-2 3s-2-1-2-3V7zm6 0c0-2 1-3 2-3s2 1 2 3v10c0 2-1 3-2 3s-2-1-2-3V7z","M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z","M6 9H3V4h3m12 5h3V4h-3M12 15a6 6 0 006-6V3H6v6a6 6 0 006 6zm0 0v4m-4 2h8","M4 19.5A2.5 2.5 0 016.5 17H20M4 19.5V4a2 2 0 012-2h14v14H6.5A2.5 2.5 0 004 18.5z","M10 2v6l-2 4h8l-2-4V2zm-2 12v2m8-2v2M8 22h8","M3 21c3 0 7-1 7-8V5M14 5c0 6.5 4 8 7 8","M9 2h6v4H9zM16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2m1 9l2 2 4-4","M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8zm11-3a3 3 0 100 6 3 3 0 000-6z","M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z","M22 2L11 13m11-11l-7 20-4-9-9-4z","M4.9 19.1C1 15.2 1 8.8 4.9 4.9m14.2 0c3.9 3.9 3.9 10.3 0 14.2M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.4m8.4 0c2.3 2.3 2.3 6.1 0 8.4M12 12h.01","M15 4V2M15 16v-2M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2L19 5M3 21l9-9M12.2 6.2L11 5","M5 5a2 2 0 100 4 2 2 0 000-4zm14 0a2 2 0 100 4 2 2 0 000-4zm-7 7a2 2 0 100 4 2 2 0 000-4zm-7 7a2 2 0 100 4 2 2 0 000-4zm14 0a2 2 0 100 4 2 2 0 000-4zM7 7l5 5m5-5l-5 5m-5 5l5-5m5 5l-5-5","M12 12m-3 0a3 3 0 106 0 3 3 0 10-6 0M12 2c-5 0-8 5-8 10s3 10 8 10 8-5 8-10-3-10-8-10z","M17 3a2.83 2.83 0 114 4L7.5 20.5 2 22l1.5-5.5z","M4 17l6-6-6-6m8 14h8","M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6"],Ot=e=>{const t=1e4*Math.sin(9999*e);return t-Math.floor(t)},Vt=(e,t,n,s,a,r,i,o,l)=>{const c=24*s;return`\n    <g transform="translate(${t-c/2}, ${n-c/2}) rotate(${a} ${c/2} ${c/2})">\n      <svg viewBox="0 0 24 24" width="${c}" height="${c}" overflow="visible">\n        ${l?`<path d="${e}" fill="${r}" opacity="${i}" />`:`<path d="${e}" stroke="${r}" stroke-width="${o}" opacity="${i}" fill="none" stroke-linecap="round" stroke-linejoin="round" />`}\n      </svg>\n    </g>\n  `},qt=({variant:e="default",className:t=""})=>{const n=de(()=>{const t=((e,t,n=!0,s=1)=>{const a=(e=>{const t=e||"default",n=[...tt,...Ut],s=n.slice(0,5),a=[n[5],n[6],n[7],n[8],...Ut.slice(2,8)],r=[n[9],n[10],n[11],n[12],n[13],...Ut.slice(8,16)],i=[n[14],n[15],...Ut.slice(17,20)],o=[n[16],n[17],n[18],n[19],n[20]];switch(t){case"video":return[...n,...s,...s,...s];case"study":return[...n,...a,...a,...a];case"tech":return[...n,...i,...i,...i];case"AI":return[...n,...r,...r,...r];case"creative":return[...n,...o,...o,...o];default:return n}})(t),r=n?"#C8903A":"#9B6B4A",i=n?"#9B6B4A":"#C8903A",o=n?["#A78BFA","#818CF8","#FBBF24","#34D399","#60A5FA","#F87171","#C084FC"]:["#8B5CF6","#6366F1","#F59E0B","#10B981","#3B82F6","#EF4444","#A855F7"],l=(e,t=!1)=>t?Ot(e)>.5?r:i:o[Math.floor(Ot(e)*o.length)],c=(e,t)=>e[Math.floor(Ot(t)*e.length)],d=e=>{const t=[0,15,-15,30,-30,45,-45,90,-90,180];return t[Math.floor(Ot(e)*t.length)]};let u="";const m={video:1e3,study:2e3,tech:3e3,AI:4e3,creative:5e3,default:0}[t]??0;for(let t=0;t<25;t++){const n=m+100+37*t,r=c(a,n),i=Ot(n+1)*e,o=Ot(n+2)*e,g=d(n+3),p=.8+.4*Ot(n+4),h=(.04+.02*Ot(n+5))*s,_=l(n+9),f=1.2+.6*(Ot(n+10)-.5);u+=Vt(r,i,o,p,g,_,h,f,!1)}for(let t=0;t<30;t++){const n=m+300+23*t,r=c(a,n),i=Ot(n+1)*e,o=Ot(n+2)*e,g=d(n+3),p=.5+.3*Ot(n+4),h=(.08+.04*Ot(n+5))*s,_=l(n+9,Ot(n+6)<.1),f=1.4+.6*(Ot(n+10)-.5);u+=Vt(r,i,o,p,g,_,h,f,!1)}for(let t=0;t<15;t++){const n=m+600+41*t,a=Ot(n+1)*e,o=Ot(n+2)*e,l=.5+1.5*Ot(n+3),c=(.1+.05*Ot(n+4))*s;u+=`<circle cx="${a}" cy="${o}" r="${l}" fill="${Ot(n+5)>.5?r:i}" opacity="${c}" />`}return`\n    <svg width="${e}" height="${e}" viewBox="0 0 ${e} ${e}" xmlns="http://www.w3.org/2000/svg" overflow="visible">\n      <defs>\n        <mask id="tileEdgeFade">\n          <rect width="${e}" height="${e}" fill="white" />\n          <radialGradient id="edgeFadeGrad" cx="50%" cy="50%" r="60%">\n            <stop offset="0%" stop-color="white" />\n            <stop offset="100%" stop-color="black" />\n          </radialGradient>\n          <circle cx="${e/2}" cy="${e/2}" r="${.55*e}" fill="url(#edgeFadeGrad)" />\n        </mask>\n      </defs>\n      <g mask="url(#tileEdgeFade)">\n        ${u}\n      </g>\n    </svg>\n  `})(200,e,!0,1);return`data:image/svg+xml,${encodeURIComponent(t)}`},[e]);return Ve("div",{className:`fixed inset-0 pointer-events-none ${t}`,style:{...de(()=>({backgroundImage:`url("${n}")`,backgroundSize:"200px 200px",backgroundRepeat:"repeat",backgroundAttachment:"fixed"}),[n]),zIndex:-1},"aria-hidden":"true"})},Ht=document.getElementById("root");Ht&&function(e){return{render:function(t){!function(e,t,n){null==t.__k&&(t.textContent=""),j(e,t),"function"==typeof n&&n(),e&&e.__c}(t,e)},unmount:function(){!function(e){!!e.__k&&j(null,e)}(e)}}}(Ht).render(Ve(()=>{const[e,t]=oe("loading"),[n,s]=oe(null),[a,r]=oe(null),[i,o]=oe(!1),[l,c]=oe(null),[d,u]=oe(null);async function m(){try{const e=await He.runtime.sendMessage({action:"GET_PLAN"});e.success&&e.plan&&r(e.plan)}catch{}}le(()=>{!async function(){try{const e=await He.runtime.sendMessage({action:"CHECK_AUTH"});e.authenticated&&e.user?(s(e.user),o(!1),await m(),t("main")):t("login")}catch{t("login")}}()},[]),le(()=>{if(!d)return;const e=setTimeout(()=>u(null),3e3);return()=>clearTimeout(e)},[d]);const g=ue(async(e,n)=>{c(null);const a=await He.runtime.sendMessage({action:"LOGIN",data:{email:e,password:n}});if(!a.success||!a.user)throw new Error(a.error||"Login failed");s(a.user),o(!1),await m(),t("main")},[]),p=ue(async()=>{c(null);const e=await He.runtime.sendMessage({action:"GOOGLE_LOGIN"});if(!e.success||!e.user)throw new Error(e.error||"Google login failed");s(e.user),o(!1),await m(),t("main")},[]),h=ue(()=>{o(!0),s(null),r(null),t("main")},[]),_=ue(async()=>{await He.runtime.sendMessage({action:"LOGOUT"}),s(null),r(null),o(!1),t("login")},[]),f=ue(()=>{o(!1),t("login")},[]),y=ue(e=>{u({message:e,type:"error"})},[]);return Ve("div",{className:"app-container noise-overlay ambient-glow",style:{position:"relative"},children:[Ve(qt,{variant:"loading"===e||"login"===e?"default":"main"===e?"AI":"default"}),Ve("div",{style:{position:"relative",zIndex:1},children:[d&&Ve("div",{className:`ds-toast ds-toast-${d.type}`,onClick:()=>u(null),children:d.message}),"loading"===e&&Ve("div",{className:"loading-view",children:Ve(it,{size:"md",speed:"normal",showLabel:!0,label:"DeepSight"})}),"login"===e&&Ve(dt,{onLogin:g,onGoogleLogin:p,onGuestMode:h,error:l}),"main"===e&&Ve(Bt,{user:n,planInfo:a,isGuest:i,onLogout:_,onLoginRedirect:f,onError:y})]})]})},{}))})()})();
+(() => {
+  var e = {
+      815(e, t) {
+        var n, s;
+        ("undefined" != typeof globalThis
+          ? globalThis
+          : "undefined" != typeof self && self,
+          (n = function (e) {
+            "use strict";
+            if (
+              !(
+                globalThis.chrome &&
+                globalThis.chrome.runtime &&
+                globalThis.chrome.runtime.id
+              )
+            )
+              throw new Error(
+                "This script should only be loaded in a browser extension.",
+              );
+            if (
+              globalThis.browser &&
+              globalThis.browser.runtime &&
+              globalThis.browser.runtime.id
+            )
+              e.exports = globalThis.browser;
+            else {
+              const t =
+                  "The message port closed before a response was received.",
+                n = (e) => {
+                  const n = {
+                    alarms: {
+                      clear: { minArgs: 0, maxArgs: 1 },
+                      clearAll: { minArgs: 0, maxArgs: 0 },
+                      get: { minArgs: 0, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                    },
+                    bookmarks: {
+                      create: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getChildren: { minArgs: 1, maxArgs: 1 },
+                      getRecent: { minArgs: 1, maxArgs: 1 },
+                      getSubTree: { minArgs: 1, maxArgs: 1 },
+                      getTree: { minArgs: 0, maxArgs: 0 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeTree: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    browserAction: {
+                      disable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      enable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      getBadgeBackgroundColor: { minArgs: 1, maxArgs: 1 },
+                      getBadgeText: { minArgs: 1, maxArgs: 1 },
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      openPopup: { minArgs: 0, maxArgs: 0 },
+                      setBadgeBackgroundColor: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setBadgeText: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    browsingData: {
+                      remove: { minArgs: 2, maxArgs: 2 },
+                      removeCache: { minArgs: 1, maxArgs: 1 },
+                      removeCookies: { minArgs: 1, maxArgs: 1 },
+                      removeDownloads: { minArgs: 1, maxArgs: 1 },
+                      removeFormData: { minArgs: 1, maxArgs: 1 },
+                      removeHistory: { minArgs: 1, maxArgs: 1 },
+                      removeLocalStorage: { minArgs: 1, maxArgs: 1 },
+                      removePasswords: { minArgs: 1, maxArgs: 1 },
+                      removePluginData: { minArgs: 1, maxArgs: 1 },
+                      settings: { minArgs: 0, maxArgs: 0 },
+                    },
+                    commands: { getAll: { minArgs: 0, maxArgs: 0 } },
+                    contextMenus: {
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeAll: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    cookies: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 1, maxArgs: 1 },
+                      getAllCookieStores: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    },
+                    devtools: {
+                      inspectedWindow: {
+                        eval: { minArgs: 1, maxArgs: 2, singleCallbackArg: !1 },
+                      },
+                      panels: {
+                        create: {
+                          minArgs: 3,
+                          maxArgs: 3,
+                          singleCallbackArg: !0,
+                        },
+                        elements: {
+                          createSidebarPane: { minArgs: 1, maxArgs: 1 },
+                        },
+                      },
+                    },
+                    downloads: {
+                      cancel: { minArgs: 1, maxArgs: 1 },
+                      download: { minArgs: 1, maxArgs: 1 },
+                      erase: { minArgs: 1, maxArgs: 1 },
+                      getFileIcon: { minArgs: 1, maxArgs: 2 },
+                      open: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      pause: { minArgs: 1, maxArgs: 1 },
+                      removeFile: { minArgs: 1, maxArgs: 1 },
+                      resume: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    extension: {
+                      isAllowedFileSchemeAccess: { minArgs: 0, maxArgs: 0 },
+                      isAllowedIncognitoAccess: { minArgs: 0, maxArgs: 0 },
+                    },
+                    history: {
+                      addUrl: { minArgs: 1, maxArgs: 1 },
+                      deleteAll: { minArgs: 0, maxArgs: 0 },
+                      deleteRange: { minArgs: 1, maxArgs: 1 },
+                      deleteUrl: { minArgs: 1, maxArgs: 1 },
+                      getVisits: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                    },
+                    i18n: {
+                      detectLanguage: { minArgs: 1, maxArgs: 1 },
+                      getAcceptLanguages: { minArgs: 0, maxArgs: 0 },
+                    },
+                    identity: { launchWebAuthFlow: { minArgs: 1, maxArgs: 1 } },
+                    idle: { queryState: { minArgs: 1, maxArgs: 1 } },
+                    management: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getSelf: { minArgs: 0, maxArgs: 0 },
+                      setEnabled: { minArgs: 2, maxArgs: 2 },
+                      uninstallSelf: { minArgs: 0, maxArgs: 1 },
+                    },
+                    notifications: {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      create: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getPermissionLevel: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    pageAction: {
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      hide: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    permissions: {
+                      contains: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      request: { minArgs: 1, maxArgs: 1 },
+                    },
+                    runtime: {
+                      getBackgroundPage: { minArgs: 0, maxArgs: 0 },
+                      getPlatformInfo: { minArgs: 0, maxArgs: 0 },
+                      openOptionsPage: { minArgs: 0, maxArgs: 0 },
+                      requestUpdateCheck: { minArgs: 0, maxArgs: 0 },
+                      sendMessage: { minArgs: 1, maxArgs: 3 },
+                      sendNativeMessage: { minArgs: 2, maxArgs: 2 },
+                      setUninstallURL: { minArgs: 1, maxArgs: 1 },
+                    },
+                    sessions: {
+                      getDevices: { minArgs: 0, maxArgs: 1 },
+                      getRecentlyClosed: { minArgs: 0, maxArgs: 1 },
+                      restore: { minArgs: 0, maxArgs: 1 },
+                    },
+                    storage: {
+                      local: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                      managed: {
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                      },
+                      sync: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                    },
+                    tabs: {
+                      captureVisibleTab: { minArgs: 0, maxArgs: 2 },
+                      create: { minArgs: 1, maxArgs: 1 },
+                      detectLanguage: { minArgs: 0, maxArgs: 1 },
+                      discard: { minArgs: 0, maxArgs: 1 },
+                      duplicate: { minArgs: 1, maxArgs: 1 },
+                      executeScript: { minArgs: 1, maxArgs: 2 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 0 },
+                      getZoom: { minArgs: 0, maxArgs: 1 },
+                      getZoomSettings: { minArgs: 0, maxArgs: 1 },
+                      goBack: { minArgs: 0, maxArgs: 1 },
+                      goForward: { minArgs: 0, maxArgs: 1 },
+                      highlight: { minArgs: 1, maxArgs: 1 },
+                      insertCSS: { minArgs: 1, maxArgs: 2 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      query: { minArgs: 1, maxArgs: 1 },
+                      reload: { minArgs: 0, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeCSS: { minArgs: 1, maxArgs: 2 },
+                      sendMessage: { minArgs: 2, maxArgs: 3 },
+                      setZoom: { minArgs: 1, maxArgs: 2 },
+                      setZoomSettings: { minArgs: 1, maxArgs: 2 },
+                      update: { minArgs: 1, maxArgs: 2 },
+                    },
+                    topSites: { get: { minArgs: 0, maxArgs: 0 } },
+                    webNavigation: {
+                      getAllFrames: { minArgs: 1, maxArgs: 1 },
+                      getFrame: { minArgs: 1, maxArgs: 1 },
+                    },
+                    webRequest: {
+                      handlerBehaviorChanged: { minArgs: 0, maxArgs: 0 },
+                    },
+                    windows: {
+                      create: { minArgs: 0, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 1 },
+                      getLastFocused: { minArgs: 0, maxArgs: 1 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                  };
+                  if (0 === Object.keys(n).length)
+                    throw new Error(
+                      "api-metadata.json has not been included in browser-polyfill",
+                    );
+                  class s extends WeakMap {
+                    constructor(e, t = void 0) {
+                      (super(t), (this.createItem = e));
+                    }
+                    get(e) {
+                      return (
+                        this.has(e) || this.set(e, this.createItem(e)),
+                        super.get(e)
+                      );
+                    }
+                  }
+                  const a =
+                      (t, n) =>
+                      (...s) => {
+                        e.runtime.lastError
+                          ? t.reject(new Error(e.runtime.lastError.message))
+                          : n.singleCallbackArg ||
+                              (s.length <= 1 && !1 !== n.singleCallbackArg)
+                            ? t.resolve(s[0])
+                            : t.resolve(s);
+                      },
+                    r = (e) => (1 == e ? "argument" : "arguments"),
+                    i = (e, t, n) =>
+                      new Proxy(t, { apply: (t, s, a) => n.call(s, e, ...a) });
+                  let o = Function.call.bind(Object.prototype.hasOwnProperty);
+                  const l = (e, t = {}, n = {}) => {
+                      let s = Object.create(null),
+                        c = {
+                          has: (t, n) => n in e || n in s,
+                          get(c, d, u) {
+                            if (d in s) return s[d];
+                            if (!(d in e)) return;
+                            let m = e[d];
+                            if ("function" == typeof m)
+                              if ("function" == typeof t[d])
+                                m = i(e, e[d], t[d]);
+                              else if (o(n, d)) {
+                                let t = ((e, t) =>
+                                  function (n, ...s) {
+                                    if (s.length < t.minArgs)
+                                      throw new Error(
+                                        `Expected at least ${t.minArgs} ${r(t.minArgs)} for ${e}(), got ${s.length}`,
+                                      );
+                                    if (s.length > t.maxArgs)
+                                      throw new Error(
+                                        `Expected at most ${t.maxArgs} ${r(t.maxArgs)} for ${e}(), got ${s.length}`,
+                                      );
+                                    return new Promise((r, i) => {
+                                      if (t.fallbackToNoCallback)
+                                        try {
+                                          n[e](
+                                            ...s,
+                                            a({ resolve: r, reject: i }, t),
+                                          );
+                                        } catch (a) {
+                                          (console.warn(
+                                            `${e} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,
+                                            a,
+                                          ),
+                                            n[e](...s),
+                                            (t.fallbackToNoCallback = !1),
+                                            (t.noCallback = !0),
+                                            r());
+                                        }
+                                      else
+                                        t.noCallback
+                                          ? (n[e](...s), r())
+                                          : n[e](
+                                              ...s,
+                                              a({ resolve: r, reject: i }, t),
+                                            );
+                                    });
+                                  })(d, n[d]);
+                                m = i(e, e[d], t);
+                              } else m = m.bind(e);
+                            else if (
+                              "object" == typeof m &&
+                              null !== m &&
+                              (o(t, d) || o(n, d))
+                            )
+                              m = l(m, t[d], n[d]);
+                            else {
+                              if (!o(n, "*"))
+                                return (
+                                  Object.defineProperty(s, d, {
+                                    configurable: !0,
+                                    enumerable: !0,
+                                    get: () => e[d],
+                                    set(t) {
+                                      e[d] = t;
+                                    },
+                                  }),
+                                  m
+                                );
+                              m = l(m, t[d], n["*"]);
+                            }
+                            return ((s[d] = m), m);
+                          },
+                          set: (t, n, a, r) => (
+                            n in s ? (s[n] = a) : (e[n] = a),
+                            !0
+                          ),
+                          defineProperty: (e, t, n) =>
+                            Reflect.defineProperty(s, t, n),
+                          deleteProperty: (e, t) =>
+                            Reflect.deleteProperty(s, t),
+                        },
+                        d = Object.create(e);
+                      return new Proxy(d, c);
+                    },
+                    c = (e) => ({
+                      addListener(t, n, ...s) {
+                        t.addListener(e.get(n), ...s);
+                      },
+                      hasListener: (t, n) => t.hasListener(e.get(n)),
+                      removeListener(t, n) {
+                        t.removeListener(e.get(n));
+                      },
+                    }),
+                    d = new s((e) =>
+                      "function" != typeof e
+                        ? e
+                        : function (t) {
+                            const n = l(
+                              t,
+                              {},
+                              { getContent: { minArgs: 0, maxArgs: 0 } },
+                            );
+                            e(n);
+                          },
+                    ),
+                    u = new s((e) =>
+                      "function" != typeof e
+                        ? e
+                        : function (t, n, s) {
+                            let a,
+                              r,
+                              i = !1,
+                              o = new Promise((e) => {
+                                a = function (t) {
+                                  ((i = !0), e(t));
+                                };
+                              });
+                            try {
+                              r = e(t, n, a);
+                            } catch (e) {
+                              r = Promise.reject(e);
+                            }
+                            const l =
+                              !0 !== r &&
+                              (c = r) &&
+                              "object" == typeof c &&
+                              "function" == typeof c.then;
+                            var c;
+                            if (!0 !== r && !l && !i) return !1;
+                            return (
+                              (l ? r : o)
+                                .then(
+                                  (e) => {
+                                    s(e);
+                                  },
+                                  (e) => {
+                                    let t;
+                                    ((t =
+                                      e &&
+                                      (e instanceof Error ||
+                                        "string" == typeof e.message)
+                                        ? e.message
+                                        : "An unexpected error occurred"),
+                                      s({
+                                        __mozWebExtensionPolyfillReject__: !0,
+                                        message: t,
+                                      }));
+                                  },
+                                )
+                                .catch((e) => {
+                                  console.error(
+                                    "Failed to send onMessage rejected reply",
+                                    e,
+                                  );
+                                }),
+                              !0
+                            );
+                          },
+                    ),
+                    m = ({ reject: n, resolve: s }, a) => {
+                      e.runtime.lastError
+                        ? e.runtime.lastError.message === t
+                          ? s()
+                          : n(new Error(e.runtime.lastError.message))
+                        : a && a.__mozWebExtensionPolyfillReject__
+                          ? n(new Error(a.message))
+                          : s(a);
+                    },
+                    g = (e, t, n, ...s) => {
+                      if (s.length < t.minArgs)
+                        throw new Error(
+                          `Expected at least ${t.minArgs} ${r(t.minArgs)} for ${e}(), got ${s.length}`,
+                        );
+                      if (s.length > t.maxArgs)
+                        throw new Error(
+                          `Expected at most ${t.maxArgs} ${r(t.maxArgs)} for ${e}(), got ${s.length}`,
+                        );
+                      return new Promise((e, t) => {
+                        const a = m.bind(null, { resolve: e, reject: t });
+                        (s.push(a), n.sendMessage(...s));
+                      });
+                    },
+                    p = {
+                      devtools: { network: { onRequestFinished: c(d) } },
+                      runtime: {
+                        onMessage: c(u),
+                        onMessageExternal: c(u),
+                        sendMessage: g.bind(null, "sendMessage", {
+                          minArgs: 1,
+                          maxArgs: 3,
+                        }),
+                      },
+                      tabs: {
+                        sendMessage: g.bind(null, "sendMessage", {
+                          minArgs: 2,
+                          maxArgs: 3,
+                        }),
+                      },
+                    },
+                    h = {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    };
+                  return (
+                    (n.privacy = {
+                      network: { "*": h },
+                      services: { "*": h },
+                      websites: { "*": h },
+                    }),
+                    l(e, p, n)
+                  );
+                };
+              e.exports = n(chrome);
+            }
+          }),
+          void 0 === (s = n.apply(t, [e])) || (e.exports = s));
+      },
+    },
+    t = {};
+  function n(s) {
+    var a = t[s];
+    if (void 0 !== a) return a.exports;
+    var r = (t[s] = { exports: {} });
+    return (e[s].call(r.exports, r, r.exports, n), r.exports);
+  }
+  ((n.n = (e) => {
+    var t = e && e.__esModule ? () => e.default : () => e;
+    return (n.d(t, { a: t }), t);
+  }),
+    (n.d = (e, t) => {
+      for (var s in t)
+        n.o(t, s) &&
+          !n.o(e, s) &&
+          Object.defineProperty(e, s, { enumerable: !0, get: t[s] });
+    }),
+    (n.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
+    (() => {
+      "use strict";
+      var e,
+        t,
+        s,
+        a,
+        r,
+        i,
+        o,
+        l,
+        c,
+        d,
+        u,
+        m,
+        g,
+        p,
+        h = {},
+        _ = [],
+        f = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,
+        y = Array.isArray;
+      function v(e, t) {
+        for (var n in t) e[n] = t[n];
+        return e;
+      }
+      function b(e) {
+        e && e.parentNode && e.parentNode.removeChild(e);
+      }
+      function A(t, n, s) {
+        var a,
+          r,
+          i,
+          o = {};
+        for (i in n)
+          "key" == i ? (a = n[i]) : "ref" == i ? (r = n[i]) : (o[i] = n[i]);
+        if (
+          (arguments.length > 2 &&
+            (o.children = arguments.length > 3 ? e.call(arguments, 2) : s),
+          "function" == typeof t && null != t.defaultProps)
+        )
+          for (i in t.defaultProps)
+            void 0 === o[i] && (o[i] = t.defaultProps[i]);
+        return x(t, o, a, r, null);
+      }
+      function x(e, n, a, r, i) {
+        var o = {
+          type: e,
+          props: n,
+          key: a,
+          ref: r,
+          __k: null,
+          __: null,
+          __b: 0,
+          __e: null,
+          __c: null,
+          constructor: void 0,
+          __v: null == i ? ++s : i,
+          __i: -1,
+          __u: 0,
+        };
+        return (null == i && null != t.vnode && t.vnode(o), o);
+      }
+      function k(e) {
+        return e.children;
+      }
+      function w(e, t) {
+        ((this.props = e), (this.context = t));
+      }
+      function N(e, t) {
+        if (null == t) return e.__ ? N(e.__, e.__i + 1) : null;
+        for (var n; t < e.__k.length; t++)
+          if (null != (n = e.__k[t]) && null != n.__e) return n.__e;
+        return "function" == typeof e.type ? N(e) : null;
+      }
+      function C(e) {
+        if (e.__P && e.__d) {
+          var n = e.__v,
+            s = n.__e,
+            a = [],
+            r = [],
+            i = v({}, n);
+          ((i.__v = n.__v + 1),
+            t.vnode && t.vnode(i),
+            R(
+              e.__P,
+              i,
+              n,
+              e.__n,
+              e.__P.namespaceURI,
+              32 & n.__u ? [s] : null,
+              a,
+              null == s ? N(n) : s,
+              !!(32 & n.__u),
+              r,
+            ),
+            (i.__v = n.__v),
+            (i.__.__k[i.__i] = i),
+            U(a, i, r),
+            (n.__e = n.__ = null),
+            i.__e != s && S(i));
+        }
+      }
+      function S(e) {
+        if (null != (e = e.__) && null != e.__c)
+          return (
+            (e.__e = e.__c.base = null),
+            e.__k.some(function (t) {
+              if (null != t && null != t.__e)
+                return (e.__e = e.__c.base = t.__e);
+            }),
+            S(e)
+          );
+      }
+      function P(e) {
+        ((!e.__d && (e.__d = !0) && a.push(e) && !z.__r++) ||
+          r != t.debounceRendering) &&
+          ((r = t.debounceRendering) || i)(z);
+      }
+      function z() {
+        try {
+          for (var e, t = 1; a.length; )
+            (a.length > t && a.sort(o), (e = a.shift()), (t = a.length), C(e));
+        } finally {
+          a.length = z.__r = 0;
+        }
+      }
+      function M(e, t, n, s, a, r, i, o, l, c, d) {
+        var u,
+          m,
+          g,
+          p,
+          f,
+          y,
+          v,
+          b = (s && s.__k) || _,
+          A = t.length;
+        for (l = T(n, t, b, l, A), u = 0; u < A; u++)
+          null != (g = n.__k[u]) &&
+            ((m = (-1 != g.__i && b[g.__i]) || h),
+            (g.__i = u),
+            (y = R(e, g, m, a, r, i, o, l, c, d)),
+            (p = g.__e),
+            g.ref &&
+              m.ref != g.ref &&
+              (m.ref && q(m.ref, null, g), d.push(g.ref, g.__c || p, g)),
+            null == f && null != p && (f = p),
+            (v = !!(4 & g.__u)) || m.__k === g.__k
+              ? ((l = E(g, l, e, v)), v && m.__e && (m.__e = null))
+              : "function" == typeof g.type && void 0 !== y
+                ? (l = y)
+                : p && (l = p.nextSibling),
+            (g.__u &= -7));
+        return ((n.__e = f), l);
+      }
+      function T(e, t, n, s, a) {
+        var r,
+          i,
+          o,
+          l,
+          c,
+          d = n.length,
+          u = d,
+          m = 0;
+        for (e.__k = new Array(a), r = 0; r < a; r++)
+          null != (i = t[r]) && "boolean" != typeof i && "function" != typeof i
+            ? ("string" == typeof i ||
+              "number" == typeof i ||
+              "bigint" == typeof i ||
+              i.constructor == String
+                ? (i = e.__k[r] = x(null, i, null, null, null))
+                : y(i)
+                  ? (i = e.__k[r] = x(k, { children: i }, null, null, null))
+                  : void 0 === i.constructor && i.__b > 0
+                    ? (i = e.__k[r] =
+                        x(i.type, i.props, i.key, i.ref ? i.ref : null, i.__v))
+                    : (e.__k[r] = i),
+              (l = r + m),
+              (i.__ = e),
+              (i.__b = e.__b + 1),
+              (o = null),
+              -1 != (c = i.__i = I(i, n, l, u)) &&
+                (u--, (o = n[c]) && (o.__u |= 2)),
+              null == o || null == o.__v
+                ? (-1 == c && (a > d ? m-- : a < d && m++),
+                  "function" != typeof i.type && (i.__u |= 4))
+                : c != l &&
+                  (c == l - 1
+                    ? m--
+                    : c == l + 1
+                      ? m++
+                      : (c > l ? m-- : m++, (i.__u |= 4))))
+            : (e.__k[r] = null);
+        if (u)
+          for (r = 0; r < d; r++)
+            null != (o = n[r]) &&
+              !(2 & o.__u) &&
+              (o.__e == s && (s = N(o)), H(o, o));
+        return s;
+      }
+      function E(e, t, n, s) {
+        var a, r;
+        if ("function" == typeof e.type) {
+          for (a = e.__k, r = 0; a && r < a.length; r++)
+            a[r] && ((a[r].__ = e), (t = E(a[r], t, n, s)));
+          return t;
+        }
+        e.__e != t &&
+          (s &&
+            (t && e.type && !t.parentNode && (t = N(e)),
+            n.insertBefore(e.__e, t || null)),
+          (t = e.__e));
+        do {
+          t = t && t.nextSibling;
+        } while (null != t && 8 == t.nodeType);
+        return t;
+      }
+      function $(e, t) {
+        return (
+          (t = t || []),
+          null == e ||
+            "boolean" == typeof e ||
+            (y(e)
+              ? e.some(function (e) {
+                  $(e, t);
+                })
+              : t.push(e)),
+          t
+        );
+      }
+      function I(e, t, n, s) {
+        var a,
+          r,
+          i,
+          o = e.key,
+          l = e.type,
+          c = t[n],
+          d = null != c && !(2 & c.__u);
+        if ((null === c && null == o) || (d && o == c.key && l == c.type))
+          return n;
+        if (s > (d ? 1 : 0))
+          for (a = n - 1, r = n + 1; a >= 0 || r < t.length; )
+            if (
+              null != (c = t[(i = a >= 0 ? a-- : r++)]) &&
+              !(2 & c.__u) &&
+              o == c.key &&
+              l == c.type
+            )
+              return i;
+        return -1;
+      }
+      function L(e, t, n) {
+        "-" == t[0]
+          ? e.setProperty(t, null == n ? "" : n)
+          : (e[t] =
+              null == n
+                ? ""
+                : "number" != typeof n || f.test(t)
+                  ? n
+                  : n + "px");
+      }
+      function D(e, t, n, s, a) {
+        var r, i;
+        e: if ("style" == t)
+          if ("string" == typeof n) e.style.cssText = n;
+          else {
+            if (("string" == typeof s && (e.style.cssText = s = ""), s))
+              for (t in s) (n && t in n) || L(e.style, t, "");
+            if (n) for (t in n) (s && n[t] == s[t]) || L(e.style, t, n[t]);
+          }
+        else if ("o" == t[0] && "n" == t[1])
+          ((r = t != (t = t.replace(u, "$1"))),
+            (i = t.toLowerCase()),
+            (t =
+              i in e || "onFocusOut" == t || "onFocusIn" == t
+                ? i.slice(2)
+                : t.slice(2)),
+            e.l || (e.l = {}),
+            (e.l[t + r] = n),
+            n
+              ? s
+                ? (n[d] = s[d])
+                : ((n[d] = m), e.addEventListener(t, r ? p : g, r))
+              : e.removeEventListener(t, r ? p : g, r));
+        else {
+          if ("http://www.w3.org/2000/svg" == a)
+            t = t.replace(/xlink(H|:h)/, "h").replace(/sName$/, "s");
+          else if (
+            "width" != t &&
+            "height" != t &&
+            "href" != t &&
+            "list" != t &&
+            "form" != t &&
+            "tabIndex" != t &&
+            "download" != t &&
+            "rowSpan" != t &&
+            "colSpan" != t &&
+            "role" != t &&
+            "popover" != t &&
+            t in e
+          )
+            try {
+              e[t] = null == n ? "" : n;
+              break e;
+            } catch (e) {}
+          "function" == typeof n ||
+            (null == n || (!1 === n && "-" != t[4])
+              ? e.removeAttribute(t)
+              : e.setAttribute(t, "popover" == t && 1 == n ? "" : n));
+        }
+      }
+      function F(e) {
+        return function (n) {
+          if (this.l) {
+            var s = this.l[n.type + e];
+            if (null == n[c]) n[c] = m++;
+            else if (n[c] < s[d]) return;
+            return s(t.event ? t.event(n) : n);
+          }
+        };
+      }
+      function R(e, n, s, a, r, i, o, l, c, d) {
+        var u,
+          m,
+          g,
+          p,
+          h,
+          f,
+          A,
+          x,
+          N,
+          C,
+          S,
+          P,
+          z,
+          T,
+          E,
+          $ = n.type;
+        if (void 0 !== n.constructor) return null;
+        (128 & s.__u && ((c = !!(32 & s.__u)), (i = [(l = n.__e = s.__e)])),
+          (u = t.__b) && u(n));
+        e: if ("function" == typeof $)
+          try {
+            if (
+              ((x = n.props),
+              (N = $.prototype && $.prototype.render),
+              (C = (u = $.contextType) && a[u.__c]),
+              (S = u ? (C ? C.props.value : u.__) : a),
+              s.__c
+                ? (A = (m = n.__c = s.__c).__ = m.__E)
+                : (N
+                    ? (n.__c = m = new $(x, S))
+                    : ((n.__c = m = new w(x, S)),
+                      (m.constructor = $),
+                      (m.render = W)),
+                  C && C.sub(m),
+                  m.state || (m.state = {}),
+                  (m.__n = a),
+                  (g = m.__d = !0),
+                  (m.__h = []),
+                  (m._sb = [])),
+              N && null == m.__s && (m.__s = m.state),
+              N &&
+                null != $.getDerivedStateFromProps &&
+                (m.__s == m.state && (m.__s = v({}, m.__s)),
+                v(m.__s, $.getDerivedStateFromProps(x, m.__s))),
+              (p = m.props),
+              (h = m.state),
+              (m.__v = n),
+              g)
+            )
+              (N &&
+                null == $.getDerivedStateFromProps &&
+                null != m.componentWillMount &&
+                m.componentWillMount(),
+                N &&
+                  null != m.componentDidMount &&
+                  m.__h.push(m.componentDidMount));
+            else {
+              if (
+                (N &&
+                  null == $.getDerivedStateFromProps &&
+                  x !== p &&
+                  null != m.componentWillReceiveProps &&
+                  m.componentWillReceiveProps(x, S),
+                n.__v == s.__v ||
+                  (!m.__e &&
+                    null != m.shouldComponentUpdate &&
+                    !1 === m.shouldComponentUpdate(x, m.__s, S)))
+              ) {
+                (n.__v != s.__v &&
+                  ((m.props = x), (m.state = m.__s), (m.__d = !1)),
+                  (n.__e = s.__e),
+                  (n.__k = s.__k),
+                  n.__k.some(function (e) {
+                    e && (e.__ = n);
+                  }),
+                  _.push.apply(m.__h, m._sb),
+                  (m._sb = []),
+                  m.__h.length && o.push(m));
+                break e;
+              }
+              (null != m.componentWillUpdate &&
+                m.componentWillUpdate(x, m.__s, S),
+                N &&
+                  null != m.componentDidUpdate &&
+                  m.__h.push(function () {
+                    m.componentDidUpdate(p, h, f);
+                  }));
+            }
+            if (
+              ((m.context = S),
+              (m.props = x),
+              (m.__P = e),
+              (m.__e = !1),
+              (P = t.__r),
+              (z = 0),
+              N)
+            )
+              ((m.state = m.__s),
+                (m.__d = !1),
+                P && P(n),
+                (u = m.render(m.props, m.state, m.context)),
+                _.push.apply(m.__h, m._sb),
+                (m._sb = []));
+            else
+              do {
+                ((m.__d = !1),
+                  P && P(n),
+                  (u = m.render(m.props, m.state, m.context)),
+                  (m.state = m.__s));
+              } while (m.__d && ++z < 25);
+            ((m.state = m.__s),
+              null != m.getChildContext &&
+                (a = v(v({}, a), m.getChildContext())),
+              N &&
+                !g &&
+                null != m.getSnapshotBeforeUpdate &&
+                (f = m.getSnapshotBeforeUpdate(p, h)),
+              (T =
+                null != u && u.type === k && null == u.key
+                  ? O(u.props.children)
+                  : u),
+              (l = M(e, y(T) ? T : [T], n, s, a, r, i, o, l, c, d)),
+              (m.base = n.__e),
+              (n.__u &= -161),
+              m.__h.length && o.push(m),
+              A && (m.__E = m.__ = null));
+          } catch (e) {
+            if (((n.__v = null), c || null != i))
+              if (e.then) {
+                for (
+                  n.__u |= c ? 160 : 128;
+                  l && 8 == l.nodeType && l.nextSibling;
+                )
+                  l = l.nextSibling;
+                ((i[i.indexOf(l)] = null), (n.__e = l));
+              } else {
+                for (E = i.length; E--; ) b(i[E]);
+                B(n);
+              }
+            else ((n.__e = s.__e), (n.__k = s.__k), e.then || B(n));
+            t.__e(e, n, s);
+          }
+        else
+          null == i && n.__v == s.__v
+            ? ((n.__k = s.__k), (n.__e = s.__e))
+            : (l = n.__e = V(s.__e, n, s, a, r, i, o, c, d));
+        return ((u = t.diffed) && u(n), 128 & n.__u ? void 0 : l);
+      }
+      function B(e) {
+        e && (e.__c && (e.__c.__e = !0), e.__k && e.__k.some(B));
+      }
+      function U(e, n, s) {
+        for (var a = 0; a < s.length; a++) q(s[a], s[++a], s[++a]);
+        (t.__c && t.__c(n, e),
+          e.some(function (n) {
+            try {
+              ((e = n.__h),
+                (n.__h = []),
+                e.some(function (e) {
+                  e.call(n);
+                }));
+            } catch (e) {
+              t.__e(e, n.__v);
+            }
+          }));
+      }
+      function O(e) {
+        return "object" != typeof e || null == e || e.__b > 0
+          ? e
+          : y(e)
+            ? e.map(O)
+            : v({}, e);
+      }
+      function V(n, s, a, r, i, o, l, c, d) {
+        var u,
+          m,
+          g,
+          p,
+          _,
+          f,
+          v,
+          A = a.props || h,
+          x = s.props,
+          k = s.type;
+        if (
+          ("svg" == k
+            ? (i = "http://www.w3.org/2000/svg")
+            : "math" == k
+              ? (i = "http://www.w3.org/1998/Math/MathML")
+              : i || (i = "http://www.w3.org/1999/xhtml"),
+          null != o)
+        )
+          for (u = 0; u < o.length; u++)
+            if (
+              (_ = o[u]) &&
+              "setAttribute" in _ == !!k &&
+              (k ? _.localName == k : 3 == _.nodeType)
+            ) {
+              ((n = _), (o[u] = null));
+              break;
+            }
+        if (null == n) {
+          if (null == k) return document.createTextNode(x);
+          ((n = document.createElementNS(i, k, x.is && x)),
+            c && (t.__m && t.__m(s, o), (c = !1)),
+            (o = null));
+        }
+        if (null == k) A === x || (c && n.data == x) || (n.data = x);
+        else {
+          if (((o = o && e.call(n.childNodes)), !c && null != o))
+            for (A = {}, u = 0; u < n.attributes.length; u++)
+              A[(_ = n.attributes[u]).name] = _.value;
+          for (u in A)
+            ((_ = A[u]),
+              "dangerouslySetInnerHTML" == u
+                ? (g = _)
+                : "children" == u ||
+                  u in x ||
+                  ("value" == u && "defaultValue" in x) ||
+                  ("checked" == u && "defaultChecked" in x) ||
+                  D(n, u, null, _, i));
+          for (u in x)
+            ((_ = x[u]),
+              "children" == u
+                ? (p = _)
+                : "dangerouslySetInnerHTML" == u
+                  ? (m = _)
+                  : "value" == u
+                    ? (f = _)
+                    : "checked" == u
+                      ? (v = _)
+                      : (c && "function" != typeof _) ||
+                        A[u] === _ ||
+                        D(n, u, _, A[u], i));
+          if (m)
+            (c ||
+              (g && (m.__html == g.__html || m.__html == n.innerHTML)) ||
+              (n.innerHTML = m.__html),
+              (s.__k = []));
+          else if (
+            (g && (n.innerHTML = ""),
+            M(
+              "template" == s.type ? n.content : n,
+              y(p) ? p : [p],
+              s,
+              a,
+              r,
+              "foreignObject" == k ? "http://www.w3.org/1999/xhtml" : i,
+              o,
+              l,
+              o ? o[0] : a.__k && N(a, 0),
+              c,
+              d,
+            ),
+            null != o)
+          )
+            for (u = o.length; u--; ) b(o[u]);
+          c ||
+            ((u = "value"),
+            "progress" == k && null == f
+              ? n.removeAttribute("value")
+              : null != f &&
+                (f !== n[u] ||
+                  ("progress" == k && !f) ||
+                  ("option" == k && f != A[u])) &&
+                D(n, u, f, A[u], i),
+            (u = "checked"),
+            null != v && v != n[u] && D(n, u, v, A[u], i));
+        }
+        return n;
+      }
+      function q(e, n, s) {
+        try {
+          if ("function" == typeof e) {
+            var a = "function" == typeof e.__u;
+            (a && e.__u(), (a && null == n) || (e.__u = e(n)));
+          } else e.current = n;
+        } catch (e) {
+          t.__e(e, s);
+        }
+      }
+      function H(e, n, s) {
+        var a, r;
+        if (
+          (t.unmount && t.unmount(e),
+          (a = e.ref) && ((a.current && a.current != e.__e) || q(a, null, n)),
+          null != (a = e.__c))
+        ) {
+          if (a.componentWillUnmount)
+            try {
+              a.componentWillUnmount();
+            } catch (e) {
+              t.__e(e, n);
+            }
+          a.base = a.__P = null;
+        }
+        if ((a = e.__k))
+          for (r = 0; r < a.length; r++)
+            a[r] && H(a[r], n, s || "function" != typeof e.type);
+        (s || b(e.__e), (e.__c = e.__ = e.__e = void 0));
+      }
+      function W(e, t, n) {
+        return this.constructor(e, n);
+      }
+      function j(n, s, a) {
+        var r, i, o, l;
+        (s == document && (s = document.documentElement),
+          t.__ && t.__(n, s),
+          (i = (r = "function" == typeof a) ? null : (a && a.__k) || s.__k),
+          (o = []),
+          (l = []),
+          R(
+            s,
+            (n = ((!r && a) || s).__k = A(k, null, [n])),
+            i || h,
+            h,
+            s.namespaceURI,
+            !r && a
+              ? [a]
+              : i
+                ? null
+                : s.firstChild
+                  ? e.call(s.childNodes)
+                  : null,
+            o,
+            !r && a ? a : i ? i.__e : s.firstChild,
+            r,
+            l,
+          ),
+          U(o, n, l));
+      }
+      ((e = _.slice),
+        (t = {
+          __e: function (e, t, n, s) {
+            for (var a, r, i; (t = t.__); )
+              if ((a = t.__c) && !a.__)
+                try {
+                  if (
+                    ((r = a.constructor) &&
+                      null != r.getDerivedStateFromError &&
+                      (a.setState(r.getDerivedStateFromError(e)), (i = a.__d)),
+                    null != a.componentDidCatch &&
+                      (a.componentDidCatch(e, s || {}), (i = a.__d)),
+                    i)
+                  )
+                    return (a.__E = a);
+                } catch (t) {
+                  e = t;
+                }
+            throw e;
+          },
+        }),
+        (s = 0),
+        (w.prototype.setState = function (e, t) {
+          var n;
+          ((n =
+            null != this.__s && this.__s != this.state
+              ? this.__s
+              : (this.__s = v({}, this.state))),
+            "function" == typeof e && (e = e(v({}, n), this.props)),
+            e && v(n, e),
+            null != e && this.__v && (t && this._sb.push(t), P(this)));
+        }),
+        (w.prototype.forceUpdate = function (e) {
+          this.__v && ((this.__e = !0), e && this.__h.push(e), P(this));
+        }),
+        (w.prototype.render = k),
+        (a = []),
+        (i =
+          "function" == typeof Promise
+            ? Promise.prototype.then.bind(Promise.resolve())
+            : setTimeout),
+        (o = function (e, t) {
+          return e.__v.__b - t.__v.__b;
+        }),
+        (z.__r = 0),
+        (l = Math.random().toString(8)),
+        (c = "__d" + l),
+        (d = "__a" + l),
+        (u = /(PointerCapture)$|Capture$/i),
+        (m = 0),
+        (g = F(!1)),
+        (p = F(!0)));
+      var G,
+        Y,
+        K,
+        Q,
+        X = 0,
+        Z = [],
+        J = t,
+        ee = J.__b,
+        te = J.__r,
+        ne = J.diffed,
+        se = J.__c,
+        ae = J.unmount,
+        re = J.__;
+      function ie(e, t) {
+        (J.__h && J.__h(Y, e, X || t), (X = 0));
+        var n = Y.__H || (Y.__H = { __: [], __h: [] });
+        return (e >= n.__.length && n.__.push({}), n.__[e]);
+      }
+      function oe(e) {
+        return (
+          (X = 1),
+          (function (e, t, n) {
+            var s = ie(G++, 2);
+            if (
+              ((s.t = e),
+              !s.__c &&
+                ((s.__ = [
+                  n ? n(t) : ye(void 0, t),
+                  function (e) {
+                    var t = s.__N ? s.__N[0] : s.__[0],
+                      n = s.t(t, e);
+                    t !== n && ((s.__N = [n, s.__[1]]), s.__c.setState({}));
+                  },
+                ]),
+                (s.__c = Y),
+                !Y.__f))
+            ) {
+              var a = function (e, t, n) {
+                if (!s.__c.__H) return !0;
+                var a = s.__c.__H.__.filter(function (e) {
+                  return e.__c;
+                });
+                if (
+                  a.every(function (e) {
+                    return !e.__N;
+                  })
+                )
+                  return !r || r.call(this, e, t, n);
+                var i = s.__c.props !== e;
+                return (
+                  a.some(function (e) {
+                    if (e.__N) {
+                      var t = e.__[0];
+                      ((e.__ = e.__N),
+                        (e.__N = void 0),
+                        t !== e.__[0] && (i = !0));
+                    }
+                  }),
+                  (r && r.call(this, e, t, n)) || i
+                );
+              };
+              Y.__f = !0;
+              var r = Y.shouldComponentUpdate,
+                i = Y.componentWillUpdate;
+              ((Y.componentWillUpdate = function (e, t, n) {
+                if (this.__e) {
+                  var s = r;
+                  ((r = void 0), a(e, t, n), (r = s));
+                }
+                i && i.call(this, e, t, n);
+              }),
+                (Y.shouldComponentUpdate = a));
+            }
+            return s.__N || s.__;
+          })(ye, e)
+        );
+      }
+      function le(e, t) {
+        var n = ie(G++, 3);
+        !J.__s && fe(n.__H, t) && ((n.__ = e), (n.u = t), Y.__H.__h.push(n));
+      }
+      function ce(e) {
+        return (
+          (X = 5),
+          de(function () {
+            return { current: e };
+          }, [])
+        );
+      }
+      function de(e, t) {
+        var n = ie(G++, 7);
+        return (fe(n.__H, t) && ((n.__ = e()), (n.__H = t), (n.__h = e)), n.__);
+      }
+      function ue(e, t) {
+        return (
+          (X = 8),
+          de(function () {
+            return e;
+          }, t)
+        );
+      }
+      function me() {
+        for (var e; (e = Z.shift()); ) {
+          var t = e.__H;
+          if (e.__P && t)
+            try {
+              (t.__h.some(he), t.__h.some(_e), (t.__h = []));
+            } catch (n) {
+              ((t.__h = []), J.__e(n, e.__v));
+            }
+        }
+      }
+      ((J.__b = function (e) {
+        ((Y = null), ee && ee(e));
+      }),
+        (J.__ = function (e, t) {
+          (e && t.__k && t.__k.__m && (e.__m = t.__k.__m), re && re(e, t));
+        }),
+        (J.__r = function (e) {
+          (te && te(e), (G = 0));
+          var t = (Y = e.__c).__H;
+          (t &&
+            (K === Y
+              ? ((t.__h = []),
+                (Y.__h = []),
+                t.__.some(function (e) {
+                  (e.__N && (e.__ = e.__N), (e.u = e.__N = void 0));
+                }))
+              : (t.__h.some(he), t.__h.some(_e), (t.__h = []), (G = 0))),
+            (K = Y));
+        }),
+        (J.diffed = function (e) {
+          ne && ne(e);
+          var t = e.__c;
+          (t &&
+            t.__H &&
+            (t.__H.__h.length &&
+              ((1 !== Z.push(t) && Q === J.requestAnimationFrame) ||
+                ((Q = J.requestAnimationFrame) || pe)(me)),
+            t.__H.__.some(function (e) {
+              (e.u && (e.__H = e.u), (e.u = void 0));
+            })),
+            (K = Y = null));
+        }),
+        (J.__c = function (e, t) {
+          (t.some(function (e) {
+            try {
+              (e.__h.some(he),
+                (e.__h = e.__h.filter(function (e) {
+                  return !e.__ || _e(e);
+                })));
+            } catch (n) {
+              (t.some(function (e) {
+                e.__h && (e.__h = []);
+              }),
+                (t = []),
+                J.__e(n, e.__v));
+            }
+          }),
+            se && se(e, t));
+        }),
+        (J.unmount = function (e) {
+          ae && ae(e);
+          var t,
+            n = e.__c;
+          n &&
+            n.__H &&
+            (n.__H.__.some(function (e) {
+              try {
+                he(e);
+              } catch (e) {
+                t = e;
+              }
+            }),
+            (n.__H = void 0),
+            t && J.__e(t, n.__v));
+        }));
+      var ge = "function" == typeof requestAnimationFrame;
+      function pe(e) {
+        var t,
+          n = function () {
+            (clearTimeout(s), ge && cancelAnimationFrame(t), setTimeout(e));
+          },
+          s = setTimeout(n, 35);
+        ge && (t = requestAnimationFrame(n));
+      }
+      function he(e) {
+        var t = Y,
+          n = e.__c;
+        ("function" == typeof n && ((e.__c = void 0), n()), (Y = t));
+      }
+      function _e(e) {
+        var t = Y;
+        ((e.__c = e.__()), (Y = t));
+      }
+      function fe(e, t) {
+        return (
+          !e ||
+          e.length !== t.length ||
+          t.some(function (t, n) {
+            return t !== e[n];
+          })
+        );
+      }
+      function ye(e, t) {
+        return "function" == typeof t ? t(e) : t;
+      }
+      function ve(e, t) {
+        for (var n in e) if ("__source" !== n && !(n in t)) return !0;
+        for (var s in t) if ("__source" !== s && e[s] !== t[s]) return !0;
+        return !1;
+      }
+      function be(e, t) {
+        ((this.props = e), (this.context = t));
+      }
+      (((be.prototype = new w()).isPureReactComponent = !0),
+        (be.prototype.shouldComponentUpdate = function (e, t) {
+          return ve(this.props, e) || ve(this.state, t);
+        }));
+      var Ae = t.__b;
+      ((t.__b = function (e) {
+        (e.type &&
+          e.type.__f &&
+          e.ref &&
+          ((e.props.ref = e.ref), (e.ref = null)),
+          Ae && Ae(e));
+      }),
+        "undefined" != typeof Symbol &&
+          Symbol.for &&
+          Symbol.for("react.forward_ref"));
+      var xe = t.__e;
+      t.__e = function (e, t, n, s) {
+        if (e.then)
+          for (var a, r = t; (r = r.__); )
+            if ((a = r.__c) && a.__c)
+              return (
+                null == t.__e && ((t.__e = n.__e), (t.__k = n.__k)),
+                a.__c(e, t)
+              );
+        xe(e, t, n, s);
+      };
+      var ke = t.unmount;
+      function we(e, t, n) {
+        return (
+          e &&
+            (e.__c &&
+              e.__c.__H &&
+              (e.__c.__H.__.forEach(function (e) {
+                "function" == typeof e.__c && e.__c();
+              }),
+              (e.__c.__H = null)),
+            null !=
+              (e = (function (e, t) {
+                for (var n in t) e[n] = t[n];
+                return e;
+              })({}, e)).__c &&
+              (e.__c.__P === n && (e.__c.__P = t),
+              (e.__c.__e = !0),
+              (e.__c = null)),
+            (e.__k =
+              e.__k &&
+              e.__k.map(function (e) {
+                return we(e, t, n);
+              }))),
+          e
+        );
+      }
+      function Ne(e, t, n) {
+        return (
+          e &&
+            n &&
+            ((e.__v = null),
+            (e.__k =
+              e.__k &&
+              e.__k.map(function (e) {
+                return Ne(e, t, n);
+              })),
+            e.__c &&
+              e.__c.__P === t &&
+              (e.__e && n.appendChild(e.__e),
+              (e.__c.__e = !0),
+              (e.__c.__P = n))),
+          e
+        );
+      }
+      function Ce() {
+        ((this.__u = 0), (this.o = null), (this.__b = null));
+      }
+      function Se(e) {
+        var t = e.__ && e.__.__c;
+        return t && t.__a && t.__a(e);
+      }
+      function Pe() {
+        ((this.i = null), (this.l = null));
+      }
+      ((t.unmount = function (e) {
+        var t = e.__c;
+        (t && (t.__z = !0),
+          t && t.__R && t.__R(),
+          t && 32 & e.__u && (e.type = null),
+          ke && ke(e));
+      }),
+        ((Ce.prototype = new w()).__c = function (e, t) {
+          var n = t.__c,
+            s = this;
+          (null == s.o && (s.o = []), s.o.push(n));
+          var a = Se(s.__v),
+            r = !1,
+            i = function () {
+              r || s.__z || ((r = !0), (n.__R = null), a ? a(l) : l());
+            };
+          n.__R = i;
+          var o = n.__P;
+          n.__P = null;
+          var l = function () {
+            if (!--s.__u) {
+              if (s.state.__a) {
+                var e = s.state.__a;
+                s.__v.__k[0] = Ne(e, e.__c.__P, e.__c.__O);
+              }
+              var t;
+              for (s.setState({ __a: (s.__b = null) }); (t = s.o.pop()); )
+                ((t.__P = o), t.forceUpdate());
+            }
+          };
+          (s.__u++ || 32 & t.__u || s.setState({ __a: (s.__b = s.__v.__k[0]) }),
+            e.then(i, i));
+        }),
+        (Ce.prototype.componentWillUnmount = function () {
+          this.o = [];
+        }),
+        (Ce.prototype.render = function (e, t) {
+          if (this.__b) {
+            if (this.__v.__k) {
+              var n = document.createElement("div"),
+                s = this.__v.__k[0].__c;
+              this.__v.__k[0] = we(this.__b, n, (s.__O = s.__P));
+            }
+            this.__b = null;
+          }
+          var a = t.__a && A(k, null, e.fallback);
+          return (
+            a && (a.__u &= -33),
+            [A(k, null, t.__a ? null : e.children), a]
+          );
+        }));
+      var ze = function (e, t, n) {
+        if (
+          (++n[1] === n[0] && e.l.delete(t),
+          e.props.revealOrder && ("t" !== e.props.revealOrder[0] || !e.l.size))
+        )
+          for (n = e.i; n; ) {
+            for (; n.length > 3; ) n.pop()();
+            if (n[1] < n[0]) break;
+            e.i = n = n[2];
+          }
+      };
+      (((Pe.prototype = new w()).__a = function (e) {
+        var t = this,
+          n = Se(t.__v),
+          s = t.l.get(e);
+        return (
+          s[0]++,
+          function (a) {
+            var r = function () {
+              t.props.revealOrder ? (s.push(a), ze(t, e, s)) : a();
+            };
+            n ? n(r) : r();
+          }
+        );
+      }),
+        (Pe.prototype.render = function (e) {
+          ((this.i = null), (this.l = new Map()));
+          var t = $(e.children);
+          e.revealOrder && "b" === e.revealOrder[0] && t.reverse();
+          for (var n = t.length; n--; )
+            this.l.set(t[n], (this.i = [1, 0, this.i]));
+          return e.children;
+        }),
+        (Pe.prototype.componentDidUpdate = Pe.prototype.componentDidMount =
+          function () {
+            var e = this;
+            this.l.forEach(function (t, n) {
+              ze(e, n, t);
+            });
+          }));
+      var Me =
+          ("undefined" != typeof Symbol &&
+            Symbol.for &&
+            Symbol.for("react.element")) ||
+          60103,
+        Te =
+          /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/,
+        Ee = /^on(Ani|Tra|Tou|BeforeInp|Compo)/,
+        $e = /[A-Z0-9]/g,
+        Ie = "undefined" != typeof document,
+        Le = function (e) {
+          return (
+            "undefined" != typeof Symbol && "symbol" == typeof Symbol()
+              ? /fil|che|rad/
+              : /fil|che|ra/
+          ).test(e);
+        };
+      ((w.prototype.isReactComponent = !0),
+        [
+          "componentWillMount",
+          "componentWillReceiveProps",
+          "componentWillUpdate",
+        ].forEach(function (e) {
+          Object.defineProperty(w.prototype, e, {
+            configurable: !0,
+            get: function () {
+              return this["UNSAFE_" + e];
+            },
+            set: function (t) {
+              Object.defineProperty(this, e, {
+                configurable: !0,
+                writable: !0,
+                value: t,
+              });
+            },
+          });
+        }));
+      var De = t.event;
+      t.event = function (e) {
+        return (
+          De && (e = De(e)),
+          (e.persist = function () {}),
+          (e.isPropagationStopped = function () {
+            return this.cancelBubble;
+          }),
+          (e.isDefaultPrevented = function () {
+            return this.defaultPrevented;
+          }),
+          (e.nativeEvent = e)
+        );
+      };
+      var Fe = {
+          configurable: !0,
+          get: function () {
+            return this.class;
+          },
+        },
+        Re = t.vnode;
+      t.vnode = function (e) {
+        ("string" == typeof e.type &&
+          (function (e) {
+            var t = e.props,
+              n = e.type,
+              s = {},
+              a = -1 == n.indexOf("-");
+            for (var r in t) {
+              var i = t[r];
+              if (
+                !(
+                  ("value" === r && "defaultValue" in t && null == i) ||
+                  (Ie && "children" === r && "noscript" === n) ||
+                  "class" === r ||
+                  "className" === r
+                )
+              ) {
+                var o = r.toLowerCase();
+                ("defaultValue" === r && "value" in t && null == t.value
+                  ? (r = "value")
+                  : "download" === r && !0 === i
+                    ? (i = "")
+                    : "translate" === o && "no" === i
+                      ? (i = !1)
+                      : "o" === o[0] && "n" === o[1]
+                        ? "ondoubleclick" === o
+                          ? (r = "ondblclick")
+                          : "onchange" !== o ||
+                              ("input" !== n && "textarea" !== n) ||
+                              Le(t.type)
+                            ? "onfocus" === o
+                              ? (r = "onfocusin")
+                              : "onblur" === o
+                                ? (r = "onfocusout")
+                                : Ee.test(r) && (r = o)
+                            : (o = r = "oninput")
+                        : a && Te.test(r)
+                          ? (r = r.replace($e, "-$&").toLowerCase())
+                          : null === i && (i = void 0),
+                  "oninput" === o && s[(r = o)] && (r = "oninputCapture"),
+                  (s[r] = i));
+              }
+            }
+            ("select" == n &&
+              (s.multiple &&
+                Array.isArray(s.value) &&
+                (s.value = $(t.children).forEach(function (e) {
+                  e.props.selected = -1 != s.value.indexOf(e.props.value);
+                })),
+              null != s.defaultValue &&
+                (s.value = $(t.children).forEach(function (e) {
+                  e.props.selected = s.multiple
+                    ? -1 != s.defaultValue.indexOf(e.props.value)
+                    : s.defaultValue == e.props.value;
+                }))),
+              t.class && !t.className
+                ? ((s.class = t.class),
+                  Object.defineProperty(s, "className", Fe))
+                : t.className && (s.class = s.className = t.className),
+              (e.props = s));
+          })(e),
+          (e.$$typeof = Me),
+          Re && Re(e));
+      };
+      var Be = t.__r;
+      t.__r = function (e) {
+        (Be && Be(e), e.__c);
+      };
+      var Ue = t.diffed;
+      t.diffed = function (e) {
+        Ue && Ue(e);
+        var t = e.props,
+          n = e.__e;
+        null != n &&
+          "textarea" === e.type &&
+          "value" in t &&
+          t.value !== n.value &&
+          (n.value = null == t.value ? "" : t.value);
+      };
+      var Oe = 0;
+      function Ve(e, n, s, a, r, i) {
+        n || (n = {});
+        var o,
+          l,
+          c = n;
+        if ("ref" in c)
+          for (l in ((c = {}), n)) "ref" == l ? (o = n[l]) : (c[l] = n[l]);
+        var d = {
+          type: e,
+          props: c,
+          key: s,
+          ref: o,
+          __k: null,
+          __: null,
+          __b: 0,
+          __e: null,
+          __c: null,
+          constructor: void 0,
+          __v: --Oe,
+          __i: -1,
+          __u: 0,
+          __source: r,
+          __self: i,
+        };
+        if ("function" == typeof e && (o = e.defaultProps))
+          for (l in o) void 0 === c[l] && (c[l] = o[l]);
+        return (t.vnode && t.vnode(d), d);
+      }
+      Array.isArray;
+      var qe = n(815);
+      const He = n.n(qe)(),
+        We = ({ size: e = 20, className: t }) =>
+          Ve("svg", {
+            width: e,
+            height: e,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: "2",
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+            className: t,
+            children: Ve("path", {
+              d: "M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z",
+            }),
+          }),
+        je = ({ size: e = 20, className: t }) =>
+          Ve("svg", {
+            width: e,
+            height: e,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: "2",
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+            className: t,
+            children: [
+              Ve("line", { x1: "22", y1: "2", x2: "11", y2: "13" }),
+              Ve("polygon", { points: "22 2 15 22 11 13 2 9 22 2" }),
+            ],
+          }),
+        Ge = ({ size: e = 20, className: t }) =>
+          Ve("svg", {
+            width: e,
+            height: e,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: "2",
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+            className: t,
+            children: [
+              Ve("line", { x1: "19", y1: "12", x2: "5", y2: "12" }),
+              Ve("polyline", { points: "12 19 5 12 12 5" }),
+            ],
+          }),
+        Ye = ({ size: e = 20, className: t }) =>
+          Ve("svg", {
+            width: e,
+            height: e,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: "2",
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+            className: t,
+            children: [
+              Ve("path", { d: "M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4" }),
+              Ve("polyline", { points: "16 17 21 12 16 7" }),
+              Ve("line", { x1: "21", y1: "12", x2: "9", y2: "12" }),
+            ],
+          }),
+        Ke = ({ size: e = 20, className: t }) =>
+          Ve("svg", {
+            width: e,
+            height: e,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: "2",
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+            className: t,
+            children: [
+              Ve("path", {
+                d: "M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6",
+              }),
+              Ve("polyline", { points: "15 3 21 3 21 9" }),
+              Ve("line", { x1: "10", y1: "14", x2: "21", y2: "3" }),
+            ],
+          }),
+        Qe = ({ size: e = 16, className: t }) =>
+          Ve("svg", {
+            width: e,
+            height: e,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: "2",
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+            className: t,
+            children: Ve("polyline", { points: "6 9 12 15 18 9" }),
+          }),
+        Xe = ({ size: e = 16, className: t }) =>
+          Ve("svg", {
+            width: e,
+            height: e,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: "2",
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+            className: t,
+            children: Ve("polyline", { points: "18 15 12 9 6 15" }),
+          }),
+        Ze = ({ size: e = 20, className: t }) =>
+          Ve("svg", {
+            width: e,
+            height: e,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: "2",
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+            className: t,
+            children: [
+              Ve("circle", { cx: "18", cy: "5", r: "3" }),
+              Ve("circle", { cx: "6", cy: "12", r: "3" }),
+              Ve("circle", { cx: "18", cy: "19", r: "3" }),
+              Ve("line", { x1: "8.59", y1: "13.51", x2: "15.42", y2: "17.49" }),
+              Ve("line", { x1: "15.41", y1: "6.51", x2: "8.59", y2: "10.49" }),
+            ],
+          }),
+        Je = () =>
+          Ve("svg", {
+            width: "18",
+            height: "18",
+            viewBox: "0 0 24 24",
+            children: [
+              Ve("path", {
+                fill: "#4285F4",
+                d: "M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z",
+              }),
+              Ve("path", {
+                fill: "#34A853",
+                d: "M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z",
+              }),
+              Ve("path", {
+                fill: "#FBBC05",
+                d: "M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z",
+              }),
+              Ve("path", {
+                fill: "#EA4335",
+                d: "M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z",
+              }),
+            ],
+          }),
+        et = {
+          play: "M5 3l14 9-14 9V3z",
+          camera:
+            "M23 7l-7 5 7 5V7zM14 5H3a2 2 0 00-2 2v10a2 2 0 002 2h11a2 2 0 002-2V7a2 2 0 00-2-2z",
+          headphones: "M3 18v-6a9 9 0 0118 0v6",
+          youtube:
+            "M22.54 6.42A2.78 2.78 0 0020.6 4.42C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 00-1.94 2A29 29 0 001 11.75a29 29 0 00.46 5.33A2.78 2.78 0 003.4 19c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 001.94-2 29 29 0 00.46-5.25 29 29 0 00-.46-5.33z",
+          waveform: "M2 12c2-3 4-3 6 0s4 3 6 0 4-3 6 0",
+          book: "M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2zm20 0h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z",
+          lightbulb:
+            "M9 18h6M10 22h4M12 2a6 6 0 00-6 6c0 2 1 3.5 2.5 5 .5.5 1 1.5 1 2.5V17h5v-1.5c0-1 .5-2 1-2.5 1.5-1.5 2.5-3 2.5-5a6 6 0 00-6-6z",
+          brain:
+            "M12 4c-2 0-3.5 1-4 2.5-.5-1-2-1.5-3-.5S3.5 8 4 9c-1 .5-1.5 2-.5 3s2 1.5 3 1c.5 1.5 2 2.5 4 2.5s3.5-1 4-2.5c1 .5 2 0 3-1s.5-2.5-.5-3c.5-1 0-2.5-1-3.5s-2.5 0-3 .5C15.5 5 14 4 12 4z",
+          graduation:
+            "M22 10l-10-5L2 10l10 5zm-16 2v5c0 2 2.7 3 6 3s6-1 6-3v-5",
+          sparkles:
+            "M12 3v2m0 14v2m9-9h-2M5 12H3m15.4-6.4l-1.4 1.4M7 17l-1.4 1.4m12.8 0L17 17M7 7L5.6 5.6",
+          lightning: "M13 2L3 14h9l-1 8 10-12h-9z",
+          robot:
+            "M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1v1a2 2 0 01-2 2H5a2 2 0 01-2-2v-1H2a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2z",
+          search: "M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z",
+          globe:
+            "M12 2a10 10 0 100 20 10 10 0 000-20zM2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z",
+          star: "M12 2l2.4 7.4h7.6l-6 4.6 2.4 7.4-6.4-4.8-6.4 4.8 2.4-7.4-6-4.6h7.6z",
+          heart:
+            "M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z",
+          sparkle4pt: "M12 2l1.5 4.5L18 8l-4.5 1.5L12 14l-1.5-4.5L6 8l4.5-1.5z",
+          crown: "M2 17l3-7 4 4 3-9 3 9 4-4 3 7z",
+          diamond: "M12 2l10 10-10 10L2 12z",
+          code: "M16 18l6-6-6-6M8 6l-6 6 6 6",
+          shield: "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z",
+        },
+        tt = Object.values(et),
+        nt = ({
+          name: e,
+          size: t = 24,
+          color: n = "currentColor",
+          strokeWidth: s = 1.5,
+          className: a = "",
+          style: r,
+        }) => {
+          const i = et[e];
+          return i
+            ? Ve("svg", {
+                width: t,
+                height: t,
+                viewBox: "0 0 24 24",
+                fill: "none",
+                stroke: n,
+                strokeWidth: s,
+                strokeLinecap: "round",
+                strokeLinejoin: "round",
+                className: `doodle-icon ${a}`,
+                style: r,
+                "aria-hidden": "true",
+                children: Ve("path", { d: i }),
+              })
+            : null;
+        },
+        st = {
+          xs: { container: 24, wheel: 22 },
+          sm: { container: 40, wheel: 36 },
+          md: { container: 64, wheel: 58 },
+          lg: { container: 96, wheel: 88 },
+        },
+        at = { slow: 8, normal: 5, fast: 2 },
+        rt = [
+          {
+            src: "platforms/youtube-icon-red.png",
+            alt: "YouTube",
+            size: 18,
+            position: { top: -8, left: "50%" },
+            delay: 0,
+          },
+          {
+            src: "platforms/tiktok-note-white.png",
+            alt: "TikTok",
+            size: 16,
+            position: { top: "50%", right: -8 },
+            delay: 0.5,
+          },
+          {
+            src: "platforms/mistral-m-orange.svg",
+            alt: "Mistral",
+            size: 16,
+            position: { bottom: -8, left: "50%" },
+            delay: 1,
+          },
+          {
+            src: "platforms/tournesol-logo.png",
+            alt: "Tournesol",
+            size: 16,
+            position: { top: "50%", left: -8 },
+            delay: 1.5,
+          },
+        ],
+        it = ({
+          size: e = "md",
+          className: t = "",
+          label: n = "Chargement...",
+          showLabel: s = !1,
+          speed: a = "normal",
+          showLogos: r = !1,
+        }) => {
+          const { container: i, wheel: o } = st[e],
+            l = at[a],
+            c = i >= 36,
+            d = r && i >= 64,
+            u = He.runtime.getURL("assets/spinner-cosmic.jpg"),
+            m = He.runtime.getURL("assets/spinner-wheel.jpg"),
+            g = d ? i + 40 : i;
+          return Ve("div", {
+            className: `ds-spinner-wrapper ${t}`,
+            role: "status",
+            "aria-label": n,
+            style: {
+              display: "inline-flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+            },
+            children: [
+              Ve("div", {
+                style: {
+                  position: "relative",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: g,
+                  height: g,
+                },
+                children: [
+                  d &&
+                    rt.map((e, t) => {
+                      const n = He.runtime.getURL(e.src),
+                        s = g / 2,
+                        a = g / 2,
+                        r = i / 2 + 14,
+                        o = (90 * t - 90) * (Math.PI / 180),
+                        l = s + Math.cos(o) * r - e.size / 2,
+                        c = a + Math.sin(o) * r - e.size / 2;
+                      return Ve(
+                        "img",
+                        {
+                          src: n,
+                          alt: e.alt,
+                          style: {
+                            position: "absolute",
+                            width: e.size,
+                            height: e.size,
+                            left: l,
+                            top: c,
+                            objectFit: "contain",
+                            zIndex: 20,
+                            filter: "drop-shadow(0 0 6px rgba(200,144,58,0.4))",
+                            animation: `logoPulse 3s ease-in-out ${e.delay}s infinite`,
+                          },
+                        },
+                        e.alt,
+                      );
+                    }),
+                  c &&
+                    Ve("img", {
+                      src: u,
+                      alt: "",
+                      "aria-hidden": "true",
+                      style: {
+                        position: "absolute",
+                        width: i,
+                        height: i,
+                        left: d ? 20 : 0,
+                        top: d ? 20 : 0,
+                        objectFit: "cover",
+                        maskImage:
+                          "radial-gradient(circle at center, transparent 0%, transparent 38%, rgba(0,0,0,0.4) 45%, black 52%, black 100%)",
+                        WebkitMaskImage:
+                          "radial-gradient(circle at center, transparent 0%, transparent 38%, rgba(0,0,0,0.4) 45%, black 52%, black 100%)",
+                        zIndex: 1,
+                        mixBlendMode: "screen",
+                        borderRadius: "50%",
+                        animation: "colorCycle 12s ease-in-out infinite",
+                      },
+                    }),
+                  Ve("img", {
+                    src: m,
+                    alt: "",
+                    "aria-hidden": "true",
+                    style: {
+                      width: o,
+                      height: o,
+                      position: "relative",
+                      zIndex: 10,
+                      mixBlendMode: "screen",
+                      opacity: 0.85,
+                      filter: "brightness(1.2) contrast(1.25) saturate(1.1)",
+                      animation: `gouvernailSpin ${l}s linear infinite`,
+                      willChange: "transform",
+                    },
+                  }),
+                ],
+              }),
+              s &&
+                Ve("span", {
+                  style: {
+                    fontSize: 13,
+                    color: "var(--text-tertiary)",
+                    animation: "glowPulse 2s ease-in-out infinite",
+                  },
+                  children: n,
+                }),
+              Ve("span", {
+                style: {
+                  position: "absolute",
+                  width: 1,
+                  height: 1,
+                  padding: 0,
+                  margin: -1,
+                  overflow: "hidden",
+                  clip: "rect(0,0,0,0)",
+                  border: 0,
+                },
+                children: n,
+              }),
+            ],
+          });
+        },
+        ot = {
+          fr: JSON.parse(
+            '{"common":{"login":"Se connecter","logout":"Déconnexion","back":"Retour","retry":"Réessayer","send":"Envoyer","hide":"Masquer","error":"Erreur","viewPlans":"Voir les plans","allPlans":"Tous les plans","createAccount":"Créer un compte","unlock":"Débloquer","analyses":"analyses","credits":"crédits"},"login":{"tagline":"Ne subissez plus vos vidéos — interrogez-les.","badgeFr":"IA Française","badgeEu":"Données en Europe","googleLoading":"Connexion Google...","googleButton":"Continuer avec Google","divider":"ou","emailPlaceholder":"Adresse e-mail","passwordPlaceholder":"Mot de passe","loginLoading":"Connexion...","guestButton":"Essayer sans compte (3 analyses gratuites)","privacy":"Confidentialité","terms":"CGU"},"plans":{"free":"Gratuit","pro":"Pro","expert":"Expert","etudiant":"Pro","student":"Pro","starter":"Pro","equipe":"Expert","team":"Expert"},"upsell":{"free":{"label":"Pro","feature":"30 analyses + Cartes mentales + Web Search","price":"5,99€"},"pro":{"label":"Expert","feature":"100 analyses + Mistral Large + Playlists 20 vidéos","price":"14,99€"}},"analysis":{"noVideo":"Ouvre une vidéo YouTube ou TikTok pour l\'analyser","analyzeButton":"Analyser cette vidéo","starting":"Démarrage de l\'analyse...","processing":"Traitement en cours...","failed":"Analyse échouée","startFailed":"Impossible de démarrer l\'analyse","recent":"Analyses récentes","quotaExceeded":"Quota atteint","quotaExceededText":"Passez au plan supérieur","mode":"Mode","language":"Langue","quickChatButton":"Quick Chat IA","quickChatPreparing":"Préparation du chat...","modes":{"standard":"Standard","accessible":"Accessible","expert":"Expert"},"languages":{"fr":"Français","en":"English","es":"Español","de":"Deutsch"}},"guest":{"banner":"Mode découverte — 3 analyses gratuites sans compte","exhaustedText":"Créez un compte gratuit pour sauvegarder vos analyses et en faire plus"},"credits":{"critical":"Plus que {count} crédits —","recharge":"Recharger","remaining":"{count} crédits restants","low":"cr."},"mistral":{"badge":"Propulsé par Mistral AI"},"synthesis":{"complete":"Analyse complète","fullAnalysis":"Analyse complète","chat":"Chat","share":"Partager","showDetail":"Voir l\'analyse détaillée","hideDetail":"Masquer l\'analyse détaillée","printPdf":"Imprimer / PDF","reliable":"Fiable","toVerify":"À vérifier","unreliable":"Peu fiable","generatingDef":"Définition en cours de génération...","shareTitle":"Synthèse DeepSight","verdict":"Verdict","keyPoints":"Points Clés","concepts":"Concepts","tags":"Tags","generatedBy":"Généré par","analysisDesc":"Analyse IA de vidéos YouTube & TikTok","euBadge":"IA 100% Européenne propulsée par Mistral AI"},"features":{"flashcards":"Flashcards","flashcardsDesc":"Révisez avec des cartes mémoire générées par l\'IA","mindMaps":"Cartes mentales","mindMapsDesc":"Visualisez les idées clés sous forme de carte","webSearch":"Recherche web","webSearchDesc":"Enrichissez l\'analyse avec des sources externes","exports":"Exports","exportsDesc":"Téléchargez en PDF, DOCX ou Markdown","playlists":"Playlists","playlistsDesc":"Analysez des playlists entières en un clic","mobileDesc":"Accédez à DeepSight sur mobile","fromPrice":"dès {price}"},"chat":{"welcome":"Pose une question sur cette vidéo.","sessionExpired":"Session expirée","reconnect":"Se reconnecter","webSearchEnable":"Activer recherche web","webSearchDisable":"Désactiver recherche web","webSearchLocked":"Recherche web — plan payant requis","inputPlaceholder":"Pose une question...","expiredPlaceholder":"Session expirée...","webEnriched":"Enrichi par le web","unavailable":"Réponse indisponible","suggestions":["Quels sont les points clés ?","Résume en 3 phrases","Y a-t-il des biais ?","Quelles sources sont citées ?"]},"widget":{"analyze":"Analyser cette vidéo","quickChat":"Quick Chat IA","back":"← Retour","minimize":"Réduire","expand":"Agrandir","analyzing":"Analyse en cours...","analysisComplete":"Analyse complète","reliability":"Fiabilité","verdict":"Verdict","keyPoints":"Points clés","seeDetail":"Voir l\'analyse détaillée","hideDetail":"Masquer","chatWith":"Chatter avec la vidéo","openFull":"Analyse complète sur DeepSight","copy":"Copier","share":"Partager","copied":"Copié!","tournesolScore":"Score Tournesol"},"panel":{"synthesis":"Synthèse","chat":"Chat","factcheck":"Faits","tournesol":"Tournesol","study":"Étude","noVideo":"Aucune vidéo détectée","noVideoSub":"Naviguez sur YouTube ou TikTok pour analyser une vidéo.","notAnalyzed":"Vidéo non analysée","notAnalyzedSub":"Lancez l\'analyse depuis le widget YouTube.","loading":"Chargement..."},"bridge":{"title":"Retrouvez cette analyse sur","web":"Application Web","ios":"App iOS","android":"App Android","upgrade":"Passer Pro"},"teaser":{"unlockMore":"Débloquez plus","flashcards":"Flashcards IA","mindmap":"Carte mentale","webSearch":"Recherche web IA","export":"Export PDF/DOCX","playlists":"Playlists entières","seeAllPlans":"Voir tous les plans →","reviewMobile":"Révisez vos flashcards sur mobile","downloadApp":"Télécharger l\'app"},"ytRecommend":{"title":"Essayez DeepSight sur YouTube !","subtitle":"Naviguez vers une vidéo pour l\'analyser avec l\'IA","dismiss":"Fermer"},"onboarding":{"welcome":"Bienvenue sur DeepSight !","step1":"Ouvrez une vidéo YouTube","step2":"Cliquez sur \'Analyser\'","step3":"Lisez la synthèse IA","shortcuts":"Raccourcis clavier","shortcutWidget":"Alt+D — Toggle widget","shortcutAnalyze":"Alt+A — Analyser","shortcutChat":"Alt+C — Chat","shortcutPanel":"Alt+S — Side Panel"},"results":{"backToAnalysis":"Nouvelle analyse"},"promos":{"free":[{"text":"30 analyses/mois + Cartes mentales + Web Search — dès 5,99€/mois","cta":"Passer à Pro"},{"text":"Seulement 5 analyses/mois ? Passez à 30 avec Pro","cta":"Upgrade →"},{"text":"Quota limité ? Débloquez 30 analyses et toutes les fonctionnalités Pro","cta":"Voir les plans"}],"pro":[{"text":"100 analyses/mois + Mistral Large + Playlists 20 vidéos — Expert","cta":"Passer à Expert"},{"text":"DeepSight sur mobile — révisez vos flashcards partout","cta":"Télécharger"}],"expert":[{"text":"Gérez vos playlists et exports sur deepsightsynthesis.com","cta":"Ouvrir"}]}}',
+          ),
+          en: JSON.parse(
+            '{"common":{"login":"Log in","logout":"Log out","back":"Back","retry":"Retry","send":"Send","hide":"Hide","error":"Error","viewPlans":"View plans","allPlans":"All plans","createAccount":"Create account","unlock":"Unlock","analyses":"analyses","credits":"credits"},"login":{"tagline":"Stop enduring your videos — question them.","badgeFr":"French AI","badgeEu":"Data in Europe","googleLoading":"Google login...","googleButton":"Continue with Google","divider":"or","emailPlaceholder":"Email address","passwordPlaceholder":"Password","loginLoading":"Logging in...","guestButton":"Try without an account (3 free analyses)","privacy":"Privacy","terms":"Terms"},"plans":{"free":"Free","pro":"Pro","expert":"Expert","etudiant":"Pro","student":"Pro","starter":"Pro","equipe":"Expert","team":"Expert"},"upsell":{"free":{"label":"Pro","feature":"30 analyses + Mind maps + Web Search","price":"€5.99"},"pro":{"label":"Expert","feature":"100 analyses + Mistral Large + 20-video playlists","price":"€14.99"}},"analysis":{"noVideo":"Open a YouTube or TikTok video to analyze it","analyzeButton":"Analyze this video","starting":"Starting analysis...","processing":"Processing...","failed":"Analysis failed","startFailed":"Could not start analysis","recent":"Recent analyses","quotaExceeded":"Quota reached","quotaExceededText":"Upgrade to a higher plan","mode":"Mode","language":"Language","quickChatButton":"Quick AI Chat","quickChatPreparing":"Preparing chat...","modes":{"standard":"Standard","accessible":"Accessible","expert":"Expert"},"languages":{"fr":"Français","en":"English","es":"Español","de":"Deutsch"}},"guest":{"banner":"Discovery mode — 3 free analyses without an account","exhaustedText":"Create a free account to save your analyses and do more"},"credits":{"critical":"Only {count} credits left —","recharge":"Top up","remaining":"{count} credits remaining","low":"cr."},"mistral":{"badge":"Powered by Mistral AI"},"synthesis":{"complete":"Analysis complete","fullAnalysis":"Full analysis","chat":"Chat","share":"Share","showDetail":"Show detailed analysis","hideDetail":"Hide detailed analysis","printPdf":"Print / PDF","reliable":"Reliable","toVerify":"To verify","unreliable":"Unreliable","generatingDef":"Generating definition...","shareTitle":"DeepSight Synthesis","verdict":"Verdict","keyPoints":"Key Points","concepts":"Concepts","tags":"Tags","generatedBy":"Generated by","analysisDesc":"AI analysis of YouTube & TikTok videos","euBadge":"100% European AI powered by Mistral AI"},"features":{"flashcards":"Flashcards","flashcardsDesc":"Study with AI-generated memory cards","mindMaps":"Mind maps","mindMapsDesc":"Visualize key ideas as a mind map","webSearch":"Web search","webSearchDesc":"Enrich analysis with external sources","exports":"Exports","exportsDesc":"Download as PDF, DOCX or Markdown","playlists":"Playlists","playlistsDesc":"Analyze entire playlists in one click","mobileDesc":"Access DeepSight on mobile","fromPrice":"from {price}"},"chat":{"welcome":"Ask a question about this video.","sessionExpired":"Session expired","reconnect":"Reconnect","webSearchEnable":"Enable web search","webSearchDisable":"Disable web search","webSearchLocked":"Web search — paid plan required","inputPlaceholder":"Ask a question...","expiredPlaceholder":"Session expired...","webEnriched":"Enriched by the web","unavailable":"Response unavailable","suggestions":["What are the key points?","Summarize in 3 sentences","Are there any biases?","What sources are cited?"]},"widget":{"analyze":"Analyze this video","quickChat":"Quick AI Chat","back":"← Back","minimize":"Minimize","expand":"Expand","analyzing":"Analyzing...","analysisComplete":"Analysis complete","reliability":"Reliability","verdict":"Verdict","keyPoints":"Key points","seeDetail":"See detailed analysis","hideDetail":"Hide","chatWith":"Chat with this video","openFull":"Full analysis on DeepSight","copy":"Copy","share":"Share","copied":"Copied!","tournesolScore":"Tournesol score"},"panel":{"synthesis":"Analysis","chat":"Chat","factcheck":"Facts","tournesol":"Tournesol","study":"Study","noVideo":"No video detected","noVideoSub":"Go to YouTube or TikTok to analyze a video.","notAnalyzed":"Video not yet analyzed","notAnalyzedSub":"Launch analysis from the YouTube widget.","loading":"Loading..."},"bridge":{"title":"Find this analysis on","web":"Web App","ios":"iOS App","android":"Android App","upgrade":"Go Pro"},"teaser":{"unlockMore":"Unlock more","flashcards":"AI Flashcards","mindmap":"Mind map","webSearch":"AI Web search","export":"PDF/DOCX Export","playlists":"Full playlists","seeAllPlans":"See all plans →","reviewMobile":"Study flashcards on mobile","downloadApp":"Download the app"},"ytRecommend":{"title":"Try DeepSight on YouTube!","subtitle":"Navigate to a video to analyze it with AI","dismiss":"Close"},"onboarding":{"welcome":"Welcome to DeepSight!","step1":"Open a YouTube video","step2":"Click \'Analyze\'","step3":"Read the AI synthesis","shortcuts":"Keyboard shortcuts","shortcutWidget":"Alt+D — Toggle widget","shortcutAnalyze":"Alt+A — Analyze","shortcutChat":"Alt+C — Chat","shortcutPanel":"Alt+S — Side Panel"},"results":{"backToAnalysis":"New analysis"},"promos":{"free":[{"text":"30 analyses/month + Mind maps + Web Search — from €5.99/mo","cta":"Upgrade to Pro"},{"text":"Only 5 analyses/month? Get 30 with Pro","cta":"Upgrade →"},{"text":"Limited quota? Unlock 30 analyses and all Pro features","cta":"View plans"}],"pro":[{"text":"100 analyses/month + Mistral Large + 20-video playlists — Expert","cta":"Upgrade to Expert"},{"text":"DeepSight on mobile — study your flashcards anywhere","cta":"Download"}],"expert":[{"text":"Manage your playlists and exports on deepsightsynthesis.com","cta":"Open"}]}}',
+          ),
+        },
+        lt = "ds_language";
+      function ct() {
+        const [e, t] = oe("fr");
+        le(() => {
+          He.storage.sync.get([lt]).then((e) => {
+            const n = e[lt];
+            ("en" !== n && "fr" !== n) || t(n);
+          });
+        }, []);
+        const n = ue((e) => {
+          (t(e), He.storage.sync.set({ [lt]: e }));
+        }, []);
+        return { t: ot[e], language: e, setLanguage: n };
+      }
+      const dt = ({
+          onLogin: e,
+          onGoogleLogin: t,
+          onGuestMode: n,
+          error: s,
+        }) => {
+          const { t: a, language: r, setLanguage: i } = ct(),
+            [o, l] = oe(""),
+            [c, d] = oe(""),
+            [u, m] = oe(!1),
+            [g, p] = oe(!1),
+            [h, _] = oe(null),
+            f = h || s;
+          return Ve("div", {
+            className: "login-view",
+            children: [
+              Ve(nt, {
+                name: "sparkles",
+                size: 32,
+                className: "doodle-decoration",
+                style: { top: 20, left: 16, transform: "rotate(-15deg)" },
+              }),
+              Ve(nt, {
+                name: "brain",
+                size: 28,
+                className: "doodle-decoration",
+                style: { top: 60, right: 20, transform: "rotate(10deg)" },
+              }),
+              Ve(nt, {
+                name: "lightning",
+                size: 24,
+                className: "doodle-decoration",
+                style: { bottom: 80, left: 24, transform: "rotate(-25deg)" },
+              }),
+              Ve(nt, {
+                name: "star",
+                size: 20,
+                className: "doodle-decoration",
+                style: { bottom: 120, right: 30, transform: "rotate(20deg)" },
+              }),
+              Ve("div", {
+                className: "login-lang-toggle",
+                children: [
+                  Ve("button", {
+                    className:
+                      "login-lang-btn " +
+                      ("fr" === r ? "login-lang-active" : ""),
+                    onClick: () => i("fr"),
+                    children: "FR",
+                  }),
+                  Ve("button", {
+                    className:
+                      "login-lang-btn " +
+                      ("en" === r ? "login-lang-active" : ""),
+                    onClick: () => i("en"),
+                    children: "EN",
+                  }),
+                ],
+              }),
+              Ve("div", {
+                className: "login-hero",
+                children: Ve(it, { size: "lg", speed: "slow", showLogos: !0 }),
+              }),
+              Ve("div", {
+                className: "login-logo",
+                children: Ve("h1", { children: "DeepSight" }),
+              }),
+              Ve("p", {
+                className: "login-tagline",
+                children: a.login.tagline,
+              }),
+              Ve("div", {
+                className: "login-platforms",
+                children: [
+                  Ve("img", {
+                    src: He.runtime.getURL("platforms/youtube-icon-red.png"),
+                    alt: "YouTube",
+                    className: "login-platform-logo",
+                    style: { height: 20, width: "auto" },
+                  }),
+                  Ve("span", { className: "login-platform-sep" }),
+                  Ve("img", {
+                    src: He.runtime.getURL("platforms/tiktok-note-white.png"),
+                    alt: "TikTok",
+                    className: "login-platform-logo",
+                    style: { height: 18, width: "auto" },
+                  }),
+                  Ve("span", { className: "login-platform-sep" }),
+                  Ve("img", {
+                    src: He.runtime.getURL("platforms/mistral-m-orange.svg"),
+                    alt: "Mistral",
+                    className: "login-platform-logo",
+                    style: { height: 18, width: "auto" },
+                  }),
+                  Ve("span", { className: "login-platform-sep" }),
+                  Ve("img", {
+                    src: He.runtime.getURL("platforms/tournesol-logo.png"),
+                    alt: "Tournesol",
+                    className: "login-platform-logo",
+                    style: { height: 16, width: "auto" },
+                  }),
+                ],
+              }),
+              Ve("div", {
+                className: "login-badges",
+                children: [
+                  Ve("span", {
+                    className: "login-badge",
+                    children: [
+                      Ve("span", {
+                        className: "login-badge-flag",
+                        children: "🇫🇷",
+                      }),
+                      " ",
+                      a.login.badgeFr,
+                    ],
+                  }),
+                  Ve("span", {
+                    className: "login-badge",
+                    children: [
+                      Ve("span", {
+                        className: "login-badge-flag",
+                        children: "🇪🇺",
+                      }),
+                      " ",
+                      a.login.badgeEu,
+                    ],
+                  }),
+                ],
+              }),
+              Ve("button", {
+                className: "btn-google",
+                onClick: async function () {
+                  (p(!0), _(null));
+                  try {
+                    await t();
+                  } catch (e) {
+                    _(e.message);
+                  } finally {
+                    p(!1);
+                  }
+                },
+                disabled: g || u,
+                children: g
+                  ? a.login.googleLoading
+                  : Ve(k, {
+                      children: [Ve(Je, {}), " ", a.login.googleButton],
+                    }),
+              }),
+              Ve("div", {
+                className: "login-divider",
+                children: a.login.divider,
+              }),
+              Ve("form", {
+                className: "login-form",
+                onSubmit: async function (t) {
+                  if ((t.preventDefault(), o && c)) {
+                    (m(!0), _(null));
+                    try {
+                      await e(o, c);
+                    } catch (e) {
+                      _(e.message);
+                    } finally {
+                      m(!1);
+                    }
+                  }
+                },
+                children: [
+                  Ve("input", {
+                    type: "email",
+                    placeholder: a.login.emailPlaceholder,
+                    value: o,
+                    onChange: (e) => l(e.target.value),
+                    required: !0,
+                    disabled: u,
+                  }),
+                  Ve("input", {
+                    type: "password",
+                    placeholder: a.login.passwordPlaceholder,
+                    value: c,
+                    onChange: (e) => d(e.target.value),
+                    required: !0,
+                    disabled: u,
+                  }),
+                  f && Ve("div", { className: "login-error", children: f }),
+                  Ve("button", {
+                    type: "submit",
+                    className: "btn-login",
+                    disabled: u || !o || !c,
+                    children: u ? a.login.loginLoading : a.common.login,
+                  }),
+                ],
+              }),
+              Ve("button", {
+                className: "btn-guest",
+                onClick: n,
+                children: a.login.guestButton,
+              }),
+              Ve("div", {
+                className: "login-footer",
+                children: [
+                  Ve("a", {
+                    href: "https://www.deepsightsynthesis.com/register",
+                    target: "_blank",
+                    rel: "noreferrer",
+                    children: a.common.createAccount,
+                  }),
+                  Ve("span", { children: "·" }),
+                  Ve("a", {
+                    href: "https://www.deepsightsynthesis.com",
+                    target: "_blank",
+                    rel: "noreferrer",
+                    children: "deepsightsynthesis.com",
+                  }),
+                ],
+              }),
+              Ve("div", {
+                className: "login-legal",
+                children: [
+                  Ve("a", {
+                    href: "https://www.deepsightsynthesis.com/legal/privacy",
+                    target: "_blank",
+                    rel: "noreferrer",
+                    children: a.login.privacy,
+                  }),
+                  Ve("span", { children: "·" }),
+                  Ve("a", {
+                    href: "https://www.deepsightsynthesis.com/legal/cgu",
+                    target: "_blank",
+                    rel: "noreferrer",
+                    children: a.login.terms,
+                  }),
+                ],
+              }),
+            ],
+          });
+        },
+        ut = [
+          /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?\s]+)/,
+          /youtube\.com\/shorts\/([^&?\s]+)/,
+        ],
+        mt = [
+          /tiktok\.com\/@[\w.-]+\/video\/(\d+)/i,
+          /vm\.tiktok\.com\/([\w-]+)/i,
+          /m\.tiktok\.com\/v\/(\d+)/i,
+          /tiktok\.com\/t\/([\w-]+)/i,
+          /tiktok\.com\/video\/(\d+)/i,
+        ];
+      function gt(e) {
+        return (function (e) {
+          return ut.some((t) => t.test(e));
+        })(e)
+          ? "youtube"
+          : (function (e) {
+                return mt.some((t) => t.test(e));
+              })(e)
+            ? "tiktok"
+            : null;
+      }
+      async function pt() {
+        return (
+          (await He.storage.local.get(["recentAnalyses"])).recentAnalyses || []
+        );
+      }
+      async function ht() {
+        return (
+          (await He.storage.local.get(["deepsight_free_analyses"]))
+            .deepsight_free_analyses || 0
+        );
+      }
+      const _t = "https://www.deepsightsynthesis.com",
+        ft = {
+          tech: "💻",
+          science: "🔬",
+          education: "📚",
+          news: "📰",
+          entertainment: "🎬",
+          gaming: "🎮",
+          music: "🎵",
+          sports: "⚽",
+          business: "💼",
+          lifestyle: "🌟",
+          other: "📋",
+        };
+      function yt(e) {
+        const t = document.createElement("div");
+        return ((t.textContent = e), t.innerHTML);
+      }
+      function vt(e) {
+        const t = e.split("\n"),
+          n = [];
+        let s = !1,
+          a = !1;
+        for (let e = 0; e < t.length; e++) {
+          let r = t[e];
+          if (/^-{3,}$/.test(r.trim()) || /^\*{3,}$/.test(r.trim())) {
+            (s && (n.push("</ul>"), (s = !1)),
+              a && (n.push("</ol>"), (a = !1)),
+              n.push('<hr class="ds-md-hr">'));
+            continue;
+          }
+          const i = r.match(/^(#{1,4})\s+(.+)$/);
+          if (i) {
+            (s && (n.push("</ul>"), (s = !1)),
+              a && (n.push("</ol>"), (a = !1)));
+            const e = i[1].length,
+              t = i[2],
+              r = e <= 2 ? At(t) : "",
+              o = xt(t),
+              l = r ? `${r}&nbsp;&nbsp;` : "";
+            n.push(`<h${e} class="ds-md-h${e}">${l}${o}</h${e}>`);
+            continue;
+          }
+          if (r.startsWith("&gt; ") || "&gt;" === r) {
+            (s && (n.push("</ul>"), (s = !1)),
+              a && (n.push("</ol>"), (a = !1)));
+            const e = xt(r.replace(/^&gt;\s?/, ""));
+            n.push(`<blockquote class="ds-md-blockquote">${e}</blockquote>`);
+            continue;
+          }
+          const o = r.match(/^(\s*)[-*]\s+(.+)$/);
+          if (o) {
+            (a && (n.push("</ol>"), (a = !1)),
+              s || (n.push('<ul class="ds-md-ul">'), (s = !0)),
+              n.push(`<li>${xt(o[2])}</li>`));
+            continue;
+          }
+          const l = r.match(/^(\s*)\d+\.\s+(.+)$/);
+          l
+            ? (s && (n.push("</ul>"), (s = !1)),
+              a || (n.push('<ol class="ds-md-ol">'), (a = !0)),
+              n.push(`<li>${xt(l[2])}</li>`))
+            : (s && (n.push("</ul>"), (s = !1)),
+              a && (n.push("</ol>"), (a = !1)),
+              "" !== r.trim()
+                ? n.push(`<p class="ds-md-p">${xt(r)}</p>`)
+                : n.push('<div class="ds-md-spacer"></div>'));
+        }
+        return (s && n.push("</ul>"), a && n.push("</ol>"), n.join("\n"));
+      }
+      const bt = {
+        résumé: "📝",
+        summary: "📝",
+        synthèse: "📝",
+        introduction: "🎬",
+        contexte: "🌍",
+        context: "🌍",
+        analyse: "🔬",
+        analysis: "🔬",
+        "points clés": "🎯",
+        "key points": "🎯",
+        "points forts": "💪",
+        strengths: "💪",
+        "points faibles": "⚠️",
+        weaknesses: "⚠️",
+        limites: "⚠️",
+        conclusion: "🏁",
+        recommandations: "💡",
+        recommendations: "💡",
+        sources: "📚",
+        références: "📚",
+        references: "📚",
+        "fact-check": "🔍",
+        vérification: "🔍",
+        arguments: "⚖️",
+        méthodologie: "🧪",
+        methodology: "🧪",
+        données: "📊",
+        data: "📊",
+        statistiques: "📊",
+        opinion: "💬",
+        avis: "💬",
+        biais: "🎭",
+        bias: "🎭",
+        nuances: "🎨",
+        perspectives: "👁️",
+        timeline: "📅",
+        chronologie: "📅",
+        définitions: "📖",
+        glossaire: "📖",
+      };
+      function At(e) {
+        const t = e.toLowerCase().trim();
+        for (const [e, n] of Object.entries(bt)) if (t.includes(e)) return n;
+        return "📌";
+      }
+      function xt(e) {
+        return e
+          .replace(/`([^`]+)`/g, '<code class="ds-md-code">$1</code>')
+          .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+          .replace(/\*(.+?)\*/g, "<em>$1</em>")
+          .replace(
+            /\[?(SOLIDE|SOLID)\]?/g,
+            '<span class="ds-marker ds-marker-solid">✅ Établi</span>',
+          )
+          .replace(
+            /\[?(PLAUSIBLE)\]?/g,
+            '<span class="ds-marker ds-marker-plausible">🔵 Probable</span>',
+          )
+          .replace(
+            /\[?(INCERTAIN|UNCERTAIN)\]?/g,
+            '<span class="ds-marker ds-marker-uncertain">🟡 Incertain</span>',
+          )
+          .replace(
+            /\[?(A VERIFIER|À VÉRIFIER|TO VERIFY|QUESTIONABLE|WEAK)\]?/g,
+            '<span class="ds-marker ds-marker-weak">🔴 À vérifier</span>',
+          );
+      }
+      function kt(e) {
+        return e
+          .replace(/\*\*(.+?)\*\*/g, "$1")
+          .replace(/\*(.+?)\*/g, "$1")
+          .replace(/`([^`]+)`/g, "$1")
+          .replace(/#{1,6}\s+/g, "")
+          .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+          .replace(/^>\s+/gm, "")
+          .replace(/\n+/g, " ")
+          .trim();
+      }
+      function wt(e, t) {
+        if (e.length <= t) return e;
+        const n = e.substring(0, t),
+          s = n.lastIndexOf(" ");
+        return (s > 0.6 * t ? n.substring(0, s) : n) + "...";
+      }
+      function Nt(e) {
+        switch (e) {
+          case "solid":
+            return "✅";
+          case "weak":
+            return "⚠️";
+          case "insight":
+            return "💡";
+        }
+      }
+      function Ct(e) {
+        switch (e) {
+          case "solid":
+            return "keypoint-solid";
+          case "weak":
+            return "keypoint-weak";
+          case "insight":
+            return "keypoint-insight";
+        }
+      }
+      const St = [
+          {
+            key: "flashcards",
+            icon: "🗂️",
+            doodleName: "book",
+            labelKey: "flashcards",
+            hash: "#flashcards",
+            minPlan: "pro",
+            price: "5,99€",
+          },
+          {
+            key: "mind_maps",
+            icon: "🧠",
+            doodleName: "brain",
+            labelKey: "mindMaps",
+            hash: "#mindmap",
+            minPlan: "pro",
+            price: "5,99€",
+          },
+          {
+            key: "web_search",
+            icon: "🌐",
+            doodleName: "globe",
+            labelKey: "webSearch",
+            hash: "#websearch",
+            minPlan: "pro",
+            price: "5,99€",
+          },
+          {
+            key: "exports",
+            icon: "📤",
+            doodleName: "code",
+            labelKey: "exports",
+            hash: "#export",
+            minPlan: "pro",
+            price: "5,99€",
+          },
+          {
+            key: "playlists",
+            icon: "🎬",
+            doodleName: "camera",
+            labelKey: "playlists",
+            hash: "#playlists",
+            minPlan: "pro",
+            price: "5,99€",
+          },
+        ],
+        Pt = ({ summary: e, summaryId: t, planInfo: n, onOpenChat: s }) => {
+          const { t: a, language: r } = ct(),
+            [i, o] = oe(!1),
+            l = (function (e) {
+              const t = (function (e) {
+                  const t = [
+                    /#+\s*(?:Conclusion|Verdict|Synthèse|Résumé|Summary|En résumé|Final Assessment|Overall Assessment)[^\n]*\n([\s\S]*?)(?=\n#|\n---|\n\*{3,}|$)/i,
+                    /\*\*(?:Conclusion|Verdict|Synthèse|En résumé|Summary)\*\*[:\s]*([\s\S]*?)(?=\n\n|\n#|\n---|\n\*{3,}|$)/i,
+                  ];
+                  for (const n of t) {
+                    const t = e.match(n);
+                    if (t && t[1]) {
+                      const e = kt(t[1]).trim();
+                      if (e.length > 20) return wt(e, 200);
+                    }
+                  }
+                  const n = e.split(/\n\n+/).filter((e) => {
+                    const t = e.trim();
+                    return (
+                      t.length > 30 &&
+                      !t.startsWith("#") &&
+                      !t.startsWith("-") &&
+                      !t.startsWith("*")
+                    );
+                  });
+                  return n.length > 0
+                    ? wt(kt(n[n.length - 1]), 200)
+                    : "Analysis complete. See detailed view for full results.";
+                })(e),
+                n = (function (e) {
+                  const t = [],
+                    n = e.split("\n"),
+                    s = [/\b(?:SOLIDE|SOLID)\b/i, /\u2705\s*\*\*/, /\u2705/],
+                    a = [
+                      /\b(?:A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK|INCERTAIN|UNCERTAIN)\b/i,
+                      /\u26A0\uFE0F\s*\*\*/,
+                      /\u2753/,
+                      /\u26A0/,
+                    ],
+                    r = [/\b(?:PLAUSIBLE)\b/i, /\uD83D\uDCA1/];
+                  for (const e of n) {
+                    const n = e.replace(/^[\s\-*]+/, "").trim();
+                    if (n.length < 10) continue;
+                    let i = null;
+                    if (
+                      (s.some((t) => t.test(e))
+                        ? (i = "solid")
+                        : a.some((t) => t.test(e))
+                          ? (i = "weak")
+                          : r.some((t) => t.test(e)) && (i = "insight"),
+                      i && t.filter((e) => e.type === i).length < 2)
+                    ) {
+                      const e = kt(n)
+                        .replace(
+                          /\b(?:SOLIDE|SOLID|PLAUSIBLE|INCERTAIN|UNCERTAIN|A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK)\b\s*[:—\-–]?\s*/gi,
+                          "",
+                        )
+                        .replace(/^[✅⚠️❓💡🔍🔬]\s*/u, "")
+                        .trim();
+                      e.length > 10 && t.push({ type: i, text: wt(e, 120) });
+                    }
+                    if (t.length >= 4) break;
+                  }
+                  if (t.length < 2) {
+                    const n =
+                      /#+\s*(?:Points?\s+(?:forts?|clés?|faibles?)|Key\s+(?:Points?|Findings?|Takeaways?)|Strengths?|Weaknesses?|Main\s+Points?)[^\n]*\n([\s\S]*?)(?=\n#|$)/gi;
+                    let s;
+                    for (; null !== (s = n.exec(e)) && t.length < 4; ) {
+                      const e = s[1].match(/^[\s]*[-*]\s+(.+)$/gm);
+                      if (e)
+                        for (const n of e.slice(0, 4 - t.length)) {
+                          const e = kt(n.replace(/^[\s]*[-*]\s+/, ""));
+                          e.length > 10 &&
+                            !t.some((t) => t.text === wt(e, 120)) &&
+                            t.push({ type: "insight", text: wt(e, 120) });
+                        }
+                    }
+                  }
+                  return t.slice(0, 4);
+                })(e),
+                s = (function (e) {
+                  const t = [],
+                    n = e.match(
+                      /#+\s*(?:Tags?|Thèmes?|Themes?|Topics?|Catégories?|Categories?)[^\n]*\n([\s\S]*?)(?=\n#|$)/i,
+                    );
+                  if (n) {
+                    const e = n[1].match(/[-*]\s+(.+)/g);
+                    if (e)
+                      for (const n of e.slice(0, 3)) {
+                        const e = kt(n.replace(/^[-*]\s+/, "")).trim();
+                        e.length > 0 && e.length < 30 && t.push(e);
+                      }
+                  }
+                  if (0 === t.length) {
+                    const n = e.match(/^#{2,3}\s+(.+)$/gm);
+                    if (n) {
+                      const e =
+                        /^(?:Conclusion|Summary|Résumé|Synthèse|Introduction|Verdict|Analysis|Points?\s+(?:clés?|forts?|faibles?)|Key\s+(?:Points?|Findings?)|Strengths?|Weaknesses?|Overview)/i;
+                      for (const s of n) {
+                        const n = kt(s.replace(/^#{2,3}\s+/, "")).trim();
+                        if (
+                          n.length > 2 &&
+                          n.length < 35 &&
+                          !e.test(n) &&
+                          (t.push(n), t.length >= 3)
+                        )
+                          break;
+                      }
+                    }
+                  }
+                  return t.slice(0, 3);
+                })(e);
+              return { verdict: t, keyPoints: n, tags: s };
+            })(e.summary_content),
+            c = ft[e.category] || "📋",
+            d = e.reliability_score,
+            u = d >= 80 ? "score-high" : d >= 60 ? "score-mid" : "score-low",
+            m = d >= 80 ? "✅" : d >= 60 ? "⚠️" : "❓",
+            g = vt(yt(e.summary_content)),
+            p = St.map((e) => ({
+              cta: e,
+              available: n?.features?.[e.key] ?? !1,
+            }));
+          return Ve("div", {
+            className: "synthesis",
+            children: [
+              Ve("div", {
+                className: "synthesis-header",
+                children: [
+                  Ve("span", {
+                    className: "synthesis-done",
+                    children: ["✅", " ", a.synthesis.complete],
+                  }),
+                  Ve("div", {
+                    className: "synthesis-badges",
+                    children: [
+                      Ve("span", {
+                        className: "synthesis-badge",
+                        children: [c, " ", e.category],
+                      }),
+                      Ve("span", {
+                        className: `synthesis-badge ${u}`,
+                        children: [m, " ", d, "%"],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+              Ve("div", {
+                className: "synthesis-platforms",
+                children: [
+                  Ve("img", {
+                    src: He.runtime.getURL("platforms/youtube-icon-red.png"),
+                    alt: "YouTube",
+                    style: { height: 16 },
+                  }),
+                  Ve("span", { className: "synthesis-platform-sep" }),
+                  Ve("img", {
+                    src: He.runtime.getURL("platforms/tiktok-note-white.png"),
+                    alt: "TikTok",
+                    style: { height: 14 },
+                  }),
+                  Ve("span", { className: "synthesis-platform-sep" }),
+                  Ve("img", {
+                    src: He.runtime.getURL("platforms/mistral-logo-white.png"),
+                    alt: "Mistral AI",
+                    style: { height: 12, opacity: 0.7 },
+                  }),
+                  Ve("span", { className: "synthesis-platform-sep" }),
+                  Ve("img", {
+                    src: He.runtime.getURL("platforms/tournesol-logo.png"),
+                    alt: "Tournesol",
+                    style: { height: 13, opacity: 0.8 },
+                  }),
+                ],
+              }),
+              e.tournesol?.found &&
+                null !== e.tournesol.tournesol_score &&
+                Ve("a", {
+                  href: `https://tournesol.app/entities/yt:${e.video_url?.match(/[?&]v=([^&]+)/)?.[1] || ""}`,
+                  target: "_blank",
+                  rel: "noreferrer",
+                  className: "tournesol-badge",
+                  title: `Score Tournesol: ${e.tournesol.tournesol_score} | ${e.tournesol.n_contributors} contributeurs | ${e.tournesol.n_comparisons} comparaisons`,
+                  style: {
+                    background:
+                      e.tournesol.tournesol_score >= 50
+                        ? "rgba(34,197,94,0.12)"
+                        : e.tournesol.tournesol_score >= 20
+                          ? "rgba(234,179,8,0.12)"
+                          : "var(--bg-secondary)",
+                    border:
+                      "1px solid " +
+                      (e.tournesol.tournesol_score >= 50
+                        ? "rgba(34,197,94,0.25)"
+                        : e.tournesol.tournesol_score >= 20
+                          ? "rgba(234,179,8,0.25)"
+                          : "var(--border-default)"),
+                  },
+                  children: [
+                    Ve("span", { style: { fontSize: "14px" }, children: "🌻" }),
+                    Ve("span", {
+                      style: { fontWeight: 600, color: "var(--text-primary)" },
+                      children: [
+                        "Tournesol: ",
+                        e.tournesol.tournesol_score > 0 ? "+" : "",
+                        Math.round(e.tournesol.tournesol_score),
+                      ],
+                    }),
+                    Ve("span", {
+                      style: {
+                        opacity: 0.6,
+                        fontSize: "11px",
+                        color: "var(--text-tertiary)",
+                      },
+                      children: ["(", e.tournesol.n_contributors, " votes)"],
+                    }),
+                  ],
+                }),
+              Ve("div", {
+                className: "synthesis-verdict",
+                children: Ve("p", { children: l.verdict }),
+              }),
+              l.keyPoints.length > 0 &&
+                Ve("div", {
+                  className: "synthesis-keypoints",
+                  children: l.keyPoints.map((e, t) =>
+                    Ve(
+                      "div",
+                      {
+                        className: `keypoint ${Ct(e.type)}`,
+                        children: [
+                          Ve("span", {
+                            className: "keypoint-icon",
+                            children: Nt(e.type),
+                          }),
+                          Ve("span", {
+                            className: "keypoint-text",
+                            children: e.text,
+                          }),
+                        ],
+                      },
+                      t,
+                    ),
+                  ),
+                }),
+              l.tags.length > 0 &&
+                Ve("div", {
+                  className: "synthesis-tags",
+                  children: l.tags.map((e, t) =>
+                    Ve("span", { className: "tag-pill", children: e }, t),
+                  ),
+                }),
+              e.concepts &&
+                e.concepts.length > 0 &&
+                Ve("div", {
+                  className: "synthesis-concepts",
+                  children: e.concepts.slice(0, 3).map((e, t) =>
+                    Ve(
+                      "div",
+                      {
+                        className: "concept-item",
+                        children: [
+                          Ve("div", {
+                            className: "concept-name",
+                            children: e.name,
+                          }),
+                          Ve("div", {
+                            className: "concept-def",
+                            children: e.definition || a.synthesis.generatingDef,
+                          }),
+                        ],
+                      },
+                      t,
+                    ),
+                  ),
+                }),
+              Ve("button", {
+                className: "toggle-detail",
+                onClick: () => o(!i),
+                children: [
+                  Ve("span", {
+                    children: i
+                      ? a.synthesis.hideDetail
+                      : a.synthesis.showDetail,
+                  }),
+                  Ve(i ? Xe : Qe, { size: 14 }),
+                ],
+              }),
+              i &&
+                Ve("div", {
+                  className: "detail-panel",
+                  dangerouslySetInnerHTML: { __html: g },
+                }),
+              Ve("div", {
+                className: "synthesis-actions",
+                children: [
+                  Ve("a", {
+                    href: `${_t}/summary/${t}`,
+                    target: "_blank",
+                    rel: "noreferrer",
+                    className: "btn-action btn-action-primary",
+                    children: [
+                      Ve(Ke, { size: 14 }),
+                      " ",
+                      a.synthesis.fullAnalysis,
+                    ],
+                  }),
+                  Ve("button", {
+                    className: "btn-action btn-action-secondary",
+                    onClick: s,
+                    children: [Ve(We, { size: 14 }), " ", a.synthesis.chat],
+                  }),
+                  Ve("button", {
+                    className: "btn-action btn-action-secondary",
+                    onClick: () => {
+                      const t =
+                          d >= 80
+                            ? a.synthesis.reliable
+                            : d >= 60
+                              ? a.synthesis.toVerify
+                              : a.synthesis.unreliable,
+                        n = (function (e, t, n, s, a, r) {
+                          const i =
+                              n >= 80
+                                ? "#22c55e"
+                                : n >= 60
+                                  ? "#eab308"
+                                  : "#ef4444",
+                            o = "fr" === r ? "fr-FR" : "en-US",
+                            l = new Date(e.created_at).toLocaleDateString(o, {
+                              day: "numeric",
+                              month: "long",
+                              year: "numeric",
+                            }),
+                            c = t.keyPoints
+                              .map(
+                                (e) =>
+                                  `<div style="display:flex;gap:10px;padding:12px 16px;border-radius:10px;background:rgba(200,144,58,0.06);border:1px solid rgba(200,144,58,0.1);margin-bottom:8px">\n      <span style="font-size:16px;flex-shrink:0">${"solid" === e.type ? "✅" : "weak" === e.type ? "⚠️" : "💡"}</span>\n      <span style="color:#F5F0E8;font-size:14px;line-height:1.6">${e.text}</span>\n    </div>`,
+                              )
+                              .join(""),
+                            d = t.tags
+                              .map(
+                                (e) =>
+                                  `<span style="display:inline-block;padding:4px 12px;border-radius:20px;background:rgba(200,144,58,0.12);color:#C8903A;font-size:12px;font-weight:500">${e}</span>`,
+                              )
+                              .join(" "),
+                            u = (e.concepts || [])
+                              .slice(0, 5)
+                              .map(
+                                (e) =>
+                                  `<div style="padding:14px 18px;border-radius:12px;background:rgba(155,107,74,0.08);border:1px solid rgba(155,107,74,0.15)">\n      <div style="font-weight:600;color:#9B6B4A;font-size:14px;margin-bottom:4px;font-family:'Cormorant Garamond',serif">${e.name}</div>\n      <div style="color:#B5A89B;font-size:13px;line-height:1.5">${e.definition || a.synthesis.generatingDef}</div>\n    </div>`,
+                              )
+                              .join("");
+                          return `<!DOCTYPE html>\n<html lang="${r}">\n<head>\n  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n  <title>${e.video_title} — ${a.synthesis.shareTitle}</title>\n  <link rel="preconnect" href="https://fonts.googleapis.com">\n  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">\n  <style>\n    *{margin:0;padding:0;box-sizing:border-box}\n    body{font-family:'DM Sans',system-ui,sans-serif;background:#0a0a0f;color:#F5F0E8;min-height:100vh}\n    .page{max-width:720px;margin:0 auto;padding:40px 24px 60px}\n    .header{text-align:center;margin-bottom:32px}\n    .logo{display:inline-flex;align-items:center;gap:8px;font-size:13px;font-weight:600;color:#C8903A;letter-spacing:0.5px;text-transform:uppercase;margin-bottom:16px;font-family:'Cormorant Garamond',serif}\n    .video-title{font-size:22px;font-weight:700;line-height:1.35;color:#F5F0E8;margin-bottom:8px;font-family:'Cormorant Garamond',serif}\n    .video-meta{display:flex;align-items:center;justify-content:center;gap:16px;font-size:13px;color:#7A7068;flex-wrap:wrap}\n    .score-badge{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:20px;font-weight:600;font-size:13px;background:${i}15;color:${i}}\n    .section{margin-top:28px}\n    .section-title{font-size:15px;font-weight:600;color:#B5A89B;text-transform:uppercase;letter-spacing:0.8px;margin-bottom:14px;display:flex;align-items:center;gap:8px;font-family:'Cormorant Garamond',serif}\n    .verdict{padding:20px 24px;border-radius:14px;background:rgba(200,144,58,0.06);border:1px solid rgba(200,144,58,0.12);border-left:3px solid #C8903A;font-size:15px;line-height:1.7;color:#F5F0E8}\n    .concepts-grid{display:grid;gap:10px}\n    .tags{display:flex;flex-wrap:wrap;gap:8px}\n    .footer{margin-top:40px;padding-top:20px;border-top:1px solid rgba(200,144,58,0.08);text-align:center;color:#45455a;font-size:12px}\n    .footer a{color:#C8903A;text-decoration:none}\n    .footer a:hover{text-decoration:underline}\n    .btn-print{display:inline-flex;align-items:center;gap:6px;padding:10px 20px;border-radius:10px;background:linear-gradient(135deg,#C8903A,#D4A054);color:#0a0a0f;font-size:13px;font-weight:600;cursor:pointer;border:none;font-family:inherit;transition:all 0.2s}\n    .btn-print:hover{transform:translateY(-1px);box-shadow:0 4px 20px rgba(200,144,58,0.35)}\n    .actions{text-align:center;margin-top:28px;display:flex;gap:12px;justify-content:center}\n    @media print{\n      body{background:white;color:#1a1a1a}\n      .verdict{background:#faf7f2;border-color:#e2e8f0}\n      .score-badge{background:#f0fdf4}\n      .actions,.btn-print{display:none!important}\n      .section-title{color:#64748b}\n      .footer{color:#94a3b8}\n    }\n  </style>\n</head>\n<body>\n  <div class="page">\n    <div class="header">\n      <div class="logo">DeepSight Synthesis</div>\n      <h1 class="video-title">${e.video_title}</h1>\n      <div class="video-meta">\n        <span>${e.video_channel}</span>\n        <span>${e.category}</span>\n        <span>${l}</span>\n        <span class="score-badge">${n}% — ${s}</span>\n      </div>\n    </div>\n\n    <div class="section">\n      <div class="section-title">${a.synthesis.verdict}</div>\n      <div class="verdict">${t.verdict}</div>\n    </div>\n\n    ${t.keyPoints.length > 0 ? `\n    <div class="section">\n      <div class="section-title">${a.synthesis.keyPoints}</div>\n      ${c}\n    </div>` : ""}\n\n    ${(e.concepts || []).length > 0 ? `\n    <div class="section">\n      <div class="section-title">${a.synthesis.concepts}</div>\n      <div class="concepts-grid">${u}</div>\n    </div>` : ""}\n\n    ${t.tags.length > 0 ? `\n    <div class="section">\n      <div class="section-title">${a.synthesis.tags}</div>\n      <div class="tags">${d}</div>\n    </div>` : ""}\n\n    <div class="actions">\n      <button class="btn-print" onclick="window.print()">${a.synthesis.printPdf}</button>\n    </div>\n\n    <div class="footer">\n      <p>${a.synthesis.generatedBy} <a href="https://www.deepsightsynthesis.com" target="_blank">DeepSight</a> — ${a.synthesis.analysisDesc}</p>\n      <p style="margin-top:4px">🇫🇷🇪🇺 ${a.synthesis.euBadge}</p>\n    </div>\n  </div>\n</body>\n</html>`;
+                        })(e, l, d, t, a, r),
+                        s = new Blob([n], { type: "text/html" }),
+                        i = URL.createObjectURL(s);
+                      He.tabs.create({ url: i });
+                    },
+                    title: a.synthesis.share,
+                    children: [Ve(Ze, { size: 14 }), " ", a.synthesis.share],
+                  }),
+                ],
+              }),
+              Ve("div", {
+                className: "feature-ctas",
+                children: [
+                  p.map(({ cta: e, available: n }) =>
+                    Ve(
+                      "button",
+                      n
+                        ? {
+                            className: "feature-cta feature-cta-available",
+                            onClick: () =>
+                              He.tabs.create({
+                                url: `${_t}/summary/${t}${e.hash}`,
+                              }),
+                            children: [
+                              Ve("span", {
+                                className: "feature-cta-icon",
+                                children: Ve(nt, {
+                                  name: e.doodleName,
+                                  size: 16,
+                                  color: "var(--accent-primary)",
+                                }),
+                              }),
+                              Ve("span", {
+                                className: "feature-cta-label",
+                                children: a.features[e.labelKey],
+                              }),
+                              Ve("span", {
+                                className: "feature-cta-arrow",
+                                children: "↗",
+                              }),
+                            ],
+                          }
+                        : {
+                            className: "feature-cta feature-cta-locked",
+                            onClick: () =>
+                              He.tabs.create({ url: `${_t}/upgrade` }),
+                            children: [
+                              Ve("span", {
+                                className: "feature-cta-icon",
+                                children: Ve(nt, {
+                                  name: e.doodleName,
+                                  size: 16,
+                                  color: "var(--text-muted)",
+                                }),
+                              }),
+                              Ve("span", {
+                                className: "feature-cta-label",
+                                children: a.features[e.labelKey],
+                              }),
+                              Ve("span", {
+                                className: "feature-cta-price",
+                                children: a.features.fromPrice.replace(
+                                  "{price}",
+                                  e.price,
+                                ),
+                              }),
+                            ],
+                          },
+                      e.key,
+                    ),
+                  ),
+                  Ve("a", {
+                    href: `${_t}/upgrade`,
+                    target: "_blank",
+                    rel: "noreferrer",
+                    className: "feature-cta-all-plans",
+                    onClick: (e) => {
+                      (e.preventDefault(),
+                        He.tabs.create({ url: `${_t}/upgrade` }));
+                    },
+                    children: [a.common.allPlans, " ", "↗"],
+                  }),
+                ],
+              }),
+            ],
+          });
+        };
+      function zt(e) {
+        return e.replace(/\[\[([^\]]+)\]\]/g, "$1").trim();
+      }
+      const Mt = [
+          "plus",
+          "pro",
+          "starter",
+          "student",
+          "etudiant",
+          "expert",
+          "team",
+          "equipe",
+        ],
+        Tt = ({
+          summaryId: e,
+          videoTitle: t,
+          onClose: n,
+          onSessionExpired: s,
+          userPlan: a,
+        }) => {
+          const { t: r } = ct(),
+            [i, o] = oe([]),
+            [l, c] = oe(""),
+            [d, u] = oe(!1),
+            [m, g] = oe(!0),
+            [p, h] = oe(!1),
+            [_, f] = oe(!1),
+            y = ce(null),
+            v = !!(b = a) && Mt.includes(b.toLowerCase());
+          var b;
+          const A = r.chat.suggestions;
+          async function x(t, n) {
+            const s = t || l.trim();
+            if (!s || d) return;
+            (t || c(""), o((e) => [...e, { role: "user", content: s }]), u(!0));
+            const a = {};
+            (n || (v && _)) && (a.use_web_search = !0);
+            try {
+              const t = await He.runtime.sendMessage({
+                action: "ASK_QUESTION",
+                data: { summaryId: e, question: s, options: a },
+              });
+              if (t.success) {
+                const e = t.result;
+                o((t) => [
+                  ...t,
+                  {
+                    role: "assistant",
+                    content: e.response,
+                    web_search_used: e.web_search_used,
+                  },
+                ]);
+              } else {
+                const e = t.error || "";
+                e.includes("SESSION_EXPIRED")
+                  ? h(!0)
+                  : o((t) => [
+                      ...t,
+                      {
+                        role: "assistant",
+                        content: `${r.common.error} : ${e || r.chat.unavailable}`,
+                      },
+                    ]);
+              }
+            } catch (e) {
+              const t = e.message || "";
+              t.includes("SESSION_EXPIRED")
+                ? h(!0)
+                : o((e) => [
+                    ...e,
+                    { role: "assistant", content: `${r.common.error} : ${t}` },
+                  ]);
+            } finally {
+              u(!1);
+            }
+          }
+          function k(e) {
+            x(zt(e));
+          }
+          (le(() => {
+            !(async function () {
+              try {
+                const t = await He.runtime.sendMessage({
+                  action: "GET_CHAT_HISTORY",
+                  data: { summaryId: e },
+                });
+                t.success && Array.isArray(t.result) && o(t.result);
+              } catch {
+              } finally {
+                g(!1);
+              }
+            })();
+          }, [e]),
+            le(() => {
+              y.current && (y.current.scrollTop = y.current.scrollHeight);
+            }, [i, d]));
+          const w = t.length > 30 ? t.substring(0, 30) + "..." : t;
+          return Ve("div", {
+            className: "chat-view",
+            children: [
+              Ve("div", {
+                className: "chat-header",
+                children: [
+                  Ve("button", {
+                    className: "icon-btn",
+                    onClick: n,
+                    title: r.common.back,
+                    children: Ve(Ge, { size: 18 }),
+                  }),
+                  Ve("span", {
+                    className: "chat-header-title",
+                    children: [r.synthesis.chat, " : « ", w, " »"],
+                  }),
+                ],
+              }),
+              Ve("div", {
+                className: "chat-messages",
+                ref: y,
+                children: [
+                  m
+                    ? Ve("div", {
+                        className: "chat-welcome",
+                        children: Ve(it, { size: "xs", speed: "fast" }),
+                      })
+                    : 0 === i.length
+                      ? Ve("div", {
+                          className: "chat-welcome",
+                          children: [
+                            Ve(nt, {
+                              name: "robot",
+                              size: 32,
+                              color: "var(--accent-primary)",
+                              style: { opacity: 0.6 },
+                            }),
+                            Ve("p", { children: r.chat.welcome }),
+                            Ve("div", {
+                              className: "chat-suggestions",
+                              children: A.map((e, t) =>
+                                Ve(
+                                  "button",
+                                  {
+                                    className: "chat-suggestion-btn",
+                                    onClick: () => {
+                                      x(e);
+                                    },
+                                    disabled: d || p,
+                                    children: [
+                                      Ve("span", {
+                                        className: "chat-suggestion-arrow",
+                                        children: "→",
+                                      }),
+                                      e,
+                                    ],
+                                  },
+                                  t,
+                                ),
+                              ),
+                            }),
+                          ],
+                        })
+                      : i.map((e, t) =>
+                          Ve(
+                            Et,
+                            {
+                              msg: e,
+                              onQuestionClick: k,
+                              webEnrichedLabel: r.chat.webEnriched,
+                            },
+                            t,
+                          ),
+                        ),
+                  d &&
+                    Ve("div", {
+                      className: "chat-typing",
+                      children: [
+                        Ve("div", { className: "chat-typing-dot" }),
+                        Ve("div", { className: "chat-typing-dot" }),
+                        Ve("div", { className: "chat-typing-dot" }),
+                      ],
+                    }),
+                ],
+              }),
+              p &&
+                Ve("div", {
+                  className: "chat-session-expired",
+                  children: [
+                    Ve("span", {
+                      children: ["🔒", " ", r.chat.sessionExpired],
+                    }),
+                    Ve("button", {
+                      className: "chat-reconnect-btn",
+                      onClick: () => {
+                        s ? s() : n();
+                      },
+                      children: r.chat.reconnect,
+                    }),
+                  ],
+                }),
+              Ve("div", {
+                className: "chat-input-area",
+                children: [
+                  Ve("button", {
+                    className:
+                      "chat-ws-toggle " + (_ && v ? "chat-ws-active" : ""),
+                    onClick: () => {
+                      v && f(!_);
+                    },
+                    title: v
+                      ? _
+                        ? r.chat.webSearchDisable
+                        : r.chat.webSearchEnable
+                      : r.chat.webSearchLocked,
+                    style: { opacity: v ? 1 : 0.4 },
+                    children: Ve(nt, {
+                      name: "globe",
+                      size: 14,
+                      color:
+                        _ && v ? "var(--accent-primary)" : "var(--text-muted)",
+                    }),
+                  }),
+                  Ve("input", {
+                    type: "text",
+                    className: "chat-input",
+                    value: l,
+                    onChange: (e) => c(e.target.value),
+                    onKeyDown: function (e) {
+                      "Enter" !== e.key ||
+                        e.shiftKey ||
+                        (e.preventDefault(), x());
+                    },
+                    placeholder: p
+                      ? r.chat.expiredPlaceholder
+                      : r.chat.inputPlaceholder,
+                    disabled: d || p,
+                    autoFocus: !0,
+                  }),
+                  Ve("button", {
+                    className: "chat-send-btn",
+                    onClick: () => x(),
+                    disabled: !l.trim() || d || p,
+                    title: r.common.send,
+                    children: Ve(je, { size: 16 }),
+                  }),
+                ],
+              }),
+            ],
+          });
+        },
+        Et = ({ msg: e, onQuestionClick: t, webEnrichedLabel: n }) => {
+          const s = de(
+            () =>
+              "user" === e.role
+                ? { text: e.content, questions: [] }
+                : (function (e) {
+                    const t = /\[ask:\s*([^\]]+)\]/g,
+                      n = [];
+                    let s;
+                    for (; null !== (s = t.exec(e)); ) {
+                      const e = s[1].trim();
+                      e && n.push(e);
+                    }
+                    return { text: e.replace(t, "").trim(), questions: n };
+                  })(e.content),
+            [e.content, e.role],
+          );
+          return Ve("div", {
+            className: `chat-msg chat-msg-${e.role}`,
+            children:
+              "assistant" === e.role
+                ? Ve(k, {
+                    children: [
+                      e.web_search_used &&
+                        Ve("div", {
+                          className: "chat-web-badge",
+                          children: [
+                            Ve(nt, {
+                              name: "globe",
+                              size: 12,
+                              color: "var(--accent-primary)",
+                              style: {
+                                display: "inline-block",
+                                verticalAlign: "middle",
+                                marginRight: 4,
+                              },
+                            }),
+                            n,
+                          ],
+                        }),
+                      Ve("div", {
+                        className: "chat-md-content",
+                        dangerouslySetInnerHTML: { __html: vt(yt(s.text)) },
+                      }),
+                      s.questions.length > 0 &&
+                        Ve("div", {
+                          className: "chat-ask-pills",
+                          children: s.questions.map((e, n) =>
+                            Ve(
+                              "button",
+                              {
+                                className: "chat-ask-pill",
+                                onClick: () => t(e),
+                                children: [
+                                  Ve("span", {
+                                    className: "chat-ask-arrow",
+                                    children: "→",
+                                  }),
+                                  zt(e),
+                                ],
+                              },
+                              n,
+                            ),
+                          ),
+                        }),
+                    ],
+                  })
+                : e.content,
+          });
+        },
+        $t =
+          "linear-gradient(135deg, rgba(200,144,58,0.15), rgba(155,107,74,0.15))",
+        It =
+          "linear-gradient(135deg, rgba(200,144,58,0.2), rgba(200,144,58,0.08))",
+        Lt = [
+          {
+            id: "free-flashcards",
+            textKey: 0,
+            url: `${_t}/upgrade`,
+            gradient: It,
+          },
+          {
+            id: "free-mindmap",
+            textKey: 1,
+            url: `${_t}/upgrade`,
+            gradient:
+              "linear-gradient(135deg, rgba(155,107,74,0.15), rgba(200,144,58,0.1))",
+          },
+          { id: "free-quota", textKey: 2, url: `${_t}/upgrade`, gradient: $t },
+        ],
+        Dt = [
+          { id: "pro-mobile", textKey: 0, url: `${_t}/mobile`, gradient: $t },
+          { id: "pro-web", textKey: 1, url: _t, gradient: It },
+        ];
+      function Ft(e) {
+        switch (e) {
+          case "plus":
+          case "pro":
+          case "expert":
+          case "etudiant":
+          case "student":
+          case "starter":
+            return "pro";
+          default:
+            return "free";
+        }
+      }
+      const Rt = ({ planInfo: e }) => {
+          const { t } = ct(),
+            [n, s] = oe(0),
+            [a, r] = oe(!1),
+            i = Ft(e?.plan_id),
+            o = ((l = e?.plan_id), "pro" === Ft(l) ? Dt : Lt);
+          var l;
+          const c = t.promos[i];
+          if (
+            (le(() => {
+              He.storage.local.get(["promoDismissedAt"]).then((e) => {
+                e.promoDismissedAt &&
+                  (Date.now() - e.promoDismissedAt > 864e5
+                    ? He.storage.local.remove(["promoDismissedAt"])
+                    : r(!0));
+              });
+            }, []),
+            le(() => {
+              if (a || o.length <= 1) return;
+              const e = setInterval(() => {
+                s((e) => (e + 1) % o.length);
+              }, 8e3);
+              return () => clearInterval(e);
+            }, [a, o.length]),
+            le(() => {
+              s(0);
+            }, [e?.plan_id]),
+            a || 0 === o.length)
+          )
+            return null;
+          const d = n % o.length,
+            u = o[d],
+            m = c[d] || c[0],
+            g = ["sparkle4pt", "star", "crown"];
+          return Ve("div", {
+            className: "promo-banner",
+            style: {
+              background: u.gradient,
+              borderTop: "1px solid var(--border-accent)",
+            },
+            children: [
+              Ve("div", {
+                className: "promo-content",
+                children: [
+                  Ve("div", {
+                    style: { display: "flex", alignItems: "center", gap: 8 },
+                    children: [
+                      Ve(nt, {
+                        name: g[d % g.length],
+                        size: 16,
+                        color: "var(--accent-primary)",
+                      }),
+                      Ve("span", {
+                        className: "promo-text",
+                        style: { color: "var(--text-primary)" },
+                        children: m.text,
+                      }),
+                    ],
+                  }),
+                  Ve("a", {
+                    href: u.url,
+                    target: "_blank",
+                    rel: "noreferrer",
+                    className: "promo-cta",
+                    style: { color: "var(--accent-primary)" },
+                    onClick: (e) => {
+                      (e.preventDefault(), He.tabs.create({ url: u.url }));
+                    },
+                    children: [m.cta, " →"],
+                  }),
+                ],
+              }),
+              Ve("button", {
+                className: "promo-close",
+                onClick: () => {
+                  (r(!0),
+                    He.storage.local.set({ promoDismissedAt: Date.now() }));
+                },
+                title: t.common.hide,
+                style: {
+                  background: "var(--accent-primary-muted)",
+                  color: "var(--accent-primary)",
+                },
+                children: "×",
+              }),
+            ],
+          });
+        },
+        Bt = ({
+          user: e,
+          planInfo: t,
+          isGuest: n,
+          onLogout: s,
+          onLoginRedirect: a,
+          onError: r,
+        }) => {
+          const { t: i, language: o } = ct(),
+            [l, c] = oe(null),
+            [d, u] = oe(e?.default_mode || "standard"),
+            [m, g] = oe(e?.default_lang || "fr"),
+            [p, h] = oe({ phase: "idle" }),
+            [_, f] = oe([]),
+            [y, v] = oe(!1),
+            [b, A] = oe(!1),
+            [x, w] = oe(!1),
+            [N, C] = oe(!1),
+            S = ce(null);
+          async function P() {
+            const e = await pt();
+            f(e);
+          }
+          (le(() => {
+            n &&
+              ht().then((e) => {
+                e >= 3 && A(!0);
+              });
+          }, [n]),
+            le(() => {
+              He.storage.local.get("showYouTubeRecommendation").then((e) => {
+                e.showYouTubeRecommendation && C(!0);
+              });
+            }, []),
+            le(
+              () => (
+                He.tabs.query({ active: !0, currentWindow: !0 }).then((e) => {
+                  const t = e[0]?.url || "",
+                    n = (function (e) {
+                      return (
+                        (function (e) {
+                          for (const t of ut) {
+                            const n = e.match(t);
+                            if (n) return n[1];
+                          }
+                          return null;
+                        })(e) ||
+                        (function (e) {
+                          for (const t of mt) {
+                            const n = e.match(t);
+                            if (n) return n[1];
+                          }
+                          return null;
+                        })(e)
+                      );
+                    })(t);
+                  if (n) {
+                    const s =
+                      "tiktok" === gt(t) ? "TikTok Video" : "YouTube Video";
+                    c({ url: t, videoId: n, title: e[0]?.title || s });
+                  }
+                }),
+                n || P(),
+                () => {
+                  S.current && clearInterval(S.current);
+                }
+              ),
+              [n],
+            ));
+          const z = !!t && t.analyses_this_month >= t.monthly_analyses,
+            M = t ? t.monthly_analyses - t.analyses_this_month : null,
+            T =
+              !!(t && t.monthly_analyses > 0) &&
+              null !== M &&
+              M / t.monthly_analyses < 0.2,
+            E = t?.credits_monthly || e?.credits_monthly || 0,
+            $ = t?.credits ?? e?.credits ?? 0,
+            I = E > 0 && $ / E < 0.3,
+            L = E > 0 && $ / E < 0.1,
+            D = t?.plan_id || e?.plan || "free",
+            F = i.upsell[D] || null,
+            R = ue(async () => {
+              if (l) {
+                w(!0);
+                try {
+                  const e = await He.runtime.sendMessage({
+                    action: "QUICK_CHAT",
+                    data: { url: l.url, lang: m },
+                  });
+                  if (!e.success)
+                    throw new Error(e.error || "Quick Chat failed");
+                  const t = e.result;
+                  He.tabs.create({ url: `${_t}/chat?summary=${t.summary_id}` });
+                } catch (e) {
+                  r(e.message);
+                } finally {
+                  w(!1);
+                }
+              }
+            }, [l, m, r]),
+            B = ue(async () => {
+              if (l) {
+                if (n && (await ht()) >= 3) return void A(!0);
+                h({
+                  phase: "analyzing",
+                  progress: 0,
+                  message: i.analysis.starting,
+                });
+                try {
+                  const e = await He.runtime.sendMessage({
+                    action: "START_ANALYSIS",
+                    data: { url: l.url, options: { mode: d, lang: m } },
+                  });
+                  if (!e.success)
+                    return void h({
+                      phase: "error",
+                      message: e.error || i.analysis.startFailed,
+                    });
+                  const t = e.result.task_id;
+                  S.current = setInterval(async () => {
+                    try {
+                      const e = await He.runtime.sendMessage({
+                        action: "GET_TASK_STATUS",
+                        data: { taskId: t },
+                      });
+                      if (!e.success || !e.status) return;
+                      const s = e.status;
+                      if ("completed" === s.status && s.result?.summary_id) {
+                        (S.current && clearInterval(S.current),
+                          n &&
+                            (await (async function () {
+                              const e = (await ht()) + 1;
+                              return (
+                                await He.storage.local.set({
+                                  deepsight_free_analyses: e,
+                                }),
+                                e
+                              );
+                            })(),
+                            A(!0)),
+                          await (async function (e) {
+                            const t = (await pt()).filter(
+                              (t) => t.videoId !== e.videoId,
+                            );
+                            (t.unshift({ ...e, timestamp: Date.now() }),
+                              await He.storage.local.set({
+                                recentAnalyses: t.slice(0, 20),
+                              }));
+                          })({
+                            videoId: l.videoId,
+                            summaryId: s.result.summary_id,
+                            title: s.result.video_title || l.title,
+                          }));
+                        const e = await He.runtime.sendMessage({
+                          action: "GET_SUMMARY",
+                          data: { summaryId: s.result.summary_id },
+                        });
+                        e.success &&
+                          e.summary &&
+                          (h({
+                            phase: "complete",
+                            summaryId: s.result.summary_id,
+                            summary: e.summary,
+                          }),
+                          P());
+                      } else
+                        "failed" === s.status
+                          ? (S.current && clearInterval(S.current),
+                            h({
+                              phase: "error",
+                              message: s.error || i.analysis.failed,
+                            }))
+                          : h({
+                              phase: "analyzing",
+                              progress: s.progress || 0,
+                              message: s.message || i.analysis.processing,
+                            });
+                    } catch {}
+                  }, 2500);
+                } catch (e) {
+                  h({ phase: "error", message: e.message });
+                }
+              }
+            }, [l, d, m, n, i]);
+          if (y && "complete" === p.phase)
+            return Ve(Tt, {
+              summaryId: p.summaryId,
+              videoTitle: p.summary.video_title,
+              onClose: () => v(!1),
+              onSessionExpired: s,
+              userPlan: t?.plan_id || e?.plan || "free",
+            });
+          const U = t ? i.plans[t.plan_id] || t.plan_name : null,
+            O = !e || "free" === e.plan;
+          return Ve("div", {
+            className: "main-view",
+            children: [
+              Ve("div", {
+                className: "main-header",
+                children: [
+                  Ve("div", {
+                    className: "main-header-left",
+                    children: [
+                      Ve(it, { size: "xs", speed: "slow" }),
+                      Ve(
+                        "h1",
+                        n
+                          ? { children: "DeepSight" }
+                          : O
+                            ? { children: ["DeepSight ", U || i.plans.free] }
+                            : { children: ["DeepSight ", U] },
+                      ),
+                    ],
+                  }),
+                  Ve("div", {
+                    className: "main-header-actions",
+                    children: [
+                      Ve("button", {
+                        className: "btn-open-webapp",
+                        onClick: () => He.tabs.create({ url: _t }),
+                        title: "Ouvrir DeepSight",
+                        children: [Ve(Ke, { size: 12 }), " Web"],
+                      }),
+                      Ve(
+                        "button",
+                        n
+                          ? {
+                              className: "btn-header-login",
+                              onClick: a,
+                              children: i.common.login,
+                            }
+                          : {
+                              className: "icon-btn icon-btn-danger",
+                              onClick: s,
+                              title: i.common.logout,
+                              children: Ve(Ye, { size: 16 }),
+                            },
+                      ),
+                    ],
+                  }),
+                ],
+              }),
+              !n &&
+                e &&
+                Ve("div", {
+                  className: "user-bar",
+                  children: [
+                    Ve("span", {
+                      className: `plan-badge plan-${e.plan}`,
+                      children: i.plans[e.plan] || e.plan,
+                    }),
+                    Ve(
+                      "span",
+                      t
+                        ? {
+                            className:
+                              "user-quota " + (T ? "quota-warning" : ""),
+                            children: [
+                              t.analyses_this_month,
+                              "/",
+                              t.monthly_analyses,
+                              " ",
+                              i.common.analyses,
+                            ],
+                          }
+                        : {
+                            className: "user-credits",
+                            children: [e.credits, " ", i.common.credits],
+                          },
+                    ),
+                    I &&
+                      Ve("span", {
+                        className:
+                          "credits-urgency " +
+                          (L ? "credits-critical" : "credits-low"),
+                        title: i.credits.remaining.replace(
+                          "{count}",
+                          String($),
+                        ),
+                        children: [L ? "🚨" : "⚠️", " ", $, " ", i.credits.low],
+                      }),
+                  ],
+                }),
+              !n &&
+                L &&
+                Ve("div", {
+                  className: "credits-banner-critical",
+                  children: [
+                    Ve("span", {
+                      children: [
+                        i.credits.critical.replace("{count}", String($)),
+                        " ",
+                      ],
+                    }),
+                    Ve("a", {
+                      href: `${_t}/upgrade`,
+                      onClick: (e) => {
+                        (e.preventDefault(),
+                          He.tabs.create({ url: `${_t}/upgrade` }));
+                      },
+                      children: [i.credits.recharge, " ", "↗"],
+                    }),
+                  ],
+                }),
+              n &&
+                Ve("div", {
+                  className: "guest-banner",
+                  children: Ve("span", { children: i.guest.banner }),
+                }),
+              N &&
+                Ve("div", {
+                  className: "yt-recommend-banner",
+                  children: [
+                    Ve("div", {
+                      className: "yt-recommend-content",
+                      children: [
+                        Ve("img", {
+                          src: He.runtime.getURL(
+                            "platforms/youtube-icon-red.png",
+                          ),
+                          alt: "YouTube",
+                          style: { height: 18, width: "auto", flexShrink: 0 },
+                        }),
+                        Ve("div", {
+                          className: "yt-recommend-text",
+                          children: [
+                            Ve("span", {
+                              className: "yt-recommend-title",
+                              children: i.ytRecommend.title,
+                            }),
+                            Ve("span", {
+                              className: "yt-recommend-subtitle",
+                              children: i.ytRecommend.subtitle,
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                    Ve("button", {
+                      className: "yt-recommend-dismiss",
+                      onClick: () => {
+                        (C(!1),
+                          He.storage.local.remove("showYouTubeRecommendation"));
+                      },
+                      title: i.ytRecommend.dismiss,
+                      children: "✕",
+                    }),
+                  ],
+                }),
+              Ve("div", {
+                className: "main-content",
+                children: [
+                  l
+                    ? (() => {
+                        const e = "tiktok" === gt(l.url),
+                          t = e
+                            ? null
+                            : `https://img.youtube.com/vi/${l.videoId}/mqdefault.jpg`,
+                          n = e
+                            ? `tiktok.com/video/${l.videoId}`
+                            : `youtube.com/watch?v=${l.videoId}`;
+                        return Ve("div", {
+                          className: "video-status-card",
+                          children: [
+                            t
+                              ? Ve("img", {
+                                  src: t,
+                                  alt: "",
+                                  className: "video-thumbnail",
+                                  onError: (e) => {
+                                    e.target.style.display = "none";
+                                  },
+                                })
+                              : Ve("div", {
+                                  className: "video-thumbnail",
+                                  style: {
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    background: "rgba(200,144,58,0.1)",
+                                  },
+                                  children: Ve(nt, {
+                                    name: "waveform",
+                                    size: 20,
+                                    color: "var(--accent-primary)",
+                                  }),
+                                }),
+                            Ve("div", {
+                              className: "video-status-body",
+                              children: [
+                                Ve("span", {
+                                  className: "video-status-title",
+                                  children:
+                                    l.title.length > 52
+                                      ? l.title.substring(0, 52) + "…"
+                                      : l.title,
+                                }),
+                                Ve("span", {
+                                  className: "video-status-url",
+                                  children: n,
+                                }),
+                              ],
+                            }),
+                            Ve("div", {
+                              className: "video-live-dot",
+                              title: "Video detected",
+                            }),
+                          ],
+                        });
+                      })()
+                    : Ve("div", {
+                        className: "video-status",
+                        children: [
+                          Ve("div", {
+                            className: "video-status-icon",
+                            children: Ve(nt, {
+                              name: "play",
+                              size: 16,
+                              color: "var(--text-muted)",
+                            }),
+                          }),
+                          Ve("span", {
+                            className: "video-status-text video-status-none",
+                            children: i.analysis.noVideo,
+                          }),
+                        ],
+                      }),
+                  l &&
+                    "idle" === p.phase &&
+                    Ve(k, {
+                      children:
+                        !n && z
+                          ? Ve("div", {
+                              className: "quota-exceeded",
+                              children: [
+                                Ve("p", {
+                                  className: "quota-exceeded-text",
+                                  children: [
+                                    i.analysis.quotaExceeded,
+                                    " (",
+                                    t?.analyses_this_month,
+                                    "/",
+                                    t?.monthly_analyses,
+                                    ") — ",
+                                    i.analysis.quotaExceededText,
+                                  ],
+                                }),
+                                Ve("button", {
+                                  className:
+                                    "analyze-btn analyze-btn-disabled btn-shimmer",
+                                  disabled: !0,
+                                  children: i.analysis.analyzeButton,
+                                }),
+                                Ve("button", {
+                                  className: "quickchat-btn",
+                                  onClick: R,
+                                  disabled: x,
+                                  children: x
+                                    ? i.analysis.quickChatPreparing
+                                    : i.analysis.quickChatButton,
+                                }),
+                                Ve("a", {
+                                  href: `${_t}/upgrade`,
+                                  target: "_blank",
+                                  rel: "noreferrer",
+                                  className: "btn-upgrade-cta",
+                                  onClick: (e) => {
+                                    (e.preventDefault(),
+                                      He.tabs.create({ url: `${_t}/upgrade` }));
+                                  },
+                                  children: [i.common.viewPlans, " ", "↗"],
+                                }),
+                              ],
+                            })
+                          : n && b
+                            ? Ve("div", {
+                                className: "guest-exhausted",
+                                children: [
+                                  Ve("p", {
+                                    className: "guest-exhausted-text",
+                                    children: i.guest.exhaustedText,
+                                  }),
+                                  Ve("button", {
+                                    className: "btn-create-account",
+                                    onClick: () =>
+                                      He.tabs.create({ url: `${_t}/register` }),
+                                    children: [
+                                      i.common.createAccount,
+                                      " ",
+                                      "↗",
+                                    ],
+                                  }),
+                                ],
+                              })
+                            : Ve(k, {
+                                children: [
+                                  Ve("div", {
+                                    className: "selectors-row",
+                                    children: [
+                                      Ve("div", {
+                                        className: "ds-select-wrapper",
+                                        children: [
+                                          Ve("label", {
+                                            children: i.analysis.mode,
+                                          }),
+                                          Ve("select", {
+                                            className: "ds-select",
+                                            value: d,
+                                            onChange: (e) => u(e.target.value),
+                                            children: [
+                                              Ve("option", {
+                                                value: "standard",
+                                                children:
+                                                  i.analysis.modes.standard,
+                                              }),
+                                              Ve("option", {
+                                                value: "accessible",
+                                                children:
+                                                  i.analysis.modes.accessible,
+                                              }),
+                                            ],
+                                          }),
+                                        ],
+                                      }),
+                                      Ve("div", {
+                                        className: "ds-select-wrapper",
+                                        children: [
+                                          Ve("label", {
+                                            children: i.analysis.language,
+                                          }),
+                                          Ve("select", {
+                                            className: "ds-select",
+                                            value: m,
+                                            onChange: (e) => g(e.target.value),
+                                            children: [
+                                              Ve("option", {
+                                                value: "fr",
+                                                children:
+                                                  i.analysis.languages.fr,
+                                              }),
+                                              Ve("option", {
+                                                value: "en",
+                                                children:
+                                                  i.analysis.languages.en,
+                                              }),
+                                              Ve("option", {
+                                                value: "es",
+                                                children:
+                                                  i.analysis.languages.es,
+                                              }),
+                                              Ve("option", {
+                                                value: "de",
+                                                children:
+                                                  i.analysis.languages.de,
+                                              }),
+                                            ],
+                                          }),
+                                        ],
+                                      }),
+                                    ],
+                                  }),
+                                  Ve("button", {
+                                    className: "quickchat-btn",
+                                    onClick: R,
+                                    disabled: !l || x,
+                                    children: x
+                                      ? i.analysis.quickChatPreparing
+                                      : i.analysis.quickChatButton,
+                                  }),
+                                  Ve("button", {
+                                    className: "analyze-btn btn-shimmer",
+                                    onClick: B,
+                                    style: {
+                                      animation:
+                                        "float 3s ease-in-out infinite",
+                                    },
+                                    children: i.analysis.analyzeButton,
+                                  }),
+                                  Ve("div", {
+                                    className: "mistral-badge",
+                                    children: [
+                                      Ve("span", { children: "🇫🇷" }),
+                                      Ve("span", { children: i.mistral.badge }),
+                                    ],
+                                  }),
+                                ],
+                              }),
+                    }),
+                  "analyzing" === p.phase &&
+                    Ve("div", {
+                      className: "progress-container",
+                      children: [
+                        Ve("div", {
+                          style: {
+                            display: "flex",
+                            justifyContent: "center",
+                            marginBottom: 8,
+                          },
+                          children: Ve(it, { size: "sm", speed: "fast" }),
+                        }),
+                        Ve("div", {
+                          className: "progress-bar",
+                          children: Ve("div", {
+                            className: "progress-fill",
+                            style: { width: `${p.progress}%` },
+                          }),
+                        }),
+                        Ve("p", {
+                          className: "progress-text",
+                          children: p.message,
+                        }),
+                      ],
+                    }),
+                  "error" === p.phase &&
+                    Ve("div", {
+                      style: { textAlign: "center", padding: "12px" },
+                      children: [
+                        Ve("p", {
+                          style: {
+                            color: "var(--error)",
+                            fontSize: "13px",
+                            marginBottom: "8px",
+                          },
+                          children: p.message,
+                        }),
+                        Ve("button", {
+                          className: "analyze-btn btn-shimmer",
+                          onClick: () => h({ phase: "idle" }),
+                          style: {
+                            height: "40px",
+                            fontSize: "13px",
+                            animation: "float 3s ease-in-out infinite",
+                          },
+                          children: i.common.retry,
+                        }),
+                      ],
+                    }),
+                  "complete" === p.phase &&
+                    Ve(k, {
+                      children: [
+                        Ve(Pt, {
+                          summary: p.summary,
+                          summaryId: p.summaryId,
+                          planInfo: t,
+                          onOpenChat: () => v(!0),
+                        }),
+                        !n &&
+                          F &&
+                          "pro" !== D &&
+                          Ve("div", {
+                            className: "post-analysis-upsell",
+                            children: [
+                              Ve("div", {
+                                className: "upsell-content",
+                                children: [
+                                  Ve(nt, {
+                                    name: "sparkle4pt",
+                                    size: 18,
+                                    color: "var(--accent-primary)",
+                                  }),
+                                  Ve("div", {
+                                    className: "upsell-text",
+                                    children: [
+                                      Ve("span", {
+                                        className: "upsell-headline",
+                                        children: F.feature,
+                                      }),
+                                      Ve("span", {
+                                        className: "upsell-sub",
+                                        children: [
+                                          "Plan ",
+                                          F.label,
+                                          " — ",
+                                          F.price,
+                                          "/",
+                                          "fr" === o ? "mois" : "mo",
+                                        ],
+                                      }),
+                                    ],
+                                  }),
+                                ],
+                              }),
+                              Ve("a", {
+                                href: `${_t}/upgrade`,
+                                className: "upsell-btn",
+                                onClick: (e) => {
+                                  (e.preventDefault(),
+                                    He.tabs.create({ url: `${_t}/upgrade` }));
+                                },
+                                children: [i.common.unlock, " ", "↗"],
+                              }),
+                            ],
+                          }),
+                        n &&
+                          Ve("div", {
+                            className: "guest-post-analysis",
+                            children: [
+                              Ve("p", { children: i.guest.exhaustedText }),
+                              Ve("button", {
+                                className: "btn-create-account",
+                                onClick: () =>
+                                  He.tabs.create({ url: `${_t}/register` }),
+                                children: [i.common.createAccount, " ", "↗"],
+                              }),
+                            ],
+                          }),
+                      ],
+                    }),
+                  !n &&
+                    "idle" === p.phase &&
+                    _.length > 0 &&
+                    Ve("div", {
+                      className: "recent-section",
+                      children: [
+                        Ve("h3", { children: i.analysis.recent }),
+                        Ve("div", {
+                          className: "recent-list",
+                          children: _.slice(0, 5).map((e) => {
+                            return Ve(
+                              "a",
+                              {
+                                href: `${_t}/summary/${e.summaryId}`,
+                                target: "_blank",
+                                rel: "noreferrer",
+                                className: "recent-item",
+                                children: [
+                                  "tiktok" === e.platform
+                                    ? Ve("div", {
+                                        style: {
+                                          width: 48,
+                                          height: 36,
+                                          display: "flex",
+                                          alignItems: "center",
+                                          justifyContent: "center",
+                                          background: "rgba(200,144,58,0.1)",
+                                          borderRadius: 4,
+                                          flexShrink: 0,
+                                        },
+                                        children: Ve(nt, {
+                                          name: "waveform",
+                                          size: 16,
+                                          color: "var(--accent-primary)",
+                                        }),
+                                      })
+                                    : Ve("img", {
+                                        src:
+                                          ((t = e.videoId),
+                                          `https://img.youtube.com/vi/${t}/default.jpg` ||
+                                            ""),
+                                        alt: "",
+                                        loading: "lazy",
+                                      }),
+                                  Ve("span", {
+                                    className: "recent-title",
+                                    children: e.title,
+                                  }),
+                                ],
+                              },
+                              e.videoId,
+                            );
+                            var t;
+                          }),
+                        }),
+                      ],
+                    }),
+                ],
+              }),
+              Ve(Rt, { planInfo: t }),
+            ],
+          });
+        },
+        Ut = [
+          "M6 4h4v16H6zm8 0h4v16h-4z",
+          "M8 7c0-2 1-3 2-3s2 1 2 3v10c0 2-1 3-2 3s-2-1-2-3V7zm6 0c0-2 1-3 2-3s2 1 2 3v10c0 2-1 3-2 3s-2-1-2-3V7z",
+          "M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z",
+          "M6 9H3V4h3m12 5h3V4h-3M12 15a6 6 0 006-6V3H6v6a6 6 0 006 6zm0 0v4m-4 2h8",
+          "M4 19.5A2.5 2.5 0 016.5 17H20M4 19.5V4a2 2 0 012-2h14v14H6.5A2.5 2.5 0 004 18.5z",
+          "M10 2v6l-2 4h8l-2-4V2zm-2 12v2m8-2v2M8 22h8",
+          "M3 21c3 0 7-1 7-8V5M14 5c0 6.5 4 8 7 8",
+          "M9 2h6v4H9zM16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2m1 9l2 2 4-4",
+          "M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8zm11-3a3 3 0 100 6 3 3 0 000-6z",
+          "M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z",
+          "M22 2L11 13m11-11l-7 20-4-9-9-4z",
+          "M4.9 19.1C1 15.2 1 8.8 4.9 4.9m14.2 0c3.9 3.9 3.9 10.3 0 14.2M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.4m8.4 0c2.3 2.3 2.3 6.1 0 8.4M12 12h.01",
+          "M15 4V2M15 16v-2M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2L19 5M3 21l9-9M12.2 6.2L11 5",
+          "M5 5a2 2 0 100 4 2 2 0 000-4zm14 0a2 2 0 100 4 2 2 0 000-4zm-7 7a2 2 0 100 4 2 2 0 000-4zm-7 7a2 2 0 100 4 2 2 0 000-4zm14 0a2 2 0 100 4 2 2 0 000-4zM7 7l5 5m5-5l-5 5m-5 5l5-5m5 5l-5-5",
+          "M12 12m-3 0a3 3 0 106 0 3 3 0 10-6 0M12 2c-5 0-8 5-8 10s3 10 8 10 8-5 8-10-3-10-8-10z",
+          "M17 3a2.83 2.83 0 114 4L7.5 20.5 2 22l1.5-5.5z",
+          "M4 17l6-6-6-6m8 14h8",
+          "M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6",
+        ],
+        Ot = (e) => {
+          const t = 1e4 * Math.sin(9999 * e);
+          return t - Math.floor(t);
+        },
+        Vt = (e, t, n, s, a, r, i, o, l) => {
+          const c = 24 * s;
+          return `\n    <g transform="translate(${t - c / 2}, ${n - c / 2}) rotate(${a} ${c / 2} ${c / 2})">\n      <svg viewBox="0 0 24 24" width="${c}" height="${c}" overflow="visible">\n        ${l ? `<path d="${e}" fill="${r}" opacity="${i}" />` : `<path d="${e}" stroke="${r}" stroke-width="${o}" opacity="${i}" fill="none" stroke-linecap="round" stroke-linejoin="round" />`}\n      </svg>\n    </g>\n  `;
+        },
+        qt = ({ variant: e = "default", className: t = "" }) => {
+          const n = de(() => {
+            const t = ((e, t, n = !0, s = 1) => {
+              const a = ((e) => {
+                  const t = e || "default",
+                    n = [...tt, ...Ut],
+                    s = n.slice(0, 5),
+                    a = [n[5], n[6], n[7], n[8], ...Ut.slice(2, 8)],
+                    r = [n[9], n[10], n[11], n[12], n[13], ...Ut.slice(8, 16)],
+                    i = [n[14], n[15], ...Ut.slice(17, 20)],
+                    o = [n[16], n[17], n[18], n[19], n[20]];
+                  switch (t) {
+                    case "video":
+                      return [...n, ...s, ...s, ...s];
+                    case "study":
+                      return [...n, ...a, ...a, ...a];
+                    case "tech":
+                      return [...n, ...i, ...i, ...i];
+                    case "AI":
+                      return [...n, ...r, ...r, ...r];
+                    case "creative":
+                      return [...n, ...o, ...o, ...o];
+                    default:
+                      return n;
+                  }
+                })(t),
+                r = n ? "#C8903A" : "#9B6B4A",
+                i = n ? "#9B6B4A" : "#C8903A",
+                o = n
+                  ? [
+                      "#A78BFA",
+                      "#818CF8",
+                      "#FBBF24",
+                      "#34D399",
+                      "#60A5FA",
+                      "#F87171",
+                      "#C084FC",
+                    ]
+                  : [
+                      "#8B5CF6",
+                      "#6366F1",
+                      "#F59E0B",
+                      "#10B981",
+                      "#3B82F6",
+                      "#EF4444",
+                      "#A855F7",
+                    ],
+                l = (e, t = !1) =>
+                  t ? (Ot(e) > 0.5 ? r : i) : o[Math.floor(Ot(e) * o.length)],
+                c = (e, t) => e[Math.floor(Ot(t) * e.length)],
+                d = (e) => {
+                  const t = [0, 15, -15, 30, -30, 45, -45, 90, -90, 180];
+                  return t[Math.floor(Ot(e) * t.length)];
+                };
+              let u = "";
+              const m =
+                {
+                  video: 1e3,
+                  study: 2e3,
+                  tech: 3e3,
+                  AI: 4e3,
+                  creative: 5e3,
+                  default: 0,
+                }[t] ?? 0;
+              for (let t = 0; t < 25; t++) {
+                const n = m + 100 + 37 * t,
+                  r = c(a, n),
+                  i = Ot(n + 1) * e,
+                  o = Ot(n + 2) * e,
+                  g = d(n + 3),
+                  p = 0.8 + 0.4 * Ot(n + 4),
+                  h = (0.04 + 0.02 * Ot(n + 5)) * s,
+                  _ = l(n + 9),
+                  f = 1.2 + 0.6 * (Ot(n + 10) - 0.5);
+                u += Vt(r, i, o, p, g, _, h, f, !1);
+              }
+              for (let t = 0; t < 30; t++) {
+                const n = m + 300 + 23 * t,
+                  r = c(a, n),
+                  i = Ot(n + 1) * e,
+                  o = Ot(n + 2) * e,
+                  g = d(n + 3),
+                  p = 0.5 + 0.3 * Ot(n + 4),
+                  h = (0.08 + 0.04 * Ot(n + 5)) * s,
+                  _ = l(n + 9, Ot(n + 6) < 0.1),
+                  f = 1.4 + 0.6 * (Ot(n + 10) - 0.5);
+                u += Vt(r, i, o, p, g, _, h, f, !1);
+              }
+              for (let t = 0; t < 15; t++) {
+                const n = m + 600 + 41 * t,
+                  a = Ot(n + 1) * e,
+                  o = Ot(n + 2) * e,
+                  l = 0.5 + 1.5 * Ot(n + 3),
+                  c = (0.1 + 0.05 * Ot(n + 4)) * s;
+                u += `<circle cx="${a}" cy="${o}" r="${l}" fill="${Ot(n + 5) > 0.5 ? r : i}" opacity="${c}" />`;
+              }
+              return `\n    <svg width="${e}" height="${e}" viewBox="0 0 ${e} ${e}" xmlns="http://www.w3.org/2000/svg" overflow="visible">\n      <defs>\n        <mask id="tileEdgeFade">\n          <rect width="${e}" height="${e}" fill="white" />\n          <radialGradient id="edgeFadeGrad" cx="50%" cy="50%" r="60%">\n            <stop offset="0%" stop-color="white" />\n            <stop offset="100%" stop-color="black" />\n          </radialGradient>\n          <circle cx="${e / 2}" cy="${e / 2}" r="${0.55 * e}" fill="url(#edgeFadeGrad)" />\n        </mask>\n      </defs>\n      <g mask="url(#tileEdgeFade)">\n        ${u}\n      </g>\n    </svg>\n  `;
+            })(200, e, !0, 1);
+            return `data:image/svg+xml,${encodeURIComponent(t)}`;
+          }, [e]);
+          return Ve("div", {
+            className: `fixed inset-0 pointer-events-none ${t}`,
+            style: {
+              ...de(
+                () => ({
+                  backgroundImage: `url("${n}")`,
+                  backgroundSize: "200px 200px",
+                  backgroundRepeat: "repeat",
+                  backgroundAttachment: "fixed",
+                }),
+                [n],
+              ),
+              zIndex: -1,
+            },
+            "aria-hidden": "true",
+          });
+        },
+        Ht = document.getElementById("root");
+      Ht &&
+        (function (e) {
+          return {
+            render: function (t) {
+              !(function (e, t, n) {
+                (null == t.__k && (t.textContent = ""),
+                  j(e, t),
+                  "function" == typeof n && n(),
+                  e && e.__c);
+              })(t, e);
+            },
+            unmount: function () {
+              !(function (e) {
+                !!e.__k && j(null, e);
+              })(e);
+            },
+          };
+        })(Ht).render(
+          Ve(() => {
+            const [e, t] = oe("loading"),
+              [n, s] = oe(null),
+              [a, r] = oe(null),
+              [i, o] = oe(!1),
+              [l, c] = oe(null),
+              [d, u] = oe(null);
+            async function m() {
+              try {
+                const e = await He.runtime.sendMessage({ action: "GET_PLAN" });
+                e.success && e.plan && r(e.plan);
+              } catch {}
+            }
+            (le(() => {
+              !(async function () {
+                try {
+                  const e = await He.runtime.sendMessage({
+                    action: "CHECK_AUTH",
+                  });
+                  e.authenticated && e.user
+                    ? (s(e.user), o(!1), await m(), t("main"))
+                    : t("login");
+                } catch {
+                  t("login");
+                }
+              })();
+            }, []),
+              le(() => {
+                if (!d) return;
+                const e = setTimeout(() => u(null), 3e3);
+                return () => clearTimeout(e);
+              }, [d]));
+            const g = ue(async (e, n) => {
+                c(null);
+                const a = await He.runtime.sendMessage({
+                  action: "LOGIN",
+                  data: { email: e, password: n },
+                });
+                if (!a.success || !a.user)
+                  throw new Error(a.error || "Login failed");
+                (s(a.user), o(!1), await m(), t("main"));
+              }, []),
+              p = ue(async () => {
+                c(null);
+                const e = await He.runtime.sendMessage({
+                  action: "GOOGLE_LOGIN",
+                });
+                if (!e.success || !e.user)
+                  throw new Error(e.error || "Google login failed");
+                (s(e.user), o(!1), await m(), t("main"));
+              }, []),
+              h = ue(() => {
+                (o(!0), s(null), r(null), t("main"));
+              }, []),
+              _ = ue(async () => {
+                (await He.runtime.sendMessage({ action: "LOGOUT" }),
+                  s(null),
+                  r(null),
+                  o(!1),
+                  t("login"));
+              }, []),
+              f = ue(() => {
+                (o(!1), t("login"));
+              }, []),
+              y = ue((e) => {
+                u({ message: e, type: "error" });
+              }, []);
+            return Ve("div", {
+              className: "app-container noise-overlay ambient-glow",
+              style: { position: "relative" },
+              children: [
+                Ve(qt, {
+                  variant:
+                    "loading" === e || "login" === e
+                      ? "default"
+                      : "main" === e
+                        ? "AI"
+                        : "default",
+                }),
+                Ve("div", {
+                  style: { position: "relative", zIndex: 1 },
+                  children: [
+                    d &&
+                      Ve("div", {
+                        className: `ds-toast ds-toast-${d.type}`,
+                        onClick: () => u(null),
+                        children: d.message,
+                      }),
+                    "loading" === e &&
+                      Ve("div", {
+                        className: "loading-view",
+                        children: Ve(it, {
+                          size: "md",
+                          speed: "normal",
+                          showLabel: !0,
+                          label: "DeepSight",
+                        }),
+                      }),
+                    "login" === e &&
+                      Ve(dt, {
+                        onLogin: g,
+                        onGoogleLogin: p,
+                        onGuestMode: h,
+                        error: l,
+                      }),
+                    "main" === e &&
+                      Ve(Bt, {
+                        user: n,
+                        planInfo: a,
+                        isGuest: i,
+                        onLogout: _,
+                        onLoginRedirect: f,
+                        onError: y,
+                      }),
+                  ],
+                }),
+              ],
+            });
+          }, {}),
+        );
+    })());
+})();

--- a/extension/dist/viewer.js
+++ b/extension/dist/viewer.js
@@ -1,1 +1,2484 @@
-(()=>{var e={815(e,n){var t,r;"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self&&self,t=function(e){"use strict";if(!(globalThis.chrome&&globalThis.chrome.runtime&&globalThis.chrome.runtime.id))throw new Error("This script should only be loaded in a browser extension.");if(globalThis.browser&&globalThis.browser.runtime&&globalThis.browser.runtime.id)e.exports=globalThis.browser;else{const n="The message port closed before a response was received.",t=e=>{const t={alarms:{clear:{minArgs:0,maxArgs:1},clearAll:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getAll:{minArgs:0,maxArgs:0}},bookmarks:{create:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},getChildren:{minArgs:1,maxArgs:1},getRecent:{minArgs:1,maxArgs:1},getSubTree:{minArgs:1,maxArgs:1},getTree:{minArgs:0,maxArgs:0},move:{minArgs:2,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeTree:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}},browserAction:{disable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},enable:{minArgs:0,maxArgs:1,fallbackToNoCallback:!0},getBadgeBackgroundColor:{minArgs:1,maxArgs:1},getBadgeText:{minArgs:1,maxArgs:1},getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},openPopup:{minArgs:0,maxArgs:0},setBadgeBackgroundColor:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setBadgeText:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},browsingData:{remove:{minArgs:2,maxArgs:2},removeCache:{minArgs:1,maxArgs:1},removeCookies:{minArgs:1,maxArgs:1},removeDownloads:{minArgs:1,maxArgs:1},removeFormData:{minArgs:1,maxArgs:1},removeHistory:{minArgs:1,maxArgs:1},removeLocalStorage:{minArgs:1,maxArgs:1},removePasswords:{minArgs:1,maxArgs:1},removePluginData:{minArgs:1,maxArgs:1},settings:{minArgs:0,maxArgs:0}},commands:{getAll:{minArgs:0,maxArgs:0}},contextMenus:{remove:{minArgs:1,maxArgs:1},removeAll:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},cookies:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:1,maxArgs:1},getAllCookieStores:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},devtools:{inspectedWindow:{eval:{minArgs:1,maxArgs:2,singleCallbackArg:!1}},panels:{create:{minArgs:3,maxArgs:3,singleCallbackArg:!0},elements:{createSidebarPane:{minArgs:1,maxArgs:1}}}},downloads:{cancel:{minArgs:1,maxArgs:1},download:{minArgs:1,maxArgs:1},erase:{minArgs:1,maxArgs:1},getFileIcon:{minArgs:1,maxArgs:2},open:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},pause:{minArgs:1,maxArgs:1},removeFile:{minArgs:1,maxArgs:1},resume:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},extension:{isAllowedFileSchemeAccess:{minArgs:0,maxArgs:0},isAllowedIncognitoAccess:{minArgs:0,maxArgs:0}},history:{addUrl:{minArgs:1,maxArgs:1},deleteAll:{minArgs:0,maxArgs:0},deleteRange:{minArgs:1,maxArgs:1},deleteUrl:{minArgs:1,maxArgs:1},getVisits:{minArgs:1,maxArgs:1},search:{minArgs:1,maxArgs:1}},i18n:{detectLanguage:{minArgs:1,maxArgs:1},getAcceptLanguages:{minArgs:0,maxArgs:0}},identity:{launchWebAuthFlow:{minArgs:1,maxArgs:1}},idle:{queryState:{minArgs:1,maxArgs:1}},management:{get:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},getSelf:{minArgs:0,maxArgs:0},setEnabled:{minArgs:2,maxArgs:2},uninstallSelf:{minArgs:0,maxArgs:1}},notifications:{clear:{minArgs:1,maxArgs:1},create:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:0},getPermissionLevel:{minArgs:0,maxArgs:0},update:{minArgs:2,maxArgs:2}},pageAction:{getPopup:{minArgs:1,maxArgs:1},getTitle:{minArgs:1,maxArgs:1},hide:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setIcon:{minArgs:1,maxArgs:1},setPopup:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},setTitle:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0},show:{minArgs:1,maxArgs:1,fallbackToNoCallback:!0}},permissions:{contains:{minArgs:1,maxArgs:1},getAll:{minArgs:0,maxArgs:0},remove:{minArgs:1,maxArgs:1},request:{minArgs:1,maxArgs:1}},runtime:{getBackgroundPage:{minArgs:0,maxArgs:0},getPlatformInfo:{minArgs:0,maxArgs:0},openOptionsPage:{minArgs:0,maxArgs:0},requestUpdateCheck:{minArgs:0,maxArgs:0},sendMessage:{minArgs:1,maxArgs:3},sendNativeMessage:{minArgs:2,maxArgs:2},setUninstallURL:{minArgs:1,maxArgs:1}},sessions:{getDevices:{minArgs:0,maxArgs:1},getRecentlyClosed:{minArgs:0,maxArgs:1},restore:{minArgs:0,maxArgs:1}},storage:{local:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}},managed:{get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1}},sync:{clear:{minArgs:0,maxArgs:0},get:{minArgs:0,maxArgs:1},getBytesInUse:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}}},tabs:{captureVisibleTab:{minArgs:0,maxArgs:2},create:{minArgs:1,maxArgs:1},detectLanguage:{minArgs:0,maxArgs:1},discard:{minArgs:0,maxArgs:1},duplicate:{minArgs:1,maxArgs:1},executeScript:{minArgs:1,maxArgs:2},get:{minArgs:1,maxArgs:1},getCurrent:{minArgs:0,maxArgs:0},getZoom:{minArgs:0,maxArgs:1},getZoomSettings:{minArgs:0,maxArgs:1},goBack:{minArgs:0,maxArgs:1},goForward:{minArgs:0,maxArgs:1},highlight:{minArgs:1,maxArgs:1},insertCSS:{minArgs:1,maxArgs:2},move:{minArgs:2,maxArgs:2},query:{minArgs:1,maxArgs:1},reload:{minArgs:0,maxArgs:2},remove:{minArgs:1,maxArgs:1},removeCSS:{minArgs:1,maxArgs:2},sendMessage:{minArgs:2,maxArgs:3},setZoom:{minArgs:1,maxArgs:2},setZoomSettings:{minArgs:1,maxArgs:2},update:{minArgs:1,maxArgs:2}},topSites:{get:{minArgs:0,maxArgs:0}},webNavigation:{getAllFrames:{minArgs:1,maxArgs:1},getFrame:{minArgs:1,maxArgs:1}},webRequest:{handlerBehaviorChanged:{minArgs:0,maxArgs:0}},windows:{create:{minArgs:0,maxArgs:1},get:{minArgs:1,maxArgs:2},getAll:{minArgs:0,maxArgs:1},getCurrent:{minArgs:0,maxArgs:1},getLastFocused:{minArgs:0,maxArgs:1},remove:{minArgs:1,maxArgs:1},update:{minArgs:2,maxArgs:2}}};if(0===Object.keys(t).length)throw new Error("api-metadata.json has not been included in browser-polyfill");class r extends WeakMap{constructor(e,n=void 0){super(n),this.createItem=e}get(e){return this.has(e)||this.set(e,this.createItem(e)),super.get(e)}}const s=(n,t)=>(...r)=>{e.runtime.lastError?n.reject(new Error(e.runtime.lastError.message)):t.singleCallbackArg||r.length<=1&&!1!==t.singleCallbackArg?n.resolve(r[0]):n.resolve(r)},i=e=>1==e?"argument":"arguments",o=(e,n,t)=>new Proxy(n,{apply:(n,r,s)=>t.call(r,e,...s)});let a=Function.call.bind(Object.prototype.hasOwnProperty);const l=(e,n={},t={})=>{let r=Object.create(null),_={has:(n,t)=>t in e||t in r,get(_,c,u){if(c in r)return r[c];if(!(c in e))return;let m=e[c];if("function"==typeof m)if("function"==typeof n[c])m=o(e,e[c],n[c]);else if(a(t,c)){let n=((e,n)=>function(t,...r){if(r.length<n.minArgs)throw new Error(`Expected at least ${n.minArgs} ${i(n.minArgs)} for ${e}(), got ${r.length}`);if(r.length>n.maxArgs)throw new Error(`Expected at most ${n.maxArgs} ${i(n.maxArgs)} for ${e}(), got ${r.length}`);return new Promise((i,o)=>{if(n.fallbackToNoCallback)try{t[e](...r,s({resolve:i,reject:o},n))}catch(s){console.warn(`${e} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,s),t[e](...r),n.fallbackToNoCallback=!1,n.noCallback=!0,i()}else n.noCallback?(t[e](...r),i()):t[e](...r,s({resolve:i,reject:o},n))})})(c,t[c]);m=o(e,e[c],n)}else m=m.bind(e);else if("object"==typeof m&&null!==m&&(a(n,c)||a(t,c)))m=l(m,n[c],t[c]);else{if(!a(t,"*"))return Object.defineProperty(r,c,{configurable:!0,enumerable:!0,get:()=>e[c],set(n){e[c]=n}}),m;m=l(m,n[c],t["*"])}return r[c]=m,m},set:(n,t,s,i)=>(t in r?r[t]=s:e[t]=s,!0),defineProperty:(e,n,t)=>Reflect.defineProperty(r,n,t),deleteProperty:(e,n)=>Reflect.deleteProperty(r,n)},c=Object.create(e);return new Proxy(c,_)},_=e=>({addListener(n,t,...r){n.addListener(e.get(t),...r)},hasListener:(n,t)=>n.hasListener(e.get(t)),removeListener(n,t){n.removeListener(e.get(t))}}),c=new r(e=>"function"!=typeof e?e:function(n){const t=l(n,{},{getContent:{minArgs:0,maxArgs:0}});e(t)}),u=new r(e=>"function"!=typeof e?e:function(n,t,r){let s,i,o=!1,a=new Promise(e=>{s=function(n){o=!0,e(n)}});try{i=e(n,t,s)}catch(e){i=Promise.reject(e)}const l=!0!==i&&((_=i)&&"object"==typeof _&&"function"==typeof _.then);var _;if(!0!==i&&!l&&!o)return!1;return(l?i:a).then(e=>{r(e)},e=>{let n;n=e&&(e instanceof Error||"string"==typeof e.message)?e.message:"An unexpected error occurred",r({__mozWebExtensionPolyfillReject__:!0,message:n})}).catch(e=>{console.error("Failed to send onMessage rejected reply",e)}),!0}),m=({reject:t,resolve:r},s)=>{e.runtime.lastError?e.runtime.lastError.message===n?r():t(new Error(e.runtime.lastError.message)):s&&s.__mozWebExtensionPolyfillReject__?t(new Error(s.message)):r(s)},g=(e,n,t,...r)=>{if(r.length<n.minArgs)throw new Error(`Expected at least ${n.minArgs} ${i(n.minArgs)} for ${e}(), got ${r.length}`);if(r.length>n.maxArgs)throw new Error(`Expected at most ${n.maxArgs} ${i(n.maxArgs)} for ${e}(), got ${r.length}`);return new Promise((e,n)=>{const s=m.bind(null,{resolve:e,reject:n});r.push(s),t.sendMessage(...r)})},f={devtools:{network:{onRequestFinished:_(c)}},runtime:{onMessage:_(u),onMessageExternal:_(u),sendMessage:g.bind(null,"sendMessage",{minArgs:1,maxArgs:3})},tabs:{sendMessage:g.bind(null,"sendMessage",{minArgs:2,maxArgs:3})}},d={clear:{minArgs:1,maxArgs:1},get:{minArgs:1,maxArgs:1},set:{minArgs:1,maxArgs:1}};return t.privacy={network:{"*":d},services:{"*":d},websites:{"*":d}},l(e,f,t)};e.exports=t(chrome)}},void 0===(r=t.apply(n,[e]))||(e.exports=r)}},n={};function t(r){var s=n[r];if(void 0!==s)return s.exports;var i=n[r]={exports:{}};return e[r].call(i.exports,i,i.exports,t),i.exports}t.n=e=>{var n=e&&e.__esModule?()=>e.default:()=>e;return t.d(n,{a:n}),n},t.d=(e,n)=>{for(var r in n)t.o(n,r)&&!t.o(e,r)&&Object.defineProperty(e,r,{enumerable:!0,get:n[r]})},t.o=(e,n)=>Object.prototype.hasOwnProperty.call(e,n),(()=>{"use strict";var e,n,r,s,i,o,a,l,_,c,u,m,g,f,d={},p=[],h=/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,A=Array.isArray;function v(e,n){for(var t in n)e[t]=n[t];return e}function b(e){e&&e.parentNode&&e.parentNode.removeChild(e)}function y(n,t,r){var s,i,o,a={};for(o in t)"key"==o?s=t[o]:"ref"==o?i=t[o]:a[o]=t[o];if(arguments.length>2&&(a.children=arguments.length>3?e.call(arguments,2):r),"function"==typeof n&&null!=n.defaultProps)for(o in n.defaultProps)void 0===a[o]&&(a[o]=n.defaultProps[o]);return x(n,a,s,i,null)}function x(e,t,s,i,o){var a={type:e,props:t,key:s,ref:i,__k:null,__:null,__b:0,__e:null,__c:null,constructor:void 0,__v:null==o?++r:o,__i:-1,__u:0};return null==o&&null!=n.vnode&&n.vnode(a),a}function k(e){return e.children}function w(e,n){this.props=e,this.context=n}function N(e,n){if(null==n)return e.__?N(e.__,e.__i+1):null;for(var t;n<e.__k.length;n++)if(null!=(t=e.__k[n])&&null!=t.__e)return t.__e;return"function"==typeof e.type?N(e):null}function S(e){if(e.__P&&e.__d){var t=e.__v,r=t.__e,s=[],i=[],o=v({},t);o.__v=t.__v+1,n.vnode&&n.vnode(o),M(e.__P,o,t,e.__n,e.__P.namespaceURI,32&t.__u?[r]:null,s,null==r?N(t):r,!!(32&t.__u),i),o.__v=t.__v,o.__.__k[o.__i]=o,H(s,o,i),t.__e=t.__=null,o.__e!=r&&P(o)}}function P(e){if(null!=(e=e.__)&&null!=e.__c)return e.__e=e.__c.base=null,e.__k.some(function(n){if(null!=n&&null!=n.__e)return e.__e=e.__c.base=n.__e}),P(e)}function C(e){(!e.__d&&(e.__d=!0)&&s.push(e)&&!E.__r++||i!=n.debounceRendering)&&((i=n.debounceRendering)||o)(E)}function E(){try{for(var e,n=1;s.length;)s.length>n&&s.sort(a),e=s.shift(),n=s.length,S(e)}finally{s.length=E.__r=0}}function T(e,n,t,r,s,i,o,a,l,_,c){var u,m,g,f,h,A,v,b=r&&r.__k||p,y=n.length;for(l=I(t,n,b,l,y),u=0;u<y;u++)null!=(g=t.__k[u])&&(m=-1!=g.__i&&b[g.__i]||d,g.__i=u,A=M(e,g,m,s,i,o,a,l,_,c),f=g.__e,g.ref&&m.ref!=g.ref&&(m.ref&&B(m.ref,null,g),c.push(g.ref,g.__c||f,g)),null==h&&null!=f&&(h=f),(v=!!(4&g.__u))||m.__k===g.__k?(l=$(g,l,e,v),v&&m.__e&&(m.__e=null)):"function"==typeof g.type&&void 0!==A?l=A:f&&(l=f.nextSibling),g.__u&=-7);return t.__e=h,l}function I(e,n,t,r,s){var i,o,a,l,_,c=t.length,u=c,m=0;for(e.__k=new Array(s),i=0;i<s;i++)null!=(o=n[i])&&"boolean"!=typeof o&&"function"!=typeof o?("string"==typeof o||"number"==typeof o||"bigint"==typeof o||o.constructor==String?o=e.__k[i]=x(null,o,null,null,null):A(o)?o=e.__k[i]=x(k,{children:o},null,null,null):void 0===o.constructor&&o.__b>0?o=e.__k[i]=x(o.type,o.props,o.key,o.ref?o.ref:null,o.__v):e.__k[i]=o,l=i+m,o.__=e,o.__b=e.__b+1,a=null,-1!=(_=o.__i=R(o,t,l,u))&&(u--,(a=t[_])&&(a.__u|=2)),null==a||null==a.__v?(-1==_&&(s>c?m--:s<c&&m++),"function"!=typeof o.type&&(o.__u|=4)):_!=l&&(_==l-1?m--:_==l+1?m++:(_>l?m--:m++,o.__u|=4))):e.__k[i]=null;if(u)for(i=0;i<c;i++)null!=(a=t[i])&&!(2&a.__u)&&(a.__e==r&&(r=N(a)),V(a,a));return r}function $(e,n,t,r){var s,i;if("function"==typeof e.type){for(s=e.__k,i=0;s&&i<s.length;i++)s[i]&&(s[i].__=e,n=$(s[i],n,t,r));return n}e.__e!=n&&(r&&(n&&e.type&&!n.parentNode&&(n=N(e)),t.insertBefore(e.__e,n||null)),n=e.__e);do{n=n&&n.nextSibling}while(null!=n&&8==n.nodeType);return n}function L(e,n){return n=n||[],null==e||"boolean"==typeof e||(A(e)?e.some(function(e){L(e,n)}):n.push(e)),n}function R(e,n,t,r){var s,i,o,a=e.key,l=e.type,_=n[t],c=null!=_&&!(2&_.__u);if(null===_&&null==a||c&&a==_.key&&l==_.type)return t;if(r>(c?1:0))for(s=t-1,i=t+1;s>=0||i<n.length;)if(null!=(_=n[o=s>=0?s--:i++])&&!(2&_.__u)&&a==_.key&&l==_.type)return o;return-1}function U(e,n,t){"-"==n[0]?e.setProperty(n,null==t?"":t):e[n]=null==t?"":"number"!=typeof t||h.test(n)?t:t+"px"}function O(e,n,t,r,s){var i,o;e:if("style"==n)if("string"==typeof t)e.style.cssText=t;else{if("string"==typeof r&&(e.style.cssText=r=""),r)for(n in r)t&&n in t||U(e.style,n,"");if(t)for(n in t)r&&t[n]==r[n]||U(e.style,n,t[n])}else if("o"==n[0]&&"n"==n[1])i=n!=(n=n.replace(u,"$1")),o=n.toLowerCase(),n=o in e||"onFocusOut"==n||"onFocusIn"==n?o.slice(2):n.slice(2),e.l||(e.l={}),e.l[n+i]=t,t?r?t[c]=r[c]:(t[c]=m,e.addEventListener(n,i?f:g,i)):e.removeEventListener(n,i?f:g,i);else{if("http://www.w3.org/2000/svg"==s)n=n.replace(/xlink(H|:h)/,"h").replace(/sName$/,"s");else if("width"!=n&&"height"!=n&&"href"!=n&&"list"!=n&&"form"!=n&&"tabIndex"!=n&&"download"!=n&&"rowSpan"!=n&&"colSpan"!=n&&"role"!=n&&"popover"!=n&&n in e)try{e[n]=null==t?"":t;break e}catch(e){}"function"==typeof t||(null==t||!1===t&&"-"!=n[4]?e.removeAttribute(n):e.setAttribute(n,"popover"==n&&1==t?"":t))}}function F(e){return function(t){if(this.l){var r=this.l[t.type+e];if(null==t[_])t[_]=m++;else if(t[_]<r[c])return;return r(n.event?n.event(t):t)}}}function M(e,t,r,s,i,o,a,l,_,c){var u,m,g,f,d,h,y,x,N,S,P,C,E,I,$,L=t.type;if(void 0!==t.constructor)return null;128&r.__u&&(_=!!(32&r.__u),o=[l=t.__e=r.__e]),(u=n.__b)&&u(t);e:if("function"==typeof L)try{if(x=t.props,N=L.prototype&&L.prototype.render,S=(u=L.contextType)&&s[u.__c],P=u?S?S.props.value:u.__:s,r.__c?y=(m=t.__c=r.__c).__=m.__E:(N?t.__c=m=new L(x,P):(t.__c=m=new w(x,P),m.constructor=L,m.render=q),S&&S.sub(m),m.state||(m.state={}),m.__n=s,g=m.__d=!0,m.__h=[],m._sb=[]),N&&null==m.__s&&(m.__s=m.state),N&&null!=L.getDerivedStateFromProps&&(m.__s==m.state&&(m.__s=v({},m.__s)),v(m.__s,L.getDerivedStateFromProps(x,m.__s))),f=m.props,d=m.state,m.__v=t,g)N&&null==L.getDerivedStateFromProps&&null!=m.componentWillMount&&m.componentWillMount(),N&&null!=m.componentDidMount&&m.__h.push(m.componentDidMount);else{if(N&&null==L.getDerivedStateFromProps&&x!==f&&null!=m.componentWillReceiveProps&&m.componentWillReceiveProps(x,P),t.__v==r.__v||!m.__e&&null!=m.shouldComponentUpdate&&!1===m.shouldComponentUpdate(x,m.__s,P)){t.__v!=r.__v&&(m.props=x,m.state=m.__s,m.__d=!1),t.__e=r.__e,t.__k=r.__k,t.__k.some(function(e){e&&(e.__=t)}),p.push.apply(m.__h,m._sb),m._sb=[],m.__h.length&&a.push(m);break e}null!=m.componentWillUpdate&&m.componentWillUpdate(x,m.__s,P),N&&null!=m.componentDidUpdate&&m.__h.push(function(){m.componentDidUpdate(f,d,h)})}if(m.context=P,m.props=x,m.__P=e,m.__e=!1,C=n.__r,E=0,N)m.state=m.__s,m.__d=!1,C&&C(t),u=m.render(m.props,m.state,m.context),p.push.apply(m.__h,m._sb),m._sb=[];else do{m.__d=!1,C&&C(t),u=m.render(m.props,m.state,m.context),m.state=m.__s}while(m.__d&&++E<25);m.state=m.__s,null!=m.getChildContext&&(s=v(v({},s),m.getChildContext())),N&&!g&&null!=m.getSnapshotBeforeUpdate&&(h=m.getSnapshotBeforeUpdate(f,d)),I=null!=u&&u.type===k&&null==u.key?W(u.props.children):u,l=T(e,A(I)?I:[I],t,r,s,i,o,a,l,_,c),m.base=t.__e,t.__u&=-161,m.__h.length&&a.push(m),y&&(m.__E=m.__=null)}catch(e){if(t.__v=null,_||null!=o)if(e.then){for(t.__u|=_?160:128;l&&8==l.nodeType&&l.nextSibling;)l=l.nextSibling;o[o.indexOf(l)]=null,t.__e=l}else{for($=o.length;$--;)b(o[$]);D(t)}else t.__e=r.__e,t.__k=r.__k,e.then||D(t);n.__e(e,t,r)}else null==o&&t.__v==r.__v?(t.__k=r.__k,t.__e=r.__e):l=t.__e=j(r.__e,t,r,s,i,o,a,_,c);return(u=n.diffed)&&u(t),128&t.__u?void 0:l}function D(e){e&&(e.__c&&(e.__c.__e=!0),e.__k&&e.__k.some(D))}function H(e,t,r){for(var s=0;s<r.length;s++)B(r[s],r[++s],r[++s]);n.__c&&n.__c(t,e),e.some(function(t){try{e=t.__h,t.__h=[],e.some(function(e){e.call(t)})}catch(e){n.__e(e,t.__v)}})}function W(e){return"object"!=typeof e||null==e||e.__b>0?e:A(e)?e.map(W):v({},e)}function j(t,r,s,i,o,a,l,_,c){var u,m,g,f,p,h,v,y=s.props||d,x=r.props,k=r.type;if("svg"==k?o="http://www.w3.org/2000/svg":"math"==k?o="http://www.w3.org/1998/Math/MathML":o||(o="http://www.w3.org/1999/xhtml"),null!=a)for(u=0;u<a.length;u++)if((p=a[u])&&"setAttribute"in p==!!k&&(k?p.localName==k:3==p.nodeType)){t=p,a[u]=null;break}if(null==t){if(null==k)return document.createTextNode(x);t=document.createElementNS(o,k,x.is&&x),_&&(n.__m&&n.__m(r,a),_=!1),a=null}if(null==k)y===x||_&&t.data==x||(t.data=x);else{if(a=a&&e.call(t.childNodes),!_&&null!=a)for(y={},u=0;u<t.attributes.length;u++)y[(p=t.attributes[u]).name]=p.value;for(u in y)p=y[u],"dangerouslySetInnerHTML"==u?g=p:"children"==u||u in x||"value"==u&&"defaultValue"in x||"checked"==u&&"defaultChecked"in x||O(t,u,null,p,o);for(u in x)p=x[u],"children"==u?f=p:"dangerouslySetInnerHTML"==u?m=p:"value"==u?h=p:"checked"==u?v=p:_&&"function"!=typeof p||y[u]===p||O(t,u,p,y[u],o);if(m)_||g&&(m.__html==g.__html||m.__html==t.innerHTML)||(t.innerHTML=m.__html),r.__k=[];else if(g&&(t.innerHTML=""),T("template"==r.type?t.content:t,A(f)?f:[f],r,s,i,"foreignObject"==k?"http://www.w3.org/1999/xhtml":o,a,l,a?a[0]:s.__k&&N(s,0),_,c),null!=a)for(u=a.length;u--;)b(a[u]);_||(u="value","progress"==k&&null==h?t.removeAttribute("value"):null!=h&&(h!==t[u]||"progress"==k&&!h||"option"==k&&h!=y[u])&&O(t,u,h,y[u],o),u="checked",null!=v&&v!=t[u]&&O(t,u,v,y[u],o))}return t}function B(e,t,r){try{if("function"==typeof e){var s="function"==typeof e.__u;s&&e.__u(),s&&null==t||(e.__u=e(t))}else e.current=t}catch(e){n.__e(e,r)}}function V(e,t,r){var s,i;if(n.unmount&&n.unmount(e),(s=e.ref)&&(s.current&&s.current!=e.__e||B(s,null,t)),null!=(s=e.__c)){if(s.componentWillUnmount)try{s.componentWillUnmount()}catch(e){n.__e(e,t)}s.base=s.__P=null}if(s=e.__k)for(i=0;i<s.length;i++)s[i]&&V(s[i],t,r||"function"!=typeof e.type);r||b(e.__e),e.__c=e.__=e.__e=void 0}function q(e,n,t){return this.constructor(e,t)}function z(t,r,s){var i,o,a,l;r==document&&(r=document.documentElement),n.__&&n.__(t,r),o=(i="function"==typeof s)?null:s&&s.__k||r.__k,a=[],l=[],M(r,t=(!i&&s||r).__k=y(k,null,[t]),o||d,d,r.namespaceURI,!i&&s?[s]:o?null:r.firstChild?e.call(r.childNodes):null,a,!i&&s?s:o?o.__e:r.firstChild,i,l),H(a,t,l)}e=p.slice,n={__e:function(e,n,t,r){for(var s,i,o;n=n.__;)if((s=n.__c)&&!s.__)try{if((i=s.constructor)&&null!=i.getDerivedStateFromError&&(s.setState(i.getDerivedStateFromError(e)),o=s.__d),null!=s.componentDidCatch&&(s.componentDidCatch(e,r||{}),o=s.__d),o)return s.__E=s}catch(n){e=n}throw e}},r=0,w.prototype.setState=function(e,n){var t;t=null!=this.__s&&this.__s!=this.state?this.__s:this.__s=v({},this.state),"function"==typeof e&&(e=e(v({},t),this.props)),e&&v(t,e),null!=e&&this.__v&&(n&&this._sb.push(n),C(this))},w.prototype.forceUpdate=function(e){this.__v&&(this.__e=!0,e&&this.__h.push(e),C(this))},w.prototype.render=k,s=[],o="function"==typeof Promise?Promise.prototype.then.bind(Promise.resolve()):setTimeout,a=function(e,n){return e.__v.__b-n.__v.__b},E.__r=0,l=Math.random().toString(8),_="__d"+l,c="__a"+l,u=/(PointerCapture)$|Capture$/i,m=0,g=F(!1),f=F(!0);var Z,K,Y,Q,G=0,J=[],X=n,ee=X.__b,ne=X.__r,te=X.diffed,re=X.__c,se=X.unmount,ie=X.__;function oe(e,n){X.__h&&X.__h(K,e,G||n),G=0;var t=K.__H||(K.__H={__:[],__h:[]});return e>=t.__.length&&t.__.push({}),t.__[e]}function ae(e){return G=1,function(e,n,t){var r=oe(Z++,2);if(r.t=e,!r.__c&&(r.__=[t?t(n):pe(void 0,n),function(e){var n=r.__N?r.__N[0]:r.__[0],t=r.t(n,e);n!==t&&(r.__N=[t,r.__[1]],r.__c.setState({}))}],r.__c=K,!K.__f)){var s=function(e,n,t){if(!r.__c.__H)return!0;var s=r.__c.__H.__.filter(function(e){return e.__c});if(s.every(function(e){return!e.__N}))return!i||i.call(this,e,n,t);var o=r.__c.props!==e;return s.some(function(e){if(e.__N){var n=e.__[0];e.__=e.__N,e.__N=void 0,n!==e.__[0]&&(o=!0)}}),i&&i.call(this,e,n,t)||o};K.__f=!0;var i=K.shouldComponentUpdate,o=K.componentWillUpdate;K.componentWillUpdate=function(e,n,t){if(this.__e){var r=i;i=void 0,s(e,n,t),i=r}o&&o.call(this,e,n,t)},K.shouldComponentUpdate=s}return r.__N||r.__}(pe,e)}function le(e,n){var t=oe(Z++,7);return de(t.__H,n)&&(t.__=e(),t.__H=n,t.__h=e),t.__}function _e(e,n){return G=8,le(function(){return e},n)}function ce(){for(var e;e=J.shift();){var n=e.__H;if(e.__P&&n)try{n.__h.some(ge),n.__h.some(fe),n.__h=[]}catch(t){n.__h=[],X.__e(t,e.__v)}}}X.__b=function(e){K=null,ee&&ee(e)},X.__=function(e,n){e&&n.__k&&n.__k.__m&&(e.__m=n.__k.__m),ie&&ie(e,n)},X.__r=function(e){ne&&ne(e),Z=0;var n=(K=e.__c).__H;n&&(Y===K?(n.__h=[],K.__h=[],n.__.some(function(e){e.__N&&(e.__=e.__N),e.u=e.__N=void 0})):(n.__h.some(ge),n.__h.some(fe),n.__h=[],Z=0)),Y=K},X.diffed=function(e){te&&te(e);var n=e.__c;n&&n.__H&&(n.__H.__h.length&&(1!==J.push(n)&&Q===X.requestAnimationFrame||((Q=X.requestAnimationFrame)||me)(ce)),n.__H.__.some(function(e){e.u&&(e.__H=e.u),e.u=void 0})),Y=K=null},X.__c=function(e,n){n.some(function(e){try{e.__h.some(ge),e.__h=e.__h.filter(function(e){return!e.__||fe(e)})}catch(t){n.some(function(e){e.__h&&(e.__h=[])}),n=[],X.__e(t,e.__v)}}),re&&re(e,n)},X.unmount=function(e){se&&se(e);var n,t=e.__c;t&&t.__H&&(t.__H.__.some(function(e){try{ge(e)}catch(e){n=e}}),t.__H=void 0,n&&X.__e(n,t.__v))};var ue="function"==typeof requestAnimationFrame;function me(e){var n,t=function(){clearTimeout(r),ue&&cancelAnimationFrame(n),setTimeout(e)},r=setTimeout(t,35);ue&&(n=requestAnimationFrame(t))}function ge(e){var n=K,t=e.__c;"function"==typeof t&&(e.__c=void 0,t()),K=n}function fe(e){var n=K;e.__c=e.__(),K=n}function de(e,n){return!e||e.length!==n.length||n.some(function(n,t){return n!==e[t]})}function pe(e,n){return"function"==typeof n?n(e):n}function he(e,n){for(var t in e)if("__source"!==t&&!(t in n))return!0;for(var r in n)if("__source"!==r&&e[r]!==n[r])return!0;return!1}function Ae(e,n){this.props=e,this.context=n}(Ae.prototype=new w).isPureReactComponent=!0,Ae.prototype.shouldComponentUpdate=function(e,n){return he(this.props,e)||he(this.state,n)};var ve=n.__b;n.__b=function(e){e.type&&e.type.__f&&e.ref&&(e.props.ref=e.ref,e.ref=null),ve&&ve(e)},"undefined"!=typeof Symbol&&Symbol.for&&Symbol.for("react.forward_ref");var be=n.__e;n.__e=function(e,n,t,r){if(e.then)for(var s,i=n;i=i.__;)if((s=i.__c)&&s.__c)return null==n.__e&&(n.__e=t.__e,n.__k=t.__k),s.__c(e,n);be(e,n,t,r)};var ye=n.unmount;function xe(e,n,t){return e&&(e.__c&&e.__c.__H&&(e.__c.__H.__.forEach(function(e){"function"==typeof e.__c&&e.__c()}),e.__c.__H=null),null!=(e=function(e,n){for(var t in n)e[t]=n[t];return e}({},e)).__c&&(e.__c.__P===t&&(e.__c.__P=n),e.__c.__e=!0,e.__c=null),e.__k=e.__k&&e.__k.map(function(e){return xe(e,n,t)})),e}function ke(e,n,t){return e&&t&&(e.__v=null,e.__k=e.__k&&e.__k.map(function(e){return ke(e,n,t)}),e.__c&&e.__c.__P===n&&(e.__e&&t.appendChild(e.__e),e.__c.__e=!0,e.__c.__P=t)),e}function we(){this.__u=0,this.o=null,this.__b=null}function Ne(e){var n=e.__&&e.__.__c;return n&&n.__a&&n.__a(e)}function Se(){this.i=null,this.l=null}n.unmount=function(e){var n=e.__c;n&&(n.__z=!0),n&&n.__R&&n.__R(),n&&32&e.__u&&(e.type=null),ye&&ye(e)},(we.prototype=new w).__c=function(e,n){var t=n.__c,r=this;null==r.o&&(r.o=[]),r.o.push(t);var s=Ne(r.__v),i=!1,o=function(){i||r.__z||(i=!0,t.__R=null,s?s(l):l())};t.__R=o;var a=t.__P;t.__P=null;var l=function(){if(! --r.__u){if(r.state.__a){var e=r.state.__a;r.__v.__k[0]=ke(e,e.__c.__P,e.__c.__O)}var n;for(r.setState({__a:r.__b=null});n=r.o.pop();)n.__P=a,n.forceUpdate()}};r.__u++||32&n.__u||r.setState({__a:r.__b=r.__v.__k[0]}),e.then(o,o)},we.prototype.componentWillUnmount=function(){this.o=[]},we.prototype.render=function(e,n){if(this.__b){if(this.__v.__k){var t=document.createElement("div"),r=this.__v.__k[0].__c;this.__v.__k[0]=xe(this.__b,t,r.__O=r.__P)}this.__b=null}var s=n.__a&&y(k,null,e.fallback);return s&&(s.__u&=-33),[y(k,null,n.__a?null:e.children),s]};var Pe=function(e,n,t){if(++t[1]===t[0]&&e.l.delete(n),e.props.revealOrder&&("t"!==e.props.revealOrder[0]||!e.l.size))for(t=e.i;t;){for(;t.length>3;)t.pop()();if(t[1]<t[0])break;e.i=t=t[2]}};(Se.prototype=new w).__a=function(e){var n=this,t=Ne(n.__v),r=n.l.get(e);return r[0]++,function(s){var i=function(){n.props.revealOrder?(r.push(s),Pe(n,e,r)):s()};t?t(i):i()}},Se.prototype.render=function(e){this.i=null,this.l=new Map;var n=L(e.children);e.revealOrder&&"b"===e.revealOrder[0]&&n.reverse();for(var t=n.length;t--;)this.l.set(n[t],this.i=[1,0,this.i]);return e.children},Se.prototype.componentDidUpdate=Se.prototype.componentDidMount=function(){var e=this;this.l.forEach(function(n,t){Pe(e,t,n)})};var Ce="undefined"!=typeof Symbol&&Symbol.for&&Symbol.for("react.element")||60103,Ee=/^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/,Te=/^on(Ani|Tra|Tou|BeforeInp|Compo)/,Ie=/[A-Z0-9]/g,$e="undefined"!=typeof document,Le=function(e){return("undefined"!=typeof Symbol&&"symbol"==typeof Symbol()?/fil|che|rad/:/fil|che|ra/).test(e)};w.prototype.isReactComponent=!0,["componentWillMount","componentWillReceiveProps","componentWillUpdate"].forEach(function(e){Object.defineProperty(w.prototype,e,{configurable:!0,get:function(){return this["UNSAFE_"+e]},set:function(n){Object.defineProperty(this,e,{configurable:!0,writable:!0,value:n})}})});var Re=n.event;n.event=function(e){return Re&&(e=Re(e)),e.persist=function(){},e.isPropagationStopped=function(){return this.cancelBubble},e.isDefaultPrevented=function(){return this.defaultPrevented},e.nativeEvent=e};var Ue={configurable:!0,get:function(){return this.class}},Oe=n.vnode;n.vnode=function(e){"string"==typeof e.type&&function(e){var n=e.props,t=e.type,r={},s=-1==t.indexOf("-");for(var i in n){var o=n[i];if(!("value"===i&&"defaultValue"in n&&null==o||$e&&"children"===i&&"noscript"===t||"class"===i||"className"===i)){var a=i.toLowerCase();"defaultValue"===i&&"value"in n&&null==n.value?i="value":"download"===i&&!0===o?o="":"translate"===a&&"no"===o?o=!1:"o"===a[0]&&"n"===a[1]?"ondoubleclick"===a?i="ondblclick":"onchange"!==a||"input"!==t&&"textarea"!==t||Le(n.type)?"onfocus"===a?i="onfocusin":"onblur"===a?i="onfocusout":Te.test(i)&&(i=a):a=i="oninput":s&&Ee.test(i)?i=i.replace(Ie,"-$&").toLowerCase():null===o&&(o=void 0),"oninput"===a&&r[i=a]&&(i="oninputCapture"),r[i]=o}}"select"==t&&(r.multiple&&Array.isArray(r.value)&&(r.value=L(n.children).forEach(function(e){e.props.selected=-1!=r.value.indexOf(e.props.value)})),null!=r.defaultValue&&(r.value=L(n.children).forEach(function(e){e.props.selected=r.multiple?-1!=r.defaultValue.indexOf(e.props.value):r.defaultValue==e.props.value}))),n.class&&!n.className?(r.class=n.class,Object.defineProperty(r,"className",Ue)):n.className&&(r.class=r.className=n.className),e.props=r}(e),e.$$typeof=Ce,Oe&&Oe(e)};var Fe=n.__r;n.__r=function(e){Fe&&Fe(e),e.__c};var Me=n.diffed;n.diffed=function(e){Me&&Me(e);var n=e.props,t=e.__e;null!=t&&"textarea"===e.type&&"value"in n&&n.value!==t.value&&(t.value=null==n.value?"":n.value)};var De=0;function He(e,t,r,s,i,o){t||(t={});var a,l,_=t;if("ref"in _)for(l in _={},t)"ref"==l?a=t[l]:_[l]=t[l];var c={type:e,props:_,key:r,ref:a,__k:null,__:null,__b:0,__e:null,__c:null,constructor:void 0,__v:--De,__i:-1,__u:0,__source:i,__self:o};if("function"==typeof e&&(a=e.defaultProps))for(l in a)void 0===_[l]&&(_[l]=a[l]);return n.vnode&&n.vnode(c),c}Array.isArray;var We=t(815);const je=t.n(We)(),Be={résumé:"📝",summary:"📝",synthèse:"📝",introduction:"🎬",contexte:"🌍",context:"🌍",analyse:"🔬",analysis:"🔬","points clés":"🎯","key points":"🎯","points forts":"💪",strengths:"💪","points faibles":"⚠️",weaknesses:"⚠️",limites:"⚠️",conclusion:"🏁",recommandations:"💡",recommendations:"💡",sources:"📚",références:"📚",references:"📚","fact-check":"🔍",vérification:"🔍",arguments:"⚖️",méthodologie:"🧪",methodology:"🧪",données:"📊",data:"📊",statistiques:"📊",opinion:"💬",avis:"💬",biais:"🎭",bias:"🎭",nuances:"🎨",perspectives:"👁️",timeline:"📅",chronologie:"📅",définitions:"📖",glossaire:"📖"};function Ve(e){const n=e.toLowerCase().trim();for(const[e,t]of Object.entries(Be))if(n.includes(e))return t;return"📌"}function qe(e){return e.replace(/`([^`]+)`/g,'<code class="ds-md-code">$1</code>').replace(/\*\*(.+?)\*\*/g,"<strong>$1</strong>").replace(/\*(.+?)\*/g,"<em>$1</em>").replace(/\[?(SOLIDE|SOLID)\]?/g,'<span class="ds-marker ds-marker-solid">✅ Établi</span>').replace(/\[?(PLAUSIBLE)\]?/g,'<span class="ds-marker ds-marker-plausible">🔵 Probable</span>').replace(/\[?(INCERTAIN|UNCERTAIN)\]?/g,'<span class="ds-marker ds-marker-uncertain">🟡 Incertain</span>').replace(/\[?(A VERIFIER|À VÉRIFIER|TO VERIFY|QUESTIONABLE|WEAK)\]?/g,'<span class="ds-marker ds-marker-weak">🔴 À vérifier</span>')}function ze(e){return e.replace(/\*\*(.+?)\*\*/g,"$1").replace(/\*(.+?)\*/g,"$1").replace(/`([^`]+)`/g,"$1").replace(/#{1,6}\s+/g,"").replace(/\[([^\]]+)\]\([^)]+\)/g,"$1").replace(/^>\s+/gm,"").replace(/\n+/g," ").trim()}function Ze(e,n){if(e.length<=n)return e;const t=e.substring(0,n),r=t.lastIndexOf(" ");return(r>.6*n?t.substring(0,r):t)+"..."}const Ke={tech:"💻",science:"🔬",education:"📚",news:"📰",entertainment:"🎬",gaming:"🎮",music:"🎵",sports:"⚽",business:"💼",lifestyle:"🌟",other:"📋"};function Ye(e){return e>=80?"v-badge v-badge-score":e>=60?"v-badge v-badge-score warn":"v-badge v-badge-score low"}function Qe(e){return e>=80?"✅":e>=60?"⚠️":"❓"}const Ge=({summary:e})=>{const n=function(e){if(!e)return{id:null,platform:"unknown"};const n=e.match(/[?&]v=([^&]+)/);if(n)return{id:n[1],platform:"youtube"};const t=e.match(/youtu\.be\/([^?&]+)/);if(t)return{id:t[1],platform:"youtube"};const r=e.match(/tiktok\.com\/[^/]+\/video\/(\d+)/);return r?{id:r[1],platform:"tiktok"}:{id:null,platform:"unknown"}}(e.video_url),t=e.thumbnail_url?e.thumbnail_url:"youtube"===n.platform&&n.id?`https://img.youtube.com/vi/${n.id}/maxresdefault.jpg`:null,r=Ke[e.category]??"📋",s=e.reliability_score,i=s>=80?"Source fiable":s>=60?"Fiabilité modérée":"À vérifier",o=s>=80?"#10b981":s>=60?"#f59e0b":"#ef4444";return He("header",{className:"v-header",children:[t&&He("div",{className:"v-header-thumb",children:He("img",{src:t,alt:e.video_title,loading:"lazy",onError:e=>{e.currentTarget.style.display="none"}})}),He("div",{className:"v-header-body",children:[He("h1",{className:"v-header-title",children:e.video_title}),e.video_channel&&He("p",{className:"v-header-channel",children:e.video_channel}),He("div",{className:"v-header-badges",children:[He("span",{className:"v-badge",children:[r," ",e.category]}),He("span",{className:Ye(s),children:[Qe(s)," ",s,"%"]}),e.tournesol?.found&&null!==e.tournesol.tournesol_score&&He("span",{className:"v-badge",children:["🌻"," Tournesol"," ",e.tournesol.tournesol_score>0?"+":"",Math.round(e.tournesol.tournesol_score)]})]}),He("div",{className:"v-header-reliability",children:[He("div",{className:"v-reliability-label",children:[He("span",{children:["Fiabilité — ",i]}),He("span",{className:"v-reliability-value",children:[s,"%"]})]}),He("div",{className:"v-reliability-bar",children:He("div",{className:"v-reliability-fill",style:{width:`${Math.max(0,Math.min(100,s))}%`,background:o}})})]})]})]})},Je=({verdict:e})=>e?He("section",{className:"v-section v-section-verdict",children:[He("h2",{className:"v-section-title",children:"Verdict"}),He("div",{className:"v-verdict",children:e})]}):null;function Xe(e){switch(e){case"solid":return"✅";case"weak":return"⚠️";case"insight":return"💡"}}function en(e){switch(e){case"solid":return"v-kp v-kp-solid";case"weak":return"v-kp v-kp-weak";case"insight":return"v-kp v-kp-default"}}const nn=({points:e})=>e&&0!==e.length?He("section",{className:"v-section",children:[He("h2",{className:"v-section-title",children:"Points clés"}),He("div",{className:"v-kp-list",children:e.map((e,n)=>He("div",{className:en(e.type),children:[He("span",{className:"v-kp-icon","aria-hidden":"true",children:Xe(e.type)}),He("span",{className:"v-kp-text",children:e.text})]},n))})]}):null,tn=({content:e})=>{const n=le(()=>{if(!e)return"";const n=function(e){const n=e.split("\n"),t=[];let r=!1,s=!1;for(let e=0;e<n.length;e++){let i=n[e];if(/^-{3,}$/.test(i.trim())||/^\*{3,}$/.test(i.trim())){r&&(t.push("</ul>"),r=!1),s&&(t.push("</ol>"),s=!1),t.push('<hr class="ds-md-hr">');continue}const o=i.match(/^(#{1,4})\s+(.+)$/);if(o){r&&(t.push("</ul>"),r=!1),s&&(t.push("</ol>"),s=!1);const e=o[1].length,n=o[2],i=e<=2?Ve(n):"",a=qe(n),l=i?`${i}&nbsp;&nbsp;`:"";t.push(`<h${e} class="ds-md-h${e}">${l}${a}</h${e}>`);continue}if(i.startsWith("&gt; ")||"&gt;"===i){r&&(t.push("</ul>"),r=!1),s&&(t.push("</ol>"),s=!1);const e=qe(i.replace(/^&gt;\s?/,""));t.push(`<blockquote class="ds-md-blockquote">${e}</blockquote>`);continue}const a=i.match(/^(\s*)[-*]\s+(.+)$/);if(a){s&&(t.push("</ol>"),s=!1),r||(t.push('<ul class="ds-md-ul">'),r=!0),t.push(`<li>${qe(a[2])}</li>`);continue}const l=i.match(/^(\s*)\d+\.\s+(.+)$/);l?(r&&(t.push("</ul>"),r=!1),s||(t.push('<ol class="ds-md-ol">'),s=!0),t.push(`<li>${qe(l[2])}</li>`)):(r&&(t.push("</ul>"),r=!1),s&&(t.push("</ol>"),s=!1),""!==i.trim()?t.push(`<p class="ds-md-p">${qe(i)}</p>`):t.push('<div class="ds-md-spacer"></div>'))}return r&&t.push("</ul>"),s&&t.push("</ol>"),t.join("\n")}(function(e){const n=document.createElement("div");return n.textContent=e,n.innerHTML}(e));return function(e){return e.replace(/\[((?:\d{1,2}:){1,2}\d{2})\]/g,(e,n)=>`<span class="v-timestamp" data-ts="${n}" role="button" tabindex="0">${n}</span>`)}(n)},[e]);return n?He("section",{className:"v-section",children:[He("h2",{className:"v-section-title",children:"Analyse détaillée"}),He("div",{className:"v-markdown",dangerouslySetInnerHTML:{__html:n}})]}):null},rn=({facts:e})=>e&&0!==e.length?He("section",{className:"v-section",children:[He("h2",{className:"v-section-title",children:"Faits à vérifier"}),He("div",{className:"v-facts",children:e.map((e,n)=>He("div",{className:"v-fact",children:[He("span",{className:"v-fact-icon","aria-hidden":"true",children:"🔍"}),He("span",{className:"v-fact-text",children:e})]},n))})]}):null,sn="https://www.deepsightsynthesis.com",on=({summary:e,summaryId:n})=>{const[t,r]=ae(null),s=function(e){if(!e)return null;const n=e.match(/[?&]v=([^&]+)/);if(n)return n[1];const t=e.match(/youtu\.be\/([^?&]+)/);if(t)return t[1];const r=e.match(/tiktok\.com\/[^/]+\/video\/(\d+)/);return r?r[1]:null}(e.video_url),i=_e(async()=>{let e=`${sn}/summary/${n}`;if(s)try{const n=await je.runtime.sendMessage({action:"SHARE_ANALYSIS",data:{videoId:s}});n?.success&&n.share_url&&(e=n.share_url)}catch{}try{await navigator.clipboard.writeText(e),r("Lien copié !")}catch{r("Erreur de copie")}setTimeout(()=>r(null),2200)},[s,n]),o=_e(()=>{je.tabs.create({url:`${sn}/summary/${n}`})},[n]),a=_e(()=>{je.tabs.create({url:"https://www.youtube.com"})},[]);return He("div",{className:"v-actions",role:"toolbar","aria-label":"Actions",children:[He("button",{type:"button",className:"v-btn v-btn-primary",onClick:i,children:[He("span",{"aria-hidden":"true",children:"🔗"}),He("span",{children:t??"Partager cette analyse"})]}),He("button",{type:"button",className:"v-btn v-btn-secondary",onClick:o,children:[He("span",{"aria-hidden":"true",children:"🌐"}),He("span",{children:"Ouvrir sur DeepSight Web"})]}),He("button",{type:"button",className:"v-btn v-btn-secondary",onClick:a,children:[He("span",{"aria-hidden":"true",children:"🎬"}),He("span",{children:"Analyser une autre vidéo"})]})]})},an=({summaryId:e})=>{const[n,t]=ae(null),[r,s]=ae(!0),[i,o]=ae(null);if(function(e,n){var t=oe(Z++,3);!X.__s&&de(t.__H,n)&&(t.__=e,t.u=n,K.__H.__h.push(t))}(()=>{if(!e)return o("ID d'analyse manquant"),void s(!1);let n=!1;return je.runtime.sendMessage({action:"GET_SUMMARY",data:{summaryId:e}}).then(e=>{if(n)return;const r=e;r?.success&&r.summary?t(r.summary):o(r?.error||"Analyse introuvable")}).catch(e=>{n||o(e.message)}).finally(()=>{n||s(!1)}),()=>{n=!0}},[e]),r)return He("div",{className:"viewer-loading",children:[He("div",{className:"viewer-spinner","aria-hidden":"true"}),He("p",{children:"Chargement de l'analyse…"})]});if(i||!n)return He("div",{className:"viewer-error",children:[He("h1",{children:"Analyse introuvable"}),He("p",{children:i??"Aucune donnée retournée."}),He("button",{type:"button",className:"v-btn v-btn-primary",onClick:()=>window.close(),children:"Fermer"})]});const a=function(e){const n=function(e){const n=[/#+\s*(?:Conclusion|Verdict|Synthèse|Résumé|Summary|En résumé|Final Assessment|Overall Assessment)[^\n]*\n([\s\S]*?)(?=\n#|\n---|\n\*{3,}|$)/i,/\*\*(?:Conclusion|Verdict|Synthèse|En résumé|Summary)\*\*[:\s]*([\s\S]*?)(?=\n\n|\n#|\n---|\n\*{3,}|$)/i];for(const t of n){const n=e.match(t);if(n&&n[1]){const e=ze(n[1]).trim();if(e.length>20)return Ze(e,200)}}const t=e.split(/\n\n+/).filter(e=>{const n=e.trim();return n.length>30&&!n.startsWith("#")&&!n.startsWith("-")&&!n.startsWith("*")});return t.length>0?Ze(ze(t[t.length-1]),200):"Analysis complete. See detailed view for full results."}(e),t=function(e){const n=[],t=e.split("\n"),r=[/\b(?:SOLIDE|SOLID)\b/i,/\u2705\s*\*\*/,/\u2705/],s=[/\b(?:A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK|INCERTAIN|UNCERTAIN)\b/i,/\u26A0\uFE0F\s*\*\*/,/\u2753/,/\u26A0/],i=[/\b(?:PLAUSIBLE)\b/i,/\uD83D\uDCA1/];for(const e of t){const t=e.replace(/^[\s\-*]+/,"").trim();if(t.length<10)continue;let o=null;if(r.some(n=>n.test(e))?o="solid":s.some(n=>n.test(e))?o="weak":i.some(n=>n.test(e))&&(o="insight"),o&&n.filter(e=>e.type===o).length<2){const e=ze(t).replace(/\b(?:SOLIDE|SOLID|PLAUSIBLE|INCERTAIN|UNCERTAIN|A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK)\b\s*[:—\-–]?\s*/gi,"").replace(/^[✅⚠️❓💡🔍🔬]\s*/u,"").trim();e.length>10&&n.push({type:o,text:Ze(e,120)})}if(n.length>=4)break}if(n.length<2){const t=/#+\s*(?:Points?\s+(?:forts?|clés?|faibles?)|Key\s+(?:Points?|Findings?|Takeaways?)|Strengths?|Weaknesses?|Main\s+Points?)[^\n]*\n([\s\S]*?)(?=\n#|$)/gi;let r;for(;null!==(r=t.exec(e))&&n.length<4;){const e=r[1].match(/^[\s]*[-*]\s+(.+)$/gm);if(e)for(const t of e.slice(0,4-n.length)){const e=ze(t.replace(/^[\s]*[-*]\s+/,""));e.length>10&&!n.some(n=>n.text===Ze(e,120))&&n.push({type:"insight",text:Ze(e,120)})}}}return n.slice(0,4)}(e),r=function(e){const n=[],t=e.match(/#+\s*(?:Tags?|Thèmes?|Themes?|Topics?|Catégories?|Categories?)[^\n]*\n([\s\S]*?)(?=\n#|$)/i);if(t){const e=t[1].match(/[-*]\s+(.+)/g);if(e)for(const t of e.slice(0,3)){const e=ze(t.replace(/^[-*]\s+/,"")).trim();e.length>0&&e.length<30&&n.push(e)}}if(0===n.length){const t=e.match(/^#{2,3}\s+(.+)$/gm);if(t){const e=/^(?:Conclusion|Summary|Résumé|Synthèse|Introduction|Verdict|Analysis|Points?\s+(?:clés?|forts?|faibles?)|Key\s+(?:Points?|Findings?)|Strengths?|Weaknesses?|Overview)/i;for(const r of t){const t=ze(r.replace(/^#{2,3}\s+/,"")).trim();if(t.length>2&&t.length<35&&!e.test(t)&&(n.push(t),n.length>=3))break}}}return n.slice(0,3)}(e);return{verdict:n,keyPoints:t,tags:r}}(n.summary_content);return He("div",{className:"viewer-container",children:[He(Ge,{summary:n}),He(Je,{verdict:a.verdict}),He(nn,{points:a.keyPoints}),He(rn,{facts:n.facts_to_verify??[]}),He(tn,{content:n.summary_content}),He(on,{summary:n,summaryId:n.id})]})},ln=new URLSearchParams(window.location.search),_n=parseInt(ln.get("id")||"0",10),cn=document.getElementById("viewer-root");var un;cn&&(un=cn,{render:function(e){!function(e,n,t){null==n.__k&&(n.textContent=""),z(e,n),"function"==typeof t&&t(),e&&e.__c}(e,un)},unmount:function(){!function(e){e.__k&&z(null,e)}(un)}}).render(He(an,{summaryId:_n}))})()})();
+(() => {
+  var e = {
+      815(e, n) {
+        var t, r;
+        ("undefined" != typeof globalThis
+          ? globalThis
+          : "undefined" != typeof self && self,
+          (t = function (e) {
+            "use strict";
+            if (
+              !(
+                globalThis.chrome &&
+                globalThis.chrome.runtime &&
+                globalThis.chrome.runtime.id
+              )
+            )
+              throw new Error(
+                "This script should only be loaded in a browser extension.",
+              );
+            if (
+              globalThis.browser &&
+              globalThis.browser.runtime &&
+              globalThis.browser.runtime.id
+            )
+              e.exports = globalThis.browser;
+            else {
+              const n =
+                  "The message port closed before a response was received.",
+                t = (e) => {
+                  const t = {
+                    alarms: {
+                      clear: { minArgs: 0, maxArgs: 1 },
+                      clearAll: { minArgs: 0, maxArgs: 0 },
+                      get: { minArgs: 0, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                    },
+                    bookmarks: {
+                      create: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getChildren: { minArgs: 1, maxArgs: 1 },
+                      getRecent: { minArgs: 1, maxArgs: 1 },
+                      getSubTree: { minArgs: 1, maxArgs: 1 },
+                      getTree: { minArgs: 0, maxArgs: 0 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeTree: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    browserAction: {
+                      disable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      enable: {
+                        minArgs: 0,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      getBadgeBackgroundColor: { minArgs: 1, maxArgs: 1 },
+                      getBadgeText: { minArgs: 1, maxArgs: 1 },
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      openPopup: { minArgs: 0, maxArgs: 0 },
+                      setBadgeBackgroundColor: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setBadgeText: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    browsingData: {
+                      remove: { minArgs: 2, maxArgs: 2 },
+                      removeCache: { minArgs: 1, maxArgs: 1 },
+                      removeCookies: { minArgs: 1, maxArgs: 1 },
+                      removeDownloads: { minArgs: 1, maxArgs: 1 },
+                      removeFormData: { minArgs: 1, maxArgs: 1 },
+                      removeHistory: { minArgs: 1, maxArgs: 1 },
+                      removeLocalStorage: { minArgs: 1, maxArgs: 1 },
+                      removePasswords: { minArgs: 1, maxArgs: 1 },
+                      removePluginData: { minArgs: 1, maxArgs: 1 },
+                      settings: { minArgs: 0, maxArgs: 0 },
+                    },
+                    commands: { getAll: { minArgs: 0, maxArgs: 0 } },
+                    contextMenus: {
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeAll: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    cookies: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 1, maxArgs: 1 },
+                      getAllCookieStores: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    },
+                    devtools: {
+                      inspectedWindow: {
+                        eval: { minArgs: 1, maxArgs: 2, singleCallbackArg: !1 },
+                      },
+                      panels: {
+                        create: {
+                          minArgs: 3,
+                          maxArgs: 3,
+                          singleCallbackArg: !0,
+                        },
+                        elements: {
+                          createSidebarPane: { minArgs: 1, maxArgs: 1 },
+                        },
+                      },
+                    },
+                    downloads: {
+                      cancel: { minArgs: 1, maxArgs: 1 },
+                      download: { minArgs: 1, maxArgs: 1 },
+                      erase: { minArgs: 1, maxArgs: 1 },
+                      getFileIcon: { minArgs: 1, maxArgs: 2 },
+                      open: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      pause: { minArgs: 1, maxArgs: 1 },
+                      removeFile: { minArgs: 1, maxArgs: 1 },
+                      resume: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    extension: {
+                      isAllowedFileSchemeAccess: { minArgs: 0, maxArgs: 0 },
+                      isAllowedIncognitoAccess: { minArgs: 0, maxArgs: 0 },
+                    },
+                    history: {
+                      addUrl: { minArgs: 1, maxArgs: 1 },
+                      deleteAll: { minArgs: 0, maxArgs: 0 },
+                      deleteRange: { minArgs: 1, maxArgs: 1 },
+                      deleteUrl: { minArgs: 1, maxArgs: 1 },
+                      getVisits: { minArgs: 1, maxArgs: 1 },
+                      search: { minArgs: 1, maxArgs: 1 },
+                    },
+                    i18n: {
+                      detectLanguage: { minArgs: 1, maxArgs: 1 },
+                      getAcceptLanguages: { minArgs: 0, maxArgs: 0 },
+                    },
+                    identity: { launchWebAuthFlow: { minArgs: 1, maxArgs: 1 } },
+                    idle: { queryState: { minArgs: 1, maxArgs: 1 } },
+                    management: {
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getSelf: { minArgs: 0, maxArgs: 0 },
+                      setEnabled: { minArgs: 2, maxArgs: 2 },
+                      uninstallSelf: { minArgs: 0, maxArgs: 1 },
+                    },
+                    notifications: {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      create: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      getPermissionLevel: { minArgs: 0, maxArgs: 0 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                    pageAction: {
+                      getPopup: { minArgs: 1, maxArgs: 1 },
+                      getTitle: { minArgs: 1, maxArgs: 1 },
+                      hide: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setIcon: { minArgs: 1, maxArgs: 1 },
+                      setPopup: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      setTitle: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                      show: {
+                        minArgs: 1,
+                        maxArgs: 1,
+                        fallbackToNoCallback: !0,
+                      },
+                    },
+                    permissions: {
+                      contains: { minArgs: 1, maxArgs: 1 },
+                      getAll: { minArgs: 0, maxArgs: 0 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      request: { minArgs: 1, maxArgs: 1 },
+                    },
+                    runtime: {
+                      getBackgroundPage: { minArgs: 0, maxArgs: 0 },
+                      getPlatformInfo: { minArgs: 0, maxArgs: 0 },
+                      openOptionsPage: { minArgs: 0, maxArgs: 0 },
+                      requestUpdateCheck: { minArgs: 0, maxArgs: 0 },
+                      sendMessage: { minArgs: 1, maxArgs: 3 },
+                      sendNativeMessage: { minArgs: 2, maxArgs: 2 },
+                      setUninstallURL: { minArgs: 1, maxArgs: 1 },
+                    },
+                    sessions: {
+                      getDevices: { minArgs: 0, maxArgs: 1 },
+                      getRecentlyClosed: { minArgs: 0, maxArgs: 1 },
+                      restore: { minArgs: 0, maxArgs: 1 },
+                    },
+                    storage: {
+                      local: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                      managed: {
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                      },
+                      sync: {
+                        clear: { minArgs: 0, maxArgs: 0 },
+                        get: { minArgs: 0, maxArgs: 1 },
+                        getBytesInUse: { minArgs: 0, maxArgs: 1 },
+                        remove: { minArgs: 1, maxArgs: 1 },
+                        set: { minArgs: 1, maxArgs: 1 },
+                      },
+                    },
+                    tabs: {
+                      captureVisibleTab: { minArgs: 0, maxArgs: 2 },
+                      create: { minArgs: 1, maxArgs: 1 },
+                      detectLanguage: { minArgs: 0, maxArgs: 1 },
+                      discard: { minArgs: 0, maxArgs: 1 },
+                      duplicate: { minArgs: 1, maxArgs: 1 },
+                      executeScript: { minArgs: 1, maxArgs: 2 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 0 },
+                      getZoom: { minArgs: 0, maxArgs: 1 },
+                      getZoomSettings: { minArgs: 0, maxArgs: 1 },
+                      goBack: { minArgs: 0, maxArgs: 1 },
+                      goForward: { minArgs: 0, maxArgs: 1 },
+                      highlight: { minArgs: 1, maxArgs: 1 },
+                      insertCSS: { minArgs: 1, maxArgs: 2 },
+                      move: { minArgs: 2, maxArgs: 2 },
+                      query: { minArgs: 1, maxArgs: 1 },
+                      reload: { minArgs: 0, maxArgs: 2 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      removeCSS: { minArgs: 1, maxArgs: 2 },
+                      sendMessage: { minArgs: 2, maxArgs: 3 },
+                      setZoom: { minArgs: 1, maxArgs: 2 },
+                      setZoomSettings: { minArgs: 1, maxArgs: 2 },
+                      update: { minArgs: 1, maxArgs: 2 },
+                    },
+                    topSites: { get: { minArgs: 0, maxArgs: 0 } },
+                    webNavigation: {
+                      getAllFrames: { minArgs: 1, maxArgs: 1 },
+                      getFrame: { minArgs: 1, maxArgs: 1 },
+                    },
+                    webRequest: {
+                      handlerBehaviorChanged: { minArgs: 0, maxArgs: 0 },
+                    },
+                    windows: {
+                      create: { minArgs: 0, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 2 },
+                      getAll: { minArgs: 0, maxArgs: 1 },
+                      getCurrent: { minArgs: 0, maxArgs: 1 },
+                      getLastFocused: { minArgs: 0, maxArgs: 1 },
+                      remove: { minArgs: 1, maxArgs: 1 },
+                      update: { minArgs: 2, maxArgs: 2 },
+                    },
+                  };
+                  if (0 === Object.keys(t).length)
+                    throw new Error(
+                      "api-metadata.json has not been included in browser-polyfill",
+                    );
+                  class r extends WeakMap {
+                    constructor(e, n = void 0) {
+                      (super(n), (this.createItem = e));
+                    }
+                    get(e) {
+                      return (
+                        this.has(e) || this.set(e, this.createItem(e)),
+                        super.get(e)
+                      );
+                    }
+                  }
+                  const s =
+                      (n, t) =>
+                      (...r) => {
+                        e.runtime.lastError
+                          ? n.reject(new Error(e.runtime.lastError.message))
+                          : t.singleCallbackArg ||
+                              (r.length <= 1 && !1 !== t.singleCallbackArg)
+                            ? n.resolve(r[0])
+                            : n.resolve(r);
+                      },
+                    i = (e) => (1 == e ? "argument" : "arguments"),
+                    o = (e, n, t) =>
+                      new Proxy(n, { apply: (n, r, s) => t.call(r, e, ...s) });
+                  let a = Function.call.bind(Object.prototype.hasOwnProperty);
+                  const l = (e, n = {}, t = {}) => {
+                      let r = Object.create(null),
+                        _ = {
+                          has: (n, t) => t in e || t in r,
+                          get(_, c, u) {
+                            if (c in r) return r[c];
+                            if (!(c in e)) return;
+                            let m = e[c];
+                            if ("function" == typeof m)
+                              if ("function" == typeof n[c])
+                                m = o(e, e[c], n[c]);
+                              else if (a(t, c)) {
+                                let n = ((e, n) =>
+                                  function (t, ...r) {
+                                    if (r.length < n.minArgs)
+                                      throw new Error(
+                                        `Expected at least ${n.minArgs} ${i(n.minArgs)} for ${e}(), got ${r.length}`,
+                                      );
+                                    if (r.length > n.maxArgs)
+                                      throw new Error(
+                                        `Expected at most ${n.maxArgs} ${i(n.maxArgs)} for ${e}(), got ${r.length}`,
+                                      );
+                                    return new Promise((i, o) => {
+                                      if (n.fallbackToNoCallback)
+                                        try {
+                                          t[e](
+                                            ...r,
+                                            s({ resolve: i, reject: o }, n),
+                                          );
+                                        } catch (s) {
+                                          (console.warn(
+                                            `${e} API method doesn't seem to support the callback parameter, falling back to call it without a callback: `,
+                                            s,
+                                          ),
+                                            t[e](...r),
+                                            (n.fallbackToNoCallback = !1),
+                                            (n.noCallback = !0),
+                                            i());
+                                        }
+                                      else
+                                        n.noCallback
+                                          ? (t[e](...r), i())
+                                          : t[e](
+                                              ...r,
+                                              s({ resolve: i, reject: o }, n),
+                                            );
+                                    });
+                                  })(c, t[c]);
+                                m = o(e, e[c], n);
+                              } else m = m.bind(e);
+                            else if (
+                              "object" == typeof m &&
+                              null !== m &&
+                              (a(n, c) || a(t, c))
+                            )
+                              m = l(m, n[c], t[c]);
+                            else {
+                              if (!a(t, "*"))
+                                return (
+                                  Object.defineProperty(r, c, {
+                                    configurable: !0,
+                                    enumerable: !0,
+                                    get: () => e[c],
+                                    set(n) {
+                                      e[c] = n;
+                                    },
+                                  }),
+                                  m
+                                );
+                              m = l(m, n[c], t["*"]);
+                            }
+                            return ((r[c] = m), m);
+                          },
+                          set: (n, t, s, i) => (
+                            t in r ? (r[t] = s) : (e[t] = s),
+                            !0
+                          ),
+                          defineProperty: (e, n, t) =>
+                            Reflect.defineProperty(r, n, t),
+                          deleteProperty: (e, n) =>
+                            Reflect.deleteProperty(r, n),
+                        },
+                        c = Object.create(e);
+                      return new Proxy(c, _);
+                    },
+                    _ = (e) => ({
+                      addListener(n, t, ...r) {
+                        n.addListener(e.get(t), ...r);
+                      },
+                      hasListener: (n, t) => n.hasListener(e.get(t)),
+                      removeListener(n, t) {
+                        n.removeListener(e.get(t));
+                      },
+                    }),
+                    c = new r((e) =>
+                      "function" != typeof e
+                        ? e
+                        : function (n) {
+                            const t = l(
+                              n,
+                              {},
+                              { getContent: { minArgs: 0, maxArgs: 0 } },
+                            );
+                            e(t);
+                          },
+                    ),
+                    u = new r((e) =>
+                      "function" != typeof e
+                        ? e
+                        : function (n, t, r) {
+                            let s,
+                              i,
+                              o = !1,
+                              a = new Promise((e) => {
+                                s = function (n) {
+                                  ((o = !0), e(n));
+                                };
+                              });
+                            try {
+                              i = e(n, t, s);
+                            } catch (e) {
+                              i = Promise.reject(e);
+                            }
+                            const l =
+                              !0 !== i &&
+                              (_ = i) &&
+                              "object" == typeof _ &&
+                              "function" == typeof _.then;
+                            var _;
+                            if (!0 !== i && !l && !o) return !1;
+                            return (
+                              (l ? i : a)
+                                .then(
+                                  (e) => {
+                                    r(e);
+                                  },
+                                  (e) => {
+                                    let n;
+                                    ((n =
+                                      e &&
+                                      (e instanceof Error ||
+                                        "string" == typeof e.message)
+                                        ? e.message
+                                        : "An unexpected error occurred"),
+                                      r({
+                                        __mozWebExtensionPolyfillReject__: !0,
+                                        message: n,
+                                      }));
+                                  },
+                                )
+                                .catch((e) => {
+                                  console.error(
+                                    "Failed to send onMessage rejected reply",
+                                    e,
+                                  );
+                                }),
+                              !0
+                            );
+                          },
+                    ),
+                    m = ({ reject: t, resolve: r }, s) => {
+                      e.runtime.lastError
+                        ? e.runtime.lastError.message === n
+                          ? r()
+                          : t(new Error(e.runtime.lastError.message))
+                        : s && s.__mozWebExtensionPolyfillReject__
+                          ? t(new Error(s.message))
+                          : r(s);
+                    },
+                    g = (e, n, t, ...r) => {
+                      if (r.length < n.minArgs)
+                        throw new Error(
+                          `Expected at least ${n.minArgs} ${i(n.minArgs)} for ${e}(), got ${r.length}`,
+                        );
+                      if (r.length > n.maxArgs)
+                        throw new Error(
+                          `Expected at most ${n.maxArgs} ${i(n.maxArgs)} for ${e}(), got ${r.length}`,
+                        );
+                      return new Promise((e, n) => {
+                        const s = m.bind(null, { resolve: e, reject: n });
+                        (r.push(s), t.sendMessage(...r));
+                      });
+                    },
+                    f = {
+                      devtools: { network: { onRequestFinished: _(c) } },
+                      runtime: {
+                        onMessage: _(u),
+                        onMessageExternal: _(u),
+                        sendMessage: g.bind(null, "sendMessage", {
+                          minArgs: 1,
+                          maxArgs: 3,
+                        }),
+                      },
+                      tabs: {
+                        sendMessage: g.bind(null, "sendMessage", {
+                          minArgs: 2,
+                          maxArgs: 3,
+                        }),
+                      },
+                    },
+                    d = {
+                      clear: { minArgs: 1, maxArgs: 1 },
+                      get: { minArgs: 1, maxArgs: 1 },
+                      set: { minArgs: 1, maxArgs: 1 },
+                    };
+                  return (
+                    (t.privacy = {
+                      network: { "*": d },
+                      services: { "*": d },
+                      websites: { "*": d },
+                    }),
+                    l(e, f, t)
+                  );
+                };
+              e.exports = t(chrome);
+            }
+          }),
+          void 0 === (r = t.apply(n, [e])) || (e.exports = r));
+      },
+    },
+    n = {};
+  function t(r) {
+    var s = n[r];
+    if (void 0 !== s) return s.exports;
+    var i = (n[r] = { exports: {} });
+    return (e[r].call(i.exports, i, i.exports, t), i.exports);
+  }
+  ((t.n = (e) => {
+    var n = e && e.__esModule ? () => e.default : () => e;
+    return (t.d(n, { a: n }), n);
+  }),
+    (t.d = (e, n) => {
+      for (var r in n)
+        t.o(n, r) &&
+          !t.o(e, r) &&
+          Object.defineProperty(e, r, { enumerable: !0, get: n[r] });
+    }),
+    (t.o = (e, n) => Object.prototype.hasOwnProperty.call(e, n)),
+    (() => {
+      "use strict";
+      var e,
+        n,
+        r,
+        s,
+        i,
+        o,
+        a,
+        l,
+        _,
+        c,
+        u,
+        m,
+        g,
+        f,
+        d = {},
+        p = [],
+        h = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,
+        A = Array.isArray;
+      function v(e, n) {
+        for (var t in n) e[t] = n[t];
+        return e;
+      }
+      function b(e) {
+        e && e.parentNode && e.parentNode.removeChild(e);
+      }
+      function y(n, t, r) {
+        var s,
+          i,
+          o,
+          a = {};
+        for (o in t)
+          "key" == o ? (s = t[o]) : "ref" == o ? (i = t[o]) : (a[o] = t[o]);
+        if (
+          (arguments.length > 2 &&
+            (a.children = arguments.length > 3 ? e.call(arguments, 2) : r),
+          "function" == typeof n && null != n.defaultProps)
+        )
+          for (o in n.defaultProps)
+            void 0 === a[o] && (a[o] = n.defaultProps[o]);
+        return x(n, a, s, i, null);
+      }
+      function x(e, t, s, i, o) {
+        var a = {
+          type: e,
+          props: t,
+          key: s,
+          ref: i,
+          __k: null,
+          __: null,
+          __b: 0,
+          __e: null,
+          __c: null,
+          constructor: void 0,
+          __v: null == o ? ++r : o,
+          __i: -1,
+          __u: 0,
+        };
+        return (null == o && null != n.vnode && n.vnode(a), a);
+      }
+      function k(e) {
+        return e.children;
+      }
+      function w(e, n) {
+        ((this.props = e), (this.context = n));
+      }
+      function N(e, n) {
+        if (null == n) return e.__ ? N(e.__, e.__i + 1) : null;
+        for (var t; n < e.__k.length; n++)
+          if (null != (t = e.__k[n]) && null != t.__e) return t.__e;
+        return "function" == typeof e.type ? N(e) : null;
+      }
+      function S(e) {
+        if (e.__P && e.__d) {
+          var t = e.__v,
+            r = t.__e,
+            s = [],
+            i = [],
+            o = v({}, t);
+          ((o.__v = t.__v + 1),
+            n.vnode && n.vnode(o),
+            M(
+              e.__P,
+              o,
+              t,
+              e.__n,
+              e.__P.namespaceURI,
+              32 & t.__u ? [r] : null,
+              s,
+              null == r ? N(t) : r,
+              !!(32 & t.__u),
+              i,
+            ),
+            (o.__v = t.__v),
+            (o.__.__k[o.__i] = o),
+            H(s, o, i),
+            (t.__e = t.__ = null),
+            o.__e != r && P(o));
+        }
+      }
+      function P(e) {
+        if (null != (e = e.__) && null != e.__c)
+          return (
+            (e.__e = e.__c.base = null),
+            e.__k.some(function (n) {
+              if (null != n && null != n.__e)
+                return (e.__e = e.__c.base = n.__e);
+            }),
+            P(e)
+          );
+      }
+      function C(e) {
+        ((!e.__d && (e.__d = !0) && s.push(e) && !E.__r++) ||
+          i != n.debounceRendering) &&
+          ((i = n.debounceRendering) || o)(E);
+      }
+      function E() {
+        try {
+          for (var e, n = 1; s.length; )
+            (s.length > n && s.sort(a), (e = s.shift()), (n = s.length), S(e));
+        } finally {
+          s.length = E.__r = 0;
+        }
+      }
+      function T(e, n, t, r, s, i, o, a, l, _, c) {
+        var u,
+          m,
+          g,
+          f,
+          h,
+          A,
+          v,
+          b = (r && r.__k) || p,
+          y = n.length;
+        for (l = I(t, n, b, l, y), u = 0; u < y; u++)
+          null != (g = t.__k[u]) &&
+            ((m = (-1 != g.__i && b[g.__i]) || d),
+            (g.__i = u),
+            (A = M(e, g, m, s, i, o, a, l, _, c)),
+            (f = g.__e),
+            g.ref &&
+              m.ref != g.ref &&
+              (m.ref && B(m.ref, null, g), c.push(g.ref, g.__c || f, g)),
+            null == h && null != f && (h = f),
+            (v = !!(4 & g.__u)) || m.__k === g.__k
+              ? ((l = $(g, l, e, v)), v && m.__e && (m.__e = null))
+              : "function" == typeof g.type && void 0 !== A
+                ? (l = A)
+                : f && (l = f.nextSibling),
+            (g.__u &= -7));
+        return ((t.__e = h), l);
+      }
+      function I(e, n, t, r, s) {
+        var i,
+          o,
+          a,
+          l,
+          _,
+          c = t.length,
+          u = c,
+          m = 0;
+        for (e.__k = new Array(s), i = 0; i < s; i++)
+          null != (o = n[i]) && "boolean" != typeof o && "function" != typeof o
+            ? ("string" == typeof o ||
+              "number" == typeof o ||
+              "bigint" == typeof o ||
+              o.constructor == String
+                ? (o = e.__k[i] = x(null, o, null, null, null))
+                : A(o)
+                  ? (o = e.__k[i] = x(k, { children: o }, null, null, null))
+                  : void 0 === o.constructor && o.__b > 0
+                    ? (o = e.__k[i] =
+                        x(o.type, o.props, o.key, o.ref ? o.ref : null, o.__v))
+                    : (e.__k[i] = o),
+              (l = i + m),
+              (o.__ = e),
+              (o.__b = e.__b + 1),
+              (a = null),
+              -1 != (_ = o.__i = R(o, t, l, u)) &&
+                (u--, (a = t[_]) && (a.__u |= 2)),
+              null == a || null == a.__v
+                ? (-1 == _ && (s > c ? m-- : s < c && m++),
+                  "function" != typeof o.type && (o.__u |= 4))
+                : _ != l &&
+                  (_ == l - 1
+                    ? m--
+                    : _ == l + 1
+                      ? m++
+                      : (_ > l ? m-- : m++, (o.__u |= 4))))
+            : (e.__k[i] = null);
+        if (u)
+          for (i = 0; i < c; i++)
+            null != (a = t[i]) &&
+              !(2 & a.__u) &&
+              (a.__e == r && (r = N(a)), V(a, a));
+        return r;
+      }
+      function $(e, n, t, r) {
+        var s, i;
+        if ("function" == typeof e.type) {
+          for (s = e.__k, i = 0; s && i < s.length; i++)
+            s[i] && ((s[i].__ = e), (n = $(s[i], n, t, r)));
+          return n;
+        }
+        e.__e != n &&
+          (r &&
+            (n && e.type && !n.parentNode && (n = N(e)),
+            t.insertBefore(e.__e, n || null)),
+          (n = e.__e));
+        do {
+          n = n && n.nextSibling;
+        } while (null != n && 8 == n.nodeType);
+        return n;
+      }
+      function L(e, n) {
+        return (
+          (n = n || []),
+          null == e ||
+            "boolean" == typeof e ||
+            (A(e)
+              ? e.some(function (e) {
+                  L(e, n);
+                })
+              : n.push(e)),
+          n
+        );
+      }
+      function R(e, n, t, r) {
+        var s,
+          i,
+          o,
+          a = e.key,
+          l = e.type,
+          _ = n[t],
+          c = null != _ && !(2 & _.__u);
+        if ((null === _ && null == a) || (c && a == _.key && l == _.type))
+          return t;
+        if (r > (c ? 1 : 0))
+          for (s = t - 1, i = t + 1; s >= 0 || i < n.length; )
+            if (
+              null != (_ = n[(o = s >= 0 ? s-- : i++)]) &&
+              !(2 & _.__u) &&
+              a == _.key &&
+              l == _.type
+            )
+              return o;
+        return -1;
+      }
+      function U(e, n, t) {
+        "-" == n[0]
+          ? e.setProperty(n, null == t ? "" : t)
+          : (e[n] =
+              null == t
+                ? ""
+                : "number" != typeof t || h.test(n)
+                  ? t
+                  : t + "px");
+      }
+      function O(e, n, t, r, s) {
+        var i, o;
+        e: if ("style" == n)
+          if ("string" == typeof t) e.style.cssText = t;
+          else {
+            if (("string" == typeof r && (e.style.cssText = r = ""), r))
+              for (n in r) (t && n in t) || U(e.style, n, "");
+            if (t) for (n in t) (r && t[n] == r[n]) || U(e.style, n, t[n]);
+          }
+        else if ("o" == n[0] && "n" == n[1])
+          ((i = n != (n = n.replace(u, "$1"))),
+            (o = n.toLowerCase()),
+            (n =
+              o in e || "onFocusOut" == n || "onFocusIn" == n
+                ? o.slice(2)
+                : n.slice(2)),
+            e.l || (e.l = {}),
+            (e.l[n + i] = t),
+            t
+              ? r
+                ? (t[c] = r[c])
+                : ((t[c] = m), e.addEventListener(n, i ? f : g, i))
+              : e.removeEventListener(n, i ? f : g, i));
+        else {
+          if ("http://www.w3.org/2000/svg" == s)
+            n = n.replace(/xlink(H|:h)/, "h").replace(/sName$/, "s");
+          else if (
+            "width" != n &&
+            "height" != n &&
+            "href" != n &&
+            "list" != n &&
+            "form" != n &&
+            "tabIndex" != n &&
+            "download" != n &&
+            "rowSpan" != n &&
+            "colSpan" != n &&
+            "role" != n &&
+            "popover" != n &&
+            n in e
+          )
+            try {
+              e[n] = null == t ? "" : t;
+              break e;
+            } catch (e) {}
+          "function" == typeof t ||
+            (null == t || (!1 === t && "-" != n[4])
+              ? e.removeAttribute(n)
+              : e.setAttribute(n, "popover" == n && 1 == t ? "" : t));
+        }
+      }
+      function F(e) {
+        return function (t) {
+          if (this.l) {
+            var r = this.l[t.type + e];
+            if (null == t[_]) t[_] = m++;
+            else if (t[_] < r[c]) return;
+            return r(n.event ? n.event(t) : t);
+          }
+        };
+      }
+      function M(e, t, r, s, i, o, a, l, _, c) {
+        var u,
+          m,
+          g,
+          f,
+          d,
+          h,
+          y,
+          x,
+          N,
+          S,
+          P,
+          C,
+          E,
+          I,
+          $,
+          L = t.type;
+        if (void 0 !== t.constructor) return null;
+        (128 & r.__u && ((_ = !!(32 & r.__u)), (o = [(l = t.__e = r.__e)])),
+          (u = n.__b) && u(t));
+        e: if ("function" == typeof L)
+          try {
+            if (
+              ((x = t.props),
+              (N = L.prototype && L.prototype.render),
+              (S = (u = L.contextType) && s[u.__c]),
+              (P = u ? (S ? S.props.value : u.__) : s),
+              r.__c
+                ? (y = (m = t.__c = r.__c).__ = m.__E)
+                : (N
+                    ? (t.__c = m = new L(x, P))
+                    : ((t.__c = m = new w(x, P)),
+                      (m.constructor = L),
+                      (m.render = q)),
+                  S && S.sub(m),
+                  m.state || (m.state = {}),
+                  (m.__n = s),
+                  (g = m.__d = !0),
+                  (m.__h = []),
+                  (m._sb = [])),
+              N && null == m.__s && (m.__s = m.state),
+              N &&
+                null != L.getDerivedStateFromProps &&
+                (m.__s == m.state && (m.__s = v({}, m.__s)),
+                v(m.__s, L.getDerivedStateFromProps(x, m.__s))),
+              (f = m.props),
+              (d = m.state),
+              (m.__v = t),
+              g)
+            )
+              (N &&
+                null == L.getDerivedStateFromProps &&
+                null != m.componentWillMount &&
+                m.componentWillMount(),
+                N &&
+                  null != m.componentDidMount &&
+                  m.__h.push(m.componentDidMount));
+            else {
+              if (
+                (N &&
+                  null == L.getDerivedStateFromProps &&
+                  x !== f &&
+                  null != m.componentWillReceiveProps &&
+                  m.componentWillReceiveProps(x, P),
+                t.__v == r.__v ||
+                  (!m.__e &&
+                    null != m.shouldComponentUpdate &&
+                    !1 === m.shouldComponentUpdate(x, m.__s, P)))
+              ) {
+                (t.__v != r.__v &&
+                  ((m.props = x), (m.state = m.__s), (m.__d = !1)),
+                  (t.__e = r.__e),
+                  (t.__k = r.__k),
+                  t.__k.some(function (e) {
+                    e && (e.__ = t);
+                  }),
+                  p.push.apply(m.__h, m._sb),
+                  (m._sb = []),
+                  m.__h.length && a.push(m));
+                break e;
+              }
+              (null != m.componentWillUpdate &&
+                m.componentWillUpdate(x, m.__s, P),
+                N &&
+                  null != m.componentDidUpdate &&
+                  m.__h.push(function () {
+                    m.componentDidUpdate(f, d, h);
+                  }));
+            }
+            if (
+              ((m.context = P),
+              (m.props = x),
+              (m.__P = e),
+              (m.__e = !1),
+              (C = n.__r),
+              (E = 0),
+              N)
+            )
+              ((m.state = m.__s),
+                (m.__d = !1),
+                C && C(t),
+                (u = m.render(m.props, m.state, m.context)),
+                p.push.apply(m.__h, m._sb),
+                (m._sb = []));
+            else
+              do {
+                ((m.__d = !1),
+                  C && C(t),
+                  (u = m.render(m.props, m.state, m.context)),
+                  (m.state = m.__s));
+              } while (m.__d && ++E < 25);
+            ((m.state = m.__s),
+              null != m.getChildContext &&
+                (s = v(v({}, s), m.getChildContext())),
+              N &&
+                !g &&
+                null != m.getSnapshotBeforeUpdate &&
+                (h = m.getSnapshotBeforeUpdate(f, d)),
+              (I =
+                null != u && u.type === k && null == u.key
+                  ? W(u.props.children)
+                  : u),
+              (l = T(e, A(I) ? I : [I], t, r, s, i, o, a, l, _, c)),
+              (m.base = t.__e),
+              (t.__u &= -161),
+              m.__h.length && a.push(m),
+              y && (m.__E = m.__ = null));
+          } catch (e) {
+            if (((t.__v = null), _ || null != o))
+              if (e.then) {
+                for (
+                  t.__u |= _ ? 160 : 128;
+                  l && 8 == l.nodeType && l.nextSibling;
+                )
+                  l = l.nextSibling;
+                ((o[o.indexOf(l)] = null), (t.__e = l));
+              } else {
+                for ($ = o.length; $--; ) b(o[$]);
+                D(t);
+              }
+            else ((t.__e = r.__e), (t.__k = r.__k), e.then || D(t));
+            n.__e(e, t, r);
+          }
+        else
+          null == o && t.__v == r.__v
+            ? ((t.__k = r.__k), (t.__e = r.__e))
+            : (l = t.__e = j(r.__e, t, r, s, i, o, a, _, c));
+        return ((u = n.diffed) && u(t), 128 & t.__u ? void 0 : l);
+      }
+      function D(e) {
+        e && (e.__c && (e.__c.__e = !0), e.__k && e.__k.some(D));
+      }
+      function H(e, t, r) {
+        for (var s = 0; s < r.length; s++) B(r[s], r[++s], r[++s]);
+        (n.__c && n.__c(t, e),
+          e.some(function (t) {
+            try {
+              ((e = t.__h),
+                (t.__h = []),
+                e.some(function (e) {
+                  e.call(t);
+                }));
+            } catch (e) {
+              n.__e(e, t.__v);
+            }
+          }));
+      }
+      function W(e) {
+        return "object" != typeof e || null == e || e.__b > 0
+          ? e
+          : A(e)
+            ? e.map(W)
+            : v({}, e);
+      }
+      function j(t, r, s, i, o, a, l, _, c) {
+        var u,
+          m,
+          g,
+          f,
+          p,
+          h,
+          v,
+          y = s.props || d,
+          x = r.props,
+          k = r.type;
+        if (
+          ("svg" == k
+            ? (o = "http://www.w3.org/2000/svg")
+            : "math" == k
+              ? (o = "http://www.w3.org/1998/Math/MathML")
+              : o || (o = "http://www.w3.org/1999/xhtml"),
+          null != a)
+        )
+          for (u = 0; u < a.length; u++)
+            if (
+              (p = a[u]) &&
+              "setAttribute" in p == !!k &&
+              (k ? p.localName == k : 3 == p.nodeType)
+            ) {
+              ((t = p), (a[u] = null));
+              break;
+            }
+        if (null == t) {
+          if (null == k) return document.createTextNode(x);
+          ((t = document.createElementNS(o, k, x.is && x)),
+            _ && (n.__m && n.__m(r, a), (_ = !1)),
+            (a = null));
+        }
+        if (null == k) y === x || (_ && t.data == x) || (t.data = x);
+        else {
+          if (((a = a && e.call(t.childNodes)), !_ && null != a))
+            for (y = {}, u = 0; u < t.attributes.length; u++)
+              y[(p = t.attributes[u]).name] = p.value;
+          for (u in y)
+            ((p = y[u]),
+              "dangerouslySetInnerHTML" == u
+                ? (g = p)
+                : "children" == u ||
+                  u in x ||
+                  ("value" == u && "defaultValue" in x) ||
+                  ("checked" == u && "defaultChecked" in x) ||
+                  O(t, u, null, p, o));
+          for (u in x)
+            ((p = x[u]),
+              "children" == u
+                ? (f = p)
+                : "dangerouslySetInnerHTML" == u
+                  ? (m = p)
+                  : "value" == u
+                    ? (h = p)
+                    : "checked" == u
+                      ? (v = p)
+                      : (_ && "function" != typeof p) ||
+                        y[u] === p ||
+                        O(t, u, p, y[u], o));
+          if (m)
+            (_ ||
+              (g && (m.__html == g.__html || m.__html == t.innerHTML)) ||
+              (t.innerHTML = m.__html),
+              (r.__k = []));
+          else if (
+            (g && (t.innerHTML = ""),
+            T(
+              "template" == r.type ? t.content : t,
+              A(f) ? f : [f],
+              r,
+              s,
+              i,
+              "foreignObject" == k ? "http://www.w3.org/1999/xhtml" : o,
+              a,
+              l,
+              a ? a[0] : s.__k && N(s, 0),
+              _,
+              c,
+            ),
+            null != a)
+          )
+            for (u = a.length; u--; ) b(a[u]);
+          _ ||
+            ((u = "value"),
+            "progress" == k && null == h
+              ? t.removeAttribute("value")
+              : null != h &&
+                (h !== t[u] ||
+                  ("progress" == k && !h) ||
+                  ("option" == k && h != y[u])) &&
+                O(t, u, h, y[u], o),
+            (u = "checked"),
+            null != v && v != t[u] && O(t, u, v, y[u], o));
+        }
+        return t;
+      }
+      function B(e, t, r) {
+        try {
+          if ("function" == typeof e) {
+            var s = "function" == typeof e.__u;
+            (s && e.__u(), (s && null == t) || (e.__u = e(t)));
+          } else e.current = t;
+        } catch (e) {
+          n.__e(e, r);
+        }
+      }
+      function V(e, t, r) {
+        var s, i;
+        if (
+          (n.unmount && n.unmount(e),
+          (s = e.ref) && ((s.current && s.current != e.__e) || B(s, null, t)),
+          null != (s = e.__c))
+        ) {
+          if (s.componentWillUnmount)
+            try {
+              s.componentWillUnmount();
+            } catch (e) {
+              n.__e(e, t);
+            }
+          s.base = s.__P = null;
+        }
+        if ((s = e.__k))
+          for (i = 0; i < s.length; i++)
+            s[i] && V(s[i], t, r || "function" != typeof e.type);
+        (r || b(e.__e), (e.__c = e.__ = e.__e = void 0));
+      }
+      function q(e, n, t) {
+        return this.constructor(e, t);
+      }
+      function z(t, r, s) {
+        var i, o, a, l;
+        (r == document && (r = document.documentElement),
+          n.__ && n.__(t, r),
+          (o = (i = "function" == typeof s) ? null : (s && s.__k) || r.__k),
+          (a = []),
+          (l = []),
+          M(
+            r,
+            (t = ((!i && s) || r).__k = y(k, null, [t])),
+            o || d,
+            d,
+            r.namespaceURI,
+            !i && s
+              ? [s]
+              : o
+                ? null
+                : r.firstChild
+                  ? e.call(r.childNodes)
+                  : null,
+            a,
+            !i && s ? s : o ? o.__e : r.firstChild,
+            i,
+            l,
+          ),
+          H(a, t, l));
+      }
+      ((e = p.slice),
+        (n = {
+          __e: function (e, n, t, r) {
+            for (var s, i, o; (n = n.__); )
+              if ((s = n.__c) && !s.__)
+                try {
+                  if (
+                    ((i = s.constructor) &&
+                      null != i.getDerivedStateFromError &&
+                      (s.setState(i.getDerivedStateFromError(e)), (o = s.__d)),
+                    null != s.componentDidCatch &&
+                      (s.componentDidCatch(e, r || {}), (o = s.__d)),
+                    o)
+                  )
+                    return (s.__E = s);
+                } catch (n) {
+                  e = n;
+                }
+            throw e;
+          },
+        }),
+        (r = 0),
+        (w.prototype.setState = function (e, n) {
+          var t;
+          ((t =
+            null != this.__s && this.__s != this.state
+              ? this.__s
+              : (this.__s = v({}, this.state))),
+            "function" == typeof e && (e = e(v({}, t), this.props)),
+            e && v(t, e),
+            null != e && this.__v && (n && this._sb.push(n), C(this)));
+        }),
+        (w.prototype.forceUpdate = function (e) {
+          this.__v && ((this.__e = !0), e && this.__h.push(e), C(this));
+        }),
+        (w.prototype.render = k),
+        (s = []),
+        (o =
+          "function" == typeof Promise
+            ? Promise.prototype.then.bind(Promise.resolve())
+            : setTimeout),
+        (a = function (e, n) {
+          return e.__v.__b - n.__v.__b;
+        }),
+        (E.__r = 0),
+        (l = Math.random().toString(8)),
+        (_ = "__d" + l),
+        (c = "__a" + l),
+        (u = /(PointerCapture)$|Capture$/i),
+        (m = 0),
+        (g = F(!1)),
+        (f = F(!0)));
+      var Z,
+        K,
+        Y,
+        Q,
+        G = 0,
+        J = [],
+        X = n,
+        ee = X.__b,
+        ne = X.__r,
+        te = X.diffed,
+        re = X.__c,
+        se = X.unmount,
+        ie = X.__;
+      function oe(e, n) {
+        (X.__h && X.__h(K, e, G || n), (G = 0));
+        var t = K.__H || (K.__H = { __: [], __h: [] });
+        return (e >= t.__.length && t.__.push({}), t.__[e]);
+      }
+      function ae(e) {
+        return (
+          (G = 1),
+          (function (e, n, t) {
+            var r = oe(Z++, 2);
+            if (
+              ((r.t = e),
+              !r.__c &&
+                ((r.__ = [
+                  t ? t(n) : pe(void 0, n),
+                  function (e) {
+                    var n = r.__N ? r.__N[0] : r.__[0],
+                      t = r.t(n, e);
+                    n !== t && ((r.__N = [t, r.__[1]]), r.__c.setState({}));
+                  },
+                ]),
+                (r.__c = K),
+                !K.__f))
+            ) {
+              var s = function (e, n, t) {
+                if (!r.__c.__H) return !0;
+                var s = r.__c.__H.__.filter(function (e) {
+                  return e.__c;
+                });
+                if (
+                  s.every(function (e) {
+                    return !e.__N;
+                  })
+                )
+                  return !i || i.call(this, e, n, t);
+                var o = r.__c.props !== e;
+                return (
+                  s.some(function (e) {
+                    if (e.__N) {
+                      var n = e.__[0];
+                      ((e.__ = e.__N),
+                        (e.__N = void 0),
+                        n !== e.__[0] && (o = !0));
+                    }
+                  }),
+                  (i && i.call(this, e, n, t)) || o
+                );
+              };
+              K.__f = !0;
+              var i = K.shouldComponentUpdate,
+                o = K.componentWillUpdate;
+              ((K.componentWillUpdate = function (e, n, t) {
+                if (this.__e) {
+                  var r = i;
+                  ((i = void 0), s(e, n, t), (i = r));
+                }
+                o && o.call(this, e, n, t);
+              }),
+                (K.shouldComponentUpdate = s));
+            }
+            return r.__N || r.__;
+          })(pe, e)
+        );
+      }
+      function le(e, n) {
+        var t = oe(Z++, 7);
+        return (de(t.__H, n) && ((t.__ = e()), (t.__H = n), (t.__h = e)), t.__);
+      }
+      function _e(e, n) {
+        return (
+          (G = 8),
+          le(function () {
+            return e;
+          }, n)
+        );
+      }
+      function ce() {
+        for (var e; (e = J.shift()); ) {
+          var n = e.__H;
+          if (e.__P && n)
+            try {
+              (n.__h.some(ge), n.__h.some(fe), (n.__h = []));
+            } catch (t) {
+              ((n.__h = []), X.__e(t, e.__v));
+            }
+        }
+      }
+      ((X.__b = function (e) {
+        ((K = null), ee && ee(e));
+      }),
+        (X.__ = function (e, n) {
+          (e && n.__k && n.__k.__m && (e.__m = n.__k.__m), ie && ie(e, n));
+        }),
+        (X.__r = function (e) {
+          (ne && ne(e), (Z = 0));
+          var n = (K = e.__c).__H;
+          (n &&
+            (Y === K
+              ? ((n.__h = []),
+                (K.__h = []),
+                n.__.some(function (e) {
+                  (e.__N && (e.__ = e.__N), (e.u = e.__N = void 0));
+                }))
+              : (n.__h.some(ge), n.__h.some(fe), (n.__h = []), (Z = 0))),
+            (Y = K));
+        }),
+        (X.diffed = function (e) {
+          te && te(e);
+          var n = e.__c;
+          (n &&
+            n.__H &&
+            (n.__H.__h.length &&
+              ((1 !== J.push(n) && Q === X.requestAnimationFrame) ||
+                ((Q = X.requestAnimationFrame) || me)(ce)),
+            n.__H.__.some(function (e) {
+              (e.u && (e.__H = e.u), (e.u = void 0));
+            })),
+            (Y = K = null));
+        }),
+        (X.__c = function (e, n) {
+          (n.some(function (e) {
+            try {
+              (e.__h.some(ge),
+                (e.__h = e.__h.filter(function (e) {
+                  return !e.__ || fe(e);
+                })));
+            } catch (t) {
+              (n.some(function (e) {
+                e.__h && (e.__h = []);
+              }),
+                (n = []),
+                X.__e(t, e.__v));
+            }
+          }),
+            re && re(e, n));
+        }),
+        (X.unmount = function (e) {
+          se && se(e);
+          var n,
+            t = e.__c;
+          t &&
+            t.__H &&
+            (t.__H.__.some(function (e) {
+              try {
+                ge(e);
+              } catch (e) {
+                n = e;
+              }
+            }),
+            (t.__H = void 0),
+            n && X.__e(n, t.__v));
+        }));
+      var ue = "function" == typeof requestAnimationFrame;
+      function me(e) {
+        var n,
+          t = function () {
+            (clearTimeout(r), ue && cancelAnimationFrame(n), setTimeout(e));
+          },
+          r = setTimeout(t, 35);
+        ue && (n = requestAnimationFrame(t));
+      }
+      function ge(e) {
+        var n = K,
+          t = e.__c;
+        ("function" == typeof t && ((e.__c = void 0), t()), (K = n));
+      }
+      function fe(e) {
+        var n = K;
+        ((e.__c = e.__()), (K = n));
+      }
+      function de(e, n) {
+        return (
+          !e ||
+          e.length !== n.length ||
+          n.some(function (n, t) {
+            return n !== e[t];
+          })
+        );
+      }
+      function pe(e, n) {
+        return "function" == typeof n ? n(e) : n;
+      }
+      function he(e, n) {
+        for (var t in e) if ("__source" !== t && !(t in n)) return !0;
+        for (var r in n) if ("__source" !== r && e[r] !== n[r]) return !0;
+        return !1;
+      }
+      function Ae(e, n) {
+        ((this.props = e), (this.context = n));
+      }
+      (((Ae.prototype = new w()).isPureReactComponent = !0),
+        (Ae.prototype.shouldComponentUpdate = function (e, n) {
+          return he(this.props, e) || he(this.state, n);
+        }));
+      var ve = n.__b;
+      ((n.__b = function (e) {
+        (e.type &&
+          e.type.__f &&
+          e.ref &&
+          ((e.props.ref = e.ref), (e.ref = null)),
+          ve && ve(e));
+      }),
+        "undefined" != typeof Symbol &&
+          Symbol.for &&
+          Symbol.for("react.forward_ref"));
+      var be = n.__e;
+      n.__e = function (e, n, t, r) {
+        if (e.then)
+          for (var s, i = n; (i = i.__); )
+            if ((s = i.__c) && s.__c)
+              return (
+                null == n.__e && ((n.__e = t.__e), (n.__k = t.__k)),
+                s.__c(e, n)
+              );
+        be(e, n, t, r);
+      };
+      var ye = n.unmount;
+      function xe(e, n, t) {
+        return (
+          e &&
+            (e.__c &&
+              e.__c.__H &&
+              (e.__c.__H.__.forEach(function (e) {
+                "function" == typeof e.__c && e.__c();
+              }),
+              (e.__c.__H = null)),
+            null !=
+              (e = (function (e, n) {
+                for (var t in n) e[t] = n[t];
+                return e;
+              })({}, e)).__c &&
+              (e.__c.__P === t && (e.__c.__P = n),
+              (e.__c.__e = !0),
+              (e.__c = null)),
+            (e.__k =
+              e.__k &&
+              e.__k.map(function (e) {
+                return xe(e, n, t);
+              }))),
+          e
+        );
+      }
+      function ke(e, n, t) {
+        return (
+          e &&
+            t &&
+            ((e.__v = null),
+            (e.__k =
+              e.__k &&
+              e.__k.map(function (e) {
+                return ke(e, n, t);
+              })),
+            e.__c &&
+              e.__c.__P === n &&
+              (e.__e && t.appendChild(e.__e),
+              (e.__c.__e = !0),
+              (e.__c.__P = t))),
+          e
+        );
+      }
+      function we() {
+        ((this.__u = 0), (this.o = null), (this.__b = null));
+      }
+      function Ne(e) {
+        var n = e.__ && e.__.__c;
+        return n && n.__a && n.__a(e);
+      }
+      function Se() {
+        ((this.i = null), (this.l = null));
+      }
+      ((n.unmount = function (e) {
+        var n = e.__c;
+        (n && (n.__z = !0),
+          n && n.__R && n.__R(),
+          n && 32 & e.__u && (e.type = null),
+          ye && ye(e));
+      }),
+        ((we.prototype = new w()).__c = function (e, n) {
+          var t = n.__c,
+            r = this;
+          (null == r.o && (r.o = []), r.o.push(t));
+          var s = Ne(r.__v),
+            i = !1,
+            o = function () {
+              i || r.__z || ((i = !0), (t.__R = null), s ? s(l) : l());
+            };
+          t.__R = o;
+          var a = t.__P;
+          t.__P = null;
+          var l = function () {
+            if (!--r.__u) {
+              if (r.state.__a) {
+                var e = r.state.__a;
+                r.__v.__k[0] = ke(e, e.__c.__P, e.__c.__O);
+              }
+              var n;
+              for (r.setState({ __a: (r.__b = null) }); (n = r.o.pop()); )
+                ((n.__P = a), n.forceUpdate());
+            }
+          };
+          (r.__u++ || 32 & n.__u || r.setState({ __a: (r.__b = r.__v.__k[0]) }),
+            e.then(o, o));
+        }),
+        (we.prototype.componentWillUnmount = function () {
+          this.o = [];
+        }),
+        (we.prototype.render = function (e, n) {
+          if (this.__b) {
+            if (this.__v.__k) {
+              var t = document.createElement("div"),
+                r = this.__v.__k[0].__c;
+              this.__v.__k[0] = xe(this.__b, t, (r.__O = r.__P));
+            }
+            this.__b = null;
+          }
+          var s = n.__a && y(k, null, e.fallback);
+          return (
+            s && (s.__u &= -33),
+            [y(k, null, n.__a ? null : e.children), s]
+          );
+        }));
+      var Pe = function (e, n, t) {
+        if (
+          (++t[1] === t[0] && e.l.delete(n),
+          e.props.revealOrder && ("t" !== e.props.revealOrder[0] || !e.l.size))
+        )
+          for (t = e.i; t; ) {
+            for (; t.length > 3; ) t.pop()();
+            if (t[1] < t[0]) break;
+            e.i = t = t[2];
+          }
+      };
+      (((Se.prototype = new w()).__a = function (e) {
+        var n = this,
+          t = Ne(n.__v),
+          r = n.l.get(e);
+        return (
+          r[0]++,
+          function (s) {
+            var i = function () {
+              n.props.revealOrder ? (r.push(s), Pe(n, e, r)) : s();
+            };
+            t ? t(i) : i();
+          }
+        );
+      }),
+        (Se.prototype.render = function (e) {
+          ((this.i = null), (this.l = new Map()));
+          var n = L(e.children);
+          e.revealOrder && "b" === e.revealOrder[0] && n.reverse();
+          for (var t = n.length; t--; )
+            this.l.set(n[t], (this.i = [1, 0, this.i]));
+          return e.children;
+        }),
+        (Se.prototype.componentDidUpdate = Se.prototype.componentDidMount =
+          function () {
+            var e = this;
+            this.l.forEach(function (n, t) {
+              Pe(e, t, n);
+            });
+          }));
+      var Ce =
+          ("undefined" != typeof Symbol &&
+            Symbol.for &&
+            Symbol.for("react.element")) ||
+          60103,
+        Ee =
+          /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/,
+        Te = /^on(Ani|Tra|Tou|BeforeInp|Compo)/,
+        Ie = /[A-Z0-9]/g,
+        $e = "undefined" != typeof document,
+        Le = function (e) {
+          return (
+            "undefined" != typeof Symbol && "symbol" == typeof Symbol()
+              ? /fil|che|rad/
+              : /fil|che|ra/
+          ).test(e);
+        };
+      ((w.prototype.isReactComponent = !0),
+        [
+          "componentWillMount",
+          "componentWillReceiveProps",
+          "componentWillUpdate",
+        ].forEach(function (e) {
+          Object.defineProperty(w.prototype, e, {
+            configurable: !0,
+            get: function () {
+              return this["UNSAFE_" + e];
+            },
+            set: function (n) {
+              Object.defineProperty(this, e, {
+                configurable: !0,
+                writable: !0,
+                value: n,
+              });
+            },
+          });
+        }));
+      var Re = n.event;
+      n.event = function (e) {
+        return (
+          Re && (e = Re(e)),
+          (e.persist = function () {}),
+          (e.isPropagationStopped = function () {
+            return this.cancelBubble;
+          }),
+          (e.isDefaultPrevented = function () {
+            return this.defaultPrevented;
+          }),
+          (e.nativeEvent = e)
+        );
+      };
+      var Ue = {
+          configurable: !0,
+          get: function () {
+            return this.class;
+          },
+        },
+        Oe = n.vnode;
+      n.vnode = function (e) {
+        ("string" == typeof e.type &&
+          (function (e) {
+            var n = e.props,
+              t = e.type,
+              r = {},
+              s = -1 == t.indexOf("-");
+            for (var i in n) {
+              var o = n[i];
+              if (
+                !(
+                  ("value" === i && "defaultValue" in n && null == o) ||
+                  ($e && "children" === i && "noscript" === t) ||
+                  "class" === i ||
+                  "className" === i
+                )
+              ) {
+                var a = i.toLowerCase();
+                ("defaultValue" === i && "value" in n && null == n.value
+                  ? (i = "value")
+                  : "download" === i && !0 === o
+                    ? (o = "")
+                    : "translate" === a && "no" === o
+                      ? (o = !1)
+                      : "o" === a[0] && "n" === a[1]
+                        ? "ondoubleclick" === a
+                          ? (i = "ondblclick")
+                          : "onchange" !== a ||
+                              ("input" !== t && "textarea" !== t) ||
+                              Le(n.type)
+                            ? "onfocus" === a
+                              ? (i = "onfocusin")
+                              : "onblur" === a
+                                ? (i = "onfocusout")
+                                : Te.test(i) && (i = a)
+                            : (a = i = "oninput")
+                        : s && Ee.test(i)
+                          ? (i = i.replace(Ie, "-$&").toLowerCase())
+                          : null === o && (o = void 0),
+                  "oninput" === a && r[(i = a)] && (i = "oninputCapture"),
+                  (r[i] = o));
+              }
+            }
+            ("select" == t &&
+              (r.multiple &&
+                Array.isArray(r.value) &&
+                (r.value = L(n.children).forEach(function (e) {
+                  e.props.selected = -1 != r.value.indexOf(e.props.value);
+                })),
+              null != r.defaultValue &&
+                (r.value = L(n.children).forEach(function (e) {
+                  e.props.selected = r.multiple
+                    ? -1 != r.defaultValue.indexOf(e.props.value)
+                    : r.defaultValue == e.props.value;
+                }))),
+              n.class && !n.className
+                ? ((r.class = n.class),
+                  Object.defineProperty(r, "className", Ue))
+                : n.className && (r.class = r.className = n.className),
+              (e.props = r));
+          })(e),
+          (e.$$typeof = Ce),
+          Oe && Oe(e));
+      };
+      var Fe = n.__r;
+      n.__r = function (e) {
+        (Fe && Fe(e), e.__c);
+      };
+      var Me = n.diffed;
+      n.diffed = function (e) {
+        Me && Me(e);
+        var n = e.props,
+          t = e.__e;
+        null != t &&
+          "textarea" === e.type &&
+          "value" in n &&
+          n.value !== t.value &&
+          (t.value = null == n.value ? "" : n.value);
+      };
+      var De = 0;
+      function He(e, t, r, s, i, o) {
+        t || (t = {});
+        var a,
+          l,
+          _ = t;
+        if ("ref" in _)
+          for (l in ((_ = {}), t)) "ref" == l ? (a = t[l]) : (_[l] = t[l]);
+        var c = {
+          type: e,
+          props: _,
+          key: r,
+          ref: a,
+          __k: null,
+          __: null,
+          __b: 0,
+          __e: null,
+          __c: null,
+          constructor: void 0,
+          __v: --De,
+          __i: -1,
+          __u: 0,
+          __source: i,
+          __self: o,
+        };
+        if ("function" == typeof e && (a = e.defaultProps))
+          for (l in a) void 0 === _[l] && (_[l] = a[l]);
+        return (n.vnode && n.vnode(c), c);
+      }
+      Array.isArray;
+      var We = t(815);
+      const je = t.n(We)(),
+        Be = {
+          résumé: "📝",
+          summary: "📝",
+          synthèse: "📝",
+          introduction: "🎬",
+          contexte: "🌍",
+          context: "🌍",
+          analyse: "🔬",
+          analysis: "🔬",
+          "points clés": "🎯",
+          "key points": "🎯",
+          "points forts": "💪",
+          strengths: "💪",
+          "points faibles": "⚠️",
+          weaknesses: "⚠️",
+          limites: "⚠️",
+          conclusion: "🏁",
+          recommandations: "💡",
+          recommendations: "💡",
+          sources: "📚",
+          références: "📚",
+          references: "📚",
+          "fact-check": "🔍",
+          vérification: "🔍",
+          arguments: "⚖️",
+          méthodologie: "🧪",
+          methodology: "🧪",
+          données: "📊",
+          data: "📊",
+          statistiques: "📊",
+          opinion: "💬",
+          avis: "💬",
+          biais: "🎭",
+          bias: "🎭",
+          nuances: "🎨",
+          perspectives: "👁️",
+          timeline: "📅",
+          chronologie: "📅",
+          définitions: "📖",
+          glossaire: "📖",
+        };
+      function Ve(e) {
+        const n = e.toLowerCase().trim();
+        for (const [e, t] of Object.entries(Be)) if (n.includes(e)) return t;
+        return "📌";
+      }
+      function qe(e) {
+        return e
+          .replace(/`([^`]+)`/g, '<code class="ds-md-code">$1</code>')
+          .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+          .replace(/\*(.+?)\*/g, "<em>$1</em>")
+          .replace(
+            /\[?(SOLIDE|SOLID)\]?/g,
+            '<span class="ds-marker ds-marker-solid">✅ Établi</span>',
+          )
+          .replace(
+            /\[?(PLAUSIBLE)\]?/g,
+            '<span class="ds-marker ds-marker-plausible">🔵 Probable</span>',
+          )
+          .replace(
+            /\[?(INCERTAIN|UNCERTAIN)\]?/g,
+            '<span class="ds-marker ds-marker-uncertain">🟡 Incertain</span>',
+          )
+          .replace(
+            /\[?(A VERIFIER|À VÉRIFIER|TO VERIFY|QUESTIONABLE|WEAK)\]?/g,
+            '<span class="ds-marker ds-marker-weak">🔴 À vérifier</span>',
+          );
+      }
+      function ze(e) {
+        return e
+          .replace(/\*\*(.+?)\*\*/g, "$1")
+          .replace(/\*(.+?)\*/g, "$1")
+          .replace(/`([^`]+)`/g, "$1")
+          .replace(/#{1,6}\s+/g, "")
+          .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+          .replace(/^>\s+/gm, "")
+          .replace(/\n+/g, " ")
+          .trim();
+      }
+      function Ze(e, n) {
+        if (e.length <= n) return e;
+        const t = e.substring(0, n),
+          r = t.lastIndexOf(" ");
+        return (r > 0.6 * n ? t.substring(0, r) : t) + "...";
+      }
+      const Ke = {
+        tech: "💻",
+        science: "🔬",
+        education: "📚",
+        news: "📰",
+        entertainment: "🎬",
+        gaming: "🎮",
+        music: "🎵",
+        sports: "⚽",
+        business: "💼",
+        lifestyle: "🌟",
+        other: "📋",
+      };
+      function Ye(e) {
+        return e >= 80
+          ? "v-badge v-badge-score"
+          : e >= 60
+            ? "v-badge v-badge-score warn"
+            : "v-badge v-badge-score low";
+      }
+      function Qe(e) {
+        return e >= 80 ? "✅" : e >= 60 ? "⚠️" : "❓";
+      }
+      const Ge = ({ summary: e }) => {
+          const n = (function (e) {
+              if (!e) return { id: null, platform: "unknown" };
+              const n = e.match(/[?&]v=([^&]+)/);
+              if (n) return { id: n[1], platform: "youtube" };
+              const t = e.match(/youtu\.be\/([^?&]+)/);
+              if (t) return { id: t[1], platform: "youtube" };
+              const r = e.match(/tiktok\.com\/[^/]+\/video\/(\d+)/);
+              return r
+                ? { id: r[1], platform: "tiktok" }
+                : { id: null, platform: "unknown" };
+            })(e.video_url),
+            t = e.thumbnail_url
+              ? e.thumbnail_url
+              : "youtube" === n.platform && n.id
+                ? `https://img.youtube.com/vi/${n.id}/maxresdefault.jpg`
+                : null,
+            r = Ke[e.category] ?? "📋",
+            s = e.reliability_score,
+            i =
+              s >= 80
+                ? "Source fiable"
+                : s >= 60
+                  ? "Fiabilité modérée"
+                  : "À vérifier",
+            o = s >= 80 ? "#10b981" : s >= 60 ? "#f59e0b" : "#ef4444";
+          return He("header", {
+            className: "v-header",
+            children: [
+              t &&
+                He("div", {
+                  className: "v-header-thumb",
+                  children: He("img", {
+                    src: t,
+                    alt: e.video_title,
+                    loading: "lazy",
+                    onError: (e) => {
+                      e.currentTarget.style.display = "none";
+                    },
+                  }),
+                }),
+              He("div", {
+                className: "v-header-body",
+                children: [
+                  He("h1", {
+                    className: "v-header-title",
+                    children: e.video_title,
+                  }),
+                  e.video_channel &&
+                    He("p", {
+                      className: "v-header-channel",
+                      children: e.video_channel,
+                    }),
+                  He("div", {
+                    className: "v-header-badges",
+                    children: [
+                      He("span", {
+                        className: "v-badge",
+                        children: [r, " ", e.category],
+                      }),
+                      He("span", {
+                        className: Ye(s),
+                        children: [Qe(s), " ", s, "%"],
+                      }),
+                      e.tournesol?.found &&
+                        null !== e.tournesol.tournesol_score &&
+                        He("span", {
+                          className: "v-badge",
+                          children: [
+                            "🌻",
+                            " Tournesol",
+                            " ",
+                            e.tournesol.tournesol_score > 0 ? "+" : "",
+                            Math.round(e.tournesol.tournesol_score),
+                          ],
+                        }),
+                    ],
+                  }),
+                  He("div", {
+                    className: "v-header-reliability",
+                    children: [
+                      He("div", {
+                        className: "v-reliability-label",
+                        children: [
+                          He("span", { children: ["Fiabilité — ", i] }),
+                          He("span", {
+                            className: "v-reliability-value",
+                            children: [s, "%"],
+                          }),
+                        ],
+                      }),
+                      He("div", {
+                        className: "v-reliability-bar",
+                        children: He("div", {
+                          className: "v-reliability-fill",
+                          style: {
+                            width: `${Math.max(0, Math.min(100, s))}%`,
+                            background: o,
+                          },
+                        }),
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          });
+        },
+        Je = ({ verdict: e }) =>
+          e
+            ? He("section", {
+                className: "v-section v-section-verdict",
+                children: [
+                  He("h2", {
+                    className: "v-section-title",
+                    children: "Verdict",
+                  }),
+                  He("div", { className: "v-verdict", children: e }),
+                ],
+              })
+            : null;
+      function Xe(e) {
+        switch (e) {
+          case "solid":
+            return "✅";
+          case "weak":
+            return "⚠️";
+          case "insight":
+            return "💡";
+        }
+      }
+      function en(e) {
+        switch (e) {
+          case "solid":
+            return "v-kp v-kp-solid";
+          case "weak":
+            return "v-kp v-kp-weak";
+          case "insight":
+            return "v-kp v-kp-default";
+        }
+      }
+      const nn = ({ points: e }) =>
+          e && 0 !== e.length
+            ? He("section", {
+                className: "v-section",
+                children: [
+                  He("h2", {
+                    className: "v-section-title",
+                    children: "Points clés",
+                  }),
+                  He("div", {
+                    className: "v-kp-list",
+                    children: e.map((e, n) =>
+                      He(
+                        "div",
+                        {
+                          className: en(e.type),
+                          children: [
+                            He("span", {
+                              className: "v-kp-icon",
+                              "aria-hidden": "true",
+                              children: Xe(e.type),
+                            }),
+                            He("span", {
+                              className: "v-kp-text",
+                              children: e.text,
+                            }),
+                          ],
+                        },
+                        n,
+                      ),
+                    ),
+                  }),
+                ],
+              })
+            : null,
+        tn = ({ content: e }) => {
+          const n = le(() => {
+            if (!e) return "";
+            const n = (function (e) {
+              const n = e.split("\n"),
+                t = [];
+              let r = !1,
+                s = !1;
+              for (let e = 0; e < n.length; e++) {
+                let i = n[e];
+                if (/^-{3,}$/.test(i.trim()) || /^\*{3,}$/.test(i.trim())) {
+                  (r && (t.push("</ul>"), (r = !1)),
+                    s && (t.push("</ol>"), (s = !1)),
+                    t.push('<hr class="ds-md-hr">'));
+                  continue;
+                }
+                const o = i.match(/^(#{1,4})\s+(.+)$/);
+                if (o) {
+                  (r && (t.push("</ul>"), (r = !1)),
+                    s && (t.push("</ol>"), (s = !1)));
+                  const e = o[1].length,
+                    n = o[2],
+                    i = e <= 2 ? Ve(n) : "",
+                    a = qe(n),
+                    l = i ? `${i}&nbsp;&nbsp;` : "";
+                  t.push(`<h${e} class="ds-md-h${e}">${l}${a}</h${e}>`);
+                  continue;
+                }
+                if (i.startsWith("&gt; ") || "&gt;" === i) {
+                  (r && (t.push("</ul>"), (r = !1)),
+                    s && (t.push("</ol>"), (s = !1)));
+                  const e = qe(i.replace(/^&gt;\s?/, ""));
+                  t.push(
+                    `<blockquote class="ds-md-blockquote">${e}</blockquote>`,
+                  );
+                  continue;
+                }
+                const a = i.match(/^(\s*)[-*]\s+(.+)$/);
+                if (a) {
+                  (s && (t.push("</ol>"), (s = !1)),
+                    r || (t.push('<ul class="ds-md-ul">'), (r = !0)),
+                    t.push(`<li>${qe(a[2])}</li>`));
+                  continue;
+                }
+                const l = i.match(/^(\s*)\d+\.\s+(.+)$/);
+                l
+                  ? (r && (t.push("</ul>"), (r = !1)),
+                    s || (t.push('<ol class="ds-md-ol">'), (s = !0)),
+                    t.push(`<li>${qe(l[2])}</li>`))
+                  : (r && (t.push("</ul>"), (r = !1)),
+                    s && (t.push("</ol>"), (s = !1)),
+                    "" !== i.trim()
+                      ? t.push(`<p class="ds-md-p">${qe(i)}</p>`)
+                      : t.push('<div class="ds-md-spacer"></div>'));
+              }
+              return (r && t.push("</ul>"), s && t.push("</ol>"), t.join("\n"));
+            })(
+              (function (e) {
+                const n = document.createElement("div");
+                return ((n.textContent = e), n.innerHTML);
+              })(e),
+            );
+            return (function (e) {
+              return e.replace(
+                /\[((?:\d{1,2}:){1,2}\d{2})\]/g,
+                (e, n) =>
+                  `<span class="v-timestamp" data-ts="${n}" role="button" tabindex="0">${n}</span>`,
+              );
+            })(n);
+          }, [e]);
+          return n
+            ? He("section", {
+                className: "v-section",
+                children: [
+                  He("h2", {
+                    className: "v-section-title",
+                    children: "Analyse détaillée",
+                  }),
+                  He("div", {
+                    className: "v-markdown",
+                    dangerouslySetInnerHTML: { __html: n },
+                  }),
+                ],
+              })
+            : null;
+        },
+        rn = ({ facts: e }) =>
+          e && 0 !== e.length
+            ? He("section", {
+                className: "v-section",
+                children: [
+                  He("h2", {
+                    className: "v-section-title",
+                    children: "Faits à vérifier",
+                  }),
+                  He("div", {
+                    className: "v-facts",
+                    children: e.map((e, n) =>
+                      He(
+                        "div",
+                        {
+                          className: "v-fact",
+                          children: [
+                            He("span", {
+                              className: "v-fact-icon",
+                              "aria-hidden": "true",
+                              children: "🔍",
+                            }),
+                            He("span", {
+                              className: "v-fact-text",
+                              children: e,
+                            }),
+                          ],
+                        },
+                        n,
+                      ),
+                    ),
+                  }),
+                ],
+              })
+            : null,
+        sn = "https://www.deepsightsynthesis.com",
+        on = ({ summary: e, summaryId: n }) => {
+          const [t, r] = ae(null),
+            s = (function (e) {
+              if (!e) return null;
+              const n = e.match(/[?&]v=([^&]+)/);
+              if (n) return n[1];
+              const t = e.match(/youtu\.be\/([^?&]+)/);
+              if (t) return t[1];
+              const r = e.match(/tiktok\.com\/[^/]+\/video\/(\d+)/);
+              return r ? r[1] : null;
+            })(e.video_url),
+            i = _e(async () => {
+              let e = `${sn}/summary/${n}`;
+              if (s)
+                try {
+                  const n = await je.runtime.sendMessage({
+                    action: "SHARE_ANALYSIS",
+                    data: { videoId: s },
+                  });
+                  n?.success && n.share_url && (e = n.share_url);
+                } catch {}
+              try {
+                (await navigator.clipboard.writeText(e), r("Lien copié !"));
+              } catch {
+                r("Erreur de copie");
+              }
+              setTimeout(() => r(null), 2200);
+            }, [s, n]),
+            o = _e(() => {
+              je.tabs.create({ url: `${sn}/summary/${n}` });
+            }, [n]),
+            a = _e(() => {
+              je.tabs.create({ url: "https://www.youtube.com" });
+            }, []);
+          return He("div", {
+            className: "v-actions",
+            role: "toolbar",
+            "aria-label": "Actions",
+            children: [
+              He("button", {
+                type: "button",
+                className: "v-btn v-btn-primary",
+                onClick: i,
+                children: [
+                  He("span", { "aria-hidden": "true", children: "🔗" }),
+                  He("span", { children: t ?? "Partager cette analyse" }),
+                ],
+              }),
+              He("button", {
+                type: "button",
+                className: "v-btn v-btn-secondary",
+                onClick: o,
+                children: [
+                  He("span", { "aria-hidden": "true", children: "🌐" }),
+                  He("span", { children: "Ouvrir sur DeepSight Web" }),
+                ],
+              }),
+              He("button", {
+                type: "button",
+                className: "v-btn v-btn-secondary",
+                onClick: a,
+                children: [
+                  He("span", { "aria-hidden": "true", children: "🎬" }),
+                  He("span", { children: "Analyser une autre vidéo" }),
+                ],
+              }),
+            ],
+          });
+        },
+        an = ({ summaryId: e }) => {
+          const [n, t] = ae(null),
+            [r, s] = ae(!0),
+            [i, o] = ae(null);
+          if (
+            ((function (e, n) {
+              var t = oe(Z++, 3);
+              !X.__s &&
+                de(t.__H, n) &&
+                ((t.__ = e), (t.u = n), K.__H.__h.push(t));
+            })(() => {
+              if (!e) return (o("ID d'analyse manquant"), void s(!1));
+              let n = !1;
+              return (
+                je.runtime
+                  .sendMessage({
+                    action: "GET_SUMMARY",
+                    data: { summaryId: e },
+                  })
+                  .then((e) => {
+                    if (n) return;
+                    const r = e;
+                    r?.success && r.summary
+                      ? t(r.summary)
+                      : o(r?.error || "Analyse introuvable");
+                  })
+                  .catch((e) => {
+                    n || o(e.message);
+                  })
+                  .finally(() => {
+                    n || s(!1);
+                  }),
+                () => {
+                  n = !0;
+                }
+              );
+            }, [e]),
+            r)
+          )
+            return He("div", {
+              className: "viewer-loading",
+              children: [
+                He("div", {
+                  className: "viewer-spinner",
+                  "aria-hidden": "true",
+                }),
+                He("p", { children: "Chargement de l'analyse…" }),
+              ],
+            });
+          if (i || !n)
+            return He("div", {
+              className: "viewer-error",
+              children: [
+                He("h1", { children: "Analyse introuvable" }),
+                He("p", { children: i ?? "Aucune donnée retournée." }),
+                He("button", {
+                  type: "button",
+                  className: "v-btn v-btn-primary",
+                  onClick: () => window.close(),
+                  children: "Fermer",
+                }),
+              ],
+            });
+          const a = (function (e) {
+            const n = (function (e) {
+                const n = [
+                  /#+\s*(?:Conclusion|Verdict|Synthèse|Résumé|Summary|En résumé|Final Assessment|Overall Assessment)[^\n]*\n([\s\S]*?)(?=\n#|\n---|\n\*{3,}|$)/i,
+                  /\*\*(?:Conclusion|Verdict|Synthèse|En résumé|Summary)\*\*[:\s]*([\s\S]*?)(?=\n\n|\n#|\n---|\n\*{3,}|$)/i,
+                ];
+                for (const t of n) {
+                  const n = e.match(t);
+                  if (n && n[1]) {
+                    const e = ze(n[1]).trim();
+                    if (e.length > 20) return Ze(e, 200);
+                  }
+                }
+                const t = e.split(/\n\n+/).filter((e) => {
+                  const n = e.trim();
+                  return (
+                    n.length > 30 &&
+                    !n.startsWith("#") &&
+                    !n.startsWith("-") &&
+                    !n.startsWith("*")
+                  );
+                });
+                return t.length > 0
+                  ? Ze(ze(t[t.length - 1]), 200)
+                  : "Analysis complete. See detailed view for full results.";
+              })(e),
+              t = (function (e) {
+                const n = [],
+                  t = e.split("\n"),
+                  r = [/\b(?:SOLIDE|SOLID)\b/i, /\u2705\s*\*\*/, /\u2705/],
+                  s = [
+                    /\b(?:A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK|INCERTAIN|UNCERTAIN)\b/i,
+                    /\u26A0\uFE0F\s*\*\*/,
+                    /\u2753/,
+                    /\u26A0/,
+                  ],
+                  i = [/\b(?:PLAUSIBLE)\b/i, /\uD83D\uDCA1/];
+                for (const e of t) {
+                  const t = e.replace(/^[\s\-*]+/, "").trim();
+                  if (t.length < 10) continue;
+                  let o = null;
+                  if (
+                    (r.some((n) => n.test(e))
+                      ? (o = "solid")
+                      : s.some((n) => n.test(e))
+                        ? (o = "weak")
+                        : i.some((n) => n.test(e)) && (o = "insight"),
+                    o && n.filter((e) => e.type === o).length < 2)
+                  ) {
+                    const e = ze(t)
+                      .replace(
+                        /\b(?:SOLIDE|SOLID|PLAUSIBLE|INCERTAIN|UNCERTAIN|A VERIFIER|TO VERIFY|QUESTIONABLE|WEAK)\b\s*[:—\-–]?\s*/gi,
+                        "",
+                      )
+                      .replace(/^[✅⚠️❓💡🔍🔬]\s*/u, "")
+                      .trim();
+                    e.length > 10 && n.push({ type: o, text: Ze(e, 120) });
+                  }
+                  if (n.length >= 4) break;
+                }
+                if (n.length < 2) {
+                  const t =
+                    /#+\s*(?:Points?\s+(?:forts?|clés?|faibles?)|Key\s+(?:Points?|Findings?|Takeaways?)|Strengths?|Weaknesses?|Main\s+Points?)[^\n]*\n([\s\S]*?)(?=\n#|$)/gi;
+                  let r;
+                  for (; null !== (r = t.exec(e)) && n.length < 4; ) {
+                    const e = r[1].match(/^[\s]*[-*]\s+(.+)$/gm);
+                    if (e)
+                      for (const t of e.slice(0, 4 - n.length)) {
+                        const e = ze(t.replace(/^[\s]*[-*]\s+/, ""));
+                        e.length > 10 &&
+                          !n.some((n) => n.text === Ze(e, 120)) &&
+                          n.push({ type: "insight", text: Ze(e, 120) });
+                      }
+                  }
+                }
+                return n.slice(0, 4);
+              })(e),
+              r = (function (e) {
+                const n = [],
+                  t = e.match(
+                    /#+\s*(?:Tags?|Thèmes?|Themes?|Topics?|Catégories?|Categories?)[^\n]*\n([\s\S]*?)(?=\n#|$)/i,
+                  );
+                if (t) {
+                  const e = t[1].match(/[-*]\s+(.+)/g);
+                  if (e)
+                    for (const t of e.slice(0, 3)) {
+                      const e = ze(t.replace(/^[-*]\s+/, "")).trim();
+                      e.length > 0 && e.length < 30 && n.push(e);
+                    }
+                }
+                if (0 === n.length) {
+                  const t = e.match(/^#{2,3}\s+(.+)$/gm);
+                  if (t) {
+                    const e =
+                      /^(?:Conclusion|Summary|Résumé|Synthèse|Introduction|Verdict|Analysis|Points?\s+(?:clés?|forts?|faibles?)|Key\s+(?:Points?|Findings?)|Strengths?|Weaknesses?|Overview)/i;
+                    for (const r of t) {
+                      const t = ze(r.replace(/^#{2,3}\s+/, "")).trim();
+                      if (
+                        t.length > 2 &&
+                        t.length < 35 &&
+                        !e.test(t) &&
+                        (n.push(t), n.length >= 3)
+                      )
+                        break;
+                    }
+                  }
+                }
+                return n.slice(0, 3);
+              })(e);
+            return { verdict: n, keyPoints: t, tags: r };
+          })(n.summary_content);
+          return He("div", {
+            className: "viewer-container",
+            children: [
+              He(Ge, { summary: n }),
+              He(Je, { verdict: a.verdict }),
+              He(nn, { points: a.keyPoints }),
+              He(rn, { facts: n.facts_to_verify ?? [] }),
+              He(tn, { content: n.summary_content }),
+              He(on, { summary: n, summaryId: n.id }),
+            ],
+          });
+        },
+        ln = new URLSearchParams(window.location.search),
+        _n = parseInt(ln.get("id") || "0", 10),
+        cn = document.getElementById("viewer-root");
+      var un;
+      cn &&
+        ((un = cn),
+        {
+          render: function (e) {
+            !(function (e, n, t) {
+              (null == n.__k && (n.textContent = ""),
+                z(e, n),
+                "function" == typeof t && t(),
+                e && e.__c);
+            })(e, un);
+          },
+          unmount: function () {
+            !(function (e) {
+              e.__k && z(null, e);
+            })(un);
+          },
+        }).render(He(an, { summaryId: _n }));
+    })());
+})();

--- a/extension/dist/widget.css
+++ b/extension/dist/widget.css
@@ -7,14 +7,35 @@
 /* Tokens loaded inline since Shadow DOM isolates from page CSS */
 
 /* ══════════════════════════════════════════
+   NUCLEAR FIX-WHITE-WIDGET — Always dark, no var() dependency
+   These rules MUST come first and use literal values so the widget
+   is dark even if CSS variables, theme detection, or `.light` class
+   ever leak through. Solid #0a0a0f beats any backdrop-filter weirdness.
+══════════════════════════════════════════ */
+
+:host {
+  color-scheme: dark !important;
+  background-color: #0a0a0f !important;
+}
+
+#deepsight-card,
+#deepsight-card.ds-widget,
+#deepsight-card.ds-widget.dark,
+#deepsight-card.ds-widget.light {
+  background-color: #0a0a0f !important;
+  background-image: none !important;
+  color: #f5f0e8 !important;
+}
+
+/* ══════════════════════════════════════════
    WIDGET CONTAINER — PREMIUM GLASSMORPHISM
 ══════════════════════════════════════════ */
 
 #deepsight-card.ds-widget {
   all: initial;
-  /* FIX-WHITE-WIDGET: hardcoded background + color so the widget renders
-     correctly even if CSS custom properties fail to resolve in the
-     closed Shadow DOM context. var() fallbacks are kept for theming. */
+  /* FIX-WHITE-WIDGET: solid hex background — NO var(), NO rgba alpha,
+     NO glass-bg. backdrop-filter could make a 0.85 alpha look near-white
+     on a light page. Solid #0a0a0f is always dark. */
   font-family: var(
     --ds-font-family,
     -apple-system,
@@ -24,12 +45,11 @@
     sans-serif
   ) !important;
   font-size: var(--ds-text-sm, 13px) !important;
-  color: var(--ds-text-primary, #f5f0e8) !important;
-  background: var(--ds-glass-bg, rgba(10, 10, 15, 0.95)) !important;
+  color: #f5f0e8 !important;
+  background-color: #0a0a0f !important;
+  background-image: none !important;
   border: 1px solid rgba(200, 144, 58, 0.15) !important;
   border-radius: var(--ds-radius-card, 14px) !important;
-  backdrop-filter: blur(24px) saturate(150%) !important;
-  -webkit-backdrop-filter: blur(24px) saturate(150%) !important;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
     0 0 20px rgba(200, 144, 58, 0.05) !important;
@@ -48,20 +68,16 @@
   font-family: var(--ds-font-family) !important;
 }
 
-/* FIX-WHITE-WIDGET: `.light` class neutralized — produces same dark output
-   as default to prevent unreadable white-text-on-white widget. */
+/* FIX-WHITE-WIDGET: `.light` class fully neutralized — identical to default
+   dark rendering. Solid hex, no var(). */
 #deepsight-card.ds-widget.light {
-  background: var(--ds-glass-bg) !important;
-  border-color: rgba(200, 144, 58, 0.06) !important;
-  color: var(--ds-text-primary) !important;
+  background-color: #0a0a0f !important;
+  background-image: none !important;
+  border-color: rgba(200, 144, 58, 0.15) !important;
+  color: #f5f0e8 !important;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
     0 0 20px rgba(200, 144, 58, 0.05) !important;
-}
-
-/* Hard fallback on host element. */
-:host {
-  color-scheme: dark;
 }
 
 /* ══════════════════════════════════════════

--- a/extension/src/content/widget.ts
+++ b/extension/src/content/widget.ts
@@ -37,12 +37,14 @@ export function createWidgetShell(
     return null;
   }
   host.id = HOST_ID;
+  // FIX-WHITE-WIDGET: solid bg + color-scheme on host as last-resort backup
+  // in case the inlined widget.css ever fails to apply. Solid #0a0a0f.
   host.style.cssText =
-    "all:initial;display:block;width:100%;max-width:420px;margin-bottom:12px;";
+    "all:initial;display:block;width:100%;max-width:420px;margin-bottom:12px;background-color:#0a0a0f;color-scheme:dark;";
 
   if (isTikTok) {
     host.style.cssText =
-      "all:initial;position:fixed;bottom:20px;right:20px;width:360px;max-height:80vh;z-index:2147483646;";
+      "all:initial;position:fixed;bottom:20px;right:20px;width:360px;max-height:80vh;z-index:2147483646;background-color:#0a0a0f;color-scheme:dark;";
   }
 
   // Attach closed shadow root — wrapped in try/catch as another extension
@@ -72,10 +74,15 @@ export function createWidgetShell(
   // FIX-WHITE-WIDGET: force dark — Shadow DOM isolates from page theme.
   void theme;
   el.className = `ds-widget deepsight-card dark`;
+  // FIX-WHITE-WIDGET: inline style backup. Inline styles beat any external
+  // CSS without !important. Combined with widget.css `!important` rules,
+  // this guarantees dark rendering even if the stylesheet ever fails to load.
+  el.style.backgroundColor = "#0a0a0f";
+  el.style.color = "#f5f0e8";
   if (isTikTok) {
     el.classList.add("deepsight-card-floating");
     el.style.cssText =
-      "overflow-y:auto;box-shadow:0 8px 32px rgba(0,0,0,0.5);border-radius:12px;";
+      "overflow-y:auto;box-shadow:0 8px 32px rgba(0,0,0,0.5);border-radius:12px;background-color:#0a0a0f;color:#f5f0e8;";
   }
   shadow.appendChild(el);
 

--- a/extension/src/styles/widget.css
+++ b/extension/src/styles/widget.css
@@ -7,14 +7,35 @@
 /* Tokens loaded inline since Shadow DOM isolates from page CSS */
 
 /* ══════════════════════════════════════════
+   NUCLEAR FIX-WHITE-WIDGET — Always dark, no var() dependency
+   These rules MUST come first and use literal values so the widget
+   is dark even if CSS variables, theme detection, or `.light` class
+   ever leak through. Solid #0a0a0f beats any backdrop-filter weirdness.
+══════════════════════════════════════════ */
+
+:host {
+  color-scheme: dark !important;
+  background-color: #0a0a0f !important;
+}
+
+#deepsight-card,
+#deepsight-card.ds-widget,
+#deepsight-card.ds-widget.dark,
+#deepsight-card.ds-widget.light {
+  background-color: #0a0a0f !important;
+  background-image: none !important;
+  color: #f5f0e8 !important;
+}
+
+/* ══════════════════════════════════════════
    WIDGET CONTAINER — PREMIUM GLASSMORPHISM
 ══════════════════════════════════════════ */
 
 #deepsight-card.ds-widget {
   all: initial;
-  /* FIX-WHITE-WIDGET: hardcoded background + color so the widget renders
-     correctly even if CSS custom properties fail to resolve in the
-     closed Shadow DOM context. var() fallbacks are kept for theming. */
+  /* FIX-WHITE-WIDGET: solid hex background — NO var(), NO rgba alpha,
+     NO glass-bg. backdrop-filter could make a 0.85 alpha look near-white
+     on a light page. Solid #0a0a0f is always dark. */
   font-family: var(
     --ds-font-family,
     -apple-system,
@@ -24,12 +45,11 @@
     sans-serif
   ) !important;
   font-size: var(--ds-text-sm, 13px) !important;
-  color: var(--ds-text-primary, #f5f0e8) !important;
-  background: var(--ds-glass-bg, rgba(10, 10, 15, 0.95)) !important;
+  color: #f5f0e8 !important;
+  background-color: #0a0a0f !important;
+  background-image: none !important;
   border: 1px solid rgba(200, 144, 58, 0.15) !important;
   border-radius: var(--ds-radius-card, 14px) !important;
-  backdrop-filter: blur(24px) saturate(150%) !important;
-  -webkit-backdrop-filter: blur(24px) saturate(150%) !important;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
     0 0 20px rgba(200, 144, 58, 0.05) !important;
@@ -48,20 +68,16 @@
   font-family: var(--ds-font-family) !important;
 }
 
-/* FIX-WHITE-WIDGET: `.light` class neutralized — produces same dark output
-   as default to prevent unreadable white-text-on-white widget. */
+/* FIX-WHITE-WIDGET: `.light` class fully neutralized — identical to default
+   dark rendering. Solid hex, no var(). */
 #deepsight-card.ds-widget.light {
-  background: var(--ds-glass-bg) !important;
-  border-color: rgba(200, 144, 58, 0.06) !important;
-  color: var(--ds-text-primary) !important;
+  background-color: #0a0a0f !important;
+  background-image: none !important;
+  border-color: rgba(200, 144, 58, 0.15) !important;
+  color: #f5f0e8 !important;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
     0 0 20px rgba(200, 144, 58, 0.05) !important;
-}
-
-/* Hard fallback on host element. */
-:host {
-  color-scheme: dark;
 }
 
 /* ══════════════════════════════════════════


### PR DESCRIPTION
## Summary

Restoration of the nuclear widget fix that was sitting in the working tree (and caught in stash@{0} of the parent worktree during parallel agent operations on backend share assets). Without this fix, the Shadow DOM widget renders near-white on YouTube under specific conditions (logged-out users, page loading, light backdrop frames).

## What changed

- ``extension/src/styles/widget.css`` — \`:host\` + \`#deepsight-card.ds-widget{,.dark,.light}\` hardcoded \`#0a0a0f\`, no \`var()\`, no rgba alpha. \`backdrop-filter\` removed from main rule (translucency root cause).
- ``extension/src/content/widget.ts`` — inline JS styles on host + card element (defense in depth, beats CSS specificity issues in closed Shadow DOM).
- ``extension/dist/*`` — webpack rebuild (popup.js, viewer.js, content.js, background.js, authSync*.js, widget.css) consistent with sources.

## Why this is in a PR not a direct commit

The fix was lost during a chain of parallel agent work (PR #114 share assets, PR #115 Dockerfile fix). It was captured in a WIP stash by the share-assets agent. Restoring it via PR rather than direct push gives reviewer visibility on the 11k+ rebuild diff.

## Verification

- \`grep -c 0a0a0f extension/src/styles/widget.css\` → 6
- \`grep -c 0a0a0f extension/dist/widget.css\` → 6
- \`grep -c 0a0a0f extension/src/content/widget.ts\` → 5
- Total ≥ 7 hardcoded occurrences (memory threshold for nuclear fix integrity).

## Test plan

- [ ] Reload extension in chrome://extensions
- [ ] Open youtube.com (logged-out and logged-in)
- [ ] Trigger DeepSight widget overlay
- [ ] Confirm widget background is solid \`#0a0a0f\` (no whiteness, no translucency)
- [ ] Test on TikTok variant
- [ ] Test in fullscreen video pause on a frame with a bright backdrop

## Reference

Reproduces the fix described in memory \`project_extension-shadow-dom-white-widget-fix.md\` (2026-04-25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)