### PR TITLE
feat(geo): sprint 2 — middleware Edge bots IA + sitemap dyn + BreadcrumbList + _locales/ Chrome

### DIFF
--- a/extension/CHROME_WEB_STORE.md
+++ b/extension/CHROME_WEB_STORE.md
@@ -123,3 +123,80 @@ https://www.deepsightsynthesis.com/privacy
 3. Quick Chat (0 credits, chat rapide)
 4. Popup avec analyse en cours (progression)
 5. Analyse TikTok (sidebar sur TikTok)
+
+## Permissions justifications (Chrome Web Store form)
+
+These justifications are pasted as-is into the CWS submission form, one per
+permission. Keep them short, factual, and tied to a user-facing feature.
+
+### Standard permissions
+
+- **storage** — Persist authentication tokens (access + refresh), user
+  preferences (UI language, voice settings), and a small cache of recent
+  analyses for offline access. No tracking, no third-party sharing.
+
+- **activeTab** — Read the URL of the YouTube or TikTok video currently
+  active in the user's tab so the user can trigger an AI analysis with one
+  click. Only the video ID is sent to our backend; no DOM scraping is
+  performed.
+
+- **tabs** — Detect URL changes (e.g. user navigates to a new YouTube
+  video) to refresh the Side Panel context (video detected card, analysis
+  state). Used solely on YouTube and TikTok.
+
+- **alarms** — Periodic background refresh of the OAuth access token
+  (15-minute lifespan) using the refresh token, so the user does not need
+  to re-login every 15 minutes.
+
+- **identity** — Used by chrome.identity.launchWebAuthFlow() to perform
+  Google OAuth login. The flow opens the standard Google consent screen
+  in a popup and returns an OAuth code we exchange server-side for a JWT.
+
+- **clipboardWrite** — Allow the user to copy generated content
+  (summaries, fact-check results, flashcards) to the system clipboard with
+  one click, from the Side Panel "Copy" buttons.
+
+- **sidePanel** — Display the DeepSight interface in Chrome's native Side
+  Panel (Chrome 114+), persistent across tab switches. Toggle via
+  Alt+Shift+D or the toolbar icon.
+
+- **offscreen** — Required by the ElevenLabs voice SDK on Chrome MV3 to
+  host an offscreen document for audio capture and playback (service
+  workers cannot access getUserMedia directly).
+
+### Optional permissions
+
+- **audioCapture** (optional, requested only when the user starts a voice
+  chat session) — Capture microphone input for the ElevenLabs ConvAI
+  voice agent. Audio is streamed directly to ElevenLabs over a secure
+  WebSocket; no audio is persisted on our servers.
+
+### Host permissions
+
+- **https://www.youtube.com/*, https://youtube.com/*** — Detect the
+  currently watched video and inject the optional content-script overlay
+  showing the analyze button. No analytics, no DOM modification beyond
+  the overlay.
+
+- **https://www.tiktok.com/*, https://tiktok.com/*, https://vm.tiktok.com/*,
+  https://m.tiktok.com/*** — Same as YouTube, for TikTok video detection.
+
+- **https://www.deepsightsynthesis.com/*** — Cross-domain authentication
+  sync between the extension and the web app, so a user logged in on the
+  web is automatically logged in on the extension (and vice versa).
+
+- **https://api.deepsightsynthesis.com/*** — Backend API endpoints for
+  analyses, chat, billing, voice sessions, etc.
+
+- **https://api.elevenlabs.io/*, wss://api.elevenlabs.io/*,
+  https://*.elevenlabs.io/*, wss://*.elevenlabs.io/*** — ElevenLabs
+  ConvAI voice chat over WebSocket. Required by the @elevenlabs/client
+  SDK; CSP whitelist already restricts connect-src to these domains.
+
+## Single purpose statement (Chrome Web Store form)
+
+DeepSight is an AI-powered analysis tool for YouTube and TikTok videos.
+Its single purpose is to help users understand, fact-check, and study
+video content via AI-generated summaries, contextual chat, flashcards,
+and an optional voice agent — all from a persistent Side Panel inside
+Chrome.

--- a/extension/public/_locales/en/messages.json
+++ b/extension/public/_locales/en/messages.json
@@ -1,0 +1,18 @@
+{
+  "extension_name": {
+    "message": "DeepSight - AI Video Analysis",
+    "description": "Extension display name shown in Chrome Web Store and the browser toolbar"
+  },
+  "extension_short_name": {
+    "message": "DeepSight",
+    "description": "Short name (max 12 chars) shown in app launcher and compact UI"
+  },
+  "extension_description": {
+    "message": "AI-powered YouTube & TikTok analysis: sourced summaries, fact-check, flashcards, voice chat. European AI by Mistral.",
+    "description": "Extension description shown in Chrome Web Store listing"
+  },
+  "extension_action_title": {
+    "message": "DeepSight",
+    "description": "Tooltip shown on hover over the extension toolbar icon"
+  }
+}

--- a/extension/public/_locales/fr/messages.json
+++ b/extension/public/_locales/fr/messages.json
@@ -1,0 +1,18 @@
+{
+  "extension_name": {
+    "message": "DeepSight - Analyse vidéo IA",
+    "description": "Nom affiché dans le Chrome Web Store et la barre d'outils"
+  },
+  "extension_short_name": {
+    "message": "DeepSight",
+    "description": "Nom court (max 12 caractères) pour le lanceur d'applis"
+  },
+  "extension_description": {
+    "message": "Analyse YouTube et TikTok par IA : synthèses sourcées, fact-checking, flashcards, chat vocal. IA européenne par Mistral.",
+    "description": "Description affichée sur la fiche Chrome Web Store"
+  },
+  "extension_action_title": {
+    "message": "DeepSight",
+    "description": "Info-bulle au survol de l'icône de l'extension"
+  }
+}

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,9 +1,10 @@
 {
   "manifest_version": 3,
-  "name": "DeepSight - AI Video Analysis",
-  "short_name": "DeepSight",
+  "default_locale": "en",
+  "name": "__MSG_extension_name__",
+  "short_name": "__MSG_extension_short_name__",
   "version": "2.0.0",
-  "description": "AI-powered YouTube & TikTok analysis: sourced summaries, fact-check, flashcards, voice chat. European AI by Mistral.",
+  "description": "__MSG_extension_description__",
   "author": "DeepSight",
   "homepage_url": "https://www.deepsightsynthesis.com",
   "minimum_chrome_version": "116",
@@ -74,7 +75,7 @@
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
     },
