### PR TITLE
feat(seo): Sprint 4 PR1 — SEO foundational (VideoObject, 410 Gone, NotFound)

### DIFF
--- a/backend/src/share/html_renderer.py
+++ b/backend/src/share/html_renderer.py
@@ -8,6 +8,7 @@ client-side for humans via /s/{token}.
 
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -38,6 +39,22 @@ def _format_duration(seconds: Optional[int]) -> str:
     if m > 0:
         return f"{m}m {s}s" if s else f"{m}m"
     return f"{s}s"
+
+
+def _format_duration_iso(seconds: Optional[int]) -> str:
+    """Format seconds to ISO 8601 PT#H#M#S for Schema.org VideoObject duration."""
+    if not seconds or seconds <= 0:
+        return ""
+    h, rem = divmod(int(seconds), 3600)
+    m, s = divmod(rem, 60)
+    out = "PT"
+    if h > 0:
+        out += f"{h}H"
+    if m > 0:
+        out += f"{m}M"
+    if s > 0:
+        out += f"{s}S"
+    return out if out != "PT" else "PT0S"
 
 
 def _format_created_at(iso: str) -> str:
@@ -119,6 +136,44 @@ def render_analysis_page(
         "sources": snapshot.get("sources") or [],
         "analyze_cta_url": analyze_cta_url,
     }
