### PR TITLE
docs(claude): fix Export PDF mobile column in features table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -790,7 +790,7 @@ export const GOOGLE_IOS_CLIENT_ID = "ios-client-id";
 | Quiz            | ✅        | ✅     | ❌ CTA         |
 | Mind Maps       | ✅        | ❌ CTA | ❌ CTA         |
 | Playlists       | ✅        | ❌ CTA | ❌ CTA         |
-| Export PDF      | ✅ Pro    | ❌ CTA | ❌ CTA         |
+| Export PDF      | ✅ Pro    | ✅ Pro | ❌ CTA         |
 | Web Search      | ✅ Pro+   | ❌ CTA | ❌ CTA         |
 | Academic Search | ✅        | ✅     | ❌             |
 | Tournesol       | ✅        | ✅     | ❌             |


### PR DESCRIPTION
## Summary

Fixes a stale row in the cross-platform features table at \`CLAUDE.md:793\`. Export PDF mobile was marked \`❌ CTA\` but is in fact implemented and gated to plus/pro tiers via \`is_feature_available\`-style flags.

Discovered during the cross-platform feature parity audit (PR #119, finding #2 — quick win).

## Evidence in code

- \`mobile/src/config/planPrivileges.ts:140\` — \`exportPdf: boolean\` type
- \`mobile/src/config/planPrivileges.ts:211, :246\` — \`exportPdf: true\` for plus and pro tiers
- \`mobile/src/config/planPrivileges.ts:799\` — UI button labelled \"Export PDF\"
- \`mobile/src/contexts/PlanContext.tsx:57\` — \`if (f.exportPdf) formats.push('pdf')\`
- \`mobile/app/(tabs)/subscription.tsx:117\` — listed in Pro plan features
- \`mobile/src/i18n/fr.json:467\` — \`pdfExport\` i18n key

## Audit note

The audit also flagged Tournesol and Academic Search mobile as misreported, but the table already shows them as ✅ — only Export PDF needed fixing.

## Test plan

- [ ] Visual review of the markdown table — column alignment preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)