-    "default_title": "DeepSight"
+    "default_title": "__MSG_extension_action_title__"
   },
 
   "side_panel": {

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -79,6 +79,7 @@ module.exports = (env, argv) => {
       new CopyPlugin({
         patterns: [
           { from: `public/${manifestFile}`, to: "manifest.json" },
+          { from: "public/_locales", to: "_locales" },
           { from: "public/viewer.html", to: "viewer.html" },
           { from: "public/offscreen-mic.html", to: "offscreen-mic.html" },
           { from: "public/mic-permission.html", to: "mic-permission.html" },

--- a/frontend/api/prerender.ts
+++ b/frontend/api/prerender.ts
@@ -1,0 +1,499 @@
+/**
+ * Vercel Edge Function — Prerender for AI generative bots
+ *
+ * Renders simplified, semantically-structured HTML for AI bots
+ * (GPTBot, ClaudeBot, PerplexityBot, etc.) that don't execute JavaScript.
+ * The Vite SPA returns a blank shell to those bots; this function exposes
+ * indexable content with full meta, JSON-LD, headings, and inner text.
+ *
+ * Reached via vercel.json rewrites that detect bot user-agents on
+ * /, /about, /upgrade, /contact. Other paths fall back to the SPA shell.
+ *
+ * GET /api/prerender?path=/about
+ */
+
+export const config = { runtime: "edge" };
+
+const SITE_URL = "https://www.deepsightsynthesis.com";
+const ORG_LOGO = `${SITE_URL}/icons/icon-512x512.png`;
+const OG_IMAGE = `${SITE_URL}/og-image.png`;
+
+interface Section {
+  heading: string;
+  body: string;
+}
+
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface Page {
+  slug: string;
+  title: string;
+  description: string;
+  h1: string;
+  sections: Section[];
+  faq?: FAQItem[];
+  extraJsonLd?: Array<Record<string, unknown>>;
+}
+
+const FAQ_LANDING: FAQItem[] = [
+  {
+    question: "Qu'est-ce que DeepSight ?",
+    answer:
+      "DeepSight est un SaaS d'analyse IA de vidéos YouTube et TikTok. Il transforme une vidéo en synthèse sourcée et nuancée, avec fact-checking, flashcards, quiz, mind maps, chat contextuel et voice agent. 100% européen, propulsé par Mistral AI (France) et hébergé chez Hetzner (Allemagne).",
+  },
+  {
+    question: "DeepSight est-il gratuit ?",
+    answer:
+      "Le plan Free permet 5 analyses par mois sur des vidéos jusqu'à 15 minutes, avec flashcards, quiz et chat contextuel. Pour plus, le plan Plus à 4,99€/mois (25 analyses, 60 min, fact-check, mind maps, web search, exports PDF) et le plan Pro à 9,99€/mois (100 analyses, 4h, voice chat ElevenLabs 45 min/mois, playlists, deep research) sont disponibles.",
+  },
+  {
+    question: "Quelle IA utilise DeepSight ?",
+    answer:
+      "Mistral AI (Paris, France) pour les analyses, le chat et le fact-checking. Le modèle Mistral utilisé dépend du plan : Mistral Small (Free), Mistral Medium (Plus), Mistral Large 2512 avec 262K context (Pro). ElevenLabs ConvAI fournit le voice agent (Pro), avec 6 types d'agents disponibles.",
+  },
+  {
+    question: "Mes données sont-elles en sécurité ?",
+    answer:
+      "Oui. DeepSight est 100% RGPD : hébergement Hetzner (Falkenstein, Allemagne), IA Mistral en France. Aucune revente de données, pas de tracking publicitaire, analytics PostHog opt-in seulement. Les vidéos ne sont jamais stockées — seules les métadonnées et les analyses générées le sont.",
+  },
+  {
+    question: "Sur quelles plateformes DeepSight est-il disponible ?",
+    answer:
+      "Trois interfaces synchronisées avec un seul compte : application Web (deepsightsynthesis.com), application mobile native (iOS et Android, via Expo), et extension Chrome avec Side Panel persistant pour analyser une vidéo YouTube en un clic.",
+  },
+  {
+    question: "Comment fonctionne le fact-checking ?",
+    answer:
+      "Chaque affirmation clé d'une vidéo est évaluée avec quatre marqueurs épistémiques : SOLIDE (consensus scientifique), PLAUSIBLE (probable mais à confirmer), INCERTAIN (hypothèse, débat), À VÉRIFIER (douteuse). Le fact-check chaîne Mistral Agent → Perplexity → Brave Search pour fournir des sources externes vérifiables.",
+  },
+  {
+    question: "Puis-je partager une analyse ?",
+    answer:
+      "Oui. Chaque analyse peut être partagée via une URL publique (`/s/<token>`) qui inclut une OG image dynamique 1200×630, un canonical, du JSON-LD Article et un compteur de vues. Idéal pour citer une analyse dans un article, un cours ou un thread Twitter/LinkedIn.",
+  },
+];
+
+const FAQ_PRICING: FAQItem[] = [
+  {
+    question: "Quels sont les plans DeepSight ?",
+    answer:
+      "Trois plans : Free (gratuit, 5 analyses/mois, 15 min max), Plus (4,99€/mois, 25 analyses, 60 min, fact-check + mind maps + web search + exports PDF), Pro (9,99€/mois, 100 analyses, 4h, voice chat ElevenLabs 45 min/mois + playlists + deep research + file prioritaire).",
+  },
+  {
+    question: "Comment fonctionne le voice chat ?",
+    answer:
+      "Le voice chat utilise ElevenLabs ConvAI couplé à LiveKit. Disponible uniquement sur le plan Pro avec 45 minutes incluses par mois. Six types d'agents : EXPLORER (discussion ouverte), TUTOR (pédagogique), DEBATE_MODERATOR (modération de débats), QUIZ_COACH (coaching study), ONBOARDING, COMPANION (chat libre).",
+  },
+  {
+    question: "Peut-on annuler ou changer de plan ?",
+    answer:
+      "Oui, à tout moment via le portail Stripe. Pas d'engagement. Le downgrade prend effet à la fin de la période de facturation en cours.",
+  },
+  {
+    question: "Y a-t-il un essai gratuit du plan Pro ?",
+    answer:
+      "Oui, un essai Pro Trial est disponible pour les nouveaux utilisateurs. Il déverrouille temporairement les features Pro pour les évaluer avant souscription.",
+  },
+];
+
+const PAGES: Record<string, Page> = {
+  "/": {
+    slug: "/",
+    title: "DeepSight — Analyse YouTube & TikTok par IA, 100% européen",
+    description:
+      "Synthèses sourcées, fact-checking, flashcards FSRS, voice agent ElevenLabs. Propulsé par Mistral AI (France) et hébergé en Europe (Hetzner Allemagne). Gratuit pour commencer.",
+    h1: "Ne subissez plus vos vidéos — interrogez-les",
+    sections: [
+      {
+        heading: "Le pitch",
+        body: "DeepSight transforme des vidéos YouTube et TikTok en analyses structurées et vérifiables. Au lieu d'un simple résumé, l'IA Mistral identifie les arguments clés, vérifie les affirmations avec des sources externes, génère des flashcards de révision et permet de poser des questions sur la vidéo. Conçu pour les étudiants, journalistes, chercheurs, créateurs et professionnels qui digèrent beaucoup de contenu vidéo.",
+      },
+      {
+        heading: "Fonctionnalités principales",
+        body: "Analyse vidéo IA via Mistral (modèles Small / Medium / Large 2512). Fact-checking nuancé avec marqueurs épistémiques SOLIDE / PLAUSIBLE / INCERTAIN / À VÉRIFIER, sources via Mistral Agent → Perplexity → Brave Search. Flashcards FSRS v5 (algorithme adaptatif type Anki). Quiz interactifs auto-générés. Mind maps interactives (Plus / Pro). Chat contextuel sur la vidéo, avec recherche web optionnelle. Voice agent ElevenLabs ConvAI avec 6 types d'agents (Pro, 45 min/mois). Débat IA entre deux vidéos pour analyser les divergences (Plus+). Recherche académique enrichie (arXiv, Crossref, Semantic Scholar, OpenAlex). Exports PDF, DOCX, Markdown. Partage public d'analyses avec OG image dynamique.",
+      },
+      {
+        heading: "Pour qui ?",
+        body: "Étudiants qui veulent réviser à partir de cours YouTube avec flashcards FSRS et quiz. Journalistes qui doivent fact-checker une interview ou un débat avec marqueurs épistémiques et sources citables. Chercheurs qui digèrent des conférences ou des présentations académiques avec enrichissement papers. Créateurs qui analysent leur niche, comparent des vidéos concurrentes et génèrent des notes structurées. Professionnels qui transforment des conférences de 2-3 heures en synthèses exploitables en métro.",
+      },
+      {
+        heading: "Plans",
+        body: "Free (0€) : 5 analyses/mois, vidéos 15 min max, flashcards, quiz, chat 5 questions/vidéo, historique 60 jours, modèle Mistral Small. Plus (4,99€/mois) : 25 analyses/mois, vidéos 60 min, mind maps, fact-check, web search 20/mois, débat IA 3/mois, exports PDF + Markdown, historique permanent, modèle Mistral Medium. Pro (9,99€/mois) : 100 analyses/mois, vidéos 4h, voice chat ElevenLabs 45 min/mois, playlists 10/mois, deep research, débat IA 20/mois, web search 60/mois, file prioritaire, modèle Mistral Large 2512 avec 262K context.",
+      },
+      {
+        heading: "Différenciateurs",
+        body: "100% européen : IA française (Mistral AI, Paris), hébergement allemand (Hetzner, Falkenstein), conformité RGPD native — vos données ne quittent pas l'Europe. Fact-checking nuancé : pas de vérité binaire, marqueurs épistémiques pour chaque affirmation. Tri-plateforme cohérent : un seul compte, un seul abonnement, trois interfaces (web, mobile iOS/Android, extension Chrome avec Side Panel). Voice agent ConvAI : conversations vocales naturelles avec contexte vidéo, rare sur ce marché. Sourcing transparent : chaque fact-check est accompagné de ses sources externes vérifiables.",
+      },
+    ],
+    faq: FAQ_LANDING,
+    extraJsonLd: [
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        name: "DeepSight",
+        alternateName: "DeepSight Synthesis",
+        url: SITE_URL,
+        description:
+          "SaaS d'analyse IA de vidéos YouTube et TikTok, 100% européen.",
+        applicationCategory: "EducationalApplication",
+        operatingSystem: "Web, iOS, Android, Chrome",
+        inLanguage: ["fr", "en"],
+        offers: [
+          {
+            "@type": "Offer",
+            price: "0",
+            priceCurrency: "EUR",
+            name: "Free",
+          },
+          {
+            "@type": "Offer",
+            price: "4.99",
+            priceCurrency: "EUR",
+            name: "Plus",
+          },
+          {
+            "@type": "Offer",
+            price: "9.99",
+            priceCurrency: "EUR",
+            name: "Pro",
+          },
+        ],
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        name: "DeepSight",
+        url: SITE_URL,
+        logo: ORG_LOGO,
+        founder: { "@type": "Person", name: "Maxime Le Parc" },
+        foundingDate: "2025",
+        address: {
+          "@type": "PostalAddress",
+          addressLocality: "Lyon",
+          addressCountry: "FR",
+        },
+      },
+    ],
+  },
+  "/about": {
+    slug: "/about",
+    title: "À propos de DeepSight — Vision, équipe, infrastructure",
+    description:
+      "Vision, fondateur, partenaires et infrastructure de DeepSight. SaaS français, IA Mistral, hébergement Hetzner (UE), open-source friendly.",
+    h1: "À propos de DeepSight",
+    sections: [
+      {
+        heading: "Vision",
+        body: "Construire un outil de digestion vidéo qui ne soit ni un résumeur paresseux, ni une boîte noire opaque. DeepSight assume une position épistémique : chaque affirmation est qualifiée (SOLIDE, PLAUSIBLE, INCERTAIN, À VÉRIFIER), les sources sont citées, les modèles sont européens et identifiés. L'objectif est d'augmenter la capacité de pensée critique de ses utilisateurs face à l'avalanche de contenu vidéo.",
+      },
+      {
+        heading: "Fondateur",
+        body: "Maxime Le Parc, basé à Lyon, France. Entrepreneur indépendant. SAS française, RCS 994 558 898. Le projet est développé en solo avec Mistral AI comme partenaire technologique principal.",
+      },
+      {
+        heading: "Partenaires technologiques",
+        body: "Mistral AI (Paris, France) : analyses, chat, fact-checking. ElevenLabs (US/UK) : voice agent ConvAI. LiveKit : infrastructure WebRTC pour les sessions voice. Hetzner Cloud (Falkenstein, Allemagne) : hébergement backend (PostgreSQL 17, Redis 7, FastAPI Docker). Vercel : hébergement frontend. Supadata : extraction transcripts YouTube prioritaire. Stripe : paiements. Resend : emails transactionnels.",
+      },
+      {
+        heading: "Infrastructure",
+        body: "Backend FastAPI Python 3.11 hébergé sur un VPS Hetzner à Falkenstein (Allemagne) avec stack Docker complète : PostgreSQL 17, Redis 7, Caddy reverse proxy avec SSL automatique. Frontend React 18 + TypeScript + Vite + Tailwind CSS sur Vercel. Mobile Expo SDK 54 + React Native 0.81 distribué via App Store et Play Store. Extension Chrome MV3 avec Side Panel + Preact (bundle 85 KB). Toute l'infrastructure tourne en Europe — vos données ne quittent pas le continent.",
+      },
+      {
+        heading: "Open-source friendly",
+        body: "DeepSight repose sur de nombreuses dépendances open-source : React, TypeScript, Vite, Tailwind, Expo, FastAPI, SQLAlchemy, Pydantic, Preact, etc. Le projet remercie explicitement ces communautés et publie ses conditions d'utilisation et politique de confidentialité conformes au RGPD.",
+      },
+    ],
+    extraJsonLd: [
+      {
+        "@context": "https://schema.org",
+        "@type": "AboutPage",
+        name: "À propos de DeepSight",
+        url: `${SITE_URL}/about`,
+        mainEntity: {
+          "@type": "Organization",
+          name: "DeepSight",
+          url: SITE_URL,
+          founder: { "@type": "Person", name: "Maxime Le Parc" },
+          foundingDate: "2025",
+        },
+      },
+    ],
+  },
+  "/upgrade": {
+    slug: "/upgrade",
+    title: "Tarifs DeepSight — Free, Plus 4,99€, Pro 9,99€",
+    description:
+      "Trois plans simples : Free (0€), Plus 4,99€/mois (fact-check + mind maps + web search), Pro 9,99€/mois (voice agent + playlists + deep research). Sans engagement.",
+    h1: "Choisissez votre plan DeepSight",
+    sections: [
+      {
+        heading: "Plan Free — 0€/mois",
+        body: "5 analyses par mois. Vidéos jusqu'à 15 minutes. 250 crédits mensuels. Modèle Mistral Small (mistral-small-2603). Flashcards FSRS et quiz inclus. Chat contextuel avec 5 questions par vidéo et 10 questions par jour. Historique conservé 60 jours. Idéal pour découvrir DeepSight sans engagement et sans carte bancaire.",
+      },
+      {
+        heading: "Plan Plus — 4,99€/mois",
+        body: "25 analyses par mois. Vidéos jusqu'à 60 minutes. 3 000 crédits mensuels. Modèle Mistral Medium (mistral-medium-2508). Tout du Free, plus : mind maps interactives, fact-checking nuancé avec sources externes, web search 20 requêtes/mois, débat IA 3/mois, exports PDF et Markdown, historique permanent, papers académiques 15 par analyse. Idéal pour usage régulier (étudiants, créateurs, journalistes).",
+      },
+      {
+        heading: "Plan Pro — 9,99€/mois",
+        body: "100 analyses par mois. Vidéos jusqu'à 4 heures. 15 000 crédits mensuels. Modèle Mistral Large 2512 (262K context). Tout du Plus, plus : voice chat ElevenLabs ConvAI 45 minutes par mois, playlists 10 par mois, deep research multi-step, débat IA 20/mois, web search 60/mois, papers 50 par analyse avec texte intégral, file prioritaire, jusqu'à 3 analyses simultanées. Idéal pour professionnels et chercheurs intensifs.",
+      },
+      {
+        heading: "Paiement et facturation",
+        body: "Paiement par carte via Stripe (PCI-DSS). Sans engagement, annulation à tout moment via le portail Stripe. Downgrade pris en compte à la fin de la période en cours. Reçus disponibles dans le portail. Possibilité d'addon packs jetables pour le voice (minutes additionnelles).",
+      },
+    ],
+    faq: FAQ_PRICING,
+    extraJsonLd: [
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        name: "DeepSight Plus",
+        description:
+          "Plan Plus de DeepSight : 25 analyses/mois, fact-check, mind maps, web search, exports PDF.",
+        offers: {
+          "@type": "Offer",
+          price: "4.99",
+          priceCurrency: "EUR",
+          url: `${SITE_URL}/upgrade`,
+          availability: "https://schema.org/InStock",
+        },
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        name: "DeepSight Pro",
+        description:
+          "Plan Pro de DeepSight : 100 analyses/mois, voice agent ElevenLabs 45 min, playlists, deep research, file prioritaire.",
+        offers: {
+          "@type": "Offer",
+          price: "9.99",
+          priceCurrency: "EUR",
+          url: `${SITE_URL}/upgrade`,
+          availability: "https://schema.org/InStock",
+        },
+      },
+    ],
+  },
+  "/contact": {
+    slug: "/contact",
+    title: "Contact DeepSight — Posez vos questions",
+    description:
+      "Formulaire de contact DeepSight pour questions, partenariats, presse, support. Réponse rapide via email.",
+    h1: "Contactez DeepSight",
+    sections: [
+      {
+        heading: "Comment nous joindre",
+        body: "Le formulaire de contact est la voie principale. DeepSight est édité par Maxime Le Parc, SAS française basée à Lyon (RCS 994 558 898). Pour des questions techniques, l'API publique est documentée à /api-docs et le statut des services en temps réel à /status.",
+      },
+      {
+        heading: "Sujets fréquents",
+        body: "Support utilisateur (problème d'analyse, quota, paiement) : utilisez le formulaire avec votre adresse email associée à votre compte. Questions presse et partenariats : précisez le contexte dans le message. Demandes RGPD (accès, rectification, suppression de données) : la procédure est détaillée dans la politique de confidentialité accessible à /legal/privacy. Sécurité (vulnérabilités responsables) : voir /.well-known/security.txt.",
+      },
+    ],
+    extraJsonLd: [
+      {
+        "@context": "https://schema.org",
+        "@type": "ContactPage",
+        name: "Contact DeepSight",
+        url: `${SITE_URL}/contact`,
+        mainEntity: {
+          "@type": "Organization",
+          name: "DeepSight",
+          url: SITE_URL,
+          contactPoint: {
+            "@type": "ContactPoint",
+            contactType: "customer support",
+            url: `${SITE_URL}/contact`,
+            availableLanguage: ["French", "English"],
+          },
+        },
+      },
+    ],
+  },
+};
+
+export default async function handler(request: Request): Promise<Response> {
+  if (request.method !== "GET") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  const url = new URL(request.url);
+  const path = url.searchParams.get("path") || "/";
+  const page = PAGES[path];
+
+  if (!page) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const html = renderPage(page);
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      "X-Robots-Tag": "index, follow",
+      "X-Prerender-For": "AI-bots",
+    },
+  });
+}
+
+function renderPage(page: Page): string {
+  const canonical = `${SITE_URL}${page.slug}`;
+
+  const baseJsonLd: Record<string, unknown>[] = [
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      name: page.title,
+      description: page.description,
+      url: canonical,
+      isPartOf: {
+        "@type": "WebSite",
+        name: "DeepSight",
+        url: SITE_URL,
+      },
+      breadcrumb: buildBreadcrumb(page.slug),
+    },
+    ...(page.extraJsonLd || []),
+  ];
+
+  if (page.faq && page.faq.length > 0) {
+    baseJsonLd.push({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: page.faq.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    });
+  }
+
+  return `<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>${escapeHtml(page.title)}</title>
+<meta name="description" content="${escapeHtml(page.description)}">
+<link rel="canonical" href="${canonical}">
+<link rel="alternate" hreflang="fr" href="${canonical}">
+<link rel="alternate" hreflang="x-default" href="${canonical}">
+<meta property="og:type" content="website">
+<meta property="og:title" content="${escapeHtml(page.title)}">
+<meta property="og:description" content="${escapeHtml(page.description)}">
+<meta property="og:url" content="${canonical}">
+<meta property="og:image" content="${OG_IMAGE}">
+<meta property="og:site_name" content="DeepSight">
+<meta property="og:locale" content="fr_FR">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${escapeHtml(page.title)}">
+<meta name="twitter:description" content="${escapeHtml(page.description)}">
+<meta name="twitter:image" content="${OG_IMAGE}">
+<meta name="robots" content="index, follow">
+<meta name="author" content="DeepSight">
+${baseJsonLd
+  .map(
+    (jsonLd) =>
+      `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`,
+  )
+  .join("\n")}
+</head>
+<body>
+<header>
+<p><a href="${SITE_URL}/">DeepSight</a> — Analyse YouTube &amp; TikTok par IA, 100% européen.</p>
+<nav>
+<a href="${SITE_URL}/">Accueil</a> ·
+<a href="${SITE_URL}/about">À propos</a> ·
+<a href="${SITE_URL}/upgrade">Tarifs</a> ·
+<a href="${SITE_URL}/contact">Contact</a> ·
+<a href="${SITE_URL}/api-docs">API</a> ·
+<a href="${SITE_URL}/status">Statut</a> ·
+<a href="${SITE_URL}/legal">Mentions légales</a>
+</nav>
+</header>
+<main>
+<h1>${escapeHtml(page.h1)}</h1>
+${page.sections
+  .map(
+    (section) => `<section>
+<h2>${escapeHtml(section.heading)}</h2>
+<p>${escapeHtml(section.body)}</p>
+</section>`,
+  )
+  .join("\n")}
+${page.faq ? renderFAQ(page.faq) : ""}
+</main>
+<footer>
+<p>DeepSight — SAS française fondée par Maxime Le Parc à Lyon (RCS 994 558 898). IA Mistral (Paris). Hébergement Hetzner (Falkenstein, Allemagne, EU). Conforme RGPD.</p>
+<p>Cette page est une version simplifiée servie aux moteurs IA générative (GPTBot, ClaudeBot, PerplexityBot, etc.). Les utilisateurs humains accèdent à l'application interactive complète.</p>
+</footer>
+</body>
+</html>`;
+}
+
+function renderFAQ(faq: FAQItem[]): string {
+  return `<section>
+<h2>FAQ</h2>
+${faq
+  .map(
+    (item) => `<article>
+<h3>${escapeHtml(item.question)}</h3>
+<p>${escapeHtml(item.answer)}</p>
+</article>`,
+  )
+  .join("\n")}
+</section>`;
+}
+
+interface BreadcrumbList {
+  "@type": "BreadcrumbList";
+  itemListElement: Array<{
+    "@type": "ListItem";
+    position: number;
+    name: string;
+    item: string;
+  }>;
+}
+
+function buildBreadcrumb(slug: string): BreadcrumbList {
+  const items: Array<{ name: string; url: string }> = [
+    { name: "Accueil", url: `${SITE_URL}/` },
+  ];
+  if (slug !== "/") {
+    const labels: Record<string, string> = {
+      "/about": "À propos",
+      "/upgrade": "Tarifs",
+      "/contact": "Contact",
+    };
+    items.push({
+      name: labels[slug] || slug.replace(/^\//, ""),
+      url: `${SITE_URL}${slug}`,
+    });
+  }
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "postinstall": "tsc -p ../packages/lighting-engine/tsconfig.build.json",
+    "prebuild": "node scripts/generate-sitemap.mjs",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/frontend/scripts/generate-sitemap.mjs
+++ b/frontend/scripts/generate-sitemap.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * generate-sitemap.mjs — Generates frontend/public/sitemap.xml at build time.
+ *
+ * Wired via the `prebuild` npm script so each `vite build` regenerates a
+ * fresh sitemap with today's lastmod, replacing the static checked-in
+ * version. Routes are listed below; add a new entry whenever a public
+ * page is added to App.tsx.
+ *
+ * Run manually: `node scripts/generate-sitemap.mjs`
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SITE_URL = "https://www.deepsightsynthesis.com";
+const TODAY = new Date().toISOString().split("T")[0];
+
+/**
+ * Public, indexable routes. Keep this in sync with App.tsx public routes.
+ * Excludes /login, /auth/callback, /payment/success, /payment/cancel
+ * (transient or auth gates) and /s/:shareToken (dynamic per-token).
+ */
+const ROUTES = [
+  { path: "/", priority: 1.0, changefreq: "weekly" },
+  { path: "/about", priority: 0.8, changefreq: "monthly" },
+  { path: "/upgrade", priority: 0.9, changefreq: "monthly" },
+  { path: "/api-docs", priority: 0.6, changefreq: "monthly" },
+  { path: "/contact", priority: 0.5, changefreq: "yearly" },
+  { path: "/status", priority: 0.4, changefreq: "daily" },
+  { path: "/legal", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/cgu", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/cgv", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/privacy", priority: 0.3, changefreq: "yearly" },
+];
+
+function buildSitemap() {
+  const urls = ROUTES.map(
+    ({ path, priority, changefreq }) => `  <url>
+    <loc>${SITE_URL}${path}</loc>
+    <lastmod>${TODAY}</lastmod>
+    <changefreq>${changefreq}</changefreq>
+    <priority>${priority.toFixed(1)}</priority>
+  </url>`,
+  ).join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+const outputPath = resolve(__dirname, "../public/sitemap.xml");
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, buildSitemap(), "utf-8");
+console.log(
+  `✓ Sitemap written: ${outputPath} (${ROUTES.length} URLs, lastmod=${TODAY})`,
+);

--- a/frontend/src/components/BreadcrumbJsonLd.tsx
+++ b/frontend/src/components/BreadcrumbJsonLd.tsx
@@ -1,0 +1,70 @@
+import { Helmet } from "react-helmet-async";
+
+const SITE_URL = "https://www.deepsightsynthesis.com";
+
+/**
+ * Map d'un path vers son label affiché dans le breadcrumb.
+ * Inclure ici toute nouvelle route publique pour qu'elle soit lisible
+ * par les LLMs et Google via le JSON-LD BreadcrumbList.
+ */
+const LABELS: Record<string, string> = {
+  "/about": "À propos",
+  "/upgrade": "Tarifs",
+  "/contact": "Contact",
+  "/api-docs": "Documentation API",
+  "/status": "Statut des services",
+  "/legal": "Mentions légales",
+  "/legal/cgu": "Conditions générales d'utilisation",
+  "/legal/cgv": "Conditions générales de vente",
+  "/legal/privacy": "Politique de confidentialité",
+};
+
+interface BreadcrumbJsonLdProps {
+  /** Path absolu de la page courante, ex: "/about" ou "/legal/cgu" */
+  path: string;
+  /** Override du label final (utile pour pages dynamiques type /s/:token) */
+  label?: string;
+}
+
+/**
+ * Émet un JSON-LD BreadcrumbList Schema.org dans le `<head>` via Helmet.
+ * Construit la hiérarchie automatiquement à partir des segments du path.
+ *
+ * Usage :
+ *   <BreadcrumbJsonLd path="/about" />
+ *   <BreadcrumbJsonLd path="/legal/cgu" />
+ *   <BreadcrumbJsonLd path={`/s/${token}`} label={videoTitle} />
+ */
+export const BreadcrumbJsonLd = ({ path, label }: BreadcrumbJsonLdProps) => {
+  const items: Array<{ name: string; url: string }> = [
+    { name: "Accueil", url: `${SITE_URL}/` },
+  ];
+
+  if (path !== "/") {
+    const segments = path.split("/").filter(Boolean);
+    let current = "";
+    segments.forEach((segment, index) => {
+      current += "/" + segment;
+      const isLast = index === segments.length - 1;
+      const itemLabel = isLast && label ? label : LABELS[current] || segment;
+      items.push({ name: itemLabel, url: `${SITE_URL}${current}` });
+    });
+  }
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+
+  return (
+    <Helmet>
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
+  );
+};

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import Layout from "../components/Layout";
 import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // ANIMATION VARIANTS
@@ -216,6 +217,7 @@ const AboutPage = () => {
         path="/about"
         keywords="DeepSight, à propos, IA française, Mistral AI, analyse vidéo, YouTube, RGPD, Europe"
       />
+      <BreadcrumbJsonLd path="/about" />
       {/* Back navigation */}
       <div className="sticky top-0 z-10 bg-bg-primary/80 backdrop-blur-lg border-b border-border-subtle">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 h-14 flex items-center">

--- a/frontend/src/pages/ApiDocsPage.tsx
+++ b/frontend/src/pages/ApiDocsPage.tsx
@@ -8,6 +8,8 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "../hooks/useTranslation";
+import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
 import {
   Key,
   Copy,
@@ -554,6 +556,13 @@ export const ApiDocsPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-bg-primary">
+      <SEO
+        title="Documentation API"
+        description="Documentation de l'API publique DeepSight v1 : endpoints, authentification par clé API, exemples curl, schémas de réponse. Réservé au plan Pro."
+        path="/api-docs"
+        keywords="DeepSight, API, documentation, REST, clé API, endpoints"
+      />
+      <BreadcrumbJsonLd path="/api-docs" />
       <div className="max-w-4xl mx-auto px-6 py-12">
         {/* Back button */}
         <button

--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -24,6 +24,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import DoodleBackground from "../components/DoodleBackground";
 import { contactApi } from "../services/api";
 import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
 import { DeepSightSpinnerMicro } from "../components/ui/DeepSightSpinner";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -161,9 +162,10 @@ const ContactPage: React.FC = () => {
     <div className="min-h-screen bg-bg-primary relative">
       <SEO
         title="Contact"
-        description="Contactez l'équipe Deep Sight. Questions, suggestions, support technique — nous vous répondons rapidement."
+        description="Contactez l'équipe DeepSight. Questions, suggestions, support technique — nous vous répondons rapidement."
         path="/contact"
       />
+      <BreadcrumbJsonLd path="/contact" />
       <DoodleBackground />
 
       {/* Header */}

--- a/frontend/src/pages/UpgradePage.tsx
+++ b/frontend/src/pages/UpgradePage.tsx
@@ -36,6 +36,7 @@ import DoodleBackground from "../components/DoodleBackground";
 import { DeepSightSpinnerMicro } from "../components/ui";
 import { billingApi, type ApiBillingPlan } from "../services/api";
 import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
 import { analytics } from "../services/analytics";
 import {
   PLANS_INFO as FALLBACK_PLANS_INFO,
@@ -1137,10 +1138,11 @@ export const UpgradePage: React.FC = () => {
   return (
     <div className="min-h-screen bg-bg-primary relative">
       <SEO
-        title="Mon plan"
+        title="Tarifs"
         description="Découvrez les plans DeepSight : Gratuit, Plus (4,99€/mois) et Pro (9,99€/mois). Analysez vos vidéos YouTube et TikTok avec l'IA."
         path="/upgrade"
       />
+      <BreadcrumbJsonLd path="/upgrade" />
       <DoodleBackground variant="creative" />
       <Sidebar
         collapsed={sidebarCollapsed}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -21,6 +21,50 @@
       ],
       "destination": "https://api.deepsightsynthesis.com/api/share/:token/og"
     },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+        }
+      ],
+      "destination": "/api/prerender?path=/"
+    },
+    {
+      "source": "/about",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+        }
+      ],
+      "destination": "/api/prerender?path=/about"
+    },
+    {
+      "source": "/upgrade",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+        }
+      ],
+      "destination": "/api/prerender?path=/upgrade"
+    },
+    {
+      "source": "/contact",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+        }
+      ],
+      "destination": "/api/prerender?path=/contact"
+    },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

