### PR TITLE
feat(ext): polish sidepanel UI — dismiss X + analyze cards

### DIFF
--- a/extension/src/sidepanel/components/PromoBanner.tsx
+++ b/extension/src/sidepanel/components/PromoBanner.tsx
@@ -167,13 +167,11 @@ export const PromoBanner: React.FC<PromoBannerProps> = ({ planInfo }) => {
         </a>
       </div>
       <button
+        type="button"
         className="promo-close"
         onClick={handleDismiss}
         title={t.common.hide}
-        style={{
-          background: "var(--accent-primary-muted)",
-          color: "var(--accent-primary)",
-        }}
+        aria-label={t.common.hide}
       >
         &times;
       </button>

--- a/extension/src/sidepanel/components/UrlInputCard.tsx
+++ b/extension/src/sidepanel/components/UrlInputCard.tsx
@@ -3,13 +3,14 @@ import { detectPlatform } from "../../utils/video";
 
 interface Props {
   onSubmit: (url: string) => void;
+  loading?: boolean;
 }
 
-export function UrlInputCard({ onSubmit }: Props): JSX.Element {
+export function UrlInputCard({ onSubmit, loading = false }: Props): JSX.Element {
   const [url, setUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = () => {
+  const submit = () => {
     setError(null);
     const trimmed = url.trim();
     if (!trimmed) return;
@@ -21,51 +22,54 @@ export function UrlInputCard({ onSubmit }: Props): JSX.Element {
     onSubmit(trimmed);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  const isDisabled = loading || url.trim().length === 0;
+
   return (
-    <div
-      style={{
-        padding: 16,
-        margin: 16,
-        background: "rgba(255,255,255,0.03)",
-        borderRadius: 12,
-      }}
-    >
+    <div className="ds-analyze-card">
       <input
+        type="url"
         value={url}
         onChange={(e) => setUrl((e.target as HTMLInputElement).value)}
+        onKeyDown={handleKeyDown}
         placeholder="URL YouTube ou TikTok"
-        style={{
-          width: "100%",
-          padding: 10,
-          background: "rgba(0,0,0,0.3)",
-          border: "1px solid rgba(255,255,255,0.1)",
-          borderRadius: 8,
-          color: "#fff",
-          fontSize: 13,
-          marginBottom: 8,
-          boxSizing: "border-box",
-        }}
+        className="ds-analyze-input"
+        disabled={loading}
+        aria-label="URL de la vidéo à analyser"
+        spellCheck={false}
+        autoComplete="off"
       />
       {error && (
-        <div style={{ color: "#ef4444", fontSize: 12, marginBottom: 8 }}>
+        <div className="ds-analyze-error" role="alert">
           {error}
         </div>
       )}
       <button
-        onClick={handleSubmit}
-        style={{
-          background: "linear-gradient(135deg, #6366f1, #8b5cf6)",
-          color: "#fff",
-          border: "none",
-          padding: "10px 16px",
-          borderRadius: 8,
-          fontSize: 13,
-          fontWeight: 500,
-          cursor: "pointer",
-          width: "100%",
-        }}
+        type="button"
+        onClick={submit}
+        disabled={isDisabled}
+        className="ds-analyze-btn"
+        aria-busy={loading}
       >
-        Analyser
+        {loading ? (
+          <>
+            <span className="ds-analyze-spinner" aria-hidden="true" />
+            <span>Analyse en cours…</span>
+          </>
+        ) : (
+          <>
+            <span className="ds-analyze-btn-icon" aria-hidden="true">
+              ✨
+            </span>
+            <span>Analyser cette vidéo</span>
+          </>
+        )}
       </button>
     </div>
   );

--- a/extension/src/sidepanel/components/VideoDetectedCard.tsx
+++ b/extension/src/sidepanel/components/VideoDetectedCard.tsx
@@ -5,6 +5,7 @@ interface Props {
   thumbnail: string;
   platform: "youtube" | "tiktok";
   onAnalyze: () => void;
+  loading?: boolean;
 }
 
 export function VideoDetectedCard({
@@ -12,44 +13,35 @@ export function VideoDetectedCard({
   thumbnail,
   platform,
   onAnalyze,
+  loading = false,
 }: Props): JSX.Element {
   return (
-    <div
-      style={{
-        padding: 16,
-        background: "rgba(255,255,255,0.03)",
-        borderRadius: 12,
-        margin: 16,
-      }}
-    >
+    <div className="ds-analyze-card">
       {thumbnail && (
-        <img
-          src={thumbnail}
-          alt={title}
-          style={{ width: "100%", borderRadius: 8, marginBottom: 12 }}
-        />
+        <img src={thumbnail} alt={title} className="ds-analyze-thumbnail" />
       )}
-      <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 8 }}>
-        {title}
-      </div>
-      <div style={{ fontSize: 11, opacity: 0.6, marginBottom: 12 }}>
-        {platform.toUpperCase()}
-      </div>
+      <div className="ds-analyze-title">{title}</div>
+      <div className="ds-analyze-platform">{platform.toUpperCase()}</div>
       <button
+        type="button"
         onClick={onAnalyze}
-        style={{
-          background: "linear-gradient(135deg, #6366f1, #8b5cf6)",
-          color: "#fff",
-          border: "none",
-          padding: "10px 16px",
-          borderRadius: 8,
-          fontSize: 13,
-          fontWeight: 500,
-          cursor: "pointer",
-          width: "100%",
-        }}
+        disabled={loading}
+        className="ds-analyze-btn"
+        aria-busy={loading}
       >
-        Analyser cette vidéo
+        {loading ? (
+          <>
+            <span className="ds-analyze-spinner" aria-hidden="true" />
+            <span>Analyse en cours…</span>
+          </>
+        ) : (
+          <>
+            <span className="ds-analyze-btn-icon" aria-hidden="true">
+              ✨
+            </span>
+            <span>Analyser cette vidéo</span>
+          </>
+        )}
       </button>
     </div>
   );

--- a/extension/src/sidepanel/styles/sidepanel.css
+++ b/extension/src/sidepanel/styles/sidepanel.css
@@ -2040,19 +2040,187 @@ a:hover {
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  border: none;
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  font-size: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  background: rgba(0, 0, 0, 0.32);
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 14px;
+  line-height: 1;
   cursor: pointer;
-  transition: background var(--transition-fast);
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  transition:
+    background 200ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .promo-close:hover {
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(0, 0, 0, 0.5);
+  transform: scale(1.1) rotate(90deg);
+}
+
+.promo-close:focus-visible {
+  outline: 2px solid var(--accent-primary, #c8903a);
+  outline-offset: 2px;
+}
+
+/* ═══════════════════════════════════════════════════
+   ANALYZE CARDS (UrlInputCard / VideoDetectedCard)
+   ═══════════════════════════════════════════════════ */
+
+.ds-analyze-card {
+  margin: 16px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  transition: border-color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ds-analyze-card:focus-within {
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.ds-analyze-thumbnail {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  display: block;
+}
+
+.ds-analyze-title {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 6px;
+  line-height: 1.35;
+  color: var(--text-primary, #f5f5f7);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ds-analyze-platform {
+  font-size: 11px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  opacity: 0.55;
+  margin-bottom: 12px;
+}
+
+.ds-analyze-input {
+  width: 100%;
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: #fff;
+  font-size: 13px;
+  font-family: inherit;
+  margin-bottom: 8px;
+  box-sizing: border-box;
+  transition:
+    border-color 200ms cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ds-analyze-input::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.ds-analyze-input:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.5);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.ds-analyze-input:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.ds-analyze-error {
+  color: #fca5a5;
+  font-size: 12px;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ds-analyze-btn {
+  position: relative;
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 11px 16px;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  letter-spacing: 0.2px;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.08) inset,
+    0 8px 22px -10px rgba(99, 102, 241, 0.65);
+  transition:
+    transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1),
+    filter 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ds-analyze-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  filter: brightness(1.06);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.12) inset,
+    0 14px 28px -12px rgba(99, 102, 241, 0.8),
+    0 0 22px -4px rgba(139, 92, 246, 0.45);
+}
+
+.ds-analyze-btn:active:not(:disabled) {
+  transform: translateY(0);
+  filter: brightness(0.96);
+}
+
+.ds-analyze-btn:focus-visible {
+  outline: 2px solid #c4b5fd;
+  outline-offset: 2px;
+}
+
+.ds-analyze-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  filter: saturate(0.5);
+  box-shadow: none;
+}
+
+.ds-analyze-btn-icon {
+  display: inline-flex;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.ds-analyze-spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
+  animation: ds-spin 700ms linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes ds-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ═══════════════════════════════════════════════════
@@ -2662,19 +2830,36 @@ a:hover {
 
 .v3-banner-dismiss {
   margin-left: auto;
-  background: transparent;
-  border: none;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 50%;
   color: inherit;
-  opacity: 0.5;
+  opacity: 0.7;
   cursor: pointer;
-  padding: 4px;
-  font-size: 14px;
+  padding: 0;
+  font-size: 11px;
+  line-height: 1;
   flex-shrink: 0;
-  transition: opacity 150ms;
+  transition:
+    opacity 200ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
+    background 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .v3-banner-dismiss:hover {
   opacity: 1;
+  background: rgba(255, 255, 255, 0.14);
+  transform: scale(1.1) rotate(90deg);
+}
+
+.v3-banner-dismiss:focus-visible {
+  outline: 2px solid var(--accent-primary, #c8903a);
+  outline-offset: 2px;
 }
 
 .v3-footer {


### PR DESCRIPTION
## Summary
Visual + a11y polish on 4 UI hot-spots du side panel extension (suite à la demande UX).

### Dismiss buttons (X)
- **`.v3-banner-dismiss`** (banner "Essayez DeepSight sur YouTube !") : était quasi-invisible (transparent + opacity 0.5). Maintenant cercle 24×24 avec fond subtil, hover scale(1.1) + rotate(90deg), focus ring keyboard.
- **`.promo-close`** (banner promo doré bas) : background passé d'alpha-white à alpha-dark pour contraste sur le gradient doré, même hover/focus polish.

### Analyze cards
- **`UrlInputCard`** (mode QG / saisie URL manuelle) et **`VideoDetectedCard`** (vidéo détectée) : inline styles migrés en classes `.ds-analyze-card` / `.ds-analyze-btn` partagées.
- Bouton : icône sparkle ✨, hover lift -1px + glow indigo, gradient brightness shift, disabled state propre (saturate down + opacity 0.45), loading state (prop `loading?`) avec spinner + "Analyse en cours…" + `aria-busy`.
- Wording aligné : les 2 cartes disent "Analyser cette vidéo" (UrlInputCard disait juste "Analyser").

### UrlInputCard UX
- Submit on **Enter**
- Bouton disabled tant que l'input est vide
- Input focus ring (border + halo 3px), invalid-state avec `role="alert"`
- `type="url"`, `autoComplete="off"`, `spellCheck={false}`

## Test plan
- [x] `npm run typecheck` clean
- [ ] `cd extension && npm run build` puis recharger l'extension dans `chrome://extensions`
- [ ] Vérifier visuellement les 2 X (banner haut + banner bas) — cercle visible, hover anime
- [ ] Vérifier le bouton "Analyser cette vidéo" en mode YouTube détectée → hover lift + glow
- [ ] Coller une URL YouTube dans la barre QG → presser Enter → l'analyse démarre
- [ ] Bouton grisé tant que l'input est vide

🤖 Generated with [Claude Code](https://claude.com/claude-code)