### PR TITLE
fix(backend/voice): Pro est le top tier voice (Expert retiré)

### DIFF
--- a/backend/src/billing/voice_quota.py
+++ b/backend/src/billing/voice_quota.py
@@ -3,10 +3,12 @@
 Spec source: ``docs/superpowers/specs/2026-04-26-quick-voice-call-design.md``
 section "e. Voice quota A+D strict".
 
-Plan-to-policy matrix (literal as per spec):
-  * Free   : 1 lifetime trial of 3 minutes (``lifetime_trial_used`` boolean)
-  * Pro    : never granted, returns CTA upgrade_expert (HTTP 402 path)
-  * Expert : 30 minutes per rolling 30-day window
+Plan-to-policy matrix (UPDATED 2026-04-27 — "Expert" tier was retired before
+the spec landed, top paid tier is now Pro €12.99/month):
+  * Free                    : 1 lifetime trial of 3 minutes
+  * Pro / Expert (alias)    : 30 minutes per rolling 30-day window
+  * Starter / Student       : refused, CTA upgrade Pro
+  * Anything else (legacy)  : refused, CTA upgrade Pro
 
 The Quick Voice Call session router branches on ``check_voice_quota`` to
 either let the call start (returning the remaining ``max_minutes``) or raise
@@ -32,13 +34,18 @@ logger = logging.getLogger(__name__)
 
 
 # ─── Spec constants (locked decision #4 — A+D strict) ────────────────────
-EXPERT_MONTHLY_MINUTES: float = 30.0
+TOP_TIER_MONTHLY_MINUTES: float = 30.0
+EXPERT_MONTHLY_MINUTES: float = TOP_TIER_MONTHLY_MINUTES  # Backwards-compat alias
 FREE_TRIAL_MINUTES: float = 3.0
 MONTHLY_PERIOD_DAYS: int = 30
 
+# Plans that grant the rolling monthly minutes quota. "expert" is kept as an
+# alias for legacy/test callers — production currently only uses "pro".
+TOP_TIER_PLANS: frozenset[str] = frozenset({"pro", "expert"})
+
 
 QuotaReason = Literal["trial_used", "pro_no_voice", "monthly_quota"]
-QuotaCta = Literal["upgrade_expert"]
+QuotaCta = Literal["upgrade_pro", "upgrade_expert"]
 
 
 @dataclass
@@ -60,18 +67,14 @@ class QuotaCheck:
     cta: Optional[QuotaCta] = None
 
 
-async def _get_or_create_quota(
-    user_id: int, plan: str, db: AsyncSession
-) -> VoiceQuotaStreaming:
+async def _get_or_create_quota(user_id: int, plan: str, db: AsyncSession) -> VoiceQuotaStreaming:
     """Fetch or insert the ``voice_quota`` row for the user.
 
     Side effect: when the existing row's ``monthly_period_start`` is older
     than ``MONTHLY_PERIOD_DAYS`` days, the rolling counter is reset
     in-memory (the caller commits if it mutates other fields).
     """
-    result = await db.execute(
-        select(VoiceQuotaStreaming).where(VoiceQuotaStreaming.user_id == user_id)
-    )
+    result = await db.execute(select(VoiceQuotaStreaming).where(VoiceQuotaStreaming.user_id == user_id))
     quota = result.scalar_one_or_none()
 
     now = datetime.now(timezone.utc)
@@ -119,7 +122,7 @@ async def check_voice_quota(user: User, db: AsyncSession) -> QuotaCheck:
             return QuotaCheck(
                 allowed=False,
                 reason="trial_used",
-                cta="upgrade_expert",
+                cta="upgrade_pro",
             )
         return QuotaCheck(
             allowed=True,
@@ -127,41 +130,36 @@ async def check_voice_quota(user: User, db: AsyncSession) -> QuotaCheck:
             is_trial=True,
         )
 
-    if plan == "pro":
-        return QuotaCheck(
-            allowed=False,
-            reason="pro_no_voice",
-            cta="upgrade_expert",
-        )
-
-    if plan == "expert":
-        remaining = EXPERT_MONTHLY_MINUTES - quota.monthly_minutes_used
+    if plan in TOP_TIER_PLANS:
+        remaining = TOP_TIER_MONTHLY_MINUTES - quota.monthly_minutes_used
         if remaining <= 0:
             return QuotaCheck(allowed=False, reason="monthly_quota")
         return QuotaCheck(allowed=True, max_minutes=remaining)
 