Sprint 2 du chantier GEO : adresse le **verrou n°1** identifié à l'audit (Vite SPA pure CSR invisible aux crawlers IA). Le contenu des 4 pages publiques principales est désormais servi en **HTML prérendu** aux 15 bots IA générative connus, via une Edge Function Vercel.

Couvre aussi : sitemap dynamique au build, BreadcrumbList JSON-LD systématique sur les pages publiques, `_locales/` natifs CWS pour l'extension Chrome, justifications des permissions rédigées.

## Ce que ce PR change

### 🤖 Middleware Edge bots IA — le cœur

- **`frontend/api/prerender.ts`** (nouveau, Edge runtime) : rend du HTML structuré pour `/`, `/about`, `/upgrade`, `/contact`. Chaque page contient :
  - `<title>`, `<meta description>`, `<link rel=canonical>`, hreflang fr+x-default, OG, Twitter Cards
  - JSON-LD : `WebPage` + `BreadcrumbList` + extras (`Organization`, `WebApplication` avec offers Free/Plus/Pro, `AboutPage`, `Product` x2, `ContactPage`, `FAQPage` quand applicable)
  - Structure sémantique H1/H2/sections, nav publique, FAQ pour landing et pricing, footer souveraineté EU
  - Cache `public, max-age=3600, s-maxage=3600`
  - Header `X-Robots-Tag: index, follow` + `X-Prerender-For: AI-bots`

