### PR TITLE
test(mobile): align api.test.ts with PKCE id_token contract

### DIFF
--- a/mobile/__tests__/services/api.test.ts
+++ b/mobile/__tests__/services/api.test.ts
@@ -308,15 +308,20 @@ describe("API Client", () => {
       };
       mockFetchResponse(response);
 
-      const result = await authApi.googleTokenLogin("google-access-token");
+      const result = await authApi.googleTokenLogin("google-id-token");
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/api/auth/google/token"),
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ access_token: "google-access-token" }),
+          body: expect.stringContaining('"id_token":"google-id-token"'),
         }),
       );
+      const callBody = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body,
+      );
+      expect(callBody.id_token).toBe("google-id-token");
+      expect(["ios", "android"]).toContain(callBody.client_platform);
       expect(result.user.email).toBe("google@test.com");
       expect(tokenStorage.setTokens).toHaveBeenCalledWith(
         "session-token",


### PR DESCRIPTION
## Summary

Aligns the mobile Jest test `mobile/__tests__/services/api.test.ts` with the actual PKCE Google Sign-In contract used by `googleTokenLogin` in `mobile/src/services/api.ts:327-338` — which sends `id_token` (Google JWT), not `access_token`.

## Changes

- Updates `googleTokenLogin` test (around L317-325 of api.test.ts):
  - Body assertion: \`access_token: "google-access-token"\` → \`id_token: "google-id-token"\`
  - Adds verification that \`callBody.client_platform\` is one of \`["ios", "android"]\`
- 7 insertions, 2 deletions (1 file)

## Why a PR

This commit was originally produced by the F4 mobile-PKCE agent on \`fix/mobile-pkce-finalization\`. It got tangled with an obsolete \`logo Mistral\` commit during rebase; cherry-picked cleanly into a fresh branch on top of latest \`main\`.

## Test plan

- [ ] CI: \`mobile/\` Jest suite passes (\`cd mobile && npm test -- api.test.ts\`)
- [ ] Verify \`googleTokenLogin\` integration still works end-to-end via EAS preview build (Google Sign-In flow on iOS + Android)

🤖 Generated with [Claude Code](https://claude.com/claude-code)