### PR TITLE
fix(ext): unblock Popup.test.tsx — loading-view class + tabs.query callback

### DIFF
--- a/extension/__tests__/components/Popup.test.tsx
+++ b/extension/__tests__/components/Popup.test.tsx
@@ -147,8 +147,8 @@ describe("App — rendering", () => {
       new Promise(() => {}),
     );
 
-    render(<App />);
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    const { container } = render(<App />);
+    expect(container.querySelector(".loading-view")).toBeTruthy();
   });
 });
 
@@ -320,14 +320,18 @@ describe("App — authenticated state", () => {
         },
       }); // GET_PLAN
 
-    // Mock tabs.query for video detection (Promise-based via webextension-polyfill)
-    (chrome.tabs.query as jest.Mock).mockResolvedValue([
-      {
-        id: 1,
-        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-        title: "Test Video",
+    // Mock tabs.query for video detection
+    (chrome.tabs.query as jest.Mock).mockImplementation(
+      (_q: unknown, cb: (tabs: unknown[]) => void) => {
+        cb([
+          {
+            id: 1,
+            url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            title: "Test Video",
+          },
+        ]);
       },
-    ]);
+    );
   });
 
   it("shows main view with video detection", async () => {
@@ -351,14 +355,18 @@ describe("App — guest mode", () => {
       authenticated: false,
     });
 
-    // Mock tabs.query for video detection (Promise-based via webextension-polyfill)
-    (chrome.tabs.query as jest.Mock).mockResolvedValue([
-      {
-        id: 1,
-        url: "https://www.youtube.com/watch?v=test123",
-        title: "Test",
+    // Mock tabs.query for video detection
+    (chrome.tabs.query as jest.Mock).mockImplementation(
+      (_q: unknown, cb: (tabs: unknown[]) => void) => {
+        cb([
+          {
+            id: 1,
+            url: "https://www.youtube.com/watch?v=test123",
+            title: "Test",
+          },
+        ]);
       },
-    ]);
+    );
 
     render(<App />);
 


### PR DESCRIPTION
## Summary

Fixes the long-standing CI red on \`extension/__tests__/components/Popup.test.tsx\`. Two issues addressed:

1. **L147-148** — \`expect(screen.getByText('Loading...'))\` no longer finds anything because the popup loading state was refactored (Aurora v2 spinner) to render a \`<div class="loading-view">\` instead of literal "Loading..." text. Asserting by class now.
2. **L320-334 + L355-368** — \`chrome.tabs.query\` mocks switched from Promise-based to callback-based — matches what the App actually invokes via the webextension-polyfill shim.

## Provenance

Cherry-picked from the orphaned PR #110 (\`claude/continue-work-Rsfwq\`, sitting unmerged since 2026-04-16). PR #110 contained 48 commits worth of work; only this single test file remains relevant for current main and is extracted here.

## Test plan

- [ ] CI: Extension Jest suite goes green
- [ ] Verify Popup tests still cover: loading state, authenticated main view, guest mode

## Why merge with admin

- Touches only a test file. Cannot regress production behavior.
- Other CI fails (frontend Vitest TS errors) are preexisting and orthogonal.
- Unblocks future PR merges that were rolling on a red CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)