### PR TITLE
feat(vault-mcp): tools — create_note + delete_note (rebased on main)

### DIFF
--- a/vault-mcp/src/vault_mcp/server.py
+++ b/vault-mcp/src/vault_mcp/server.py
@@ -30,8 +30,10 @@ from vault_mcp.tools.list import (
 from vault_mcp.security import PathTraversalError
 from vault_mcp.tools.write import (
     create_note as _create_note_impl,
+    delete_note as _delete_note_impl,
     WriteForbiddenError,
     NoteAlreadyExistsError,
+    NoteNotFoundForDeleteError,
 )
 
 
@@ -126,6 +128,42 @@ async def create_note(path: str, content: str) -> str:
         WriteForbiddenError,
         NoteAlreadyExistsError,
         ValueError,
+    ) as e:
+        return f"ERROR: {e}"
+
+
+@mcp.tool()
+async def delete_note(path: str) -> str:
+    """
+    Delete a markdown note from the vault.
+
+    Allowed delete zones (same as create_note):
+    - 00-Inbox/
+    - 03-Archive/
+    - 01-Projects/<project>/Sessions/
+    - 01-Projects/<project>/Ideas/
+    - 01-Projects/<project>/Bugs/
+
+    Constraints:
+    - path must end with .md
+    - file must exist
+    - Specs/ and Decisions/ are NOT deletable via MCP
+
+    Args:
+        path: vault-relative path (e.g., '00-Inbox/test.md')
+
+    Returns:
+        Success message with the deleted path, or "ERROR: ..." string.
+    """
+    try:
+        result = _delete_note_impl(SETTINGS, path)
+        rel = result.relative_to(SETTINGS.vault_path.resolve()).as_posix()
+        log.info("delete_note: %s", rel)
+        return f"OK: deleted {rel}"
+    except (
+        PathTraversalError,
+        WriteForbiddenError,
+        NoteNotFoundForDeleteError,
     ) as e:
         return f"ERROR: {e}"
 

--- a/vault-mcp/src/vault_mcp/server.py
+++ b/vault-mcp/src/vault_mcp/server.py
@@ -28,6 +28,11 @@ from vault_mcp.tools.list import (
     MemoryInfo,
 )
 from vault_mcp.security import PathTraversalError
+from vault_mcp.tools.write import (
+    create_note as _create_note_impl,
+    WriteForbiddenError,
+    NoteAlreadyExistsError,
+)
 
 
 setup_logging()
@@ -85,6 +90,44 @@ async def get_memory(name: str) -> str:
 async def list_memory() -> list[MemoryInfo]:
     """List all memory files with their type and description from frontmatter."""
     return _list_memory_impl(SETTINGS)
+
+
+@mcp.tool()
+async def create_note(path: str, content: str) -> str:
+    """
+    Create a new markdown note in the vault.
+
+    Allowed write zones (path prefix):
+    - 00-Inbox/                          → quick captures, ideas
+    - 03-Archive/                        → archived content
+    - 01-Projects/<project>/Sessions/    → session notes
+    - 01-Projects/<project>/Ideas/       → project-scoped ideas
+    - 01-Projects/<project>/Bugs/        → bug reports
+
+    Constraints:
+    - path must end with .md
+    - file must not already exist (no overwrite — use a different filename)
+    - Specs/ and Decisions/ are NOT writable (use slash commands /new-spec, /new-decision in Claude Code instead)
+
+    Args:
+        path: vault-relative path (e.g., '01-Projects/DeepSight/Sessions/2026-04-28-test.md')
+        content: full markdown content (frontmatter + body)
+
+    Returns:
+        Success message with the created path, or "ERROR: ..." string.
+    """
+    try:
+        result = _create_note_impl(SETTINGS, path, content)
+        rel = result.relative_to(SETTINGS.vault_path.resolve()).as_posix()
+        log.info("create_note: %s (%d bytes)", rel, len(content.encode("utf-8")))
+        return f"OK: created {rel}"
+    except (
+        PathTraversalError,
+        WriteForbiddenError,
+        NoteAlreadyExistsError,
+        ValueError,
+    ) as e:
+        return f"ERROR: {e}"
 
 
 class _RateLimiter:

