### PR TITLE
feat(voice): UX improvements — bigger Call button, live settings, UI zoom

### DIFF
--- a/frontend/src/__tests__/index-css-zoom.test.ts
+++ b/frontend/src/__tests__/index-css-zoom.test.ts
@@ -1,0 +1,31 @@
+/**
+ * index-css-zoom.test.ts — Light regression test ensuring the global UI
+ * scale-up is wired via `html { font-size: 18px; }` in index.css.
+ *
+ * The +12.5% zoom is purely declarative — a single CSS rule ahead of
+ * @tailwind. If anyone removes or changes it, this test catches it before
+ * anyone notices that the entire app shrunk back to 16px-based sizing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("Global UI zoom (index.css)", () => {
+  const cssPath = resolve(__dirname, "..", "index.css");
+  const css = readFileSync(cssPath, "utf-8");
+
+  it("declares html font-size: 18px before @tailwind", () => {
+    const tailwindIdx = css.indexOf("@tailwind base");
+    expect(tailwindIdx).toBeGreaterThan(-1);
+    const before = css.slice(0, tailwindIdx);
+    // Must contain a rule like: html { font-size: 18px; }
+    expect(before).toMatch(/html\s*\{[^}]*font-size:\s*18px;[^}]*\}/);
+  });
+
+  it("does not also override <body> font-size — keeps cascade clean", () => {
+    // We want to scale via html only so the rem unit becomes 18px.
+    // Setting body to a px size as well would re-anchor children.
+    expect(css).not.toMatch(/body\s*\{[^}]*font-size:\s*\d+px[^}]*\}/);
+  });
+});

--- a/frontend/src/components/voice/VoiceCallButton.tsx
+++ b/frontend/src/components/voice/VoiceCallButton.tsx
@@ -1,0 +1,124 @@
+/**
+ * VoiceCallButton — Header-variant "Appeler / Raccrocher" call toggle.
+ *
+ * Rendered in the ChatPage header (and reusable elsewhere). The "header"
+ * variant is the prominent call button: bigger sizing (h-12, px-5), a
+ * violet → blue gradient background, semibold base text and the
+ * ElevenLabs logo on the left of the label.
+ *
+ * Visual identity: voice features use the violet accent across the app
+ * (cf. VoiceOverlay header pill, voice transcript bubbles), so the call
+ * button leans into that gradient as the strongest entry point.
+ *
+ * Accessibility:
+ *  - role="button" via native <button>
+ *  - aria-pressed reflects active call state
+ *  - aria-label switches between "Appeler" and "Raccrocher"
+ */
+
+import React from "react";
+import { Mic, PhoneOff } from "lucide-react";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ElevenLabs logo — official "11" mark (two vertical bars).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface ElevenLabsLogoProps {
+  className?: string;
+}
+
+export const ElevenLabsLogo: React.FC<ElevenLabsLogoProps> = ({
+  className,
+}) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    aria-label="ElevenLabs"
+    role="img"
+  >
+    <rect x="6" y="4" width="3" height="16" rx="1.5" />
+    <rect x="15" y="4" width="3" height="16" rx="1.5" />
+  </svg>
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// VoiceCallButton
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export type VoiceCallButtonVariant = "header";
+
+export interface VoiceCallButtonProps {
+  /** Visual variant — currently only "header" but reserved for future use. */
+  variant: VoiceCallButtonVariant;
+  /** Whether a call is currently in progress (toggles label + style). */
+  active: boolean;
+  /** Click handler — toggles open/close of the voice overlay. */
+  onClick: () => void;
+  /** i18n: idle label, e.g. "Appeler" / "Call". */
+  label: string;
+  /** i18n: active label, e.g. "Raccrocher" / "Hang up". */
+  endLabel: string;
+  /** Disable interactions (e.g. plan-locked or quota-exhausted). */
+  disabled?: boolean;
+  /** Optional data-testid for test selectors. */
+  testId?: string;
+}
+
+export const VoiceCallButton: React.FC<VoiceCallButtonProps> = ({
+  variant,
+  active,
+  onClick,
+  label,
+  endLabel,
+  disabled = false,
+  testId,
+}) => {
+  // Currently only "header" — future variants would branch here.
+  void variant;
+
+  const ariaLabel = active ? endLabel : label;
+
+  // Idle: violet → blue gradient (voice identity = violet, modulated to blue
+  // for an inviting, calm-but-energetic call-to-action).
+  // Active: red-tinted to communicate "press to end" affordance.
+  const visualClasses = active
+    ? "bg-gradient-to-r from-red-500/20 to-rose-500/20 border-red-400/40 text-red-100 hover:from-red-500/30 hover:to-rose-500/30"
+    : "bg-gradient-to-r from-violet-500 to-blue-500 border-violet-400/50 text-white shadow-lg shadow-violet-500/20 hover:from-violet-400 hover:to-blue-400";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      aria-label={ariaLabel}
+      data-testid={testId ?? "voice-call-button"}
+      className={`
+        flex-shrink-0 inline-flex items-center gap-2.5
+        h-12 px-5 rounded-xl
+        text-base font-semibold
+        border transition-all duration-200
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400/60
+        disabled:opacity-50 disabled:cursor-not-allowed
+        ${visualClasses}
+      `}
+    >
+      {active ? (
+        <>
+          <PhoneOff className="w-4 h-4" aria-hidden="true" />
+          <span className="hidden sm:inline">{endLabel}</span>
+        </>
+      ) : (
+        <>
+          <ElevenLabsLogo className="w-4 h-4" />
+          <Mic className="w-4 h-4" aria-hidden="true" />
+          <span className="hidden sm:inline">{label}</span>
+        </>
+      )}
+    </button>
+  );
+};
+
+export default VoiceCallButton;

