### PR TITLE
feat(voice): Spec #0 — fix web_search prompts + Redis cache + tracking

### DIFF
--- a/backend/src/voice/agent_types.py
+++ b/backend/src/voice/agent_types.py
@@ -102,7 +102,21 @@ Ton style :
 - Ton amical et pédagogique
 - Si tu ne trouves pas l'info, dis-le honnêtement
 
-Tu as accès à l'analyse complète, au transcript, aux sources et aux flashcards.""",
+Tu as accès à l'analyse complète, au transcript, aux sources et aux flashcards.
+
+## Tools available
+
+Tu disposes en plus d'outils de recherche web. Sers-t'en SYSTÉMATIQUEMENT \
+quand la question dépasse l'analyse vidéo (actualité, définition, fait extérieur, vérification).
+
+- web_search(query, num_results=5) : recherche web via Brave Search.
+  À utiliser SYSTÉMATIQUEMENT quand l'utilisateur pose une question
+  factuelle non couverte par le transcript ou l'analyse de la vidéo.
+  Annonce "Je vais chercher sur le web" avant l'appel pour gérer la latence.
+- deep_research(query, num_queries=3) : recherche multi-requêtes pour synthèse.
+- check_fact(claim) : vérification d'affirmation factuelle.
+
+Refuse-toi à répondre "je n'ai pas accès au web" : tu en as l'accès.""",
     system_prompt_en="""\
 You are the DeepSight voice assistant. You help the user understand \
 and explore a YouTube video analysis.
@@ -118,7 +132,23 @@ Your style:
 - Friendly and educational tone
 - If you can't find the info, say so honestly
 
-You have access to the full analysis, transcript, sources, and flashcards.""",
+You have access to the full analysis, transcript, sources, and flashcards.
+
+## Tools available
+
+You also have web search tools. Use them SYSTEMATICALLY whenever the question \
+goes beyond the video analysis (current events, definitions, external facts, verification).
+
+- web_search(query, num_results=5): web search via Brave Search.
+  Use it SYSTEMATICALLY when the user asks a factual question not covered
+  by the video transcript or analysis.
+  Announce "Let me search the web" before calling it to mask latency.
+- deep_research(query, num_queries=3): multi-query deep research for synthesis.
+  Use it for broad topics needing several angles.
+- check_fact(claim): factual claim verification.
+  Use it when the user disputes a statement or asks "is this true?".
+
+Never refuse with "I don't have web access" — you do.""",
     tools=[
         "search_in_transcript",
         "get_analysis_section",

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -74,10 +74,35 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Rate limiting: in-memory fallback when Redis is unavailable
+# Rate limiting (Spec #0): per-summary AND per-user caps with Redis INCR + TTL.
+# In-memory dicts are used when Redis is unavailable.
 _web_search_counts: dict[str, int] = {}
-_WEB_SEARCH_MAX = 5
+_user_web_search_counts: dict[int, int] = {}
+_WEB_SEARCH_MAX = 15  # per summary_id per hour (raised from 5 in Spec #0)
+_WEB_SEARCH_USER_MAX = 60  # per user_id per hour (Spec #0 global cap)
 _WEB_SEARCH_TTL = 3600  # 1 hour
+
+
+async def _redis_incr_with_ttl(redis_key: str, ttl: int) -> int | None:
+    """Run an INCR + EXPIRE pair on the shared Redis backend.
+
+    Returns the post-increment count or ``None`` if Redis is unavailable
+    (callers should fall back to their in-memory dict).
+    """
+    try:
+        from core.cache import cache_service
+
+        if not cache_service._redis_available:
+            return None
+        redis_client = cache_service.backend.redis
+        full_key = f"deepsight:{redis_key}"
+        count = await redis_client.incr(full_key)
+        if count == 1:
+            await redis_client.expire(full_key, ttl)
+        return count
+    except Exception as exc:
+        logger.warning("Redis INCR failed for %s, falling back to in-memory: %s", redis_key, exc)
+        return None
 
 
 async def _increment_web_search_count(summary_id: str) -> int:
@@ -86,25 +111,67 @@ async def _increment_web_search_count(summary_id: str) -> int:
     Uses Redis INCR with TTL when available, falls back to the in-memory dict.
     Returns the count *after* incrementing.
     """
