### PR TITLE
fix(backend): isolate quota BG task session — kills 'close() in progress' SQLAlchemy error

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3210,10 +3210,21 @@ async def _analyze_video_background_v6(
                     logger.error(f"⚠️ [GLOBAL CACHE] Analysis cache set failed: {_vce}")
 
             async def _increment_quota():
+                # ⚠️ Fire-and-forget background task — must NOT reuse the
+                # caller's `session` because the surrounding `async with
+                # async_session_maker() as session` may exit (and close the
+                # session) before this task completes. That race triggers
+                # SQLAlchemy IllegalStateChangeError ("Method 'close()' can't
+                # be called here; method '_connection_for_bind()' is already
+                # in progress" — https://sqlalche.me/e/20/isce) which then
+                # bubbles up to the outer try/except and surfaces as an
+                # "Analysis error" in the client UI even though the analysis
+                # itself succeeded. Open a dedicated session for this BG op.
                 try:
                     from core.plan_limits import increment_daily_usage
 
-                    await increment_daily_usage(session, user_id)
+                    async with async_session_maker() as bg_session:
+                        await increment_daily_usage(bg_session, user_id)
                 except Exception as quota_err:
                     logger.error(f"⚠️ [QUOTA] Failed to increment daily usage: {quota_err}")
 


### PR DESCRIPTION
## Summary

Fixes SQLAlchemy `IllegalStateChangeError` ("Method 'close()' can't be called here; method '_connection_for_bind()' is already in progress and this would cause an unexpected state change to `<SessionTransactionState.CLOSED: 5>`") observed in production on the v6.0 analysis pipeline. Surfaced to end users as a misleading "Analysis error" toast in the extension/web UI even though the analysis itself succeeded.

## Root cause

In `backend/src/videos/router.py` v6.3 path, the fire-and-forget background task `_increment_quota()` was capturing the outer `session` from `async with async_session_maker() as session:` and being launched via:

```python
asyncio.create_task(asyncio.gather(_cache_analysis(), _increment_quota()))
```

The `async with` exits very shortly after that line (the analysis is essentially done at that point). If the BG task is still inside `await session.execute(...)` / `await session.commit()` when teardown runs, SQLAlchemy raises the close/in-progress error. That error bubbles up to the outer `try/except Exception as e: logger.error(f"❌ Analysis error for task {task_id}: ...")` and the failure status is propagated to the client.

Observed in prod logs (Hetzner) on `2026-04-27T06:50:53Z`:
- request_id `37b5a8b4-1f40-4c81-bb05-d9f6d882912c`
- task `63e862b9-1a18-4fb2-807a-e39642e84c2e`, summary_id 129
- Sequence: `Task completed → Enrichment → ❌ Analysis error → chunking continues normally`

## Fix

`_increment_quota()` now opens its own short-lived session via `async with async_session_maker() as bg_session:`. Lifecycle is independent of the caller. `increment_daily_usage()` already commits internally, no other change needed.

## Audit of sibling BG tasks (verified safe — no fix needed)

- `_cache_analysis()` — only Redis, no DB session.
- `_send_complete_notification()` → `notify_analysis_complete()` does not accept a session parameter.
- `ensure_thumbnail()` (also create_task'd) — uses R2/storage, not the parent session.
- v2 / v2.1 paths call `increment_daily_usage(session, user_id)` directly inline (no create_task), so they wait for completion before the `with` exits — safe.

## Test plan

- [ ] SSH VPS → `cd /opt/deepsight/repo && git pull && docker build && docker recreate repo-backend-1`
- [ ] Trigger a v6.0 analysis from the extension (with quota tracking active — non-admin user, free or pro plan)
- [ ] `docker logs repo-backend-1 --since 5m | grep -E 'close|isce|Analysis error'` → 0 matches
- [ ] DailyQuota table → row for today incremented by 1
- [ ] Extension UI shows the synthesis (not the error card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)