--- a/frontend/src/components/voice/VoiceLiveSettings.tsx
+++ b/frontend/src/components/voice/VoiceLiveSettings.tsx
@@ -1,0 +1,361 @@
+/**
+ * VoiceLiveSettings — Compact, in-call settings panel embedded inside
+ * VoiceOverlay. Exposes the 5 most useful live-tweakable preferences:
+ *  - Agent volume (slider 0-100, applied locally to <audio> elements)
+ *  - Playback rate preset (0.75 / 1 / 1.25 / 1.5 / 1.75)
+ *  - Input mode (PTT vs VAD/always-listening)
+ *  - PTT key (text input, e.g. "Espace")
+ *  - Language (FR/EN)
+ *
+ * Heavy fields (voice catalog, stability, model selection) live in the
+ * full VoiceSettings page — this panel intentionally stays minimal so
+ * the in-call experience does not become a wall of controls.
+ *
+ * Live application:
+ *  - playback_rate via voicePrefsBus → useVoiceChat re-applies on the
+ *    active <audio> elements without restarting the session.
+ *  - volume sets HTMLAudioElement.volume directly through the bus.
+ *  - input_mode / ptt_key / language are persisted via voiceApi but
+ *    typically apply on next session start.
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Volume2, Mic, Keyboard, Globe, Gauge } from "lucide-react";
+import { voiceApi } from "../../services/api";
+import type { VoicePreferences } from "../../services/api";
+import { emitVoicePrefsEvent } from "./voicePrefsBus";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// I18N
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const I18N = {
+  fr: {
+    loading: "Chargement…",
+    error: "Impossible de charger les réglages.",
+    volume: "Volume agent",
+    rate: "Vitesse de lecture",
+    mode: "Mode d'entrée",
+    modePtt: "Appuyer pour parler",
+    modeVad: "Toujours à l'écoute",
+    pttKey: "Touche push-to-talk",
+    pttHelp: "Espace, Shift, etc.",
+    language: "Langue",
+    needsRestart: "Le changement s'appliquera au prochain appel.",
+  },
+  en: {
+    loading: "Loading…",
+    error: "Failed to load settings.",
+    volume: "Agent volume",
+    rate: "Playback rate",
+    mode: "Input mode",
+    modePtt: "Push to talk",
+    modeVad: "Always listening",
+    pttKey: "Push-to-talk key",
+    pttHelp: "Space, Shift, etc.",
+    language: "Language",
+    needsRestart: "The change will apply on the next call.",
+  },
+} as const;
+
+// Playback rate presets — kept conservative (no 2x+) for in-call use,
+// where extreme rates are rarely useful.
+const RATE_PRESETS: { id: string; value: number }[] = [
+  { id: "0.75x", value: 0.75 },
+  { id: "1x", value: 1.0 },
+  { id: "1.25x", value: 1.25 },
+  { id: "1.5x", value: 1.5 },
+  { id: "1.75x", value: 1.75 },
+];
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const formatPttKey = (key: string): string => {
+  if (key === " " || key === "Space" || key === "Spacebar") return "Espace";
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Component
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface VoiceLiveSettingsProps {
+  /** UI language (FR or EN). */
+  language: "fr" | "en";
+  /** Optional callback fired after a successful save. */
+  onChange?: (updates: Partial<VoicePreferences>) => void;
+}
+
+export const VoiceLiveSettings: React.FC<VoiceLiveSettingsProps> = ({
+  language,
+  onChange,
+}) => {
+  const t = I18N[language];
+
+  const [prefs, setPrefs] = useState<VoicePreferences | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  // Local volume slider (0-100). Independent from prefs since volume is
+  // applied client-side to <audio> elements, not persisted to the backend.
+  const [volume, setVolume] = useState<number>(100);
+  const [pttListening, setPttListening] = useState(false);
+
+  // ── Initial load ────────────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const next = await voiceApi.getPreferences();
+        if (!cancelled) {
+          setPrefs(next);
+          setError(null);
+        }
+      } catch {
+        if (!cancelled) setError(t.error);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [t.error]);
+
+  // ── Save helper (optimistic) ────────────────────────────────────────────
+  const save = useCallback(
+    async (updates: Partial<VoicePreferences>) => {
+      if (!prefs) return;
+      const snapshot = prefs;
+      setPrefs({ ...prefs, ...updates });
+      setSaving(true);
+      try {
+        const next = await voiceApi.updatePreferences(updates);
+        setPrefs(next);
+        onChange?.(updates);
+      } catch {
+        // Rollback on failure.
+        setPrefs(snapshot);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [prefs, onChange],
+  );
+
+  // ── Volume change → live-apply via bus + local state ────────────────────
+  const handleVolume = useCallback((next: number) => {
+    setVolume(next);
+    // Apply directly to all live <audio> elements.
+    const audioEls = Array.from(
+      document.querySelectorAll<HTMLAudioElement>("audio"),
+    );
+    audioEls.forEach((el) => {
+      el.volume = Math.max(0, Math.min(1, next / 100));
+    });
+  }, []);
+
+  // ── Playback rate change → bus + persist ────────────────────────────────
+  const handleRate = useCallback(
+    (preset: { id: string; value: number }) => {
+      emitVoicePrefsEvent({
+        type: "playback_rate_changed",
+        value: preset.value,
+      });
+      void save({ voice_chat_speed_preset: preset.id });
+    },
+    [save],
+  );
+
+  // ── PTT-key picker ──────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!pttListening) return;
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.key === "Escape") {
+        setPttListening(false);
+        return;
+      }
+      const newKey = e.key === " " ? " " : e.key;
+      void save({ ptt_key: newKey });
+      setPttListening(false);
+    };
+    window.addEventListener("keydown", handler, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", handler, {
+        capture: true,
+      } as EventListenerOptions);
+  }, [pttListening, save]);
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div
+        data-testid="voice-live-loading"
+        className="px-4 py-3 text-[11px] text-white/40"
+      >
+        {t.loading}
+      </div>
+    );
+  }
+
+  if (!prefs || error) {
+    return (
+      <div
+        data-testid="voice-live-error"
+        className="px-4 py-3 text-[11px] text-red-300/80"
+      >
+        {error ?? t.error}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="voice-live-settings"
+      className="px-4 py-3 space-y-4 border-b border-white/[0.06] bg-[#0a0a0f]/60"
+    >
+      {/* ─── Volume ─── */}
+      <div>
+        <label
+          htmlFor="voice-live-volume"
+          className="flex items-center gap-1.5 text-[11px] font-medium text-white/55 mb-1.5"
+        >
+          <Volume2 className="w-3 h-3" aria-hidden="true" />
+          {t.volume}
+          <span className="ml-auto text-white/40 font-mono">{volume}</span>
+        </label>
+        <input
+          id="voice-live-volume"
+          data-testid="voice-live-volume"
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={volume}
+          onChange={(e) => handleVolume(parseInt(e.target.value, 10))}
+          aria-label={t.volume}
+          className="w-full accent-violet-500 h-1.5 bg-white/10 rounded-full"
+        />
+      </div>
+
+      {/* ─── Playback rate presets ─── */}
+      <div>
+        <p className="flex items-center gap-1.5 text-[11px] font-medium text-white/55 mb-1.5">
+          <Gauge className="w-3 h-3" aria-hidden="true" />
+          {t.rate}
+        </p>
+        <div className="grid grid-cols-5 gap-1.5">
+          {RATE_PRESETS.map((p) => {
+            const isActive = prefs.voice_chat_speed_preset === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                disabled={saving}
+                data-testid={`voice-live-rate-${p.id}`}
+                onClick={() => handleRate(p)}
+                className={`px-1 py-1 rounded text-[10px] font-medium transition-colors ${
+                  isActive
+                    ? "bg-violet-500/25 text-violet-200 border border-violet-400/40"
+                    : "bg-white/[0.04] text-white/55 border border-white/[0.06] hover:text-white/85"
+                }`}
+              >
+                {p.id}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ─── Input mode ─── */}
+      <div>
+        <p className="flex items-center gap-1.5 text-[11px] font-medium text-white/55 mb-1.5">
+          <Mic className="w-3 h-3" aria-hidden="true" />
+          {t.mode}
+        </p>
+        <div className="grid grid-cols-2 gap-1.5">
+          {(["ptt", "vad"] as const).map((mode) => {
+            const isActive = prefs.input_mode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                disabled={saving}
+                data-testid={`voice-live-mode-${mode}`}
+                onClick={() => save({ input_mode: mode })}
+                className={`px-2 py-1.5 rounded text-[10px] font-medium transition-colors ${
+                  isActive
+                    ? "bg-violet-500/25 text-violet-200 border border-violet-400/40"
+                    : "bg-white/[0.04] text-white/55 border border-white/[0.06] hover:text-white/85"
+                }`}
+              >
+                {mode === "ptt" ? t.modePtt : t.modeVad}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ─── PTT key ─── */}
+      <div>
+        <label
+          htmlFor="voice-live-ptt-key"
+          className="flex items-center gap-1.5 text-[11px] font-medium text-white/55 mb-1.5"
+        >
+          <Keyboard className="w-3 h-3" aria-hidden="true" />
+          {t.pttKey}
+        </label>
+        <button
+          id="voice-live-ptt-key"
+          type="button"
+          data-testid="voice-live-ptt-key"
+          disabled={saving || prefs.input_mode !== "ptt"}
+          onClick={() => setPttListening(true)}
+          className="w-full inline-flex items-center justify-between px-2 py-1.5 rounded text-[11px] bg-white/[0.04] border border-white/[0.06] text-white/85 hover:border-white/[0.12] disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <span>{pttListening ? "…" : formatPttKey(prefs.ptt_key)}</span>
+          <span className="text-[10px] text-white/35">{t.pttHelp}</span>
+        </button>
+      </div>
+
+      {/* ─── Language ─── */}
+      <div>
+        <p className="flex items-center gap-1.5 text-[11px] font-medium text-white/55 mb-1.5">
+          <Globe className="w-3 h-3" aria-hidden="true" />
+          {t.language}
+        </p>
+        <div className="grid grid-cols-2 gap-1.5">
+          {(["fr", "en"] as const).map((lang) => {
+            const isActive = prefs.language === lang;
+            return (
+              <button
+                key={lang}
+                type="button"
+                disabled={saving}
+                data-testid={`voice-live-lang-${lang}`}
+                onClick={() => save({ language: lang })}
+                className={`px-2 py-1.5 rounded text-[10px] font-medium uppercase transition-colors ${
+                  isActive
+                    ? "bg-violet-500/25 text-violet-200 border border-violet-400/40"
+                    : "bg-white/[0.04] text-white/55 border border-white/[0.06] hover:text-white/85"
+                }`}
+              >
+                {lang === "fr" ? "Français" : "English"}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VoiceLiveSettings;

--- a/frontend/src/components/voice/VoiceOverlay.tsx
+++ b/frontend/src/components/voice/VoiceOverlay.tsx
@@ -20,7 +20,13 @@
  * pas de drag pour V1.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -31,9 +37,11 @@ import {
   AlertCircle,
   Loader2,
   Volume2,
+  Settings,
 } from "lucide-react";
 import { useVoiceChat } from "./useVoiceChat";
 import { VoiceQuotaBadge } from "./VoiceQuotaBadge";
+import { VoiceLiveSettings } from "./VoiceLiveSettings";
 import { voiceApi } from "../../services/api";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -61,7 +69,12 @@ export interface VoiceOverlayProps {
   /** Summary id for the agent (omit for companion mode). */
   summaryId?: number | null;
   /** Agent type — defaults to "explorer" if summaryId, "companion" otherwise. */
-  agentType?: "explorer" | "companion" | "tutor" | "debate_moderator" | "quiz_coach";
+  agentType?:
+    | "explorer"
+    | "companion"
+    | "tutor"
+    | "debate_moderator"
+    | "quiz_coach";
   /** Language used by the agent. */
   language?: "fr" | "en";
   /**
@@ -113,6 +126,7 @@ const I18N = {
     transcriptEmpty: "La conversation s'affichera ici en temps réel.",
     minutesLeft: "min restantes",
     micMuted: "Micro coupé",
+    settings: "Réglages",
   },
   en: {
     callTitle: "Voice call",
@@ -128,6 +142,7 @@ const I18N = {
     transcriptEmpty: "The conversation will appear here in real time.",
     minutesLeft: "min left",
     micMuted: "Mic muted",
+    settings: "Settings",
   },
 } as const;
 
@@ -151,6 +166,9 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
   const resolvedAgent: VoiceOverlayProps["agentType"] =
     agentType ?? (summaryId ? "explorer" : "companion");
 
+  // ── Settings panel collapsible state ──
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
   // ── Voice chat hook ──
   const voice = useVoiceChat({
     summaryId: summaryId ?? undefined,
@@ -163,7 +181,10 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
 
   // ── Forward new transcripts to parent + persist to backend ──
   useEffect(() => {
-    if (!voice.messages || voice.messages.length <= lastForwardedIndexRef.current) {
+    if (
+      !voice.messages ||
+      voice.messages.length <= lastForwardedIndexRef.current
+    ) {
       return;
     }
     const startedAt = voice.sessionStartedAt;
@@ -204,7 +225,12 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
           });
       }
     });
-  }, [voice.messages, voice.sessionStartedAt, voice.voiceSessionId, onVoiceMessage]);
+  }, [
+    voice.messages,
+    voice.sessionStartedAt,
+    voice.voiceSessionId,
+    onVoiceMessage,
+  ]);
 
   // ── Reset the forwarded index when a new session starts ──
   useEffect(() => {
@@ -326,19 +352,55 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
                   {title || t.callTitle}
                 </p>
                 <p className="text-[11px] text-white/40 truncate">
-                  {subtitle || (resolvedAgent === "companion" ? t.companion : null)}
+                  {subtitle ||
+                    (resolvedAgent === "companion" ? t.companion : null)}
                 </p>
               </div>
             </div>
-            <button
-              type="button"
-              onClick={handleClose}
-              aria-label={t.close}
-              className="p-1.5 rounded-lg hover:bg-white/[0.06] text-white/40 hover:text-white/70 transition-colors flex-shrink-0"
-            >
-              <X className="w-4 h-4" />
-            </button>
+            <div className="flex items-center gap-1 flex-shrink-0">
+              <button
+                type="button"
+                onClick={() => setSettingsOpen((v) => !v)}
+                aria-label={t.settings}
+                aria-expanded={settingsOpen}
+                aria-controls="voice-overlay-settings-panel"
+                data-testid="voice-overlay-settings-toggle"
+                className={`p-1.5 rounded-lg transition-colors ${
+                  settingsOpen
+                    ? "bg-violet-500/20 text-violet-200"
+                    : "hover:bg-white/[0.06] text-white/40 hover:text-white/70"
+                }`}
+              >
+                <Settings className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={handleClose}
+                aria-label={t.close}
+                className="p-1.5 rounded-lg hover:bg-white/[0.06] text-white/40 hover:text-white/70 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
           </header>
+
+          {/* ── Live settings panel (collapsible) ── */}
+          <AnimatePresence initial={false}>
+            {settingsOpen && (
+              <motion.div
+                key="voice-overlay-settings"
+                id="voice-overlay-settings-panel"
+                data-testid="voice-overlay-settings-panel"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
+                className="flex-shrink-0 overflow-hidden"
+              >
+                <VoiceLiveSettings language={language} />
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           {/* ── Status + quota row ── */}
           <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-white/[0.04] flex-shrink-0">

--- a/frontend/src/components/voice/__tests__/VoiceCallButton.test.tsx
+++ b/frontend/src/components/voice/__tests__/VoiceCallButton.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * VoiceCallButton.test.tsx — Tests for the header variant of the
+ * voice "Appeler" button.
+ *
+ * The header variant is rendered in ChatPage and is bigger (h-12),
+ * carries an ElevenLabs logo on the left and a violet→blue gradient
+ * background. It also exposes an "active" mode used while a call is
+ * in progress (label switches to "Raccrocher").
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { VoiceCallButton } from "../VoiceCallButton";
+
+describe("VoiceCallButton (header variant)", () => {
+  it("renders the call label with the ElevenLabs logo by default", () => {
+    render(
+      <VoiceCallButton
+        variant="header"
+        active={false}
+        onClick={() => {}}
+        label="Appeler"
+        endLabel="Raccrocher"
+      />,
+    );
+    const button = screen.getByRole("button", { name: /appeler/i });
+    expect(button).toBeDefined();
+    // ElevenLabs logo is rendered as an SVG identified by its aria-label.
+    const logo = button.querySelector("svg[aria-label='ElevenLabs']");
+    expect(logo).not.toBeNull();
+  });
+
+  it("uses h-12 + px-5 sizing for the header variant (bigger button)", () => {
+    render(
+      <VoiceCallButton
+        variant="header"
+        active={false}
+        onClick={() => {}}
+        label="Appeler"
+        endLabel="Raccrocher"
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("h-12");
+    expect(button.className).toContain("px-5");
+  });
+
+  it("uses the violet→blue gradient when not active", () => {
+    render(
+      <VoiceCallButton
+        variant="header"
+        active={false}
+        onClick={() => {}}
+        label="Appeler"
+        endLabel="Raccrocher"
+      />,
+    );
+    const button = screen.getByRole("button");
+    // The visual identity for voice = violet, gradient → blue.
+    expect(button.className).toContain("from-violet-500");
+    expect(button.className).toContain("to-blue-500");
+  });
+
+  it("shows the end-call label in active state", () => {
+    render(
+      <VoiceCallButton
+        variant="header"
+        active={true}
+        onClick={() => {}}
+        label="Appeler"
+        endLabel="Raccrocher"
+      />,
+    );
+    const button = screen.getByRole("button", { name: /raccrocher/i });
+    expect(button).toBeDefined();
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("calls onClick when pressed", () => {
+    const onClick = vi.fn();
+    render(
+      <VoiceCallButton
+        variant="header"
+        active={false}
+        onClick={onClick}
+        label="Appeler"
+        endLabel="Raccrocher"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onClick when disabled", () => {
+    const onClick = vi.fn();
+    render(
+      <VoiceCallButton
+        variant="header"
+        active={false}
+        onClick={onClick}
+        disabled
+        label="Appeler"
+        endLabel="Raccrocher"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("matches the snapshot for the header variant rendering", () => {
+    const { container } = render(
+      <VoiceCallButton
+        variant="header"
+        active={false}
+        onClick={() => {}}
+        label="Appeler"
+        endLabel="Raccrocher"
+        testId="chat-page-voice-toggle"
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/voice/__tests__/VoiceLiveSettings.test.tsx
+++ b/frontend/src/components/voice/__tests__/VoiceLiveSettings.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * VoiceLiveSettings.test.tsx — Tests for the in-call collapsible settings
+ * panel embedded inside VoiceOverlay.
+ *
+ * Behaviour covered:
+ *  - Loading state while fetching preferences
+ *  - Renders all 5 fields (volume, playback rate, input mode, PTT key, language)
+ *  - Save handler called when user changes a field
+ *  - voicePrefsBus.emitVoicePrefsEvent fires for live-applicable changes
+ *    (playback_rate)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const getPreferencesMock = vi.fn();
+const updatePreferencesMock = vi.fn();
+
+vi.mock("../../../services/api", () => ({
+  voiceApi: {
+    getPreferences: () => getPreferencesMock(),
+    updatePreferences: (updates: Record<string, unknown>) =>
+      updatePreferencesMock(updates),
+  },
+}));
+
+const emitVoicePrefsEventMock = vi.fn();
+vi.mock("../voicePrefsBus", async () => {
+  const actual =
+    await vi.importActual<Record<string, unknown>>("../voicePrefsBus");
+  return {
+    ...actual,
+    emitVoicePrefsEvent: (...args: unknown[]) =>
+      emitVoicePrefsEventMock(...args),
+  };
+});
+
+import { VoiceLiveSettings } from "../VoiceLiveSettings";
+
+const baselinePrefs = {
+  voice_id: "v1",
+  voice_name: "Aria",
+  speed: 1.0,
+  stability: 0.5,
+  similarity_boost: 0.75,
+  style: 0.3,
+  use_speaker_boost: true,
+  tts_model: "eleven_multilingual_v2",
+  voice_chat_model: "eleven_flash_v2_5",
+  language: "fr",
+  gender: "female",
+  input_mode: "ptt" as const,
+  ptt_key: " ",
+  interruptions_enabled: true,
+  turn_eagerness: 0.5,
+  voice_chat_speed_preset: "1x",
+  turn_timeout: 15,
+  soft_timeout_seconds: 300,
+};
+
+describe("VoiceLiveSettings (in-call collapsible panel)", () => {
+  beforeEach(() => {
+    getPreferencesMock.mockReset();
+    updatePreferencesMock.mockReset();
+    emitVoicePrefsEventMock.mockReset();
+    getPreferencesMock.mockResolvedValue({ ...baselinePrefs });
+    updatePreferencesMock.mockImplementation(
+      async (updates: Record<string, unknown>) => ({
+        ...baselinePrefs,
+        ...updates,
+      }),
+    );
+  });
+
+  it("loads preferences from voiceApi on mount", async () => {
+    render(<VoiceLiveSettings language="fr" />);
+    await waitFor(() => expect(getPreferencesMock).toHaveBeenCalled());
+  });
+
+  it("renders the 5 expected sections after preferences load", async () => {
+    render(<VoiceLiveSettings language="fr" />);
+    await waitFor(() => {
+      // Volume slider
+      expect(screen.getByLabelText(/volume/i)).toBeDefined();
+      // Playback rate buttons
+      expect(screen.getByTestId("voice-live-rate-1x")).toBeDefined();
+      // Input mode toggle (PTT / VAD)
+      expect(screen.getByTestId("voice-live-mode-ptt")).toBeDefined();
+      expect(screen.getByTestId("voice-live-mode-vad")).toBeDefined();
+      // PTT key input
+      expect(screen.getByTestId("voice-live-ptt-key")).toBeDefined();
+      // Language selector (FR / EN)
+      expect(screen.getByTestId("voice-live-lang-fr")).toBeDefined();
+      expect(screen.getByTestId("voice-live-lang-en")).toBeDefined();
+    });
+  });
+
+  it("emits playback_rate_changed on bus when user picks a new rate", async () => {
+    render(<VoiceLiveSettings language="fr" />);
+    const rate15 = await screen.findByTestId("voice-live-rate-1.5x");
+    fireEvent.click(rate15);
+    await waitFor(() =>
+      expect(emitVoicePrefsEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "playback_rate_changed",
+          value: 1.5,
+        }),
+      ),
+    );
+  });
+
+  it("calls voiceApi.updatePreferences when input_mode changes", async () => {
+    render(<VoiceLiveSettings language="fr" />);
+    const vad = await screen.findByTestId("voice-live-mode-vad");
+    fireEvent.click(vad);
+    await waitFor(() =>
+      expect(updatePreferencesMock).toHaveBeenCalledWith(
+        expect.objectContaining({ input_mode: "vad" }),
+      ),
+    );
+  });
+
+  it("calls voiceApi.updatePreferences when language changes", async () => {
+    render(<VoiceLiveSettings language="fr" />);
+    const en = await screen.findByTestId("voice-live-lang-en");
+    fireEvent.click(en);
+    await waitFor(() =>
+      expect(updatePreferencesMock).toHaveBeenCalledWith(
+        expect.objectContaining({ language: "en" }),
+      ),
+    );
+  });
+
+  it("displays an error message if preferences fail to load", async () => {
+    getPreferencesMock.mockRejectedValueOnce(new Error("network"));
+    render(<VoiceLiveSettings language="fr" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("voice-live-error")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/components/voice/__tests__/VoiceOverlay.test.tsx
+++ b/frontend/src/components/voice/__tests__/VoiceOverlay.test.tsx
@@ -37,7 +37,14 @@ vi.mock("../../../services/api", async () => {
 type Listener = () => void;
 let mockState: {
   messages: { text: string; source: "user" | "ai" }[];
-  status: "idle" | "connecting" | "listening" | "speaking" | "thinking" | "error" | "quota_exceeded";
+  status:
+    | "idle"
+    | "connecting"
+    | "listening"
+    | "speaking"
+    | "thinking"
+    | "error"
+    | "quota_exceeded";
   voiceSessionId: string | null;
   sessionStartedAt: number | null;
   isMuted: boolean;
@@ -156,16 +163,18 @@ describe("VoiceOverlay", () => {
   });
 
   it("ne démarre pas automatiquement si autoStart=false", () => {
-    render(
-      <VoiceOverlay isOpen={true} onClose={() => {}} autoStart={false} />,
-    );
+    render(<VoiceOverlay isOpen={true} onClose={() => {}} autoStart={false} />);
     expect(startMock).not.toHaveBeenCalled();
   });
 
   it("forward chaque transcript user/ai au callback onVoiceMessage", async () => {
     const onVoiceMessage = vi.fn();
     render(
-      <VoiceOverlay isOpen={true} onClose={() => {}} onVoiceMessage={onVoiceMessage} />,
+      <VoiceOverlay
+        isOpen={true}
+        onClose={() => {}}
+        onVoiceMessage={onVoiceMessage}
+      />,
     );
     // Simulate the call connecting and producing two turns.
     act(() => {
@@ -283,5 +292,30 @@ describe("VoiceOverlay", () => {
     await user.click(endBtn);
     await waitFor(() => expect(stopMock).toHaveBeenCalled());
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("expose un bouton réglages avec aria-expanded=false par défaut", async () => {
+    render(<VoiceOverlay isOpen={true} onClose={() => {}} />);
+    const toggle = await screen.findByTestId("voice-overlay-settings-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByTestId("voice-overlay-settings-panel")).toBeNull();
+  });
+
+  it("toggle le panel de réglages au click", async () => {
+    const user = userEvent.setup();
+    render(<VoiceOverlay isOpen={true} onClose={() => {}} />);
+    const toggle = await screen.findByTestId("voice-overlay-settings-toggle");
+    await user.click(toggle);
+    await waitFor(() =>
+      expect(toggle.getAttribute("aria-expanded")).toBe("true"),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("voice-overlay-settings-panel")).toBeDefined(),
+    );
+    // Re-click closes the panel
+    await user.click(toggle);
+    await waitFor(() =>
+      expect(toggle.getAttribute("aria-expanded")).toBe("false"),
+    );
   });
 });

--- a/frontend/src/components/voice/__tests__/__snapshots__/VoiceCallButton.test.tsx.snap
+++ b/frontend/src/components/voice/__tests__/__snapshots__/VoiceCallButton.test.tsx.snap
@@ -1,0 +1,74 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`VoiceCallButton (header variant) > matches the snapshot for the header variant rendering 1`] = `
+<button
+  aria-label="Appeler"
+  aria-pressed="false"
+  class="
+        flex-shrink-0 inline-flex items-center gap-2.5
+        h-12 px-5 rounded-xl
+        text-base font-semibold
+        border transition-all duration-200
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400/60
+        disabled:opacity-50 disabled:cursor-not-allowed
+        bg-gradient-to-r from-violet-500 to-blue-500 border-violet-400/50 text-white shadow-lg shadow-violet-500/20 hover:from-violet-400 hover:to-blue-400
+      "
+  data-testid="chat-page-voice-toggle"
+  type="button"
+>
+  <svg
+    aria-label="ElevenLabs"
+    class="w-4 h-4"
+    fill="currentColor"
+    role="img"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      height="16"
+      rx="1.5"
+      width="3"
+      x="6"
+      y="4"
+    />
+    <rect
+      height="16"
+      rx="1.5"
+      width="3"
+      x="15"
+      y="4"
+    />
+  </svg>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-mic w-4 h-4"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"
+    />
+    <path
+      d="M19 10v2a7 7 0 0 1-14 0v-2"
+    />
+    <line
+      x1="12"
+      x2="12"
+      y1="19"
+      y2="22"
+    />
+  </svg>
+  <span
+    class="hidden sm:inline"
+  >
+    Appeler
+  </span>
+</button>
+`;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,16 @@
 
 /* Fonts loaded via <link> in index.html for non-render-blocking loading */
 
+/* ═══════════════════════════════════════════════════════════════════════════════
+   GLOBAL UI SCALE — Bump root font-size to 18px (+12.5% over the 16px default).
+   This scales every Tailwind utility expressed in rem (text-*, p-*, m-*, gap-*…)
+   while leaving px-based values (icons, borders, fixed widths) untouched.
+   Applied at the root (html) so it cascades everywhere without layout shifts.
+   ═══════════════════════════════════════════════════════════════════════════════ */
+html {
+  font-size: 18px;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -37,7 +37,6 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   Mic,
-  Phone,
   Keyboard,
 } from "lucide-react";
 import {
@@ -67,6 +66,7 @@ import {
   type VoiceOverlayMessage,
 } from "../components/voice/VoiceOverlay";
 import { useVoiceEnabled } from "../components/voice/hooks/useVoiceEnabled";
+import { VoiceCallButton } from "../components/voice/VoiceCallButton";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // 📦 TYPES
@@ -271,15 +271,11 @@ const ChatPage: React.FC = () => {
   }, [messages]);
 
   // ── Detect manual scroll up to disable auto-scroll ──
-  const handleScroll = useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      const el = e.currentTarget;
-      const distanceFromBottom =
-        el.scrollHeight - el.scrollTop - el.clientHeight;
-      userScrolledUpRef.current = distanceFromBottom > 80;
-    },
-    [],
-  );
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    userScrolledUpRef.current = distanceFromBottom > 80;
+  }, []);
 
   // ── Select analysis ──
   const handleSelectAnalysis = (analysis: Summary) => {
@@ -354,7 +350,7 @@ const ChatPage: React.FC = () => {
         content: message,
         source: voiceActive ? "voice_user" : "text",
         voice_session_id: voiceActive
-          ? voiceController?.voiceSessionId ?? null
+          ? (voiceController?.voiceSessionId ?? null)
           : undefined,
         timestamp: Date.now(),
       };
@@ -769,32 +765,16 @@ const ChatPage: React.FC = () => {
             </div>
           )}
 
-          {/* 🎙️ Spec #5a — Voice call header button */}
+          {/* 🎙️ Spec #5a — Voice call header button (bigger, ElevenLabs branded) */}
           {voiceEnabled && (
-            <button
-              type="button"
+            <VoiceCallButton
+              variant="header"
+              active={voiceOverlayOpen}
               onClick={() => setVoiceOverlayOpen((v) => !v)}
-              aria-pressed={voiceOverlayOpen}
-              aria-label={voiceOverlayOpen ? t.endCall : t.callButton}
-              data-testid="chat-page-voice-toggle"
-              className={`flex-shrink-0 inline-flex items-center gap-1.5 h-8 px-3 rounded-lg text-xs font-medium transition-colors border ${
-                voiceOverlayOpen
-                  ? "bg-violet-500/15 border-violet-500/35 text-violet-200"
-                  : "bg-white/[0.04] border-white/[0.06] text-white/55 hover:text-white/85 hover:border-white/[0.12]"
-              }`}
-            >
-              {voiceOverlayOpen ? (
-                <>
-                  <Phone className="w-3.5 h-3.5" />
-                  <span className="hidden sm:inline">{t.endCall}</span>
-                </>
-              ) : (
-                <>
-                  <Mic className="w-3.5 h-3.5" />
-                  <span className="hidden sm:inline">{t.callButton}</span>
-                </>
-              )}
-            </button>
+              label={t.callButton}
+              endLabel={t.endCall}
+              testId="chat-page-voice-toggle"
+            />
           )}
         </header>
 


### PR DESCRIPTION
## Summary

Three independent UX improvements on the DeepSight web frontend (no backend, no mobile, no extension touched).

### 1. Bigger header Call button with ElevenLabs branding (`feat/voice/VoiceCallButton.tsx`)

- New dedicated `VoiceCallButton` component (`variant="header"`)
- Sizing: `h-12 px-5` (was `h-8 px-3`) — much more discoverable in the ChatPage header.
- Text: `text-base font-semibold` (was `text-xs font-medium`).
- Visual identity: violet→blue gradient idle, red gradient when call is active.
- Inline ElevenLabs "11" logo (two-bar SVG) on the left of the label.
- 7 unit tests + snapshot.

### 2. Live settings panel inside VoiceOverlay (`VoiceLiveSettings`)

- New gear icon in the overlay header → toggles a collapsible in-call settings panel.
- 5 quick-tweak fields: agent volume (live to <audio>), playback rate preset (0.75 → 1.75), input mode (PTT/VAD), PTT key picker, language (FR/EN).
- Uses the existing `voicePrefsBus` to live-apply playback rate without restarting the session.
- Optimistic save with rollback on `voiceApi.updatePreferences` failure.
- 6 tests for VoiceLiveSettings + 2 new tests for VoiceOverlay (toggle behaviour, aria-expanded).

### 3. Global UI scale-up via root font-size

- `html { font-size: 18px; }` injected at the top of `frontend/src/index.css`, before the @tailwind directives.
- Result: every Tailwind utility expressed in rem (text-*, p-*, m-*, gap-*…) scales up ~12.5% over the 16px default. Pixel-based icons / borders stay crisp.
- Verified: `npm run build` succeeds (1m37s); dev server boots cleanly; `/`, `/dashboard`, `/history`, `/chat` all return HTTP 200 with the patched stylesheet.
- Light regression test guards the rule + ordering.

## Test plan

- [x] `npm run build` succeeds (Vite 5)
- [x] `npm test -- --run` — 444 tests passing (was 427 on baseline). 17 new tests added across the 3 changes; 0 new failures.
- [x] 28 pre-existing failures unchanged (`planPrivileges.test.ts` + `useVoiceChat.test.ts` — `MediaStream is not defined` jsdom issue, untouched in this PR).
- [x] Dev server smoke test: `/`, `/dashboard`, `/history`, `/chat` → HTTP 200.
- [ ] Visual diff to confirm Dashboard/History/Chat layouts after the +12.5% font-size bump are still clean (requires a human eye on a real browser).

## Notes

- Did NOT touch backend, mobile, extension, or unrelated frontend files.
- Did NOT push to main; PR target is `main`.
- A few unrelated noise diffs (CSS line endings, etc.) were left out of the commits to keep them atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)