-    redis_key = f"voice:websearch:{summary_id}"
-
-    try:
-        from core.cache import cache_service
-
-        if cache_service._redis_available:
-            redis_client = cache_service.backend.redis
-            full_key = f"deepsight:{redis_key}"
-            count = await redis_client.incr(full_key)
-            if count == 1:
-                await redis_client.expire(full_key, _WEB_SEARCH_TTL)
-            return count
-    except Exception as exc:
-        logger.warning("Redis INCR failed for %s, falling back to in-memory: %s", redis_key, exc)
+    count = await _redis_incr_with_ttl(f"voice:websearch:{summary_id}", _WEB_SEARCH_TTL)
+    if count is not None:
+        return count
 
     # In-memory fallback
     current = _web_search_counts.get(summary_id, 0) + 1
     _web_search_counts[summary_id] = current
     return current
+
+
+async def _increment_user_web_search_count(user_id: int) -> int:
+    """Increment and return the per-user web search count.
+
+    Independent of summary_id so a user can't fan out across many videos.
+    """
+    count = await _redis_incr_with_ttl(f"voice:websearch:user:{user_id}", _WEB_SEARCH_TTL)
+    if count is not None:
+        return count
+
+    current = _user_web_search_counts.get(user_id, 0) + 1
+    _user_web_search_counts[user_id] = current
+    return current
+
+
+async def record_web_search_usage(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    summary_id: int,
+    source: str,
+    query: str,
+) -> None:
+    """Track a successful web_search invocation in WebSearchUsage.
+
+    Mirrors the chat router pattern (see videos/service.py:increment_web_search_usage)
+    and adds a structured log line so we can attribute calls to voice vs chat.
+    """
+    from videos.service import increment_web_search_usage
+
+    try:
+        await increment_web_search_usage(db, user_id)
+    except Exception as exc:
+        logger.warning(
+            "record_web_search_usage failed",
+            extra={
+                "user_id": user_id,
+                "summary_id": summary_id,
+                "source": source,
+                "error": str(exc),
+            },
+        )
+
+    logger.info(
+        "web_search_usage_recorded",
+        extra={
+            "user_id": user_id,
+            "summary_id": summary_id,
+            "source": source,
+            "query": query[:200],
+        },
+    )
 
 
 async def verify_tool_request(request: Request, db: AsyncSession) -> tuple[Summary, dict]:
