### PR TITLE
feat(voice): Perplexity provider + multi-source web search chain for ElevenLabs agents

### DIFF
--- a/backend/src/videos/perplexity_provider.py
+++ b/backend/src/videos/perplexity_provider.py
@@ -1,0 +1,212 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🔮 PERPLEXITY PROVIDER — sonar-pro web search avec citations natives             ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  RÔLE :                                                                            ║
+║  • Provider direct Perplexity (api.perplexity.ai)                                  ║
+║  • Utilisé comme fallback intermédiaire entre Mistral Agent et Brave               ║
+║  • Modèle sonar-pro : réponse synthétisée + citations natives                      ║
+║  • Retourne un WebSearchResult compatible avec web_search_provider                 ║
+║  • Timeout court (15s) — la chaîne complète doit rester sous 30s                   ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+import httpx
+
+from core.config import get_perplexity_key
+
+logger = logging.getLogger(__name__)
+
+
+PERPLEXITY_ENDPOINT = "https://api.perplexity.ai/chat/completions"
+PERPLEXITY_DEFAULT_MODEL = "sonar-pro"
+PERPLEXITY_DEFAULT_TIMEOUT = 15.0
+
+
+def is_perplexity_provider_available() -> bool:
+    """Check if a Perplexity API key is configured."""
+    return bool(get_perplexity_key())
+
+
+def _build_system_prompt(purpose: str, lang: str = "fr") -> str:
+    """Build a purpose-aware system prompt for Perplexity."""
+    is_fr = lang.lower().startswith("fr")
+
+    base = (
+        "Tu es un assistant de recherche web. Réponds de manière factuelle, "
+        "concise (max 200 mots), et cite tes sources. "
+        "Si la question demande des informations récentes, privilégie les sources de moins de 3 mois."
+        if is_fr
+        else "You are a web research assistant. Answer factually, concisely (max 200 words), "
+        "and cite your sources. For time-sensitive questions, prefer sources less than 3 months old."
+    )
+
+    if purpose == "fact_check":
+        addon = (
+            " Évalue chaque affirmation : VRAIE / PARTIELLEMENT VRAIE / FAUSSE / NON VÉRIFIABLE."
+            if is_fr
+            else " Evaluate each claim: TRUE / PARTIALLY TRUE / FALSE / UNVERIFIABLE."
+        )
+    elif purpose == "deep_research":
+        addon = (
+            " Donne un panorama complet : consensus, désaccords, perspectives minoritaires."
+            if is_fr
+            else " Provide a complete overview: consensus, disagreements, minority views."
+        )
+    elif purpose == "debate":
+        addon = (
+            " Présente plusieurs angles de manière équilibrée."
+            if is_fr
+            else " Present multiple angles in a balanced way."
+        )
+    else:
+        addon = ""
+
+    return base + addon
+
+
+async def perplexity_search(
+    query: str,
+    context: str = "",
+    purpose: str = "chat",
+    lang: str = "fr",
+    model: Optional[str] = None,
+    max_tokens: int = 1500,
+    timeout: float = PERPLEXITY_DEFAULT_TIMEOUT,
+) -> Optional["object"]:
+    """
+    Direct call to Perplexity sonar-pro for web-grounded answers.
+
+    Returns a WebSearchResult-shaped object on success, None on failure
+    (so the caller can fall back to the next provider in the chain).
+    """
+    # Late import to avoid circular dep with web_search_provider
+    from videos.web_search_provider import WebSearchResult
+
+    api_key = get_perplexity_key()
+    if not api_key:
+        logger.debug("[PERPLEXITY] No API key configured, skipping")
+        return None
+
+    model = model or PERPLEXITY_DEFAULT_MODEL
+    system_prompt = _build_system_prompt(purpose, lang)
+
+    user_content = query.strip()
+    if context:
+        user_content = f"Contexte : {context[:1500]}\n\nQuestion : {query.strip()}"
+
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0.2,
+        "return_citations": True,
+        "return_related_questions": False,
+    }
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    logger.info(
+        "[PERPLEXITY] Calling %s, query='%s', purpose=%s",
+        model,
+        query[:80],
+        purpose,
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout, http2=True) as client:
+            response = await client.post(PERPLEXITY_ENDPOINT, json=payload, headers=headers)
+
+        if response.status_code != 200:
+            logger.warning(
+                "[PERPLEXITY] HTTP %s: %s",
+                response.status_code,
+                response.text[:300],
+            )
+            return None
+
+        data = response.json()
+
+        # Extract content
+        choices = data.get("choices", [])
+        if not choices:
+            logger.warning("[PERPLEXITY] Empty choices")
+            return None
+
+        message = choices[0].get("message", {})
+        content = (message.get("content") or "").strip()
+        if not content:
+            logger.warning("[PERPLEXITY] Empty content")
+            return None
+
+        # Extract citations — Perplexity returns them as a list of URLs
+        citations = data.get("citations") or message.get("citations") or []
+        sources = []
+        for i, url in enumerate(citations[:10], 1):
+            if isinstance(url, str):
+                sources.append(
+                    {
+                        "title": f"Source {i}",
+                        "url": url,
+                        "snippet": "",
+                    }
+                )
+            elif isinstance(url, dict):
+                sources.append(
+                    {
+                        "title": url.get("title", f"Source {i}"),
+                        "url": url.get("url", ""),
+                        "snippet": url.get("snippet", ""),
+                    }
+                )
+
+        # Token usage
+        usage = data.get("usage", {}) or {}
+        tokens_used = int(usage.get("total_tokens", 0))
+
+        logger.info(
+            "[PERPLEXITY] OK: %d chars, %d sources, %d tokens",
+            len(content),
+            len(sources),
+            tokens_used,
+        )
+
+        return WebSearchResult(
+            success=True,
+            content=content,
+            sources=sources,
+            tokens_used=tokens_used,
+            provider="perplexity",
+        )
+
+    except (httpx.TimeoutException, asyncio.TimeoutError):
+        logger.warning("[PERPLEXITY] Timeout after %ss", timeout)
+        return None
+    except httpx.HTTPError as e:
+        logger.warning("[PERPLEXITY] HTTP error: %s", e)
+        return None
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        logger.warning("[PERPLEXITY] Parse error: %s", e)
+        return None
+    except Exception as e:
+        logger.warning("[PERPLEXITY] Unexpected exception: %s", e)
+        return None
+
+
+__all__ = [
+    "perplexity_search",
+    "is_perplexity_provider_available",
+    "PERPLEXITY_DEFAULT_MODEL",
+]

