### PR TITLE
feat(geo): sprint 3a — pages agrégatrices /chaine/* et /categorie/*

### DIFF
--- a/backend/src/aggregate/html_renderer.py
+++ b/backend/src/aggregate/html_renderer.py
@@ -1,0 +1,124 @@
+"""Jinja2 HTML rendering for aggregator pages (channel + category).
+
+Produces standalone styled pages indexable by AI bots and Google. Uses the
+shared `templates/share/base.html` layout for visual consistency with the
+share pages, plus dedicated `templates/aggregate/*.html` content blocks.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from aggregate.queries import (
+    AnalysisRef,
+    CategoryInfo,
+    ChannelInfo,
+)
+
+
+_TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "..", "templates")
+
+_env = Environment(
+    loader=FileSystemLoader(_TEMPLATES_DIR),
+    autoescape=select_autoescape(["html", "htm", "xml"]),
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+_FRONTEND_URL = "https://www.deepsightsynthesis.com"
+
+
+def render_channel_page(
+    channel: ChannelInfo,
+    analyses: Sequence[AnalysisRef],
+) -> str:
+    """Render the HTML page for `/c/<slug>/page`."""
+    canonical = f"{_FRONTEND_URL}/chaine/{channel.slug}"
+    description = (
+        f"{channel.analyses_count} analyses IA de vidéos de la chaîne "
+        f"{channel.name} sur DeepSight. Synthèses sourcées, fact-checking, "
+        f"flashcards. {channel.total_views} vues cumulées."
+    )[:300]
+    title = f"Analyses de la chaîne {channel.name} | DeepSight"
+
+    template = _env.get_template("aggregate/channel.html")
+    return template.render(
+        page_title=title,
+        page_description=description,
+        canonical_url=canonical,
+        frontend_url=_FRONTEND_URL,
+        channel=channel,
+        analyses=analyses,
+        analyses_count=len(analyses),
+        breadcrumb=[
+            {"name": "Accueil", "url": f"{_FRONTEND_URL}/"},
+            {"name": "Chaînes", "url": f"{_FRONTEND_URL}/chaines"},
+            {"name": channel.name, "url": canonical},
+        ],
+    )
+
+
+def render_category_page(
+    category: CategoryInfo,
+    analyses: Sequence[AnalysisRef],
+) -> str:
+    """Render the HTML page for `/cat/<slug>/page`."""
+    canonical = f"{_FRONTEND_URL}/categorie/{category.slug}"
+    description = (
+        f"{category.analyses_count} analyses IA de vidéos de la catégorie "
+        f"{category.name} sur DeepSight. Synthèses sourcées, fact-checking, "
+        f"flashcards. {category.total_views} vues cumulées."
+    )[:300]
+    title = f"Analyses de la catégorie {category.name} | DeepSight"
+
+    template = _env.get_template("aggregate/category.html")
+    return template.render(
+        page_title=title,
+        page_description=description,
+        canonical_url=canonical,
+        frontend_url=_FRONTEND_URL,
+        category=category,
+        analyses=analyses,
+        analyses_count=len(analyses),
+        breadcrumb=[
+            {"name": "Accueil", "url": f"{_FRONTEND_URL}/"},
+            {"name": "Catégories", "url": f"{_FRONTEND_URL}/categories"},
+            {"name": category.name, "url": canonical},
+        ],
+    )
+
+
+def render_channels_index(channels: Sequence[ChannelInfo]) -> str:
+    """Render the index page for `/chaines`."""
+    canonical = f"{_FRONTEND_URL}/chaines"
+    template = _env.get_template("aggregate/channels_index.html")
+    return template.render(
+        page_title="Toutes les chaînes analysées sur DeepSight",
+        page_description=(
+            "Explorez les analyses IA de DeepSight regroupées par chaîne YouTube "
+            f"ou TikTok. {len(channels)} chaînes avec analyses publiques, classées "
+            "par popularité."
+        ),
+        canonical_url=canonical,
+        frontend_url=_FRONTEND_URL,
+        channels=channels,
+    )
+
+
+def render_categories_index(categories: Sequence[CategoryInfo]) -> str:
+    canonical = f"{_FRONTEND_URL}/categories"
+    template = _env.get_template("aggregate/categories_index.html")
+    return template.render(
+        page_title="Toutes les catégories d'analyses sur DeepSight",
+        page_description=(
+            f"Explorez {len(categories)} catégories d'analyses IA de vidéos sur "
+            "DeepSight. Sciences, économie, politique, philosophie, et plus."
+        ),
+        canonical_url=canonical,
+        frontend_url=_FRONTEND_URL,
+        categories=categories,
+    )

--- a/backend/src/aggregate/queries.py
+++ b/backend/src/aggregate/queries.py
@@ -26,9 +26,7 @@ class ChannelInfo:
 
     __slots__ = ("name", "slug", "analyses_count", "total_views")
 
-    def __init__(
-        self, name: str, slug: str, analyses_count: int, total_views: int
-    ) -> None:
+    def __init__(self, name: str, slug: str, analyses_count: int, total_views: int) -> None:
         self.name = name
         self.slug = slug
         self.analyses_count = analyses_count
@@ -77,9 +75,7 @@ class AnalysisRef:
 # ─── Channels ────────────────────────────────────────────────────────────────
 
 
-async def list_channels(
-    db: AsyncSession, *, min_analyses: int = 1, limit: int = 200
-) -> list[ChannelInfo]:
+async def list_channels(db: AsyncSession, *, min_analyses: int = 1, limit: int = 200) -> list[ChannelInfo]:
     """List public channels ranked by number of public analyses, then views.
 
     Only channels with `is_active=true` SharedAnalysis are returned.
@@ -120,9 +116,7 @@ async def list_channels(
     ]
 
 
-async def find_channel_by_slug(
-    db: AsyncSession, slug: str
-) -> Optional[ChannelInfo]:
+async def find_channel_by_slug(db: AsyncSession, slug: str) -> Optional[ChannelInfo]:
     """Resolve a slug to a channel (slug is computed on the fly, not stored)."""
     if not slug:
         return None
@@ -133,9 +127,7 @@ async def find_channel_by_slug(
     return None
 
 
-async def list_analyses_for_channel(
-    db: AsyncSession, channel_name: str, *, limit: int = 50
-) -> list[AnalysisRef]:
+async def list_analyses_for_channel(db: AsyncSession, channel_name: str, *, limit: int = 50) -> list[AnalysisRef]:
     """List public analyses for a given channel, sorted by view_count desc."""
     stmt = (
         select(
@@ -187,18 +179,14 @@ async def list_analyses_for_channel(
 class CategoryInfo:
     __slots__ = ("name", "slug", "analyses_count", "total_views")
 
-    def __init__(
-        self, name: str, slug: str, analyses_count: int, total_views: int
-    ) -> None:
+    def __init__(self, name: str, slug: str, analyses_count: int, total_views: int) -> None:
         self.name = name
         self.slug = slug
         self.analyses_count = analyses_count
         self.total_views = total_views
 
 
-async def list_categories(
-    db: AsyncSession, *, min_analyses: int = 1, limit: int = 100
-) -> list[CategoryInfo]:
+async def list_categories(db: AsyncSession, *, min_analyses: int = 1, limit: int = 100) -> list[CategoryInfo]:
     stmt = (
         select(
             Summary.category.label("category"),
@@ -233,9 +221,7 @@ async def list_categories(
     ]
 
 
-async def find_category_by_slug(
-    db: AsyncSession, slug: str
-) -> Optional[CategoryInfo]:
+async def find_category_by_slug(db: AsyncSession, slug: str) -> Optional[CategoryInfo]:
     if not slug:
         return None
     categories = await list_categories(db, min_analyses=1, limit=1000)
@@ -245,9 +231,7 @@ async def find_category_by_slug(
     return None
 
 
-async def list_analyses_for_category(
-    db: AsyncSession, category_name: str, *, limit: int = 50
-) -> list[AnalysisRef]:
+async def list_analyses_for_category(db: AsyncSession, category_name: str, *, limit: int = 50) -> list[AnalysisRef]:
     stmt = (
         select(
             SharedAnalysis.share_token,

--- a/backend/src/aggregate/queries.py
+++ b/backend/src/aggregate/queries.py
@@ -1,0 +1,292 @@
+"""
+DB queries for aggregator pages.
+
+Joins SharedAnalysis (is_active=true) with Summary on (user_id, video_id) to
+expose channel + category metadata that SharedAnalysis itself doesn't store.
+The JOIN is covered by `idx_shared_analyses_user_video` and
+`idx_summaries_user_video`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import select, func, desc, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import SharedAnalysis, Summary
+from aggregate.slug import to_slug
+
+
+# ─── Models for templating ───────────────────────────────────────────────────
+
+
+class ChannelInfo:
+    """Lightweight DTO consumed by the Jinja2 template."""
+
+    __slots__ = ("name", "slug", "analyses_count", "total_views")
+
+    def __init__(
+        self, name: str, slug: str, analyses_count: int, total_views: int
+    ) -> None:
+        self.name = name
+        self.slug = slug
+        self.analyses_count = analyses_count
+        self.total_views = total_views
+
+
+class AnalysisRef:
+    __slots__ = (
+        "share_token",
+        "video_id",
+        "video_title",
+        "video_thumbnail",
+        "verdict",
+        "view_count",
+        "channel",
+        "category",
+        "platform",
+        "created_at",
+    )
+
+    def __init__(
+        self,
+        share_token: str,
+        video_id: str,
+        video_title: Optional[str],
+        video_thumbnail: Optional[str],
+        verdict: Optional[str],
+        view_count: int,
+        channel: Optional[str],
+        category: Optional[str],
+        platform: Optional[str],
+        created_at,
+    ) -> None:
+        self.share_token = share_token
+        self.video_id = video_id
+        self.video_title = video_title
+        self.video_thumbnail = video_thumbnail
+        self.verdict = verdict
+        self.view_count = view_count
+        self.channel = channel
+        self.category = category
+        self.platform = platform
+        self.created_at = created_at
+
+
+# ─── Channels ────────────────────────────────────────────────────────────────
+
+
+async def list_channels(
+    db: AsyncSession, *, min_analyses: int = 1, limit: int = 200
+) -> list[ChannelInfo]:
+    """List public channels ranked by number of public analyses, then views.
+
+    Only channels with `is_active=true` SharedAnalysis are returned.
+    Channels with fewer than `min_analyses` public analyses are filtered out
+    (low-signal pages).
+    """
+    stmt = (
+        select(
+            Summary.video_channel.label("channel"),
+            func.count(SharedAnalysis.id).label("analyses_count"),
+            func.coalesce(func.sum(SharedAnalysis.view_count), 0).label("total_views"),
+        )
+        .select_from(SharedAnalysis)
+        .join(
+            Summary,
+            and_(
+                Summary.user_id == SharedAnalysis.user_id,
+                Summary.video_id == SharedAnalysis.video_id,
+            ),
+        )
+        .where(SharedAnalysis.is_active.is_(True))
+        .where(Summary.video_channel.isnot(None))
+        .where(Summary.video_channel != "")
+        .group_by(Summary.video_channel)
+        .having(func.count(SharedAnalysis.id) >= min_analyses)
+        .order_by(desc("analyses_count"), desc("total_views"))
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        ChannelInfo(
+            name=row.channel,
+            slug=to_slug(row.channel),
+            analyses_count=int(row.analyses_count),
+            total_views=int(row.total_views or 0),
+        )
+        for row in rows
+    ]
+
+
+async def find_channel_by_slug(
+    db: AsyncSession, slug: str
+) -> Optional[ChannelInfo]:
+    """Resolve a slug to a channel (slug is computed on the fly, not stored)."""
+    if not slug:
+        return None
+    channels = await list_channels(db, min_analyses=1, limit=10000)
+    for ch in channels:
+        if ch.slug == slug:
+            return ch
+    return None
+
+
+async def list_analyses_for_channel(
+    db: AsyncSession, channel_name: str, *, limit: int = 50
+) -> list[AnalysisRef]:
+    """List public analyses for a given channel, sorted by view_count desc."""
+    stmt = (
+        select(
+            SharedAnalysis.share_token,
+            SharedAnalysis.video_id,
+            SharedAnalysis.video_title,
+            SharedAnalysis.video_thumbnail,
+            SharedAnalysis.verdict,
+            SharedAnalysis.view_count,
+            Summary.video_channel.label("channel"),
+            Summary.category,
+            Summary.platform,
+            SharedAnalysis.created_at,
+        )
+        .select_from(SharedAnalysis)
+        .join(
+            Summary,
+            and_(
+                Summary.user_id == SharedAnalysis.user_id,
+                Summary.video_id == SharedAnalysis.video_id,
+            ),
+        )
+        .where(SharedAnalysis.is_active.is_(True))
+        .where(Summary.video_channel == channel_name)
+        .order_by(desc(SharedAnalysis.view_count), desc(SharedAnalysis.created_at))
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        AnalysisRef(
+            share_token=row.share_token,
+            video_id=row.video_id,
+            video_title=row.video_title,
+            video_thumbnail=row.video_thumbnail,
+            verdict=row.verdict,
+            view_count=int(row.view_count or 0),
+            channel=row.channel,
+            category=row.category,
+            platform=row.platform,
+            created_at=row.created_at,
+        )
+        for row in rows
+    ]
+
+
+# ─── Categories ──────────────────────────────────────────────────────────────
+
+
+class CategoryInfo:
+    __slots__ = ("name", "slug", "analyses_count", "total_views")
+
+    def __init__(
+        self, name: str, slug: str, analyses_count: int, total_views: int
+    ) -> None:
+        self.name = name
+        self.slug = slug
+        self.analyses_count = analyses_count
+        self.total_views = total_views
+
+
+async def list_categories(
+    db: AsyncSession, *, min_analyses: int = 1, limit: int = 100
+) -> list[CategoryInfo]:
+    stmt = (
+        select(
+            Summary.category.label("category"),
+            func.count(SharedAnalysis.id).label("analyses_count"),
+            func.coalesce(func.sum(SharedAnalysis.view_count), 0).label("total_views"),
+        )
+        .select_from(SharedAnalysis)
+        .join(
+            Summary,
+            and_(
+                Summary.user_id == SharedAnalysis.user_id,
+                Summary.video_id == SharedAnalysis.video_id,
+            ),
+        )
+        .where(SharedAnalysis.is_active.is_(True))
+        .where(Summary.category.isnot(None))
+        .where(Summary.category != "")
+        .group_by(Summary.category)
+        .having(func.count(SharedAnalysis.id) >= min_analyses)
+        .order_by(desc("analyses_count"), desc("total_views"))
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        CategoryInfo(
+            name=row.category,
+            slug=to_slug(row.category),
+            analyses_count=int(row.analyses_count),
+            total_views=int(row.total_views or 0),
+        )
+        for row in rows
+    ]
+
+
+async def find_category_by_slug(
+    db: AsyncSession, slug: str
+) -> Optional[CategoryInfo]:
+    if not slug:
+        return None
+    categories = await list_categories(db, min_analyses=1, limit=1000)
+    for cat in categories:
+        if cat.slug == slug:
+            return cat
+    return None
+
+
+async def list_analyses_for_category(
+    db: AsyncSession, category_name: str, *, limit: int = 50
+) -> list[AnalysisRef]:
+    stmt = (
+        select(
+            SharedAnalysis.share_token,
+            SharedAnalysis.video_id,
+            SharedAnalysis.video_title,
+            SharedAnalysis.video_thumbnail,
+            SharedAnalysis.verdict,
+            SharedAnalysis.view_count,
+            Summary.video_channel.label("channel"),
+            Summary.category,
+            Summary.platform,
+            SharedAnalysis.created_at,
+        )
+        .select_from(SharedAnalysis)
+        .join(
+            Summary,
+            and_(
+                Summary.user_id == SharedAnalysis.user_id,
+                Summary.video_id == SharedAnalysis.video_id,
+            ),
+        )
+        .where(SharedAnalysis.is_active.is_(True))
+        .where(Summary.category == category_name)
+        .order_by(desc(SharedAnalysis.view_count), desc(SharedAnalysis.created_at))
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        AnalysisRef(
+            share_token=row.share_token,
+            video_id=row.video_id,
+            video_title=row.video_title,
+            video_thumbnail=row.video_thumbnail,
+            verdict=row.verdict,
+            view_count=int(row.view_count or 0),
+            channel=row.channel,
+            category=row.category,
+            platform=row.platform,
+            created_at=row.created_at,
+        )
+        for row in rows
+    ]

--- a/backend/src/aggregate/router.py
+++ b/backend/src/aggregate/router.py
@@ -1,0 +1,282 @@
+"""
+Aggregate Router — Public landing pages grouping shared analyses.
+
+These pages turn user-shared analyses into long-tail SEO/GEO content. Only
+analyses with `SharedAnalysis.is_active=true` are exposed (RGPD: explicit
+share opt-in by the original user).
+
+All routes are public (no auth) and mounted under `/api/aggregate` in main.py.
+Path naming distinguishes JSON endpoints (resource-style: /channels,
+/channels/{slug}) from HTML render endpoints (suffixed: /channels-render,
+/channel-render/{slug}) to avoid path conflicts between detail-by-slug and
+index-render routes.
+
+Vercel rewrites map user-friendly paths to these endpoints:
+  /chaines           → /api/aggregate/channels-render
+  /chaine/:slug      → /api/aggregate/channel-render/:slug
+  /categories        → /api/aggregate/categories-render
+  /categorie/:slug   → /api/aggregate/category-render/:slug
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import get_session
+from aggregate.html_renderer import (
+    render_categories_index,
+    render_category_page,
+    render_channel_page,
+    render_channels_index,
+)
+from aggregate.queries import (
+    find_category_by_slug,
+    find_channel_by_slug,
+    list_analyses_for_category,
+    list_analyses_for_channel,
+    list_categories,
+    list_channels,
+)
+
+
+router = APIRouter()
+
+
+# ─── JSON DTOs ───────────────────────────────────────────────────────────────
+
+
+class ChannelDTO(BaseModel):
+    name: str
+    slug: str
+    analyses_count: int
+    total_views: int
+
+
+class CategoryDTO(BaseModel):
+    name: str
+    slug: str
+    analyses_count: int
+    total_views: int
+
+
+class AnalysisRefDTO(BaseModel):
+    share_token: str
+    video_id: str
+    video_title: str | None
+    video_thumbnail: str | None
+    verdict: str | None
+    view_count: int
+    channel: str | None
+    category: str | None
+    platform: str | None
+
+
+class ChannelDetailDTO(BaseModel):
+    channel: ChannelDTO
+    analyses: list[AnalysisRefDTO]
+
+
+class CategoryDetailDTO(BaseModel):
+    category: CategoryDTO
+    analyses: list[AnalysisRefDTO]
+
+
+# ─── JSON endpoints (resource-style) ─────────────────────────────────────────
+
+
+@router.get("/channels", response_model=list[ChannelDTO])
+async def get_channels(
+    db: AsyncSession = Depends(get_session),
+    min_analyses: int = 1,
+    limit: int = 200,
+) -> list[ChannelDTO]:
+    items = await list_channels(db, min_analyses=min_analyses, limit=limit)
+    return [
+        ChannelDTO(
+            name=item.name,
+            slug=item.slug,
+            analyses_count=item.analyses_count,
+            total_views=item.total_views,
+        )
+        for item in items
+    ]
+
+
+@router.get("/channels/{slug}", response_model=ChannelDetailDTO)
+async def get_channel_detail(
+    slug: str,
+    db: AsyncSession = Depends(get_session),
+    limit: int = 50,
+) -> ChannelDetailDTO:
+    channel = await find_channel_by_slug(db, slug)
+    if not channel:
+        raise HTTPException(status_code=404, detail="Channel not found")
+    analyses = await list_analyses_for_channel(db, channel.name, limit=limit)
+    return ChannelDetailDTO(
+        channel=ChannelDTO(
+            name=channel.name,
+            slug=channel.slug,
+            analyses_count=channel.analyses_count,
+            total_views=channel.total_views,
+        ),
+        analyses=[
+            AnalysisRefDTO(
+                share_token=a.share_token,
+                video_id=a.video_id,
+                video_title=a.video_title,
+                video_thumbnail=a.video_thumbnail,
+                verdict=a.verdict,
+                view_count=a.view_count,
+                channel=a.channel,
+                category=a.category,
+                platform=a.platform,
+            )
+            for a in analyses
+        ],
+    )
+
+
+@router.get("/categories", response_model=list[CategoryDTO])
+async def get_categories(
+    db: AsyncSession = Depends(get_session),
+    min_analyses: int = 1,
+    limit: int = 100,
+) -> list[CategoryDTO]:
+    items = await list_categories(db, min_analyses=min_analyses, limit=limit)
+    return [
+        CategoryDTO(
+            name=item.name,
+            slug=item.slug,
+            analyses_count=item.analyses_count,
+            total_views=item.total_views,
+        )
+        for item in items
+    ]
+
+
+@router.get("/categories/{slug}", response_model=CategoryDetailDTO)
+async def get_category_detail(
+    slug: str,
+    db: AsyncSession = Depends(get_session),
+    limit: int = 50,
+) -> CategoryDetailDTO:
+    category = await find_category_by_slug(db, slug)
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+    analyses = await list_analyses_for_category(db, category.name, limit=limit)
+    return CategoryDetailDTO(
+        category=CategoryDTO(
+            name=category.name,
+            slug=category.slug,
+            analyses_count=category.analyses_count,
+            total_views=category.total_views,
+        ),
+        analyses=[
+            AnalysisRefDTO(
+                share_token=a.share_token,
+                video_id=a.video_id,
+                video_title=a.video_title,
+                video_thumbnail=a.video_thumbnail,
+                verdict=a.verdict,
+                view_count=a.view_count,
+                channel=a.channel,
+                category=a.category,
+                platform=a.platform,
+            )
+            for a in analyses
+        ],
+    )
+
+
+# ─── SSR HTML pages (consumed by Vercel rewrites) ────────────────────────────
+
+
+@router.get(
+    "/channel-render/{slug}",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def render_channel_html(
+    slug: str,
+    db: AsyncSession = Depends(get_session),
+) -> HTMLResponse:
+    channel = await find_channel_by_slug(db, slug)
+    if not channel:
+        raise HTTPException(status_code=404, detail="Channel not found")
+    analyses = await list_analyses_for_channel(db, channel.name, limit=50)
+    html = render_channel_page(channel, analyses)
+    return HTMLResponse(
+        content=html,
+        status_code=200,
+        headers={
+            "Cache-Control": "public, max-age=900, s-maxage=900",
+            "X-Robots-Tag": "index, follow",
+        },
+    )
+
+
+@router.get(
+    "/category-render/{slug}",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def render_category_html(
+    slug: str,
+    db: AsyncSession = Depends(get_session),
+) -> HTMLResponse:
+    category = await find_category_by_slug(db, slug)
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+    analyses = await list_analyses_for_category(db, category.name, limit=50)
+    html = render_category_page(category, analyses)
+    return HTMLResponse(
+        content=html,
+        status_code=200,
+        headers={
+            "Cache-Control": "public, max-age=900, s-maxage=900",
+            "X-Robots-Tag": "index, follow",
+        },
+    )
+
+
+@router.get(
+    "/channels-render",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def render_channels_index_html(
+    db: AsyncSession = Depends(get_session),
+) -> HTMLResponse:
+    channels = await list_channels(db, min_analyses=1, limit=200)
+    html = render_channels_index(channels)
+    return HTMLResponse(
+        content=html,
+        status_code=200,
+        headers={
+            "Cache-Control": "public, max-age=1800, s-maxage=1800",
+            "X-Robots-Tag": "index, follow",
+        },
+    )
+
+
+@router.get(
+    "/categories-render",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def render_categories_index_html(
+    db: AsyncSession = Depends(get_session),
+) -> HTMLResponse:
+    categories = await list_categories(db, min_analyses=1, limit=100)
+    html = render_categories_index(categories)
+    return HTMLResponse(
+        content=html,
+        status_code=200,
+        headers={
+            "Cache-Control": "public, max-age=1800, s-maxage=1800",
+            "X-Robots-Tag": "index, follow",
+        },
+    )

--- a/backend/src/aggregate/slug.py
+++ b/backend/src/aggregate/slug.py
@@ -1,0 +1,31 @@
+"""
+Slug utilities for aggregator pages.
+
+Channels are stored in DB as their human-readable name (e.g. "Lex Fridman",
+"HugoDécrypte"), but URLs need lowercase ASCII slugs. We compute slugs on
+the fly (no DB column) and resolve them back via case-insensitive search.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def to_slug(name: str) -> str:
+    """Convert a channel name or category to a URL-safe slug.
+
+    "Lex Fridman" → "lex-fridman"
+    "HugoDécrypte" → "hugodecrypte"
+    "Science & Vie" → "science-vie"
+    """
+    if not name:
+        return ""
+    nfd = unicodedata.normalize("NFD", name)
+    ascii_only = nfd.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_only.lower().strip()
+    slug = _NON_ALNUM.sub("-", lowered).strip("-")
+    return slug

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1121,12 +1121,8 @@ if SHARE_ROUTER_AVAILABLE:
 
 # 🌐 Aggregate router (channel/category landing pages for SEO/GEO)
 if AGGREGATE_ROUTER_AVAILABLE:
-    app.include_router(
-        aggregate_router, prefix="/api/aggregate", tags=["Aggregate"]
-    )
-    logger.info(
-        "🌐 Aggregate router loaded (GET /api/aggregate/channels, /channels-render, /channel-render/{slug}, …)"
-    )
+    app.include_router(aggregate_router, prefix="/api/aggregate", tags=["Aggregate"])
+    logger.info("🌐 Aggregate router loaded (GET /api/aggregate/channels, /channels-render, /channel-render/{slug}, …)")
 
 # 📊 Analytics router
 if ANALYTICS_ROUTER_AVAILABLE:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -262,6 +262,15 @@ except ImportError as e:
     SHARE_ROUTER_AVAILABLE = False
     logger.warning(f"⚠️ Share router not available: {e}")
 
+# 🌐 Aggregate router (channel/category landing pages for SEO/GEO)
+try:
+    from aggregate.router import router as aggregate_router
+
+    AGGREGATE_ROUTER_AVAILABLE = True
+except ImportError as e:
+    AGGREGATE_ROUTER_AVAILABLE = False
+    logger.warning(f"⚠️ Aggregate router not available: {e}")
+
 # 📊 Analytics router (event tracking)
 try:
     from analytics.router import router as analytics_router
@@ -1109,6 +1118,15 @@ if CONTACT_AVAILABLE:
 if SHARE_ROUTER_AVAILABLE:
     app.include_router(share_router, prefix="/api/share", tags=["Share"])
     logger.info("🔗 Share router loaded (POST /api/share, GET /api/share/{token})")
+
+# 🌐 Aggregate router (channel/category landing pages for SEO/GEO)
+if AGGREGATE_ROUTER_AVAILABLE:
+    app.include_router(
+        aggregate_router, prefix="/api/aggregate", tags=["Aggregate"]
+    )
+    logger.info(
+        "🌐 Aggregate router loaded (GET /api/aggregate/channels, /channels-render, /channel-render/{slug}, …)"
+    )
 
 # 📊 Analytics router
 if ANALYTICS_ROUTER_AVAILABLE:

--- a/backend/src/templates/aggregate/_layout.html
+++ b/backend/src/templates/aggregate/_layout.html
@@ -1,0 +1,273 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ page_title }}</title>
+    <meta name="description" content="{{ page_description }}" />
+    <link rel="canonical" href="{{ canonical_url }}" />
+    <link rel="alternate" hreflang="fr" href="{{ canonical_url }}" />
+    <link rel="alternate" hreflang="x-default" href="{{ canonical_url }}" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="DeepSight" />
+    <meta property="og:locale" content="fr_FR" />
+    <meta property="og:title" content="{{ page_title }}" />
+    <meta property="og:description" content="{{ page_description }}" />
+    <meta property="og:url" content="{{ canonical_url }}" />
+    <meta property="og:image" content="{{ frontend_url }}/og-image.png" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="{{ page_title }}" />
+    <meta name="twitter:description" content="{{ page_description }}" />
+    <meta name="twitter:image" content="{{ frontend_url }}/og-image.png" />
+
+    <meta name="robots" content="index, follow" />
+    <meta name="author" content="DeepSight" />
+
+    {% block jsonld %}{% endblock %}
+
+    <style>
+      :root {
+        --bg: #0a0a0f;
+        --surface: #12121a;
+        --border: rgba(255, 255, 255, 0.06);
+        --text: #f5f5f7;
+        --text-muted: #a1a1b5;
+        --accent: #6366f1;
+        --accent-soft: rgba(99, 102, 241, 0.15);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
+        line-height: 1.6;
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .ds-container {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 24px 20px;
+      }
+      header.ds-top {
+        border-bottom: 1px solid var(--border);
+        padding: 14px 20px;
+        background: rgba(10, 10, 15, 0.85);
+        backdrop-filter: blur(12px);
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
+      header.ds-top .ds-top-inner {
+        max-width: 920px;
+        margin: 0 auto;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+      }
+      header.ds-top a.ds-brand {
+        color: var(--text);
+        font-weight: 700;
+        font-size: 18px;
+      }
+      header.ds-top nav a {
+        color: var(--text-muted);
+        margin-left: 16px;
+        font-size: 14px;
+      }
+      header.ds-top nav a:hover {
+        color: var(--text);
+      }
+      nav.ds-breadcrumb {
+        padding: 16px 0;
+        font-size: 14px;
+        color: var(--text-muted);
+      }
+      nav.ds-breadcrumb a {
+        color: var(--text-muted);
+      }
+      nav.ds-breadcrumb span.sep {
+        padding: 0 8px;
+        color: var(--border);
+      }
+      h1 {
+        font-size: 32px;
+        line-height: 1.2;
+        margin: 8px 0 16px;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 32px 0 12px;
+      }
+      h3 {
+        font-size: 17px;
+        margin: 0 0 6px;
+      }
+      .ds-meta-row {
+        color: var(--text-muted);
+        font-size: 14px;
+        margin-bottom: 24px;
+      }
+      .ds-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 16px;
+        margin: 24px 0;
+      }
+      @media (min-width: 720px) {
+        .ds-grid {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+      .ds-card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+        transition:
+          border-color 0.2s ease,
+          transform 0.2s ease;
+      }
+      .ds-card:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
+      }
+      .ds-card a {
+        color: var(--text);
+        display: block;
+      }
+      .ds-card a:hover {
+        text-decoration: none;
+      }
+      .ds-thumb {
+        width: 100%;
+        aspect-ratio: 16/9;
+        object-fit: cover;
+        border-radius: 8px;
+        margin-bottom: 10px;
+        background: var(--border);
+      }
+      .ds-card-title {
+        font-weight: 600;
+        margin: 0 0 6px;
+        font-size: 16px;
+        line-height: 1.3;
+      }
+      .ds-card-meta {
+        font-size: 13px;
+        color: var(--text-muted);
+        margin-bottom: 8px;
+      }
+      .ds-card-verdict {
+        font-size: 14px;
+        color: var(--text-muted);
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .ds-pill {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 12px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 12px;
+        font-weight: 500;
+        margin-right: 6px;
+      }
+      .ds-list-channels {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 8px;
+        padding: 0;
+        list-style: none;
+      }
+      @media (min-width: 720px) {
+        .ds-list-channels {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+      .ds-list-channels li {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 12px 14px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .ds-list-channels li a {
+        color: var(--text);
+        font-weight: 500;
+      }
+      .ds-list-channels li small {
+        color: var(--text-muted);
+      }
+      footer.ds-foot {
+        border-top: 1px solid var(--border);
+        padding: 24px 20px;
+        margin-top: 48px;
+        color: var(--text-muted);
+        font-size: 13px;
+      }
+      footer.ds-foot .ds-foot-inner {
+        max-width: 920px;
+        margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="ds-top">
+      <div class="ds-top-inner">
+        <a class="ds-brand" href="{{ frontend_url }}/">DeepSight</a>
+        <nav>
+          <a href="{{ frontend_url }}/about">À propos</a>
+          <a href="{{ frontend_url }}/upgrade">Tarifs</a>
+          <a href="{{ frontend_url }}/chaines">Chaînes</a>
+          <a href="{{ frontend_url }}/categories">Catégories</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="ds-container">
+      {% if breadcrumb %}
+      <nav class="ds-breadcrumb" aria-label="Fil d'ariane">
+        {% for item in breadcrumb %} {% if not loop.last %}
+        <a href="{{ item.url }}">{{ item.name }}</a><span class="sep">/</span>
+        {% else %}
+        <span>{{ item.name }}</span>
+        {% endif %} {% endfor %}
+      </nav>
+      {% endif %} {% block content %}{% endblock %}
+    </main>
+
+    <footer class="ds-foot">
+      <div class="ds-foot-inner">
+        <p>
+          DeepSight — Analyse YouTube &amp; TikTok par IA, 100% européenne. SAS
+          française à Lyon (RCS 994 558 898). IA Mistral (Paris). Hébergement
+          Hetzner (Allemagne, EU). Conforme RGPD.
+        </p>
+        <p>
+          <a href="{{ frontend_url }}/legal">Mentions légales</a> ·
+          <a href="{{ frontend_url }}/legal/privacy">Confidentialité</a> ·
+          <a href="{{ frontend_url }}/contact">Contact</a> ·
+          <a href="{{ frontend_url }}/sitemap.xml">Sitemap</a>
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/backend/src/templates/aggregate/categories_index.html
+++ b/backend/src/templates/aggregate/categories_index.html
@@ -1,0 +1,57 @@
+{% extends "aggregate/_layout.html" %} {% block jsonld %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "{{ page_title }}",
+    "description": "{{ page_description }}",
+    "url": "{{ canonical_url }}",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "DeepSight",
+      "url": "{{ frontend_url }}"
+    },
+    "mainEntity": {
+      "@type": "ItemList",
+      "numberOfItems": {{ categories | length }},
+      "itemListElement": [
+        {% for cat in categories %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "url": "{{ frontend_url }}/categorie/{{ cat.slug }}",
+          "name": "{{ cat.name | replace('"', '\\"') }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+      ]
+    }
+  }
+</script>
+{% endblock %} {% block content %}
+<h1>Toutes les catégories d'analyses sur DeepSight</h1>
+<p class="ds-meta-row">
+  <span class="ds-pill"
+    >{{ categories | length }} catégorie{{ 's' if (categories | length) > 1 else
+    '' }}</span
+  >
+</p>
+
+<p>
+  Les analyses publiques de DeepSight regroupées par catégorie thématique. La
+  catégorisation est faite automatiquement par l'IA Mistral en fonction du
+  contenu réel de la vidéo. Sciences, économie, politique, philosophie,
+  histoire, technologie : explorez par sujet.
+</p>
+
+<ul class="ds-list-channels">
+  {% for cat in categories %}
+  <li>
+    <a href="{{ frontend_url }}/categorie/{{ cat.slug }}">{{ cat.name }}</a>
+    <small
+      >{{ cat.analyses_count }} analyse{{ 's' if cat.analyses_count > 1 else ''
+      }} · {{ cat.total_views }} vues</small
+    >
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/backend/src/templates/aggregate/category.html
+++ b/backend/src/templates/aggregate/category.html
@@ -1,0 +1,102 @@
+{% extends "aggregate/_layout.html" %} {% block jsonld %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "{{ page_title }}",
+    "description": "{{ page_description }}",
+    "url": "{{ canonical_url }}",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "DeepSight",
+      "url": "{{ frontend_url }}"
+    },
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {% for item in breadcrumb %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "name": "{{ item.name }}",
+          "item": "{{ item.url }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+      ]
+    },
+    "mainEntity": {
+      "@type": "ItemList",
+      "numberOfItems": {{ analyses_count }},
+      "itemListElement": [
+        {% for a in analyses %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "url": "{{ frontend_url }}/s/{{ a.share_token }}",
+          "name": "{{ a.video_title | default('') | replace('"', '\\"') }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+      ]
+    }
+  }
+</script>
+{% endblock %} {% block content %}
+<h1>Analyses IA de la catégorie {{ category.name }}</h1>
+
+<p class="ds-meta-row">
+  <span class="ds-pill"
+    >{{ category.analyses_count }} analyse{{ 's' if category.analyses_count > 1
+    else '' }}</span
+  >
+  <span class="ds-pill">{{ category.total_views }} vues cumulées</span>
+</p>
+
+<p>
+  Toutes les analyses publiques DeepSight classées dans la catégorie
+  <strong>{{ category.name }}</strong>. La catégorie est attribuée
+  automatiquement par l'IA Mistral lors de l'analyse, en fonction du contenu
+  réel de la vidéo (pas de la chaîne). Chaque analyse inclut un fact-checking
+  nuancé avec sources externes vérifiables.
+</p>
+
+<h2>Analyses publiques ({{ analyses_count }})</h2>
+
+<div class="ds-grid">
+  {% for a in analyses %}
+  <article class="ds-card">
+    <a href="{{ frontend_url }}/s/{{ a.share_token }}">
+      {% if a.video_thumbnail %}
+      <img
+        class="ds-thumb"
+        src="{{ a.video_thumbnail }}"
+        alt="{{ a.video_title }}"
+        loading="lazy"
+      />
+      {% else %}
+      <div class="ds-thumb"></div>
+      {% endif %}
+      <h3 class="ds-card-title">{{ a.video_title or '(Sans titre)' }}</h3>
+      <p class="ds-card-meta">
+        {% if a.platform %}{{ a.platform | capitalize }}{% endif %} {% if
+        a.channel %} · {{ a.channel }}{% endif %} · {{ a.view_count }} vue{{ 's'
+        if a.view_count > 1 else '' }}
+      </p>
+      {% if a.verdict %}
+      <p class="ds-card-verdict">{{ a.verdict }}</p>
+      {% endif %}
+    </a>
+  </article>
+  {% endfor %}
+</div>
+
+<h2>À propos de DeepSight</h2>
+<p>
+  DeepSight est un SaaS d'analyse vidéo IA 100% européen, propulsé par Mistral
+  AI (Paris) et hébergé chez Hetzner (Allemagne). Chaque vidéo YouTube ou TikTok
+  est transformée en analyse structurée avec fact-checking nuancé, flashcards
+  FSRS, quiz, mind maps et chat contextuel.
+  <a href="{{ frontend_url }}/upgrade"
+    >Découvrir les plans Free / Plus 4,99€ / Pro 9,99€</a
+  >.
+</p>
+{% endblock %}

--- a/backend/src/templates/aggregate/channel.html
+++ b/backend/src/templates/aggregate/channel.html
@@ -1,0 +1,102 @@
+{% extends "aggregate/_layout.html" %} {% block jsonld %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "{{ page_title }}",
+    "description": "{{ page_description }}",
+    "url": "{{ canonical_url }}",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "DeepSight",
+      "url": "{{ frontend_url }}"
+    },
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {% for item in breadcrumb %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "name": "{{ item.name }}",
+          "item": "{{ item.url }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+      ]
+    },
+    "mainEntity": {
+      "@type": "ItemList",
+      "numberOfItems": {{ analyses_count }},
+      "itemListElement": [
+        {% for a in analyses %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "url": "{{ frontend_url }}/s/{{ a.share_token }}",
+          "name": "{{ a.video_title | default('') | replace('"', '\\"') }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+      ]
+    }
+  }
+</script>
+{% endblock %} {% block content %}
+<h1>Analyses IA de la chaîne {{ channel.name }}</h1>
+
+<p class="ds-meta-row">
+  <span class="ds-pill"
+    >{{ channel.analyses_count }} analyse{{ 's' if channel.analyses_count > 1
+    else '' }}</span
+  >
+  <span class="ds-pill">{{ channel.total_views }} vues cumulées</span>
+</p>
+
+<p>
+  Cette page agrège les analyses publiques de DeepSight portant sur des vidéos
+  de la chaîne <strong>{{ channel.name }}</strong>. Chaque analyse est une
+  synthèse sourcée et fact-checkée générée par IA (Mistral), avec marqueurs
+  épistémiques (SOLIDE / PLAUSIBLE / INCERTAIN) et chat contextuel disponible.
+  Les analyses sont partagées par leurs auteurs et accessibles sans compte.
+</p>
+
+<h2>Analyses publiques ({{ analyses_count }})</h2>
+
+<div class="ds-grid">
+  {% for a in analyses %}
+  <article class="ds-card">
+    <a href="{{ frontend_url }}/s/{{ a.share_token }}">
+      {% if a.video_thumbnail %}
+      <img
+        class="ds-thumb"
+        src="{{ a.video_thumbnail }}"
+        alt="{{ a.video_title }}"
+        loading="lazy"
+      />
+      {% else %}
+      <div class="ds-thumb"></div>
+      {% endif %}
+      <h3 class="ds-card-title">{{ a.video_title or '(Sans titre)' }}</h3>
+      <p class="ds-card-meta">
+        {% if a.platform %}{{ a.platform | capitalize }}{% endif %} {% if
+        a.category %} · {{ a.category }}{% endif %} · {{ a.view_count }} vue{{
+        's' if a.view_count > 1 else '' }}
+      </p>
+      {% if a.verdict %}
+      <p class="ds-card-verdict">{{ a.verdict }}</p>
+      {% endif %}
+    </a>
+  </article>
+  {% endfor %}
+</div>
+
+<h2>À propos de DeepSight</h2>
+<p>
+  DeepSight est un SaaS d'analyse vidéo IA 100% européen, propulsé par Mistral
+  AI (Paris) et hébergé chez Hetzner (Allemagne). Chaque vidéo YouTube ou TikTok
+  est transformée en analyse structurée avec fact-checking nuancé, flashcards
+  FSRS, quiz, mind maps et chat contextuel.
+  <a href="{{ frontend_url }}/upgrade"
+    >Découvrir les plans Free / Plus 4,99€ / Pro 9,99€</a
+  >.
+</p>
+{% endblock %}

--- a/backend/src/templates/aggregate/channels_index.html
+++ b/backend/src/templates/aggregate/channels_index.html
@@ -1,0 +1,65 @@
+{% extends "aggregate/_layout.html" %} {% block jsonld %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "{{ page_title }}",
+    "description": "{{ page_description }}",
+    "url": "{{ canonical_url }}",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "DeepSight",
+      "url": "{{ frontend_url }}"
+    },
+    "mainEntity": {
+      "@type": "ItemList",
+      "numberOfItems": {{ channels | length }},
+      "itemListElement": [
+        {% for c in channels %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "url": "{{ frontend_url }}/chaine/{{ c.slug }}",
+          "name": "{{ c.name | replace('"', '\\"') }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+      ]
+    }
+  }
+</script>
+{% endblock %} {% block content %}
+<h1>Toutes les chaînes analysées sur DeepSight</h1>
+<p class="ds-meta-row">
+  <span class="ds-pill"
+    >{{ channels | length }} chaîne{{ 's' if (channels | length) > 1 else ''
+    }}</span
+  >
+</p>
+
+<p>
+  Index des chaînes YouTube et TikTok dont au moins une vidéo a été analysée
+  publiquement sur DeepSight. Chaque chaîne agrège les analyses partagées par
+  les utilisateurs (synthèses sourcées, fact-checking, flashcards). Cliquez sur
+  une chaîne pour voir ses analyses.
+</p>
+
+<ul class="ds-list-channels">
+  {% for c in channels %}
+  <li>
+    <a href="{{ frontend_url }}/chaine/{{ c.slug }}">{{ c.name }}</a>
+    <small
+      >{{ c.analyses_count }} analyse{{ 's' if c.analyses_count > 1 else '' }} ·
+      {{ c.total_views }} vues</small
+    >
+  </li>
+  {% endfor %}
+</ul>
+
+<h2>Et après ?</h2>
+<p>
+  Vous voulez analyser une vidéo qui n'apparait pas ici ?
+  <a href="{{ frontend_url }}/">DeepSight est gratuit pour commencer</a> : 5
+  analyses par mois, vidéos jusqu'à 15 min, flashcards et chat inclus. Sans
+  carte bancaire.
+</p>
+{% endblock %}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -65,6 +65,22 @@
       ],
       "destination": "/api/prerender?path=/contact"
     },
+    {
+      "source": "/chaines",
+      "destination": "https://api.deepsightsynthesis.com/api/aggregate/channels-render"
+    },
+    {
+      "source": "/chaine/:slug",
+      "destination": "https://api.deepsightsynthesis.com/api/aggregate/channel-render/:slug"
+    },
+    {
+      "source": "/categories",
+      "destination": "https://api.deepsightsynthesis.com/api/aggregate/categories-render"
+    },
+    {
+      "source": "/categorie/:slug",
+      "destination": "https://api.deepsightsynthesis.com/api/aggregate/category-render/:slug"
+    },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

Sprint 3a du chantier GEO : transforme **les analyses partagées par les utilisateurs** en pages indexables long-tail. Levier majeur — chaque chaîne YouTube/TikTok populaire et chaque catégorie devient une page autonome citable par ChatGPT, Perplexity, Claude, Gemini.

C'est l'application directe du levier "nourrir le GEO avec l'historique réel" qu'on a discuté : on n'invente pas de contenu, on agrège ce que les users ont déjà créé et explicitement partagé.

## Pages produites

Pour chaque chaîne ayant ≥1 analyse partagée (`SharedAnalysis.is_active=true`) :
- `/chaine/lex-fridman` — toutes les analyses publiques de Lex Fridman
- `/chaine/hugodecrypte` — idem HugoDécrypte
- … (50-500+ pages potentielles selon volume DB)

Pour chaque catégorie YouTube avec analyses partagées :
- `/categorie/sciences`, `/categorie/economie`, `/categorie/politique`, etc.

Plus deux index :
- `/chaines` — index des chaînes (avec compteurs)
- `/categories` — index des catégories

Toutes en HTML SSR Jinja2, dark mode, JSON-LD `CollectionPage` + `BreadcrumbList` + `ItemList`, canonical, hreflang, OG, twitter cards.

## Architecture

### Backend (nouveau module `aggregate/`)
- **`aggregate/slug.py`** — `to_slug("Lex Fridman") → "lex-fridman"` (NFD ASCII + URL-safe). Slugs computed à la volée, pas de colonne DB.
- **`aggregate/queries.py`** — JOIN `SharedAnalysis × Summary` sur `(user_id, video_id)` pour exposer `video_channel` + `category` que `SharedAnalysis` ne stocke pas. Couvert par les indexes existants (`idx_shared_analyses_user_video`, `idx_summaries_user_video`).
- **`aggregate/html_renderer.py`** — wrapper Jinja2 dédié (templates dans `templates/aggregate/`).
- **`aggregate/router.py`** — 8 routes sous `/api/aggregate/*` :

| Route | Type | Cache | Description |
|---|---|---|---|
| `/channels` | JSON | — | List channels triées par `analyses_count desc, total_views desc` |
| `/channels/{slug}` | JSON | — | Detail channel + 50 analyses |
| `/categories` | JSON | — | List categories |
| `/categories/{slug}` | JSON | — | Detail category + 50 analyses |
| `/channel-render/{slug}` | HTML | 15 min | Page SSR consommée par `/chaine/:slug` |
| `/category-render/{slug}` | HTML | 15 min | Page SSR consommée par `/categorie/:slug` |
| `/channels-render` | HTML | 30 min | Index des chaînes, consommé par `/chaines` |
| `/categories-render` | HTML | 30 min | Index, consommé par `/categories` |

Le suffixe `-render` (au lieu de `/page`) évite tout conflit FastAPI entre `/categories/{slug}` et `/categories/page`.

### Frontend
- **`vercel.json`** : 4 rewrites mappant les paths user-friendly aux endpoints backend, **pour TOUS UAs** (humains comme bots) → pas de 404 SPA, tout le monde voit la même page SSR :
  - `/chaines` → `/api/aggregate/channels-render`
  - `/chaine/:slug` → `/api/aggregate/channel-render/:slug`
  - `/categories` → `/api/aggregate/categories-render`
  - `/categorie/:slug` → `/api/aggregate/category-render/:slug`

### Templates Jinja2 (5 fichiers, `templates/aggregate/`)
- `_layout.html` — base autonome, dark mode, CSS inline (pas de dépendance externe pour rester rapide), sticky nav, breadcrumb, footer souveraineté EU
- `channel.html` / `category.html` — page detail avec H1 + paragraphe contextuel + grille de cards (thumbnail + titre + verdict tronqué) + JSON-LD `CollectionPage`
- `channels_index.html` / `categories_index.html` — index avec compteurs + JSON-LD `ItemList`

## RGPD & consentement

Seules les analyses avec `SharedAnalysis.is_active=true` sont exposées — c'est-à-dire celles dont l'utilisateur a explicitement cliqué \"Partager\" (consentement public ipso facto). Aucune donnée privée n'est exposée.

⚠️ **Recommandation Sprint 3b** : enrichir la copy autour du bouton \"Partager\" pour mentionner que l'analyse pourra apparaître dans des pages d'agrégation (`/chaine/*`, `/categorie/*`). Ajouter aussi un email batch pour proposer aux users existants de re-confirmer l'opt-in.

## Test plan
- [ ] Build backend Docker OK : `cd backend && docker build -f ../deploy/hetzner/Dockerfile .`
- [ ] Backend démarre sans erreur d'import : `cd backend/src && uvicorn main:app --port 8000`
- [ ] `curl http://localhost:8000/api/aggregate/channels` → 200 JSON list
- [ ] `curl http://localhost:8000/api/aggregate/categories` → 200 JSON list
- [ ] `curl http://localhost:8000/api/aggregate/channels-render` → 200 HTML index
- [ ] Si une chaîne existe en DB : `curl http://localhost:8000/api/aggregate/channels/lex-fridman` → 200 JSON detail
- [ ] Idem `/api/aggregate/channel-render/lex-fridman` → 200 HTML
- [ ] Frontend Vercel preview : `https://<preview>/chaines` → page index Jinja2 servie via rewrite
- [ ] `view-source:` : JSON-LD `CollectionPage` + `BreadcrumbList` + `ItemList` présents
- [ ] Slug helper validé localement (5 cas test passés)

## Volume

11 nouveaux fichiers (5 Python + 5 templates + 1 frontend), 2 fichiers modifiés (main.py + vercel.json).

## Sprints suivants

**Sprint 3b (UX opt-in)** — Reformuler la copy autour du bouton \"Partager\" pour mentionner les pages d'agrégation. Modal d'opt-in dédié pour les anciennes analyses partagées (avant ce changement).

**Sprint 3c (mailing batch)** — Email automatique aux users qui ont déjà partagé ≥3 analyses, expliquant la nouvelle visibilité et leur permettant de désactiver une analyse spécifique en 1 clic.

**Sprint 3d (sitemap dynamique étendu)** — Le `generate-sitemap.mjs` actuel hardcode 10 routes statiques. À étendre pour fetcher au build le top N chaînes et top M catégories du backend, et les ajouter au sitemap. Permet à Google de découvrir les pages plus vite.

**Sprint 3e (le-saviez-vous quotidien)** — Pipeline backend déjà préparé (`PROMPT_LE_SAVIEZ_VOUS.md`). Page `/le-saviez-vous/<slug>` avec 1 fact/jour généré depuis les analyses publiques. Signal de site vivant pour les LLMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)