--- a/vault-mcp/src/vault_mcp/tools/write.py
+++ b/vault-mcp/src/vault_mcp/tools/write.py
@@ -1,4 +1,4 @@
-"""Write tools for the vault — create_note only (no update/delete by design)."""
+"""Write tools for the vault — create_note + delete_note (zone-restricted)."""
 
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,6 +21,10 @@ class WriteForbiddenError(ValueError):
 
 class NoteAlreadyExistsError(FileExistsError):
     """Raised when create_note targets an existing file (no overwrite)."""
+
+
+class NoteNotFoundForDeleteError(FileNotFoundError):
+    """Raised when delete_note targets a non-existent file."""
 
 
 def _is_allowed_write_path(rel_path: str) -> bool:
@@ -90,5 +94,45 @@ def create_note(settings: Settings, rel_path: str, content: str) -> Path:
     safe_path.write_text(content, encoding="utf-8")
 
     _audit_log(settings, "create_note", rel_path, len(content_bytes))
+
+    return safe_path
+
+
+def delete_note(settings: Settings, rel_path: str) -> Path:
+    """
+    Delete a markdown note from the vault.
+
+    Constraints:
+        - rel_path must end with .md
+        - rel_path must be in an allowed write zone (same as create_note)
+        - File must exist and be a regular file
+
+    Raises:
+        PathTraversalError: rel_path escapes vault or hits forbidden dir
+        WriteForbiddenError: rel_path is outside allowed write zones, or not a regular file
+        NoteNotFoundForDeleteError: file does not exist at rel_path
+    """
+    if not rel_path.endswith(".md"):
+        raise WriteForbiddenError(f"Path must end with .md: {rel_path!r}")
+
+    safe_path = resolve_safe_path(settings.vault_path, rel_path)
+    rel_resolved = safe_path.relative_to(settings.vault_path.resolve()).as_posix()
+
+    if not _is_allowed_write_path(rel_resolved):
+        raise WriteForbiddenError(
+            f"Path not in allowed delete zones (00-Inbox/, 03-Archive/, "
+            f"01-Projects/<project>/Sessions|Ideas|Bugs/): resolved to {rel_resolved!r}"
+        )
+
+    if not safe_path.exists():
+        raise NoteNotFoundForDeleteError(f"File does not exist: {rel_path}")
+
+    if not safe_path.is_file():
+        raise WriteForbiddenError(f"Path is not a regular file: {rel_path}")
+
+    size = safe_path.stat().st_size
+    safe_path.unlink()
+
+    _audit_log(settings, "delete_note", rel_path, size)
 
     return safe_path