--- a/backend/src/videos/web_search_provider.py
+++ b/backend/src/videos/web_search_provider.py
@@ -20,6 +20,7 @@ import logging
 from core.config import get_mistral_key, get_brave_key, is_mistral_agent_available
 from core.llm_provider import llm_complete
 from videos.brave_search import _call_brave_api
+from videos.perplexity_provider import perplexity_search, is_perplexity_provider_available
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +49,12 @@ class WebSearchResult:
 
 def is_web_search_available() -> bool:
     """Vérifie que au moins un pipeline web search est disponible."""
-    # Agent Mistral OU Brave+Mistral
-    return is_mistral_agent_available() or (bool(get_brave_key()) and bool(get_mistral_key()))
+    # Agent Mistral OU Perplexity OU Brave+Mistral
+    return (
+        is_mistral_agent_available()
+        or is_perplexity_provider_available()
+        or (bool(get_brave_key()) and bool(get_mistral_key()))
+    )
 
 
 ENRICHMENT_AVAILABLE = is_web_search_available()
@@ -395,17 +400,18 @@ async def web_search_and_synthesize(
     """
     Exécute une recherche web + synthèse IA.
 
-    Pipeline:
-      1. PRIMARY: Mistral Agent (web_search natif, 1 appel API)
-      2. FALLBACK: Brave Search + Mistral synthesis (2 appels API)
+    Pipeline (chaîne de fallback) :
+      1. PRIMARY  : Mistral Agent (web_search natif, 1 appel API)
+      2. FALLBACK : Perplexity sonar-pro (citations natives, 1 appel API)
+      3. FALLBACK : Brave Search + Mistral synthesis (2 appels API)
 
     Interface inchangée — les appelants n'ont pas besoin de modifier leur code.
-    Le champ `provider` indique quel pipeline a servi le résultat ("agent" ou "brave").
+    Le champ `provider` indique quel pipeline a servi le résultat ("agent", "perplexity" ou "brave").
     """
 
     logger.info(f"[WEB_SEARCH] Starting: query='{query[:80]}', purpose={purpose}, lang={lang}")
 
-    # --- Try Agent first ---
+    # --- 1. Try Mistral Agent first ---
     agent_result = await _try_agent_search(
         query=query,
         context=context,
@@ -417,8 +423,25 @@ async def web_search_and_synthesize(
     if agent_result and agent_result.success:
         return agent_result
 
-    # --- Fallback to Brave + Mistral ---
-    logger.info("[WEB_SEARCH] Agent unavailable, falling back to Brave pipeline")
+    # --- 2. Fallback: Perplexity sonar-pro ---
+    if is_perplexity_provider_available():
+        logger.info("[WEB_SEARCH] Agent unavailable, trying Perplexity")
+        try:
+            perplexity_result = await perplexity_search(
+                query=query,
+                context=context,
+                purpose=purpose,
+                lang=lang,
+                max_tokens=max_tokens,
+                timeout=min(timeout * 0.5, 15.0),
+            )
+            if perplexity_result and perplexity_result.success:
+                return perplexity_result
+        except Exception as e:
+            logger.warning(f"[WEB_SEARCH] Perplexity exception (will fallback to Brave): {e}")
+
+    # --- 3. Fallback: Brave + Mistral ---
+    logger.info("[WEB_SEARCH] Falling back to Brave + Mistral pipeline")
 
     return await _brave_fallback_search(
         query=query,

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -2015,6 +2015,79 @@ async def tool_debate_fact_check(request: Request, db: AsyncSession = Depends(ge
     return {"result": result}
 
 
+@router.post("/tools/debate-web-search")
+async def tool_debate_web_search(request: Request, db: AsyncSession = Depends(get_session)):
+    """ElevenLabs tool webhook: web search for debate moderator agents.
+
+    Same multi-provider chain as /tools/web-search (Mistral Agent → Perplexity → Brave),
+    but authenticates against debate_id instead of summary_id since debate agents
+    are not bound to a single video summary.
+
+    Rate-limited:
+      - 15 calls / hour / debate_id (anti spam)
+      - 60 calls / hour / user_id   (global cap, anti fan-out)
+    """
+    debate, body = await verify_debate_tool_request(request, db)
+    query = body.get("query") or body.get("parameters", {}).get("query", "")
+
+    if not query or not query.strip():
+        return {"result": "Aucune requête de recherche fournie."}
+
+    # Per-debate rate limit (reuse summary counter pool with namespaced key)
+    debate_count = await _increment_web_search_count(f"debate:{debate.id}")
+    if debate_count > _WEB_SEARCH_MAX:
+        return {
+            "result": "Limite de recherches web atteinte pour ce débat. "
+            "Utilise les informations déjà disponibles."
+        }
+
+    # Per-user global cap
+    user_count = await _increment_user_web_search_count(int(debate.user_id))
+    if user_count > _WEB_SEARCH_USER_MAX:
+        return {"result": "Limite horaire de recherches web atteinte pour ton compte. Réessaie dans quelques minutes."}
+
+    # Build context from the debate topic so Perplexity/Brave search is well-grounded
+    debate_topic = (debate.detected_topic or "").strip()
+    context_str = f"Débat sur : {debate_topic}" if debate_topic else ""
+
+    try:
+        from videos.web_search_provider import web_search_and_synthesize
+
+        result = await web_search_and_synthesize(
+            query=query.strip(),
+            context=context_str,
+            purpose="debate",
+            lang="fr",
+            max_sources=5,
+            max_tokens=1500,
+            timeout=20.0,
+        )
+        if result.success:
+            answer = result.content
+            # Include up to 3 source URLs in plain text for the agent to mention briefly
+            if result.sources:
+                src_lines = []
+                for src in result.sources[:3]:
+                    title = src.get("title", "")
+                    url = src.get("url", "")
+                    if title or url:
+                        src_lines.append(f"• {title} — {url}")
+                if src_lines:
+                    answer = answer + "\n\nSources :\n" + "\n".join(src_lines)
+            await record_web_search_usage(
+                db,
+                user_id=int(debate.user_id),
+                summary_id=0,  # debate context, no summary
+                source="voice_debate",
+                query=query.strip(),
+            )
+            return {"result": answer[:2000]}
+        return {"result": f"Aucun résultat trouvé pour la recherche : {query[:100]}"}
+    except Exception as e:
+        logger.error("debate-web-search error: %s", e, exc_info=True)
+        return {"result": "Une erreur est survenue lors de la recherche web."}
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # GET /debate/{debate_id}/avatar — Dynamic avatar for the debate moderator agent
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/tests/videos/test_perplexity_provider.py
+++ b/backend/tests/videos/test_perplexity_provider.py
@@ -1,0 +1,218 @@
+"""
+Tests for videos.perplexity_provider — direct Perplexity API integration
+with fallback semantics for the web_search_and_synthesize chain.
+"""
+
+import json
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# is_perplexity_provider_available
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_is_perplexity_provider_available_with_key():
+    from videos.perplexity_provider import is_perplexity_provider_available
+
+    with patch("videos.perplexity_provider.get_perplexity_key", return_value="pplx-test-123"):
+        assert is_perplexity_provider_available() is True
+
+
+def test_is_perplexity_provider_available_without_key():
+    from videos.perplexity_provider import is_perplexity_provider_available
+
+    with patch("videos.perplexity_provider.get_perplexity_key", return_value=""):
+        assert is_perplexity_provider_available() is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# perplexity_search — return shape & graceful failure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_perplexity_search_no_key_returns_none():
+    from videos.perplexity_provider import perplexity_search
+
+    with patch("videos.perplexity_provider.get_perplexity_key", return_value=""):
+        result = await perplexity_search("test query")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_perplexity_search_success_returns_websearchresult():
+    from videos.perplexity_provider import perplexity_search
+
+    fake_response_payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "Voici une réponse synthétisée avec faits récents.",
+                }
+            }
+        ],
+        "citations": [
+            "https://example.com/article1",
+            "https://example.com/article2",
+        ],
+        "usage": {"total_tokens": 350},
+    }
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value=fake_response_payload)
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("videos.perplexity_provider.get_perplexity_key", return_value="pplx-fake"), patch(
+        "videos.perplexity_provider.httpx.AsyncClient", return_value=mock_client
+    ):
+        result = await perplexity_search("dernières news IA")
+
+    assert result is not None
+    assert result.success is True
+    assert result.provider == "perplexity"
+    assert "synthétisée" in result.content
+    assert len(result.sources) == 2
+    assert result.sources[0]["url"] == "https://example.com/article1"
+    assert result.tokens_used == 350
+
+
+@pytest.mark.asyncio
+async def test_perplexity_search_http_error_returns_none():
+    from videos.perplexity_provider import perplexity_search
+
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+    mock_response.text = "rate limited"
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("videos.perplexity_provider.get_perplexity_key", return_value="pplx-fake"), patch(
+        "videos.perplexity_provider.httpx.AsyncClient", return_value=mock_client
+    ):
+        result = await perplexity_search("query")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_perplexity_search_empty_choices_returns_none():
+    from videos.perplexity_provider import perplexity_search
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"choices": []})
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("videos.perplexity_provider.get_perplexity_key", return_value="pplx-fake"), patch(
+        "videos.perplexity_provider.httpx.AsyncClient", return_value=mock_client
+    ):
+        result = await perplexity_search("query")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_perplexity_search_timeout_returns_none():
+    import httpx
+    from videos.perplexity_provider import perplexity_search
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("videos.perplexity_provider.get_perplexity_key", return_value="pplx-fake"), patch(
+        "videos.perplexity_provider.httpx.AsyncClient", return_value=mock_client
+    ):
+        result = await perplexity_search("query", timeout=1.0)
+
+    assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Fallback chain integration (web_search_provider)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_chain_uses_perplexity_when_agent_fails():
+    """When Mistral Agent returns None, the chain should try Perplexity before Brave."""
+    from videos import web_search_provider
+    from videos.web_search_provider import WebSearchResult
+
+    pplx_result = WebSearchResult(
+        success=True,
+        content="Réponse Perplexity",
+        sources=[{"title": "S1", "url": "https://x.com", "snippet": ""}],
+        tokens_used=200,
+        provider="perplexity",
+    )
+
+    with patch(
+        "videos.web_search_provider._try_agent_search", AsyncMock(return_value=None)
+    ), patch(
+        "videos.web_search_provider.is_perplexity_provider_available", return_value=True
+    ), patch(
+        "videos.web_search_provider.perplexity_search", AsyncMock(return_value=pplx_result)
+    ), patch(
+        "videos.web_search_provider._brave_fallback_search", AsyncMock()
+    ) as brave_mock:
+        result = await web_search_provider.web_search_and_synthesize(
+            query="test",
+            context="",
+            purpose="chat",
+        )
+
+    assert result.success is True
+    assert result.provider == "perplexity"
+    brave_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chain_falls_through_to_brave_when_perplexity_fails():
+    """When Agent and Perplexity both return None, Brave fallback must run."""
+    from videos import web_search_provider
+    from videos.web_search_provider import WebSearchResult
+
+    brave_result = WebSearchResult(
+        success=True,
+        content="Brave answer",
+        sources=[],
+        tokens_used=100,
+        provider="brave",
+    )
+
+    with patch(
+        "videos.web_search_provider._try_agent_search", AsyncMock(return_value=None)
+    ), patch(
+        "videos.web_search_provider.is_perplexity_provider_available", return_value=True
+    ), patch(
+        "videos.web_search_provider.perplexity_search", AsyncMock(return_value=None)
+    ), patch(
+        "videos.web_search_provider._brave_fallback_search", AsyncMock(return_value=brave_result)
+    ) as brave_mock:
+        result = await web_search_provider.web_search_and_synthesize(
+            query="test",
+            context="",
+            purpose="chat",
+        )
+
+    assert result.success is True
+    assert result.provider == "brave"
+    brave_mock.assert_called_once()


### PR DESCRIPTION
## Quoi

Ajoute Perplexity comme provider intermediaire dans la chaine de fallback web search pour les agents ElevenLabs.

## Chaine finale
1. Mistral Agent (web_search natif)
2. Perplexity sonar-pro (citations natives)
3. Brave + Mistral synthesis (existant)

## Endpoints
- Nouveau POST /api/voice/tools/debate-web-search pour les debate agents (3 agents qui n'ont pas web_search car non lies a un summary_id)
- Existant /api/voice/tools/web-search beneficie automatiquement de la chaine elargie

## Tests
8 tests dans tests/videos/test_perplexity_provider.py couvrant le provider et la chaine de fallback.