### PR TITLE
chore(backend): ruff format voice/router.py

### DIFF
--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -2036,10 +2036,7 @@ async def tool_debate_web_search(request: Request, db: AsyncSession = Depends(ge
     # Per-debate rate limit (reuse summary counter pool with namespaced key)
     debate_count = await _increment_web_search_count(f"debate:{debate.id}")
     if debate_count > _WEB_SEARCH_MAX:
-        return {
-            "result": "Limite de recherches web atteinte pour ce débat. "
-            "Utilise les informations déjà disponibles."
-        }
+        return {"result": "Limite de recherches web atteinte pour ce débat. Utilise les informations déjà disponibles."}
 
     # Per-user global cap
     user_count = await _increment_user_web_search_count(int(debate.user_id))


### PR DESCRIPTION
## Summary

One-shot ruff format fix for `backend/src/voice/router.py` — preexisting drift on main (Ruff format check only triggers on PR workflows, never validated against main HEAD, so the file diverged from format spec).

Unblocks subsequent ambient-lighting-v3 PRs (PR2/PR3/PR4) from inheriting this CI failure.

## Test plan

- [ ] Backend CI Lint & Type Check → ruff format check passes
- [ ] No functional change (formatting only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)