### PR TITLE
fix(alembic): correct revision id of 001_initial_schema

### DIFF
--- a/backend/alembic/versions/001_initial_schema.py
+++ b/backend/alembic/versions/001_initial_schema.py
@@ -13,7 +13,7 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "001"
+revision: str = "001_initial_schema"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
## Summary

Fixes a long-standing latent bug in the alembic revision graph: `001_initial_schema.py` declared `revision = "001"`, but every subsequent migration (002-007) references it as `'001_initial_schema'`. This caused `KeyError: '001_initial_schema'` whenever alembic tried to resolve the graph (e.g. `alembic upgrade head`, `alembic stamp`, `alembic history`).

## Why now

Discovered during PR #124 final-reviewer follow-up #3 — when implementing a SQLite round-trip test for migration 007 (Spec #1 unified chat/voice timeline), alembic failed to load the script directory at all because of this bug.

This explains:
- 🔴 Why the prod DB has **no `alembic_version` table** — the schema was originally built via `Base.metadata.create_all()` because alembic was broken from the start.
- 🔴 Why migration 007 was applied via **raw SQL on prod** (2026-04-26 deploy) instead of `alembic upgrade head`.
- 🔴 Why future migrations (008+) would have continued to require manual SQL.

## Change

`backend/alembic/versions/001_initial_schema.py`:

```diff
- revision: str = "001"
+ revision: str = "001_initial_schema"
```

That's it. One line.

## Impact

- **Dev**: `alembic history`, `alembic upgrade`, `alembic stamp` will all work properly going forward.
- **Prod**: no immediate impact (the prod DB still lacks `alembic_version`); but next time we want to run an alembic command, we can now `alembic stamp 007_unify_chat_voice_messages` to bring it under management.
- **Test that triggered this**: dropped from this PR. Round-trip testing requires refactoring migrations 002-006 to use `batch_alter_table` for SQLite compatibility — out of scope.

## Test plan

- [x] `alembic history` no longer raises KeyError (ran locally in worktree)
- [ ] After merge: `alembic stamp 007_unify_chat_voice_messages` on prod to bring DB under alembic management

🤖 Generated with [Claude Code](https://claude.com/claude-code)