+
+    # Schema.org VideoObject JSON-LD — built Python-side and HTML-escaped for inline <script>
+    video_object: Dict[str, Any] = {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": video_title,
+        "description": context["page_description"],
+        "uploadDate": created_at_iso,
+        "publisher": {
+            "@type": "Organization",
+            "name": "DeepSight",
+            "logo": {
+                "@type": "ImageObject",
+                "url": f"{web_base}/icons/icon-512x512.png",
+            },
+        },
+        "isAccessibleForFree": True,
+        "isFamilyFriendly": True,
+        "inLanguage": lang,
+    }
+    if snapshot.get("video_thumbnail"):
+        video_object["thumbnailUrl"] = snapshot["video_thumbnail"]
+    if context["video_url"]:
+        video_object["contentUrl"] = context["video_url"]
+    if platform == "youtube" and video_id:
+        video_object["embedUrl"] = f"https://www.youtube.com/embed/{video_id}"
+    duration_iso = _format_duration_iso(snapshot.get("duration_seconds"))
+    if duration_iso:
+        video_object["duration"] = duration_iso
+    if snapshot.get("channel"):
+        video_object["creator"] = {"@type": "Person", "name": snapshot["channel"]}
+
+    context["video_object_jsonld"] = (
+        json.dumps(video_object, ensure_ascii=False)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
 
     template = _env.get_template("share/analysis.html")
     html = template.render(**context)

--- a/backend/src/share/router.py
+++ b/backend/src/share/router.py
@@ -312,17 +312,17 @@ async def get_shared_og(
     """
     Returns minimal HTML with OG meta tags for social bot crawlers.
     Used by Vercel rewrite to serve OG tags for /s/:token URLs.
+
+    Returns 404 if the token never existed, 410 Gone if it existed but has
+    been revoked — letting Google deindex revoked pages faster.
     """
-    result = await session.execute(
-        select(SharedAnalysis).where(
-            SharedAnalysis.share_token == share_token,
-            SharedAnalysis.is_active,
-        )
-    )
+    result = await session.execute(select(SharedAnalysis).where(SharedAnalysis.share_token == share_token))
     shared = result.scalar_one_or_none()
 
     if not shared:
         raise HTTPException(status_code=404, detail="Shared analysis not found")
+    if not shared.is_active:
+        raise HTTPException(status_code=410, detail="Shared analysis revoked")
 
     html = _build_og_html(shared, share_token)
     return HTMLResponse(content=html)
@@ -336,17 +336,15 @@ async def get_share_og_image(
     """Dynamic 1200×630 OG image for social previews.
 
     Cached 1h client-side + 24h on CDN edge to avoid re-rendering for each
-    bot fetch. Falls back to 404 if share doesn't exist or has been revoked.
+    bot fetch. Returns 404 if the token never existed, 410 Gone if it
+    existed but has been revoked — letting Google deindex revoked pages.
     """
-    result = await session.execute(
-        select(SharedAnalysis).where(
-            SharedAnalysis.share_token == token,
-            SharedAnalysis.is_active.is_(True),
-        )
-    )
+    result = await session.execute(select(SharedAnalysis).where(SharedAnalysis.share_token == token))
     share: Optional[SharedAnalysis] = result.scalar_one_or_none()
     if not share:
         raise HTTPException(status_code=404, detail="Share not found")
+    if not share.is_active:
+        raise HTTPException(status_code=410, detail="Share revoked")
 
     try:
         snapshot = json.loads(share.analysis_snapshot or "{}")
@@ -383,18 +381,16 @@ async def get_share_page(
     - Fallback for users whose frontend SPA fails to load.
     - Direct links from email/SMS/QR where rich preview matters.
 
-    Returns 404 if token is unknown or share has been revoked.
+    Returns 404 if the token never existed, 410 Gone if it existed but has
+    been revoked — letting Google deindex revoked pages faster.
     Increments view_count on each call (best-effort, non-blocking).
     """
-    result = await session.execute(
-        select(SharedAnalysis).where(
-            SharedAnalysis.share_token == token,
-            SharedAnalysis.is_active.is_(True),
-        )
-    )
+    result = await session.execute(select(SharedAnalysis).where(SharedAnalysis.share_token == token))
     share: Optional[SharedAnalysis] = result.scalar_one_or_none()
     if not share:
-        raise HTTPException(status_code=404, detail="Share not found or revoked")
+        raise HTTPException(status_code=404, detail="Share not found")
+    if not share.is_active:
+        raise HTTPException(status_code=410, detail="Share revoked")
 
     try:
         snapshot = json.loads(share.analysis_snapshot or "{}")

--- a/backend/src/templates/share/analysis.html
+++ b/backend/src/templates/share/analysis.html
@@ -1,4 +1,7 @@
 {% extends "share/base.html" %} {% block content %}
+<script type="application/ld+json">
+  {{ video_object_jsonld | safe }}
+</script>
 <article class="ds-article">
   <section class="ds-hero">
     <a

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -107,6 +107,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="format-detection" content="telephone=no" />
 
+    <!-- 🔍 Search Engines Verification — décommenter et coller le code après création des comptes Google Search Console / Bing Webmaster / Yandex -->
+    <!-- <meta name="google-site-verification" content="REPLACE_WITH_GSC_CODE" /> -->
+    <!-- <meta name="msvalidate.01" content="REPLACE_WITH_BING_CODE" /> -->
+    <!-- <meta name="yandex-verification" content="REPLACE_WITH_YANDEX_CODE" /> -->
+
     <!-- 📊 Preload des ressources critiques -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -105,5 +105,11 @@ Disallow: /admin
 Disallow: /api/
 Disallow: /payment/
 
+User-agent: Meta-ExternalAgent
+Allow: /
+Disallow: /admin
+Disallow: /api/
+Disallow: /payment/
+
 # === Sitemap ===
 Sitemap: https://www.deepsightsynthesis.com/sitemap.xml

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, Link } from "react-router-dom";
 import { motion } from "framer-motion";
 
 const NotFoundPage = () => {
@@ -109,6 +109,45 @@ const NotFoundPage = () => {
             Aller au Dashboard
           </button>
         </motion.div>
+
+        {/* Internal links — SEO crawlability + UX */}
+        <motion.nav
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.7 }}
+          className="mt-10 pt-6 border-t border-border-subtle"
+          aria-label="Pages utiles"
+        >
+          <p className="text-text-tertiary text-xs uppercase tracking-wider mb-3">
+            Pages utiles
+          </p>
+          <div className="flex flex-wrap gap-2 justify-center text-sm">
+            <Link
+              to="/"
+              className="px-3 py-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-secondary transition-colors"
+            >
+              Accueil
+            </Link>
+            <Link
+              to="/upgrade"
+              className="px-3 py-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-secondary transition-colors"
+            >
+              Tarifs
+            </Link>
+            <Link
+              to="/about"
+              className="px-3 py-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-secondary transition-colors"
+            >
+              À propos
+            </Link>
+            <Link
+              to="/chaines"
+              className="px-3 py-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-secondary transition-colors"
+            >
+              Toutes les chaînes
+            </Link>
+          </div>
+        </motion.nav>
       </motion.div>
     </div>
   );

--- a/frontend/src/pages/SharedAnalysisPage.tsx
+++ b/frontend/src/pages/SharedAnalysisPage.tsx
@@ -11,6 +11,7 @@ import { Eye } from "lucide-react";
 import { shareApi, SharedAnalysisResponse } from "../services/api";
 import { sanitizeTitle } from "../utils/sanitize";
 import { DeepSightSpinner } from "../components/ui/DeepSightSpinner";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -27,6 +28,18 @@ function formatDuration(seconds: number | undefined): string {
   const s = seconds % 60;
   if (h > 0) return `${h}h${m.toString().padStart(2, "0")}m`;
   return `${m}m${s.toString().padStart(2, "0")}s`;
+}
+
+function formatDurationISO(seconds: number | undefined): string {
+  if (!seconds || seconds <= 0) return "";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  let out = "PT";
+  if (h > 0) out += `${h}H`;
+  if (m > 0) out += `${m}M`;
+  if (s > 0) out += `${s}S`;
+  return out === "PT" ? "PT0S" : out;
 }
 
 function formatContent(content: string): string {
@@ -223,7 +236,43 @@ export default function SharedAnalysisPage() {
             inLanguage: "fr",
           })}
         </script>
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "VideoObject",
+            name: data.video_title,
+            description,
+            ...(thumbnailUrl && { thumbnailUrl }),
+            ...(youtubeUrl && { contentUrl: youtubeUrl }),
+            ...(videoId &&
+              (analysis.video_url || "").includes("youtu") && {
+                embedUrl: `https://www.youtube.com/embed/${videoId}`,
+              }),
+            ...(duration && { duration: formatDurationISO(duration) }),
+            ...(createdAt && {
+              uploadDate: new Date(createdAt).toISOString(),
+            }),
+            ...(channel && {
+              creator: { "@type": "Person", name: channel },
+            }),
+            publisher: {
+              "@type": "Organization",
+              name: "DeepSight",
+              logo: {
+                "@type": "ImageObject",
+                url: "https://www.deepsightsynthesis.com/icons/icon-512x512.png",
+              },
+            },
+            isFamilyFriendly: true,
+            isAccessibleForFree: true,
+            inLanguage: "fr",
+          })}
+        </script>
       </Helmet>
+      <BreadcrumbJsonLd
+        path={`/s/${shareToken}`}
+        label={data.video_title}
+      />
 
       {/* Header */}
       <header className="border-b border-border-subtle bg-bg-primary/80 backdrop-blur-xl sticky top-0 z-50">

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,5 +1,6 @@
 {
   "framework": "vite",
+  "trailingSlash": false,
   "rewrites": [
     {
       "source": "/s/:token/og-image.png",


### PR DESCRIPTION
## Summary

PR1 du **Sprint 4 SEO classique** (post-GEO mergé via PRs #165/#168/#170). Quick wins groupés sur les fondamentaux Schema / HTTP / canonical pour maximiser l'indexation Google Search avec un effort modéré.

**6 commits atomiques :**

1. `feat(seo): VideoObject + Breadcrumb JSON-LD on shared analyses` — frontend SPA + backend Jinja `analysis.html`. Pages `/s/<token>` deviennent éligibles à **Google Vidéos**.
2. `fix(seo): 410 Gone for revoked share endpoints` — les 3 endpoints HTML (`/og`, `/og-image.png`, `/page`) distinguent maintenant token-inexistant (404) vs revoked (410). Signal de désindexation rapide pour Google.
3. `feat(seo): NotFoundPage internal links` — 4 liens publics (`/`, `/upgrade`, `/about`, `/chaines`) pour crawlability + UX.
4. `feat(seo): GSC/Bing/Yandex verification placeholders` — 3 meta tags commentés dans `index.html`, à dé-commenter après création des propriétés Search Console.
5. `feat(seo): trailingSlash:false in vercel.json` — élimine le duplicate `/about` vs `/about/` (308 redirect).
6. `feat(seo): allow Meta-ExternalAgent` — 16e bot IA explicitement Allow dans `robots.txt`.

## Audit pré-PR

Audit parallèle (5 sub-agents Explore Opus) sur les 10 chantiers Sprint 4. Cette PR couvre les **quick wins effort-S impact-gros**. Les chantiers restants iront en PR suivantes :
- **PR2 (M)** : Image SEO — wrapper `<OptimizedImage />`, `width/height` systématiques (99% manquants), WebP/AVIF, sitemap-images, suppression assets morts (~5 MB de PNGs).
- **PR3 (M)** : Bundle CWV — `framer-motion` lazy hors LandingPage (chargé sur `/` actuellement), `manualChunks` étendus (recharts/mermaid/sentry/supabase), self-host fonts critiques, Lighthouse CI workflow.
- **PR4 (M)** : IndexNow ping (point d'insertion `share/router.py:298`) + pagination `?page=N` sur `/chaine/<slug>` `/categorie/<slug>` + canonical `rel=prev/next`.

## Test plan

- [ ] CI Backend tests verts — refactor des `where(...is_active.is_(True))` en check séparé préserve la sémantique pour les shares actifs.
- [ ] CI Frontend Lint/Typecheck — `SharedAnalysisPage.tsx`, `NotFoundPage.tsx`, `BreadcrumbJsonLd.tsx` ne doivent pas apparaître dans les erreurs (les autres erreurs `StudyPage`/`UpgradePage`/`api.ts` sont pré-existantes, hors scope).
- [ ] **Vérif prod backend (post-merge auto-deploy Hetzner ~30s)** :
  - `curl -sI https://api.deepsightsynthesis.com/api/share/INVALID/page` → `404`
  - Désactiver un share `is_active=false` + `curl -sI https://api.deepsightsynthesis.com/api/share/<REVOKED>/page` → `410`
  - Idem `/og` et `/og-image.png` → `410` quand revoked
- [ ] **Vérif prod frontend (Vercel auto-deploy)** :
  - `curl -sI https://www.deepsightsynthesis.com/about/` → `308` vers `/about`
  - View-source `https://www.deepsightsynthesis.com/s/<TOKEN>` → présence de `"@type":"VideoObject"` ET `"@type":"BreadcrumbList"` ET `"@type":"Article"`
  - Naviguer vers `/this-page-does-not-exist` → NotFoundPage avec 4 liens visibles
- [ ] **Google Rich Results Test** : <https://search.google.com/test/rich-results> avec une URL `/s/<token>` active — doit valider VideoObject + Article + BreadcrumbList.
- [ ] **Étape user post-merge** : créer la propriété `deepsightsynthesis.com` dans Google Search Console + Bing Webmaster + (optionnel) Yandex, copier les codes, dé-commenter les meta tags dans `frontend/index.html`, push.

## Volume

- **6 commits** atomiques (Conventional Commits + co-author Claude)
- **7 fichiers touchés** : 3 backend (`share/router.py`, `share/html_renderer.py`, `templates/share/analysis.html`) + 4 frontend (`pages/SharedAnalysisPage.tsx`, `pages/NotFoundPage.tsx`, `index.html`, `vercel.json`, `public/robots.txt`)
- **~175 lignes ajoutées**, ~22 supprimées (refactor 410)

🤖 Generated with [Claude Code](https://claude.com/claude-code)