### PR TITLE
hotfix: asyncio coroutine + extend JWT sessions (7d/365d)

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -342,8 +342,8 @@ GOOGLE_OAUTH_CONFIG = {
 JWT_CONFIG = {
     "SECRET_KEY": _settings.JWT_SECRET_KEY or _settings.ADMIN_SECRET_KEY,
     "ALGORITHM": "HS256",
-    "ACCESS_TOKEN_EXPIRE_MINUTES": 1440,  # 24h — long session UX for Chrome extension (was 60)
-    "REFRESH_TOKEN_EXPIRE_DAYS": 30,
+    "ACCESS_TOKEN_EXPIRE_MINUTES": 10080,  # 7 jours — long session UX (was 24h, then 1h originally) ; rotation actif via /refresh
+    "REFRESH_TOKEN_EXPIRE_DAYS": 365,  # 1 an — session quasi-éternelle pour user actif (rotation à chaque /refresh étend la durée)
 }
 
 # =============================================================================

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3270,7 +3270,10 @@ async def _analyze_video_background_v6(
                 logger.info(f"   └─ Enrichment: {enrichment_level.value}, {len(enrichment_sources)} sources")
 
             # ⚡ Cache + quota fire-and-forget (perf v6.3) — le frontend voit "completed" 100-500ms plus tôt
-            asyncio.create_task(asyncio.gather(_cache_analysis(), _increment_quota()))
+            async def _post_completion_tasks():
+                await asyncio.gather(_cache_analysis(), _increment_quota())
+
+            asyncio.create_task(_post_completion_tasks())
 
             # 🔔 NOTIFICATION PUSH fire-and-forget — Alerter l'utilisateur que l'analyse est prête
             async def _send_complete_notification():


### PR DESCRIPTION
## Summary
- **fix(router)** : wrap fire-and-forget `asyncio.gather()` in a coroutine so `asyncio.create_task()` accepts it. Without this, every successful analysis raised `"a coroutine was expected, got <_GatheringFuture pending>"` immediately after `update_task_status(... status="completed" ...)`, making the frontend display the analysis as failed even though the summary was persisted in DB.
- **feat(auth)** : bump JWT windows so users on the extension never see "Session expirée" : access token 24h → 7 jours, refresh token 30 jours → 365 jours. Rotation is already active (`auth/router.py:152` emits a fresh refresh_token on every `/refresh`), so each call re-anchors the 365d window.

## Confirmation prod (Hetzner logs)
```
✅ [v6.0] Task completed: 1f45d3f0-...
   └─ Enrichment: full, 0 sources
❌ Analysis error: a coroutine was expected, got <_GatheringFuture pending>
```
Bug introduit dans `6cbba4bc6` (perf v6.3 fire-and-forget post-analysis).

## Test plan
- [x] Identifié le seul `asyncio.create_task(asyncio.gather(...))` dans le backend (`videos/router.py:3273`) — pas d'autres occurrences
- [ ] Deploy Hetzner : `cd /opt/deepsight/repo && git pull && docker build && docker recreate repo-backend-1`
- [ ] Lancer une nouvelle analyse depuis l'extension
- [ ] Vérifier dans `docker logs repo-backend-1` qu'on voit `✅ [v6.0] Task completed` sans le `❌ Analysis error` qui suivait
- [ ] Vérifier que le widget affiche le résultat (pas d'écran "Réessayer")

🤖 Generated with [Claude Code](https://claude.com/claude-code)