### PR TITLE
feat(vault-mcp): add delete_note tool

### DIFF
--- a/vault-mcp/src/vault_mcp/server.py
+++ b/vault-mcp/src/vault_mcp/server.py
@@ -30,8 +30,10 @@ from vault_mcp.tools.list import (
 from vault_mcp.security import PathTraversalError
 from vault_mcp.tools.write import (
     create_note as _create_note_impl,
+    delete_note as _delete_note_impl,
     WriteForbiddenError,
     NoteAlreadyExistsError,
+    NoteNotFoundForDeleteError,
 )
 
 
@@ -126,6 +128,42 @@ async def create_note(path: str, content: str) -> str:
         WriteForbiddenError,
         NoteAlreadyExistsError,
         ValueError,
+    ) as e:
+        return f"ERROR: {e}"
+
+
+@mcp.tool()
+async def delete_note(path: str) -> str:
+    """
+    Delete a markdown note from the vault.
+
+    Allowed delete zones (same as create_note):
+    - 00-Inbox/
+    - 03-Archive/
+    - 01-Projects/<project>/Sessions/
+    - 01-Projects/<project>/Ideas/
+    - 01-Projects/<project>/Bugs/
+
+    Constraints:
+    - path must end with .md
+    - file must exist
+    - Specs/ and Decisions/ are NOT deletable via MCP
+
+    Args:
+        path: vault-relative path (e.g., '00-Inbox/test.md')
+
+    Returns:
+        Success message with the deleted path, or "ERROR: ..." string.
+    """
+    try:
+        result = _delete_note_impl(SETTINGS, path)
+        rel = result.relative_to(SETTINGS.vault_path.resolve()).as_posix()
+        log.info("delete_note: %s", rel)
+        return f"OK: deleted {rel}"
+    except (
+        PathTraversalError,
+        WriteForbiddenError,
+        NoteNotFoundForDeleteError,
     ) as e:
         return f"ERROR: {e}"
 

--- a/vault-mcp/src/vault_mcp/tools/write.py
+++ b/vault-mcp/src/vault_mcp/tools/write.py
@@ -1,4 +1,4 @@
-"""Write tools for the vault — create_note only (no update/delete by design)."""
+"""Write tools for the vault — create_note + delete_note (zone-restricted)."""
 
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,6 +21,10 @@ class WriteForbiddenError(ValueError):
 
 class NoteAlreadyExistsError(FileExistsError):
     """Raised when create_note targets an existing file (no overwrite)."""
+
+
+class NoteNotFoundForDeleteError(FileNotFoundError):
+    """Raised when delete_note targets a non-existent file."""
 
 
 def _is_allowed_write_path(rel_path: str) -> bool:
@@ -90,5 +94,45 @@ def create_note(settings: Settings, rel_path: str, content: str) -> Path:
     safe_path.write_text(content, encoding="utf-8")
 
     _audit_log(settings, "create_note", rel_path, len(content_bytes))
+
+    return safe_path
+
+
+def delete_note(settings: Settings, rel_path: str) -> Path:
+    """
+    Delete a markdown note from the vault.
+
+    Constraints:
+        - rel_path must end with .md
+        - rel_path must be in an allowed write zone (same as create_note)
+        - File must exist and be a regular file
+
+    Raises:
+        PathTraversalError: rel_path escapes vault or hits forbidden dir
+        WriteForbiddenError: rel_path is outside allowed write zones, or not a regular file
+        NoteNotFoundForDeleteError: file does not exist at rel_path
+    """
+    if not rel_path.endswith(".md"):
+        raise WriteForbiddenError(f"Path must end with .md: {rel_path!r}")
+
+    safe_path = resolve_safe_path(settings.vault_path, rel_path)
+    rel_resolved = safe_path.relative_to(settings.vault_path.resolve()).as_posix()
+
+    if not _is_allowed_write_path(rel_resolved):
+        raise WriteForbiddenError(
+            f"Path not in allowed delete zones (00-Inbox/, 03-Archive/, "
+            f"01-Projects/<project>/Sessions|Ideas|Bugs/): resolved to {rel_resolved!r}"
+        )
+
+    if not safe_path.exists():
+        raise NoteNotFoundForDeleteError(f"File does not exist: {rel_path}")
+
+    if not safe_path.is_file():
+        raise WriteForbiddenError(f"Path is not a regular file: {rel_path}")
+
+    size = safe_path.stat().st_size
+    safe_path.unlink()
+
+    _audit_log(settings, "delete_note", rel_path, size)
 
     return safe_path

--- a/vault-mcp/tests/test_write.py
+++ b/vault-mcp/tests/test_write.py
@@ -1,4 +1,4 @@
-"""Tests for create_note write tool."""
+"""Tests for create_note + delete_note write tools."""
 
 import pytest
 from pathlib import Path
@@ -6,8 +6,10 @@ from pathlib import Path
 from vault_mcp.config import Settings
 from vault_mcp.tools.write import (
     create_note,
+    delete_note,
     WriteForbiddenError,
     NoteAlreadyExistsError,
+    NoteNotFoundForDeleteError,
 )
 from vault_mcp.security import PathTraversalError
 