--- a/vault-mcp/src/vault_mcp/tools/write.py
+++ b/vault-mcp/src/vault_mcp/tools/write.py
@@ -1,0 +1,94 @@
+"""Write tools for the vault — create_note only (no update/delete by design)."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from vault_mcp.config import Settings
+from vault_mcp.security import resolve_safe_path, PathTraversalError
+
+
+# Allowed write zones (vault-relative path patterns)
+ALLOWED_WRITE_FOLDERS = (
+    "00-Inbox/",
+    "03-Archive/",
+)
+ALLOWED_PROJECT_SUBFOLDERS = ("Sessions", "Ideas", "Bugs")
+
+
+class WriteForbiddenError(ValueError):
+    """Raised when a write target path is outside allowed zones."""
+
+
+class NoteAlreadyExistsError(FileExistsError):
+    """Raised when create_note targets an existing file (no overwrite)."""
+
+
+def _is_allowed_write_path(rel_path: str) -> bool:
+    """Check if the path is in an allowed write zone."""
+    if any(rel_path.startswith(prefix) for prefix in ALLOWED_WRITE_FOLDERS):
+        return True
+    parts = rel_path.split("/")
+    if (
+        len(parts) >= 4
+        and parts[0] == "01-Projects"
+        and parts[2] in ALLOWED_PROJECT_SUBFOLDERS
+    ):
+        return True
+    return False
+
+
+def _audit_log(settings: Settings, action: str, rel_path: str, size: int) -> None:
+    """Append a single line to the MCP audit log."""
+    audit_dir = settings.vault_path / "02-Meta" / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log_file = audit_dir / "mcp-writes.log"
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = f"{timestamp}\t{action}\t{rel_path}\t{size}\n"
+    with log_file.open("a", encoding="utf-8") as f:
+        f.write(line)
+
+
+def create_note(settings: Settings, rel_path: str, content: str) -> Path:
+    """
+    Create a new markdown note in the vault.
+
+    Constraints:
+        - rel_path must end with .md
+        - rel_path must be in an allowed write zone (Inbox, Archive, or Project Sessions/Ideas/Bugs)
+        - File must not already exist (no overwrite)
+        - Content size limited via settings.max_note_size_bytes
+
+    Raises:
+        PathTraversalError: rel_path escapes vault or hits forbidden dir
+        WriteForbiddenError: rel_path is outside allowed write zones
+        NoteAlreadyExistsError: file already exists at rel_path
+        ValueError: content too large
+    """
+    if not rel_path.endswith(".md"):
+        raise WriteForbiddenError(f"Path must end with .md: {rel_path!r}")
+
+    safe_path = resolve_safe_path(settings.vault_path, rel_path)
+    rel_resolved = safe_path.relative_to(settings.vault_path.resolve()).as_posix()
+
+    if not _is_allowed_write_path(rel_resolved):
+        raise WriteForbiddenError(
+            f"Path not in allowed write zones (00-Inbox/, 03-Archive/, "
+            f"01-Projects/<project>/Sessions|Ideas|Bugs/): resolved to {rel_resolved!r}"
+        )
+
+    if safe_path.exists():
+        raise NoteAlreadyExistsError(f"File already exists: {rel_path}")
+
+    content_bytes = content.encode("utf-8")
+    if len(content_bytes) > settings.max_note_size_bytes:
+        raise ValueError(
+            f"Content too large ({len(content_bytes)} bytes, "
+            f"max {settings.max_note_size_bytes})"
+        )
+
+    safe_path.parent.mkdir(parents=True, exist_ok=True)
+    safe_path.write_text(content, encoding="utf-8")
+
+    _audit_log(settings, "create_note", rel_path, len(content_bytes))
+
+    return safe_path

--- a/vault-mcp/tests/test_write.py
+++ b/vault-mcp/tests/test_write.py
@@ -1,0 +1,127 @@
+"""Tests for create_note write tool."""
+
+import pytest
+from pathlib import Path
+
+from vault_mcp.config import Settings
+from vault_mcp.tools.write import (
+    create_note,
+    WriteForbiddenError,
+    NoteAlreadyExistsError,
+)
+from vault_mcp.security import PathTraversalError
+
+
+@pytest.fixture
+def settings(fake_vault: Path) -> Settings:
+    return Settings(vault_path=fake_vault, mcp_token="test-token")
+
+
+def test_create_note_inbox_ok(settings: Settings, fake_vault: Path):
+    path = create_note(settings, "00-Inbox/new-idea.md", "# New idea\n\nBody.")
+    assert path.exists()
+    assert path.read_text(encoding="utf-8") == "# New idea\n\nBody."
+
+
+def test_create_note_archive_ok(settings: Settings, fake_vault: Path):
+    path = create_note(
+        settings, "03-Archive/old-thoughts.md", "# Archived\n"
+    )
+    assert path.exists()
+
+
+def test_create_note_session_ok(settings: Settings, fake_vault: Path):
+    path = create_note(
+        settings,
+        "01-Projects/DeepSight/Sessions/2026-04-28-test.md",
+        "# Session\n",
+    )
+    assert path.exists()
+
+
+def test_create_note_idea_ok(settings: Settings, fake_vault: Path):
+    (fake_vault / "01-Projects" / "DeepSight" / "Ideas").mkdir(parents=True, exist_ok=True)
+    path = create_note(
+        settings,
+        "01-Projects/DeepSight/Ideas/feature-x.md",
+        "# Feature X\n",
+    )
+    assert path.exists()
+
+
+def test_create_note_bug_ok(settings: Settings, fake_vault: Path):
+    (fake_vault / "01-Projects" / "DeepSight" / "Bugs").mkdir(parents=True, exist_ok=True)
+    path = create_note(
+        settings,
+        "01-Projects/DeepSight/Bugs/2026-04-28-something.md",
+        "# Bug\n",
+    )
+    assert path.exists()
+
+
+def test_create_note_specs_forbidden(settings: Settings, fake_vault: Path):
+    with pytest.raises(WriteForbiddenError):
+        create_note(
+            settings,
+            "01-Projects/DeepSight/Specs/spec-z.md",
+            "# Spec\n",
+        )
+
+
+def test_create_note_decisions_forbidden(settings: Settings, fake_vault: Path):
+    with pytest.raises(WriteForbiddenError):
+        create_note(
+            settings,
+            "01-Projects/DeepSight/Decisions/ADR-001-z.md",
+            "# ADR\n",
+        )
+
+
+def test_create_note_meta_forbidden(settings: Settings, fake_vault: Path):
+    with pytest.raises(WriteForbiddenError):
+        create_note(settings, "02-Meta/Claude/test.md", "# Test\n")
+
+
+def test_create_note_root_forbidden(settings: Settings, fake_vault: Path):
+    with pytest.raises(WriteForbiddenError):
+        create_note(settings, "test-at-root.md", "# Test\n")
+
+
+def test_create_note_must_end_md(settings: Settings, fake_vault: Path):
+    with pytest.raises(WriteForbiddenError):
+        create_note(settings, "00-Inbox/note.txt", "Test")
+
+
+def test_create_note_no_overwrite(settings: Settings, fake_vault: Path):
+    create_note(settings, "00-Inbox/once.md", "First\n")
+    with pytest.raises(NoteAlreadyExistsError):
+        create_note(settings, "00-Inbox/once.md", "Second\n")
+
+
+def test_create_note_path_traversal_blocked(settings: Settings, fake_vault: Path):
+    with pytest.raises((PathTraversalError, WriteForbiddenError)):
+        create_note(settings, "00-Inbox/../etc/passwd.md", "evil")
+
+
+def test_create_note_content_too_large(settings: Settings, fake_vault: Path):
+    settings.max_note_size_bytes = 100
+    with pytest.raises(ValueError):
+        create_note(settings, "00-Inbox/big.md", "a" * 200)
+
+
+def test_create_note_audit_log_appended(settings: Settings, fake_vault: Path):
+    create_note(settings, "00-Inbox/audit-test.md", "content")
+    log = fake_vault / "02-Meta" / "audit" / "mcp-writes.log"
+    assert log.exists()
+    line = log.read_text(encoding="utf-8")
+    assert "create_note" in line
+    assert "00-Inbox/audit-test.md" in line
+
+
+def test_create_note_creates_parent_dir(settings: Settings, fake_vault: Path):
+    path = create_note(
+        settings,
+        "01-Projects/Grassmotion/Ideas/new.md",
+        "# Idea\n",
+    )
+    assert path.exists()

--- a/vault-mcp/tests/test_write.py
+++ b/vault-mcp/tests/test_write.py
@@ -1,4 +1,4 @@
-"""Tests for create_note write tool."""
+"""Tests for create_note + delete_note write tools."""
 
 import pytest
 from pathlib import Path
@@ -6,8 +6,10 @@ from pathlib import Path
 from vault_mcp.config import Settings
 from vault_mcp.tools.write import (
     create_note,
+    delete_note,
     WriteForbiddenError,
     NoteAlreadyExistsError,
+    NoteNotFoundForDeleteError,
 )
 from vault_mcp.security import PathTraversalError
 
@@ -125,3 +127,96 @@ def test_create_note_creates_parent_dir(settings: Settings, fake_vault: Path):
         "# Idea\n",
     )
     assert path.exists()
+
+
+def test_delete_note_inbox_ok(settings: Settings, fake_vault: Path):
+    create_note(settings, "00-Inbox/to-delete.md", "# Bye\n")
+    target = fake_vault / "00-Inbox" / "to-delete.md"
+    assert target.exists()
+    delete_note(settings, "00-Inbox/to-delete.md")
+    assert not target.exists()
+
+
+def test_delete_note_archive_ok(settings: Settings, fake_vault: Path):
+    create_note(settings, "03-Archive/old.md", "# Old\n")
+    delete_note(settings, "03-Archive/old.md")
+    assert not (fake_vault / "03-Archive" / "old.md").exists()
+
+
+def test_delete_note_session_ok(settings: Settings, fake_vault: Path):
+    create_note(
+        settings,
+        "01-Projects/DeepSight/Sessions/2026-04-28-bye.md",
+        "# Session\n",
+    )
+    delete_note(settings, "01-Projects/DeepSight/Sessions/2026-04-28-bye.md")
+    assert not (
+        fake_vault / "01-Projects" / "DeepSight" / "Sessions" / "2026-04-28-bye.md"
+    ).exists()
+
+
+def test_delete_note_specs_forbidden(settings: Settings, fake_vault: Path):
+    spec = fake_vault / "01-Projects" / "DeepSight" / "Specs" / "spec.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# Spec\n")
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "01-Projects/DeepSight/Specs/spec.md")
+    assert spec.exists()
+
+
+def test_delete_note_decisions_forbidden(settings: Settings, fake_vault: Path):
+    adr = fake_vault / "01-Projects" / "DeepSight" / "Decisions" / "ADR-001.md"
+    adr.parent.mkdir(parents=True, exist_ok=True)
+    adr.write_text("# ADR\n")
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "01-Projects/DeepSight/Decisions/ADR-001.md")
+    assert adr.exists()
+
+
+def test_delete_note_meta_forbidden(settings: Settings, fake_vault: Path):
+    meta = fake_vault / "02-Meta" / "Claude" / "global.md"
+    meta.parent.mkdir(parents=True, exist_ok=True)
+    meta.write_text("# Global\n")
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "02-Meta/Claude/global.md")
+    assert meta.exists()
+
+
+def test_delete_note_root_forbidden(settings: Settings, fake_vault: Path):
+    f = fake_vault / "root-file.md"
+    f.write_text("x")
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "root-file.md")
+    assert f.exists()
+
+
+def test_delete_note_must_end_md(settings: Settings, fake_vault: Path):
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "00-Inbox/note.txt")
+
+
+def test_delete_note_missing_file(settings: Settings, fake_vault: Path):
+    with pytest.raises(NoteNotFoundForDeleteError):
+        delete_note(settings, "00-Inbox/never-existed.md")
+
+
+def test_delete_note_path_traversal_blocked(settings: Settings, fake_vault: Path):
+    with pytest.raises((PathTraversalError, WriteForbiddenError)):
+        delete_note(settings, "00-Inbox/../etc/passwd.md")
+
+
+def test_delete_note_audit_log_appended(settings: Settings, fake_vault: Path):
+    create_note(settings, "00-Inbox/audit-del.md", "content")
+    delete_note(settings, "00-Inbox/audit-del.md")
+    log = fake_vault / "02-Meta" / "audit" / "mcp-writes.log"
+    text = log.read_text(encoding="utf-8")
+    assert "delete_note" in text
+    assert "00-Inbox/audit-del.md" in text
+
+
+def test_delete_note_directory_rejected(settings: Settings, fake_vault: Path):
+    d = fake_vault / "00-Inbox" / "fake-dir.md"
+    d.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(WriteForbiddenError):
+        delete_note(settings, "00-Inbox/fake-dir.md")
+    assert d.exists()


### PR DESCRIPTION
## Contexte

Stack auparavant sur `feat/vault-mcp-foundation` (#175 mergée). Rebasé sur main après le squash de #175 pour résoudre les conflits.

## Summary

2 commits pour ajouter les outils d'écriture sur le vault MCP avec restriction de zones identique à la lecture :

- `feat(vault-mcp): B4-3 — add create_note tool with write zone safety + audit log + 16 tests`
- `feat(vault-mcp): add delete_note tool — same zone-restriction as create_note`

Zones autorisées en écriture : Inbox, Archive, project Sessions/Ideas/Bugs.
Zones refusées : 02-Meta, Specs, Decisions (lecture seule par design).

## Stats

3 fichiers, +441 lignes (server.py + tools/write.py + tests/test_write.py).

## Test plan

- [x] `pytest tests/` côté `vault-mcp/` : 56 passed (29 read + 16 create + 11 delete)
- [x] E2E via JSON-RPC : `tools/list` montre `create_note` + `delete_note`
- [x] E2E delete : `create → delete OK`, `delete-again → ERROR: File does not exist`, `delete on 02-Meta/... → ERROR: Path not in allowed delete zones`
- [x] E2E via Claude Code MCP client : `mcp__vault__create_note` + `mcp__vault__delete_note` validés