-    # Unknown / legacy plan label → treat as Pro (blocked, CTA upgrade)
-    logger.warning(
-        "Unknown plan '%s' in check_voice_quota for user_id=%d — falling back to pro_no_voice",
+    # Starter / Student / unknown legacy plan → blocked, CTA upgrade Pro.
+    # We reuse the historical "pro_no_voice" reason code so the existing
+    # extension UI (UpgradeCTA / VoiceView) keeps rendering its upgrade card
+    # without a release-coupling change.
+    logger.info(
+        "Plan '%s' is not a top-tier voice plan for user_id=%d — returning upgrade CTA",
         plan,
         user.id,
     )
     return QuotaCheck(
         allowed=False,
         reason="pro_no_voice",
-        cta="upgrade_expert",
+        cta="upgrade_pro",
     )
 
 
-async def consume_voice_minutes(
-    user: User, minutes: float, db: AsyncSession
-) -> None:
+async def consume_voice_minutes(user: User, minutes: float, db: AsyncSession) -> None:
     """Record ``minutes`` of voice usage against ``user``'s quota.
 
     For Free users, flips the lifetime trial flag (single-shot).
-    For Expert users, increments the monthly rolling counter.
-    For Pro users, no-op (they are blocked upstream — but stays safe if
-    called).
+    For top-tier users (Pro / Expert legacy), increments the monthly rolling
+    counter.
+    For other plans (Starter / Student), no-op — they are blocked upstream by
+    ``check_voice_quota``, this stays safe if called by mistake.
 
     Always commits.
     """
@@ -171,7 +169,7 @@ async def consume_voice_minutes(
     if plan == "free":
         quota.lifetime_trial_used = True
         quota.lifetime_trial_used_at = datetime.now(timezone.utc)
-    elif plan == "expert":
+    elif plan in TOP_TIER_PLANS:
         quota.monthly_minutes_used = float(quota.monthly_minutes_used or 0.0) + float(minutes)
 
     await db.commit()

--- a/backend/tests/billing/test_voice_quota.py
+++ b/backend/tests/billing/test_voice_quota.py
@@ -1,11 +1,12 @@
 """Tests for the A+D strict Quick Voice Call quota service (Task 2).
 
-Cover the 5 paths of ``check_voice_quota`` plus ``consume_voice_minutes``:
+Cover the paths of ``check_voice_quota`` plus ``consume_voice_minutes``:
   * Free user with no prior quota row → trial allowed (3 min)
-  * Free user whose lifetime trial was used → blocked, cta=upgrade_expert
-  * Pro user → always blocked, cta=upgrade_expert
-  * Expert user with quota remaining → allowed, max_minutes = 30 - used
-  * Expert user with quota exhausted → blocked, reason=monthly_quota
+  * Free user whose lifetime trial was used → blocked, cta=upgrade_pro
+  * Pro user (top tier) → allowed, monthly counter applies
+  * Pro user with quota exhausted → blocked, reason=monthly_quota
+  * Expert user (legacy alias of Pro) → same monthly behaviour
+  * Starter / unknown plan → blocked with CTA upgrade_pro
 
 Mocks db.execute as in the existing voice quota tests (tests/test_voice.py)
 to stay consistent with the project's fixture style — no live DB.
@@ -60,7 +61,7 @@ async def test_free_first_use_allowed():
 
 @pytest.mark.asyncio
 async def test_free_after_trial_blocked():
-    """Free user whose lifetime trial flag is set → blocked, cta=upgrade_expert."""
+    """Free user whose lifetime trial flag is set → blocked, cta=upgrade_pro."""
     quota = MagicMock()
     quota.plan = "free"
     quota.monthly_period_start = datetime.now(timezone.utc)
@@ -73,19 +74,38 @@ async def test_free_after_trial_blocked():
     result = await check_voice_quota(user, db)
     assert result.allowed is False
     assert result.reason == "trial_used"
-    assert result.cta == "upgrade_expert"
+    assert result.cta == "upgrade_pro"
     assert result.max_minutes == 0.0
 
 
 @pytest.mark.asyncio
-async def test_pro_always_blocked_with_cta():
-    """Pro plan never gets voice access — always blocked with CTA upgrade."""
+async def test_pro_now_top_tier_grants_monthly_quota():
+    """Pro is now the top paid tier — gets the 30-min/month rolling quota."""
+    quota = MagicMock()
+    quota.plan = "pro"
+    quota.monthly_period_start = datetime.now(timezone.utc)
+    quota.monthly_minutes_used = 12.0
+    quota.lifetime_trial_used = False
+    quota.lifetime_trial_used_at = None
+
     user = _make_user("pro")
+    db = _make_db_session(quota_row=quota)
+    result = await check_voice_quota(user, db)
+    assert result.allowed is True
+    assert result.max_minutes == EXPERT_MONTHLY_MINUTES - 12.0
+    assert result.is_trial is False
+    assert result.cta is None
+
+
+@pytest.mark.asyncio
+async def test_starter_blocked_with_cta_upgrade_pro():
+    """Starter (low-tier paid) is blocked with CTA upgrade_pro."""
+    user = _make_user("starter")
     db = _make_db_session(quota_row=None)
     result = await check_voice_quota(user, db)
     assert result.allowed is False
     assert result.reason == "pro_no_voice"
-    assert result.cta == "upgrade_expert"
+    assert result.cta == "upgrade_pro"
 
 
 @pytest.mark.asyncio
@@ -179,18 +199,35 @@ async def test_consume_increments_expert_minutes():
 
 
 @pytest.mark.asyncio
-async def test_consume_pro_no_op():
-    """Pro user has no quota counter to update — but still no-op safely."""
+async def test_consume_starter_no_op():
+    """Starter (blocked tier) → consume is a safe no-op if accidentally called."""
     quota = MagicMock()
-    quota.plan = "pro"
+    quota.plan = "starter"
     quota.monthly_period_start = datetime.now(timezone.utc)
     quota.monthly_minutes_used = 0.0
     quota.lifetime_trial_used = False
     quota.lifetime_trial_used_at = None
 
-    user = _make_user("pro")
+    user = _make_user("starter")
     db = _make_db_session(quota_row=quota)
     await consume_voice_minutes(user, 5.0, db)
-    # Pro never accumulates against this counter
+    # Starter is upstream-blocked; counter stays at zero
     assert quota.monthly_minutes_used == 0.0
     assert quota.lifetime_trial_used is False
+
+
+@pytest.mark.asyncio
+async def test_consume_pro_increments_monthly_minutes():
+    """Pro is now top tier — consume should add to monthly_minutes_used."""
+    quota = MagicMock()
+    quota.plan = "pro"
+    quota.monthly_period_start = datetime.now(timezone.utc)
+    quota.monthly_minutes_used = 5.0
+    quota.lifetime_trial_used = False
+    quota.lifetime_trial_used_at = None
+
+    user = _make_user("pro")
+    db = _make_db_session(quota_row=quota)
+    await consume_voice_minutes(user, 4.5, db)
+    assert quota.monthly_minutes_used == 9.5
+    db.commit.assert_called_once()


### PR DESCRIPTION
## Bug
Un user en plan Pro (€12.99 = top paid tier réel) qui cliquait 🎙️ recevait une 402 avec `cta=upgrade_expert`. Le tier Expert n'existe plus dans le pricing actuel (Free / Starter / Student / Pro), les Pro étaient piégés.

## Cause
La spec voice call avait été figée quand le pricing comprenait encore Expert €14.99/mois. Le code suivait littéralement : `free → trial`, `pro → CTA upgrade`, `expert → 30 min/mois`.

## Fix
Plan-to-policy matrix aligné avec la réalité business actuelle :
- **Free** : 1 trial 3 min (inchangé)
- **Pro** : 30 min/mois (anciennement Expert)
- **Expert** : conservé comme alias rétrocompat dans `TOP_TIER_PLANS` frozenset
- **Starter / Student / autre** : refusé, CTA upgrade Pro

L'extension UI (`UpgradeCTA.tsx`, `VoiceView.tsx`) ne lit que `reason` (pas `cta`), donc rendu cohérent sans release frontend couplée.

## Tests
- ruff format / ruff check : OK
- pytest `tests/billing/test_voice_quota.py tests/voice/` : **53 passed** (51 existants + 2 nouveaux : `test_pro_now_top_tier_grants_monthly_quota`, `test_starter_blocked_with_cta_upgrade_pro`)

## Test plan post-merge
- [ ] User Pro clique 🎙️ → l'appel démarre, max 30 min
- [ ] User Free clique 🎙️ 1ère fois → trial 3 min, lifetime flag flip après
- [ ] User Free 2ème fois → 402 avec `reason=trial_used` + UpgradeCTA visible
- [ ] User Starter → 402 avec `reason=pro_no_voice` + UpgradeCTA visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)