### PR TITLE
fix(a11y-test): wait 1.5s for Framer Motion animations

### DIFF
--- a/frontend/e2e/a11y-contrast.spec.ts
+++ b/frontend/e2e/a11y-contrast.spec.ts
@@ -31,6 +31,10 @@ for (const route of PUBLIC_ROUTES) {
   }) => {
     await page.goto(route.path);
     await page.waitForLoadState("networkidle");
+    // Wait for Framer Motion entrance animations to complete — otherwise
+    // axe-core reads the "computed" color of elements still at opacity:0
+    // and reports false-positive contrast violations.
+    await page.waitForTimeout(1500);
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2aa", "wcag2aaa"])


### PR DESCRIPTION
## Summary
Sur la PR #163, axe-core a remonté plusieurs faux positifs de contraste sur des éléments encore en cours d'animation d'entrée (`style=\"opacity: 0; transform: translateY(...)\"`). axe lit la couleur "computed" même quand l'élément est invisible à l'écran.

Exemples remontés :
- `fgColor #525256` sur `bgColor #0c0c12`, ratio 2.5 (élément `opacity:0`)
- `fgColor #4a4c51` sur `bgColor #0c0c12`, ratio 2.26 (élément `opacity:0`)
- `fgColor #27272c` sur `bgColor #0b0b10`, ratio 1.32 (élément `opacity:0`)

## Fix
Ajouter `waitForTimeout(1500)` après `networkidle` pour laisser les animations Framer Motion (initial + animate) se stabiliser.

Solution pragmatique avant un setup plus structuré (ex : `reduced-motion` media query ou fixture qui désactive les anims en CI).

## Test plan
- [ ] CI Axe-core a11y contrast tests : nombre de violations chute drastiquement
- [ ] S'il reste des violations après ce fix, ce sont de **vraies** violations à traiter dans une PR follow-up (text-muted, text-accent-primary contraste sur fond sombre)

## Impact
Test runtime augmente de 1.5s × 3 routes = ~4.5s ajoutés au workflow A11y. Acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)