@@ -125,3 +127,96 @@ def test_create_note_creates_parent_dir(settings: Settings, fake_vault: Path):
         "# Idea\n",
     )
     assert path.exists()
+
+
+def test_delete_note_inbox_ok(settings: Settings, fake_vault: Path):
+    create_note(settings, "00-Inbox/to-delete.md", "# Bye\n")
+    target = fake_vault / "00-Inbox" / "to-delete.md"
+    assert target.exists()
+    delete_note(settings, "00-Inbox/to-delete.md")
+    assert not target.exists()
+
+
+def test_delete_note_archive_ok(settings: Settings, fake_vault: Path):
+    create_note(settings, "03-Archive/old.md", "# Old\n")
+    delete_note(settings, "03-Archive/old.md")
+    assert not (fake_vault / "03-Archive" / "old.md").exists()
+
+
+def test_delete_note_session_ok(settings: Settings, fake_vault: Path):
+    create_note(
+        settings,
+        "01-Projects/DeepSight/Sessions/2026-04-28-bye.md",
+        "# Session\n",
+    )
+    delete_note(settings, "01-Projects/DeepSight/Sessions/2026-04-28-bye.md")
+    assert not (
+        fake_vault / "01-Projects" / "DeepSight" / "Sessions" / "2026-04-28-bye.md"
+    ).exists()
+
+
+def test_delete_note_specs_forbidden(settings: Settings, fake_vault: Path):
+    spec = fake_vault / "01-Projects" / "DeepSight" / "Specs" / "spec.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# Spec\n")
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "01-Projects/DeepSight/Specs/spec.md")
+    assert spec.exists()
+
+
+def test_delete_note_decisions_forbidden(settings: Settings, fake_vault: Path):
+    adr = fake_vault / "01-Projects" / "DeepSight" / "Decisions" / "ADR-001.md"
+    adr.parent.mkdir(parents=True, exist_ok=True)
+    adr.write_text("# ADR\n")
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "01-Projects/DeepSight/Decisions/ADR-001.md")
+    assert adr.exists()
+
+
+def test_delete_note_meta_forbidden(settings: Settings, fake_vault: Path):
+    meta = fake_vault / "02-Meta" / "Claude" / "global.md"
+    meta.parent.mkdir(parents=True, exist_ok=True)
+    meta.write_text("# Global\n")
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "02-Meta/Claude/global.md")
+    assert meta.exists()
+
+
+def test_delete_note_root_forbidden(settings: Settings, fake_vault: Path):
+    f = fake_vault / "root-file.md"
+    f.write_text("x")
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "root-file.md")
+    assert f.exists()
+
+
+def test_delete_note_must_end_md(settings: Settings, fake_vault: Path):
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "00-Inbox/note.txt")
+
+
+def test_delete_note_missing_file(settings: Settings, fake_vault: Path):
+    with pytest.raises(NoteNotFoundForDeleteError):
+        delete_note(settings, "00-Inbox/never-existed.md")
+
+
+def test_delete_note_path_traversal_blocked(settings: Settings, fake_vault: Path):
+    with pytest.raises((PathTraversalError, WriteForbiddenError)):
+        delete_note(settings, "00-Inbox/../etc/passwd.md")
+
+
+def test_delete_note_audit_log_appended(settings: Settings, fake_vault: Path):
+    create_note(settings, "00-Inbox/audit-del.md", "content")
+    delete_note(settings, "00-Inbox/audit-del.md")
+    log = fake_vault / "02-Meta" / "audit" / "mcp-writes.log"
+    text = log.read_text(encoding="utf-8")
+    assert "delete_note" in text
+    assert "00-Inbox/audit-del.md" in text
+
+
+def test_delete_note_directory_rejected(settings: Settings, fake_vault: Path):
+    d = fake_vault / "00-Inbox" / "fake-dir.md"
+    d.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "00-Inbox/fake-dir.md")
+    assert d.exists()


### PR DESCRIPTION
## Summary
- Adds `delete_note` MCP tool to vault-mcp, mirroring `create_note` zone restrictions (Inbox, Archive, project Sessions/Ideas/Bugs)
- Specs/Decisions/Meta paths refused; missing files raise `NoteNotFoundForDeleteError`; directories rejected; audit-logged
- 11 unit tests added (forbidden zones, traversal, audit log, directory rejection, missing file). 56/56 tests pass.

## Why
Without a delete tool, MCP write-tests created notes that could only be cleaned up via SSH + `docker exec rm`. Surfaced this morning while validating the vault MCP scope-user setup.

## Test plan
- [x] `pytest tests/` — 56 passed (16 create + 11 delete + 29 read/search/list/security)
- [x] Container rebuilt + recreated (vault-mcp:latest)
- [x] E2E via JSON-RPC: tools/list shows delete_note; create→delete OK; delete-again returns `ERROR: File does not exist`; delete on `02-Meta/...` returns `ERROR: Path not in allowed delete zones`
- [x] E2E via Claude Code MCP client (`mcp__vault__delete_note`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)