@@ -1353,20 +1420,45 @@ async def tool_flashcards(request: Request, db: AsyncSession = Depends(get_sessi
 
 @router.post("/tools/web-search")
 async def tool_web_search(request: Request, db: AsyncSession = Depends(get_session)):
-    """ElevenLabs tool webhook: web search via Brave."""
+    """ElevenLabs tool webhook: web search via Brave.
+
+    Rate-limited:
+      - 15 calls / hour / summary_id (anti spam at session level)
+      - 60 calls / hour / user_id    (global cap, anti fan-out)
+
+    Successful calls are tracked in WebSearchUsage (source='voice') so the
+    monthly quota and admin dashboards see them alongside chat searches.
+    """
     summary, body = await verify_tool_request(request, db)
     query = body.get("query") or body.get("parameters", {}).get("query", "")
 
-    # Rate limiting: max 5 web searches per summary_id (Redis with in-memory fallback)
-    key = str(summary.id)
-    count = await _increment_web_search_count(key)
-    if count > _WEB_SEARCH_MAX:
+    # Per-summary rate limit (Spec #0 — raised from 5 to 15)
+    summary_count = await _increment_web_search_count(str(summary.id))
+    if summary_count > _WEB_SEARCH_MAX:
         return {
             "result": "Limite de recherches web atteinte pour cette session. "
             "Utilisez les informations déjà disponibles."
         }
 
+    # Per-user global cap (Spec #0)
+    user_count = await _increment_user_web_search_count(int(summary.user_id))
+    if user_count > _WEB_SEARCH_USER_MAX:
+        return {
+            "result": "Limite horaire de recherches web atteinte pour ton compte. "
+            "Réessaie dans quelques minutes."
+        }
+
     result = await web_search(summary.id, query, db)
+
+    # Track usage for monthly quota + voice attribution
+    await record_web_search_usage(
+        db,
+        user_id=int(summary.user_id),
+        summary_id=int(summary.id),
+        source="voice",
+        query=query,
+    )
+
     return {"result": result}
 
 

--- a/backend/src/voice/web_tools.py
+++ b/backend/src/voice/web_tools.py
@@ -13,7 +13,7 @@ import logging
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import get_brave_key
-from videos.brave_search import _call_brave_api
+from voice.web_tools_cache import cached_brave_search
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ async def web_search(
         return "Aucune requête de recherche fournie."
 
     try:
-        result = await _call_brave_api(query.strip(), count=5)
+        result = await cached_brave_search(query.strip(), count=5)
 
         if not result.success or not result.sources:
             return f"Aucun résultat trouvé pour la recherche : {query}"
@@ -99,7 +99,7 @@ async def deep_research(
         ]
 
         results = await asyncio.gather(
-            *[_call_brave_api(qr, count=5) for qr in queries],
+            *[cached_brave_search(qr, count=5) for qr in queries],
             return_exceptions=True,
         )
 
@@ -152,7 +152,7 @@ async def check_fact(
 
     try:
         search_query = f"{claim.strip()} fact check verification"
-        result = await _call_brave_api(search_query, count=5)
+        result = await cached_brave_search(search_query, count=5)
 
         if not result.success or not result.sources:
             return f"Aucune source trouvée pour vérifier cette affirmation : {claim}"

--- a/backend/src/voice/web_tools_cache.py
+++ b/backend/src/voice/web_tools_cache.py
@@ -1,0 +1,103 @@
+"""
+Voice Web Tools Cache — Redis-backed wrapper around Brave Search.
+
+Spec #0 (express fix): every Brave call from the voice agent goes through this
+wrapper so identical queries within an hour reuse the previous payload.
+
+Cache key: brave:search:{sha1(query|count)}
+TTL: 3600s (1 hour)
+
+The `cache_service` is the project's unified Redis/in-memory backend. When
+Redis is unavailable the wrapper degrades silently to direct Brave calls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any
+
+from core.cache import cache_service
+from videos.brave_search import BraveSearchResult, _call_brave_api
+
+logger = logging.getLogger(__name__)
+
+_CACHE_TTL_SECONDS = 3600  # 1 hour, per spec L99
+
+
+def _make_cache_key(query: str, count: int) -> str:
+    """Derive the cache key for a Brave query.
+
+    Format mandated by spec #0 (L94): ``brave:search:{sha1(query|count)}``.
+    """
+    digest = hashlib.sha1(f"{query}|{count}".encode("utf-8")).hexdigest()
+    return f"brave:search:{digest}"
+
+
+def _result_to_dict(result: BraveSearchResult) -> dict[str, Any]:
+    """Serialize a BraveSearchResult to a JSON-friendly dict for Redis."""
+    return {
+        "success": result.success,
+        "snippets": result.snippets,
+        "sources": result.sources,
+        "query": result.query,
+        "error": result.error,
+    }
+
+
+def _result_from_dict(payload: dict[str, Any]) -> BraveSearchResult:
+    """Rehydrate a BraveSearchResult from a cached dict."""
+    return BraveSearchResult(
+        success=bool(payload.get("success", False)),
+        snippets=payload.get("snippets", "") or "",
+        sources=payload.get("sources", []) or [],
+        query=payload.get("query", "") or "",
+        error=payload.get("error"),
+    )
+
+
+async def cached_brave_search(query: str, count: int = 5) -> BraveSearchResult:
+    """Cache-aware Brave Search wrapper used by the voice agent tools.
+
+    Args:
+        query: Free-text search query.
+        count: Maximum number of results requested to Brave (default 5).
+
+    Returns:
+        BraveSearchResult — same shape as :func:`videos.brave_search._call_brave_api`.
+
+    Notes:
+        - Successful results are cached for 1 hour.
+        - Failed results are NEVER cached (avoid persisting transient errors).
+        - Cache backend errors are logged but never propagated.
+    """
+    if not query or not query.strip():
+        # Don't bother cache lookups for empty queries — let Brave handle it.
+        return await _call_brave_api(query, count=count)
+
+    key = _make_cache_key(query, count)
+
+    try:
+        cached = await cache_service.get(key)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("cached_brave_search GET failed: %s", exc)
+        cached = None
+
+    if cached is not None:
+        try:
+            return _result_from_dict(cached)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("cached_brave_search payload corrupted: %s", exc)
+
+    result = await _call_brave_api(query, count=count)
+
+    if result.success:
+        try:
+            await cache_service.set(key, _result_to_dict(result), ttl=_CACHE_TTL_SECONDS)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("cached_brave_search SET failed: %s", exc)
+
+    return result
+
+
+__all__ = ["cached_brave_search"]

--- a/backend/tests/voice/test_web_tools_cache.py
+++ b/backend/tests/voice/test_web_tools_cache.py
@@ -1,0 +1,375 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 VOICE WEB TOOLS CACHE — Tests for Spec #0 express fix                          ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+
+Coverage:
+  - cached_brave_search: cache hit, cache miss, key derivation
+  - voice/router.py:tool_web_search: Brave cache used, tracking incremented,
+    rate-limit triggered at 15th call per summary_id and at 60th per user_id
+"""
+
+import hashlib
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from videos.brave_search import BraveSearchResult
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _result(query: str = "ai 2026") -> BraveSearchResult:
+    """Build a successful BraveSearchResult fixture."""
+    return BraveSearchResult(
+        success=True,
+        snippets="• [Mistral AI](2025): Mistral lance un nouveau modèle.",
+        sources=[
+            {
+                "title": "Mistral AI",
+                "url": "https://mistral.ai/news",
+                "snippet": "Mistral lance un nouveau modèle.",
+                "age": "2025",
+            }
+        ],
+        query=query,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 cached_brave_search — Redis-backed cache wrapper
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCachedBraveSearch:
+    """Unit tests for voice.web_tools_cache.cached_brave_search."""
+
+    def test_cache_key_uses_sha1_of_query_and_count(self):
+        """Cache key must follow the spec: brave:search:{sha1(query|count)}."""
+        from voice.web_tools_cache import _make_cache_key
+
+        key = _make_cache_key("ai future", 5)
+        expected_hash = hashlib.sha1(b"ai future|5").hexdigest()
+        assert key == f"brave:search:{expected_hash}"
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_calls_brave_and_stores_result(self):
+        """On cache miss, _call_brave_api is invoked and the result is cached."""
+        from voice import web_tools_cache
+
+        result = _result("ai 2026")
+        cache_storage: dict = {}
+
+        async def fake_get(key):
+            return cache_storage.get(key)
+
+        async def fake_set(key, value, ttl=None):
+            cache_storage[key] = value
+            return True
+
+        mock_cache = MagicMock()
+        mock_cache.get = AsyncMock(side_effect=fake_get)
+        mock_cache.set = AsyncMock(side_effect=fake_set)
+
+        with patch.object(web_tools_cache, "cache_service", mock_cache), patch.object(
+            web_tools_cache, "_call_brave_api", AsyncMock(return_value=result)
+        ) as mock_brave:
+            out = await web_tools_cache.cached_brave_search("ai 2026", count=5)
+
+        assert out.success is True
+        assert out.sources[0]["url"] == "https://mistral.ai/news"
+        mock_brave.assert_awaited_once_with("ai 2026", count=5)
+        # Stored in cache with 3600s TTL
+        assert mock_cache.set.await_count == 1
+        _, kwargs = mock_cache.set.call_args
+        assert kwargs.get("ttl") == 3600 or mock_cache.set.call_args.args[2] == 3600
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_brave_api(self):
+        """On cache hit, _call_brave_api must not be called."""
+        from voice import web_tools_cache
+
+        cached_payload = {
+            "success": True,
+            "snippets": "cached",
+            "sources": [{"title": "C", "url": "https://c.example", "snippet": "c", "age": ""}],
+            "query": "ai 2026",
+            "error": None,
+        }
+        mock_cache = MagicMock()
+        mock_cache.get = AsyncMock(return_value=cached_payload)
+        mock_cache.set = AsyncMock(return_value=True)
+
+        with patch.object(web_tools_cache, "cache_service", mock_cache), patch.object(
+            web_tools_cache, "_call_brave_api", AsyncMock()
+        ) as mock_brave:
+            out = await web_tools_cache.cached_brave_search("ai 2026", count=5)
+
+        assert out.success is True
+        assert out.snippets == "cached"
+        mock_brave.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cache_skipped_on_failure(self):
+        """A failed Brave call must not poison the cache."""
+        from voice import web_tools_cache
+
+        bad = BraveSearchResult(success=False, snippets="", sources=[], query="x", error="boom")
+        mock_cache = MagicMock()
+        mock_cache.get = AsyncMock(return_value=None)
+        mock_cache.set = AsyncMock(return_value=True)
+
+        with patch.object(web_tools_cache, "cache_service", mock_cache), patch.object(
+            web_tools_cache, "_call_brave_api", AsyncMock(return_value=bad)
+        ):
+            out = await web_tools_cache.cached_brave_search("x", count=5)
+
+        assert out.success is False
+        mock_cache.set.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 voice.web_tools — wired through cached_brave_search
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWebToolsUseCache:
+    """voice.web_tools.{web_search,deep_research,check_fact} use the cache wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_web_search_uses_cached_brave(self):
+        from voice import web_tools
+
+        result = _result("aripiprazole")
+        with patch.object(web_tools, "get_brave_key", return_value="key"), patch.object(
+            web_tools, "cached_brave_search", AsyncMock(return_value=result)
+        ) as mock_cached:
+            db = AsyncMock()
+            out = await web_tools.web_search(42, "aripiprazole", db)
+
+        mock_cached.assert_awaited_once_with("aripiprazole", count=5)
+        assert "Mistral lance un nouveau modèle" in out
+
+    @pytest.mark.asyncio
+    async def test_deep_research_uses_cached_brave(self):
+        from voice import web_tools
+
+        result = _result("aripiprazole")
+        with patch.object(web_tools, "get_brave_key", return_value="key"), patch.object(
+            web_tools, "cached_brave_search", AsyncMock(return_value=result)
+        ) as mock_cached:
+            db = AsyncMock()
+            out = await web_tools.deep_research(42, "aripiprazole", db)
+
+        # 3 sub-queries
+        assert mock_cached.await_count == 3
+        assert "Recherche approfondie" in out
+
+    @pytest.mark.asyncio
+    async def test_check_fact_uses_cached_brave(self):
+        from voice import web_tools
+
+        result = _result("aripiprazole")
+        with patch.object(web_tools, "get_brave_key", return_value="key"), patch.object(
+            web_tools, "cached_brave_search", AsyncMock(return_value=result)
+        ) as mock_cached:
+            db = AsyncMock()
+            out = await web_tools.check_fact(42, "Aripiprazole soigne le TOC", db)
+
+        mock_cached.assert_awaited_once()
+        assert "Aripiprazole" in out
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Rate-limit & tracking on /tools/web-search
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWebSearchRateLimitAndTracking:
+    """tool_web_search rate-limits to 15/h per summary_id, 60/h per user_id, and tracks usage."""
+
+    @pytest.mark.asyncio
+    async def test_summary_rate_limit_is_15(self):
+        """The 16th call within an hour for the same summary_id must be blocked."""
+        from voice import router as voice_router
+
+        assert voice_router._WEB_SEARCH_MAX == 15
+
+    @pytest.mark.asyncio
+    async def test_user_rate_limit_is_60(self):
+        """The 61st call within an hour for the same user_id must be blocked."""
+        from voice import router as voice_router
+
+        assert voice_router._WEB_SEARCH_USER_MAX == 60
+
+    @pytest.mark.asyncio
+    async def test_summary_counter_blocks_at_16th_call(self):
+        """_increment_web_search_count(summary) returns count > 15 → blocked."""
+        from voice import router as voice_router
+
+        # In-memory fallback (Redis unavailable)
+        voice_router._web_search_counts.clear()
+        with patch("core.cache.cache_service") as mock_cache:
+            mock_cache._redis_available = False
+            counts = []
+            for _ in range(16):
+                c = await voice_router._increment_web_search_count("sumX")
+                counts.append(c)
+
+        assert counts[14] == 15  # 15th call OK
+        assert counts[15] == 16  # 16th call exceeds threshold
+
+    @pytest.mark.asyncio
+    async def test_user_counter_blocks_at_61st_call(self):
+        """_increment_user_web_search_count returns count > 60 → blocked."""
+        from voice import router as voice_router
+
+        voice_router._user_web_search_counts.clear()
+        with patch("core.cache.cache_service") as mock_cache:
+            mock_cache._redis_available = False
+            for _ in range(60):
+                await voice_router._increment_user_web_search_count(7)
+            count = await voice_router._increment_user_web_search_count(7)
+
+        assert count == 61
+
+    @pytest.mark.asyncio
+    async def test_tool_web_search_increments_tracking(self):
+        """tool_web_search must call increment_web_search_usage(user_id, summary_id, source='voice', query=...)."""
+        from fastapi import Request
+        from voice import router as voice_router
+
+        # Fake summary owned by user 7
+        summary = MagicMock()
+        summary.id = 99
+        summary.user_id = 7
+        body = {"summary_id": 99, "query": "aripiprazole"}
+
+        request = MagicMock(spec=Request)
+        db = AsyncMock()
+
+        voice_router._web_search_counts.clear()
+        voice_router._user_web_search_counts.clear()
+
+        with patch.object(
+            voice_router,
+            "verify_tool_request",
+            AsyncMock(return_value=(summary, body)),
+        ), patch.object(
+            voice_router,
+            "web_search",
+            AsyncMock(return_value="Résultats: ..."),
+        ), patch.object(
+            voice_router,
+            "record_web_search_usage",
+            AsyncMock(),
+        ) as mock_record, patch("core.cache.cache_service") as mock_cache:
+            mock_cache._redis_available = False
+            await voice_router.tool_web_search(request, db)
+
+        mock_record.assert_awaited_once()
+        kwargs = mock_record.await_args.kwargs
+        # Allow positional or keyword binding
+        if kwargs:
+            assert kwargs.get("source") == "voice"
+            assert kwargs.get("query") == "aripiprazole"
+            assert kwargs.get("user_id") == 7
+            assert kwargs.get("summary_id") == 99
+        else:
+            args = mock_record.await_args.args
+            # signature: (db, user_id, summary_id, source, query)
+            assert "voice" in args
+            assert "aripiprazole" in args
+
+    @pytest.mark.asyncio
+    async def test_tool_web_search_blocks_at_summary_limit(self):
+        """When summary counter exceeds 15, the tool returns the limit message and skips brave call."""
+        from fastapi import Request
+        from voice import router as voice_router
+
+        summary = MagicMock()
+        summary.id = 99
+        summary.user_id = 7
+        body = {"summary_id": 99, "query": "aripiprazole"}
+
+        request = MagicMock(spec=Request)
+        db = AsyncMock()
+
+        voice_router._web_search_counts.clear()
+        voice_router._user_web_search_counts.clear()
+        # Pre-fill the counter to its max
+        voice_router._web_search_counts["99"] = 15
+
+        with patch.object(
+            voice_router,
+            "verify_tool_request",
+            AsyncMock(return_value=(summary, body)),
+        ), patch.object(
+            voice_router, "web_search", AsyncMock()
+        ) as mock_ws, patch.object(
+            voice_router,
+            "record_web_search_usage",
+            AsyncMock(),
+        ) as mock_record, patch("core.cache.cache_service") as mock_cache:
+            mock_cache._redis_available = False
+            response = await voice_router.tool_web_search(request, db)
+
+        assert "Limite" in response["result"]
+        mock_ws.assert_not_awaited()
+        mock_record.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_explorer_prompts_advertise_web_search_tools(self):
+        """Spec #0 (a): explorer agent prompts must explicitly mention web_search,
+        deep_research, check_fact, and instruct to announce the search."""
+        from voice.agent_types import EXPLORER
+
+        for prompt in (EXPLORER.system_prompt_fr, EXPLORER.system_prompt_en):
+            assert "web_search" in prompt
+            assert "deep_research" in prompt
+            assert "check_fact" in prompt
+
+        # FR — exact French announcement phrase from spec L84
+        assert "Je vais chercher sur le web" in EXPLORER.system_prompt_fr
+        # EN — equivalent phrasing
+        assert "Let me search the web" in EXPLORER.system_prompt_en or \
+               "I'll search the web" in EXPLORER.system_prompt_en
+
+    @pytest.mark.asyncio
+    async def test_tool_web_search_blocks_at_user_limit(self):
+        """When user counter exceeds 60, the tool returns a user-level limit message."""
+        from fastapi import Request
+        from voice import router as voice_router
+
+        summary = MagicMock()
+        summary.id = 99
+        summary.user_id = 7
+        body = {"summary_id": 99, "query": "aripiprazole"}
+
+        request = MagicMock(spec=Request)
+        db = AsyncMock()
+
+        voice_router._web_search_counts.clear()
+        voice_router._user_web_search_counts.clear()
+        voice_router._user_web_search_counts[7] = 60
+
+        with patch.object(
+            voice_router,
+            "verify_tool_request",
+            AsyncMock(return_value=(summary, body)),
+        ), patch.object(
+            voice_router, "web_search", AsyncMock()
+        ) as mock_ws, patch.object(
+            voice_router,
+            "record_web_search_usage",
+            AsyncMock(),
+        ) as mock_record, patch("core.cache.cache_service") as mock_cache:
+            mock_cache._redis_available = False
+            response = await voice_router.tool_web_search(request, db)
+
+        assert "Limite" in response["result"] or "limite" in response["result"].lower()
+        mock_ws.assert_not_awaited()
+        mock_record.assert_not_awaited()


### PR DESCRIPTION
## Summary

Spec #0 (express fix, déployable seul) issu de [docs/superpowers/specs/2026-04-25-elevenlabs-ecosystem-architecture-design.md](docs/superpowers/specs/2026-04-25-elevenlabs-ecosystem-architecture-design.md#spec-0--fix-express-recherche-web-déployable-seul) (lignes 74-114), branche stable `spec/elevenlabs-base@f219dbc6`.

Fix le bug où l'agent vocal ElevenLabs `explorer` répond "je n'ai pas accès au web" alors que `web_search` est branché côté backend.

### Changements

- **(a) Prompts FR + EN** (`backend/src/voice/agent_types.py`) — section "Tools available" injectée dans `EXPLORER.system_prompt_fr` et `system_prompt_en`. Format : signature + comportement attendu pour `web_search`, `deep_research`, `check_fact`. Inclut "Je vais chercher sur le web" / "Let me search the web" pour gérer la latence.
- **(b) Cache Redis Brave** (`backend/src/voice/web_tools_cache.py`, nouveau, ~95 lignes) — wrapper `cached_brave_search(query, count=5)`. Clé `brave:search:{sha1(query|count)}`, TTL 3600s, échecs jamais cachés. Branché aux 3 sites d'appels dans `voice/web_tools.py`.
- **(c) Tracking** — `record_web_search_usage(db, user_id, summary_id, source='voice', query=...)` dans `tool_web_search`, basé sur le pattern existant `videos.service.increment_web_search_usage`.
- **(d) Rate-limits**
  - per-summary 5/h → **15/h** (`_WEB_SEARCH_MAX`)
  - nouveau cap global **60/h par user_id** (`_WEB_SEARCH_USER_MAX`)
  - Redis INCR + EXPIRE TTL 3600s, fallback in-memory.

### Tests

Nouveaux tests pytest (TDD) dans `backend/tests/voice/test_web_tools_cache.py` :
- 4 tests pour `cached_brave_search` (clé sha1, miss → call + cache, hit → skip, échec → pas de cache)
- 3 tests pour la wire-up dans `voice/web_tools.py` (`web_search`, `deep_research`, `check_fact`)
- 8 tests pour `tool_web_search` : limites 15/60, blocage au 16e/61e call, tracking incrémenté avec `source='voice'`, prompts FR/EN advertise les tools.

```
$ pytest tests/voice/test_web_tools_cache.py tests/test_voice.py -v
======================= 70 passed, 3 warnings in 22.13s =======================
```

(15 nouveaux + 55 existants `test_voice.py` = 70/70 PASS, aucune régression)

## Test plan

- [ ] `cd backend && pytest tests/voice/test_web_tools_cache.py -v` doit afficher 15 PASS
- [ ] `cd backend && pytest tests/test_voice.py -v` doit toujours afficher 55 PASS
- [ ] Validation manuelle staging : démarrer une session vocale, demander "Qui est Aripiprazole ?" → l'agent doit annoncer "Je vais chercher sur le web", puis répondre avec les sources Brave (au lieu de refuser)
- [ ] Vérifier dans Redis : `KEYS deepsight:brave:search:*` après 1 call, puis hit cache au 2e call identique
- [ ] Vérifier dans la table `web_search_usage` : `search_count` incrémenté après chaque appel voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)