### PR TITLE
fix(lighting-engine): build via postinstall (fix CI A11y + dev)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "tsc -p ../packages/lighting-engine/tsconfig.build.json",
+    "postinstall": "tsc -p ../packages/lighting-engine/tsconfig.build.json",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- Le hook `prebuild` ne couvrait que `npm run build`, pas `npm run dev` ni `npm run test:a11y` → CI A11y cassé sur main depuis PR #156.
- Remplace `prebuild` par `postinstall` → le build du package `@deepsight/lighting-engine` se fait après `npm install` / `npm ci`, donc disponible pour tous les scripts (dev, test, build, etc.).

## Root cause
`packages/lighting-engine/dist/` est gitignored. Le CI A11y workflow lance `npm run test:a11y` → `playwright test` → spawn `npm run dev` via webServer.command → Vite charge `vite.config.ts` → import `@deepsight/lighting-engine` → `main: ./dist/index.js` → 404 → `Failed to resolve entry for package`.

Vercel build passait grâce à `prebuild` (tsc avant `vite build`), mais aucun autre flow ne déclenchait ce hook.

## Test plan
- [x] `rm -rf packages/lighting-engine/dist && npx tsc -p ../packages/lighting-engine/tsconfig.build.json` recompile le bundle complet ✅
- [ ] CI A11y passe vert sur cette PR
- [ ] Vercel preview build OK (postinstall remplace prebuild sans régression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)