- **`frontend/vercel.json`** : 4 rewrites conditionnels avec `has.user-agent` matchant 15 bots IA (`GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot`). Les autres UA continuent de recevoir le SPA shell — les humains ne sont pas affectés.

### 🗺️ Sitemap dynamique

- **`frontend/scripts/generate-sitemap.mjs`** (nouveau) : régénère `public/sitemap.xml` avec `lastmod=today` à chaque build. Liste de 10 routes publiques en source, à mettre à jour manuellement quand une nouvelle page publique est ajoutée à `App.tsx`.
- **`frontend/package.json`** : nouveau script `\"prebuild\": \"node scripts/generate-sitemap.mjs\"` → exécuté automatiquement avant `vite build`.

### 🍞 BreadcrumbList JSON-LD systématique

- **`frontend/src/components/BreadcrumbJsonLd.tsx`** (nouveau) : composant utilitaire qui émet un JSON-LD `BreadcrumbList` via Helmet. Hiérarchie auto à partir du path (`/legal/cgu` → Accueil > Mentions légales > CGU). Override possible via prop `label` pour pages dynamiques (futur usage `/s/:token`).
- Ajouté sur `AboutPage`, `UpgradePage`, `ContactPage`, `ApiDocsPage`. `LandingPage` non concernée (Accueil seul = breadcrumb d'un item, inutile).

### 🌍 `_locales/` Chrome natif

- **`extension/public/_locales/{en,fr}/messages.json`** (nouveaux) : 4 messages (`extension_name`, `extension_short_name`, `extension_description`, `extension_action_title`).
- **`extension/public/manifest.json`** : `default_locale: \"en\"` ajouté ; `name`, `short_name`, `description`, `action.default_title` migrés vers `__MSG_*__`. Chrome Web Store affichera désormais la fiche en français pour les utilisateurs FR (au lieu de toujours afficher l'EN).
- **`extension/webpack.config.js`** : `_locales/` ajouté au `CopyPlugin` pour être copié dans `dist/` au build.

### 🔐 Justifications permissions Chrome

- **`extension/CHROME_WEB_STORE.md`** : nouvelle section \"Permissions justifications\" rédigée prête à coller dans le formulaire CWS. Couvre :
  - 8 permissions standard : `storage`, `activeTab`, `tabs`, `alarms`, `identity`, `clipboardWrite`, `sidePanel`, `offscreen`
  - 1 permission optionnelle : `audioCapture` (voice chat)
  - 5 catégories de host_permissions (YouTube, TikTok, deepsightsynthesis.com, api.deepsightsynthesis.com, ElevenLabs)
- Section \"Single purpose statement\" ajoutée (CWS exige un statement explicite depuis 2024).

### Détails côté pages

- `UpgradePage` : `<SEO title=\"Mon plan\">` → `<SEO title=\"Tarifs\">` (plus GEO-friendly)
- `ContactPage` : harmonisation \"Deep Sight\" → \"DeepSight\" dans la description meta (résidu Sprint 1)
- `ApiDocsPage` : ajout `<SEO>` (manquait totalement) + `<BreadcrumbJsonLd>`

## Volume
13 fichiers modifiés ou créés, 5 nouveaux fichiers, +900+ insertions.

## Test plan
- [ ] `npm run build` côté frontend : doit exécuter `prebuild` (regénère sitemap.xml) puis `vite build` sans erreur
- [ ] `vercel deploy` (preview) : vérifier que `/api/prerender?path=/` renvoie 200 avec le HTML prérendu attendu
- [ ] `curl -A 'GPTBot' https://<preview>.vercel.app/` doit renvoyer le HTML prérendu (pas le SPA shell)
- [ ] `curl -A 'Mozilla/5.0' https://<preview>.vercel.app/` doit renvoyer le SPA shell habituel (humains non affectés)
- [ ] `view-source:` sur `/about` (avec UA normal) : doit voir le `<script type=\"application/ld+json\">` BreadcrumbList injecté par Helmet une fois React monté
- [ ] `cd extension && npm run build` : `dist/_locales/{en,fr}/messages.json` doivent exister, `dist/manifest.json` doit avoir `default_locale: \"en\"` + `__MSG_*__` strings
- [ ] Charger `extension/dist/` dans Chrome (test local) : la fiche doit afficher \"DeepSight - AI Video Analysis\" en EN, \"DeepSight - Analyse vidéo IA\" en FR (selon langue browser)
- [ ] Frontend typecheck OK sur fichiers modifiés (vérifié localement, pas de nouvelle erreur)

## Notes
- Les 4 pages prerender (`/`, `/about`, `/upgrade`, `/contact`) couvrent l'essentiel du GEO. Pages `legal`, `status`, `api-docs` sont laissées au SPA shell (moins critiques) — peuvent être ajoutées au prerender si besoin.
- Le hreflang `en` reste retiré (Sprint 1) — sera réintroduit en Sprint 2bis avec routes `/en/*` réelles.
- Le contenu de `prerender.ts` est inline (pas de fetch backend) → cold-start très rapide, pas de dépendance externe.

## Sprints suivants

**Sprint 2bis (i18n EN)** : refacto routing pour exposer `/en/*` réelles, restaurer hreflang en, dupliquer/traduire le contenu prerender.

**Sprint 3 — Contenu (1-2 semaines)** : sous-domaine `blog.deepsightsynthesis.com` (Astro MDX) + 10 pages prioritaires (compare/notebooklm, glossaire IA, use-cases, méthodologie fact-checking, changelog, ISR `/chaine/[slug]`).

**Sprint 4 — Stores assets** : screenshots Chrome/iOS/Android + feature graphic + promo video CWS + metadata mobile ES/DE/IT/PT.

**Sprint 5 — SSOT plans automation** : `marketing/store-listings/` injecté depuis `plan_config.py`, CI checks cohérence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)