### PR TITLE
feat(voice): Apply button for voice prefs — staging provider + restart-on-apply

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -1572,6 +1572,9 @@ async def _analyze_video_background_v2(
             else:
                 await deduct_credit(session, user_id, credit_cost, f"Video v2: {video_info['title'][:50]}")
 
+            _task_store[task_id]["progress"] = 94
+            _task_store[task_id]["message"] = "💾 Enregistrement de l'analyse..."
+
             enrichment_metadata = None
             if enrichment_sources:
                 enrichment_metadata = {
@@ -1624,6 +1627,9 @@ async def _analyze_video_background_v2(
                 music_author=video_info.get("music_author"),
                 carousel_images=video_info.get("carousel_images"),
             )
+
+            _task_store[task_id]["progress"] = 97
+            _task_store[task_id]["message"] = "🧩 Indexation et finalisation..."
 
             # 🆕 v4.0: Générer et sauvegarder l'index structuré
             await _save_structured_index(
@@ -3099,6 +3105,9 @@ async def _analyze_video_background_v6(
             else:
                 await deduct_credit(session, user_id, credit_cost, f"Video: {video_info['title'][:50]}")
 
+            _task_store[task_id]["progress"] = 94
+            _task_store[task_id]["message"] = "💾 Enregistrement de l'analyse..."
+
             # Préparer les métadonnées d'enrichissement
             enrichment_metadata = None
             if enrichment_sources:
@@ -3152,6 +3161,9 @@ async def _analyze_video_background_v6(
             )
 
             logger.info(f"💾 Summary saved: id={summary_id}")
+
+            _task_store[task_id]["progress"] = 97
+            _task_store[task_id]["message"] = "🧩 Indexation et finalisation..."
 
             # 🆕 v4.0: Index structuré
             await _save_structured_index(

--- a/docs/superpowers/plans/2026-04-26-ambient-lighting-v3.md
+++ b/docs/superpowers/plans/2026-04-26-ambient-lighting-v3.md
@@ -1,0 +1,4255 @@
+# Ambient Lighting v3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refondre la feature ambient lighting cross-platform en signature visuelle DeepSight : un beam de précision suivant l'arc solaire, un halo de source diffus, et un tournesol 3D photoréaliste héliotrope (luminescent la nuit) — apparaissant sur les 3 plateformes (web/mobile/extension) sans gêner la lecture.
+
+**Architecture:** Engine TypeScript partagé (`@deepsight/lighting-engine`) qui calcule angle/couleur/frameIndex selon l'heure → consommé par 3 composants UI plateforme-spécifiques (web React, mobile RN, extension Chrome). Tournesol 3D pré-rendu offline (Three.js headless → 2 sprite sheets WebP), runtime juste cross-fade entre frames. Critical CSS inliné en `<head>` pour visibilité immédiate avant hydratation.
+
+**Tech Stack:** TypeScript strict, Vitest, Three.js headless via Puppeteer + sharp (sprite pipeline), React 18 + Vite 5 + Tailwind 3 (web), Expo SDK 54 + Reanimated 4 (mobile), Webpack 5 + Manifest V3 (extension), Playwright (E2E web), Maestro (mobile snapshots).
+
+**Spec:** `docs/superpowers/specs/2026-04-26-ambient-lighting-v3-design.md`
+
+---
+
+## File Structure (à créer / modifier)
+
+### Engine partagé (Phase 1)
+
+| Fichier                                                | Action     | Responsabilité                                                                                                                             |
+| ------------------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/lighting-engine/src/types.ts`                | **Modify** | Étendre `AmbientPreset` avec `frameIndex`, `nightMode`, `haloAccentColor?`, `isReducedMotion`, `isHighContrast`, `readingZoneIntensityCap` |
+| `packages/lighting-engine/src/keyframes.v3.ts`         | **Create** | 48 keyframes v3 palette mix réaliste + accents brand                                                                                       |
+| `packages/lighting-engine/src/preset.ts`               | **Modify** | Étendre `getAmbientPreset` pour calculer les nouveaux champs                                                                               |
+| `packages/lighting-engine/src/accessibility.ts`        | **Create** | Helpers `detectReducedMotion()`, `detectHighContrast()`, `getReadingZoneCap()`                                                             |
+| `packages/lighting-engine/src/sprite-frame.ts`         | **Create** | `getSpriteFrameIndex(date)` → 0-23                                                                                                         |
+| `packages/lighting-engine/src/index.ts`                | **Modify** | Ajouter exports v3                                                                                                                         |
+| `packages/lighting-engine/tests/preset.v3.test.ts`     | **Create** | Tests couverture v3                                                                                                                        |
+| `packages/lighting-engine/tests/accessibility.test.ts` | **Create** | Tests reduced-motion + high-contrast                                                                                                       |
+
+### Pipeline pré-rendu tournesol (Phase 1)
+
+| Fichier                                      | Action        | Responsabilité                            |
+| -------------------------------------------- | ------------- | ----------------------------------------- |
+| `scripts/sunflower-frames/generate.mjs`      | **Create**    | Script orchestrateur Puppeteer + sharp    |
+| `scripts/sunflower-frames/scene-day.html`    | **Create**    | Three.js scene rendering jour             |
+| `scripts/sunflower-frames/scene-night.html`  | **Create**    | Three.js scene rendering nuit luminescent |
+| `scripts/sunflower-frames/encode-sprite.mjs` | **Create**    | Encoder WebP via sharp                    |
+| `assets/ambient/sunflower-day.webp`          | **Generated** | Sprite jour 6×4 grid (1536×1024, ~75KB)   |
+| `assets/ambient/sunflower-night.webp`        | **Generated** | Sprite nuit (idem)                        |
+| `package.json` (root)                        | **Modify**    | Ajouter script `build:sunflower-frames`   |
+
+### Design tokens (Phase 1)
+
+| Fichier                                        | Action     | Responsabilité                                 |
+| ---------------------------------------------- | ---------- | ---------------------------------------------- |
+| `frontend/src/styles/tokens.css`               | **Modify** | Shift `--text-secondary`, `--text-muted`, etc. |
+| `frontend/tailwind.config.js`                  | **Modify** | Étendre `colors.text.*` avec nouvelles valeurs |
+| `mobile/src/theme/colors.ts`                   | **Modify** | Shift `colors.text.secondary` etc.             |
+| `extension/src/sidepanel/styles/sidepanel.css` | **Modify** | Variables CSS texte                            |
+| `extension/src/popup/styles/popup.css`         | **Modify** | Idem                                           |
+
+### Backend pref (Phase 1)
+
+| Fichier                                  | Action     | Responsabilité                                            |
+| ---------------------------------------- | ---------- | --------------------------------------------------------- |
+| `backend/src/db/database.py`             | **Verify** | Confirmer `User.preferences` est JSON column (sans modif) |
+| `backend/src/auth/router.py`             | **Verify** | Confirmer `PUT /api/auth/preferences` existe              |
+| `backend/tests/test_user_preferences.py` | **Modify** | Ajouter test pour `ambient_lighting_enabled`              |
+
+### Web (Phase 2)
+
+| Fichier                                                        | Action               | Responsabilité                                     |
+| -------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| `frontend/src/components/AmbientLightLayer.tsx`                | **Replace**          | Nouveau composant overlay rayon + halo             |
+| `frontend/src/components/SunflowerLayer.tsx`                   | **Create**           | Tournesol mascot + hero, route-aware               |
+| `frontend/src/contexts/AmbientLightingContext.tsx`             | **Create**           | Provider + `useAmbientLightingContext()`           |
+| `frontend/src/hooks/useAmbientPreset.ts`                       | **Modify**           | Réécrire pour consommer engine v3                  |
+| `frontend/src/plugins/vite-plugin-ambient-critical-css.ts`     | **Create**           | Plugin Vite pour inline `<style>`                  |
+| `frontend/vite.config.ts`                                      | **Modify**           | Charger le plugin                                  |
+| `frontend/src/App.tsx`                                         | **Modify**           | Wrap `<AmbientLightingProvider>` + monter overlays |
+| `frontend/src/pages/SettingsPage.tsx`                          | **Modify**           | Ajouter toggle "Effet ambiant lumineux"            |
+| `frontend/public/assets/ambient/sunflower-day.webp`            | **Copy**             | Depuis assets/ambient/                             |
+| `frontend/public/assets/ambient/sunflower-night.webp`          | **Copy**             | Idem                                               |
+| `frontend/src/components/__tests__/AmbientLightLayer.test.tsx` | **Create**           | RTL tests                                          |
+| `frontend/src/components/__tests__/SunflowerLayer.test.tsx`    | **Create**           | RTL tests                                          |
+| `frontend/e2e/ambient-lighting.spec.ts`                        | **Create**           | Playwright E2E                                     |
+| `frontend/src/hooks/useTimeOfDay.ts`                           | **Delete** (Phase 5) | Legacy v1                                          |
+| `frontend/src/components/AmbientLightDevPanel.tsx`             | **Delete** (Phase 5) | Dev panel obsolète                                 |
+| `frontend/src/hooks/useAmbientLightingFeatureFlag.ts`          | **Delete** (Phase 5) | Flag PostHog plus utilisé                          |
+
+### Mobile (Phase 3)
+
+| Fichier                                                                  | Action               | Responsabilité                                                        |
+| ------------------------------------------------------------------------ | -------------------- | --------------------------------------------------------------------- |
+| `mobile/metro.config.js`                                                 | **Modify**           | `watchFolders` + `extraNodeModules` pour `@deepsight/lighting-engine` |
+| `mobile/src/components/backgrounds/AmbientLightLayer.tsx`                | **Replace**          | Nouveau composant Reanimated                                          |
+| `mobile/src/components/backgrounds/SunflowerLayer.tsx`                   | **Create**           | Tournesol mascot only                                                 |
+| `mobile/src/contexts/AmbientLightingContext.tsx`                         | **Create**           | Provider RN                                                           |
+| `mobile/src/hooks/useAmbientPreset.ts`                                   | **Modify**           | Consommer engine v3                                                   |
+| `mobile/app/_layout.tsx`                                                 | **Modify**           | Wrap provider + monter overlays                                       |
+| `mobile/app.json`                                                        | **Modify**           | Splash screen avec image fallback beam                                |
+| `mobile/app/(tabs)/profile.tsx`                                          | **Modify**           | Toggle "Effet ambiant lumineux"                                       |
+| `mobile/assets/ambient/sunflower-day.webp`                               | **Copy**             | Depuis assets/ambient/                                                |
+| `mobile/assets/ambient/sunflower-night.webp`                             | **Copy**             | Idem                                                                  |
+| `mobile/assets/splash-beam.png`                                          | **Create**           | Image fallback splash (généré offline une fois)                       |
+| `mobile/src/components/backgrounds/__tests__/AmbientLightLayer.test.tsx` | **Create**           | Jest+RNTL                                                             |
+| `mobile/src/components/backgrounds/__tests__/SunflowerLayer.test.tsx`    | **Create**           | Jest+RNTL                                                             |
+| `mobile/.maestro/ambient-lighting.yaml`                                  | **Create**           | Maestro snapshot tests                                                |
+| `mobile/src/hooks/useTimeOfDay.ts`                                       | **Delete** (Phase 5) | Legacy v1                                                             |
+
+### Extension (Phase 4)
+
+| Fichier                                                       | Action      | Responsabilité                                                           |
+| ------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------ |
+| `extension/webpack.config.js`                                 | **Modify**  | copy-webpack-plugin pour sprites + html-webpack-plugin pour critical CSS |
+| `extension/src/sidepanel/components/AmbientLightLayer.tsx`    | **Replace** | Nouveau composant (existing est orphelin)                                |
+| `extension/src/sidepanel/components/SunflowerLayer.tsx`       | **Create**  | Tournesol mascot                                                         |
+| `extension/src/viewer/components/AmbientLightLayer.tsx`       | **Replace** | Idem viewer                                                              |
+| `extension/src/viewer/components/SunflowerLayer.tsx`          | **Create**  | Idem viewer                                                              |
+| `extension/src/popup/components/AmbientLightLayer.tsx`        | **Replace** | Beam minimal popup                                                       |
+| `extension/src/sidepanel/contexts/AmbientLightingContext.tsx` | **Create**  | Provider                                                                 |
+| `extension/src/sidepanel/hooks/useAmbientPreset.ts`           | **Create**  | Hook custom                                                              |
+| `extension/src/sidepanel/App.tsx`                             | **Modify**  | Wrap provider + monter overlays                                          |
+| `extension/src/viewer/App.tsx`                                | **Modify**  | Idem                                                                     |
+| `extension/src/popup/App.tsx`                                 | **Modify**  | Idem (sans SunflowerLayer)                                               |
+| `extension/src/sidepanel/shared/BeamCard.tsx`                 | **Modify**  | (livré par PR0) — ajouter `useContext` optionnel pour override defaults  |
+| `extension/public/assets/ambient/sunflower-day.webp`          | **Copy**    | Depuis assets/ambient/                                                   |
+| `extension/public/assets/ambient/sunflower-night.webp`        | **Copy**    | Idem                                                                     |
+| `extension/__tests__/sidepanel/AmbientLightLayer.test.tsx`    | **Create**  | Jest+jsdom                                                               |
+| `extension/__tests__/sidepanel/SunflowerLayer.test.tsx`       | **Create**  | Jest+jsdom                                                               |
+
+### Cleanup (Phase 5)
+
+| Fichier                                         | Action      | Responsabilité                                                 |
+| ----------------------------------------------- | ----------- | -------------------------------------------------------------- |
+| `docs/PRD-ambient-lighting-v2.md`               | **Replace** | Renommer en `docs/PRD-ambient-lighting-v3.md` + update content |
+| `CHANGELOG.md`                                  | **Modify**  | Ajouter entry "Ambient lighting v3"                            |
+| (Suppressions listées dans Web/Mobile sections) | **Delete**  | Legacy v1/v2 obsolètes                                         |
+
+---
+
+## Phase 1 — Foundation (PR1)
+
+**Branche:** `feat/ambient-lighting-v3-foundation`
+**Durée estimée:** ~2 jours
+**Dépendances:** PR0 (`feat/extension-sidepanel-v3`) doit être mergée AVANT le démarrage des Phases 2-4 (mais Phase 1 ne dépend pas de PR0).
+
+### Task 1.1: Créer la branche foundation
+
+**Files:**
+
+- Modify: working tree
+
+- [ ] **Step 1: Vérifier état git propre**
+
+```bash
+git status --short
+```
+
+Expected: pas de modifications non committées dans `packages/lighting-engine/`, `scripts/`, `frontend/src/styles/`, `mobile/src/theme/`, `extension/src/*/styles/`. Si modifs non liées présentes (ex: voice feature), créer un worktree dédié plutôt que checkout direct.
+
+- [ ] **Step 2: Créer la branche depuis main**
+
+```bash
+git fetch origin
+git checkout -b feat/ambient-lighting-v3-foundation origin/main
+```
+
+Expected: branche créée et checkée.
+
+- [ ] **Step 3: Vérifier le worktree de la session parallèle existe**
+
+```bash
+git worktree list
+```
+
+Expected: voir `.claude/worktrees/extension-sidepanel-v3` listé. Si présent, ne pas y toucher (c'est l'autre session). Si absent, on n'aura pas de coordination directe — le Context Provider de Phase 4 fonctionnera quand même avec les defaults statiques de BeamCard.
+
+### Task 1.2: Étendre les types `AmbientPreset` v3
+
+**Files:**
+
+- Modify: `packages/lighting-engine/src/types.ts`
+- Test: `packages/lighting-engine/tests/types.v3.test.ts` (créé)
+
+- [ ] **Step 1: Écrire le test failing — vérifier que `AmbientPreset` accepte les nouveaux champs**
+
+Créer `packages/lighting-engine/tests/types.v3.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { AmbientPreset, NightMode } from "../src/types";
+
+describe("AmbientPreset v3 type extensions", () => {
+  it("accepts frameIndex 0-23", () => {
+    const preset: AmbientPreset = {
+      hour: 12,
+      mood: "noon-zenith",
+      beam: {
+        type: "sun",
+        color: [255, 250, 225],
+        angleDeg: -3,
+        opacity: 0.95,
+      },
+      sun: { visible: true, opacity: 0.8, x: 50, y: 20 },
+      moon: { visible: false, opacity: 0, x: 0, y: 0 },
+      ambient: { primary: 0.3, secondary: 0.2, tertiary: 0.1 },
+      starOpacityMul: 0,
+      starDensity: "sparse",
+      haloX: 50,
+      haloY: 20,
+      colors: {
+        primary: [255, 200, 140],
+        secondary: [255, 250, 225],
+        tertiary: [99, 102, 241],
+        rays: [255, 240, 200],
+        accent: [165, 180, 252],
+      },
+      // Nouveaux champs v3
+      frameIndex: 23,
+      nightMode: null,
+      haloAccentColor: "rgba(99,102,241,0.30)",
+      isReducedMotion: false,
+      isHighContrast: false,
+      readingZoneIntensityCap: 0.5,
+    };
+    expect(preset.frameIndex).toBe(23);
+  });
+
+  it("NightMode type accepts asleep | glowing | null", () => {
+    const a: NightMode = "asleep";
+    const g: NightMode = "glowing";
+    expect(a).toBe("asleep");
+    expect(g).toBe("glowing");
+  });
+});
+```
+
+- [ ] **Step 2: Lancer le test pour confirmer l'échec**
+
+```bash
+cd packages/lighting-engine && npm test -- types.v3
+```
+
+Expected: FAIL — `Property 'frameIndex' does not exist on type 'AmbientPreset'.` ou similaire.
+
+- [ ] **Step 3: Étendre le type `AmbientPreset` dans `types.ts`**
+
+Ajouter à la fin de `packages/lighting-engine/src/types.ts`:
+
+```ts
+// === v3 extensions ===
+
+export type NightMode = "asleep" | "glowing";
+```
+
+Et **modifier** l'interface `AmbientPreset` existante pour ajouter les nouveaux champs (entre `colors` et `debug`):
+
+```ts
+export interface AmbientPreset {
+  // ... champs v2 existants (hour, mood, beam, sun, moon, ambient, starOpacityMul, starDensity, haloX, haloY, colors)
+
+  // === v3 extensions ===
+  /** Index de frame du sprite tournesol (0-23). */
+  frameIndex: number;
+  /** Mode du tournesol la nuit. null en journée. */
+  nightMode: NightMode | null;
+  /** Couleur d'accent du halo (twilight/nuit uniquement). undefined sinon. */
+  haloAccentColor?: string;
+  /** Vrai si l'utilisateur a `prefers-reduced-motion: reduce`. */
+  isReducedMotion: boolean;
+  /** Vrai si l'utilisateur a `prefers-contrast: more`. */
+  isHighContrast: boolean;
+  /** Cap d'intensité dans la zone de lecture (30-70% viewport). 0-1. */
+  readingZoneIntensityCap: number;
+
+  debug?: {
+    factor: number;
+    fromMood: string;
+    toMood: string;
+    seed: number;
+    angleVariation: number;
+  };
+}
+```
+
+Et exporter `NightMode` depuis `index.ts`:
+
+```ts
+// packages/lighting-engine/src/index.ts
+export type {
+  // ... existing
+  NightMode,
+} from "./types";
+```
+
+- [ ] **Step 4: Relancer le test pour confirmer le passage**
+
+```bash
+cd packages/lighting-engine && npm test -- types.v3
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/lighting-engine/src/types.ts packages/lighting-engine/src/index.ts packages/lighting-engine/tests/types.v3.test.ts
+git commit -m "feat(lighting-engine): extend AmbientPreset with v3 fields (frameIndex, nightMode, accessibility flags)"
+```
+
+### Task 1.3: Helpers d'accessibilité
+
+**Files:**
+
+- Create: `packages/lighting-engine/src/accessibility.ts`
+- Test: `packages/lighting-engine/tests/accessibility.test.ts`
+
+- [ ] **Step 1: Écrire les tests failing**
+
+Créer `packages/lighting-engine/tests/accessibility.test.ts`:
+
+```ts
+import { describe, expect, it, vi, afterEach } from "vitest";
+import {
+  detectReducedMotion,
+  detectHighContrast,
+  getReadingZoneCap,
+} from "../src/accessibility";
+
+describe("detectReducedMotion", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns false when no matchMedia available", () => {
+    vi.stubGlobal("window", { matchMedia: undefined });
+    expect(detectReducedMotion()).toBe(false);
+  });
+
+  it("returns true when prefers-reduced-motion matches", () => {
+    vi.stubGlobal("window", {
+      matchMedia: (q: string) => ({ matches: q.includes("reduce") }),
+    });
+    expect(detectReducedMotion()).toBe(true);
+  });
+
+  it("returns false when no preference", () => {
+    vi.stubGlobal("window", {
+      matchMedia: () => ({ matches: false }),
+    });
+    expect(detectReducedMotion()).toBe(false);
+  });
+});
+
+describe("detectHighContrast", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns true when prefers-contrast: more", () => {
+    vi.stubGlobal("window", {
+      matchMedia: (q: string) => ({ matches: q.includes("more") }),
+    });
+    expect(detectHighContrast()).toBe(true);
+  });
+});
+
+describe("getReadingZoneCap", () => {
+  it("caps intensity to 0.5 maximum", () => {
+    expect(getReadingZoneCap(0.9)).toBe(0.5);
+    expect(getReadingZoneCap(0.5)).toBe(0.5);
+    expect(getReadingZoneCap(0.3)).toBe(0.3);
+  });
+
+  it("respects high contrast (cap to 0.3)", () => {
+    expect(getReadingZoneCap(0.9, true)).toBe(0.3);
+  });
+});
+```
+
+- [ ] **Step 2: Lancer les tests, confirmer l'échec**
+
+```bash
+cd packages/lighting-engine && npm test -- accessibility
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implémenter `accessibility.ts`**
+
+Créer `packages/lighting-engine/src/accessibility.ts`:
+
+```ts
+/**
+ * Détecte la préférence utilisateur prefers-reduced-motion.
+ * Safe sur Node (window absent) et Mobile (RN remplacera via Platform-specific impl).
+ */
+export function detectReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Détecte la préférence utilisateur prefers-contrast: more.
+ */
+export function detectHighContrast(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  try {
+    return window.matchMedia("(prefers-contrast: more)").matches;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Cap d'intensité applicable dans la zone de lecture (bande verticale 30%-70% viewport).
+ * @param baseIntensity intensité de base (0-1)
+ * @param highContrast si true, cap à 0.3 (sinon 0.5)
+ */
+export function getReadingZoneCap(
+  baseIntensity: number,
+  highContrast: boolean = false,
+): number {
+  const cap = highContrast ? 0.3 : 0.5;
+  return Math.min(baseIntensity, cap);
+}
+```
+
+- [ ] **Step 4: Lancer les tests, confirmer le passage**
+
+```bash
+cd packages/lighting-engine && npm test -- accessibility
+```
+
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/lighting-engine/src/accessibility.ts packages/lighting-engine/tests/accessibility.test.ts
+git commit -m "feat(lighting-engine): add accessibility helpers (reduced-motion, high-contrast, reading-zone cap)"
+```
+
+### Task 1.4: Sprite frame index calculator
+
+**Files:**
+
+- Create: `packages/lighting-engine/src/sprite-frame.ts`
+- Test: `packages/lighting-engine/tests/sprite-frame.test.ts`
+
+- [ ] **Step 1: Écrire les tests failing**
+
+Créer `packages/lighting-engine/tests/sprite-frame.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getSpriteFrameIndex } from "../src/sprite-frame";
+
+describe("getSpriteFrameIndex", () => {
+  it("returns 0 at midnight", () => {
+    expect(getSpriteFrameIndex(new Date("2026-04-26T00:00:00"))).toBe(0);
+  });
+
+  it("returns 23 at 23:30", () => {
+    expect(getSpriteFrameIndex(new Date("2026-04-26T23:30:00"))).toBe(23);
+  });
+
+  it("returns 24 frames per day, 1 every 30 minutes (modulo 24)", () => {
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:00:00"))).toBe(0); // 24 % 24 = 0
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:30:00"))).toBe(1);
+    expect(getSpriteFrameIndex(new Date("2026-04-26T13:00:00"))).toBe(2);
+  });
+
+  it("rounds down within a 30-min slot", () => {
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:00:00"))).toBe(0);
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:14:59"))).toBe(0);
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:15:00"))).toBe(0);
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:29:59"))).toBe(0);
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:30:00"))).toBe(1);
+  });
+});
+```
+
+Note : 24 frames par jour signifie 1 frame toutes les 60 minutes, pas toutes les 30. Mais le sprite contient 24 frames, donc il faut `Math.floor(minutes / 60)`. Or, avec 48 keyframes (toutes les 30 min) dans `keyframes.ts`, on a 2 keyframes par frame de sprite. Pour simplifier, on prend la frame qui correspond à l'heure ronde la plus proche (1 frame / heure × 24 heures = 24 frames). C'est cohérent avec 24 frames pour la rotation Y du tournesol = un angle par heure suffit (le tournesol tourne ~15°/heure).
+
+Mettre à jour le test :
+
+```ts
+it("returns 12 at noon (12h00) and 13 at 13h00", () => {
+  expect(getSpriteFrameIndex(new Date("2026-04-26T12:00:00"))).toBe(12);
+  expect(getSpriteFrameIndex(new Date("2026-04-26T13:00:00"))).toBe(13);
+  expect(getSpriteFrameIndex(new Date("2026-04-26T12:30:00"))).toBe(12); // dans le slot 12h
+});
+```
+
+Réécrire le bloc complet :
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getSpriteFrameIndex } from "../src/sprite-frame";
+
+describe("getSpriteFrameIndex", () => {
+  it("returns 0 at midnight", () => {
+    expect(getSpriteFrameIndex(new Date("2026-04-26T00:00:00"))).toBe(0);
+  });
+
+  it("returns 12 at noon", () => {
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:00:00"))).toBe(12);
+  });
+
+  it("returns 23 at 23h59", () => {
+    expect(getSpriteFrameIndex(new Date("2026-04-26T23:59:00"))).toBe(23);
+  });
+
+  it("rounds down within an hour slot", () => {
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:30:00"))).toBe(12);
+    expect(getSpriteFrameIndex(new Date("2026-04-26T12:59:59"))).toBe(12);
+    expect(getSpriteFrameIndex(new Date("2026-04-26T13:00:00"))).toBe(13);
+  });
+});
+```
+
+- [ ] **Step 2: Lancer les tests, confirmer l'échec**
+
+```bash
+cd packages/lighting-engine && npm test -- sprite-frame
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implémenter `sprite-frame.ts`**
+
+Créer `packages/lighting-engine/src/sprite-frame.ts`:
+
+```ts
+/**
+ * Calcule l'index de frame (0-23) dans le sprite tournesol pour une date donnée.
+ * 24 frames sur 24 heures = 1 frame par heure (le tournesol tourne ~15°/heure).
+ *
+ * @param date date courante
+ * @returns 0..23
+ */
+export function getSpriteFrameIndex(date: Date): number {
+  return date.getHours();
+}
+```
+
+- [ ] **Step 4: Lancer les tests, confirmer le passage**
+
+```bash
+cd packages/lighting-engine && npm test -- sprite-frame
+```
+
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Exporter depuis index.ts**
+
+Modifier `packages/lighting-engine/src/index.ts`:
+
+```ts
+export { getSpriteFrameIndex } from "./sprite-frame";
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/lighting-engine/src/sprite-frame.ts packages/lighting-engine/src/index.ts packages/lighting-engine/tests/sprite-frame.test.ts
+git commit -m "feat(lighting-engine): add getSpriteFrameIndex for sunflower sprite (24 frames/day)"
+```
+
+### Task 1.5: Keyframes v3 (palette mix réaliste + accents brand)
+
+**Files:**
+
+- Create: `packages/lighting-engine/src/keyframes.v3.ts`
+- Test: `packages/lighting-engine/tests/keyframes.v3.test.ts`
+
+- [ ] **Step 1: Écrire le test failing — v3 keyframes ont 48 entrées et accents brand aux twilights**
+
+Créer `packages/lighting-engine/tests/keyframes.v3.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { KEYFRAMES_V3 } from "../src/keyframes.v3";
+
+describe("KEYFRAMES_V3", () => {
+  it("has exactly 48 entries (every 30 min)", () => {
+    expect(KEYFRAMES_V3).toHaveLength(48);
+  });
+
+  it("starts at hour 0 and ends at hour 23.5", () => {
+    expect(KEYFRAMES_V3[0].hour).toBe(0);
+    expect(KEYFRAMES_V3[47].hour).toBe(23.5);
+  });
+
+  it("has nightMode set to glowing for all night keyframes (22h-05h)", () => {
+    const nightKeyframes = KEYFRAMES_V3.filter(
+      (k) => k.hour >= 22 || k.hour < 5,
+    );
+    expect(nightKeyframes.every((k) => k.nightMode === "glowing")).toBe(true);
+  });
+
+  it("has nightMode null for daytime keyframes (07h-19h)", () => {
+    const dayKeyframes = KEYFRAMES_V3.filter((k) => k.hour >= 7 && k.hour < 19);
+    expect(dayKeyframes.every((k) => k.nightMode === null)).toBe(true);
+  });
+
+  it("has haloAccentColor (indigo/violet) at twilights (06h, 19h, 20h)", () => {
+    const twilights = KEYFRAMES_V3.filter((k) =>
+      [6, 6.5, 19, 19.5, 20].includes(k.hour),
+    );
+    expect(twilights.every((k) => k.haloAccentColor !== undefined)).toBe(true);
+  });
+
+  it("has angle close to -50° at sunrise (06h00)", () => {
+    const sunrise = KEYFRAMES_V3.find((k) => k.hour === 6)!;
+    expect(sunrise.beamAngleDeg).toBeGreaterThanOrEqual(-55);
+    expect(sunrise.beamAngleDeg).toBeLessThanOrEqual(-40);
+  });
+
+  it("has angle close to -3° at noon (12h00)", () => {
+    const noon = KEYFRAMES_V3.find((k) => k.hour === 12)!;
+    expect(noon.beamAngleDeg).toBeGreaterThanOrEqual(-10);
+    expect(noon.beamAngleDeg).toBeLessThanOrEqual(5);
+  });
+
+  it("has angle close to +48° at sunset (18h00)", () => {
+    const sunset = KEYFRAMES_V3.find((k) => k.hour === 18)!;
+    expect(sunset.beamAngleDeg).toBeGreaterThanOrEqual(40);
+    expect(sunset.beamAngleDeg).toBeLessThanOrEqual(55);
+  });
+});
+```
+
+- [ ] **Step 2: Lancer le test, confirmer l'échec**
+
+```bash
+cd packages/lighting-engine && npm test -- keyframes.v3
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implémenter `keyframes.v3.ts`**
+
+Créer `packages/lighting-engine/src/keyframes.v3.ts`:
+
+```ts
+import type { NightMode, RGB } from "./types";
+
+export interface KeyframeV3 {
+  hour: number;
+  mood: string;
+  beamColor: RGB;
+  beamAngleDeg: number;
+  beamOpacity: number;
+  haloPrimary: RGB;
+  haloAccentColor?: string;
+  intensity: number;
+  nightMode: NightMode | null;
+}
+
+/**
+ * 48 keyframes v3 - 1 toutes les 30 minutes.
+ * Palette: mix réaliste (doré matin/blanc midi/orange couchant/argent nuit)
+ *          + accents indigo/violet brand DeepSight aux twilights et nuit.
+ */
+export const KEYFRAMES_V3: KeyframeV3[] = [
+  // === NUIT PROFONDE (00h-05h) — tournesol luminescent ===
+  {
+    hour: 0,
+    mood: "midnight",
+    beamColor: [220, 232, 255],
+    beamAngleDeg: -10,
+    beamOpacity: 0.65,
+    haloPrimary: [199, 210, 254],
+    haloAccentColor: "rgba(79,70,229,0.45)",
+    intensity: 0.55,
+    nightMode: "glowing",
+  },
+  {
+    hour: 0.5,
+    mood: "late-night",
+    beamColor: [220, 232, 255],
+    beamAngleDeg: -8,
+    beamOpacity: 0.62,
+    haloPrimary: [199, 210, 254],
+    haloAccentColor: "rgba(79,70,229,0.42)",
+    intensity: 0.52,
+    nightMode: "glowing",
+  },
+  {
+    hour: 1,
+    mood: "late-night",
+    beamColor: [218, 228, 252],
+    beamAngleDeg: -6,
+    beamOpacity: 0.6,
+    haloPrimary: [196, 206, 250],
+    haloAccentColor: "rgba(79,70,229,0.40)",
+    intensity: 0.5,
+    nightMode: "glowing",
+  },
+  {
+    hour: 1.5,
+    mood: "late-night",
+    beamColor: [216, 224, 250],
+    beamAngleDeg: -4,
+    beamOpacity: 0.58,
+    haloPrimary: [194, 202, 248],
+    haloAccentColor: "rgba(79,70,229,0.38)",
+    intensity: 0.48,
+    nightMode: "glowing",
+  },
+  {
+    hour: 2,
+    mood: "deep-night",
+    beamColor: [212, 220, 248],
+    beamAngleDeg: -2,
+    beamOpacity: 0.55,
+    haloPrimary: [192, 200, 246],
+    haloAccentColor: "rgba(67,56,202,0.40)",
+    intensity: 0.46,
+    nightMode: "glowing",
+  },
+  {
+    hour: 2.5,
+    mood: "deep-night",
+    beamColor: [210, 218, 246],
+    beamAngleDeg: 0,
+    beamOpacity: 0.55,
+    haloPrimary: [190, 198, 244],
+    haloAccentColor: "rgba(67,56,202,0.40)",
+    intensity: 0.46,
+    nightMode: "glowing",
+  },
+  {
+    hour: 3,
+    mood: "deep-night",
+    beamColor: [212, 220, 248],
+    beamAngleDeg: 4,
+    beamOpacity: 0.55,
+    haloPrimary: [192, 200, 246],
+    haloAccentColor: "rgba(67,56,202,0.40)",
+    intensity: 0.46,
+    nightMode: "glowing",
+  },
+  {
+    hour: 3.5,
+    mood: "deep-night",
+    beamColor: [216, 224, 250],
+    beamAngleDeg: 8,
+    beamOpacity: 0.58,
+    haloPrimary: [194, 202, 248],
+    haloAccentColor: "rgba(67,56,202,0.42)",
+    intensity: 0.48,
+    nightMode: "glowing",
+  },
+  {
+    hour: 4,
+    mood: "pre-dawn",
+    beamColor: [222, 230, 252],
+    beamAngleDeg: 12,
+    beamOpacity: 0.62,
+    haloPrimary: [200, 208, 252],
+    haloAccentColor: "rgba(99,102,241,0.45)",
+    intensity: 0.52,
+    nightMode: "glowing",
+  },
+  {
+    hour: 4.5,
+    mood: "pre-dawn",
+    beamColor: [232, 220, 232],
+    beamAngleDeg: 18,
+    beamOpacity: 0.66,
+    haloPrimary: [216, 200, 220],
+    haloAccentColor: "rgba(165,180,252,0.50)",
+    intensity: 0.58,
+    nightMode: "glowing",
+  },
+
+  // === AUBE / LEVER (05h-07h) — twilight transition ===
+  {
+    hour: 5,
+    mood: "dawn-blush",
+    beamColor: [255, 198, 178],
+    beamAngleDeg: 25,
+    beamOpacity: 0.72,
+    haloPrimary: [255, 200, 180],
+    haloAccentColor: "rgba(165,180,252,0.55)",
+    intensity: 0.68,
+    nightMode: "glowing",
+  },
+  {
+    hour: 5.5,
+    mood: "dawn-rose",
+    beamColor: [255, 192, 168],
+    beamAngleDeg: -55,
+    beamOpacity: 0.75,
+    haloPrimary: [255, 198, 178],
+    haloAccentColor: "rgba(165,180,252,0.50)",
+    intensity: 0.74,
+    nightMode: null,
+  },
+  {
+    hour: 6,
+    mood: "sunrise",
+    beamColor: [255, 214, 153],
+    beamAngleDeg: -50,
+    beamOpacity: 0.8,
+    haloPrimary: [255, 200, 140],
+    haloAccentColor: "rgba(165,180,252,0.45)",
+    intensity: 0.78,
+    nightMode: null,
+  },
+  {
+    hour: 6.5,
+    mood: "sunrise-warming",
+    beamColor: [255, 220, 168],
+    beamAngleDeg: -45,
+    beamOpacity: 0.84,
+    haloPrimary: [255, 210, 158],
+    haloAccentColor: "rgba(165,180,252,0.30)",
+    intensity: 0.82,
+    nightMode: null,
+  },
+
+  // === MATIN (07h-11h) — doré chaud ===
+  {
+    hour: 7,
+    mood: "morning-gold",
+    beamColor: [255, 230, 184],
+    beamAngleDeg: -38,
+    beamOpacity: 0.86,
+    haloPrimary: [255, 220, 174],
+    intensity: 0.84,
+    nightMode: null,
+  },
+  {
+    hour: 7.5,
+    mood: "morning",
+    beamColor: [255, 234, 192],
+    beamAngleDeg: -32,
+    beamOpacity: 0.88,
+    haloPrimary: [255, 226, 184],
+    intensity: 0.86,
+    nightMode: null,
+  },
+  {
+    hour: 8,
+    mood: "morning",
+    beamColor: [255, 238, 200],
+    beamAngleDeg: -28,
+    beamOpacity: 0.9,
+    haloPrimary: [255, 232, 196],
+    intensity: 0.88,
+    nightMode: null,
+  },
+  {
+    hour: 8.5,
+    mood: "morning-fresh",
+    beamColor: [255, 242, 208],
+    beamAngleDeg: -24,
+    beamOpacity: 0.91,
+    haloPrimary: [255, 238, 204],
+    intensity: 0.89,
+    nightMode: null,
+  },
+  {
+    hour: 9,
+    mood: "morning-fresh",
+    beamColor: [255, 246, 216],
+    beamAngleDeg: -20,
+    beamOpacity: 0.92,
+    haloPrimary: [255, 242, 212],
+    intensity: 0.9,
+    nightMode: null,
+  },
+  {
+    hour: 9.5,
+    mood: "morning-bright",
+    beamColor: [255, 248, 220],
+    beamAngleDeg: -16,
+    beamOpacity: 0.93,
+    haloPrimary: [255, 244, 218],
+    intensity: 0.91,
+    nightMode: null,
+  },
+  {
+    hour: 10,
+    mood: "morning-bright",
+    beamColor: [255, 250, 224],
+    beamAngleDeg: -12,
+    beamOpacity: 0.94,
+    haloPrimary: [255, 248, 224],
+    intensity: 0.92,
+    nightMode: null,
+  },
+  {
+    hour: 10.5,
+    mood: "pre-noon",
+    beamColor: [255, 251, 225],
+    beamAngleDeg: -8,
+    beamOpacity: 0.95,
+    haloPrimary: [255, 250, 226],
+    intensity: 0.93,
+    nightMode: null,
+  },
+  {
+    hour: 11,
+    mood: "pre-noon",
+    beamColor: [255, 252, 226],
+    beamAngleDeg: -6,
+    beamOpacity: 0.95,
+    haloPrimary: [255, 252, 228],
+    intensity: 0.94,
+    nightMode: null,
+  },
+  {
+    hour: 11.5,
+    mood: "almost-noon",
+    beamColor: [255, 252, 226],
+    beamAngleDeg: -4,
+    beamOpacity: 0.95,
+    haloPrimary: [255, 252, 228],
+    intensity: 0.94,
+    nightMode: null,
+  },
+
+  // === MIDI / ZENITH (12h-13h) — blanc-or ===
+  {
+    hour: 12,
+    mood: "noon-zenith",
+    beamColor: [255, 250, 225],
+    beamAngleDeg: -3,
+    beamOpacity: 0.95,
+    haloPrimary: [255, 244, 204],
+    intensity: 0.95,
+    nightMode: null,
+  },
+  {
+    hour: 12.5,
+    mood: "noon",
+    beamColor: [255, 250, 224],
+    beamAngleDeg: 0,
+    beamOpacity: 0.95,
+    haloPrimary: [255, 244, 204],
+    intensity: 0.95,
+    nightMode: null,
+  },
+  {
+    hour: 13,
+    mood: "after-noon",
+    beamColor: [255, 248, 220],
+    beamAngleDeg: 4,
+    beamOpacity: 0.94,
+    haloPrimary: [255, 240, 200],
+    intensity: 0.94,
+    nightMode: null,
+  },
+  {
+    hour: 13.5,
+    mood: "after-noon",
+    beamColor: [255, 246, 216],
+    beamAngleDeg: 8,
+    beamOpacity: 0.94,
+    haloPrimary: [255, 238, 196],
+    intensity: 0.93,
+    nightMode: null,
+  },
+
+  // === APRES-MIDI (14h-16h) — doré chaud ===
+  {
+    hour: 14,
+    mood: "afternoon",
+    beamColor: [255, 240, 200],
+    beamAngleDeg: 12,
+    beamOpacity: 0.92,
+    haloPrimary: [255, 230, 188],
+    intensity: 0.91,
+    nightMode: null,
+  },
+  {
+    hour: 14.5,
+    mood: "afternoon",
+    beamColor: [255, 234, 188],
+    beamAngleDeg: 16,
+    beamOpacity: 0.91,
+    haloPrimary: [255, 224, 178],
+    intensity: 0.89,
+    nightMode: null,
+  },
+  {
+    hour: 15,
+    mood: "afternoon-warm",
+    beamColor: [255, 226, 172],
+    beamAngleDeg: 22,
+    beamOpacity: 0.89,
+    haloPrimary: [255, 218, 166],
+    intensity: 0.87,
+    nightMode: null,
+  },
+  {
+    hour: 15.5,
+    mood: "afternoon-warm",
+    beamColor: [255, 218, 156],
+    beamAngleDeg: 28,
+    beamOpacity: 0.88,
+    haloPrimary: [255, 212, 154],
+    intensity: 0.85,
+    nightMode: null,
+  },
+  {
+    hour: 16,
+    mood: "late-afternoon",
+    beamColor: [255, 208, 138],
+    beamAngleDeg: 32,
+    beamOpacity: 0.87,
+    haloPrimary: [255, 204, 142],
+    intensity: 0.83,
+    nightMode: null,
+  },
+  {
+    hour: 16.5,
+    mood: "late-afternoon",
+    beamColor: [255, 196, 118],
+    beamAngleDeg: 36,
+    beamOpacity: 0.86,
+    haloPrimary: [255, 196, 128],
+    intensity: 0.81,
+    nightMode: null,
+  },
+
+  // === COUCHER (17h-18h30) — orange-rouge intense ===
+  {
+    hour: 17,
+    mood: "sunset-approach",
+    beamColor: [255, 168, 92],
+    beamAngleDeg: 40,
+    beamOpacity: 0.86,
+    haloPrimary: [255, 178, 110],
+    haloAccentColor: "rgba(216,180,254,0.30)",
+    intensity: 0.83,
+    nightMode: null,
+  },
+  {
+    hour: 17.5,
+    mood: "sunset-warm",
+    beamColor: [255, 148, 78],
+    beamAngleDeg: 44,
+    beamOpacity: 0.86,
+    haloPrimary: [255, 162, 94],
+    haloAccentColor: "rgba(216,180,254,0.35)",
+    intensity: 0.84,
+    nightMode: null,
+  },
+  {
+    hour: 18,
+    mood: "sunset",
+    beamColor: [255, 140, 80],
+    beamAngleDeg: 48,
+    beamOpacity: 0.85,
+    haloPrimary: [255, 153, 102],
+    haloAccentColor: "rgba(216,180,254,0.40)",
+    intensity: 0.85,
+    nightMode: null,
+  },
+  {
+    hour: 18.5,
+    mood: "sunset-fading",
+    beamColor: [232, 124, 92],
+    beamAngleDeg: 52,
+    beamOpacity: 0.82,
+    haloPrimary: [240, 142, 110],
+    haloAccentColor: "rgba(216,180,254,0.42)",
+    intensity: 0.8,
+    nightMode: null,
+  },
+
+  // === CRÉPUSCULE (19h-21h) — twilight indigo ===
+  {
+    hour: 19,
+    mood: "dusk",
+    beamColor: [196, 144, 152],
+    beamAngleDeg: 38,
+    beamOpacity: 0.74,
+    haloPrimary: [212, 158, 168],
+    haloAccentColor: "rgba(165,180,252,0.55)",
+    intensity: 0.72,
+    nightMode: null,
+  },
+  {
+    hour: 19.5,
+    mood: "dusk-blue-hour",
+    beamColor: [168, 152, 198],
+    beamAngleDeg: 22,
+    beamOpacity: 0.68,
+    haloPrimary: [184, 168, 212],
+    haloAccentColor: "rgba(165,180,252,0.60)",
+    intensity: 0.65,
+    nightMode: null,
+  },
+  {
+    hour: 20,
+    mood: "blue-hour",
+    beamColor: [148, 152, 220],
+    beamAngleDeg: 8,
+    beamOpacity: 0.62,
+    haloPrimary: [164, 166, 232],
+    haloAccentColor: "rgba(99,102,241,0.55)",
+    intensity: 0.58,
+    nightMode: null,
+  },
+  {
+    hour: 20.5,
+    mood: "evening-violet",
+    beamColor: [188, 196, 240],
+    beamAngleDeg: -8,
+    beamOpacity: 0.6,
+    haloPrimary: [196, 204, 244],
+    haloAccentColor: "rgba(99,102,241,0.50)",
+    intensity: 0.58,
+    nightMode: "glowing",
+  },
+  {
+    hour: 21,
+    mood: "early-night",
+    beamColor: [196, 208, 248],
+    beamAngleDeg: -14,
+    beamOpacity: 0.62,
+    haloPrimary: [200, 210, 248],
+    haloAccentColor: "rgba(99,102,241,0.50)",
+    intensity: 0.58,
+    nightMode: "glowing",
+  },
+  {
+    hour: 21.5,
+    mood: "early-night",
+    beamColor: [202, 214, 250],
+    beamAngleDeg: -18,
+    beamOpacity: 0.62,
+    haloPrimary: [200, 210, 248],
+    haloAccentColor: "rgba(99,102,241,0.48)",
+    intensity: 0.56,
+    nightMode: "glowing",
+  },
+  {
+    hour: 22,
+    mood: "night",
+    beamColor: [216, 224, 250],
+    beamAngleDeg: -22,
+    beamOpacity: 0.62,
+    haloPrimary: [199, 210, 254],
+    haloAccentColor: "rgba(99,102,241,0.50)",
+    intensity: 0.56,
+    nightMode: "glowing",
+  },
+  {
+    hour: 22.5,
+    mood: "night",
+    beamColor: [220, 228, 252],
+    beamAngleDeg: -20,
+    beamOpacity: 0.64,
+    haloPrimary: [199, 210, 254],
+    haloAccentColor: "rgba(99,102,241,0.48)",
+    intensity: 0.56,
+    nightMode: "glowing",
+  },
+  {
+    hour: 23,
+    mood: "late-night",
+    beamColor: [222, 232, 254],
+    beamAngleDeg: -16,
+    beamOpacity: 0.65,
+    haloPrimary: [199, 210, 254],
+    haloAccentColor: "rgba(99,102,241,0.46)",
+    intensity: 0.55,
+    nightMode: "glowing",
+  },
+  {
+    hour: 23.5,
+    mood: "almost-midnight",
+    beamColor: [222, 232, 254],
+    beamAngleDeg: -12,
+    beamOpacity: 0.65,
+    haloPrimary: [199, 210, 254],
+    haloAccentColor: "rgba(79,70,229,0.45)",
+    intensity: 0.55,
+    nightMode: "glowing",
+  },
+];
+```
+
+- [ ] **Step 4: Lancer les tests, confirmer le passage**
+
+```bash
+cd packages/lighting-engine && npm test -- keyframes.v3
+```
+
+Expected: PASS — 8 tests.
+
+- [ ] **Step 5: Exporter depuis index.ts**
+
+```ts
+// packages/lighting-engine/src/index.ts
+export { KEYFRAMES_V3 } from "./keyframes.v3";
+export type { KeyframeV3 } from "./keyframes.v3";
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/lighting-engine/src/keyframes.v3.ts packages/lighting-engine/src/index.ts packages/lighting-engine/tests/keyframes.v3.test.ts
+git commit -m "feat(lighting-engine): add v3 keyframes (mix realistic + brand accents palette)"
+```
+
+### Task 1.6: Étendre `getAmbientPreset` v3
+
+**Files:**
+
+- Modify: `packages/lighting-engine/src/preset.ts`
+- Test: `packages/lighting-engine/tests/preset.v3.test.ts`
+
+- [ ] **Step 1: Lire l'implémentation v2 actuelle pour comprendre la signature**
+
+```bash
+cat packages/lighting-engine/src/preset.ts
+```
+
+Noter les imports et la fonction `getAmbientPreset` existante. On va ajouter une **nouvelle fonction** `getAmbientPresetV3` à côté pour éviter de casser les consumers v2 immédiatement (les anciens consumers seront supprimés en Phase 5).
+
+- [ ] **Step 2: Écrire les tests v3**
+
+Créer `packages/lighting-engine/tests/preset.v3.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { getAmbientPresetV3 } from "../src/preset";
+
+describe("getAmbientPresetV3", () => {
+  it("returns frameIndex matching the hour", () => {
+    const preset = getAmbientPresetV3(new Date("2026-04-26T12:30:00"));
+    expect(preset.frameIndex).toBe(12);
+  });
+
+  it('returns nightMode "glowing" at midnight', () => {
+    const preset = getAmbientPresetV3(new Date("2026-04-26T00:00:00"));
+    expect(preset.nightMode).toBe("glowing");
+  });
+
+  it("returns nightMode null at noon", () => {
+    const preset = getAmbientPresetV3(new Date("2026-04-26T12:00:00"));
+    expect(preset.nightMode).toBeNull();
+  });
+
+  it("exposes haloAccentColor at sunset (18h)", () => {
+    const preset = getAmbientPresetV3(new Date("2026-04-26T18:00:00"));
+    expect(preset.haloAccentColor).toBeDefined();
+    expect(preset.haloAccentColor).toMatch(/rgba/);
+  });
+
+  it("does NOT expose haloAccentColor at noon (12h)", () => {
+    const preset = getAmbientPresetV3(new Date("2026-04-26T12:00:00"));
+    expect(preset.haloAccentColor).toBeUndefined();
+  });
+
+  it("readingZoneIntensityCap is 0.5 by default", () => {
+    const preset = getAmbientPresetV3(new Date("2026-04-26T12:00:00"));
+    expect(preset.readingZoneIntensityCap).toBe(0.5);
+  });
+
+  it("readingZoneIntensityCap is 0.3 when high contrast", () => {
+    vi.stubGlobal("window", {
+      matchMedia: (q: string) => ({ matches: q.includes("more") }),
+    });
+    const preset = getAmbientPresetV3(new Date("2026-04-26T12:00:00"));
+    expect(preset.readingZoneIntensityCap).toBe(0.3);
+    expect(preset.isHighContrast).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it("isReducedMotion true freezes the angle to its current value", () => {
+    vi.stubGlobal("window", {
+      matchMedia: (q: string) => ({ matches: q.includes("reduce") }),
+    });
+    const preset = getAmbientPresetV3(new Date("2026-04-26T12:00:00"));
+    expect(preset.isReducedMotion).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it("interpolates between 06h00 and 06h30 keyframes", () => {
+    const at0615 = getAmbientPresetV3(new Date("2026-04-26T06:15:00"));
+    expect(at0615.beam.angleDeg).toBeGreaterThan(-55);
+    expect(at0615.beam.angleDeg).toBeLessThan(-40);
+  });
+});
+```
+
+- [ ] **Step 3: Confirmer l'échec**
+
+```bash
+cd packages/lighting-engine && npm test -- preset.v3
+```
+
+Expected: FAIL — `getAmbientPresetV3` not exported.
+
+- [ ] **Step 4: Implémenter `getAmbientPresetV3`**
+
+Ajouter à `packages/lighting-engine/src/preset.ts` (en gardant l'ancien `getAmbientPreset` v2 intact) :
+
+```ts
+import { KEYFRAMES_V3, type KeyframeV3 } from "./keyframes.v3";
+import { getSpriteFrameIndex } from "./sprite-frame";
+import {
+  detectReducedMotion,
+  detectHighContrast,
+  getReadingZoneCap,
+} from "./accessibility";
+import { lerp, lerpAngle, lerpColor, rgbToCss } from "./interpolate";
+import type { AmbientPreset, PresetOptions } from "./types";
+
+/**
+ * v3 — Calcule le preset ambient lighting pour une date donnée.
+ * Étend v2 avec frameIndex, nightMode, accessibility flags, readingZoneCap.
+ */
+export function getAmbientPresetV3(
+  date: Date,
+  opts: PresetOptions = {},
+): AmbientPreset {
+  const totalHour = date.getHours() + date.getMinutes() / 60;
+
+  // Trouver les 2 keyframes encadrants
+  const { fromIdx, toIdx, factor } = findKeyframeV3Pair(totalHour);
+  const from = KEYFRAMES_V3[fromIdx];
+  const to = KEYFRAMES_V3[toIdx];
+
+  // Détection accessibilité
+  const isReducedMotion = detectReducedMotion();
+  const isHighContrast = detectHighContrast();
+
+  // Si reduced-motion, geler sur la keyframe la plus proche
+  const f = isReducedMotion ? Math.round(factor) : factor;
+
+  // Interpoler
+  const angleDeg = lerpAngle(from.beamAngleDeg, to.beamAngleDeg, f);
+  const beamRgb = lerpColor(from.beamColor, to.beamColor, f);
+  const haloRgb = lerpColor(from.haloPrimary, to.haloPrimary, f);
+  const opacity =
+    lerp(from.beamOpacity, to.beamOpacity, f) * (opts.intensityMul ?? 1);
+  const intensity =
+    lerp(from.intensity, to.intensity, f) * (opts.intensityMul ?? 1);
+
+  // Cap intensity en haute-contraste
+  const cappedIntensity = isHighContrast ? Math.min(intensity, 0.3) : intensity;
+
+  // nightMode: prendre la keyframe la plus proche (pas d'interpolation pour énum)
+  const nightMode = factor < 0.5 ? from.nightMode : to.nightMode;
+
+  // haloAccentColor: si l'une des 2 keyframes en a, garder celle de la plus proche
+  const haloAccentColor =
+    factor < 0.5 ? from.haloAccentColor : to.haloAccentColor;
+
+  return {
+    hour: totalHour,
+    mood: f < 0.5 ? from.mood : to.mood,
+    beam: {
+      type: nightMode === "glowing" ? "moon" : "sun",
+      color: beamRgb,
+      cssColor: opts.skipCssStrings ? undefined : rgbToCss(beamRgb, opacity),
+      angleDeg,
+      opacity,
+    },
+    sun: {
+      visible: nightMode === null,
+      opacity: nightMode === null ? opacity : 0,
+      x: 50,
+      y: 20,
+    },
+    moon: {
+      visible: nightMode !== null,
+      opacity: nightMode !== null ? opacity : 0,
+      x: 50,
+      y: 20,
+    },
+    ambient: {
+      primary: 0.3 * cappedIntensity,
+      secondary: 0.2 * cappedIntensity,
+      tertiary: 0.1 * cappedIntensity,
+    },
+    starOpacityMul: nightMode !== null ? 1 : 0,
+    starDensity: nightMode !== null ? "dense" : "sparse",
+    haloX: 50,
+    haloY: 20,
+    colors: {
+      primary: haloRgb,
+      secondary: beamRgb,
+      tertiary: [99, 102, 241],
+      rays: beamRgb,
+      accent: [165, 180, 252],
+    },
+    // === v3 fields ===
+    frameIndex: getSpriteFrameIndex(date),
+    nightMode,
+    haloAccentColor,
+    isReducedMotion,
+    isHighContrast,
+    readingZoneIntensityCap: getReadingZoneCap(intensity, isHighContrast),
+  };
+}
+
+function findKeyframeV3Pair(hour: number): {
+  fromIdx: number;
+  toIdx: number;
+  factor: number;
+} {
+  const exact = KEYFRAMES_V3.findIndex((k) => k.hour === hour);
+  if (exact !== -1) return { fromIdx: exact, toIdx: exact, factor: 0 };
+
+  const upperIdx = KEYFRAMES_V3.findIndex((k) => k.hour > hour);
+  if (upperIdx === -1) {
+    // Wrap: on est entre 23h30 et 00h00
+    return { fromIdx: 47, toIdx: 0, factor: (hour - 23.5) / 0.5 };
+  }
+  if (upperIdx === 0) {
+    // hour < 0 : ne devrait pas arriver
+    return { fromIdx: 0, toIdx: 0, factor: 0 };
+  }
+  const fromIdx = upperIdx - 1;
+  const from = KEYFRAMES_V3[fromIdx];
+  const to = KEYFRAMES_V3[upperIdx];
+  const factor = (hour - from.hour) / (to.hour - from.hour);
+  return { fromIdx, toIdx: upperIdx, factor };
+}
+```
+
+- [ ] **Step 5: Confirmer le passage**
+
+```bash
+cd packages/lighting-engine && npm test -- preset.v3
+```
+
+Expected: PASS — 9 tests.
+
+- [ ] **Step 6: Exporter depuis index.ts**
+
+```ts
+// packages/lighting-engine/src/index.ts
+export {
+  getAmbientPreset,
+  findKeyframePair,
+  getAmbientPresetV3,
+} from "./preset";
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/lighting-engine/src/preset.ts packages/lighting-engine/src/index.ts packages/lighting-engine/tests/preset.v3.test.ts
+git commit -m "feat(lighting-engine): add getAmbientPresetV3 with frameIndex, nightMode, accessibility flags"
+```
+
+### Task 1.7: Pipeline tournesol — setup script
+
+**Files:**
+
+- Create: `scripts/sunflower-frames/generate.mjs`
+- Create: `scripts/sunflower-frames/scene-day.html`
+- Create: `scripts/sunflower-frames/scene-night.html`
+- Create: `scripts/sunflower-frames/encode-sprite.mjs`
+- Modify: `package.json` (root)
+
+- [ ] **Step 1: Créer le dossier**
+
+```bash
+mkdir -p scripts/sunflower-frames
+mkdir -p assets/ambient
+```
+
+- [ ] **Step 2: Créer la scène Three.js jour**
+
+Créer `scripts/sunflower-frames/scene-day.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        margin: 0;
+        background: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas" width="256" height="256"></canvas>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://unpkg.com/three@0.160.0/build/three.module.js"
+        }
+      }
+    </script>
+    <script type="module">
+      import * as THREE from "three";
+
+      const renderer = new THREE.WebGLRenderer({
+        canvas: document.getElementById("canvas"),
+        alpha: true,
+        antialias: true,
+      });
+      renderer.setClearColor(0x000000, 0);
+      renderer.setSize(256, 256);
+
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(35, 1, 0.1, 100);
+      camera.position.set(0, 0, 5);
+      camera.lookAt(0, 0, 0);
+
+      // Lighting jour : directional + ambient
+      scene.add(new THREE.AmbientLight(0xfff4cc, 0.45));
+      const sun = new THREE.DirectionalLight(0xfffae1, 1.2);
+      sun.position.set(2, 3, 4);
+      scene.add(sun);
+
+      // Tournesol génératif
+      function buildSunflower() {
+        const group = new THREE.Group();
+
+        // 12 pétales radiaux
+        const petalGeom = new THREE.SphereGeometry(0.4, 16, 8);
+        petalGeom.scale(0.35, 1.2, 0.18); // ellipsoïde
+
+        for (let i = 0; i < 12; i++) {
+          const theta = (i / 12) * Math.PI * 2;
+          const petalMat = new THREE.MeshStandardMaterial({
+            color: new THREE.Color().lerpColors(
+              new THREE.Color(0xfef9c3),
+              new THREE.Color(0xb45309),
+              0.5,
+            ),
+            roughness: 0.55,
+            metalness: 0.05,
+          });
+          const petal = new THREE.Mesh(petalGeom, petalMat);
+          petal.position.set(Math.cos(theta) * 1.2, Math.sin(theta) * 1.2, 0);
+          petal.rotation.z = theta - Math.PI / 2;
+          group.add(petal);
+        }
+
+        // Centre disque
+        const centerGeom = new THREE.CylinderGeometry(0.85, 0.85, 0.18, 32);
+        centerGeom.rotateX(Math.PI / 2);
+        const centerMat = new THREE.MeshStandardMaterial({
+          color: 0x451a03,
+          roughness: 0.85,
+          metalness: 0.05,
+          bumpScale: 0.05,
+        });
+        const center = new THREE.Mesh(centerGeom, centerMat);
+        group.add(center);
+
+        return group;
+      }
+
+      const flower = buildSunflower();
+      scene.add(flower);
+
+      // API exposée pour le script orchestrateur
+      window.renderFrame = (rotationY) => {
+        flower.rotation.y = rotationY;
+        renderer.render(scene, camera);
+      };
+
+      window.READY = true;
+    </script>
+  </body>
+</html>
+```
+
+- [ ] **Step 3: Créer la scène Three.js nuit luminescent**
+
+Créer `scripts/sunflower-frames/scene-night.html` (identique à scene-day.html sauf le lighting et les materials) :
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        margin: 0;
+        background: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas" width="256" height="256"></canvas>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://unpkg.com/three@0.160.0/build/three.module.js"
+        }
+      }
+    </script>
+    <script type="module">
+      import * as THREE from "three";
+
+      const renderer = new THREE.WebGLRenderer({
+        canvas: document.getElementById("canvas"),
+        alpha: true,
+        antialias: true,
+      });
+      renderer.setClearColor(0x000000, 0);
+      renderer.setSize(256, 256);
+
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(35, 1, 0.1, 100);
+      camera.position.set(0, 0, 5);
+      camera.lookAt(0, 0, 0);
+
+      // Lighting nuit : ambient cool + faible directional + emissive interne
+      scene.add(new THREE.AmbientLight(0x1e1b4b, 0.3));
+      const moon = new THREE.DirectionalLight(0xc7d2fe, 0.4);
+      moon.position.set(-1, 2, 3);
+      scene.add(moon);
+
+      function buildSunflowerNight() {
+        const group = new THREE.Group();
+
+        const petalGeom = new THREE.SphereGeometry(0.4, 16, 8);
+        petalGeom.scale(0.35, 1.2, 0.18);
+
+        for (let i = 0; i < 12; i++) {
+          const theta = (i / 12) * Math.PI * 2;
+          const petalMat = new THREE.MeshStandardMaterial({
+            color: 0xa5b4fc, // indigo-300
+            roughness: 0.4,
+            metalness: 0.1,
+            emissive: 0x4f46e5, // indigo-600 (luminescence)
+            emissiveIntensity: 0.85,
+          });
+          const petal = new THREE.Mesh(petalGeom, petalMat);
+          petal.position.set(Math.cos(theta) * 1.2, Math.sin(theta) * 1.2, 0);
+          petal.rotation.z = theta - Math.PI / 2;
+          group.add(petal);
+        }
+
+        const centerGeom = new THREE.CylinderGeometry(0.85, 0.85, 0.18, 32);
+        centerGeom.rotateX(Math.PI / 2);
+        const centerMat = new THREE.MeshStandardMaterial({
+          color: 0x312e81,
+          roughness: 0.85,
+          emissive: 0x6366f1,
+          emissiveIntensity: 0.4,
+        });
+        const center = new THREE.Mesh(centerGeom, centerMat);
+        group.add(center);
+
+        return group;
+      }
+
+      const flower = buildSunflowerNight();
+      scene.add(flower);
+
+      window.renderFrame = (rotationY) => {
+        flower.rotation.y = rotationY;
+        renderer.render(scene, camera);
+      };
+
+      window.READY = true;
+    </script>
+  </body>
+</html>
+```
+
+- [ ] **Step 4: Créer le script orchestrateur Puppeteer**
+
+Créer `scripts/sunflower-frames/generate.mjs`:
+
+```mjs
+import puppeteer from "puppeteer";
+import sharp from "sharp";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "../..");
+const ASSETS = path.join(ROOT, "assets/ambient");
+
+const FRAME_SIZE = 256;
+const FRAMES = 24;
+const GRID_COLS = 6;
+const GRID_ROWS = 4;
+const SHEET_W = FRAME_SIZE * GRID_COLS;
+const SHEET_H = FRAME_SIZE * GRID_ROWS;
+
+async function renderScene(scenePath, outputName) {
+  console.log(`[render] ${scenePath}`);
+  const browser = await puppeteer.launch({
+    headless: "new",
+    args: [
+      "--no-sandbox",
+      "--disable-web-security",
+      "--enable-webgl",
+      "--use-gl=angle",
+    ],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: FRAME_SIZE, height: FRAME_SIZE });
+  await page.goto(`file://${scenePath}`);
+  await page.waitForFunction(() => window.READY === true, { timeout: 10000 });
+
+  const frames = [];
+  for (let i = 0; i < FRAMES; i++) {
+    // Le tournesol fait une rotation complète sur 24h → 15° par heure
+    const rotationY = (i / FRAMES) * Math.PI * 2;
+    await page.evaluate((rot) => window.renderFrame(rot), rotationY);
+    const buf = await page.screenshot({
+      type: "png",
+      omitBackground: true,
+      clip: { x: 0, y: 0, width: FRAME_SIZE, height: FRAME_SIZE },
+    });
+    frames.push(buf);
+    process.stdout.write(`\r  frame ${i + 1}/${FRAMES}`);
+  }
+  process.stdout.write("\n");
+
+  await browser.close();
+
+  // Composer le sprite sheet
+  const compositeOps = [];
+  for (let i = 0; i < FRAMES; i++) {
+    const col = i % GRID_COLS;
+    const row = Math.floor(i / GRID_COLS);
+    compositeOps.push({
+      input: frames[i],
+      left: col * FRAME_SIZE,
+      top: row * FRAME_SIZE,
+    });
+  }
+
+  const out = path.join(ASSETS, outputName);
+  await sharp({
+    create: {
+      width: SHEET_W,
+      height: SHEET_H,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .composite(compositeOps)
+    .webp({ quality: 85, lossless: false, alphaQuality: 90 })
+    .toFile(out);
+
+  const stats = await fs.stat(out);
+  console.log(`[done] ${outputName}: ${(stats.size / 1024).toFixed(1)} KB`);
+}
+
+async function main() {
+  await fs.mkdir(ASSETS, { recursive: true });
+  await renderScene(
+    path.join(__dirname, "scene-day.html"),
+    "sunflower-day.webp",
+  );
+  await renderScene(
+    path.join(__dirname, "scene-night.html"),
+    "sunflower-night.webp",
+  );
+  console.log("[all done]");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 5: Ajouter le script au `package.json` root**
+
+Vérifier que `puppeteer` et `sharp` sont installés à la racine. Si non :
+
+```bash
+npm install --save-dev puppeteer sharp
+```
+
+Puis modifier `package.json` (root) pour ajouter dans `"scripts"`:
+
+```json
+"build:sunflower-frames": "node scripts/sunflower-frames/generate.mjs"
+```
+
+- [ ] **Step 6: Lancer le pipeline**
+
+```bash
+npm run build:sunflower-frames
+```
+
+Expected: génération des 2 fichiers dans `assets/ambient/`. Sortie console attendue :
+
+```
+[render] .../scene-day.html
+  frame 24/24
+[done] sunflower-day.webp: 78.4 KB
+[render] .../scene-night.html
+  frame 24/24
+[done] sunflower-night.webp: 81.2 KB
+[all done]
+```
+
+Si la taille dépasse 100KB par sprite : ajuster `quality` à 75 dans `sharp.webp()`.
+
+- [ ] **Step 7: Vérifier visuellement**
+
+Ouvrir `assets/ambient/sunflower-day.webp` dans un viewer image. Confirmer : 24 vignettes de tournesol vues sous différents angles, chacune 256×256 px transparente. Le tournesol doit pivoter progressivement frame par frame.
+
+Si le rendu est cassé (tournesol invisible / trop petit / déformé), ajuster les paramètres `sphere.scale`, `camera.position`, etc. dans la scène HTML.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/sunflower-frames/ assets/ambient/sunflower-day.webp assets/ambient/sunflower-night.webp package.json package-lock.json
+git commit -m "feat(scripts): add sunflower frames pipeline (Puppeteer Three.js → 2 WebP sprite sheets)"
+```
+
+### Task 1.8: Design tokens shift — Web
+
+**Files:**
+
+- Modify: `frontend/src/styles/tokens.css`
+- Modify: `frontend/tailwind.config.js`
+- Test: `frontend/src/styles/__tests__/tokens.test.ts`
+
+- [ ] **Step 1: Inspecter `tokens.css` actuel**
+
+```bash
+cat frontend/src/styles/tokens.css | head -80
+```
+
+Repérer les variables `--text-*` ou les couleurs grises. Si pas de fichier `tokens.css`, vérifier `frontend/src/index.css` ou `frontend/src/styles/globals.css`.
+
+- [ ] **Step 2: Écrire le test (smoke test) qui assert les nouvelles valeurs**
+
+Créer `frontend/src/styles/__tests__/tokens.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("design tokens v3", () => {
+  const tokensPath = path.resolve(__dirname, "../tokens.css");
+  const content = fs.existsSync(tokensPath)
+    ? fs.readFileSync(tokensPath, "utf-8")
+    : "";
+
+  it("text-secondary uses slate-100 (#f1f5f9)", () => {
+    expect(content).toMatch(/--text-secondary:\s*#f1f5f9/i);
+  });
+
+  it("text-muted uses slate-200 (#e2e8f0)", () => {
+    expect(content).toMatch(/--text-muted:\s*#e2e8f0/i);
+  });
+
+  it("text-disabled uses rgba opacity", () => {
+    expect(content).toMatch(
+      /--text-disabled:\s*rgba\(255,\s*255,\s*255,\s*0\.45\)/i,
+    );
+  });
+
+  it("text-meta uses slate-300", () => {
+    expect(content).toMatch(/--text-meta:\s*#cbd5e1/i);
+  });
+});
+```
+
+- [ ] **Step 3: Lancer le test, confirmer l'échec**
+
+```bash
+cd frontend && npm test -- tokens
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Modifier `tokens.css`**
+
+Si le fichier n'existe pas, le créer. Sinon, modifier les variables. Ajouter ou modifier ces déclarations dans `:root { ... }`:
+
+```css
+:root {
+  /* === Text tokens v3 (ambient lighting) === */
+  --text-primary: #ffffff;
+  --text-secondary: #f1f5f9; /* slate-100 — était #94a3b8 (slate-400) */
+  --text-muted: #e2e8f0; /* slate-200 — était #64748b (slate-500) */
+  --text-disabled: rgba(255, 255, 255, 0.45); /* opacité au lieu de gris */
+  --text-meta: #cbd5e1; /* slate-300 pour timestamps/counts */
+}
+```
+
+Si le fichier n'inclut pas déjà ces variables, ajouter le bloc complet en haut du `:root`.
+
+- [ ] **Step 5: Lancer le test, confirmer le passage**
+
+```bash
+cd frontend && npm test -- tokens
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Étendre `tailwind.config.js`**
+
+Modifier `frontend/tailwind.config.js` pour ajouter dans `theme.extend.colors`:
+
+```js
+text: {
+  primary: 'var(--text-primary)',
+  secondary: 'var(--text-secondary)',
+  muted: 'var(--text-muted)',
+  disabled: 'var(--text-disabled)',
+  meta: 'var(--text-meta)',
+},
+```
+
+Cela permet d'utiliser `text-text-secondary` etc. (ou de redéfinir l'aliasing : `text-secondary` directement).
+
+- [ ] **Step 7: Lancer typecheck**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected: 0 erreur.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/styles/tokens.css frontend/tailwind.config.js frontend/src/styles/__tests__/tokens.test.ts
+git commit -m "feat(frontend): shift text design tokens (secondary/muted/disabled) to white-cast for ambient lighting v3"
+```
+
+### Task 1.9: Design tokens shift — Mobile
+
+**Files:**
+
+- Modify: `mobile/src/theme/colors.ts`
+- Test: `mobile/src/theme/__tests__/colors.test.ts`
+
+- [ ] **Step 1: Inspecter `colors.ts` actuel**
+
+```bash
+cat mobile/src/theme/colors.ts
+```
+
+Repérer la structure `text.*`.
+
+- [ ] **Step 2: Test failing**
+
+Créer `mobile/src/theme/__tests__/colors.test.ts`:
+
+```ts
+import { colors } from "../colors";
+
+describe("text colors v3", () => {
+  it("text.primary is pure white", () => {
+    expect(colors.text.primary).toBe("#ffffff");
+  });
+
+  it("text.secondary is slate-100", () => {
+    expect(colors.text.secondary).toBe("#f1f5f9");
+  });
+
+  it("text.muted is slate-200", () => {
+    expect(colors.text.muted).toBe("#e2e8f0");
+  });
+
+  it("text.disabled uses rgba opacity", () => {
+    expect(colors.text.disabled).toBe("rgba(255,255,255,0.45)");
+  });
+
+  it("text.meta is slate-300", () => {
+    expect(colors.text.meta).toBe("#cbd5e1");
+  });
+});
+```
+
+- [ ] **Step 3: Confirmer l'échec**
+
+```bash
+cd mobile && npm test -- colors
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Modifier `colors.ts`**
+
+Mettre à jour la section `text` :
+
+```ts
+export const colors = {
+  // ... existing
+  text: {
+    primary: "#ffffff",
+    secondary: "#f1f5f9",
+    muted: "#e2e8f0",
+    disabled: "rgba(255,255,255,0.45)",
+    meta: "#cbd5e1",
+  },
+  // ... rest
+};
+```
+
+- [ ] **Step 5: Confirmer le passage**
+
+```bash
+cd mobile && npm test -- colors
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Lancer le typecheck**
+
+```bash
+cd mobile && npm run typecheck
+```
+
+Expected: 0 erreur. Si erreurs sur des consumers qui utilisent les anciennes valeurs, NE PAS les fixer ici (hors scope) — noter les fichiers affectés et les fixer dans une PR follow-up.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/src/theme/colors.ts mobile/src/theme/__tests__/colors.test.ts
+git commit -m "feat(mobile): shift text colors theme to white-cast for ambient lighting v3"
+```
+
+### Task 1.10: Design tokens shift — Extension
+
+**Files:**
+
+- Modify: `extension/src/sidepanel/styles/sidepanel.css`
+- Modify: `extension/src/popup/styles/popup.css`
+
+- [ ] **Step 1: Inspecter les CSS actuels**
+
+```bash
+grep -n "text-secondary\|text-muted\|color:\s*#" extension/src/sidepanel/styles/sidepanel.css | head -20
+grep -n "text-secondary\|text-muted\|color:\s*#" extension/src/popup/styles/popup.css | head -20
+```
+
+- [ ] **Step 2: Modifier `sidepanel.css`**
+
+Ajouter en haut du fichier (ou modifier le bloc `:root` existant) :
+
+```css
+:root {
+  /* === Text tokens v3 (ambient lighting) === */
+  --v3-text-primary: #ffffff;
+  --v3-text-secondary: #f1f5f9;
+  --v3-text-muted: #e2e8f0;
+  --v3-text-disabled: rgba(255, 255, 255, 0.45);
+  --v3-text-meta: #cbd5e1;
+}
+```
+
+(Note : `--v3-text-*` plutôt que `--text-*` pour éviter collision avec les classes `.v3-*` que la session parallèle a installées.)
+
+- [ ] **Step 3: Idem dans `popup.css`**
+
+Ajouter le même bloc.
+
+- [ ] **Step 4: Build de validation**
+
+```bash
+cd extension && npm run typecheck && npm run build
+```
+
+Expected: 0 erreur, build OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/sidepanel/styles/sidepanel.css extension/src/popup/styles/popup.css
+git commit -m "feat(extension): shift text CSS variables to white-cast for ambient lighting v3"
+```
+
+### Task 1.11: Backend — vérifier le champ `User.preferences.ambient_lighting_enabled`
+
+**Files:**
+
+- Verify: `backend/src/db/database.py`
+- Verify: `backend/src/auth/router.py`
+- Test: `backend/tests/test_user_preferences_v3.py`
+
+- [ ] **Step 1: Inspecter `User.preferences`**
+
+```bash
+grep -n "preferences" backend/src/db/database.py | head -10
+grep -n "preferences" backend/src/auth/router.py | head -10
+```
+
+Si `User.preferences` est une `Column(JSON)`, c'est good — pas de migration nécessaire. Si c'est une autre forme (relation, JSONB), adapter.
+
+- [ ] **Step 2: Écrire un test pour confirmer que l'endpoint accepte `ambient_lighting_enabled`**
+
+Créer `backend/tests/test_user_preferences_v3.py`:
+
+```python
+import pytest
+from httpx import AsyncClient
+
+@pytest.mark.asyncio
+async def test_user_preferences_accepts_ambient_lighting_enabled(client: AsyncClient, auth_headers):
+    """User can toggle ambient_lighting_enabled in preferences."""
+    response = await client.put(
+        "/api/auth/preferences",
+        json={"ambient_lighting_enabled": False},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+
+    me = await client.get("/api/auth/me", headers=auth_headers)
+    assert me.json()["preferences"].get("ambient_lighting_enabled") is False
+
+    # Toggle back on
+    response = await client.put(
+        "/api/auth/preferences",
+        json={"ambient_lighting_enabled": True},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    me = await client.get("/api/auth/me", headers=auth_headers)
+    assert me.json()["preferences"].get("ambient_lighting_enabled") is True
+
+
+@pytest.mark.asyncio
+async def test_user_preferences_default_ambient_lighting_enabled_true(client: AsyncClient, auth_headers):
+    """New users have ambient_lighting_enabled=True by default."""
+    me = await client.get("/api/auth/me", headers=auth_headers)
+    # Default may be missing in JSON — handle both cases
+    pref = me.json().get("preferences", {})
+    val = pref.get("ambient_lighting_enabled", True)  # default True if absent
+    assert val is True
+```
+
+- [ ] **Step 3: Lancer le test**
+
+```bash
+cd backend && pytest tests/test_user_preferences_v3.py -v
+```
+
+Si déjà pass : aucune modif backend nécessaire (l'endpoint accepte n'importe quel JSON valide).
+
+Si fail à cause d'un schema Pydantic strict : ajouter le champ optionnel dans le schema. Trouver le schema avec :
+
+```bash
+grep -rn "class.*Preferences" backend/src/auth/
+```
+
+Et ajouter dans la classe correspondante (ex: `UserPreferencesUpdate` ou `UserPreferencesIn`):
+
+```python
+class UserPreferencesUpdate(BaseModel):
+    # ... existing fields
+    ambient_lighting_enabled: bool | None = None
+```
+
+Si le model `User.preferences` est typé strict (par exemple un dict typé), élargir le type pour accepter le nouveau champ.
+
+- [ ] **Step 4: Re-lancer le test**
+
+```bash
+cd backend && pytest tests/test_user_preferences_v3.py -v
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/test_user_preferences_v3.py backend/src/auth/  # + tout fichier modifié
+git commit -m "test(backend): add ambient_lighting_enabled to user preferences (v3)"
+```
+
+### Task 1.12: PR1 — Push & PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/ambient-lighting-v3-foundation
+```
+
+- [ ] **Step 2: Créer la PR**
+
+```bash
+gh pr create --title "feat(ambient-lighting-v3): foundation - engine + sprite pipeline + tokens" --body "$(cat <<'EOF'
+## Summary
+
+PR1 of 5 for ambient lighting v3 — see spec at `docs/superpowers/specs/2026-04-26-ambient-lighting-v3-design.md`.
+
+This PR delivers the foundation that PRs 2-4 will consume:
+- Extended `@deepsight/lighting-engine` v3 (frameIndex, nightMode, accessibility flags, 48 v3 keyframes with brand accents)
+- Sprite pipeline (Three.js headless via Puppeteer → 2 WebP sprite sheets ~150KB total)
+- Design tokens shift (text-secondary/muted/disabled in white-cast — pas de gris moyen sur fond sombre)
+- Backend pref `ambient_lighting_enabled` validation
+
+## Test plan
+
+- [ ] `cd packages/lighting-engine && npm test` — all green (4 new test files)
+- [ ] `npm run build:sunflower-frames` — produces 2 .webp ~75KB each in `assets/ambient/`
+- [ ] `cd frontend && npm test -- tokens` + `npm run typecheck` — green
+- [ ] `cd mobile && npm test -- colors` + `npm run typecheck` — green
+- [ ] `cd extension && npm run typecheck && npm run build` — green
+- [ ] `cd backend && pytest tests/test_user_preferences_v3.py -v` — green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Note la PR URL pour reference**
+
+Récupérer l'URL retournée et la noter pour les PR2-4 qui dépendent de ce merge.
+
+---
+
+## Phase 2 — Web Platform (PR2)
+
+**Branche:** `feat/ambient-lighting-v3-web`
+**Durée estimée:** ~1.5 jour
+**Dépendances:** PR1 mergée. Peut s'exécuter EN PARALLÈLE avec PR3 (Mobile) et PR4 (Extension).
+
+### Task 2.1: Créer la branche
+
+- [ ] **Step 1**
+
+```bash
+git fetch origin
+git checkout -b feat/ambient-lighting-v3-web origin/main
+```
+
+### Task 2.2: Plugin Vite critical CSS
+
+**Files:**
+
+- Create: `frontend/src/plugins/vite-plugin-ambient-critical-css.ts`
+- Modify: `frontend/vite.config.ts`
+- Test: `frontend/src/plugins/__tests__/vite-plugin-ambient-critical-css.test.ts`
+
+- [ ] **Step 1: Test failing**
+
+Créer `frontend/src/plugins/__tests__/vite-plugin-ambient-critical-css.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { ambientCriticalCssPlugin } from "../vite-plugin-ambient-critical-css";
+
+describe("ambientCriticalCssPlugin", () => {
+  it("returns a Vite plugin object", () => {
+    const plugin = ambientCriticalCssPlugin();
+    expect(plugin.name).toBe("vite-plugin-ambient-critical-css");
+    expect(plugin.transformIndexHtml).toBeDefined();
+  });
+
+  it('injects <style id="ambient-critical"> in <head>', () => {
+    const plugin = ambientCriticalCssPlugin();
+    const html = `<html><head></head><body></body></html>`;
+    const result = (plugin.transformIndexHtml as Function)(html);
+    expect(result).toContain('<style id="ambient-critical">');
+    expect(result).toContain("--ambient-beam-angle");
+    expect(result).toContain("background-color: #0a0a0f");
+  });
+
+  it('injects <link rel="preload" as="image"> for sprite', () => {
+    const plugin = ambientCriticalCssPlugin();
+    const html = `<html><head></head><body></body></html>`;
+    const result = (plugin.transformIndexHtml as Function)(html);
+    expect(result).toMatch(
+      /<link rel="preload" as="image" href="\/assets\/ambient\/sunflower-(day|night)\.webp"/,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Implémenter le plugin**
+
+Créer `frontend/src/plugins/vite-plugin-ambient-critical-css.ts`:
+
+```ts
+import type { Plugin } from "vite";
+import { getAmbientPresetV3, rgbToCss } from "@deepsight/lighting-engine";
+
+export function ambientCriticalCssPlugin(): Plugin {
+  return {
+    name: "vite-plugin-ambient-critical-css",
+    transformIndexHtml(html: string) {
+      const preset = getAmbientPresetV3(new Date());
+      const beamColor = rgbToCss(preset.beam.color, preset.beam.opacity);
+      const haloColor = rgbToCss(
+        preset.colors.primary,
+        preset.beam.opacity * 0.5,
+      );
+      const sprite =
+        preset.nightMode === "glowing"
+          ? "sunflower-night.webp"
+          : "sunflower-day.webp";
+
+      const inlineCss = `
+:root {
+  --ambient-beam-angle: ${preset.beam.angleDeg}deg;
+  --ambient-beam-color: ${beamColor};
+  --ambient-halo-color: ${haloColor};
+  --ambient-halo-accent: ${preset.haloAccentColor || "transparent"};
+  --ambient-intensity: ${preset.beam.opacity};
+  --ambient-frame-index: ${preset.frameIndex};
+}
+html { background-color: #0a0a0f; }
+body { background-color: #0a0a0f; }
+.ambient-beam-initial {
+  position: fixed; inset: 0; pointer-events: none; z-index: 1;
+  background: linear-gradient(var(--ambient-beam-angle),
+    transparent 45%, var(--ambient-beam-color) 50%, transparent 55%);
+}
+.ambient-halo-initial {
+  position: fixed; top: -100px; left: -100px; width: 400px; height: 400px;
+  background: radial-gradient(circle, var(--ambient-halo-color), transparent 60%);
+  filter: blur(40px); mix-blend-mode: screen; z-index: 1; pointer-events: none;
+}
+.ambient-disabled .ambient-beam-initial,
+.ambient-disabled .ambient-halo-initial { display: none; }
+      `.trim();
+
+      const injection = `
+<style id="ambient-critical">${inlineCss}</style>
+<link rel="preload" as="image" href="/assets/ambient/${sprite}">
+      `.trim();
+
+      return html.replace("</head>", `${injection}\n</head>`);
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Confirmer le passage des tests**
+
+```bash
+cd frontend && npm test -- vite-plugin-ambient
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 4: Charger le plugin dans `vite.config.ts`**
+
+Modifier `frontend/vite.config.ts` :
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { ambientCriticalCssPlugin } from "./src/plugins/vite-plugin-ambient-critical-css";
+
+export default defineConfig({
+  plugins: [react(), ambientCriticalCssPlugin()],
+  // ...
+});
+```
+
+- [ ] **Step 5: Build dev pour valider**
+
+```bash
+cd frontend && npm run build
+grep -c "ambient-critical" dist/index.html
+```
+
+Expected: count >= 1 (plugin a injecté son `<style>`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/plugins/ frontend/vite.config.ts
+git commit -m "feat(frontend): add Vite plugin for ambient critical CSS injection (visible before React hydrates)"
+```
+
+### Task 2.3: AmbientLightingContext
+
+**Files:**
+
+- Create: `frontend/src/contexts/AmbientLightingContext.tsx`
+- Test: `frontend/src/contexts/__tests__/AmbientLightingContext.test.tsx`
+
+- [ ] **Step 1: Test failing**
+
+Créer `frontend/src/contexts/__tests__/AmbientLightingContext.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { render, renderHook } from "@testing-library/react";
+import {
+  AmbientLightingProvider,
+  useAmbientLightingContext,
+} from "../AmbientLightingContext";
+
+describe("AmbientLightingProvider", () => {
+  it("provides preset to children via context", () => {
+    const { result } = renderHook(() => useAmbientLightingContext(), {
+      wrapper: ({ children }) => (
+        <AmbientLightingProvider>{children}</AmbientLightingProvider>
+      ),
+    });
+    expect(result.current.preset).toBeDefined();
+    expect(result.current.preset.frameIndex).toBeGreaterThanOrEqual(0);
+    expect(result.current.preset.frameIndex).toBeLessThanOrEqual(23);
+  });
+
+  it("renders nothing when enabled=false", () => {
+    const { container } = render(
+      <AmbientLightingProvider enabled={false}>
+        <div data-testid="child">child</div>
+      </AmbientLightingProvider>,
+    );
+    expect(container.querySelector('[data-testid="child"]')).toBeTruthy();
+  });
+
+  it("refreshes preset every 30 seconds", async () => {
+    // tested via vi.useFakeTimers
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useAmbientLightingContext(), {
+      wrapper: ({ children }) => (
+        <AmbientLightingProvider>{children}</AmbientLightingProvider>
+      ),
+    });
+    const initialFrame = result.current.preset.frameIndex;
+    vi.advanceTimersByTime(30 * 1000);
+    // We can't assert change without time control, but we can assert no throw
+    expect(result.current.preset).toBeDefined();
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Implémenter le Context**
+
+Créer `frontend/src/contexts/AmbientLightingContext.tsx`:
+
+```tsx
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  getAmbientPresetV3,
+  type AmbientPreset,
+} from "@deepsight/lighting-engine";
+
+interface AmbientLightingContextValue {
+  preset: AmbientPreset;
+  enabled: boolean;
+}
+
+const Ctx = createContext<AmbientLightingContextValue | null>(null);
+
+interface ProviderProps {
+  enabled?: boolean;
+  children: ReactNode;
+}
+
+export function AmbientLightingProvider({
+  enabled = true,
+  children,
+}: ProviderProps) {
+  const [preset, setPreset] = useState<AmbientPreset>(() =>
+    getAmbientPresetV3(new Date()),
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    const update = () => setPreset(getAmbientPresetV3(new Date()));
+    update();
+    const interval = setInterval(update, 30 * 1000); // refresh every 30s
+    return () => clearInterval(interval);
+  }, [enabled]);
+
+  return <Ctx.Provider value={{ preset, enabled }}>{children}</Ctx.Provider>;
+}
+
+export function useAmbientLightingContext(): AmbientLightingContextValue {
+  const v = useContext(Ctx);
+  if (!v) {
+    // Fallback : retourner un preset live sans Context (au cas où)
+    return { preset: getAmbientPresetV3(new Date()), enabled: false };
+  }
+  return v;
+}
+```
+
+- [ ] **Step 3: Confirmer le passage**
+
+```bash
+cd frontend && npm test -- AmbientLightingContext
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/contexts/AmbientLightingContext.tsx frontend/src/contexts/__tests__/
+git commit -m "feat(frontend): add AmbientLightingProvider context (refreshes preset every 30s)"
+```
+
+### Task 2.4: AmbientLightLayer composant Web
+
+**Files:**
+
+- Replace: `frontend/src/components/AmbientLightLayer.tsx`
+- Test: `frontend/src/components/__tests__/AmbientLightLayer.test.tsx`
+
+- [ ] **Step 1: Test failing**
+
+Créer `frontend/src/components/__tests__/AmbientLightLayer.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { AmbientLightLayer } from "../AmbientLightLayer";
+import { AmbientLightingProvider } from "../../contexts/AmbientLightingContext";
+
+describe("AmbientLightLayer", () => {
+  it("renders fixed inset overlay with aria-hidden", () => {
+    const { container } = render(
+      <AmbientLightingProvider>
+        <AmbientLightLayer />
+      </AmbientLightingProvider>,
+    );
+    const layer = container.querySelector('[aria-hidden="true"]');
+    expect(layer).toBeTruthy();
+    expect(getComputedStyle(layer!).position).toBe("fixed");
+  });
+
+  it("renders nothing when provider disabled", () => {
+    const { container } = render(
+      <AmbientLightingProvider enabled={false}>
+        <AmbientLightLayer />
+      </AmbientLightingProvider>,
+    );
+    expect(container.querySelector(".ambient-light-layer")).toBeFalsy();
+  });
+
+  it("applies beam angle from preset as CSS transform", () => {
+    const { container } = render(
+      <AmbientLightingProvider>
+        <AmbientLightLayer />
+      </AmbientLightingProvider>,
+    );
+    const beam = container.querySelector(".ambient-beam");
+    expect(beam).toBeTruthy();
+    const style = (beam as HTMLElement).style;
+    expect(style.transform).toMatch(/rotate\(-?\d+(\.\d+)?deg\)/);
+  });
+});
+```
+
+- [ ] **Step 2: Implémenter le composant**
+
+Remplacer `frontend/src/components/AmbientLightLayer.tsx`:
+
+```tsx
+import { useAmbientLightingContext } from "../contexts/AmbientLightingContext";
+import { rgbToCss } from "@deepsight/lighting-engine";
+
+export function AmbientLightLayer() {
+  const { preset, enabled } = useAmbientLightingContext();
+  if (!enabled) return null;
+
+  const beamColor = rgbToCss(preset.beam.color, preset.beam.opacity);
+  const haloColor = rgbToCss(preset.colors.primary, preset.beam.opacity * 0.5);
+  const accentColor = preset.haloAccentColor;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="ambient-light-layer"
+      style={{
+        position: "fixed",
+        inset: 0,
+        pointerEvents: "none",
+        zIndex: 1,
+        overflow: "hidden",
+      }}
+    >
+      {/* Halo de source — radial gradient flou */}
+      <div
+        className="ambient-halo"
+        style={{
+          position: "absolute",
+          top: -150,
+          left: -150,
+          width: 500,
+          height: 500,
+          background: accentColor
+            ? `radial-gradient(circle, ${haloColor} 0%, ${accentColor} 40%, transparent 70%)`
+            : `radial-gradient(circle, ${haloColor}, transparent 60%)`,
+          filter: "blur(40px)",
+          mixBlendMode: "screen",
+          transition: "background 4s cubic-bezier(0.4,0,0.2,1)",
+        }}
+      />
+
+      {/* Beam — linear gradient fin avec halo */}
+      <div
+        className="ambient-beam"
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "-15%",
+          width: "130%",
+          height: 1.5,
+          background: `linear-gradient(90deg, transparent, ${beamColor} 50%, transparent)`,
+          boxShadow: `0 0 12px ${beamColor}, 0 0 32px ${beamColor}, 0 0 80px ${beamColor}`,
+          transform: `rotate(${preset.beam.angleDeg}deg)`,
+          transformOrigin: "center",
+          transition:
+            "transform 4s cubic-bezier(0.4,0,0.2,1), background 4s, box-shadow 4s",
+        }}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Confirmer le passage**
+
+```bash
+cd frontend && npm test -- AmbientLightLayer
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/AmbientLightLayer.tsx frontend/src/components/__tests__/AmbientLightLayer.test.tsx
+git commit -m "feat(frontend): rewrite AmbientLightLayer to consume engine v3 (beam + halo + accent)"
+```
+
+### Task 2.5: SunflowerLayer composant Web (mascot + hero)
+
+**Files:**
+
+- Create: `frontend/src/components/SunflowerLayer.tsx`
+- Test: `frontend/src/components/__tests__/SunflowerLayer.test.tsx`
+- Copy: `frontend/public/assets/ambient/sunflower-day.webp`
+- Copy: `frontend/public/assets/ambient/sunflower-night.webp`
+
+- [ ] **Step 1: Copier les sprites**
+
+```bash
+mkdir -p frontend/public/assets/ambient
+cp assets/ambient/sunflower-day.webp frontend/public/assets/ambient/
+cp assets/ambient/sunflower-night.webp frontend/public/assets/ambient/
+```
+
+- [ ] **Step 2: Test failing**
+
+Créer `frontend/src/components/__tests__/SunflowerLayer.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { SunflowerLayer } from "../SunflowerLayer";
+import { AmbientLightingProvider } from "../../contexts/AmbientLightingContext";
+
+const renderWithRoute = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AmbientLightingProvider>
+        <Routes>
+          <Route path="*" element={<SunflowerLayer />} />
+        </Routes>
+      </AmbientLightingProvider>
+    </MemoryRouter>,
+  );
+
+describe("SunflowerLayer", () => {
+  it("renders hero variant on /", () => {
+    const { container } = renderWithRoute("/");
+    const flower = container.querySelector(".sunflower-hero");
+    expect(flower).toBeTruthy();
+  });
+
+  it("renders mascot variant on /dashboard", () => {
+    const { container } = renderWithRoute("/dashboard");
+    const flower = container.querySelector(".sunflower-mascot");
+    expect(flower).toBeTruthy();
+  });
+
+  it("uses sunflower-day.webp by day", () => {
+    // Mock noon
+    const { container } = renderWithRoute("/");
+    const flower = container.querySelector(
+      ".sunflower-hero img, .sunflower-hero [data-sprite]",
+    );
+    expect(flower).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 3: Implémenter le composant**
+
+Créer `frontend/src/components/SunflowerLayer.tsx`:
+
+```tsx
+import { useLocation } from "react-router-dom";
+import { useAmbientLightingContext } from "../contexts/AmbientLightingContext";
+
+const HERO_ROUTES = ["/", "/login", "/signup", "/forgot-password"];
+const FRAME_SIZE = 256;
+const GRID_COLS = 6;
+
+function getSpritePosition(frameIndex: number): string {
+  const col = frameIndex % GRID_COLS;
+  const row = Math.floor(frameIndex / GRID_COLS);
+  return `-${col * FRAME_SIZE}px -${row * FRAME_SIZE}px`;
+}
+
+export function SunflowerLayer() {
+  const location = useLocation();
+  const { preset, enabled } = useAmbientLightingContext();
+  if (!enabled) return null;
+
+  const isHero = HERO_ROUTES.includes(location.pathname);
+  const sprite =
+    preset.nightMode === "glowing"
+      ? "sunflower-night.webp"
+      : "sunflower-day.webp";
+  const url = `/assets/ambient/${sprite}`;
+  const position = getSpritePosition(preset.frameIndex);
+
+  if (isHero) {
+    return (
+      <div
+        aria-hidden="true"
+        className="sunflower-hero"
+        style={{
+          position: "fixed",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: 90,
+          height: 90,
+          backgroundImage: `url(${url})`,
+          backgroundSize: `${FRAME_SIZE * GRID_COLS}px auto`,
+          backgroundPosition: position,
+          pointerEvents: "none",
+          zIndex: 2,
+          opacity: preset.beam.opacity * 0.9,
+          transition: "opacity 4s cubic-bezier(0.4,0,0.2,1)",
+          backgroundRepeat: "no-repeat",
+          backgroundClip: "border-box",
+          imageRendering: "crisp-edges",
+        }}
+      />
+    );
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className="sunflower-mascot"
+      style={{
+        position: "fixed",
+        bottom: 22,
+        right: 22,
+        width: 76,
+        height: 76,
+        backgroundImage: `url(${url})`,
+        backgroundSize: `${FRAME_SIZE * GRID_COLS}px auto`,
+        backgroundPosition: position,
+        pointerEvents: "none",
+        zIndex: 2,
+        opacity: preset.beam.opacity,
+        transition:
+          "opacity 4s cubic-bezier(0.4,0,0.2,1), background-position 4s",
+        backgroundRepeat: "no-repeat",
+      }}
+    />
+  );
+}
+```
+
+Note : la `width: 76 / height: 76` mais background-size de la frame entière `256px`. Le sprite est rendu à 76×76, donc le 256×256 frame est compressé. Pour un rendu plus précis, ajuster `backgroundSize`. Voir Step 4 pour le fix.
+
+- [ ] **Step 4: Corriger le `backgroundSize`**
+
+Pour afficher correctement la frame 256×256 dans 76×76 sans compression visuelle, on dimensionne le sprite sheet ainsi : si une frame fait 76 px de large affichée, le sheet fait `76 * GRID_COLS` de large. Donc `backgroundSize: '${76 * 6}px auto' = '456px'`.
+
+Le `backgroundPosition` doit aussi être scaled : `-${col * 76}px -${row * 76}px`.
+
+Refactorer la fonction et le composant :
+
+```tsx
+function getSpritePosition(frameIndex: number, displaySize: number): string {
+  const col = frameIndex % GRID_COLS;
+  const row = Math.floor(frameIndex / GRID_COLS);
+  return `-${col * displaySize}px -${row * displaySize}px`;
+}
+
+export function SunflowerLayer() {
+  // ...
+
+  const displaySize = isHero ? 90 : 76;
+  const position = getSpritePosition(preset.frameIndex, displaySize);
+
+  return (
+    <div
+      style={{
+        // ...
+        width: displaySize,
+        height: displaySize,
+        backgroundImage: `url(${url})`,
+        backgroundSize: `${displaySize * GRID_COLS}px auto`,
+        backgroundPosition: position,
+        // ...
+      }}
+    />
+  );
+}
+```
+
+- [ ] **Step 5: Confirmer le passage**
+
+```bash
+cd frontend && npm test -- SunflowerLayer
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/SunflowerLayer.tsx frontend/src/components/__tests__/SunflowerLayer.test.tsx frontend/public/assets/ambient/
+git commit -m "feat(frontend): add SunflowerLayer (route-aware hero + mascot variants)"
+```
+
+### Task 2.6: Intégration App.tsx + UI Settings
+
+**Files:**
+
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/pages/SettingsPage.tsx`
+- Test: `frontend/src/App.test.tsx` (si existe)
+
+- [ ] **Step 1: Modifier `App.tsx`**
+
+Wrapping de l'App :
+
+```tsx
+import { AmbientLightingProvider } from "./contexts/AmbientLightingContext";
+import { AmbientLightLayer } from "./components/AmbientLightLayer";
+import { SunflowerLayer } from "./components/SunflowerLayer";
+import { useAuth } from "./contexts/AuthContext";
+
+function AppContent() {
+  const { user } = useAuth();
+  const enabled = user?.preferences?.ambient_lighting_enabled !== false; // default true
+
+  return (
+    <AmbientLightingProvider enabled={enabled}>
+      <AmbientLightLayer />
+      <SunflowerLayer />
+      {/* ... routes existantes */}
+    </AmbientLightingProvider>
+  );
+}
+```
+
+(Adapter selon la structure réelle de `App.tsx` — si pas de AuthContext disponible au top-level, lire le pref directement depuis localStorage avec un default `true`.)
+
+- [ ] **Step 2: Modifier `SettingsPage.tsx`**
+
+Localiser le bloc des préférences. Ajouter un Switch :
+
+```tsx
+const [ambientEnabled, setAmbientEnabled] = useState(
+  user?.preferences?.ambient_lighting_enabled !== false,
+);
+
+const handleToggle = async (checked: boolean) => {
+  setAmbientEnabled(checked);
+  await api.put("/api/auth/preferences", { ambient_lighting_enabled: checked });
+};
+
+// JSX
+<div className="settings-row">
+  <div>
+    <h3 className="text-text-primary font-semibold">Effet ambiant lumineux</h3>
+    <p className="text-text-meta text-sm">
+      Affiche un rayon de lumière subtil et un tournesol qui suit la course du
+      soleil.
+    </p>
+  </div>
+  <Switch checked={ambientEnabled} onCheckedChange={handleToggle} />
+</div>;
+```
+
+(Adapter à la lib UI utilisée — si shadcn, c'est `<Switch>` ; si HeadlessUI, c'est `<Switch>` aussi mais import différent.)
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+cd frontend && npm run dev
+```
+
+Ouvrir http://localhost:5173 et vérifier visuellement :
+
+- Le rayon est visible
+- Le halo doux apparaît
+- Le tournesol mascot est visible bottom-right (sur /dashboard) ou hero centré (sur /)
+- Aller sur /settings, toggle off → tout disparaît
+- Toggle on → réapparaît
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/pages/SettingsPage.tsx
+git commit -m "feat(frontend): mount AmbientLightingProvider + AmbientLightLayer + SunflowerLayer in App, add Settings toggle"
+```
+
+### Task 2.7: E2E Playwright
+
+**Files:**
+
+- Create: `frontend/e2e/ambient-lighting.spec.ts`
+
+- [ ] **Step 1: Test E2E**
+
+Créer `frontend/e2e/ambient-lighting.spec.ts`:
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test.describe("ambient lighting v3", () => {
+  test("rayon visible avant hydratation (critical CSS)", async ({ page }) => {
+    await page.goto("/");
+    // Critical CSS doit avoir injecté un <style id="ambient-critical">
+    const styleTag = await page.$("style#ambient-critical");
+    expect(styleTag).toBeTruthy();
+  });
+
+  test("AmbientLightLayer monté après hydratation", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".ambient-light-layer")).toBeVisible();
+  });
+
+  test("SunflowerLayer hero sur landing /", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".sunflower-hero")).toBeVisible();
+  });
+
+  test("SunflowerLayer mascot sur dashboard /dashboard", async ({ page }) => {
+    // Login required for /dashboard — adapter selon auth flow
+    await page.goto("/login");
+    // ... auth steps
+    await page.goto("/dashboard");
+    await expect(page.locator(".sunflower-mascot")).toBeVisible();
+  });
+
+  test("respect prefers-reduced-motion", async ({ page, context }) => {
+    await context.addInitScript(() => {
+      Object.defineProperty(window, "matchMedia", {
+        value: (q: string) => ({
+          matches: q.includes("reduce"),
+          addEventListener: () => {},
+          removeEventListener: () => {},
+        }),
+      });
+    });
+    await page.goto("/");
+    // Le rayon ne doit pas avoir de transition
+    const beam = await page.locator(".ambient-beam");
+    const transition = await beam.evaluate(
+      (el) => getComputedStyle(el).transition,
+    );
+    // Soit transition: none, soit transition: 0s
+    expect(transition).toMatch(/(none|0s)/);
+  });
+});
+```
+
+- [ ] **Step 2: Lancer**
+
+```bash
+cd frontend && npm run test:e2e -- ambient-lighting
+```
+
+Expected: 4-5 tests pass. Le test "mascot sur dashboard" peut nécessiter d'ignorer si auth flow est complexe — l'enrober en `test.skip()` si nécessaire et noter pour follow-up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/e2e/ambient-lighting.spec.ts
+git commit -m "test(frontend): add Playwright E2E for ambient lighting v3"
+```
+
+### Task 2.8: PR2 — Push & PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/ambient-lighting-v3-web
+```
+
+- [ ] **Step 2: Créer la PR**
+
+```bash
+gh pr create --title "feat(ambient-lighting-v3): web platform — AmbientLightLayer + SunflowerLayer + critical CSS" --body "PR2 of 5 — depends on PR1 merged. See spec.
+
+## Test plan
+- [ ] cd frontend && npm test — all green
+- [ ] cd frontend && npm run typecheck — green
+- [ ] cd frontend && npm run test:e2e -- ambient-lighting — green
+- [ ] Manual visual check : sunflower mascot bottom-right, rayon visible, settings toggle works
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Phase 3 — Mobile Platform (PR3)
+
+**Branche:** `feat/ambient-lighting-v3-mobile`
+**Durée estimée:** ~1.5 jour
+**Dépendances:** PR1 mergée. Peut s'exécuter EN PARALLÈLE avec PR2 et PR4.
+
+### Task 3.1: Setup branche + Metro config
+
+**Files:**
+
+- Modify: `mobile/metro.config.js`
+
+- [ ] **Step 1: Créer la branche**
+
+```bash
+git fetch origin
+git checkout -b feat/ambient-lighting-v3-mobile origin/main
+```
+
+- [ ] **Step 2: Étendre metro.config.js**
+
+Ajouter dans `mobile/metro.config.js`:
+
+```js
+const path = require("path");
+const config = getDefaultConfig(__dirname);
+
+config.watchFolders = [
+  ...(config.watchFolders || []),
+  path.resolve(__dirname, "../packages/lighting-engine"),
+];
+
+config.resolver = {
+  ...config.resolver,
+  extraNodeModules: {
+    ...config.resolver.extraNodeModules,
+    "@deepsight/lighting-engine": path.resolve(
+      __dirname,
+      "../packages/lighting-engine",
+    ),
+  },
+};
+
+module.exports = config;
+```
+
+- [ ] **Step 3: Vérifier le résolveur**
+
+```bash
+cd mobile && npx tsc --noEmit
+```
+
+Expected: pas d'erreur "Cannot find module '@deepsight/lighting-engine'".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/metro.config.js
+git commit -m "feat(mobile): wire @deepsight/lighting-engine workspace via Metro extraNodeModules"
+```
+
+### Task 3.2: Copy sprites + AmbientLightingContext
+
+**Files:**
+
+- Copy: `mobile/assets/ambient/sunflower-day.webp`
+- Copy: `mobile/assets/ambient/sunflower-night.webp`
+- Create: `mobile/src/contexts/AmbientLightingContext.tsx`
+- Test: `mobile/src/contexts/__tests__/AmbientLightingContext.test.tsx`
+
+- [ ] **Step 1: Copy sprites**
+
+```bash
+mkdir -p mobile/assets/ambient
+cp assets/ambient/sunflower-day.webp mobile/assets/ambient/
+cp assets/ambient/sunflower-night.webp mobile/assets/ambient/
+```
+
+- [ ] **Step 2: Test failing**
+
+Créer `mobile/src/contexts/__tests__/AmbientLightingContext.test.tsx`:
+
+```tsx
+import React from "react";
+import { renderHook } from "@testing-library/react-native";
+import {
+  AmbientLightingProvider,
+  useAmbientLightingContext,
+} from "../AmbientLightingContext";
+
+describe("AmbientLightingProvider (RN)", () => {
+  it("provides preset", () => {
+    const { result } = renderHook(() => useAmbientLightingContext(), {
+      wrapper: ({ children }) => (
+        <AmbientLightingProvider>{children}</AmbientLightingProvider>
+      ),
+    });
+    expect(result.current.preset).toBeDefined();
+    expect(result.current.preset.frameIndex).toBeGreaterThanOrEqual(0);
+  });
+
+  it("respects enabled=false", () => {
+    const { result } = renderHook(() => useAmbientLightingContext(), {
+      wrapper: ({ children }) => (
+        <AmbientLightingProvider enabled={false}>
+          {children}
+        </AmbientLightingProvider>
+      ),
+    });
+    expect(result.current.enabled).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Implémenter**
+
+Créer `mobile/src/contexts/AmbientLightingContext.tsx`:
+
+```tsx
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { AppState } from "react-native";
+import {
+  getAmbientPresetV3,
+  type AmbientPreset,
+} from "@deepsight/lighting-engine";
+
+interface AmbientLightingContextValue {
+  preset: AmbientPreset;
+  enabled: boolean;
+}
+
+const Ctx = createContext<AmbientLightingContextValue | null>(null);
+
+interface ProviderProps {
+  enabled?: boolean;
+  children: ReactNode;
+}
+
+export function AmbientLightingProvider({
+  enabled = true,
+  children,
+}: ProviderProps) {
+  const [preset, setPreset] = useState<AmbientPreset>(() =>
+    getAmbientPresetV3(new Date()),
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    const update = () => setPreset(getAmbientPresetV3(new Date()));
+
+    const start = () => {
+      update();
+      interval = setInterval(update, 30 * 1000);
+    };
+    const stop = () => {
+      if (interval) clearInterval(interval);
+      interval = null;
+    };
+
+    start();
+
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") start();
+      else stop();
+    });
+
+    return () => {
+      stop();
+      sub.remove();
+    };
+  }, [enabled]);
+
+  return <Ctx.Provider value={{ preset, enabled }}>{children}</Ctx.Provider>;
+}
+
+export function useAmbientLightingContext(): AmbientLightingContextValue {
+  const v = useContext(Ctx);
+  if (!v) {
+    return { preset: getAmbientPresetV3(new Date()), enabled: false };
+  }
+  return v;
+}
+```
+
+- [ ] **Step 4: Confirmer le passage**
+
+```bash
+cd mobile && npm test -- AmbientLightingContext
+```
+
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/src/contexts/AmbientLightingContext.tsx mobile/src/contexts/__tests__/AmbientLightingContext.test.tsx mobile/assets/ambient/
+git commit -m "feat(mobile): add AmbientLightingProvider with AppState pause"
+```
+
+### Task 3.3: AmbientLightLayer Mobile (Reanimated)
+
+**Files:**
+
+- Replace: `mobile/src/components/backgrounds/AmbientLightLayer.tsx`
+- Test: `mobile/src/components/backgrounds/__tests__/AmbientLightLayer.test.tsx`
+
+- [ ] **Step 1: Test failing**
+
+Créer `mobile/src/components/backgrounds/__tests__/AmbientLightLayer.test.tsx`:
+
+```tsx
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { AmbientLightLayer } from "../AmbientLightLayer";
+import { AmbientLightingProvider } from "../../../contexts/AmbientLightingContext";
+
+describe("AmbientLightLayer (RN)", () => {
+  it("renders with absoluteFill and pointerEvents=none", () => {
+    const { getByTestId } = render(
+      <AmbientLightingProvider>
+        <AmbientLightLayer />
+      </AmbientLightingProvider>,
+    );
+    const layer = getByTestId("ambient-light-layer");
+    expect(layer.props.pointerEvents).toBe("none");
+  });
+
+  it("returns null when disabled", () => {
+    const { queryByTestId } = render(
+      <AmbientLightingProvider enabled={false}>
+        <AmbientLightLayer />
+      </AmbientLightingProvider>,
+    );
+    expect(queryByTestId("ambient-light-layer")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Implémenter**
+
+Remplacer `mobile/src/components/backgrounds/AmbientLightLayer.tsx`:
+
+```tsx
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+  Easing,
+} from "react-native-reanimated";
+import { LinearGradient } from "expo-linear-gradient";
+import { rgbToCss } from "@deepsight/lighting-engine";
+import { useAmbientLightingContext } from "../../contexts/AmbientLightingContext";
+
+const TRANSITION_MS = 4000;
+const EASE = Easing.bezier(0.4, 0, 0.2, 1);
+
+export function AmbientLightLayer() {
+  const { preset, enabled } = useAmbientLightingContext();
+  if (!enabled) return null;
+
+  const beamColor = rgbToCss(preset.beam.color, preset.beam.opacity);
+  const haloColor = rgbToCss(preset.colors.primary, preset.beam.opacity * 0.5);
+
+  // Reanimated angle
+  const angle = useSharedValue(preset.beam.angleDeg);
+  React.useEffect(() => {
+    angle.value = withTiming(preset.beam.angleDeg, {
+      duration: preset.isReducedMotion ? 0 : TRANSITION_MS,
+      easing: EASE,
+    });
+  }, [preset.beam.angleDeg, preset.isReducedMotion]);
+
+  const beamStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${angle.value}deg` }],
+  }));
+
+  return (
+    <View
+      testID="ambient-light-layer"
+      pointerEvents="none"
+      style={StyleSheet.absoluteFill}
+    >
+      {/* Halo */}
+      <View
+        style={{
+          position: "absolute",
+          top: -150,
+          left: -150,
+          width: 500,
+          height: 500,
+          borderRadius: 250,
+        }}
+      >
+        <LinearGradient
+          colors={[haloColor, "transparent"]}
+          style={{ flex: 1, opacity: 0.6 }}
+          start={{ x: 0.5, y: 0.5 }}
+          end={{ x: 1, y: 1 }}
+        />
+      </View>
+
+      {/* Beam — gradient horizontal puis rotation */}
+      <Animated.View
+        style={[
+          {
+            position: "absolute",
+            top: "50%",
+            left: "-15%",
+            width: "130%",
+            height: 1.5,
+          },
+          beamStyle,
+        ]}
+      >
+        <LinearGradient
+          colors={["transparent", beamColor, "transparent"]}
+          start={{ x: 0, y: 0.5 }}
+          end={{ x: 1, y: 0.5 }}
+          style={{ flex: 1 }}
+        />
+      </Animated.View>
+    </View>
+  );
+}
+```
+
+- [ ] **Step 3: Confirmer le passage**
+
+```bash
+cd mobile && npm test -- AmbientLightLayer
+```
+
+Expected: PASS — 2 tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/src/components/backgrounds/AmbientLightLayer.tsx mobile/src/components/backgrounds/__tests__/AmbientLightLayer.test.tsx
+git commit -m "feat(mobile): rewrite AmbientLightLayer with Reanimated 4 + engine v3"
+```
+
+### Task 3.4: SunflowerLayer Mobile (mascot only)
+
+**Files:**
+
+- Create: `mobile/src/components/backgrounds/SunflowerLayer.tsx`
+- Test: `mobile/src/components/backgrounds/__tests__/SunflowerLayer.test.tsx`
+
+- [ ] **Step 1: Test failing**
+
+```tsx
+// mobile/src/components/backgrounds/__tests__/SunflowerLayer.test.tsx
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { SunflowerLayer } from "../SunflowerLayer";
+import { AmbientLightingProvider } from "../../../contexts/AmbientLightingContext";
+
+describe("SunflowerLayer (RN)", () => {
+  it("renders mascot bottom-right with pointerEvents=none", () => {
+    const { getByTestId } = render(
+      <AmbientLightingProvider>
+        <SunflowerLayer />
+      </AmbientLightingProvider>,
+    );
+    const layer = getByTestId("sunflower-mascot");
+    expect(layer.props.pointerEvents).toBe("none");
+  });
+
+  it("returns null when disabled", () => {
+    const { queryByTestId } = render(
+      <AmbientLightingProvider enabled={false}>
+        <SunflowerLayer />
+      </AmbientLightingProvider>,
+    );
+    expect(queryByTestId("sunflower-mascot")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Implémenter**
+
+Créer `mobile/src/components/backgrounds/SunflowerLayer.tsx`:
+
+```tsx
+import React from "react";
+import { Image, View } from "react-native";
+import { useAmbientLightingContext } from "../../contexts/AmbientLightingContext";
+
+const FRAME_SIZE = 256;
+const GRID_COLS = 6;
+const DISPLAY_SIZE = 60;
+
+const SPRITE_DAY = require("../../../assets/ambient/sunflower-day.webp");
+const SPRITE_NIGHT = require("../../../assets/ambient/sunflower-night.webp");
+
+export function SunflowerLayer() {
+  const { preset, enabled } = useAmbientLightingContext();
+  if (!enabled) return null;
+
+  const sprite = preset.nightMode === "glowing" ? SPRITE_NIGHT : SPRITE_DAY;
+  const col = preset.frameIndex % GRID_COLS;
+  const row = Math.floor(preset.frameIndex / GRID_COLS);
+
+  return (
+    <View
+      testID="sunflower-mascot"
+      pointerEvents="none"
+      style={{
+        position: "absolute",
+        bottom: 86, // au-dessus du tab bar
+        right: 16,
+        width: DISPLAY_SIZE,
+        height: DISPLAY_SIZE,
+        overflow: "hidden",
+      }}
+    >
+      <Image
+        source={sprite}
+        style={{
+          width: DISPLAY_SIZE * GRID_COLS,
+          height: DISPLAY_SIZE * 4, // 4 rows
+          position: "absolute",
+          left: -col * DISPLAY_SIZE,
+          top: -row * DISPLAY_SIZE,
+        }}
+        resizeMode="cover"
+      />
+    </View>
+  );
+}
+```
+
+- [ ] **Step 3: Confirmer le passage**
+
+```bash
+cd mobile && npm test -- SunflowerLayer
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/src/components/backgrounds/SunflowerLayer.tsx mobile/src/components/backgrounds/__tests__/SunflowerLayer.test.tsx
+git commit -m "feat(mobile): add SunflowerLayer mascot with sprite frame from engine v3"
+```
+
+### Task 3.5: Intégration `_layout.tsx` + UI Settings
+
+**Files:**
+
+- Modify: `mobile/app/_layout.tsx`
+- Modify: `mobile/app/(tabs)/profile.tsx`
+
+- [ ] **Step 1: Modifier `_layout.tsx`**
+
+Wrapping :
+
+```tsx
+import { AmbientLightingProvider } from "../src/contexts/AmbientLightingContext";
+import { AmbientLightLayer } from "../src/components/backgrounds/AmbientLightLayer";
+import { SunflowerLayer } from "../src/components/backgrounds/SunflowerLayer";
+import { useAuth } from "../src/contexts/AuthContext";
+
+export default function RootLayout() {
+  const { user } = useAuth();
+  const enabled = user?.preferences?.ambient_lighting_enabled !== false;
+
+  return (
+    <AmbientLightingProvider enabled={enabled}>
+      <Stack /* existing config */ />
+      <AmbientLightLayer />
+      <SunflowerLayer />
+    </AmbientLightingProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Modifier `profile.tsx` (toggle)**
+
+Ajouter une row :
+
+```tsx
+const [enabled, setEnabled] = useState(
+  user?.preferences?.ambient_lighting_enabled !== false,
+);
+
+const handleToggle = async (val: boolean) => {
+  setEnabled(val);
+  await api.put("/api/auth/preferences", { ambient_lighting_enabled: val });
+};
+
+// JSX
+<View style={styles.row}>
+  <View>
+    <Text style={[styles.title, { color: colors.text.primary }]}>
+      Effet ambiant lumineux
+    </Text>
+    <Text style={[styles.desc, { color: colors.text.meta }]}>
+      Affiche un rayon de lumière subtil et un tournesol qui suit la course du
+      soleil.
+    </Text>
+  </View>
+  <Switch value={enabled} onValueChange={handleToggle} />
+</View>;
+```
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+cd mobile && npx expo start
+```
+
+Lancer sur simulateur. Vérifier visuel : rayon, halo, tournesol mascot bas-droite, toggle profil.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/app/_layout.tsx mobile/app/\(tabs\)/profile.tsx
+git commit -m "feat(mobile): mount AmbientLightingProvider + overlays in _layout, add Settings toggle"
+```
+
+### Task 3.6: Maestro snapshot test
+
+**Files:**
+
+- Create: `mobile/.maestro/ambient-lighting.yaml`
+
+- [ ] **Step 1: Créer le test**
+
+```yaml
+# mobile/.maestro/ambient-lighting.yaml
+appId: com.deepsight.app
+---
+- launchApp
+- assertVisible:
+    id: "sunflower-mascot"
+- takeScreenshot: "ambient-lighting-home"
+- tapOn: "Profil"
+- assertVisible: "Effet ambiant lumineux"
+- takeScreenshot: "ambient-lighting-settings"
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cd mobile && maestro test .maestro/ambient-lighting.yaml
+```
+
+Expected: 2 screenshots taken, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/.maestro/ambient-lighting.yaml
+git commit -m "test(mobile): add Maestro snapshot for ambient lighting v3"
+```
+
+### Task 3.7: PR3 — Push & PR
+
+```bash
+git push -u origin feat/ambient-lighting-v3-mobile
+gh pr create --title "feat(ambient-lighting-v3): mobile platform — Reanimated 4 + sprite mascot" --body "PR3 of 5 — depends on PR1 merged."
+```
+
+---
+
+## Phase 4 — Extension Platform (PR4)
+
+**Branche:** `feat/ambient-lighting-v3-extension`
+**Durée estimée:** ~1 jour
+**Dépendances:** PR1 ET PR0 (`feat/extension-sidepanel-v3`) mergées. Peut s'exécuter EN PARALLÈLE avec PR2 et PR3.
+
+### Task 4.1: Setup branche + sprites + webpack
+
+**Files:**
+
+- Modify: `extension/webpack.config.js`
+- Copy: sprites vers `extension/public/assets/ambient/`
+
+- [ ] **Step 1: Branche depuis main (post-PR0 merge)**
+
+```bash
+git fetch origin
+git checkout -b feat/ambient-lighting-v3-extension origin/main
+```
+
+- [ ] **Step 2: Copy sprites**
+
+```bash
+mkdir -p extension/public/assets/ambient
+cp assets/ambient/sunflower-day.webp extension/public/assets/ambient/
+cp assets/ambient/sunflower-night.webp extension/public/assets/ambient/
+```
+
+- [ ] **Step 3: Étendre webpack pour copier les sprites au build**
+
+Modifier `extension/webpack.config.js` pour ajouter dans `plugins`:
+
+```js
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+
+// dans plugins:
+new CopyWebpackPlugin({
+  patterns: [
+    { from: 'public/assets/ambient', to: 'assets/ambient' },
+  ],
+}),
+```
+
+Si `copy-webpack-plugin` n'est pas installé :
+
+```bash
+cd extension && npm install --save-dev copy-webpack-plugin
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+cd extension && npm run build
+ls dist/assets/ambient/
+```
+
+Expected: sunflower-day.webp + sunflower-night.webp présents dans dist.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/webpack.config.js extension/package.json extension/package-lock.json extension/public/assets/ambient/
+git commit -m "feat(extension): wire sprite sheets via copy-webpack-plugin"
+```
+
+### Task 4.2: AmbientLightingContext + AmbientLightLayer (sidepanel)
+
+**Files:**
+
+- Create: `extension/src/sidepanel/contexts/AmbientLightingContext.tsx`
+- Create: `extension/src/sidepanel/hooks/useAmbientPreset.ts`
+- Replace: `extension/src/sidepanel/components/AmbientLightLayer.tsx`
+- Test: `extension/__tests__/sidepanel/AmbientLightLayer.test.tsx`
+
+- [ ] **Step 1: Créer le Context** (similar to web mais avec `chrome.storage` sync optionnel pour le pref)
+
+Créer `extension/src/sidepanel/contexts/AmbientLightingContext.tsx`:
+
+```tsx
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  getAmbientPresetV3,
+  type AmbientPreset,
+} from "@deepsight/lighting-engine";
+
+interface Value {
+  preset: AmbientPreset;
+  enabled: boolean;
+}
+
+const Ctx = createContext<Value | null>(null);
+
+interface ProviderProps {
+  enabled?: boolean;
+  children: ReactNode;
+}
+
+export function AmbientLightingProvider({
+  enabled = true,
+  children,
+}: ProviderProps) {
+  const [preset, setPreset] = useState<AmbientPreset>(() =>
+    getAmbientPresetV3(new Date()),
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    const update = () => setPreset(getAmbientPresetV3(new Date()));
+    update();
+    const interval = setInterval(update, 30_000);
+    return () => clearInterval(interval);
+  }, [enabled]);
+
+  return <Ctx.Provider value={{ preset, enabled }}>{children}</Ctx.Provider>;
+}
+
+export function useAmbientLightingContext(): Value {
+  const v = useContext(Ctx);
+  if (!v) return { preset: getAmbientPresetV3(new Date()), enabled: false };
+  return v;
+}
+```
+
+- [ ] **Step 2: AmbientLightLayer pour sidepanel**
+
+Créer `extension/src/sidepanel/components/AmbientLightLayer.tsx` (overwrite l'orphelin):
+
+```tsx
+import { useAmbientLightingContext } from "../contexts/AmbientLightingContext";
+import { rgbToCss } from "@deepsight/lighting-engine";
+
+export function AmbientLightLayer() {
+  const { preset, enabled } = useAmbientLightingContext();
+  if (!enabled) return null;
+
+  const beamColor = rgbToCss(preset.beam.color, preset.beam.opacity);
+  const haloColor = rgbToCss(preset.colors.primary, preset.beam.opacity * 0.5);
+  const accentColor = preset.haloAccentColor;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="ambient-light-layer"
+      style={{
+        position: "fixed",
+        inset: 0,
+        pointerEvents: "none",
+        zIndex: 1,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: -100,
+          left: -100,
+          width: 360,
+          height: 360,
+          background: accentColor
+            ? `radial-gradient(circle, ${haloColor} 0%, ${accentColor} 40%, transparent 70%)`
+            : `radial-gradient(circle, ${haloColor}, transparent 60%)`,
+          filter: "blur(30px)",
+          mixBlendMode: "screen",
+          transition: "background 4s cubic-bezier(0.4,0,0.2,1)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "-15%",
+          width: "130%",
+          height: 1.5,
+          background: `linear-gradient(90deg, transparent, ${beamColor} 50%, transparent)`,
+          boxShadow: `0 0 12px ${beamColor}, 0 0 32px ${beamColor}`,
+          transform: `rotate(${preset.beam.angleDeg}deg)`,
+          transition:
+            "transform 4s cubic-bezier(0.4,0,0.2,1), background 4s, box-shadow 4s",
+        }}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Test**
+
+```tsx
+// extension/__tests__/sidepanel/AmbientLightLayer.test.tsx
+import { render } from "@testing-library/react";
+import { AmbientLightLayer } from "../../src/sidepanel/components/AmbientLightLayer";
+import { AmbientLightingProvider } from "../../src/sidepanel/contexts/AmbientLightingContext";
+
+describe("AmbientLightLayer (extension)", () => {
+  it("renders fixed inset overlay", () => {
+    const { container } = render(
+      <AmbientLightingProvider>
+        <AmbientLightLayer />
+      </AmbientLightingProvider>,
+    );
+    expect(container.querySelector(".ambient-light-layer")).toBeTruthy();
+  });
+
+  it("returns null when disabled", () => {
+    const { container } = render(
+      <AmbientLightingProvider enabled={false}>
+        <AmbientLightLayer />
+      </AmbientLightingProvider>,
+    );
+    expect(container.querySelector(".ambient-light-layer")).toBeFalsy();
+  });
+});
+```
+
+```bash
+cd extension && npm test -- sidepanel/AmbientLightLayer
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/src/sidepanel/contexts/ extension/src/sidepanel/components/AmbientLightLayer.tsx extension/__tests__/sidepanel/AmbientLightLayer.test.tsx
+git commit -m "feat(extension/sidepanel): add AmbientLightingProvider + rewrite AmbientLightLayer with engine v3"
+```
+
+### Task 4.3: SunflowerLayer extension
+
+**Files:**
+
+- Create: `extension/src/sidepanel/components/SunflowerLayer.tsx`
+- Create: `extension/src/viewer/components/SunflowerLayer.tsx` (idem)
+- Test: `extension/__tests__/sidepanel/SunflowerLayer.test.tsx`
+
+- [ ] **Step 1: Implémenter (mascot only — pas de hero)**
+
+Créer `extension/src/sidepanel/components/SunflowerLayer.tsx`:
+
+```tsx
+import { useAmbientLightingContext } from "../contexts/AmbientLightingContext";
+
+const FRAME_SIZE = 256;
+const GRID_COLS = 6;
+const DISPLAY_SIZE = 56;
+
+export function SunflowerLayer() {
+  const { preset, enabled } = useAmbientLightingContext();
+  if (!enabled) return null;
+
+  const sprite =
+    preset.nightMode === "glowing"
+      ? "sunflower-night.webp"
+      : "sunflower-day.webp";
+  const col = preset.frameIndex % GRID_COLS;
+  const row = Math.floor(preset.frameIndex / GRID_COLS);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="sunflower-mascot"
+      style={{
+        position: "fixed",
+        bottom: 14,
+        right: 14,
+        width: DISPLAY_SIZE,
+        height: DISPLAY_SIZE,
+        backgroundImage: `url(/assets/ambient/${sprite})`,
+        backgroundSize: `${DISPLAY_SIZE * GRID_COLS}px auto`,
+        backgroundPosition: `-${col * DISPLAY_SIZE}px -${row * DISPLAY_SIZE}px`,
+        backgroundRepeat: "no-repeat",
+        zIndex: 2,
+        pointerEvents: "none",
+        opacity: preset.beam.opacity,
+        transition:
+          "opacity 4s cubic-bezier(0.4,0,0.2,1), background-position 4s",
+      }}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Idem pour viewer**
+
+Copier le même fichier dans `extension/src/viewer/components/SunflowerLayer.tsx` (même contenu, l'import du context devra adapter — soit on duplique aussi le Context dans viewer, soit on partage). Décision : pour Phase 4 on duplique `AmbientLightingContext` aussi dans viewer (pas de hero, code identique).
+
+- [ ] **Step 3: Test**
+
+```tsx
+// extension/__tests__/sidepanel/SunflowerLayer.test.tsx
+import { render } from "@testing-library/react";
+import { SunflowerLayer } from "../../src/sidepanel/components/SunflowerLayer";
+import { AmbientLightingProvider } from "../../src/sidepanel/contexts/AmbientLightingContext";
+
+describe("SunflowerLayer (extension sidepanel)", () => {
+  it("renders mascot fixed bottom-right", () => {
+    const { container } = render(
+      <AmbientLightingProvider>
+        <SunflowerLayer />
+      </AmbientLightingProvider>,
+    );
+    expect(container.querySelector(".sunflower-mascot")).toBeTruthy();
+  });
+
+  it("returns null when disabled", () => {
+    const { container } = render(
+      <AmbientLightingProvider enabled={false}>
+        <SunflowerLayer />
+      </AmbientLightingProvider>,
+    );
+    expect(container.querySelector(".sunflower-mascot")).toBeFalsy();
+  });
+});
+```
+
+```bash
+cd extension && npm test -- SunflowerLayer
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/src/sidepanel/components/SunflowerLayer.tsx extension/src/viewer/components/SunflowerLayer.tsx extension/src/viewer/contexts/ extension/__tests__/sidepanel/SunflowerLayer.test.tsx
+git commit -m "feat(extension): add SunflowerLayer mascot for sidepanel + viewer"
+```
+
+### Task 4.4: Intégration App.tsx (sidepanel + popup + viewer)
+
+**Files:**
+
+- Modify: `extension/src/sidepanel/App.tsx`
+- Modify: `extension/src/viewer/ViewerApp.tsx`
+- Modify: `extension/src/popup/App.tsx`
+
+- [ ] **Step 1: Sidepanel App.tsx**
+
+```tsx
+import { AmbientLightingProvider } from "./contexts/AmbientLightingContext";
+import { AmbientLightLayer } from "./components/AmbientLightLayer";
+import { SunflowerLayer } from "./components/SunflowerLayer";
+// ... existing imports (LoginView, MainView, etc.)
+
+export function App() {
+  // Read pref from chrome.storage or default true
+  // ... existing auth state
+  const enabled = userPrefs?.ambient_lighting_enabled !== false;
+
+  return (
+    <AmbientLightingProvider enabled={enabled}>
+      <AmbientLightLayer />
+      <SunflowerLayer />
+      {/* existing routes / views */}
+    </AmbientLightingProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Viewer App**
+
+Idem pour `extension/src/viewer/ViewerApp.tsx`.
+
+- [ ] **Step 3: Popup App (sans SunflowerLayer)**
+
+Pour `extension/src/popup/App.tsx`, **monter uniquement** AmbientLightLayer (pas de tournesol, espace 360×600 trop contraint) :
+
+```tsx
+import { AmbientLightingProvider } from "./contexts/AmbientLightingContext";
+import { AmbientLightLayer } from "./components/AmbientLightLayer";
+
+export function App() {
+  return (
+    <AmbientLightingProvider>
+      <AmbientLightLayer />
+      {/* popup content */}
+    </AmbientLightingProvider>
+  );
+}
+```
+
+- [ ] **Step 4: Build & test loadunpacked**
+
+```bash
+cd extension && npm run typecheck && npm run build
+```
+
+Expected: 0 erreur. Charger `dist/` dans Chrome (chrome://extensions, mode dev), ouvrir le sidepanel et le popup, vérifier visuel.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/sidepanel/App.tsx extension/src/viewer/ViewerApp.tsx extension/src/popup/App.tsx extension/src/popup/contexts/ extension/src/popup/components/AmbientLightLayer.tsx
+git commit -m "feat(extension): mount ambient lighting overlays in 3 entries (sidepanel + viewer + popup)"
+```
+
+### Task 4.5: Connect BeamCard to Context (modif minimal)
+
+**Files:**
+
+- Modify: `extension/src/sidepanel/shared/BeamCard.tsx` (si livrée par PR0 et accessible)
+
+- [ ] **Step 1: Lire BeamCard actuel (livré par PR0)**
+
+```bash
+cat extension/src/sidepanel/shared/BeamCard.tsx
+```
+
+- [ ] **Step 2: Ajouter un `useContext` optionnel**
+
+Modifier la signature pour qu'elle lise le Context si présent :
+
+```tsx
+import { useAmbientLightingContext } from "../contexts/AmbientLightingContext";
+
+interface BeamCardProps {
+  children: ReactNode;
+  beamColor?: string;
+  haloColor?: string;
+  angle?: number;
+  intensity?: number;
+  className?: string;
+  onClick?: () => void;
+  /** If true, derive beamColor/haloColor/angle/intensity from AmbientLightingContext (overrides props). */
+  usePreset?: boolean;
+}
+
+export function BeamCard({
+  children,
+  beamColor: beamColorProp,
+  haloColor: haloColorProp,
+  angle: angleProp,
+  intensity: intensityProp,
+  className,
+  onClick,
+  usePreset = true, // default ON pour intégration auto
+}: BeamCardProps) {
+  let preset: ReturnType<typeof useAmbientLightingContext> | null = null;
+  try {
+    if (usePreset) preset = useAmbientLightingContext();
+  } catch {
+    /* no provider — use props */
+  }
+
+  const beamColor = preset?.enabled
+    ? rgbToCss(preset.preset.beam.color, preset.preset.beam.opacity)
+    : (beamColorProp ?? "#d4a574");
+
+  const haloColor = preset?.enabled
+    ? rgbToCss(preset.preset.colors.primary, preset.preset.beam.opacity * 0.5)
+    : (haloColorProp ?? "#d4a574");
+
+  const angle = preset?.enabled
+    ? preset.preset.beam.angleDeg
+    : (angleProp ?? 22);
+  const intensity = preset?.enabled
+    ? preset.preset.beam.opacity
+    : (intensityProp ?? 0.4);
+
+  // ... rest of existing render with beamColor/haloColor/angle/intensity
+}
+```
+
+- [ ] **Step 3: Build & verify**
+
+```bash
+cd extension && npm run typecheck && npm run build
+```
+
+Expected: green. Le redesign MainView V3 livré par PR0 reste inchangé fonctionnellement (ses BeamCard prennent maintenant les couleurs du preset si Provider présent).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/src/sidepanel/shared/BeamCard.tsx
+git commit -m "feat(extension): wire BeamCard to AmbientLightingContext via optional usePreset prop"
+```
+
+### Task 4.6: PR4 — Push & PR
+
+```bash
+git push -u origin feat/ambient-lighting-v3-extension
+gh pr create --title "feat(ambient-lighting-v3): extension platform — sidepanel + popup + viewer + BeamCard integration" --body "PR4 of 5 — depends on PR1 + PR0 (extension-sidepanel-v3) merged."
+```
+
+---
+
+## Phase 5 — Cleanup (PR5)
+
+**Branche:** `feat/ambient-lighting-v3-cleanup`
+**Durée estimée:** ~0.5 jour
+**Dépendances:** PR2 + PR3 + PR4 mergées.
+
+### Task 5.1: Supprimer les composants legacy
+
+**Files:**
+
+- Delete: `frontend/src/hooks/useTimeOfDay.ts`
+- Delete: `frontend/src/components/AmbientLightDevPanel.tsx`
+- Delete: `frontend/src/hooks/useAmbientLightingFeatureFlag.ts`
+- Delete: `mobile/src/hooks/useTimeOfDay.ts`
+
+- [ ] **Step 1: Branche**
+
+```bash
+git fetch origin
+git checkout -b feat/ambient-lighting-v3-cleanup origin/main
+```
+
+- [ ] **Step 2: Vérifier qu'aucun consumer**
+
+```bash
+grep -rn "useTimeOfDay\|AmbientLightDevPanel\|useAmbientLightingFeatureFlag" frontend/src mobile/src extension/src
+```
+
+Expected: 0 résultat. Si résultats, ce sont des consumers à migrer ou supprimer dans cette task aussi.
+
+- [ ] **Step 3: Supprimer**
+
+```bash
+rm frontend/src/hooks/useTimeOfDay.ts
+rm frontend/src/components/AmbientLightDevPanel.tsx
+rm frontend/src/hooks/useAmbientLightingFeatureFlag.ts
+rm mobile/src/hooks/useTimeOfDay.ts
+```
+
+- [ ] **Step 4: Lancer typecheck partout**
+
+```bash
+cd frontend && npm run typecheck
+cd ../mobile && npm run typecheck
+cd ../extension && npm run typecheck
+```
+
+Expected: 0 erreur partout.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "chore(ambient-lighting): remove v1/v2 legacy (useTimeOfDay, AmbientLightDevPanel, feature flag)"
+```
+
+### Task 5.2: PRD migration v2 → v3
+
+**Files:**
+
+- Rename: `docs/PRD-ambient-lighting-v2.md` → `docs/PRD-ambient-lighting-v3.md`
+- Modify: PRD content with v3 reality
+
+- [ ] **Step 1: Renommer**
+
+```bash
+git mv docs/PRD-ambient-lighting-v2.md docs/PRD-ambient-lighting-v3.md
+```
+
+- [ ] **Step 2: Mise à jour du contenu**
+
+Ouvrir `docs/PRD-ambient-lighting-v3.md`. Remplacer :
+
+- Header `**Version**: v2` → `**Version**: v3`
+- Section status : `Implemented` → `Implemented v3 (PRs #X #Y #Z)`
+- Description : ajouter mention du tournesol, du sprite pipeline, du critical CSS
+- Architecture : pointer vers `docs/superpowers/specs/2026-04-26-ambient-lighting-v3-design.md`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/PRD-ambient-lighting-v3.md
+git commit -m "docs(ambient-lighting): migrate PRD to v3"
+```
+
+### Task 5.3: CHANGELOG entry
+
+- [ ] **Step 1: Ajouter une entry**
+
+Modifier `CHANGELOG.md` (ou créer si absent), ajouter en haut :
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- **Ambient Lighting v3** — refonte complète cross-platform (web/mobile/extension) :
+  - Beam de précision suivant l'arc solaire avec interpolation cubic-bezier
+  - Tournesol 3D photoréaliste héliotrope (luminescent la nuit)
+  - Pipeline pré-rendu Three.js → 2 sprite WebP (~150KB total)
+  - Critical CSS preload (rayon visible avant hydratation React)
+  - Toggle préférences user + respect prefers-reduced-motion
+  - Design tokens textuels shifted vers blanc cassé (lisibilité)
+
+### Removed
+
+- `useTimeOfDay` legacy (web + mobile)
+- `AmbientLightDevPanel` (dev panel obsolète)
+- `useAmbientLightingFeatureFlag` (PostHog flag plus utilisé)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): add Ambient Lighting v3 entry"
+```
+
+### Task 5.4: PR5 — Push & PR
+
+```bash
+git push -u origin feat/ambient-lighting-v3-cleanup
+gh pr create --title "chore(ambient-lighting-v3): cleanup legacy + PRD update + CHANGELOG" --body "PR5 of 5 — final cleanup."
+```
+
+---
+
+## Self-Review Checklist (après écriture)
+
+**1. Spec coverage** : pour chaque section du spec, identifier la task correspondante.
+
+| Spec section          | Task                                                               |
+| --------------------- | ------------------------------------------------------------------ |
+| §1 Objectif           | Plan global                                                        |
+| §2 Décisions          | Captées dans header + tâches                                       |
+| §3 Architecture       | Tasks 1.1-1.6 + 2.3 + 3.2 + 4.2 (engine + 3 providers)             |
+| §4 API engine v3      | Tasks 1.2-1.6                                                      |
+| §5 Pipeline tournesol | Task 1.7                                                           |
+| §6.1 Web              | Tasks 2.1-2.8                                                      |
+| §6.2 Mobile           | Tasks 3.1-3.7                                                      |
+| §6.3 Extension        | Tasks 4.1-4.6                                                      |
+| §7 Audit textes       | Tasks 1.8-1.10                                                     |
+| §8 User preferences   | Tasks 1.11 + 2.6 + 3.5                                             |
+| §9 Tests & a11y       | Tâches inline (test step à chaque task)                            |
+| §10 Roadmap           | Phase 1-5 ordering                                                 |
+| §11 Risques           | Adressés dans tasks (cap intensity, AppState pause, bundle budget) |
+| §12 Hors scope        | Pas de tâche (volontaire)                                          |
+
+**2. Placeholder scan** : aucun "TBD/TODO/implement later" trouvé. Step 6.1 recommande "adapter à la lib UI utilisée" — c'est une instruction conditionnelle, pas un placeholder.
+
+**3. Type consistency** : `getAmbientPresetV3` est utilisé partout (Tasks 1.6, 2.2, 2.3, 2.4, 2.5, 3.2, 4.2, 4.3). `AmbientPreset` étendu en Task 1.2 est consistant. `AmbientLightingProvider` / `useAmbientLightingContext` cohérents sur web/mobile/extension. `getSpriteFrameIndex` utilisé en 1.4. `KEYFRAMES_V3` en 1.5/1.6.
+
+**4. Ambiguity** : Step 4.5 "Connect BeamCard to Context" dépend de la disponibilité de BeamCard livré par PR0 — fallback expliqué (props statiques default). Step 2.2 plugin Vite peut nécessiter un ajustement si vite-plugin-html déjà utilisé — adressé en commentaire.
+
+---
+
+## Execution Handoff
+
+**Plan complet et sauvegardé dans `docs/superpowers/plans/2026-04-26-ambient-lighting-v3.md`.**
+
+Deux options pour exécuter ce plan :
+
+**1. Subagent-Driven (recommandée pour ce plan multi-PR cross-platform)** — je dispatch un fresh subagent par task, review entre les tasks, fast iteration. Particulièrement adapté pour PR2/PR3/PR4 qui peuvent s'exécuter en parallèle (3 agents simultanés).
+
+**2. Inline Execution** — j'exécute les tasks dans cette session avec executing-plans, batch avec checkpoints.
+
+**Quel approche tu préfères ?**

--- a/docs/superpowers/plans/2026-04-27-voice-prefs-apply-button.md
+++ b/docs/superpowers/plans/2026-04-27-voice-prefs-apply-button.md
@@ -1,0 +1,2033 @@
+# Voice Prefs Apply Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-change auto-save in DeepSight web voice settings with a staged "Apply" flow backed by a global provider and a floating toolbar; when an ElevenLabs call is active and a restart-required field changes, Apply silently restarts the session via the existing `useVoiceChat.restart()`.
+
+**Architecture:** A new `VoicePrefsStagingProvider` mounted at the root holds `applied` (last persisted prefs) and `staged` (pending diff). Both `VoiceSettings` (full page) and `VoiceLiveSettings` (in-call panel) write changes through `stage()` instead of calling `voiceApi.updatePreferences()` directly. A `StagedPrefsToolbar` floating component renders globally while changes are pending, exposing Apply / Cancel. Communication with the active call goes through 2 new events on the existing `voicePrefsBus`: `call_status_changed` (hook → provider) and `apply_with_restart` (provider → hook).
+
+**Tech Stack:** React 18, TypeScript strict, Tailwind CSS, Framer Motion, Vitest + Testing Library, Playwright. Working directory: `C:\Users\33667\DeepSight-Main` (frontend at `frontend/`).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-27-voice-prefs-apply-button-design.md`
+
+---
+
+## File Structure
+
+### NEW files
+
+| Path | Responsibility |
+|---|---|
+| `frontend/src/components/voice/staging/restartRequiredFields.ts` | Static set of fields that need a session restart + `isRestartRequired(staged, catalog)` helper |
+| `frontend/src/components/voice/staging/VoicePrefsStagingProvider.tsx` | React Context Provider holding `applied`, `staged`, `callActive`, exposing `stage` / `cancel` / `apply` |
+| `frontend/src/components/voice/staging/StagedPrefsToolbar.tsx` | Floating toolbar UI rendered globally when `hasChanges` |
+| `frontend/src/components/voice/staging/__tests__/restartRequiredFields.test.ts` | Unit tests for the helper |
+| `frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx` | Unit tests for the provider |
+| `frontend/src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx` | Unit tests for the toolbar |
+| `frontend/e2e/voice-apply-flow.spec.ts` | E2E happy path |
+
+### MODIFIED files
+
+| Path | What changes |
+|---|---|
+| `frontend/src/components/voice/voicePrefsBus.ts` | Extend `VoicePrefsEvent` with 2 new event types |
+| `frontend/src/components/voice/__tests__/voicePrefsBus.test.ts` (create if missing) | Cover new event types |
+| `frontend/src/components/voice/useVoiceChat.ts` | Publish `call_status_changed`; subscribe to `apply_with_restart` |
+| `frontend/src/components/voice/__tests__/useVoiceChat.test.ts` | New test cases for bus events |
+| `frontend/src/components/voice/VoiceLiveSettings.tsx` | Replace direct `voiceApi.updatePreferences` calls with `stage()` for non-live fields |
+| `frontend/src/components/voice/VoiceSettings.tsx` | Replace `savePreferences` with `stage()` everywhere; reset-defaults stages |
+| `frontend/src/components/voice/__tests__/VoiceLiveSettings.test.tsx` | Adapt to staging-based behavior |
+| `frontend/src/components/voice/__tests__/VoiceSettings.test.tsx` (or equivalent if exists) | Idem |
+| `frontend/src/components/voice/VoiceModal.tsx` | Remove `restartRequired` state + amber banner + `restart_required` subscription |
+| `frontend/src/App.tsx` | Wrap tree with `<VoicePrefsStagingProvider>` and render `<StagedPrefsToolbar />` |
+
+---
+
+## Tasks
+
+### Task 1: Static set + isRestartRequired helper
+
+**Files:**
+
+- Create: `frontend/src/components/voice/staging/restartRequiredFields.ts`
+- Test: `frontend/src/components/voice/staging/__tests__/restartRequiredFields.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/components/voice/staging/__tests__/restartRequiredFields.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  RESTART_REQUIRED_FIELDS,
+  isRestartRequired,
+} from "../restartRequiredFields";
+import type { VoiceChatSpeedPreset } from "../../../../services/api";
+
+const PRESETS: VoiceChatSpeedPreset[] = [
+  { id: "1x", label_fr: "Normal", label_en: "Normal", api_speed: 1, playback_rate: 1, concise: false },
+  { id: "1.5x", label_fr: "Rapide", label_en: "Fast", api_speed: 1, playback_rate: 1.5, concise: false },
+  { id: "3x", label_fr: "Concis", label_en: "Concise", api_speed: 1, playback_rate: 1, concise: true },
+];
+
+describe("RESTART_REQUIRED_FIELDS", () => {
+  it("includes voice_id, voice_name, models, voice tuning, language, gender", () => {
+    for (const key of [
+      "voice_id",
+      "voice_name",
+      "tts_model",
+      "voice_chat_model",
+      "stability",
+      "similarity_boost",
+      "style",
+      "use_speaker_boost",
+      "language",
+      "gender",
+    ] as const) {
+      expect(RESTART_REQUIRED_FIELDS.has(key)).toBe(true);
+    }
+  });
+
+  it("does not include soft fields", () => {
+    for (const key of [
+      "ptt_key",
+      "input_mode",
+      "turn_timeout",
+      "soft_timeout_seconds",
+      "speed",
+      "voice_chat_speed_preset",
+    ] as const) {
+      expect(RESTART_REQUIRED_FIELDS.has(key)).toBe(false);
+    }
+  });
+});
+
+describe("isRestartRequired", () => {
+  it("returns false for empty staged", () => {
+    expect(isRestartRequired({}, PRESETS)).toBe(false);
+  });
+
+  it("returns true when a hard field is staged", () => {
+    expect(isRestartRequired({ voice_id: "abc" }, PRESETS)).toBe(true);
+  });
+
+  it("returns false when only soft fields are staged", () => {
+    expect(
+      isRestartRequired(
+        { ptt_key: "Space", input_mode: "vad", turn_timeout: 12 },
+        PRESETS,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when staged voice_chat_speed_preset is a concise variant", () => {
+    expect(
+      isRestartRequired({ voice_chat_speed_preset: "3x" }, PRESETS),
+    ).toBe(true);
+  });
+
+  it("returns false when staged voice_chat_speed_preset is a non-concise variant", () => {
+    expect(
+      isRestartRequired({ voice_chat_speed_preset: "1.5x" }, PRESETS),
+    ).toBe(false);
+  });
+
+  it("returns false if catalog is empty (presets unknown → assume non-restart)", () => {
+    expect(isRestartRequired({ voice_chat_speed_preset: "3x" }, [])).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/voice/staging/__tests__/restartRequiredFields.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// frontend/src/components/voice/staging/restartRequiredFields.ts
+import type {
+  VoicePreferences,
+  VoiceChatSpeedPreset,
+} from "../../../services/api";
+
+/**
+ * Fields that, when changed, require a fresh ElevenLabs session
+ * (start/stop) for the change to take effect — they are baked into the
+ * agent at startSession() time.
+ *
+ * Soft fields (input_mode, ptt_key, turn_timeout, soft_timeout_seconds,
+ * speed, voice_chat_speed_preset non-concise) are persisted but do not
+ * require a session restart.
+ *
+ * Live fields (volume, playback_rate) are not staged at all — they apply
+ * directly to the DOM <audio> elements.
+ */
+export const RESTART_REQUIRED_FIELDS: ReadonlySet<keyof VoicePreferences> =
+  new Set<keyof VoicePreferences>([
+    "voice_id",
+    "voice_name",
+    "tts_model",
+    "voice_chat_model",
+    "stability",
+    "similarity_boost",
+    "style",
+    "use_speaker_boost",
+    "language",
+    "gender",
+  ]);
+
+/**
+ * Decide whether the staged diff requires an ElevenLabs session restart
+ * to take effect. Handles the special case of voice_chat_speed_preset:
+ * only concise variants need a restart (because they inject a system
+ * prompt server-side at agent creation).
+ */
+export function isRestartRequired(
+  staged: Partial<VoicePreferences>,
+  speedPresets: VoiceChatSpeedPreset[],
+): boolean {
+  for (const key of Object.keys(staged) as (keyof VoicePreferences)[]) {
+    if (RESTART_REQUIRED_FIELDS.has(key)) return true;
+    if (key === "voice_chat_speed_preset") {
+      const presetId = staged.voice_chat_speed_preset;
+      const preset = speedPresets.find((p) => p.id === presetId);
+      if (preset?.concise) return true;
+    }
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/voice/staging/__tests__/restartRequiredFields.test.ts`
+Expected: PASS — 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/staging/restartRequiredFields.ts frontend/src/components/voice/staging/__tests__/restartRequiredFields.test.ts
+git commit -m "feat(voice): add RESTART_REQUIRED_FIELDS + isRestartRequired helper"
+```
+
+---
+
+### Task 2: Extend voicePrefsBus event types
+
+**Files:**
+
+- Modify: `frontend/src/components/voice/voicePrefsBus.ts`
+- Test: `frontend/src/components/voice/__tests__/voicePrefsBus.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/components/voice/__tests__/voicePrefsBus.test.ts
+import { describe, it, expect, vi } from "vitest";
+import {
+  emitVoicePrefsEvent,
+  subscribeVoicePrefsEvents,
+  presetToPlaybackRate,
+} from "../voicePrefsBus";
+
+describe("voicePrefsBus", () => {
+  it("delivers playback_rate_changed (legacy)", () => {
+    const listener = vi.fn();
+    const unsub = subscribeVoicePrefsEvents(listener);
+    emitVoicePrefsEvent({ type: "playback_rate_changed", value: 1.25 });
+    expect(listener).toHaveBeenCalledWith({
+      type: "playback_rate_changed",
+      value: 1.25,
+    });
+    unsub();
+  });
+
+  it("delivers apply_with_restart (new)", () => {
+    const listener = vi.fn();
+    const unsub = subscribeVoicePrefsEvents(listener);
+    emitVoicePrefsEvent({ type: "apply_with_restart" });
+    expect(listener).toHaveBeenCalledWith({ type: "apply_with_restart" });
+    unsub();
+  });
+
+  it("delivers call_status_changed (new)", () => {
+    const listener = vi.fn();
+    const unsub = subscribeVoicePrefsEvents(listener);
+    emitVoicePrefsEvent({ type: "call_status_changed", active: true });
+    expect(listener).toHaveBeenCalledWith({
+      type: "call_status_changed",
+      active: true,
+    });
+    unsub();
+  });
+
+  it("unsubscribe stops delivery", () => {
+    const listener = vi.fn();
+    const unsub = subscribeVoicePrefsEvents(listener);
+    unsub();
+    emitVoicePrefsEvent({ type: "apply_with_restart" });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("preserves presetToPlaybackRate behavior", () => {
+    expect(presetToPlaybackRate("1x")).toBe(1);
+    expect(presetToPlaybackRate("1.5x")).toBe(1.5);
+    expect(presetToPlaybackRate("unknown")).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/voicePrefsBus.test.ts`
+Expected: FAIL on `apply_with_restart` and `call_status_changed` types (TS narrowing rejects unknown event types).
+
+- [ ] **Step 3: Update the union type**
+
+Edit `frontend/src/components/voice/voicePrefsBus.ts`. Replace the existing `VoicePrefsEvent` type definition with:
+
+```ts
+export type VoicePrefsEvent =
+  | { type: "playback_rate_changed"; value: number }
+  | { type: "restart_required"; reason: string }
+  | { type: "apply_with_restart" }
+  | { type: "call_status_changed"; active: boolean };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/voicePrefsBus.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/voicePrefsBus.ts frontend/src/components/voice/__tests__/voicePrefsBus.test.ts
+git commit -m "feat(voice): add apply_with_restart and call_status_changed bus events"
+```
+
+---
+
+### Task 3: VoicePrefsStagingProvider — skeleton + initial fetch
+
+**Files:**
+
+- Create: `frontend/src/components/voice/staging/VoicePrefsStagingProvider.tsx`
+- Test: `frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx`
+
+- [ ] **Step 1: Write the failing test for hydration + stage/cancel**
+
+```tsx
+// frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  VoicePrefsStagingProvider,
+  useVoicePrefsStaging,
+} from "../VoicePrefsStagingProvider";
+import type {
+  VoicePreferences,
+  VoiceCatalog,
+  VoiceChatSpeedPreset,
+} from "../../../../services/api";
+
+vi.mock("../../../../services/api", async () => {
+  const actual = await vi.importActual<typeof import("../../../../services/api")>(
+    "../../../../services/api",
+  );
+  return {
+    ...actual,
+    voiceApi: {
+      getPreferences: vi.fn(),
+      getCatalog: vi.fn(),
+      updatePreferences: vi.fn(),
+    },
+  };
+});
+
+import { voiceApi } from "../../../../services/api";
+
+const APPLIED: VoicePreferences = {
+  voice_id: "v1",
+  voice_name: "Sophie",
+  speed: 1.0,
+  stability: 0.5,
+  similarity_boost: 0.75,
+  style: 0.3,
+  use_speaker_boost: true,
+  tts_model: "eleven_multilingual_v2",
+  voice_chat_model: "eleven_flash_v2_5",
+  language: "fr",
+  gender: "female",
+  input_mode: "ptt",
+  ptt_key: " ",
+  interruptions_enabled: true,
+  turn_eagerness: 0.5,
+  voice_chat_speed_preset: "1x",
+  turn_timeout: 15,
+  soft_timeout_seconds: 300,
+};
+
+const PRESETS: VoiceChatSpeedPreset[] = [
+  { id: "1x", label_fr: "Normal", label_en: "Normal", api_speed: 1, playback_rate: 1, concise: false },
+  { id: "3x", label_fr: "Concis", label_en: "Concise", api_speed: 1, playback_rate: 1, concise: true },
+];
+
+const CATALOG: VoiceCatalog = {
+  voices: [],
+  speed_presets: [],
+  voice_chat_speed_presets: PRESETS,
+  models: [],
+};
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <VoicePrefsStagingProvider>{children}</VoicePrefsStagingProvider>
+);
+
+beforeEach(() => {
+  vi.mocked(voiceApi.getPreferences).mockResolvedValue(APPLIED);
+  vi.mocked(voiceApi.getCatalog).mockResolvedValue(CATALOG);
+  vi.mocked(voiceApi.updatePreferences).mockReset();
+});
+
+describe("VoicePrefsStagingProvider", () => {
+  it("hydrates applied + catalog on mount", async () => {
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    expect(voiceApi.getPreferences).toHaveBeenCalled();
+    expect(voiceApi.getCatalog).toHaveBeenCalled();
+  });
+
+  it("stage() merges into staged", async () => {
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2" }));
+    expect(result.current.staged).toEqual({ voice_id: "v2" });
+    expect(result.current.hasChanges).toBe(true);
+  });
+
+  it("stage() with applied value removes the key (no-op detect)", async () => {
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2" }));
+    act(() => result.current.stage({ voice_id: "v1" }));
+    expect(result.current.staged).toEqual({});
+    expect(result.current.hasChanges).toBe(false);
+  });
+
+  it("cancel() clears staged", async () => {
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2", language: "en" }));
+    act(() => result.current.cancel());
+    expect(result.current.staged).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation (skeleton — apply() comes in Task 4)**
+
+```tsx
+// frontend/src/components/voice/staging/VoicePrefsStagingProvider.tsx
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  voiceApi,
+  type VoicePreferences,
+  type VoiceCatalog,
+} from "../../../services/api";
+import {
+  emitVoicePrefsEvent,
+  subscribeVoicePrefsEvents,
+} from "../voicePrefsBus";
+import { isRestartRequired } from "./restartRequiredFields";
+
+export interface VoicePrefsStagingContextValue {
+  applied: VoicePreferences | null;
+  catalog: VoiceCatalog | null;
+  staged: Partial<VoicePreferences>;
+  hasChanges: boolean;
+  hasRestartRequired: boolean;
+  callActive: boolean;
+  applying: boolean;
+  applyError: string | null;
+  stage: (updates: Partial<VoicePreferences>) => void;
+  cancel: () => void;
+  apply: () => Promise<void>;
+}
+
+const VoicePrefsStagingContext =
+  createContext<VoicePrefsStagingContextValue | null>(null);
+
+export const VoicePrefsStagingProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [applied, setApplied] = useState<VoicePreferences | null>(null);
+  const [catalog, setCatalog] = useState<VoiceCatalog | null>(null);
+  const [staged, setStaged] = useState<Partial<VoicePreferences>>({});
+  const [callActive, setCallActive] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  // Hydrate prefs + catalog at mount.
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([voiceApi.getPreferences(), voiceApi.getCatalog()])
+      .then(([prefs, cat]) => {
+        if (cancelled) return;
+        setApplied(prefs);
+        setCatalog(cat);
+      })
+      .catch(() => {
+        // Silent failure — provider stays in loading state until the
+        // first real `apply()` retries network.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Subscribe to call_status_changed.
+  useEffect(() => {
+    const unsubscribe = subscribeVoicePrefsEvents((event) => {
+      if (event.type === "call_status_changed") {
+        setCallActive(event.active);
+      }
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const stage = useCallback(
+    (updates: Partial<VoicePreferences>) => {
+      setStaged((prev) => {
+        const next: Partial<VoicePreferences> = { ...prev };
+        for (const key of Object.keys(updates) as (keyof VoicePreferences)[]) {
+          const value = updates[key];
+          // No-op detect: if value matches applied, drop the key.
+          if (applied && Object.is(applied[key], value)) {
+            delete next[key];
+          } else {
+            // @ts-expect-error — heterogeneous union write is safe at runtime
+            next[key] = value;
+          }
+        }
+        return next;
+      });
+    },
+    [applied],
+  );
+
+  const cancel = useCallback(() => {
+    setStaged({});
+    setApplyError(null);
+  }, []);
+
+  const apply = useCallback(async () => {
+    if (Object.keys(staged).length === 0) return;
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const next = await voiceApi.updatePreferences(staged);
+      if (!isMountedRef.current) return;
+      setApplied(next);
+      const restartNeeded =
+        callActive &&
+        catalog != null &&
+        isRestartRequired(staged, catalog.voice_chat_speed_presets);
+      setStaged({});
+      if (restartNeeded) {
+        emitVoicePrefsEvent({ type: "apply_with_restart" });
+      }
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      setApplyError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      if (isMountedRef.current) setApplying(false);
+    }
+  }, [staged, callActive, catalog]);
+
+  const hasChanges = useMemo(() => Object.keys(staged).length > 0, [staged]);
+  const hasRestartRequired = useMemo(
+    () =>
+      hasChanges &&
+      catalog != null &&
+      isRestartRequired(staged, catalog.voice_chat_speed_presets),
+    [hasChanges, staged, catalog],
+  );
+
+  const value = useMemo<VoicePrefsStagingContextValue>(
+    () => ({
+      applied,
+      catalog,
+      staged,
+      hasChanges,
+      hasRestartRequired,
+      callActive,
+      applying,
+      applyError,
+      stage,
+      cancel,
+      apply,
+    }),
+    [
+      applied,
+      catalog,
+      staged,
+      hasChanges,
+      hasRestartRequired,
+      callActive,
+      applying,
+      applyError,
+      stage,
+      cancel,
+      apply,
+    ],
+  );
+
+  return (
+    <VoicePrefsStagingContext.Provider value={value}>
+      {children}
+    </VoicePrefsStagingContext.Provider>
+  );
+};
+
+export function useVoicePrefsStaging(): VoicePrefsStagingContextValue {
+  const ctx = useContext(VoicePrefsStagingContext);
+  if (!ctx) {
+    throw new Error(
+      "useVoicePrefsStaging must be used inside <VoicePrefsStagingProvider>",
+    );
+  }
+  return ctx;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/staging/VoicePrefsStagingProvider.tsx frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx
+git commit -m "feat(voice): add VoicePrefsStagingProvider with stage/cancel/apply"
+```
+
+---
+
+### Task 4: Provider — apply() happy path + error path + restart event
+
+**Files:**
+
+- Modify: `frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx`
+
+- [ ] **Step 1: Add failing tests for apply behavior**
+
+Append to the existing `describe("VoicePrefsStagingProvider", ...)` block in `frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx`:
+
+```tsx
+  it("apply() sends a single batched updatePreferences call and resets staged", async () => {
+    vi.mocked(voiceApi.updatePreferences).mockResolvedValue({
+      ...APPLIED,
+      voice_id: "v2",
+      language: "en",
+    });
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2", language: "en" }));
+    await act(async () => {
+      await result.current.apply();
+    });
+    expect(voiceApi.updatePreferences).toHaveBeenCalledTimes(1);
+    expect(voiceApi.updatePreferences).toHaveBeenCalledWith({
+      voice_id: "v2",
+      language: "en",
+    });
+    expect(result.current.staged).toEqual({});
+    expect(result.current.applied?.voice_id).toBe("v2");
+  });
+
+  it("apply() emits apply_with_restart when callActive and hard field staged", async () => {
+    const { emitVoicePrefsEvent: emit, subscribeVoicePrefsEvents: sub } =
+      await import("../../voicePrefsBus");
+    const listener = vi.fn();
+    const unsub = sub(listener);
+    vi.mocked(voiceApi.updatePreferences).mockResolvedValue(APPLIED);
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => emit({ type: "call_status_changed", active: true }));
+    await waitFor(() => expect(result.current.callActive).toBe(true));
+    act(() => result.current.stage({ voice_id: "v2" }));
+    await act(async () => {
+      await result.current.apply();
+    });
+    expect(listener).toHaveBeenCalledWith({ type: "apply_with_restart" });
+    unsub();
+  });
+
+  it("apply() does NOT emit apply_with_restart when callActive but only soft fields staged", async () => {
+    const { subscribeVoicePrefsEvents: sub } = await import(
+      "../../voicePrefsBus"
+    );
+    const listener = vi.fn();
+    const unsub = sub(listener);
+    vi.mocked(voiceApi.updatePreferences).mockResolvedValue(APPLIED);
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    const { emitVoicePrefsEvent: emit } = await import("../../voicePrefsBus");
+    act(() => emit({ type: "call_status_changed", active: true }));
+    await waitFor(() => expect(result.current.callActive).toBe(true));
+    act(() => result.current.stage({ ptt_key: "Shift" }));
+    await act(async () => {
+      await result.current.apply();
+    });
+    const apply = listener.mock.calls.find(
+      ([e]) => e.type === "apply_with_restart",
+    );
+    expect(apply).toBeUndefined();
+    unsub();
+  });
+
+  it("apply() preserves staged on error and sets applyError", async () => {
+    vi.mocked(voiceApi.updatePreferences).mockRejectedValue(
+      new Error("network down"),
+    );
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2" }));
+    await act(async () => {
+      await result.current.apply();
+    });
+    expect(result.current.staged).toEqual({ voice_id: "v2" });
+    expect(result.current.applyError).toBe("network down");
+  });
+
+  it("apply() is a no-op when staged is empty", async () => {
+    vi.mocked(voiceApi.updatePreferences).mockResolvedValue(APPLIED);
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    await act(async () => {
+      await result.current.apply();
+    });
+    expect(voiceApi.updatePreferences).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx`
+Expected: PASS — 9 tests total (4 from Task 3 + 5 new).
+
+If any apply-related test fails, the implementation in Task 3 is the source of truth — fix it inline. The skeleton above is intended to make all these green; if it doesn't, debug.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx
+git commit -m "test(voice): cover provider apply() happy + error + restart event"
+```
+
+---
+
+### Task 5: StagedPrefsToolbar — UI component
+
+**Files:**
+
+- Create: `frontend/src/components/voice/staging/StagedPrefsToolbar.tsx`
+- Test: `frontend/src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// frontend/src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StagedPrefsToolbar } from "../StagedPrefsToolbar";
+import { VoicePrefsStagingProvider } from "../VoicePrefsStagingProvider";
+import type { VoicePrefsStagingContextValue } from "../VoicePrefsStagingProvider";
+import * as ProviderModule from "../VoicePrefsStagingProvider";
+
+function renderWithStaging(
+  override: Partial<VoicePrefsStagingContextValue>,
+) {
+  const value: VoicePrefsStagingContextValue = {
+    applied: null,
+    catalog: null,
+    staged: {},
+    hasChanges: false,
+    hasRestartRequired: false,
+    callActive: false,
+    applying: false,
+    applyError: null,
+    stage: vi.fn(),
+    cancel: vi.fn(),
+    apply: vi.fn(),
+    ...override,
+  };
+  vi.spyOn(ProviderModule, "useVoicePrefsStaging").mockReturnValue(value);
+  return { value, ...render(<StagedPrefsToolbar />) };
+}
+
+describe("StagedPrefsToolbar", () => {
+  it("renders nothing when hasChanges is false", () => {
+    renderWithStaging({ hasChanges: false });
+    expect(screen.queryByTestId("staged-prefs-toolbar")).toBeNull();
+  });
+
+  it("shows count and Apply / Cancel when hasChanges", () => {
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2", language: "en" },
+    });
+    const bar = screen.getByTestId("staged-prefs-toolbar");
+    expect(bar).toBeTruthy();
+    expect(screen.getByTestId("staged-count").textContent).toContain("2");
+    expect(screen.getByTestId("staged-apply")).toBeTruthy();
+    expect(screen.getByTestId("staged-cancel")).toBeTruthy();
+  });
+
+  it("uses 'Appliquer & redémarrer' label when callActive and restart required", () => {
+    renderWithStaging({
+      hasChanges: true,
+      hasRestartRequired: true,
+      callActive: true,
+      staged: { voice_id: "v2" },
+    });
+    expect(screen.getByTestId("staged-apply").textContent).toMatch(
+      /redémarrer/i,
+    );
+  });
+
+  it("uses 'Appliquer' label otherwise", () => {
+    renderWithStaging({
+      hasChanges: true,
+      hasRestartRequired: false,
+      callActive: false,
+      staged: { ptt_key: "Shift" },
+    });
+    expect(screen.getByTestId("staged-apply").textContent).toMatch(/appliquer/i);
+    expect(screen.getByTestId("staged-apply").textContent).not.toMatch(
+      /redémarrer/i,
+    );
+  });
+
+  it("clicking Apply calls apply()", () => {
+    const apply = vi.fn();
+    renderWithStaging({ hasChanges: true, staged: { voice_id: "v2" }, apply });
+    fireEvent.click(screen.getByTestId("staged-apply"));
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking Cancel calls cancel()", () => {
+    const cancel = vi.fn();
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2" },
+      cancel,
+    });
+    fireEvent.click(screen.getByTestId("staged-cancel"));
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both buttons while applying", () => {
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2" },
+      applying: true,
+    });
+    expect(
+      (screen.getByTestId("staged-apply") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByTestId("staged-cancel") as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("shows applyError when set", () => {
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2" },
+      applyError: "Erreur réseau",
+    });
+    expect(screen.getByTestId("staged-error").textContent).toContain(
+      "Erreur réseau",
+    );
+  });
+
+  it("count container has aria-live=polite", () => {
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2" },
+    });
+    expect(screen.getByTestId("staged-count").getAttribute("aria-live")).toBe(
+      "polite",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// frontend/src/components/voice/staging/StagedPrefsToolbar.tsx
+import React from "react";
+import { createPortal } from "react-dom";
+import { motion, AnimatePresence } from "framer-motion";
+import { Check, X, RotateCcw, AlertCircle, Loader2 } from "lucide-react";
+import { useVoicePrefsStaging } from "./VoicePrefsStagingProvider";
+
+export const StagedPrefsToolbar: React.FC = () => {
+  const {
+    hasChanges,
+    hasRestartRequired,
+    callActive,
+    staged,
+    applying,
+    applyError,
+    cancel,
+    apply,
+  } = useVoicePrefsStaging();
+
+  const count = Object.keys(staged).length;
+  const wantsRestart = hasRestartRequired && callActive;
+
+  const node = (
+    <AnimatePresence>
+      {hasChanges && (
+        <motion.div
+          key="staged-prefs-toolbar"
+          data-testid="staged-prefs-toolbar"
+          role="region"
+          aria-label="Modifications en attente"
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 24 }}
+          transition={{ duration: 0.2, ease: "easeOut" }}
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[1100] max-w-[calc(100vw-32px)]"
+        >
+          <div className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-[#12121a]/85 backdrop-blur-xl border border-white/10 shadow-2xl shadow-indigo-500/20">
+            <span
+              data-testid="staged-count"
+              role="status"
+              aria-live="polite"
+              className="text-sm text-white/80 font-medium tabular-nums"
+            >
+              <span className="inline-block w-1.5 h-1.5 rounded-full bg-indigo-400 mr-2 align-middle" />
+              {count} modification{count > 1 ? "s" : ""} en attente
+            </span>
+
+            <button
+              type="button"
+              data-testid="staged-cancel"
+              onClick={cancel}
+              disabled={applying}
+              className="px-3 py-1.5 rounded-lg text-xs font-medium text-white/70 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus-visible:ring-2 focus-visible:ring-white/30"
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <X className="w-3.5 h-3.5" />
+                Annuler
+              </span>
+            </button>
+
+            <button
+              type="button"
+              data-testid="staged-apply"
+              onClick={apply}
+              disabled={applying}
+              aria-keyshortcuts="Mod+Enter"
+              className={`px-4 py-1.5 rounded-lg text-xs font-semibold transition-all focus-visible:ring-2 focus-visible:ring-indigo-300 ${
+                wantsRestart
+                  ? "bg-amber-500 text-[#0a0a0f] hover:bg-amber-400"
+                  : "bg-indigo-500 text-white hover:bg-indigo-400"
+              } disabled:opacity-50 disabled:cursor-wait`}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                {applying ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : wantsRestart ? (
+                  <RotateCcw className="w-3.5 h-3.5" />
+                ) : (
+                  <Check className="w-3.5 h-3.5" />
+                )}
+                {wantsRestart ? "Appliquer & redémarrer" : "Appliquer"}
+              </span>
+            </button>
+          </div>
+
+          {applyError && (
+            <div
+              data-testid="staged-error"
+              className="mt-2 mx-auto flex items-start gap-2 px-3 py-2 rounded-xl bg-amber-500/15 border border-amber-400/30 text-amber-200 text-xs"
+            >
+              <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+              <span>{applyError}</span>
+            </div>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+
+  if (typeof document === "undefined" || !document.body) return node;
+  return createPortal(node, document.body);
+};
+
+export default StagedPrefsToolbar;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx`
+Expected: PASS — 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/staging/StagedPrefsToolbar.tsx frontend/src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx
+git commit -m "feat(voice): add StagedPrefsToolbar floating UI"
+```
+
+---
+
+### Task 6: Wire provider + toolbar into App
+
+**Files:**
+
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: Read current App.tsx structure**
+
+Run: `head -200 frontend/src/App.tsx | grep -n "Provider\|<Router\|<Outlet\|<App"`
+
+Identify the innermost provider wrapping the router (usually `AuthProvider`). The new `<VoicePrefsStagingProvider>` should be **inside** `AuthProvider` (it calls `voiceApi` which requires the auth token) and **outside** the router so the toolbar is rendered globally.
+
+- [ ] **Step 2: Add the import**
+
+In `frontend/src/App.tsx`, add near the existing voice imports:
+
+```ts
+import { VoicePrefsStagingProvider } from "./components/voice/staging/VoicePrefsStagingProvider";
+import { StagedPrefsToolbar } from "./components/voice/staging/StagedPrefsToolbar";
+```
+
+- [ ] **Step 3: Wrap the tree**
+
+Open `frontend/src/App.tsx` and locate the `AuthProvider` wrapper. The provider must be **inside** `AuthProvider` (it calls `voiceApi.getPreferences()` which needs auth) and must wrap the routing tree as well as the toolbar.
+
+Concretely, find the JSX block that looks roughly like this (existing code):
+
+```tsx
+<AuthProvider>
+  <LanguageProvider>
+    {/* ... other providers ... */}
+    <Router>
+      <Routes>
+        {/* existing routes */}
+      </Routes>
+    </Router>
+  </LanguageProvider>
+</AuthProvider>
+```
+
+Insert `<VoicePrefsStagingProvider>` as a child of the outermost auth-aware provider that wraps the router. The toolbar goes as a sibling of the `<Router>` block, INSIDE the new provider. Result:
+
+```tsx
+<AuthProvider>
+  <LanguageProvider>
+    {/* ... other providers ... */}
+    <VoicePrefsStagingProvider>
+      <Router>
+        <Routes>
+          {/* existing routes — UNCHANGED */}
+        </Routes>
+      </Router>
+      <StagedPrefsToolbar />
+    </VoicePrefsStagingProvider>
+  </LanguageProvider>
+</AuthProvider>
+```
+
+Do not modify any existing route, layout, or other provider — only insert the two tags. If the actual structure differs (e.g. multiple `<Router>` instances, or routing via `<Outlet>`), keep the existing wiring exactly and just slot the new provider+toolbar pair around the routing block while keeping it a descendant of `AuthProvider`.
+
+- [ ] **Step 4: Verify the app still type-checks and tests pass**
+
+Run: `cd frontend && npm run typecheck`
+Expected: zero errors.
+
+Run: `cd frontend && npm run test -- --run --reporter=verbose src/components/voice/staging`
+Expected: PASS — provider + toolbar tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/App.tsx
+git commit -m "feat(voice): mount VoicePrefsStagingProvider + StagedPrefsToolbar globally"
+```
+
+---
+
+### Task 7: useVoiceChat publishes call_status_changed
+
+**Files:**
+
+- Modify: `frontend/src/components/voice/useVoiceChat.ts`
+- Test: `frontend/src/components/voice/__tests__/useVoiceChat.test.ts`
+
+- [ ] **Step 1: Add failing test for call_status_changed publish**
+
+The existing `useVoiceChat.test.ts` already mocks `@elevenlabs/client` (`mockStartSession` returns `{ endSession: mockEndSession }`) and `fetch` (returns a session response). Configure `mockStartSession` to invoke `onConnect` synchronously, then capture bus events.
+
+Append to `frontend/src/components/voice/__tests__/useVoiceChat.test.ts` (after the existing top-level `describe("useVoiceChat", ...)` block):
+
+```ts
+import { subscribeVoicePrefsEvents } from "../voicePrefsBus";
+
+describe("useVoiceChat — call_status_changed events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetUserMedia.mockResolvedValue(mockMediaStream);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          session_id: "sess-123",
+          signed_url: "wss://test/signed",
+          quota_remaining_minutes: 10,
+          max_session_minutes: 30,
+          input_mode: "ptt",
+          ptt_key: " ",
+          playback_rate: 1.0,
+        }),
+    });
+    // Invoke onConnect synchronously when startSession is called.
+    mockStartSession.mockImplementation(async (opts: any) => {
+      opts.onConnect?.();
+      return { endSession: mockEndSession, setVolume: vi.fn() };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits call_status_changed { active: true } onConnect", async () => {
+    const events: boolean[] = [];
+    const unsub = subscribeVoicePrefsEvents((e) => {
+      if (e.type === "call_status_changed") events.push(e.active);
+    });
+
+    const { result } = renderHook(() => useVoiceChat({ summaryId: 1 }));
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(events).toContain(true);
+    unsub();
+  });
+
+  it("emits call_status_changed { active: false } on stop", async () => {
+    const events: boolean[] = [];
+    const unsub = subscribeVoicePrefsEvents((e) => {
+      if (e.type === "call_status_changed") events.push(e.active);
+    });
+
+    const { result } = renderHook(() => useVoiceChat({ summaryId: 1 }));
+
+    await act(async () => {
+      await result.current.start();
+    });
+    await act(async () => {
+      await result.current.stop();
+    });
+
+    expect(events.filter((v) => v === false)).toHaveLength(1);
+    unsub();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/useVoiceChat.test.ts -t "call_status_changed"`
+Expected: FAIL — events array is empty.
+
+- [ ] **Step 3: Add publish points in useVoiceChat**
+
+In `frontend/src/components/voice/useVoiceChat.ts`:
+
+a) At the top, change the existing import from `voicePrefsBus` to also pull `emitVoicePrefsEvent`:
+
+```ts
+import {
+  subscribeVoicePrefsEvents,
+  emitVoicePrefsEvent,
+} from "./voicePrefsBus";
+```
+
+b) Inside the `Conversation.startSession({ ... })` call, find the existing `onConnect` handler and add the emit at the very end of its body:
+
+```ts
+onConnect: () => {
+  if (isMountedRef.current) {
+    setStatus("listening");
+    setSessionStartedAt(Date.now());
+  }
+  emitVoicePrefsEvent({ type: "call_status_changed", active: true });
+},
+```
+
+c) Inside the existing `stop()` callback, add the emit at the very end of the body (after the state resets):
+
+```ts
+const stop = useCallback(async () => {
+  stopTimer();
+  cleanupPlaybackObserver();
+  cleanupPlaybackPolling();
+
+  if (conversationRef.current) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (conversationRef.current as any).endSession();
+    } catch {
+      /* ignore */
+    }
+    conversationRef.current = null;
+  }
+
+  releaseMediaStream();
+
+  if (isMountedRef.current) {
+    setStatus("idle");
+    setIsSpeaking(false);
+    setIsMuted(false);
+    setIsTalking(false);
+    setActiveTool(null);
+    setElapsedSeconds(0);
+    setPlaybackRate(1.0);
+    setVoiceSessionId(null);
+    setSessionStartedAt(null);
+  }
+
+  emitVoicePrefsEvent({ type: "call_status_changed", active: false });
+}, [
+  stopTimer,
+  releaseMediaStream,
+  cleanupPlaybackObserver,
+  cleanupPlaybackPolling,
+]);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/useVoiceChat.test.ts -t "call_status_changed"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/useVoiceChat.ts frontend/src/components/voice/__tests__/useVoiceChat.test.ts
+git commit -m "feat(voice): publish call_status_changed from useVoiceChat"
+```
+
+---
+
+### Task 8: useVoiceChat subscribes to apply_with_restart
+
+**Files:**
+
+- Modify: `frontend/src/components/voice/useVoiceChat.ts`
+- Test: `frontend/src/components/voice/__tests__/useVoiceChat.test.ts`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `frontend/src/components/voice/__tests__/useVoiceChat.test.ts`:
+
+```ts
+import { emitVoicePrefsEvent } from "../voicePrefsBus";
+
+describe("useVoiceChat — apply_with_restart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetUserMedia.mockResolvedValue(mockMediaStream);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          session_id: "sess-123",
+          signed_url: "wss://test/signed",
+          quota_remaining_minutes: 10,
+          max_session_minutes: 30,
+          input_mode: "ptt",
+          ptt_key: " ",
+          playback_rate: 1.0,
+        }),
+    });
+    mockStartSession.mockImplementation(async (opts: any) => {
+      opts.onConnect?.();
+      return { endSession: mockEndSession, setVolume: vi.fn() };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls restart (start invoked again) when active session receives apply_with_restart", async () => {
+    const { result } = renderHook(() => useVoiceChat({ summaryId: 1 }));
+    await act(async () => {
+      await result.current.start();
+    });
+    const callsAfterStart = mockStartSession.mock.calls.length;
+
+    await act(async () => {
+      emitVoicePrefsEvent({ type: "apply_with_restart" });
+      // restart() awaits 400ms internally before re-calling start()
+      vi.advanceTimersByTime(500);
+      // Flush pending microtasks
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockStartSession.mock.calls.length).toBeGreaterThan(callsAfterStart);
+  });
+
+  it("is a no-op when there is no active conversation", async () => {
+    renderHook(() => useVoiceChat({ summaryId: 1 }));
+
+    await act(async () => {
+      emitVoicePrefsEvent({ type: "apply_with_restart" });
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(mockStartSession).not.toHaveBeenCalled();
+  });
+});
+```
+
+> The 400ms delay corresponds to the existing `restart()` implementation: `stop()` → `await new Promise(r => setTimeout(r, 400))` → `start()`. `vi.advanceTimersByTime(500)` flushes that delay under fake timers.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/useVoiceChat.test.ts -t "apply_with_restart"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the subscription**
+
+In `frontend/src/components/voice/useVoiceChat.ts`, add a new `useEffect` near the existing `useEffect` that subscribes to `playback_rate_changed`:
+
+```ts
+// Live-restart when the staging provider applies a restart-required diff.
+useEffect(() => {
+  const unsubscribe = subscribeVoicePrefsEvents((event) => {
+    if (event.type !== "apply_with_restart") return;
+    if (!conversationRef.current) return;
+    void restart();
+  });
+  return unsubscribe;
+}, [restart]);
+```
+
+> The existing `restart` callback (defined just above this effect in the file) already chains `stop` + 400ms + `start`; reuse it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/useVoiceChat.test.ts -t "apply_with_restart"`
+Expected: PASS — both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/useVoiceChat.ts frontend/src/components/voice/__tests__/useVoiceChat.test.ts
+git commit -m "feat(voice): wire useVoiceChat to apply_with_restart event"
+```
+
+---
+
+### Task 9: Migrate VoiceLiveSettings to staging
+
+**Files:**
+
+- Modify: `frontend/src/components/voice/VoiceLiveSettings.tsx`
+- Modify: `frontend/src/components/voice/__tests__/VoiceLiveSettings.test.tsx`
+
+- [ ] **Step 1: Update existing tests for stage-based behavior**
+
+Open `frontend/src/components/voice/__tests__/VoiceLiveSettings.test.tsx`. For tests that currently assert `voiceApi.updatePreferences` was called when a user clicks input_mode / ptt_key / language, change the assertion to check that a mocked `useVoicePrefsStaging().stage()` was called instead.
+
+Add this mock at the top of the test file (after existing imports):
+
+```tsx
+const stageMock = vi.fn();
+vi.mock("../staging/VoicePrefsStagingProvider", () => ({
+  useVoicePrefsStaging: () => ({
+    applied: {
+      voice_id: "v1",
+      voice_name: "Sophie",
+      speed: 1,
+      stability: 0.5,
+      similarity_boost: 0.75,
+      style: 0.3,
+      use_speaker_boost: true,
+      tts_model: "eleven_multilingual_v2",
+      voice_chat_model: "eleven_flash_v2_5",
+      language: "fr",
+      gender: "female",
+      input_mode: "ptt",
+      ptt_key: " ",
+      interruptions_enabled: true,
+      turn_eagerness: 0.5,
+      voice_chat_speed_preset: "1x",
+      turn_timeout: 15,
+      soft_timeout_seconds: 300,
+    },
+    catalog: null,
+    staged: {},
+    hasChanges: false,
+    hasRestartRequired: false,
+    callActive: false,
+    applying: false,
+    applyError: null,
+    stage: stageMock,
+    cancel: vi.fn(),
+    apply: vi.fn(),
+  }),
+  VoicePrefsStagingProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+beforeEach(() => {
+  stageMock.mockReset();
+});
+```
+
+For each existing test that simulates a click on an input_mode toggle, ptt_key recorder result, or language toggle, replace the existing `voiceApi.updatePreferences` assertion with:
+
+```tsx
+expect(stageMock).toHaveBeenCalledWith({ input_mode: "vad" });
+// or { ptt_key: "a" }, { language: "en" }, etc.
+```
+
+For volume slider tests, **keep** the existing behavior assertion — the volume must still update DOM `<audio>.volume` and **must not** call `stageMock`.
+
+For playback_rate tests, **keep** the existing `emitVoicePrefsEvent({ type: "playback_rate_changed", value })` and `voiceApi.updatePreferences({ voice_chat_speed_preset })` assertions for now — we keep that one as live for backward compatibility (rate ≤ 1.x is live-applicable). If existing tests don't cover rate at all, leave them alone.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/VoiceLiveSettings.test.tsx`
+Expected: FAIL on the new assertions.
+
+- [ ] **Step 3: Refactor the component**
+
+Edit `frontend/src/components/voice/VoiceLiveSettings.tsx`:
+
+a) Add the import at the top:
+
+```ts
+import { useVoicePrefsStaging } from "./staging/VoicePrefsStagingProvider";
+```
+
+b) Replace the local-state `prefs` initial fetch with reads from the provider. Inside the component body, replace:
+
+```ts
+const [prefs, setPrefs] = useState<VoicePreferences | null>(null);
+const [loading, setLoading] = useState(true);
+const [error, setError] = useState<string | null>(null);
+const [saving, setSaving] = useState(false);
+```
+
+with:
+
+```ts
+const { applied, staged, stage } = useVoicePrefsStaging();
+const prefs = applied
+  ? ({ ...applied, ...staged } as VoicePreferences)
+  : null;
+const loading = applied === null;
+const error = null; // surfaced by the toolbar if any
+const saving = false;
+```
+
+c) Remove the `useEffect` that calls `voiceApi.getPreferences()` (the provider does it now). Remove the unused `voiceApi` import if no other callsite remains in this file.
+
+d) Replace the `save` callback body. The volume + playback_rate paths stay live; everything else routes through `stage()`:
+
+```ts
+const save = useCallback(
+  async (updates: Partial<VoicePreferences>) => {
+    stage(updates);
+    onChange?.(updates);
+  },
+  [stage, onChange],
+);
+```
+
+e) Keep `handleVolume` exactly as-is (DOM-only).
+
+f) Keep `handleRate` as-is (still emits `playback_rate_changed` + persists via `save({ voice_chat_speed_preset: preset.id })` → which now goes through `stage()`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/VoiceLiveSettings.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/VoiceLiveSettings.tsx frontend/src/components/voice/__tests__/VoiceLiveSettings.test.tsx
+git commit -m "refactor(voice): route VoiceLiveSettings non-live changes through stage()"
+```
+
+---
+
+### Task 10: Migrate VoiceSettings to staging
+
+**Files:**
+
+- Modify: `frontend/src/components/voice/VoiceSettings.tsx`
+- Modify or Create: `frontend/src/components/voice/__tests__/VoiceSettings.test.tsx`
+
+- [ ] **Step 1: Inspect existing VoiceSettings tests**
+
+Run: `ls frontend/src/components/voice/__tests__ | grep -i voicesettings`
+
+If a test file exists, read it to identify which assertions reference `voiceApi.updatePreferences`. If no test file exists, create one with the staging mock from Task 9 and a single happy-path test:
+
+```tsx
+// frontend/src/components/voice/__tests__/VoiceSettings.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import VoiceSettings from "../VoiceSettings";
+
+const stageMock = vi.fn();
+vi.mock("../staging/VoicePrefsStagingProvider", () => ({
+  useVoicePrefsStaging: () => ({
+    applied: {
+      voice_id: "v1",
+      voice_name: "Sophie",
+      speed: 1,
+      stability: 0.5,
+      similarity_boost: 0.75,
+      style: 0.3,
+      use_speaker_boost: true,
+      tts_model: "eleven_multilingual_v2",
+      voice_chat_model: "eleven_flash_v2_5",
+      language: "fr",
+      gender: "female",
+      input_mode: "ptt",
+      ptt_key: " ",
+      interruptions_enabled: true,
+      turn_eagerness: 0.5,
+      voice_chat_speed_preset: "1x",
+      turn_timeout: 15,
+      soft_timeout_seconds: 300,
+    },
+    catalog: {
+      voices: [
+        {
+          voice_id: "v2",
+          name: "Mathieu",
+          description_fr: "",
+          description_en: "",
+          gender: "male",
+          accent: "fr",
+          language: "fr",
+          use_case: "tutor",
+          recommended: false,
+          preview_url: "https://example.com/v2.mp3",
+        },
+      ],
+      speed_presets: [
+        { id: "1.0", label_fr: "1x", label_en: "1x", value: 1, icon: "" },
+      ],
+      voice_chat_speed_presets: [
+        {
+          id: "1x",
+          label_fr: "Normal",
+          label_en: "Normal",
+          api_speed: 1,
+          playback_rate: 1,
+          concise: false,
+        },
+      ],
+      models: [
+        {
+          id: "eleven_flash_v2_5",
+          name: "Flash",
+          description_fr: "",
+          description_en: "",
+          latency: "lowest",
+          recommended_for: "voice_chat",
+        },
+      ],
+    },
+    staged: {},
+    hasChanges: false,
+    hasRestartRequired: false,
+    callActive: false,
+    applying: false,
+    applyError: null,
+    stage: stageMock,
+    cancel: vi.fn(),
+    apply: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  stageMock.mockReset();
+});
+
+describe("VoiceSettings — staging", () => {
+  it("clicking a different voice card calls stage()", async () => {
+    render(<VoiceSettings />);
+    // Voice section is collapsed by default — open it.
+    fireEvent.click(screen.getByText("Sélection de voix"));
+    await waitFor(() => screen.getByText("Mathieu"));
+    fireEvent.click(screen.getByText("Mathieu"));
+    expect(stageMock).toHaveBeenCalledWith({
+      voice_id: "v2",
+      voice_name: "Mathieu",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/VoiceSettings.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Refactor VoiceSettings**
+
+Edit `frontend/src/components/voice/VoiceSettings.tsx`:
+
+a) Add the import:
+
+```ts
+import { useVoicePrefsStaging } from "./staging/VoicePrefsStagingProvider";
+```
+
+b) Replace the local fetch + state. Replace:
+
+```tsx
+const [preferences, setPreferences] = useState<VoicePreferences | null>(null);
+const [catalog, setCatalog] = useState<VoiceCatalog | null>(null);
+const [loading, setLoading] = useState(true);
+const [saving, setSaving] = useState(false);
+const [error, setError] = useState<string | null>(null);
+const [successMsg, setSuccessMsg] = useState<string | null>(null);
+```
+
+with:
+
+```tsx
+const { applied, staged, catalog, stage } = useVoicePrefsStaging();
+const preferences = applied
+  ? ({ ...applied, ...staged } as VoicePreferences)
+  : null;
+const loading = applied === null || catalog === null;
+const saving = false;
+const error: string | null = null;
+const successMsg: string | null = null;
+```
+
+c) Delete the `useEffect` that loads `voiceApi.getPreferences` + `voiceApi.getCatalog` (provider does it).
+
+d) Replace the body of `savePreferences`:
+
+```tsx
+const savePreferences = useCallback(
+  async (updates: Partial<VoicePreferences>) => {
+    stage(updates);
+  },
+  [stage],
+);
+```
+
+The optimistic-update logic disappears — the merged `applied + staged` covers it.
+
+e) Find the "Réinitialiser les valeurs par défaut" button. Its `onClick` already calls `savePreferences({...defaults})`; thanks to the refactor above this is now `stage(defaults)`. Leave it.
+
+f) Remove the floating "Saving indicator" at the bottom of the component (`{saving && (...)}`); the toolbar covers feedback now.
+
+g) Remove unused imports: `useState`, `useEffect`, `voiceApi`, `DeepSightSpinnerMicro` if no longer referenced. Run typecheck to identify.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npm run typecheck`
+Expected: zero errors.
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/VoiceSettings.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/VoiceSettings.tsx frontend/src/components/voice/__tests__/VoiceSettings.test.tsx
+git commit -m "refactor(voice): route VoiceSettings changes through stage()"
+```
+
+---
+
+### Task 11: Remove restart_required banner in VoiceModal
+
+**Files:**
+
+- Modify: `frontend/src/components/voice/VoiceModal.tsx`
+
+- [ ] **Step 1: Identify and remove**
+
+In `frontend/src/components/voice/VoiceModal.tsx`:
+
+a) Remove the imports:
+
+```ts
+import { subscribeVoicePrefsEvents } from "./voicePrefsBus";
+```
+
+(Only if no other usage remains — grep first.)
+
+b) Remove these two state hooks:
+
+```ts
+const [restartRequired, setRestartRequired] = useState(false);
+const [restarting, setRestarting] = useState(false);
+```
+
+c) Remove the `useEffect` that subscribes to `restart_required`:
+
+```ts
+useEffect(() => {
+  const unsubscribe = subscribeVoicePrefsEvents((event) => {
+    if (event.type === "restart_required") {
+      setRestartRequired(true);
+    }
+  });
+  return unsubscribe;
+}, []);
+```
+
+d) Remove the `handleRestart` callback (the toolbar's Apply now triggers restart automatically via the bus).
+
+e) Inside the settings overlay JSX, remove the entire amber banner block (the one wrapped in `{hasActiveSession && (<div className={`mx-3 sm:mx-5 mt-3 ...`}>...</div>)}` that mentions "Redémarrage requis"). Keep the rest of the settings overlay unchanged.
+
+- [ ] **Step 2: Verify no orphan references remain**
+
+Run: `cd frontend && grep -n "restartRequired\|restart_required\|handleRestart" src/components/voice/VoiceModal.tsx`
+Expected: no output (all references gone) or only the `onRestart` prop, which is fine to keep — VoiceModal still accepts an `onRestart` prop in case any caller wants to wire a manual restart button later.
+
+- [ ] **Step 3: Type-check + run modal tests**
+
+Run: `cd frontend && npm run typecheck`
+Expected: zero errors.
+
+Run: `cd frontend && npx vitest run src/components/voice`
+Expected: all voice tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/voice/VoiceModal.tsx
+git commit -m "refactor(voice): remove restart_required banner from VoiceModal (toolbar covers it)"
+```
+
+---
+
+### Task 12: E2E happy-path for the apply flow
+
+**Files:**
+
+- Create: `frontend/e2e/voice-apply-flow.spec.ts`
+
+- [ ] **Step 1: Inspect existing E2E patterns**
+
+Run: `ls frontend/e2e && head -30 frontend/e2e/*.spec.ts | head -100`
+
+Identify how other specs mock auth + how they navigate. Match the pattern.
+
+- [ ] **Step 2: Write the spec**
+
+```ts
+// frontend/e2e/voice-apply-flow.spec.ts
+import { test, expect } from "@playwright/test";
+
+// Adapt the route mocks to the existing harness — the patterns below
+// match the typical setup but should be aligned with what other voice
+// E2E specs in this repo already do (auth bypass, prefs fixture, etc.).
+
+const PREFS_FIXTURE = {
+  voice_id: "v1",
+  voice_name: "Sophie",
+  speed: 1.0,
+  stability: 0.5,
+  similarity_boost: 0.75,
+  style: 0.3,
+  use_speaker_boost: true,
+  tts_model: "eleven_multilingual_v2",
+  voice_chat_model: "eleven_flash_v2_5",
+  language: "fr",
+  gender: "female",
+  input_mode: "ptt",
+  ptt_key: " ",
+  interruptions_enabled: true,
+  turn_eagerness: 0.5,
+  voice_chat_speed_preset: "1x",
+  turn_timeout: 15,
+  soft_timeout_seconds: 300,
+};
+
+const CATALOG_FIXTURE = {
+  voices: [
+    {
+      voice_id: "v1",
+      name: "Sophie",
+      description_fr: "",
+      description_en: "",
+      gender: "female",
+      accent: "fr",
+      language: "fr",
+      use_case: "tutor",
+      recommended: true,
+      preview_url: "https://example.com/v1.mp3",
+    },
+    {
+      voice_id: "v2",
+      name: "Mathieu",
+      description_fr: "",
+      description_en: "",
+      gender: "male",
+      accent: "fr",
+      language: "fr",
+      use_case: "tutor",
+      recommended: false,
+      preview_url: "https://example.com/v2.mp3",
+    },
+  ],
+  speed_presets: [
+    { id: "1.0", label_fr: "1x", label_en: "1x", value: 1, icon: "" },
+  ],
+  voice_chat_speed_presets: [
+    {
+      id: "1x",
+      label_fr: "Normal",
+      label_en: "Normal",
+      api_speed: 1,
+      playback_rate: 1,
+      concise: false,
+    },
+    {
+      id: "3x",
+      label_fr: "Concis",
+      label_en: "Concise",
+      api_speed: 1,
+      playback_rate: 1,
+      concise: true,
+    },
+  ],
+  models: [
+    {
+      id: "eleven_flash_v2_5",
+      name: "Flash",
+      description_fr: "",
+      description_en: "",
+      latency: "lowest",
+      recommended_for: "voice_chat",
+    },
+  ],
+};
+
+test.describe("Voice prefs apply flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/voice/preferences", async (route) => {
+      const method = route.request().method();
+      if (method === "GET") {
+        await route.fulfill({ json: PREFS_FIXTURE });
+      } else {
+        const body = route.request().postDataJSON();
+        await route.fulfill({ json: { ...PREFS_FIXTURE, ...body } });
+      }
+    });
+    await page.route("**/api/voice/catalog", async (route) => {
+      await route.fulfill({ json: CATALOG_FIXTURE });
+    });
+  });
+
+  test("staging voice + concise preset triggers a single batched updatePreferences", async ({
+    page,
+  }) => {
+    let postBody: Record<string, unknown> | null = null;
+    let postCount = 0;
+    await page.route("**/api/voice/preferences", async (route) => {
+      const method = route.request().method();
+      if (method === "POST" || method === "PATCH" || method === "PUT") {
+        postCount += 1;
+        postBody = route.request().postDataJSON();
+        await route.fulfill({ json: { ...PREFS_FIXTURE, ...postBody } });
+      } else {
+        await route.fulfill({ json: PREFS_FIXTURE });
+      }
+    });
+
+    // Navigate to the voice settings page (adapt path if different)
+    await page.goto("/settings/voice");
+
+    // Open the voice catalog section
+    await page.getByText("Sélection de voix").click();
+    await page.getByText("Mathieu").click();
+
+    // Open the chat-speed section + pick the concise variant
+    await page.getByText("Vitesse du chat vocal").click();
+    await page.getByText("Concis").click();
+
+    // Toolbar should now show "2 modifications"
+    const bar = page.getByTestId("staged-prefs-toolbar");
+    await expect(bar).toBeVisible();
+    await expect(page.getByTestId("staged-count")).toContainText("2");
+
+    // Apply
+    await page.getByTestId("staged-apply").click();
+    await expect(bar).toBeHidden();
+
+    expect(postCount).toBe(1);
+    expect(postBody).toEqual({
+      voice_id: "v2",
+      voice_name: "Mathieu",
+      voice_chat_speed_preset: "3x",
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the spec**
+
+Run: `cd frontend && npx playwright test voice-apply-flow.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 4: If the page route or auth differs from the assumption above, adapt**
+
+If `/settings/voice` doesn't exist or requires auth, mirror the auth-mock pattern from a sibling spec (e.g. `frontend/e2e/voice-modal.spec.ts` if it exists, or any other passing spec).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/e2e/voice-apply-flow.spec.ts
+git commit -m "test(e2e): cover voice prefs apply happy path"
+```
+
+---
+
+### Task 13: Final verification + cleanup
+
+- [ ] **Step 1: Full type-check**
+
+Run: `cd frontend && npm run typecheck`
+Expected: zero errors.
+
+- [ ] **Step 2: Full unit test suite**
+
+Run: `cd frontend && npm run test`
+Expected: all tests pass.
+
+- [ ] **Step 3: Lint**
+
+Run: `cd frontend && npm run lint`
+Expected: zero errors.
+
+- [ ] **Step 4: Manual QA checklist**
+
+Run the dev server: `cd frontend && npm run dev`
+
+Open `http://localhost:5173` (or the configured port) and verify on three surfaces:
+
+1. **Page Paramètres vocaux standalone** (`/settings/voice` or wherever the route lives):
+   - Change voix → toolbar apparaît avec compteur 1
+   - Change preset vitesse normal (non-concis) → compteur passe à 2, label reste "Appliquer"
+   - Click Apply → un seul appel réseau, applied mis à jour, toolbar disparaît
+
+2. **Modal d'analyse** (`VoiceModal` ouvert depuis une analyse) :
+   - Bouton settings ouvre le panneau, plus de banner amber
+   - Hors appel : Apply persiste, pas de restart
+   - Démarrer appel → modifier voix → toolbar dit "Appliquer & redémarrer" → click → coupure ~1.5s → reprise
+
+3. **Hub Chat IA** (`/chat` avec call actif) :
+   - Bouton settings dans VoiceOverlay ouvre VoiceLiveSettings
+   - Volume slider reste live (DOM)
+   - Changer langue → toolbar avec "Appliquer & redémarrer" → click → restart silencieux
+
+- [ ] **Step 5: Commit any QA fixes**
+
+If manual QA reveals a small UI bug, fix it inline and commit.
+
+```bash
+git add -A
+git commit -m "fix(voice): <specific QA issue>"
+```
+
+If no fixes needed, skip this step.
+
+- [ ] **Step 6: Push for review**
+
+```bash
+git push origin feat/voice-mobile-final
+```
+
+(or whichever branch the work happened on).
+
+---
+
+## Spec Coverage Audit (post-write self-check)
+
+| Spec section | Tasks |
+|---|---|
+| 5. Architecture (provider + bus + toolbar) | T3, T4, T5, T6 |
+| 6. Categorization (live / soft / hard) | T1 |
+| 7. Provider API (stage / cancel / apply) | T3, T4 |
+| 8.1 Provider component | T3 |
+| 8.2 Toolbar | T5 |
+| 8.3 restartRequiredFields | T1 |
+| 8.4 voicePrefsBus extension | T2 |
+| 8.5 useVoiceChat publish + subscribe | T7, T8 |
+| 8.6 VoiceLiveSettings refactor | T9 |
+| 8.7 VoiceSettings refactor | T10 |
+| 8.8 VoiceModal banner removal | T11 |
+| 8.9 App.tsx wrap | T6 |
+| 9. Data flow scenarios A/B/C | Covered by E2E (T12) + manual QA (T13) |
+| 10. Edge cases | T4 (no-op detect, error path), T11 (idempotent stop) |
+| 11. Tests (unit) | T1, T2, T3, T4, T5, T7, T8, T9, T10 |
+| 11. Tests (E2E) | T12 |
+| 12. Critères d'acceptation | T13 |
+| 13. Plan de migration phases 1-8 | T1 → T11 |
+
+No gaps detected.

--- a/docs/superpowers/specs/2026-04-26-ambient-lighting-v3-design.md
+++ b/docs/superpowers/specs/2026-04-26-ambient-lighting-v3-design.md
@@ -1,0 +1,550 @@
+# Ambient Lighting v3 — Design Spec
+
+**Date** : 2026-04-26
+**Status** : Brainstormed, awaiting implementation plan
+**Owner** : Fonira
+**Plateformes** : Web (frontend/) + Mobile (mobile/) + Extension Chrome (extension/)
+**Predecessor** : `docs/PRD-ambient-lighting-v2.md` (v2 implémentée mais fragmentée, 4 implémentations divergentes)
+
+---
+
+## 1. Objectif
+
+Refondre la feature "ambient lighting" en signature visuelle DeepSight cohérente sur les 3 plateformes :
+
+- Un **rayon de lumière unique** (beam de précision) qui traverse l'écran selon l'arc solaire (lever Est → zénith → coucher Ouest → lune au-dessus)
+- Un **halo de source** doux à l'origine du rayon (ni disque solaire net, ni orbe lunaire net)
+- Un **tournesol photoréaliste 3D** qui pivote pour suivre la course du soleil (héliotropisme), luminescent la nuit (bioluminescence cyan/violet)
+- Une **palette mix** : couleurs réalistes (doré matin → blanc midi → orange couchant → argent nuit) + accents indigo/violet brand DeepSight aux twilights et nuit
+- **Préchargée** en critical CSS pour apparaître AVANT que React/RN bootstrap
+- **Sans gêner la lecture** : tous les textes en blanc pur ou très clair (>= slate-200), cap d'intensité du rayon dans la zone de lecture, design tokens audités
+
+C'est la "marque de fabrique" visible sur toutes les pages, toutes les plateformes, toujours discrète.
+
+## 2. Décisions de design (validées en brainstorming)
+
+| #   | Domaine                        | Choix                                                                                                         |
+| --- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| 1   | Direction artistique           | Beam de précision (trait fin + halo subtil, ni god rays cinématiques ni aurora sans pic)                      |
+| 2   | Composition de la source       | Halo doux à l'origine, sans disque solaire/lunaire net                                                        |
+| 3   | Comportement temporel          | Arc solaire continu (l'angle suit le soleil dans le ciel) avec interpolation cubic-bezier ~4s entre keyframes |
+| 4   | Palette                        | Mix réaliste (doré/blanc/orange/argent) + accents indigo/violet aux twilights et nuit                         |
+| 5   | Style 3D du tournesol          | Réaliste photoréaliste, ombrages, pétales nuancés, centre texturé                                             |
+| 6   | Comportement nuit du tournesol | Luminescent (bioluminescence cyan/violet, pétales bleutés glowing, source de lumière interne)                 |
+| 7   | Placement                      | Hybride : Hero centré 90px (landing/login) + Mascotte 76px bottom-right (pages de travail)                    |
+| 8   | Tech 3D                        | **Pré-rendu** : 48 frames PNG/WebP générées offline en Three.js, runtime juste un sprite cross-fade           |
+| 9   | Lisibilité textes              | Audit ciblé via design tokens (`text-secondary`, `text-muted` etc.) shift vers blanc pur ou très clair        |
+| 10  | User control                   | Toggle "Effet ambiant lumineux" dans Préférences user + respect strict de `prefers-reduced-motion`            |
+| 11  | Preload                        | Critical CSS inlined (`<head>`) + `<link rel="preload">` du sprite WebP                                       |
+
+## 3. Architecture globale
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  packages/lighting-engine/   (TypeScript pur, zéro dépendance UI)   │
+│                                                                     │
+│  • 48 keyframes v3 (toutes les 30 min, palette mix + accents brand) │
+│  • getAmbientPreset(date, opts) → AmbientPreset                     │
+│  • Daily seed mulberry32 pour ±15° de variation par jour            │
+│  • Cap intensity dans la zone de lecture (anti-gêne)                │
+│  • Respect prefers-reduced-motion (mouvement gelé)                  │
+└──────┬──────────────────┬──────────────────┬───────────────────────┘
+       │                  │                  │
+       ▼                  ▼                  ▼
+┌──────────────┐  ┌──────────────┐  ┌──────────────────────────────┐
+│  Web         │  │  Mobile      │  │  Extension Chrome            │
+│  (React 18)  │  │  (RN 0.81)   │  │  (sidepanel + popup + viewer)│
+│              │  │              │  │                              │
+│ AmbientLight │  │ AmbientLight │  │ AmbientLightLayer +          │
+│ Layer +      │  │ Layer +      │  │ SunflowerLayer +             │
+│ SunflowerLay │  │ SunflowerLay │  │ AmbientLightingProvider →    │
+│ er           │  │ er (mascot   │  │ <BeamCard> (livré par        │
+│ + Critical   │  │ only)        │  │ session parallèle)           │
+│ CSS plugin   │  │ + Reanimated │  │                              │
+│ Vite         │  │ 4 + Splash   │  │                              │
+└──────────────┘  └──────────────┘  └──────────────────────────────┘
+```
+
+### Principes structurants
+
+1. **Source de vérité unique** : `packages/lighting-engine/` calcule TOUT (angle, couleur, frameIndex, mode jour/nuit). Les composants UI sont des "vues" de cet état. Aucune logique temporelle dupliquée.
+
+2. **Sprites WebP partagés** : `assets/ambient/sunflower-day.webp` (24 frames jour) + `assets/ambient/sunflower-night.webp` (24 frames nuit luminescente). Consommés tels quels par les 3 plateformes.
+
+3. **Pas de Three.js au runtime** : le rendu 3D photoréaliste est fait UNE FOIS au build (offline). Au runtime, juste des `background-position` qui shift sur le sprite. Bundle ajouté ~5KB JS + ~150KB d'assets WebP par plateforme.
+
+4. **Critical CSS auto-généré** : un plugin Vite/Webpack lit `lighting-engine`, calcule les valeurs initiales pour l'heure courante au cold start, et émet une `<style>` inlinée dans `<head>`. Le rayon est visible avant l'hydratation React.
+
+5. **Coordination avec session parallèle** : la session `feat/extension-sidepanel-v3` livre `<BeamCard>` SVG inline avec props `(beamColor, haloColor, angle, intensity)`. Mon implémentation ajoute un `<AmbientLightingProvider>` qui passe les valeurs courantes du preset par Context React → BeamCard les consomme via un hook `useAmbientPreset()` au lieu de ses defaults statiques.
+
+## 4. API du `lighting-engine` v3
+
+```ts
+// packages/lighting-engine/src/types.ts
+
+export type NightMode = "asleep" | "glowing";
+
+export interface AmbientPreset {
+  // Angle du rayon (degrés CSS, -90 à +90)
+  angle: number;
+
+  // Couleurs du beam (radial gradient ready)
+  beamColor: string; // ex: "rgba(255,200,140,0.92)"
+  haloColor: string; // ex: "rgba(255,200,140,0.45)"
+  haloAccentColor?: string; // ex: "rgba(99,102,241,0.30)" (twilight/nuit uniquement)
+
+  // Intensity 0-1 (consommé pour box-shadow et opacity)
+  intensity: number;
+
+  // Frame index pour le sprite (0-23 dans le sprite jour ou nuit)
+  frameIndex: number;
+
+  // Mode du tournesol
+  nightMode: NightMode | null; // null = jour
+
+  // États accessibilité
+  isReducedMotion: boolean;
+  isHighContrast: boolean;
+
+  // Cap d'intensité dans la zone de lecture (computed)
+  readingZoneIntensityCap: number; // 0-1
+}
+
+export interface PresetOptions {
+  intensityMul?: number; // 0-1, default 1.0 (web), 0.5 (mobile)
+  forceNightMode?: NightMode; // override pour testing
+  forceTime?: Date; // override pour testing/dev panel
+}
+
+export function getAmbientPreset(
+  date: Date,
+  opts?: PresetOptions,
+): AmbientPreset;
+
+// Hook React shared (re-exported par chaque plateforme avec leur propre useEffect/setState)
+export function useAmbientPreset(opts?: PresetOptions): AmbientPreset;
+```
+
+### Keyframes (48 entries, toutes les 30 min)
+
+```ts
+// packages/lighting-engine/src/keyframes.v3.ts
+
+export const KEYFRAMES_V3: AmbientPresetRaw[] = [
+  // 00:00 — pleine nuit, lune au zénith, tournesol luminescent
+  {
+    time: "00:00",
+    angle: -10,
+    beamColor: "#dce8ff",
+    haloColor: "#c7d2fe",
+    haloAccentColor: "#4f46e5",
+    intensity: 0.65,
+    nightMode: "glowing",
+  },
+  { time: "00:30", angle: -8 /* ... */ },
+  // ...
+  // 06:00 — lever, rayon doré rosé bas-droite vers haut-gauche, fleur s'éveille
+  {
+    time: "06:00",
+    angle: -50,
+    beamColor: "#ffd699",
+    haloColor: "#ffc88c",
+    haloAccentColor: "#a5b4fc",
+    intensity: 0.78,
+    nightMode: null,
+  },
+  // 12:00 — zénith, rayon blanc-or quasi horizontal, fleur regarde haut
+  {
+    time: "12:00",
+    angle: -3,
+    beamColor: "#fffae1",
+    haloColor: "#fff4cc",
+    intensity: 0.95,
+    nightMode: null,
+  },
+  // 18:00 — coucher, orange-rouge, fleur regarde Ouest
+  {
+    time: "18:00",
+    angle: 48,
+    beamColor: "#ff8c50",
+    haloColor: "#ff9966",
+    haloAccentColor: "#d8b4fe",
+    intensity: 0.85,
+    nightMode: null,
+  },
+  // 22:00 — nuit, transition vers luminescent
+  { time: "22:00", angle: -22, /* ... */ nightMode: "glowing" },
+  // 48 entries au total
+];
+```
+
+### Algorithme `getAmbientPreset`
+
+```
+1. Trouver les 2 keyframes encadrant `date.getHours() + date.getMinutes()/60`
+2. Calculer le ratio d'interpolation (0-1) entre les 2 keyframes
+3. Interpoler chaque champ numérique (angle, intensity, RGB des couleurs)
+4. Calculer frameIndex = floor((minutes since midnight) / 30) % 24 (par sprite)
+5. Appliquer daily seed mulberry32(date.toDateString()) pour ±15° de variation sur angle
+6. Détecter prefers-reduced-motion → si reduce, geler toutes les valeurs
+7. Détecter prefers-contrast: more → cap intensity à 0.3
+8. Calculer readingZoneIntensityCap (toujours <= 0.5 dans la bande verticale 30%-70% de viewport height)
+9. Retourner AmbientPreset
+```
+
+### Compat v2
+
+- L'ancien `useTimeOfDay()` (web + mobile) est **supprimé** dans la PR cleanup
+- L'ancien `getAmbientPreset()` v2 est **réécrit** (signature compatible mais `AmbientPreset` étendu avec nouveaux champs)
+- Les anciens consumers (`AmbientLightDevPanel`, `useAmbientLightingFeatureFlag`) sont **supprimés**
+
+## 5. Pipeline pré-rendu du tournesol
+
+### Script de génération
+
+**Path** : `scripts/gen-sunflower-frames.mjs` (à créer)
+
+**Stack** : Three.js headless via `gl` (canvas WebGL Node.js) ou `puppeteer` avec WebGL flag. Alternative : Blender CLI avec un fichier `.blend` versionné.
+
+**Modèle 3D** :
+
+- Tournesol low-poly (~2K tris)
+- Pétales : 12 pétales générés algorithmiquement (ellipsoïdes radiaux, dégradé jaune `#fef9c3` → orange `#fbbf24` → marron `#b45309`)
+- Centre : disque texturé "tournesol" (graines) avec dégradé radial marron `#a16207` → `#451a03` → `#1c1917`
+- Tige : off (économise pixels du sprite)
+
+**Lighting** :
+
+- Variant jour : HDRI golden hour + directional light blanc-or
+- Variant nuit (luminescent) : MeshStandardMaterial avec `emissive` cyan/violet (`#4f46e5`) + faible directional cool light, glow renderpass
+
+**Output** :
+
+- 24 angles de rotation Y (1 frame / 30 min de keyframe principal) × 2 modes = 48 frames
+- Render : 256×256 px transparent (alpha)
+- Encoding : WebP qualité 85 via `sharp`
+- Layout : 2 sprite sheets, grille 6×4 (1536×1024 par sprite)
+
+**Commande** :
+
+```bash
+npm run build:sunflower-frames
+# →  assets/ambient/sunflower-day.webp     ~75KB
+#   assets/ambient/sunflower-night.webp   ~75KB
+```
+
+### Distribution
+
+Les sprites sont **commit dans le repo** (pas regénérés à chaque CI) :
+
+- Web : `frontend/public/assets/ambient/sunflower-{day,night}.webp`
+- Mobile : `mobile/assets/ambient/sunflower-{day,night}.webp` (require statique)
+- Extension : `extension/public/assets/ambient/sunflower-{day,night}.webp` (copié par `copy-webpack-plugin` vers `dist/`)
+
+Pour mutualiser, on peut symlink ou créer un step `npm run sync:sprites` qui copie depuis `assets/ambient/` (root) vers les 3 destinations. Décision : **fichiers committés dupliqués** dans chaque plateforme pour éviter les pièges de bundlers (Metro RN qui ne suit pas les symlinks correctement).
+
+### Cross-fade au runtime
+
+```tsx
+// Pseudocode (web), équivalent RN avec Animated.Image
+const preset = useAmbientPreset();
+const [prevIdx, setPrevIdx] = useState(preset.frameIndex);
+const sprite =
+  preset.nightMode === "glowing"
+    ? "sunflower-night.webp"
+    : "sunflower-day.webp";
+
+// Quand frameIndex change : transition opacity 0→1 sur 4s du nouveau layer,
+// 1→0 du précédent. Les 2 sont rendus simultanément.
+return (
+  <div className="sunflower-cross-fade">
+    <div
+      className="frame-prev"
+      style={{
+        backgroundImage: `url(/assets/ambient/${sprite})`,
+        backgroundPosition: spritePosition(prevIdx),
+        opacity: 0,
+      }}
+    />
+    <div
+      className="frame-next"
+      style={{
+        backgroundImage: `url(/assets/ambient/${sprite})`,
+        backgroundPosition: spritePosition(preset.frameIndex),
+        opacity: 1,
+      }}
+    />
+  </div>
+);
+```
+
+## 6. Composants par plateforme
+
+### 6.1 Web (`frontend/`)
+
+**Fichiers** :
+
+- `frontend/src/components/AmbientLightLayer.tsx` — réécriture (overlay rayon + halo)
+- `frontend/src/components/SunflowerLayer.tsx` — nouveau (route-aware : hero sur `/`, `/login`, `/signup` + mascotte ailleurs)
+- `frontend/src/contexts/AmbientLightingContext.tsx` — nouveau Provider (passe le preset courant aux consumers)
+- `frontend/src/hooks/useAmbientPreset.ts` — réécrit pour consommer le package `@deepsight/lighting-engine`
+- `frontend/vite.config.ts` — nouveau plugin `vite-plugin-ambient-critical-css.ts` injecté
+
+**Structure** :
+
+```tsx
+// frontend/src/App.tsx
+<AmbientLightingProvider>
+  <AmbientLightLayer /> {/* fixed inset-0 z-1 pointer-events-none */}
+  <SunflowerLayer />{" "}
+  {/* fixed bottom-22 right-22 z-2 (mascot) ou center hero */}
+  <Router>{/* routes */}</Router>
+</AmbientLightingProvider>
+```
+
+**Critical CSS plugin** :
+
+- Lit `lighting-engine` au build/dev start
+- Calcule les valeurs initiales pour l'heure courante
+- Émet un `<style>` inliné dans `index.html` (head) avec :
+  - `body { background: #0a0a0f; }`
+  - `.ambient-beam { transform: rotate(<angle>); background: <gradient>; }`
+  - `.ambient-halo { background: <radial>; }`
+  - `<link rel="preload" as="image" href="/assets/ambient/sunflower-{mode}.webp">`
+- Le rayon est donc visible AVANT que le bundle JS soit téléchargé
+
+**Z-indexes** :
+
+- 0 : background `#0a0a0f` (body)
+- 1 : `<AmbientLightLayer>` (rayon + halo source)
+- 2 : `<SunflowerLayer>` (tournesol mascot bottom-right OU hero centré)
+- 10+ : contenu app (header, routes, modals)
+
+**Tests** :
+
+- `frontend/src/components/__tests__/AmbientLightLayer.test.tsx`
+- `frontend/src/components/__tests__/SunflowerLayer.test.tsx`
+- `frontend/e2e/ambient-lighting.spec.ts` (Playwright, 4 horaires × 2 routes)
+
+### 6.2 Mobile (`mobile/`)
+
+**Fichiers** :
+
+- `mobile/src/components/backgrounds/AmbientLightLayer.tsx` — réécriture
+- `mobile/src/components/backgrounds/SunflowerLayer.tsx` — nouveau (mascot only, pas de hero)
+- `mobile/src/contexts/AmbientLightingContext.tsx` — nouveau
+- `mobile/src/hooks/useAmbientPreset.ts` — réécrit pour consommer `@deepsight/lighting-engine`
+- `mobile/metro.config.js` — `watchFolders` étendu pour inclure `packages/lighting-engine/`
+- `mobile/app/_layout.tsx` — réécrit pour wrapper avec `<AmbientLightingProvider>` et monter les overlays
+- `mobile/app.json` — splash screen mis à jour avec une PNG fallback statique du beam + halo
+
+**Structure** :
+
+```tsx
+// mobile/app/_layout.tsx
+<AmbientLightingProvider>
+  <Stack /* expo router */ />
+  <AmbientLightLayer /> {/* absoluteFill pointerEvents=none */}
+  <SunflowerLayer variant="mascot" />{" "}
+  {/* fixed bottom-right au-dessus tab bar */}
+</AmbientLightingProvider>
+```
+
+**Spécificités** :
+
+- Reanimated 4 `withTiming(value, { duration: 4000, easing: Easing.bezier(0.4, 0, 0.2, 1) })` sur angle, opacity, position
+- Sprite via `<Image source={require('../../assets/ambient/sunflower-day.webp')} />` (Metro bundle natif)
+- BottomTabBar collapse-aware : le tournesol mascot remonte de 64px quand le tab bar est visible (useBottomTabBarHeight)
+- Pas de critical CSS (RN n'a pas de DOM) → on utilise le splash screen Expo pour afficher le beam initial dès le boot
+- AppState listener : pause cross-fade quand background
+
+**Tests** :
+
+- `mobile/src/components/backgrounds/__tests__/AmbientLightLayer.test.tsx`
+- `mobile/src/components/backgrounds/__tests__/SunflowerLayer.test.tsx`
+- Maestro : `mobile/.maestro/ambient-lighting.yaml` (snapshots à 4 horaires)
+
+### 6.3 Extension (`extension/`)
+
+**Fichiers** :
+
+- `extension/src/sidepanel/components/AmbientLightLayer.tsx` — nouveau (réécriture par-dessus l'orphelin existant)
+- `extension/src/viewer/components/AmbientLightLayer.tsx` — nouveau (idem viewer)
+- `extension/src/popup/components/AmbientLightLayer.tsx` — nouveau (popup, beam minimal)
+- `extension/src/sidepanel/components/SunflowerLayer.tsx` — nouveau (mascot)
+- `extension/src/viewer/components/SunflowerLayer.tsx` — nouveau (mascot)
+- (PAS de SunflowerLayer dans popup — espace 360×600 trop contraint)
+- `extension/src/sidepanel/contexts/AmbientLightingContext.tsx` — nouveau Provider
+- `extension/src/sidepanel/hooks/useAmbientPreset.ts` — nouveau
+- `extension/webpack.config.js` — copy-webpack-plugin pour les sprites + html-webpack-plugin pour critical CSS inline
+
+**Coordination avec PR0 (session parallèle)** :
+
+- Sa `<BeamCard>` accepte `beamColor`, `haloColor`, `angle`, `intensity` en props
+- Mon `<AmbientLightingProvider>` (root du sidepanel) wrap tout
+- Un hook custom `useBeamCardPropsFromPreset()` dérive les props BeamCard depuis le preset courant
+- Modification minime de BeamCard : si elle accepte un prop optionnel `usePreset?: boolean = false`, elle peut elle-même appeler le hook et override ses defaults. Sinon, c'est l'appelant (MainView) qui passe les props depuis le hook.
+- **Décision recommandée** : modification de `<BeamCard>` pour qu'elle lise le Context si présent (back-compat avec ses defaults statiques)
+
+**Structure** :
+
+```tsx
+// extension/src/sidepanel/App.tsx (réécriture)
+<AmbientLightingProvider>
+  <AmbientLightLayer /> {/* fixed inset-0 z-1 */}
+  <SunflowerLayer /> {/* fixed bottom-22 right-22 z-2 */}
+  <Routes>
+    <Route path="/" element={<MainView />} />{" "}
+    {/* livré par PR0, ses BeamCard consomment le Context */}
+    <Route path="/login" element={<LoginView />} />
+    {/* ... */}
+  </Routes>
+</AmbientLightingProvider>
+```
+
+**Bundle constraint** : tous les composants additionnels < 50KB (Manifest V3 limite stricte sur popup, plus relax sur sidepanel mais on reste prudent).
+
+**Tests** :
+
+- `extension/__tests__/sidepanel/AmbientLightLayer.test.tsx`
+- `extension/__tests__/sidepanel/SunflowerLayer.test.tsx`
+- Visual : screenshots manuels après reload Chrome (pas de Playwright pour extension)
+
+## 7. Audit textes / design tokens
+
+### Mapping des shifts (cohérent sur les 3 plateformes)
+
+| Token                    | Avant               | Après                    | Justification               |
+| ------------------------ | ------------------- | ------------------------ | --------------------------- |
+| `text-primary`           | `#fff` / `#f5f5f7`  | inchangé                 | Déjà très clair             |
+| `text-secondary`         | `#94a3b8` slate-400 | `#f1f5f9` slate-100      | Gris moyen → blanc cassé    |
+| `text-muted`             | `#64748b` slate-500 | `#e2e8f0` slate-200      | Gris foncé → blanc cassé    |
+| `text-disabled`          | `#475569` slate-600 | `rgba(255,255,255,0.45)` | Plus de gris, juste opacité |
+| `text-meta` (timestamps) | `#64748b`           | `#cbd5e1` slate-300      | Reste lisible mais distinct |
+
+### Fichiers touchés
+
+- **Web** : `frontend/src/styles/tokens.css` (variables CSS) + `frontend/tailwind.config.js` (extend `colors.text.*` + remplacer instances de `text-slate-400`/`text-slate-500` dans les composants pour utiliser les tokens)
+- **Mobile** : `mobile/src/theme/colors.ts` (objet `colors.text.*`) + chaque consumer qui hardcode des hex à corriger
+- **Extension** : `extension/src/sidepanel/styles/sidepanel.css` (classes `.v3-text-*`) + `extension/src/popup/styles/popup.css`
+
+### Vérification WCAG
+
+- Tous les textes sur fond `#0a0a0f` doivent atteindre WCAG AA (4.5:1 minimum)
+- Vérifié via `@axe-core/playwright` dans la CI sur 4 horaires différents (au cas où le rayon altère le contraste)
+
+## 8. User preferences
+
+### Backend
+
+**Champ** : `User.preferences.ambient_lighting_enabled` (bool, default `true`)
+
+- Le model `User` a déjà un champ `preferences` (JSON column) → on ajoute la clé sans migration breaking
+- Endpoint `PUT /api/auth/preferences` (existant) accepte `{ ambient_lighting_enabled: bool }`
+
+### UI Settings (3 plateformes)
+
+- **Web** : `frontend/src/pages/SettingsPage.tsx` — switch toggle "Effet ambiant lumineux" avec description "Affiche un rayon de lumière subtil et un tournesol qui suit la course du soleil"
+- **Mobile** : `mobile/app/(tabs)/profile.tsx` — Switch RN avec même label
+- **Extension** : pas d'UI dédiée (le pref vient du backend, sync via le AuthContext)
+
+### Comportement
+
+- Toggle OFF → `<AmbientLightingProvider>` rend `null` au lieu des overlays
+- Critical CSS conditionnel : si `User.preferences.ambient_lighting_enabled === false` au cold start, on émet une classe `.ambient-disabled` sur `<html>` qui masque tout via `display: none`
+- Sync : changement web → backend → mobile/extension via TanStack Query refresh sur `userPreferences` query key
+
+## 9. Tests & Accessibilité
+
+### Couverture cible
+
+| Layer                    | Tooling      | Couverture                                                                                                                          |
+| ------------------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `lighting-engine`        | Vitest unit  | `getAmbientPreset()` à 8 horaires clés, daily seed déterministe, `prefers-reduced-motion`, cap intensity, transitions interpolation |
+| Composants Web           | Vitest + RTL | `<AmbientLightLayer>`, `<SunflowerLayer>`, route-aware mounting, sprite preload, toggle off                                         |
+| Composants Mobile        | Jest + RNTL  | Reanimated mocks, sprite require, splash integration, AppState pause                                                                |
+| Composants Extension     | Jest + jsdom | Mount dans 3 entries, BeamCard Context integration, no-Three.js bundle assertion                                                    |
+| Visual regression Web    | Playwright   | 4 horaires × 4 pages → screenshots vs baseline                                                                                      |
+| Visual regression Mobile | Maestro      | 4 horaires × home → snapshots                                                                                                       |
+| Bundle budget            | size-limit   | Web +<200KB, Mobile +<200KB, Extension +<150KB                                                                                      |
+| Lighthouse               | LHCI         | LCP regression check (rayon en critical CSS doit pas dégrader)                                                                      |
+
+### Accessibilité
+
+| Préférence/contexte              | Comportement                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `prefers-reduced-motion: reduce` | Angle/couleur figés sur la valeur courante. Pas de cross-fade. Pas de pivot tournesol.                  |
+| `prefers-contrast: more`         | Cap intensity beam à 30% max, tournesol opacity 0.5.                                                    |
+| Toggle utilisateur OFF           | Overlays montent un fragment vide (`null`). Critical CSS conditionnel `.ambient-disabled` sur `<html>`. |
+| Focus / clavier                  | Tous les overlays = `aria-hidden="true"`, jamais focusables, jamais dans le tab order.                  |
+| Lecteurs d'écran                 | Aucun `alt`/`aria-label` parlant — purement décoratif.                                                  |
+| WCAG AA contraste textes         | Vérifié via `@axe-core/playwright` dans CI sur 4 horaires.                                              |
+
+## 10. Roadmap d'implémentation
+
+### Ordre des PRs
+
+```
+PR 0 (session parallèle) — feat/extension-sidepanel-v3
+  Statut : EN COURS, mergée avant PR1.
+  Livrables : <BeamCard>, classes .v3-*, redesign MainView.
+
+PR 1 (~2 jours) — feat/lighting-engine-v3-foundation
+  • packages/lighting-engine/ étendu (48 keyframes v3, nightMode, accents brand)
+  • scripts/gen-sunflower-frames.mjs + sprites WebP committed
+  • Design tokens shift (text-secondary/muted/disabled) sur 3 plateformes
+  • Backend champ User.preferences.ambient_lighting_enabled
+  • Tests engine + tokens (Vitest)
+
+PR 2-4 (en parallèle, ~1.5 j chaque)
+  • PR 2 — feat/ambient-lighting-v3-web
+  • PR 3 — feat/ambient-lighting-v3-mobile
+  • PR 4 — feat/ambient-lighting-v3-extension
+
+PR 5 (~0.5 j) — feat/ambient-lighting-v3-cleanup
+  • Supprime useTimeOfDay legacy, AmbientLightDevPanel,
+    useAmbientLightingFeatureFlag
+  • Met à jour docs/PRD-ambient-lighting-v2.md → v3
+  • Met à jour CHANGELOG
+```
+
+### Effort total
+
+- Sans parallélisation : ~6.5 jours
+- Avec dispatch d'agents sur PR2/3/4 : ~3-4 jours réels
+
+### Stratégie de rollout
+
+- **Default ON** dès PR1 (champ pref initialisé à `true`)
+- **Feature flag PostHog** `ambient_lighting_v3` pour kill-switch d'urgence
+- **Pas de A/B test** — feature de polish, pas de mécanique métier
+
+## 11. Risques & Mitigations
+
+| Risque                                                           | Mitigation                                                                                                                           |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Sprite pipeline rend mal (3D approximative)                      | Itérations sur `gen-sunflower-frames.mjs`, sprite committable indépendamment du code                                                 |
+| Bundle mobile dépasse budget                                     | Lazy-load du sprite après mount + Hermes engine                                                                                      |
+| Conflit avec session parallèle MainView                          | Le Context Provider override les defaults de BeamCard, pas l'API. Modifications de BeamCard se limitent à un `useContext` optionnel. |
+| Lighthouse LCP régression                                        | Critical CSS ~2KB inline, mesure prouve impact négligeable                                                                           |
+| Performance battery mobile                                       | Cross-fade pause si app en background (`AppState`)                                                                                   |
+| Bundle extension popup (1MB max)                                 | Pas de SunflowerLayer dans popup, AmbientLightLayer minimal (~6KB total)                                                             |
+| Metro RN ne résout pas le workspace `@deepsight/lighting-engine` | `metro.config.js` `watchFolders` + `extraNodeModules` configurés explicitement                                                       |
+
+## 12. Hors scope (PR follow-up éventuelles)
+
+- Audit complet du monorepo pour chasser TOUTES les couleurs grises hex (utilisateur a opté pour audit ciblé via tokens uniquement)
+- A/B test de différentes palettes (palette validée = mix réaliste + accents brand)
+- Customization avancée (intensité, palette) côté user (rejeté en faveur d'un simple toggle)
+- Tournesol interactif (cliquable, easter eggs) — peut venir en v3.1
+
+## 13. Références
+
+- Brainstorming session : 2026-04-26 (visual companion `http://localhost:54368` puis `:56930`)
+- Engine v2 existant : `packages/lighting-engine/` (à étendre)
+- PRD v2 : `docs/PRD-ambient-lighting-v2.md` (sera mis à jour vers v3 dans PR5)
+- Composants v2 (à remplacer) :
+  - Web : `frontend/src/components/AmbientLightLayer.tsx`, `frontend/src/hooks/useTimeOfDay.ts`, `frontend/src/components/AmbientLightDevPanel.tsx`
+  - Mobile : `mobile/src/components/backgrounds/AmbientLightLayer.tsx`
+  - Extension : `extension/src/popup/components/AmbientLightLayer.tsx`, `extension/src/viewer/components/AmbientLightLayer.tsx` (orphelins jamais montés)
+- Session parallèle (coordination) : worktree `C:\Users\33667\DeepSight-Main\.claude\worktrees\extension-sidepanel-v3`, branche `feat/extension-sidepanel-v3`, spec `docs/superpowers/specs/2026-04-26-extension-sidepanel-design.md`

--- a/docs/superpowers/specs/2026-04-27-voice-prefs-apply-button-design.md
+++ b/docs/superpowers/specs/2026-04-27-voice-prefs-apply-button-design.md
@@ -1,0 +1,374 @@
+# Voice Prefs Apply Button — Design Spec
+
+**Date** : 2026-04-27
+**Auteur** : Maxime (DeepSight)
+**Statut** : Draft v1
+**Périmètre** : DeepSight Web (`frontend/`)
+
+---
+
+## 1. Problème
+
+Aujourd'hui, dans le hub Chat IA voice (`/chat`) et la page de paramètres vocaux, chaque modification de préférence ElevenLabs (sélection de voix, vitesse, modèle, stability, etc.) déclenche un `voiceApi.updatePreferences()` immédiat. Mais :
+
+- La plupart des champs sont **bakés à `startSession`** côté SDK ElevenLabs — ils ne s'appliquent qu'à la prochaine session.
+- Pendant un appel actif, changer la voix ne fait rien d'audible — l'utilisateur croit que c'est cassé.
+- Le seul mécanisme existant (`restart_required` event + banner amber dans `VoiceModal`) demande à l'utilisateur de cliquer un bouton "Redémarrer" caché dans le panneau de paramètres, qui n'est même pas câblé dans le `VoiceOverlay` du hub Chat.
+- Plusieurs modifications successives = plusieurs round-trips backend isolés au lieu d'un batch.
+
+L'utilisateur attend un comportement de type "form Apply" : tweaker plusieurs paramètres puis valider d'un coup, avec application immédiate (incluant restart de la session si nécessaire).
+
+## 2. Objectifs
+
+1. **Application immédiate** : à l'Apply, les nouveaux paramètres affectent la session ElevenLabs en cours (restart silencieux ~1-2s si nécessaire).
+2. **Batch** : un seul appel backend par Apply, peu importe le nombre de champs modifiés.
+3. **Cohérence inter-UI** : même flow dans `VoiceLiveSettings` (panneau in-call) et `VoiceSettings` (page complète).
+4. **Préserver le live feedback** des contrôles où c'est attendu (volume, playback rate ≤ 1x).
+5. **Réversibilité** : possibilité d'annuler les changements en attente avant Apply.
+
+## 3. Non-objectifs (V1)
+
+- Persistance des changements stagés à travers reloads/onglets.
+- Synchronisation multi-onglets.
+- Diff visuel détaillé (avant/après) dans la toolbar — un compteur suffit.
+- Mobile (`mobile/`) et extension Chrome — V2.
+
+## 4. Décisions de design (validées)
+
+| ID  | Décision                         | Choix retenu                                                                                    |
+| --- | -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| D1  | Périmètre UI                     | Les deux : `VoiceLiveSettings` + `VoiceSettings`                                                |
+| D2  | Comportement pendant appel actif | Restart silencieux automatique (~1-2s coupure, contexte agent réinitialisé)                     |
+| D3  | Granularité du staging           | Hybride : volume + playback_rate restent live ; tout le reste est stagé                         |
+| D4  | UX du bouton                     | Toolbar flottante avec compteur + Apply + Annuler, conditionnelle (visible ssi changes pending) |
+
+## 5. Architecture
+
+```
+App.tsx
+└─ <VoicePrefsStagingProvider>             ← NEW (root, always mounted)
+   ├─ state: applied, staged, callActive, applying, applyError
+   ├─ actions: stage(), cancel(), apply()
+   │
+   ├─ <ChatPage>
+   │  └─ <VoiceOverlay>
+   │     ├─ useVoiceChat
+   │     │   ├─ publishes bus event `call_status_changed`
+   │     │   └─ subscribes to bus event `apply_with_restart` → restart()
+   │     └─ <VoiceLiveSettings>            ← stage() au lieu de save()
+   │
+   ├─ <VoiceModal>
+   │  └─ <VoiceSettings compact>           ← stage() au lieu de savePreferences()
+   │
+   ├─ /settings/voice (page standalone)
+   │  └─ <VoiceSettings>                   ← idem
+   │
+   └─ <StagedPrefsToolbar />               ← NEW, render conditionnel global
+```
+
+### Source de vérité
+
+Le provider tient deux états :
+
+- `applied: VoicePreferences | null` — dernière version persistée backend (vérité).
+- `staged: Partial<VoicePreferences>` — delta non encore appliqué.
+
+Les UI lisent les valeurs comme `{ ...applied, ...staged }` pour l'affichage (overlay du diff). L'écriture passe toujours par `stage()`.
+
+### Communication avec `useVoiceChat`
+
+Extension de `voicePrefsBus` avec deux nouveaux events :
+
+| Event                 | Sens            | Charge utile          | Rôle                                                   |
+| --------------------- | --------------- | --------------------- | ------------------------------------------------------ |
+| `apply_with_restart`  | provider → hook | —                     | « Persistance OK, restart la session si tu es active » |
+| `call_status_changed` | hook → provider | `{ active: boolean }` | Adapte le label du bouton Apply                        |
+
+Les events legacy `playback_rate_changed` et `restart_required` sont conservés pour ne pas casser le code existant ; le banner `restart_required` dans `VoiceModal` est supprimé au profit de la toolbar globale.
+
+## 6. Catégorisation des champs
+
+Une constante `restartRequiredFields.ts` centralise la classification :
+
+| Catégorie      | Champs                                                                                                                                                                                                    | Comportement                                                    |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **Live**       | `volume` (DOM only, jamais persisté) ; `playback_rate` (toute valeur) — déjà live-applicable via `voicePrefsBus` + `<audio>.playbackRate`                                                                 | Pas de stage. Save direct + emit `playback_rate_changed`.       |
+| **Stagé soft** | `voice_chat_speed_preset` (variantes non-concises), `ptt_key`, `input_mode`, `turn_timeout`, `soft_timeout_seconds`                                                                                       | `stage()`. À Apply : save backend uniquement.                   |
+| **Stagé hard** | `voice_id`, `voice_name`, `tts_model`, `voice_chat_model`, `stability`, `similarity_boost`, `style`, `use_speaker_boost`, `language`, `gender`, `voice_chat_speed_preset` (variantes concises uniquement) | `stage()`. À Apply : save backend + `restart()` si appel actif. |
+
+Helper exposé : `isRestartRequired(updates: Partial<VoicePreferences>): boolean`.
+
+## 7. API du provider
+
+```ts
+interface VoicePrefsStagingContextValue {
+  applied: VoicePreferences | null;
+  staged: Partial<VoicePreferences>;
+  hasChanges: boolean;
+  hasRestartRequired: boolean;
+  callActive: boolean;
+  applying: boolean;
+  applyError: string | null;
+
+  stage: (updates: Partial<VoicePreferences>) => void;
+  cancel: () => void;
+  apply: () => Promise<void>;
+}
+
+export function useVoicePrefsStaging(): VoicePrefsStagingContextValue;
+```
+
+### Sémantique des actions
+
+- `stage(updates)` : merge dans `staged`. Pour chaque clé dont la valeur revient à `applied[key]`, retire la clé (no-op auto-detect → `hasChanges` reflète la réalité).
+- `cancel()` : `setStaged({})`. Idempotent.
+- `apply()` :
+  1. `setApplying(true)`
+  2. `next = await voiceApi.updatePreferences(staged)` → `setApplied(next)`
+  3. Si `hasRestartRequired && callActive` → `emitVoicePrefsEvent({ type: 'apply_with_restart' })`
+  4. `setStaged({})`
+  5. `setApplying(false)`
+  6. Erreur réseau/HTTP → `setApplyError(msg)`, conserver `staged`
+
+### Initial fetch
+
+`useEffect` au mount : `voiceApi.getPreferences()` → `setApplied()`. Spinner global non nécessaire (les UI consommatrices ont déjà leur propre `loading` qu'on peut câbler sur `applied === null`).
+
+## 8. Composants
+
+### 8.1 NEW — `frontend/src/components/voice/staging/VoicePrefsStagingProvider.tsx`
+
+Provider React Context. Souscrit à `voicePrefsBus.call_status_changed` pour `setCallActive`. Implémente la logique d'API ci-dessus.
+
+### 8.2 NEW — `frontend/src/components/voice/staging/StagedPrefsToolbar.tsx`
+
+Toolbar flottante :
+
+- `position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); z-index: 1100`
+- Mount/unmount via `AnimatePresence` selon `hasChanges`
+- Layout :
+  ```
+  ● {N} modifications en attente   [Annuler]   [Appliquer →]
+                                                ou
+                                   [Appliquer & redémarrer ↻]
+  ```
+- Variantes label sur le bouton primaire :
+  - `callActive && hasRestartRequired` → "Appliquer & redémarrer"
+  - sinon → "Appliquer"
+- États :
+  - `applying === true` → bouton primaire affiche un spinner, Annuler désactivé
+  - `applyError !== null` → ligne d'erreur amber sous la toolbar avec bouton Réessayer
+- A11y :
+  - `role="status"`, `aria-live="polite"` sur le compteur
+  - `aria-keyshortcuts="Mod+Enter"` pour Apply
+  - Focus sur Apply au mount
+- Style : glassmorphism cohérent avec le design system (`bg-[#12121a]/85 backdrop-blur-xl border border-white/10`)
+
+### 8.3 NEW — `frontend/src/components/voice/staging/restartRequiredFields.ts`
+
+```ts
+export const RESTART_REQUIRED_FIELDS: ReadonlySet<keyof VoicePreferences> =
+  new Set([
+    "voice_id",
+    "voice_name",
+    "tts_model",
+    "voice_chat_model",
+    "stability",
+    "similarity_boost",
+    "style",
+    "use_speaker_boost",
+    "language",
+    "gender",
+  ]);
+
+export function isRestartRequired(
+  updates: Partial<VoicePreferences>,
+  speedPresets: VoiceChatSpeedPreset[],
+): boolean {
+  /* ... handles concise mode for voice_chat_speed_preset */
+}
+```
+
+### 8.4 MODIFY — `frontend/src/components/voice/voicePrefsBus.ts`
+
+```ts
+export type VoicePrefsEvent =
+  | { type: "playback_rate_changed"; value: number }
+  | { type: "restart_required"; reason: string } // legacy
+  | { type: "apply_with_restart" } // NEW
+  | { type: "call_status_changed"; active: boolean }; // NEW
+```
+
+### 8.5 MODIFY — `frontend/src/components/voice/useVoiceChat.ts`
+
+- Dans `start()` après `onConnect` → emit `call_status_changed: { active: true }`
+- Dans `stop()` → emit `call_status_changed: { active: false }`
+- Nouveau `useEffect` qui souscrit à `apply_with_restart` :
+  ```ts
+  if (event.type === "apply_with_restart" && conversationRef.current) {
+    void restart();
+  }
+  ```
+
+### 8.6 MODIFY — `frontend/src/components/voice/VoiceLiveSettings.tsx`
+
+- Lit `applied` et `staged` depuis `useVoicePrefsStaging()`
+- Affichage : valeur affichée = `staged[key] ?? applied[key]`
+- Indicateur visuel (point violet 6px) sur les contrôles dont la clé est dans `staged`
+- Volume : reste inchangé (DOM direct, pas de stage)
+- Playback rate : reste inchangé (live emit + persist immédiat — c'est un cas live spécial)
+- `input_mode`, `ptt_key`, `language` : `staging.stage({...})` au lieu de `save({...})`
+
+### 8.7 MODIFY — `frontend/src/components/voice/VoiceSettings.tsx`
+
+- Lit `applied` et `staged` depuis `useVoicePrefsStaging()`
+- Suppression de l'état local `preferences` et de la fonction `savePreferences()` interne
+- Tous les `onSave` / `onClick` qui appelaient `savePreferences({...})` deviennent `staging.stage({...})`
+- Le bouton "Réinitialiser les valeurs par défaut" stage les valeurs par défaut (ne save pas)
+- Le toast "Préférences enregistrées !" est déplacé dans la toolbar (visible globalement, plus pertinent)
+
+### 8.8 MODIFY — `frontend/src/components/voice/VoiceModal.tsx`
+
+- Suppression du `useState` `restartRequired`, du banner amber, et du `useEffect` qui souscrit à `restart_required`
+- Le bouton "Redémarrer" du header reste comme escape hatch manuel
+- (La toolbar globale couvre désormais le besoin)
+
+### 8.9 MODIFY — `frontend/src/App.tsx` (ou root équivalent)
+
+```tsx
+<VoicePrefsStagingProvider>
+  <RouterProvider router={router} />
+  <StagedPrefsToolbar />
+</VoicePrefsStagingProvider>
+```
+
+## 9. Data flow — scénarios
+
+### Scénario A — Hors appel, page Paramètres vocaux
+
+1. User change voix → `stage({ voice_id, voice_name })`
+2. User change preset vitesse vers une variante concise → `stage({ voice_chat_speed_preset })` (les variantes concises sont définies côté backend dans `VOICE_CHAT_SPEED_PRESETS`)
+3. Toolbar apparaît : "2 modifications • Annuler • Appliquer"
+4. Click Apply → `voiceApi.updatePreferences({voice_id, voice_name, voice_chat_speed_preset})` (1 round-trip)
+5. `applied` mis à jour, `staged = {}`, toolbar disparaît
+6. Pas de restart (pas d'appel actif)
+
+### Scénario B — Pendant un appel, panneau in-call (VoiceOverlay)
+
+1. User ouvre `VoiceLiveSettings`, change langue FR → EN
+2. `stage({ language: 'en' })` (langue est dans `RESTART_REQUIRED_FIELDS`)
+3. Toolbar : "1 modification • Annuler • Appliquer & redémarrer ↻"
+4. Click Apply :
+   - save backend OK
+   - emit `apply_with_restart`
+   - `useVoiceChat` reçoit, appelle `restart()` (stop → 400ms → start)
+   - Backend `/api/voice/session` lit les prefs fraîchement persistées et bake l'agent EN
+5. ~1.5s coupure audible, l'agent reprend en anglais
+6. Le contexte conversationnel précédent est perdu (limitation SDK ElevenLabs documentée)
+
+### Scénario C — Slider volume pendant un appel
+
+1. User bouge le slider volume → DOM `audio.volume` direct, **pas de stage**
+2. Toolbar n'apparaît pas
+3. Pas de persistance backend (volume est purement client-side)
+
+## 10. Edge cases
+
+| Cas                                         | Réponse                                                                                               |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Apply backend échoue (500/429)              | `applyError` set, `staged` conservé, toolbar montre erreur amber + bouton Réessayer                   |
+| Apply pendant qu'un Apply est déjà en cours | `applying === true` → bouton désactivé, idempotent                                                    |
+| User ferme l'onglet avec staged non-empty   | Aucune persistance — clear au reload (évite fantômes)                                                 |
+| `stage()` avec valeur identique à `applied` | Auto-removal de la clé du staged (no-op detect)                                                       |
+| Pref refetch (reload page) pendant staging  | Initial fetch écrase `applied`, `staged` conservé → toolbar à jour                                    |
+| Apply réussit mais `restart()` throw        | Toolbar disparaît (save OK), erreur loggée non bloquante, escape hatch via header                     |
+| Slider stability bougé en continu           | Chaque drag = un `stage()` ; comme stage merge sur la même clé, pas d'inflation. Toolbar reste stable |
+| Multi-onglets simultanés                    | Out of V1. Last-write-wins backend. Acceptable.                                                       |
+| User Apply puis change idée immédiat        | `staged = {}` après Apply ; nouveau change = nouveau staged. Le restart précédent est terminé.        |
+| Restart pendant que l'agent parle           | `stop()` du SDK ElevenLabs gère le tear-down ; pas de fuite mémoire / audio resté ouvert.             |
+
+## 11. Tests
+
+### Unit (Vitest)
+
+- `VoicePrefsStagingProvider.test.tsx`
+  - Initial fetch hydrate `applied`
+  - `stage()` accumule dans `staged`
+  - `stage()` avec valeur égale à applied retire la clé
+  - `cancel()` vide `staged`
+  - `apply()` happy path : 1 call backend batch, `applied` mis à jour, `staged` vidé
+  - `apply()` avec hasRestartRequired + callActive → bus event émis
+  - `apply()` avec hasRestartRequired + !callActive → pas de bus event
+  - `apply()` erreur → `applyError` set, `staged` conservé
+  - Souscription `call_status_changed` → `callActive` mis à jour
+- `StagedPrefsToolbar.test.tsx`
+  - Visible ssi `hasChanges`
+  - Compteur correct (nombre de clés dans `staged`)
+  - Label "Appliquer" vs "Appliquer & redémarrer" selon callActive + hasRestartRequired
+  - Click Annuler → `cancel()` appelé
+  - Click Apply → `apply()` appelé
+  - `applying` → bouton spinner, Annuler désactivé
+  - `applyError` → message visible + Réessayer
+  - A11y : role status, aria-live polite
+- `VoiceLiveSettings.test.tsx`
+  - Update existing tests : changer mode/ptt/lang → `stage()` (pas `voiceApi.updatePreferences()`)
+  - Volume slider → DOM direct, pas de stage
+- `VoiceSettings.test.tsx`
+  - Update existing tests : tous les changements → `stage()`
+  - Reset defaults → stage les valeurs par défaut (pas save)
+- `useVoiceChat.test.ts`
+  - Réception `apply_with_restart` pendant call → `restart()` triggered
+  - Réception `apply_with_restart` sans call → no-op
+  - Publish `call_status_changed` sur start/stop
+- `restartRequiredFields.test.ts`
+  - `isRestartRequired` retourne true pour chaque champ hard
+  - false pour live + soft staged
+  - true pour preset concis, false pour preset normal
+
+### E2E (Playwright)
+
+- `e2e/voice-apply-flow.spec.ts`
+  - Mock SDK ElevenLabs (existant)
+  - Ouvrir page settings → changer voix + vitesse → vérifier toolbar count=2 → Apply → vérifier 1 seul POST `/api/voice/preferences` avec batch payload
+  - Démarrer appel mocké → ouvrir VoiceLiveSettings → changer langue → vérifier label "Appliquer & redémarrer" → Apply → vérifier endSession + nouveau startSession appelés sur le SDK mock
+
+## 12. Critères d'acceptation
+
+- [ ] Aucun changement non-live ne déclenche `voiceApi.updatePreferences()` avant click Apply
+- [ ] Apply en appel actif déclenche restart automatique en moins de 2s côté UI
+- [ ] Volume slider reste réactif en temps réel (pas de stage)
+- [ ] Toolbar visible si et seulement si `hasChanges === true`
+- [ ] Compteur de la toolbar reflète le nombre exact de clés dans `staged`
+- [ ] Le bouton primaire affiche "Appliquer & redémarrer" quand call_active + restart_required
+- [ ] Aucun banner `restart_required` legacy reste actif dans `VoiceModal`
+- [ ] Tous les tests unitaires existants restent verts
+- [ ] Nouveaux tests unitaires + E2E happy path passent
+
+## 13. Plan de migration
+
+1. Créer fichiers NEW sans toucher aux composants existants (provider, toolbar, helpers, bus events)
+2. Wrap `App.tsx` avec provider + toolbar (rendu mais inerte tant que personne n'appelle `stage()`)
+3. Refactor `VoiceSettings.tsx` pour utiliser `stage()` (le plus gros changement)
+4. Refactor `VoiceLiveSettings.tsx` pour utiliser `stage()` sur les champs non-live
+5. Câbler `useVoiceChat` (publish + subscribe)
+6. Supprimer banner restart_required de `VoiceModal`
+7. Tests unitaires + E2E
+8. Manual QA sur les 3 surfaces : page standalone, modal, overlay in-call
+
+Chaque étape est shippable indépendamment avec backwards compat (le provider `stage()` peut tomber back sur save direct si pas wrap).
+
+## 14. Risques
+
+| Risque                                                                                 | Mitigation                                                                                                                            |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Restart ElevenLabs perd le contexte agent en cours                                     | Documenté comme limitation acceptée (D2). Tooltip discret sur le bouton "Appliquer & redémarrer" pour informer.                       |
+| Backend `updatePreferences` ne supporte pas tous les champs en batch                   | Vérifier `backend/src/voice/preferences.py` — endpoint accepte déjà un `Partial<VoicePreferences>`. À confirmer dans phase 0 du plan. |
+| Régression sur tests existants `VoiceLiveSettings.test.tsx` etc.                       | Les modifs sont additives (changement d'appel save → stage). Tests à adapter.                                                         |
+| Toolbar masque du contenu en bas de page                                               | `bottom: 24px` au-dessus du Quick Voice Call FAB existant ; adjust si conflit visuel.                                                 |
+| Provider mounted globalement = fetch préf au login même si user ne va jamais sur voice | Lazy : ne fetch `applied` que sur premier `stage()` ou première lecture.                                                              |
+
+## 15. Références
+
+- Code existant : `frontend/src/components/voice/{VoiceSettings,VoiceLiveSettings,VoiceOverlay,VoiceModal,useVoiceChat,voicePrefsBus}.tsx`
+- Spec parent ElevenLabs ecosystem : `docs/superpowers/specs/2026-04-25-elevenlabs-ecosystem-architecture-design.md`
+- Spec Quick Voice Call (UI voisine, ne pas confondre) : `docs/superpowers/specs/2026-04-26-quick-voice-call-design.md`

--- a/frontend/e2e/voice-apply-flow.spec.ts
+++ b/frontend/e2e/voice-apply-flow.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * 🧪 E2E — Voice prefs apply flow
+ * Covers the happy path: stage two changes (voice + concise preset),
+ * confirm the toolbar shows them, click Apply, confirm a single batched
+ * PUT /api/voice/preferences with the correct body.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const PREFS_FIXTURE = {
+  voice_id: "v1",
+  voice_name: "Sophie",
+  speed: 1.0,
+  stability: 0.5,
+  similarity_boost: 0.75,
+  style: 0.3,
+  use_speaker_boost: true,
+  tts_model: "eleven_multilingual_v2",
+  voice_chat_model: "eleven_flash_v2_5",
+  language: "fr",
+  gender: "female",
+  input_mode: "ptt",
+  ptt_key: " ",
+  interruptions_enabled: true,
+  turn_eagerness: 0.5,
+  voice_chat_speed_preset: "1x",
+  turn_timeout: 15,
+  soft_timeout_seconds: 300,
+};
+
+const CATALOG_FIXTURE = {
+  voices: [
+    {
+      voice_id: "v1",
+      name: "Sophie",
+      description_fr: "",
+      description_en: "",
+      gender: "female",
+      accent: "fr",
+      language: "fr",
+      use_case: "tutor",
+      recommended: true,
+      preview_url: "https://example.com/v1.mp3",
+    },
+    {
+      voice_id: "v2",
+      name: "Mathieu",
+      description_fr: "",
+      description_en: "",
+      gender: "male",
+      accent: "fr",
+      language: "fr",
+      use_case: "tutor",
+      recommended: false,
+      preview_url: "https://example.com/v2.mp3",
+    },
+  ],
+  speed_presets: [
+    { id: "1.0", label_fr: "1x", label_en: "1x", value: 1, icon: "" },
+  ],
+  voice_chat_speed_presets: [
+    {
+      id: "1x",
+      label_fr: "Normal",
+      label_en: "Normal",
+      api_speed: 1,
+      playback_rate: 1,
+      concise: false,
+    },
+    {
+      id: "3x",
+      label_fr: "Rapide concis",
+      label_en: "Concise",
+      api_speed: 1,
+      playback_rate: 1,
+      concise: true,
+    },
+  ],
+  models: [
+    {
+      id: "eleven_flash_v2_5",
+      name: "Flash",
+      description_fr: "",
+      description_en: "",
+      latency: "lowest",
+      recommended_for: "voice_chat",
+    },
+    {
+      id: "eleven_multilingual_v2",
+      name: "Multilingual",
+      description_fr: "",
+      description_en: "",
+      latency: "low",
+      recommended_for: "tts",
+    },
+  ],
+};
+
+const MOCK_USER = {
+  id: 1,
+  username: "testuser",
+  email: "test@test.com",
+  plan: "expert",
+  credits: 150,
+  credits_monthly: 150,
+  is_admin: false,
+  total_videos: 0,
+  total_words: 0,
+  total_playlists: 0,
+  email_verified: true,
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+test.describe("Voice prefs apply flow", () => {
+  test("staging voice + concise preset triggers a single batched updatePreferences", async ({
+    page,
+  }) => {
+    // ── Auth mocks ───────────────────────────────────────────────────────
+    await page.route("**/api/auth/me", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_USER),
+      }),
+    );
+    // /auth/refresh fires whenever any other endpoint 401s. If it 401s too,
+    // the app clears tokens and bounces to /login. Keep it green.
+    await page.route("**/api/auth/refresh", (route) => {
+      const futureExp = Math.floor((Date.now() + 24 * 3600 * 1000) / 1000);
+      const b64url = (obj: object) =>
+        Buffer.from(JSON.stringify(obj))
+          .toString("base64")
+          .replace(/=/g, "")
+          .replace(/\+/g, "-")
+          .replace(/\//g, "_");
+      const fakeJwt = `header.${b64url({ exp: futureExp, sub: "1" })}.sig`;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          access_token: fakeJwt,
+          refresh_token: fakeJwt,
+        }),
+      });
+    });
+
+    // ── Catalog ──────────────────────────────────────────────────────────
+    await page.route("**/api/voice/catalog", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(CATALOG_FIXTURE),
+      }),
+    );
+
+    // ── Prefs (GET + PUT) ────────────────────────────────────────────────
+    let putBody: Record<string, unknown> | null = null;
+    let putCount = 0;
+    await page.route("**/api/voice/preferences", async (route) => {
+      const method = route.request().method();
+      if (method === "PUT" || method === "POST" || method === "PATCH") {
+        putCount += 1;
+        putBody = route.request().postDataJSON() as Record<string, unknown>;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ...PREFS_FIXTURE, ...putBody }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(PREFS_FIXTURE),
+        });
+      }
+    });
+
+    // ── Seed tokens BEFORE the first navigation so AuthContext sees them ─
+    // useAuth parses the JWT to check `exp` — we must produce a parseable
+    // JWT or it will be marked expired and clearTokens() will run.
+    await page.addInitScript(() => {
+      const futureExp = Math.floor((Date.now() + 24 * 3600 * 1000) / 1000);
+      const b64url = (obj: object) =>
+        btoa(JSON.stringify(obj))
+          .replace(/=/g, "")
+          .replace(/\+/g, "-")
+          .replace(/\//g, "_");
+      const fakeJwt = `header.${b64url({ exp: futureExp, sub: "1" })}.sig`;
+      localStorage.setItem("access_token", fakeJwt);
+      localStorage.setItem("refresh_token", fakeJwt);
+      // useAuth wraps cached_user in { user, timestamp }
+      localStorage.setItem(
+        "cached_user",
+        JSON.stringify({
+          user: {
+            id: 1,
+            email: "test@test.com",
+            username: "testuser",
+            plan: "expert",
+            credits: 150,
+            credits_monthly: 150,
+            is_admin: false,
+            total_videos: 0,
+            total_words: 0,
+            total_playlists: 0,
+            email_verified: true,
+            created_at: "2024-01-01T00:00:00Z",
+          },
+          timestamp: Date.now(),
+        }),
+      );
+    });
+
+    // ── Navigate to settings ─────────────────────────────────────────────
+    await page.goto("/settings");
+    // Don't waitForLoadState("networkidle") — boot-time API calls keep
+    // firing intermittently. Just wait for the voice settings header to
+    // be present, which proves Settings rendered.
+    await page
+      .getByRole("heading", { name: "🎙️ Paramètres vocaux" })
+      .waitFor({ state: "visible", timeout: 15000 });
+
+    // ── Open "Sélection de voix" and pick Mathieu ────────────────────────
+    // (voiceSelection is closed by default; chatSpeed is open by default —
+    // do NOT toggle it again, that would close it.)
+    await page
+      .getByRole("button", { name: "Sélection de voix" })
+      .click();
+    await page.getByText("Mathieu", { exact: true }).click();
+
+    // ── Pick the concise speed preset (3x + Rapide concis) ──────────────
+    // The concise preset button shows preset.id ("3x") + label_fr ("Rapide
+    // concis") + a "Concis" badge — filter on both for an unambiguous match.
+    await page
+      .getByRole("button")
+      .filter({ hasText: "3x" })
+      .filter({ hasText: "Rapide concis" })
+      .click();
+
+    // ── Toolbar: 3 staged keys (voice_id + voice_name + speed_preset) ───
+    const bar = page.getByTestId("staged-prefs-toolbar");
+    await expect(bar).toBeVisible();
+    await expect(page.getByTestId("staged-count")).toContainText("3");
+
+    // ── Apply ────────────────────────────────────────────────────────────
+    await page.getByTestId("staged-apply").click();
+    await expect(bar).toBeHidden();
+
+    // ── Single batched PUT with both diffs ───────────────────────────────
+    expect(putCount).toBe(1);
+    expect(putBody).toEqual({
+      voice_id: "v2",
+      voice_name: "Mathieu",
+      voice_chat_speed_preset: "3x",
+    });
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,8 @@ import { ErrorBoundary as RouteErrorBoundary } from "./components/ErrorBoundary"
 import { CrispChat } from "./components/CrispChat";
 import { CookieBanner } from "./components/CookieBanner";
 import { UpgradeModal } from "./components/UpgradeModal";
+import { VoicePrefsStagingProvider } from "./components/voice/staging/VoicePrefsStagingProvider";
+import { StagedPrefsToolbar } from "./components/voice/staging/StagedPrefsToolbar";
 import { analytics } from "./services/analytics";
 import { DeepSightSpinner } from "./components/ui/DeepSightSpinner";
 
@@ -482,6 +484,7 @@ const AppRoutes = () => {
       <LoadingWordProvider>
         <AuthProvider value={auth}>
           <TTSProvider>
+            <VoicePrefsStagingProvider>
             <Router>
               <AmbientLightingProvider enabled={getAmbientLightingEnabled()}>
                 {/* ✨ Couche lumineuse cosmique (engine v3 — beam + halo) — restreinte aux routes vitrines */}
@@ -973,8 +976,14 @@ const AppRoutes = () => {
                 <ErrorBoundary fallback={null}>
                   <CookieBanner />
                 </ErrorBoundary>
+
+                {/* 🎙️ Floating "Apply staged voice prefs" toolbar */}
+                <ErrorBoundary fallback={null}>
+                  <StagedPrefsToolbar />
+                </ErrorBoundary>
               </AmbientLightingProvider>
             </Router>
+            </VoicePrefsStagingProvider>
           </TTSProvider>
         </AuthProvider>
       </LoadingWordProvider>

--- a/frontend/src/components/voice/VoiceLiveSettings.tsx
+++ b/frontend/src/components/voice/VoiceLiveSettings.tsx
@@ -21,9 +21,9 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { Volume2, Mic, Keyboard, Globe, Gauge } from "lucide-react";
-import { voiceApi } from "../../services/api";
 import type { VoicePreferences } from "../../services/api";
 import { emitVoicePrefsEvent } from "./voicePrefsBus";
+import { useVoicePrefsStaging } from "./staging/VoicePrefsStagingProvider";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // I18N
@@ -95,57 +95,26 @@ export const VoiceLiveSettings: React.FC<VoiceLiveSettingsProps> = ({
 }) => {
   const t = I18N[language];
 
-  const [prefs, setPrefs] = useState<VoicePreferences | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
+  const { applied, staged, stage } = useVoicePrefsStaging();
+  const prefs = applied
+    ? ({ ...applied, ...staged } as VoicePreferences)
+    : null;
+  const loading = applied === null;
+  const error = null; // surfaced by the toolbar if any
+  const saving = false;
+
   // Local volume slider (0-100). Independent from prefs since volume is
   // applied client-side to <audio> elements, not persisted to the backend.
   const [volume, setVolume] = useState<number>(100);
   const [pttListening, setPttListening] = useState(false);
 
-  // ── Initial load ────────────────────────────────────────────────────────
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        setLoading(true);
-        const next = await voiceApi.getPreferences();
-        if (!cancelled) {
-          setPrefs(next);
-          setError(null);
-        }
-      } catch {
-        if (!cancelled) setError(t.error);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [t.error]);
-
-  // ── Save helper (optimistic) ────────────────────────────────────────────
+  // ── Save helper — routes updates through staging ────────────────────────
   const save = useCallback(
     async (updates: Partial<VoicePreferences>) => {
-      if (!prefs) return;
-      const snapshot = prefs;
-      setPrefs({ ...prefs, ...updates });
-      setSaving(true);
-      try {
-        const next = await voiceApi.updatePreferences(updates);
-        setPrefs(next);
-        onChange?.(updates);
-      } catch {
-        // Rollback on failure.
-        setPrefs(snapshot);
-      } finally {
-        setSaving(false);
-      }
+      stage(updates);
+      onChange?.(updates);
     },
-    [prefs, onChange],
+    [stage, onChange],
   );
 
   // ── Volume change → live-apply via bus + local state ────────────────────

--- a/frontend/src/components/voice/VoiceModal.tsx
+++ b/frontend/src/components/voice/VoiceModal.tsx
@@ -26,7 +26,6 @@ import {
   RotateCcw,
   Settings2,
   Video,
-  Info,
 } from "lucide-react";
 import { DeepSightSpinner } from "../ui/DeepSightSpinner";
 import { VoiceToolIndicator } from "./VoiceToolIndicator";
@@ -37,7 +36,6 @@ import { VoicePTTButton } from "./VoicePTTButton";
 import DoodleBackground from "../DoodleBackground";
 import { voiceApi, type VoiceThumbnailResponse } from "../../services/api";
 import { ThumbnailImage } from "./utils/ThumbnailImage";
-import { subscribeVoicePrefsEvents } from "./voicePrefsBus";
 
 // Lazy-load VoiceSettings to avoid circular imports + reduce initial bundle
 const VoiceSettings = lazy(() => import("./VoiceSettings"));
@@ -283,30 +281,6 @@ export const VoiceModal: React.FC<VoiceModalProps> = ({
   const descId = useId();
   const { language } = useTranslation();
   const [showSettings, setShowSettings] = useState(false);
-  // Flag set when a pref change requires a fresh session (voice, concise mode,
-  // model). Banner then offers a one-click restart button.
-  const [restartRequired, setRestartRequired] = useState(false);
-  const [restarting, setRestarting] = useState(false);
-
-  useEffect(() => {
-    const unsubscribe = subscribeVoicePrefsEvents((event) => {
-      if (event.type === "restart_required") {
-        setRestartRequired(true);
-      }
-    });
-    return unsubscribe;
-  }, []);
-
-  const handleRestart = useCallback(async () => {
-    if (!onRestart) return;
-    setRestarting(true);
-    try {
-      await onRestart();
-      setRestartRequired(false);
-    } finally {
-      setRestarting(false);
-    }
-  }, [onRestart]);
 
   // 🖼️ Thumbnail HD backend (fetch asynchrone, fallback silencieux sur videoThumbnailUrl).
   // Le backend garantit l'URL HD YouTube (maxresdefault) ou une image générée
@@ -910,9 +884,9 @@ export const VoiceModal: React.FC<VoiceModalProps> = ({
             )}
             {/* ── Settings panel overlay (in-modal) ───────────────────── */}
             {/* Non-destructive overlay: the active call keeps running behind.
-                The banner below tells the user changes apply to the NEXT call
-                so we never kill the ElevenLabs session to reconfigure — the
-                SDK must not be forced to tear down mid-call. */}
+                Staged changes are applied via the global StagedPrefsToolbar
+                which triggers the restart through the voice prefs bus — we
+                never kill the ElevenLabs session to reconfigure mid-call. */}
             <AnimatePresence>
               {showSettings && (
                 <motion.div
@@ -957,61 +931,6 @@ export const VoiceModal: React.FC<VoiceModalProps> = ({
                       </button>
                     </div>
                   </div>
-                  {/* Banner — ambers when a pending change needs a new
-                      session; offers one-click restart. */}
-                  {hasActiveSession && (
-                    <div
-                      className={`mx-3 sm:mx-5 mt-3 flex items-start gap-2 rounded-xl px-3 py-2.5 text-xs flex-shrink-0 transition-colors ${
-                        restartRequired
-                          ? "bg-amber-500/10 border border-amber-400/30 text-amber-100"
-                          : "bg-indigo-500/10 border border-indigo-400/25 text-indigo-200/90"
-                      }`}
-                    >
-                      <Info
-                        className={`w-4 h-4 flex-shrink-0 mt-0.5 ${
-                          restartRequired ? "text-amber-300" : "text-indigo-300"
-                        }`}
-                      />
-                      <div className="leading-relaxed flex-1">
-                        <span
-                          className={`font-semibold ${
-                            restartRequired
-                              ? "text-amber-200"
-                              : "text-indigo-200"
-                          }`}
-                        >
-                          {restartRequired
-                            ? tr("Redémarrage requis", "Restart required")
-                            : tr("Appel en cours", "Call in progress")}
-                          {" — "}
-                        </span>
-                        {restartRequired
-                          ? tr(
-                              "certains changements (voix, mode concis, modèle) demandent une nouvelle session pour s'appliquer.",
-                              "some changes (voice, concise mode, model) require a new session to take effect.",
-                            )
-                          : tr(
-                              "vitesse de lecture appliquée en direct. Les autres changements s'appliqueront au prochain appel.",
-                              "playback speed applies live. Other changes will apply on your next call.",
-                            )}
-                      </div>
-                      {restartRequired && onRestart && (
-                        <button
-                          type="button"
-                          onClick={handleRestart}
-                          disabled={restarting}
-                          className="flex items-center gap-1.5 h-8 px-3 rounded-lg bg-amber-500 text-[#0a0a0f] font-semibold text-[11px] hover:bg-amber-400 transition-colors disabled:opacity-60 disabled:cursor-wait flex-shrink-0 focus-visible:ring-2 focus-visible:ring-amber-300"
-                        >
-                          <RotateCcw
-                            className={`w-3.5 h-3.5 ${restarting ? "animate-spin" : ""}`}
-                          />
-                          {restarting
-                            ? tr("Redémarrage…", "Restarting…")
-                            : tr("Redémarrer", "Restart")}
-                        </button>
-                      )}
-                    </div>
-                  )}
                   <div className="flex-1 overflow-y-auto px-2 sm:px-4 py-3">
                     <Suspense
                       fallback={

--- a/frontend/src/components/voice/VoiceModal.tsx
+++ b/frontend/src/components/voice/VoiceModal.tsx
@@ -98,8 +98,6 @@ interface VoiceModalProps {
   avatarFallback?: string;
   /** Niveau micro temps réel [0,1] — drive waveform + halo PTT. */
   micLevel?: number;
-  /** Redémarre la session (stop + start) pour appliquer de nouveaux paramètres. */
-  onRestart?: () => void | Promise<void>;
 }
 
 /** Format seconds to MM:SS */
@@ -272,7 +270,6 @@ export const VoiceModal: React.FC<VoiceModalProps> = ({
   avatarStatus = "unavailable",
   avatarFallback,
   micLevel = 0,
-  onRestart,
 }) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const transcriptRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/voice/VoiceSettings.tsx
+++ b/frontend/src/components/voice/VoiceSettings.tsx
@@ -4,11 +4,7 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { voiceApi } from "../../services/api";
-import {
-  DeepSightSpinner,
-  DeepSightSpinnerMicro,
-} from "../ui/DeepSightSpinner";
+import { DeepSightSpinner } from "../ui/DeepSightSpinner";
 import {
   MessageSquare,
   Zap,
@@ -20,12 +16,12 @@ import {
 import { CollapsibleSection } from "./CollapsibleSection";
 import { InteractionModeSection } from "./InteractionModeSection";
 import { VoiceChatSpeedSection } from "./VoiceChatSpeedSection";
+import { useVoicePrefsStaging } from "./staging/VoicePrefsStagingProvider";
 import type {
   VoicePreferences,
   VoiceCatalogEntry,
   VoiceSpeedPreset,
   VoiceModel,
-  VoiceCatalog,
 } from "../../services/api";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -46,12 +42,14 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
   compact = false,
 }) => {
   // ── State ──────────────────────────────────────────────────────────────
-  const [preferences, setPreferences] = useState<VoicePreferences | null>(null);
-  const [catalog, setCatalog] = useState<VoiceCatalog | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const { applied, staged, catalog, stage } = useVoicePrefsStaging();
+  const preferences = applied
+    ? ({ ...applied, ...staged } as VoicePreferences)
+    : null;
+  const loading = applied === null || catalog === null;
+  const saving = false;
+  const error: string | null = null;
+  const successMsg: string | null = null;
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
     interaction: true,
     chatSpeed: true,
@@ -68,54 +66,14 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
     setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
-  // ── Load data ──────────────────────────────────────────────────────────
-  useEffect(() => {
-    const loadData = async () => {
-      try {
-        setLoading(true);
-        const [prefs, cat] = await Promise.all([
-          voiceApi.getPreferences(),
-          voiceApi.getCatalog(),
-        ]);
-        setPreferences(prefs);
-        setCatalog(cat);
-      } catch (err: unknown) {
-        setError("Impossible de charger les préférences vocales.");
-        console.error("VoiceSettings load error:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    loadData();
-  }, []);
-
   // ── Save handler ───────────────────────────────────────────────────────
-  // Optimistic update: UI reflects change instantly, rollback on error.
-  // Fixes revert-visual bug where selects snapped back to previous value
-  // during the API round-trip.
+  // Stages updates in the VoicePrefsStagingProvider; the floating Apply
+  // toolbar is responsible for committing them server-side.
   const savePreferences = useCallback(
     async (updates: Partial<VoicePreferences>) => {
-      if (!preferences) return;
-      const snapshot = preferences;
-      // Optimistic apply — UI updates immediately
-      setPreferences({ ...preferences, ...updates });
-      try {
-        setSaving(true);
-        setError(null);
-        const updated = await voiceApi.updatePreferences(updates);
-        setPreferences(updated);
-        setSuccessMsg("Préférences enregistrées !");
-        setTimeout(() => setSuccessMsg(null), 2000);
-      } catch (err: unknown) {
-        // Rollback on failure
-        setPreferences(snapshot);
-        setError("Erreur lors de la sauvegarde.");
-        console.error("VoiceSettings save error:", err);
-      } finally {
-        setSaving(false);
-      }
+      stage(updates);
     },
-    [preferences],
+    [stage],
   );
 
   // ── Voice preview ──────────────────────────────────────────────────────
@@ -222,9 +180,7 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
           preferences={preferences}
           saving={saving}
           onSave={savePreferences}
-          onLocalUpdate={(updates) =>
-            setPreferences({ ...preferences, ...updates })
-          }
+          onLocalUpdate={(updates) => stage(updates)}
         />
       </CollapsibleSection>
       {/* ══════════════════════════════════════════════════════════════
@@ -417,13 +373,8 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
               step="0.05"
               value={preferences.speed}
               onChange={(e) =>
-                setPreferences({
-                  ...preferences,
-                  speed: parseFloat(e.target.value),
-                })
+                stage({ speed: parseFloat(e.target.value) })
               }
-              onMouseUp={() => savePreferences({ speed: preferences.speed })}
-              onTouchEnd={() => savePreferences({ speed: preferences.speed })}
               className="flex-1 accent-indigo-500 h-2 bg-white/10 rounded-full appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-5
                 [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:shadow-lg"
@@ -571,16 +522,7 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
               step="0.05"
               value={preferences.stability}
               onChange={(e) =>
-                setPreferences({
-                  ...preferences,
-                  stability: parseFloat(e.target.value),
-                })
-              }
-              onMouseUp={() =>
-                savePreferences({ stability: preferences.stability })
-              }
-              onTouchEnd={() =>
-                savePreferences({ stability: preferences.stability })
+                stage({ stability: parseFloat(e.target.value) })
               }
               className="w-full accent-indigo-500 h-2 bg-white/10 rounded-full appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4
@@ -612,20 +554,7 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
               step="0.05"
               value={preferences.similarity_boost}
               onChange={(e) =>
-                setPreferences({
-                  ...preferences,
-                  similarity_boost: parseFloat(e.target.value),
-                })
-              }
-              onMouseUp={() =>
-                savePreferences({
-                  similarity_boost: preferences.similarity_boost,
-                })
-              }
-              onTouchEnd={() =>
-                savePreferences({
-                  similarity_boost: preferences.similarity_boost,
-                })
+                stage({ similarity_boost: parseFloat(e.target.value) })
               }
               className="w-full accent-indigo-500 h-2 bg-white/10 rounded-full appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4
@@ -657,13 +586,8 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
               step="0.05"
               value={preferences.style}
               onChange={(e) =>
-                setPreferences({
-                  ...preferences,
-                  style: parseFloat(e.target.value),
-                })
+                stage({ style: parseFloat(e.target.value) })
               }
-              onMouseUp={() => savePreferences({ style: preferences.style })}
-              onTouchEnd={() => savePreferences({ style: preferences.style })}
               className="w-full accent-indigo-500 h-2 bg-white/10 rounded-full appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4
                 [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:rounded-full"
@@ -726,16 +650,7 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
               step="1"
               value={preferences.turn_timeout}
               onChange={(e) =>
-                setPreferences({
-                  ...preferences,
-                  turn_timeout: parseInt(e.target.value),
-                })
-              }
-              onMouseUp={() =>
-                savePreferences({ turn_timeout: preferences.turn_timeout })
-              }
-              onTouchEnd={() =>
-                savePreferences({ turn_timeout: preferences.turn_timeout })
+                stage({ turn_timeout: parseInt(e.target.value) })
               }
               className="w-full accent-indigo-500 h-2 bg-white/10 rounded-full appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4
@@ -770,20 +685,7 @@ const VoiceSettings: React.FC<VoiceSettingsProps> = ({
               step="30"
               value={preferences.soft_timeout_seconds}
               onChange={(e) =>
-                setPreferences({
-                  ...preferences,
-                  soft_timeout_seconds: parseInt(e.target.value),
-                })
-              }
-              onMouseUp={() =>
-                savePreferences({
-                  soft_timeout_seconds: preferences.soft_timeout_seconds,
-                })
-              }
-              onTouchEnd={() =>
-                savePreferences({
-                  soft_timeout_seconds: preferences.soft_timeout_seconds,
-                })
+                stage({ soft_timeout_seconds: parseInt(e.target.value) })
               }
               className="w-full accent-indigo-500 h-2 bg-white/10 rounded-full appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4

--- a/frontend/src/components/voice/__tests__/VoiceLiveSettings.test.tsx
+++ b/frontend/src/components/voice/__tests__/VoiceLiveSettings.test.tsx
@@ -3,27 +3,54 @@
  * panel embedded inside VoiceOverlay.
  *
  * Behaviour covered:
- *  - Loading state while fetching preferences
  *  - Renders all 5 fields (volume, playback rate, input mode, PTT key, language)
- *  - Save handler called when user changes a field
+ *  - stage() called when user changes a stage-routed field
  *  - voicePrefsBus.emitVoicePrefsEvent fires for live-applicable changes
  *    (playback_rate)
  */
 
+import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
-const getPreferencesMock = vi.fn();
-const updatePreferencesMock = vi.fn();
-
-vi.mock("../../../services/api", () => ({
-  voiceApi: {
-    getPreferences: () => getPreferencesMock(),
-    updatePreferences: (updates: Record<string, unknown>) =>
-      updatePreferencesMock(updates),
-  },
+const stageMock = vi.fn();
+vi.mock("../staging/VoicePrefsStagingProvider", () => ({
+  useVoicePrefsStaging: () => ({
+    applied: {
+      voice_id: "v1",
+      voice_name: "Sophie",
+      speed: 1,
+      stability: 0.5,
+      similarity_boost: 0.75,
+      style: 0.3,
+      use_speaker_boost: true,
+      tts_model: "eleven_multilingual_v2",
+      voice_chat_model: "eleven_flash_v2_5",
+      language: "fr",
+      gender: "female",
+      input_mode: "ptt",
+      ptt_key: " ",
+      interruptions_enabled: true,
+      turn_eagerness: 0.5,
+      voice_chat_speed_preset: "1x",
+      turn_timeout: 15,
+      soft_timeout_seconds: 300,
+    },
+    catalog: null,
+    staged: {},
+    hasChanges: false,
+    hasRestartRequired: false,
+    callActive: false,
+    applying: false,
+    applyError: null,
+    stage: stageMock,
+    cancel: vi.fn(),
+    apply: vi.fn(),
+  }),
+  VoicePrefsStagingProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
 }));
 
 const emitVoicePrefsEventMock = vi.fn();
@@ -39,47 +66,13 @@ vi.mock("../voicePrefsBus", async () => {
 
 import { VoiceLiveSettings } from "../VoiceLiveSettings";
 
-const baselinePrefs = {
-  voice_id: "v1",
-  voice_name: "Aria",
-  speed: 1.0,
-  stability: 0.5,
-  similarity_boost: 0.75,
-  style: 0.3,
-  use_speaker_boost: true,
-  tts_model: "eleven_multilingual_v2",
-  voice_chat_model: "eleven_flash_v2_5",
-  language: "fr",
-  gender: "female",
-  input_mode: "ptt" as const,
-  ptt_key: " ",
-  interruptions_enabled: true,
-  turn_eagerness: 0.5,
-  voice_chat_speed_preset: "1x",
-  turn_timeout: 15,
-  soft_timeout_seconds: 300,
-};
+beforeEach(() => {
+  stageMock.mockReset();
+  emitVoicePrefsEventMock.mockReset();
+});
 
 describe("VoiceLiveSettings (in-call collapsible panel)", () => {
-  beforeEach(() => {
-    getPreferencesMock.mockReset();
-    updatePreferencesMock.mockReset();
-    emitVoicePrefsEventMock.mockReset();
-    getPreferencesMock.mockResolvedValue({ ...baselinePrefs });
-    updatePreferencesMock.mockImplementation(
-      async (updates: Record<string, unknown>) => ({
-        ...baselinePrefs,
-        ...updates,
-      }),
-    );
-  });
-
-  it("loads preferences from voiceApi on mount", async () => {
-    render(<VoiceLiveSettings language="fr" />);
-    await waitFor(() => expect(getPreferencesMock).toHaveBeenCalled());
-  });
-
-  it("renders the 5 expected sections after preferences load", async () => {
+  it("renders the 5 expected sections from staging context", async () => {
     render(<VoiceLiveSettings language="fr" />);
     await waitFor(() => {
       // Volume slider
@@ -97,7 +90,7 @@ describe("VoiceLiveSettings (in-call collapsible panel)", () => {
     });
   });
 
-  it("emits playback_rate_changed on bus when user picks a new rate", async () => {
+  it("emits playback_rate_changed on bus and stages voice_chat_speed_preset when user picks a new rate", async () => {
     render(<VoiceLiveSettings language="fr" />);
     const rate15 = await screen.findByTestId("voice-live-rate-1.5x");
     fireEvent.click(rate15);
@@ -109,35 +102,26 @@ describe("VoiceLiveSettings (in-call collapsible panel)", () => {
         }),
       ),
     );
+    expect(stageMock).toHaveBeenCalledWith({
+      voice_chat_speed_preset: "1.5x",
+    });
   });
 
-  it("calls voiceApi.updatePreferences when input_mode changes", async () => {
+  it("calls stage() when input_mode changes", async () => {
     render(<VoiceLiveSettings language="fr" />);
     const vad = await screen.findByTestId("voice-live-mode-vad");
     fireEvent.click(vad);
     await waitFor(() =>
-      expect(updatePreferencesMock).toHaveBeenCalledWith(
-        expect.objectContaining({ input_mode: "vad" }),
-      ),
+      expect(stageMock).toHaveBeenCalledWith({ input_mode: "vad" }),
     );
   });
 
-  it("calls voiceApi.updatePreferences when language changes", async () => {
+  it("calls stage() when language changes", async () => {
     render(<VoiceLiveSettings language="fr" />);
     const en = await screen.findByTestId("voice-live-lang-en");
     fireEvent.click(en);
     await waitFor(() =>
-      expect(updatePreferencesMock).toHaveBeenCalledWith(
-        expect.objectContaining({ language: "en" }),
-      ),
+      expect(stageMock).toHaveBeenCalledWith({ language: "en" }),
     );
-  });
-
-  it("displays an error message if preferences fail to load", async () => {
-    getPreferencesMock.mockRejectedValueOnce(new Error("network"));
-    render(<VoiceLiveSettings language="fr" />);
-    await waitFor(() => {
-      expect(screen.getByTestId("voice-live-error")).toBeDefined();
-    });
   });
 });

--- a/frontend/src/components/voice/__tests__/VoiceOverlay.test.tsx
+++ b/frontend/src/components/voice/__tests__/VoiceOverlay.test.tsx
@@ -303,7 +303,15 @@ describe("VoiceOverlay", () => {
 
   it("toggle le panel de réglages au click", async () => {
     const user = userEvent.setup();
-    render(<VoiceOverlay isOpen={true} onClose={() => {}} />);
+    // The settings panel mounts VoiceLiveSettings, which now reads from
+    // VoicePrefsStagingProvider — wrap the render so that hook resolves.
+    const { VoicePrefsStagingProvider } =
+      await import("../staging/VoicePrefsStagingProvider");
+    render(
+      <VoicePrefsStagingProvider>
+        <VoiceOverlay isOpen={true} onClose={() => {}} />
+      </VoicePrefsStagingProvider>,
+    );
     const toggle = await screen.findByTestId("voice-overlay-settings-toggle");
     await user.click(toggle);
     await waitFor(() =>

--- a/frontend/src/components/voice/__tests__/VoiceSettings.test.tsx
+++ b/frontend/src/components/voice/__tests__/VoiceSettings.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import VoiceSettings from "../VoiceSettings";
+
+const stageMock = vi.fn();
+vi.mock("../staging/VoicePrefsStagingProvider", () => ({
+  useVoicePrefsStaging: () => ({
+    applied: {
+      voice_id: "v1",
+      voice_name: "Sophie",
+      speed: 1,
+      stability: 0.5,
+      similarity_boost: 0.75,
+      style: 0.3,
+      use_speaker_boost: true,
+      tts_model: "eleven_multilingual_v2",
+      voice_chat_model: "eleven_flash_v2_5",
+      language: "fr",
+      gender: "female",
+      input_mode: "ptt",
+      ptt_key: " ",
+      interruptions_enabled: true,
+      turn_eagerness: 0.5,
+      voice_chat_speed_preset: "1x",
+      turn_timeout: 15,
+      soft_timeout_seconds: 300,
+    },
+    catalog: {
+      voices: [
+        {
+          voice_id: "v2",
+          name: "Mathieu",
+          description_fr: "",
+          description_en: "",
+          gender: "male",
+          accent: "fr",
+          language: "fr",
+          use_case: "tutor",
+          recommended: false,
+          preview_url: "https://example.com/v2.mp3",
+        },
+      ],
+      speed_presets: [
+        { id: "1.0", label_fr: "1x", label_en: "1x", value: 1, icon: "" },
+      ],
+      voice_chat_speed_presets: [
+        {
+          id: "1x",
+          label_fr: "Normal",
+          label_en: "Normal",
+          api_speed: 1,
+          playback_rate: 1,
+          concise: false,
+        },
+      ],
+      models: [
+        {
+          id: "eleven_flash_v2_5",
+          name: "Flash",
+          description_fr: "",
+          description_en: "",
+          latency: "lowest",
+          recommended_for: "voice_chat",
+        },
+      ],
+    },
+    staged: {},
+    hasChanges: false,
+    hasRestartRequired: false,
+    callActive: false,
+    applying: false,
+    applyError: null,
+    stage: stageMock,
+    cancel: vi.fn(),
+    apply: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  stageMock.mockReset();
+});
+
+describe("VoiceSettings — staging", () => {
+  it("clicking a different voice card calls stage()", async () => {
+    render(<VoiceSettings />);
+    fireEvent.click(screen.getByText("Sélection de voix"));
+    await waitFor(() => screen.getByText("Mathieu"));
+    fireEvent.click(screen.getByText("Mathieu"));
+    expect(stageMock).toHaveBeenCalledWith({
+      voice_id: "v2",
+      voice_name: "Mathieu",
+    });
+  });
+});

--- a/frontend/src/components/voice/__tests__/useVoiceChat.test.ts
+++ b/frontend/src/components/voice/__tests__/useVoiceChat.test.ts
@@ -356,23 +356,29 @@ describe("useVoiceChat — apply_with_restart", () => {
     await act(async () => {
       await result.current.start();
     });
-    // Sanity: initial start did call mockStartSession exactly once and set up
-    // the conversation so the listener's `conversationRef.current` guard
-    // passes when apply_with_restart fires.
     const startCallsAfterStart = mockStartSession.mock.calls.length;
     expect(startCallsAfterStart).toBe(1);
     mockEndSession.mockClear();
 
     await act(async () => {
       emitVoicePrefsEvent({ type: "apply_with_restart" });
-      // restart() awaits stop() (calls endSession), then 400ms timer, then
-      // start() — flush all timers + microtasks.
-      await vi.runAllTimersAsync();
+      // restart() awaits stop() (calls endSession), then a 400ms setTimeout,
+      // then start(). Advance just past 400ms — runAllTimersAsync would loop
+      // forever on the 1s session-elapsed interval set up by start().
+      await vi.advanceTimersByTimeAsync(500);
+      // Flush the microtasks introduced by the awaited start() (mocked
+      // import/fetch/startSession all resolve as microtasks).
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
-    // Observable proof that restart() fired: the stop() phase of restart()
-    // calls endSession on the conversation it captured when it began.
+    // restart() must call BOTH endSession (stop phase) and a fresh
+    // startSession (start phase). The latter only fires if the closure trap
+    // in start() is fixed.
     expect(mockEndSession).toHaveBeenCalled();
+    expect(mockStartSession.mock.calls.length).toBeGreaterThan(
+      startCallsAfterStart,
+    );
   });
 
   it("is a no-op when there is no active conversation", async () => {

--- a/frontend/src/components/voice/__tests__/useVoiceChat.test.ts
+++ b/frontend/src/components/voice/__tests__/useVoiceChat.test.ts
@@ -26,6 +26,19 @@ vi.mock("@elevenlabs/client", () => ({
   },
 }));
 
+// Polyfill MediaStream for jsdom (production code uses `instanceof MediaStream`)
+class MediaStreamPolyfill {
+  getTracks() {
+    return [{ stop: vi.fn(), enabled: true }];
+  }
+  getAudioTracks() {
+    return [{ stop: vi.fn(), enabled: true }];
+  }
+}
+if (typeof (globalThis as any).MediaStream === "undefined") {
+  (globalThis as any).MediaStream = MediaStreamPolyfill;
+}
+
 // Mock navigator.mediaDevices
 const mockGetUserMedia = vi.fn();
 Object.defineProperty(global.navigator, "mediaDevices", {
@@ -38,14 +51,15 @@ const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 import { useVoiceChat } from "../useVoiceChat";
+import {
+  emitVoicePrefsEvent,
+  subscribeVoicePrefsEvents,
+} from "../voicePrefsBus";
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("useVoiceChat", () => {
-  const mockMediaStream = {
-    getTracks: () => [{ stop: vi.fn(), enabled: true }],
-    getAudioTracks: () => [{ stop: vi.fn(), enabled: true }],
-  };
+  const mockMediaStream = new MediaStreamPolyfill();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -104,7 +118,7 @@ describe("useVoiceChat", () => {
           "Content-Type": "application/json",
           Authorization: "Bearer test-token-123",
         }),
-        body: JSON.stringify({ summary_id: 42 }),
+        body: expect.stringContaining('"summary_id":42'),
       }),
     );
   });
@@ -236,5 +250,140 @@ describe("useVoiceChat", () => {
 
     // Should remain false (no session to mute)
     expect(result.current.isMuted).toBe(false);
+  });
+});
+
+describe("useVoiceChat — call_status_changed events", () => {
+  const mockMediaStream = new MediaStreamPolyfill();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetUserMedia.mockResolvedValue(mockMediaStream);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          session_id: "sess-123",
+          signed_url: "wss://test/signed",
+          quota_remaining_minutes: 10,
+          max_session_minutes: 30,
+          input_mode: "ptt",
+          ptt_key: " ",
+          playback_rate: 1.0,
+        }),
+    });
+    mockStartSession.mockImplementation(async (opts: any) => {
+      opts.onConnect?.();
+      return { endSession: mockEndSession, setVolume: vi.fn() };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits call_status_changed { active: true } onConnect", async () => {
+    const events: boolean[] = [];
+    const unsub = subscribeVoicePrefsEvents((e) => {
+      if (e.type === "call_status_changed") events.push(e.active);
+    });
+
+    const { result } = renderHook(() => useVoiceChat({ summaryId: 1 }));
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(events).toContain(true);
+    unsub();
+  });
+
+  it("emits call_status_changed { active: false } on stop", async () => {
+    const events: boolean[] = [];
+    const unsub = subscribeVoicePrefsEvents((e) => {
+      if (e.type === "call_status_changed") events.push(e.active);
+    });
+
+    const { result } = renderHook(() => useVoiceChat({ summaryId: 1 }));
+
+    await act(async () => {
+      await result.current.start();
+    });
+    await act(async () => {
+      await result.current.stop();
+    });
+
+    expect(events.filter((v) => v === false)).toHaveLength(1);
+    unsub();
+  });
+});
+
+describe("useVoiceChat — apply_with_restart", () => {
+  const mockMediaStream = new MediaStreamPolyfill();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetUserMedia.mockResolvedValue(mockMediaStream);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          session_id: "sess-123",
+          signed_url: "wss://test/signed",
+          quota_remaining_minutes: 10,
+          max_session_minutes: 30,
+          input_mode: "ptt",
+          ptt_key: " ",
+          playback_rate: 1.0,
+        }),
+    });
+    mockStartSession.mockImplementation(async (opts: any) => {
+      opts.onConnect?.();
+      return { endSession: mockEndSession, setVolume: vi.fn() };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls restart (start invoked again) when active session receives apply_with_restart", async () => {
+    const { result } = renderHook(() => useVoiceChat({ summaryId: 1 }));
+    await act(async () => {
+      await result.current.start();
+    });
+    // Sanity: initial start did call mockStartSession exactly once and set up
+    // the conversation so the listener's `conversationRef.current` guard
+    // passes when apply_with_restart fires.
+    const startCallsAfterStart = mockStartSession.mock.calls.length;
+    expect(startCallsAfterStart).toBe(1);
+    mockEndSession.mockClear();
+
+    await act(async () => {
+      emitVoicePrefsEvent({ type: "apply_with_restart" });
+      // restart() awaits stop() (calls endSession), then 400ms timer, then
+      // start() — flush all timers + microtasks.
+      await vi.runAllTimersAsync();
+    });
+
+    // Observable proof that restart() fired: the stop() phase of restart()
+    // calls endSession on the conversation it captured when it began.
+    expect(mockEndSession).toHaveBeenCalled();
+  });
+
+  it("is a no-op when there is no active conversation", async () => {
+    renderHook(() => useVoiceChat({ summaryId: 1 }));
+
+    await act(async () => {
+      emitVoicePrefsEvent({ type: "apply_with_restart" });
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(mockStartSession).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/voice/__tests__/useVoiceChat.test.ts
+++ b/frontend/src/components/voice/__tests__/useVoiceChat.test.ts
@@ -35,8 +35,11 @@ class MediaStreamPolyfill {
     return [{ stop: vi.fn(), enabled: true }];
   }
 }
-if (typeof (globalThis as any).MediaStream === "undefined") {
-  (globalThis as any).MediaStream = MediaStreamPolyfill;
+{
+  const g = globalThis as unknown as { MediaStream?: unknown };
+  if (typeof g.MediaStream === "undefined") {
+    g.MediaStream = MediaStreamPolyfill;
+  }
 }
 
 // Mock navigator.mediaDevices
@@ -274,10 +277,12 @@ describe("useVoiceChat — call_status_changed events", () => {
           playback_rate: 1.0,
         }),
     });
-    mockStartSession.mockImplementation(async (opts: any) => {
-      opts.onConnect?.();
-      return { endSession: mockEndSession, setVolume: vi.fn() };
-    });
+    mockStartSession.mockImplementation(
+      async (opts: { onConnect?: () => void }) => {
+        opts.onConnect?.();
+        return { endSession: mockEndSession, setVolume: vi.fn() };
+      },
+    );
   });
 
   afterEach(() => {
@@ -341,10 +346,12 @@ describe("useVoiceChat — apply_with_restart", () => {
           playback_rate: 1.0,
         }),
     });
-    mockStartSession.mockImplementation(async (opts: any) => {
-      opts.onConnect?.();
-      return { endSession: mockEndSession, setVolume: vi.fn() };
-    });
+    mockStartSession.mockImplementation(
+      async (opts: { onConnect?: () => void }) => {
+        opts.onConnect?.();
+        return { endSession: mockEndSession, setVolume: vi.fn() };
+      },
+    );
   });
 
   afterEach(() => {

--- a/frontend/src/components/voice/__tests__/voicePrefsBus.test.ts
+++ b/frontend/src/components/voice/__tests__/voicePrefsBus.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  emitVoicePrefsEvent,
+  subscribeVoicePrefsEvents,
+  presetToPlaybackRate,
+} from "../voicePrefsBus";
+
+describe("voicePrefsBus", () => {
+  it("delivers playback_rate_changed (legacy)", () => {
+    const listener = vi.fn();
+    const unsub = subscribeVoicePrefsEvents(listener);
+    emitVoicePrefsEvent({ type: "playback_rate_changed", value: 1.25 });
+    expect(listener).toHaveBeenCalledWith({
+      type: "playback_rate_changed",
+      value: 1.25,
+    });
+    unsub();
+  });
+
+  it("delivers apply_with_restart (new)", () => {
+    const listener = vi.fn();
+    const unsub = subscribeVoicePrefsEvents(listener);
+    emitVoicePrefsEvent({ type: "apply_with_restart" });
+    expect(listener).toHaveBeenCalledWith({ type: "apply_with_restart" });
+    unsub();
+  });
+
+  it("delivers call_status_changed (new)", () => {
+    const listener = vi.fn();
+    const unsub = subscribeVoicePrefsEvents(listener);
+    emitVoicePrefsEvent({ type: "call_status_changed", active: true });
+    expect(listener).toHaveBeenCalledWith({
+      type: "call_status_changed",
+      active: true,
+    });
+    unsub();
+  });
+
+  it("unsubscribe stops delivery", () => {
+    const listener = vi.fn();
+    const unsub = subscribeVoicePrefsEvents(listener);
+    unsub();
+    emitVoicePrefsEvent({ type: "apply_with_restart" });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("preserves presetToPlaybackRate behavior", () => {
+    expect(presetToPlaybackRate("1x")).toBe(1);
+    expect(presetToPlaybackRate("1.5x")).toBe(1.5);
+    expect(presetToPlaybackRate("unknown")).toBe(1);
+  });
+});

--- a/frontend/src/components/voice/staging/StagedPrefsToolbar.tsx
+++ b/frontend/src/components/voice/staging/StagedPrefsToolbar.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import { motion, AnimatePresence } from "framer-motion";
+import { Check, X, RotateCcw, AlertCircle, Loader2 } from "lucide-react";
+import { useVoicePrefsStaging } from "./VoicePrefsStagingProvider";
+
+export const StagedPrefsToolbar: React.FC = () => {
+  const {
+    hasChanges,
+    hasRestartRequired,
+    callActive,
+    staged,
+    applying,
+    applyError,
+    cancel,
+    apply,
+  } = useVoicePrefsStaging();
+
+  const count = Object.keys(staged).length;
+  const wantsRestart = hasRestartRequired && callActive;
+
+  const node = (
+    <AnimatePresence>
+      {hasChanges && (
+        <motion.div
+          key="staged-prefs-toolbar"
+          data-testid="staged-prefs-toolbar"
+          role="region"
+          aria-label="Modifications en attente"
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 24 }}
+          transition={{ duration: 0.2, ease: "easeOut" }}
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[1100] max-w-[calc(100vw-32px)]"
+        >
+          <div className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-[#12121a]/85 backdrop-blur-xl border border-white/10 shadow-2xl shadow-indigo-500/20">
+            <span
+              data-testid="staged-count"
+              role="status"
+              aria-live="polite"
+              className="text-sm text-white/80 font-medium tabular-nums"
+            >
+              <span className="inline-block w-1.5 h-1.5 rounded-full bg-indigo-400 mr-2 align-middle" />
+              {count} modification{count > 1 ? "s" : ""} en attente
+            </span>
+
+            <button
+              type="button"
+              data-testid="staged-cancel"
+              onClick={cancel}
+              disabled={applying}
+              className="px-3 py-1.5 rounded-lg text-xs font-medium text-white/70 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus-visible:ring-2 focus-visible:ring-white/30"
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <X className="w-3.5 h-3.5" />
+                Annuler
+              </span>
+            </button>
+
+            <button
+              type="button"
+              data-testid="staged-apply"
+              onClick={apply}
+              disabled={applying}
+              aria-keyshortcuts="Mod+Enter"
+              className={`px-4 py-1.5 rounded-lg text-xs font-semibold transition-all focus-visible:ring-2 focus-visible:ring-indigo-300 ${
+                wantsRestart
+                  ? "bg-amber-500 text-[#0a0a0f] hover:bg-amber-400"
+                  : "bg-indigo-500 text-white hover:bg-indigo-400"
+              } disabled:opacity-50 disabled:cursor-wait`}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                {applying ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : wantsRestart ? (
+                  <RotateCcw className="w-3.5 h-3.5" />
+                ) : (
+                  <Check className="w-3.5 h-3.5" />
+                )}
+                {wantsRestart ? "Appliquer & redémarrer" : "Appliquer"}
+              </span>
+            </button>
+          </div>
+
+          {applyError && (
+            <div
+              data-testid="staged-error"
+              className="mt-2 mx-auto flex items-start gap-2 px-3 py-2 rounded-xl bg-amber-500/15 border border-amber-400/30 text-amber-200 text-xs"
+            >
+              <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+              <span>{applyError}</span>
+            </div>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+
+  if (typeof document === "undefined" || !document.body) return node;
+  return createPortal(node, document.body);
+};
+
+export default StagedPrefsToolbar;

--- a/frontend/src/components/voice/staging/VoicePrefsStagingProvider.tsx
+++ b/frontend/src/components/voice/staging/VoicePrefsStagingProvider.tsx
@@ -1,0 +1,186 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  voiceApi,
+  type VoicePreferences,
+  type VoiceCatalog,
+} from "../../../services/api";
+import {
+  emitVoicePrefsEvent,
+  subscribeVoicePrefsEvents,
+} from "../voicePrefsBus";
+import { isRestartRequired } from "./restartRequiredFields";
+
+export interface VoicePrefsStagingContextValue {
+  applied: VoicePreferences | null;
+  catalog: VoiceCatalog | null;
+  staged: Partial<VoicePreferences>;
+  hasChanges: boolean;
+  hasRestartRequired: boolean;
+  callActive: boolean;
+  applying: boolean;
+  applyError: string | null;
+  stage: (updates: Partial<VoicePreferences>) => void;
+  cancel: () => void;
+  apply: () => Promise<void>;
+}
+
+const VoicePrefsStagingContext =
+  createContext<VoicePrefsStagingContextValue | null>(null);
+
+export const VoicePrefsStagingProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [applied, setApplied] = useState<VoicePreferences | null>(null);
+  const [catalog, setCatalog] = useState<VoiceCatalog | null>(null);
+  const [staged, setStaged] = useState<Partial<VoicePreferences>>({});
+  const [callActive, setCallActive] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  // Hydrate prefs + catalog at mount.
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([voiceApi.getPreferences(), voiceApi.getCatalog()])
+      .then(([prefs, cat]) => {
+        if (cancelled) return;
+        setApplied(prefs);
+        setCatalog(cat);
+      })
+      .catch(() => {
+        // Silent failure — provider stays in loading state until the
+        // first real `apply()` retries network.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Subscribe to call_status_changed.
+  useEffect(() => {
+    const unsubscribe = subscribeVoicePrefsEvents((event) => {
+      if (event.type === "call_status_changed") {
+        setCallActive(event.active);
+      }
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const stage = useCallback(
+    (updates: Partial<VoicePreferences>) => {
+      setStaged((prev) => {
+        const next: Partial<VoicePreferences> = { ...prev };
+        for (const key of Object.keys(updates) as (keyof VoicePreferences)[]) {
+          const value = updates[key];
+          // No-op detect: if value matches applied, drop the key.
+          if (applied && Object.is(applied[key], value)) {
+            delete next[key];
+          } else {
+            // @ts-expect-error — heterogeneous union write is safe at runtime
+            next[key] = value;
+          }
+        }
+        return next;
+      });
+    },
+    [applied],
+  );
+
+  const cancel = useCallback(() => {
+    setStaged({});
+    setApplyError(null);
+  }, []);
+
+  const apply = useCallback(async () => {
+    if (Object.keys(staged).length === 0) return;
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const next = await voiceApi.updatePreferences(staged);
+      if (!isMountedRef.current) return;
+      setApplied(next);
+      const restartNeeded =
+        callActive &&
+        catalog != null &&
+        isRestartRequired(staged, catalog.voice_chat_speed_presets);
+      setStaged({});
+      if (restartNeeded) {
+        emitVoicePrefsEvent({ type: "apply_with_restart" });
+      }
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      setApplyError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      if (isMountedRef.current) setApplying(false);
+    }
+  }, [staged, callActive, catalog]);
+
+  const hasChanges = useMemo(() => Object.keys(staged).length > 0, [staged]);
+  const hasRestartRequired = useMemo(
+    () =>
+      hasChanges &&
+      catalog != null &&
+      isRestartRequired(staged, catalog.voice_chat_speed_presets),
+    [hasChanges, staged, catalog],
+  );
+
+  const value = useMemo<VoicePrefsStagingContextValue>(
+    () => ({
+      applied,
+      catalog,
+      staged,
+      hasChanges,
+      hasRestartRequired,
+      callActive,
+      applying,
+      applyError,
+      stage,
+      cancel,
+      apply,
+    }),
+    [
+      applied,
+      catalog,
+      staged,
+      hasChanges,
+      hasRestartRequired,
+      callActive,
+      applying,
+      applyError,
+      stage,
+      cancel,
+      apply,
+    ],
+  );
+
+  return (
+    <VoicePrefsStagingContext.Provider value={value}>
+      {children}
+    </VoicePrefsStagingContext.Provider>
+  );
+};
+
+export function useVoicePrefsStaging(): VoicePrefsStagingContextValue {
+  const ctx = useContext(VoicePrefsStagingContext);
+  if (!ctx) {
+    throw new Error(
+      "useVoicePrefsStaging must be used inside <VoicePrefsStagingProvider>",
+    );
+  }
+  return ctx;
+}

--- a/frontend/src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx
+++ b/frontend/src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StagedPrefsToolbar } from "../StagedPrefsToolbar";
+import { VoicePrefsStagingProvider } from "../VoicePrefsStagingProvider";
+import type { VoicePrefsStagingContextValue } from "../VoicePrefsStagingProvider";
+import * as ProviderModule from "../VoicePrefsStagingProvider";
+
+function renderWithStaging(
+  override: Partial<VoicePrefsStagingContextValue>,
+) {
+  const value: VoicePrefsStagingContextValue = {
+    applied: null,
+    catalog: null,
+    staged: {},
+    hasChanges: false,
+    hasRestartRequired: false,
+    callActive: false,
+    applying: false,
+    applyError: null,
+    stage: vi.fn(),
+    cancel: vi.fn(),
+    apply: vi.fn(),
+    ...override,
+  };
+  vi.spyOn(ProviderModule, "useVoicePrefsStaging").mockReturnValue(value);
+  return { value, ...render(<StagedPrefsToolbar />) };
+}
+
+describe("StagedPrefsToolbar", () => {
+  it("renders nothing when hasChanges is false", () => {
+    renderWithStaging({ hasChanges: false });
+    expect(screen.queryByTestId("staged-prefs-toolbar")).toBeNull();
+  });
+
+  it("shows count and Apply / Cancel when hasChanges", () => {
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2", language: "en" },
+    });
+    const bar = screen.getByTestId("staged-prefs-toolbar");
+    expect(bar).toBeTruthy();
+    expect(screen.getByTestId("staged-count").textContent).toContain("2");
+    expect(screen.getByTestId("staged-apply")).toBeTruthy();
+    expect(screen.getByTestId("staged-cancel")).toBeTruthy();
+  });
+
+  it("uses 'Appliquer & redémarrer' label when callActive and restart required", () => {
+    renderWithStaging({
+      hasChanges: true,
+      hasRestartRequired: true,
+      callActive: true,
+      staged: { voice_id: "v2" },
+    });
+    expect(screen.getByTestId("staged-apply").textContent).toMatch(
+      /redémarrer/i,
+    );
+  });
+
+  it("uses 'Appliquer' label otherwise", () => {
+    renderWithStaging({
+      hasChanges: true,
+      hasRestartRequired: false,
+      callActive: false,
+      staged: { ptt_key: "Shift" },
+    });
+    expect(screen.getByTestId("staged-apply").textContent).toMatch(/appliquer/i);
+    expect(screen.getByTestId("staged-apply").textContent).not.toMatch(
+      /redémarrer/i,
+    );
+  });
+
+  it("clicking Apply calls apply()", () => {
+    const apply = vi.fn();
+    renderWithStaging({ hasChanges: true, staged: { voice_id: "v2" }, apply });
+    fireEvent.click(screen.getByTestId("staged-apply"));
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking Cancel calls cancel()", () => {
+    const cancel = vi.fn();
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2" },
+      cancel,
+    });
+    fireEvent.click(screen.getByTestId("staged-cancel"));
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both buttons while applying", () => {
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2" },
+      applying: true,
+    });
+    expect(
+      (screen.getByTestId("staged-apply") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByTestId("staged-cancel") as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("shows applyError when set", () => {
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2" },
+      applyError: "Erreur réseau",
+    });
+    expect(screen.getByTestId("staged-error").textContent).toContain(
+      "Erreur réseau",
+    );
+  });
+
+  it("count container has aria-live=polite", () => {
+    renderWithStaging({
+      hasChanges: true,
+      staged: { voice_id: "v2" },
+    });
+    expect(screen.getByTestId("staged-count").getAttribute("aria-live")).toBe(
+      "polite",
+    );
+  });
+});

--- a/frontend/src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx
+++ b/frontend/src/components/voice/staging/__tests__/StagedPrefsToolbar.test.tsx
@@ -1,13 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { StagedPrefsToolbar } from "../StagedPrefsToolbar";
-import { VoicePrefsStagingProvider } from "../VoicePrefsStagingProvider";
 import type { VoicePrefsStagingContextValue } from "../VoicePrefsStagingProvider";
 import * as ProviderModule from "../VoicePrefsStagingProvider";
 
-function renderWithStaging(
-  override: Partial<VoicePrefsStagingContextValue>,
-) {
+function renderWithStaging(override: Partial<VoicePrefsStagingContextValue>) {
   const value: VoicePrefsStagingContextValue = {
     applied: null,
     catalog: null,
@@ -63,7 +60,9 @@ describe("StagedPrefsToolbar", () => {
       callActive: false,
       staged: { ptt_key: "Shift" },
     });
-    expect(screen.getByTestId("staged-apply").textContent).toMatch(/appliquer/i);
+    expect(screen.getByTestId("staged-apply").textContent).toMatch(
+      /appliquer/i,
+    );
     expect(screen.getByTestId("staged-apply").textContent).not.toMatch(
       /redémarrer/i,
     );

--- a/frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx
+++ b/frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx
@@ -101,4 +101,90 @@ describe("VoicePrefsStagingProvider", () => {
     act(() => result.current.cancel());
     expect(result.current.staged).toEqual({});
   });
+
+  it("apply() sends a single batched updatePreferences call and resets staged", async () => {
+    vi.mocked(voiceApi.updatePreferences).mockResolvedValue({
+      ...APPLIED,
+      voice_id: "v2",
+      language: "en",
+    });
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2", language: "en" }));
+    await act(async () => {
+      await result.current.apply();
+    });
+    expect(voiceApi.updatePreferences).toHaveBeenCalledTimes(1);
+    expect(voiceApi.updatePreferences).toHaveBeenCalledWith({
+      voice_id: "v2",
+      language: "en",
+    });
+    expect(result.current.staged).toEqual({});
+    expect(result.current.applied?.voice_id).toBe("v2");
+  });
+
+  it("apply() emits apply_with_restart when callActive and hard field staged", async () => {
+    const { emitVoicePrefsEvent: emit, subscribeVoicePrefsEvents: sub } =
+      await import("../../voicePrefsBus");
+    const listener = vi.fn();
+    const unsub = sub(listener);
+    vi.mocked(voiceApi.updatePreferences).mockResolvedValue(APPLIED);
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => emit({ type: "call_status_changed", active: true }));
+    await waitFor(() => expect(result.current.callActive).toBe(true));
+    act(() => result.current.stage({ voice_id: "v2" }));
+    await act(async () => {
+      await result.current.apply();
+    });
+    expect(listener).toHaveBeenCalledWith({ type: "apply_with_restart" });
+    unsub();
+  });
+
+  it("apply() does NOT emit apply_with_restart when callActive but only soft fields staged", async () => {
+    const { subscribeVoicePrefsEvents: sub } = await import(
+      "../../voicePrefsBus"
+    );
+    const listener = vi.fn();
+    const unsub = sub(listener);
+    vi.mocked(voiceApi.updatePreferences).mockResolvedValue(APPLIED);
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    const { emitVoicePrefsEvent: emit } = await import("../../voicePrefsBus");
+    act(() => emit({ type: "call_status_changed", active: true }));
+    await waitFor(() => expect(result.current.callActive).toBe(true));
+    act(() => result.current.stage({ ptt_key: "Shift" }));
+    await act(async () => {
+      await result.current.apply();
+    });
+    const apply = listener.mock.calls.find(
+      ([e]) => e.type === "apply_with_restart",
+    );
+    expect(apply).toBeUndefined();
+    unsub();
+  });
+
+  it("apply() preserves staged on error and sets applyError", async () => {
+    vi.mocked(voiceApi.updatePreferences).mockRejectedValue(
+      new Error("network down"),
+    );
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2" }));
+    await act(async () => {
+      await result.current.apply();
+    });
+    expect(result.current.staged).toEqual({ voice_id: "v2" });
+    expect(result.current.applyError).toBe("network down");
+  });
+
+  it("apply() is a no-op when staged is empty", async () => {
+    vi.mocked(voiceApi.updatePreferences).mockResolvedValue(APPLIED);
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    await act(async () => {
+      await result.current.apply();
+    });
+    expect(voiceApi.updatePreferences).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx
+++ b/frontend/src/components/voice/staging/__tests__/VoicePrefsStagingProvider.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  VoicePrefsStagingProvider,
+  useVoicePrefsStaging,
+} from "../VoicePrefsStagingProvider";
+import type {
+  VoicePreferences,
+  VoiceCatalog,
+  VoiceChatSpeedPreset,
+} from "../../../../services/api";
+
+vi.mock("../../../../services/api", async () => {
+  const actual = await vi.importActual<typeof import("../../../../services/api")>(
+    "../../../../services/api",
+  );
+  return {
+    ...actual,
+    voiceApi: {
+      getPreferences: vi.fn(),
+      getCatalog: vi.fn(),
+      updatePreferences: vi.fn(),
+    },
+  };
+});
+
+import { voiceApi } from "../../../../services/api";
+
+const APPLIED: VoicePreferences = {
+  voice_id: "v1",
+  voice_name: "Sophie",
+  speed: 1.0,
+  stability: 0.5,
+  similarity_boost: 0.75,
+  style: 0.3,
+  use_speaker_boost: true,
+  tts_model: "eleven_multilingual_v2",
+  voice_chat_model: "eleven_flash_v2_5",
+  language: "fr",
+  gender: "female",
+  input_mode: "ptt",
+  ptt_key: " ",
+  interruptions_enabled: true,
+  turn_eagerness: 0.5,
+  voice_chat_speed_preset: "1x",
+  turn_timeout: 15,
+  soft_timeout_seconds: 300,
+};
+
+const PRESETS: VoiceChatSpeedPreset[] = [
+  { id: "1x", label_fr: "Normal", label_en: "Normal", api_speed: 1, playback_rate: 1, concise: false },
+  { id: "3x", label_fr: "Concis", label_en: "Concise", api_speed: 1, playback_rate: 1, concise: true },
+];
+
+const CATALOG: VoiceCatalog = {
+  voices: [],
+  speed_presets: [],
+  voice_chat_speed_presets: PRESETS,
+  models: [],
+};
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <VoicePrefsStagingProvider>{children}</VoicePrefsStagingProvider>
+);
+
+beforeEach(() => {
+  vi.mocked(voiceApi.getPreferences).mockResolvedValue(APPLIED);
+  vi.mocked(voiceApi.getCatalog).mockResolvedValue(CATALOG);
+  vi.mocked(voiceApi.updatePreferences).mockReset();
+});
+
+describe("VoicePrefsStagingProvider", () => {
+  it("hydrates applied + catalog on mount", async () => {
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    expect(voiceApi.getPreferences).toHaveBeenCalled();
+    expect(voiceApi.getCatalog).toHaveBeenCalled();
+  });
+
+  it("stage() merges into staged", async () => {
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2" }));
+    expect(result.current.staged).toEqual({ voice_id: "v2" });
+    expect(result.current.hasChanges).toBe(true);
+  });
+
+  it("stage() with applied value removes the key (no-op detect)", async () => {
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2" }));
+    act(() => result.current.stage({ voice_id: "v1" }));
+    expect(result.current.staged).toEqual({});
+    expect(result.current.hasChanges).toBe(false);
+  });
+
+  it("cancel() clears staged", async () => {
+    const { result } = renderHook(() => useVoicePrefsStaging(), { wrapper });
+    await waitFor(() => expect(result.current.applied).toEqual(APPLIED));
+    act(() => result.current.stage({ voice_id: "v2", language: "en" }));
+    act(() => result.current.cancel());
+    expect(result.current.staged).toEqual({});
+  });
+});

--- a/frontend/src/components/voice/staging/__tests__/restartRequiredFields.test.ts
+++ b/frontend/src/components/voice/staging/__tests__/restartRequiredFields.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  RESTART_REQUIRED_FIELDS,
+  isRestartRequired,
+} from "../restartRequiredFields";
+import type { VoiceChatSpeedPreset } from "../../../../services/api";
+
+const PRESETS: VoiceChatSpeedPreset[] = [
+  { id: "1x", label_fr: "Normal", label_en: "Normal", api_speed: 1, playback_rate: 1, concise: false },
+  { id: "1.5x", label_fr: "Rapide", label_en: "Fast", api_speed: 1, playback_rate: 1.5, concise: false },
+  { id: "3x", label_fr: "Concis", label_en: "Concise", api_speed: 1, playback_rate: 1, concise: true },
+];
+
+describe("RESTART_REQUIRED_FIELDS", () => {
+  it("includes voice_id, voice_name, models, voice tuning, language, gender", () => {
+    for (const key of [
+      "voice_id",
+      "voice_name",
+      "tts_model",
+      "voice_chat_model",
+      "stability",
+      "similarity_boost",
+      "style",
+      "use_speaker_boost",
+      "language",
+      "gender",
+    ] as const) {
+      expect(RESTART_REQUIRED_FIELDS.has(key)).toBe(true);
+    }
+  });
+
+  it("does not include soft fields", () => {
+    for (const key of [
+      "ptt_key",
+      "input_mode",
+      "turn_timeout",
+      "soft_timeout_seconds",
+      "speed",
+      "voice_chat_speed_preset",
+    ] as const) {
+      expect(RESTART_REQUIRED_FIELDS.has(key)).toBe(false);
+    }
+  });
+});
+
+describe("isRestartRequired", () => {
+  it("returns false for empty staged", () => {
+    expect(isRestartRequired({}, PRESETS)).toBe(false);
+  });
+
+  it("returns true when a hard field is staged", () => {
+    expect(isRestartRequired({ voice_id: "abc" }, PRESETS)).toBe(true);
+  });
+
+  it("returns false when only soft fields are staged", () => {
+    expect(
+      isRestartRequired(
+        { ptt_key: "Space", input_mode: "vad", turn_timeout: 12 },
+        PRESETS,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when staged voice_chat_speed_preset is a concise variant", () => {
+    expect(
+      isRestartRequired({ voice_chat_speed_preset: "3x" }, PRESETS),
+    ).toBe(true);
+  });
+
+  it("returns false when staged voice_chat_speed_preset is a non-concise variant", () => {
+    expect(
+      isRestartRequired({ voice_chat_speed_preset: "1.5x" }, PRESETS),
+    ).toBe(false);
+  });
+
+  it("returns false if catalog is empty (presets unknown → assume non-restart)", () => {
+    expect(isRestartRequired({ voice_chat_speed_preset: "3x" }, [])).toBe(false);
+  });
+});

--- a/frontend/src/components/voice/staging/restartRequiredFields.ts
+++ b/frontend/src/components/voice/staging/restartRequiredFields.ts
@@ -1,0 +1,51 @@
+import type {
+  VoicePreferences,
+  VoiceChatSpeedPreset,
+} from "../../../services/api";
+
+/**
+ * Fields that, when changed, require a fresh ElevenLabs session
+ * (start/stop) for the change to take effect — they are baked into the
+ * agent at startSession() time.
+ *
+ * Soft fields (input_mode, ptt_key, turn_timeout, soft_timeout_seconds,
+ * speed, voice_chat_speed_preset non-concise) are persisted but do not
+ * require a session restart.
+ *
+ * Live fields (volume, playback_rate) are not staged at all — they apply
+ * directly to the DOM <audio> elements.
+ */
+export const RESTART_REQUIRED_FIELDS: ReadonlySet<keyof VoicePreferences> =
+  new Set<keyof VoicePreferences>([
+    "voice_id",
+    "voice_name",
+    "tts_model",
+    "voice_chat_model",
+    "stability",
+    "similarity_boost",
+    "style",
+    "use_speaker_boost",
+    "language",
+    "gender",
+  ]);
+
+/**
+ * Decide whether the staged diff requires an ElevenLabs session restart
+ * to take effect. Handles the special case of voice_chat_speed_preset:
+ * only concise variants need a restart (because they inject a system
+ * prompt server-side at agent creation).
+ */
+export function isRestartRequired(
+  staged: Partial<VoicePreferences>,
+  speedPresets: VoiceChatSpeedPreset[],
+): boolean {
+  for (const key of Object.keys(staged) as (keyof VoicePreferences)[]) {
+    if (RESTART_REQUIRED_FIELDS.has(key)) return true;
+    if (key === "voice_chat_speed_preset") {
+      const presetId = staged.voice_chat_speed_preset;
+      const preset = speedPresets.find((p) => p.id === presetId);
+      if (preset?.concise) return true;
+    }
+  }
+  return false;
+}

--- a/frontend/src/components/voice/useVoiceChat.ts
+++ b/frontend/src/components/voice/useVoiceChat.ts
@@ -11,7 +11,10 @@ import {
   type RefObject,
 } from "react";
 import { API_URL, getAccessToken } from "../../services/api";
-import { subscribeVoicePrefsEvents } from "./voicePrefsBus";
+import {
+  subscribeVoicePrefsEvents,
+  emitVoicePrefsEvent,
+} from "./voicePrefsBus";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Types
@@ -373,6 +376,7 @@ export function useVoiceChat({
       voiceSessionIdRef.current = null;
       setSessionStartedAt(null);
     }
+    emitVoicePrefsEvent({ type: "call_status_changed", active: false });
   }, [
     stopTimer,
     releaseMediaStream,
@@ -534,6 +538,7 @@ export function useVoiceChat({
             // Spec #5 — timestamp précis du démarrage pour time_in_call_secs
             setSessionStartedAt(Date.now());
           }
+          emitVoicePrefsEvent({ type: "call_status_changed", active: true });
         },
         onDisconnect: () => {
           if (isMountedRef.current) {
@@ -714,6 +719,16 @@ export function useVoiceChat({
     });
     return unsubscribe;
   }, [applyPlaybackRate, cleanupPlaybackObserver, cleanupPlaybackPolling]);
+
+  // Live-restart when the staging provider applies a restart-required diff.
+  useEffect(() => {
+    const unsubscribe = subscribeVoicePrefsEvents((event) => {
+      if (event.type !== "apply_with_restart") return;
+      if (!conversationRef.current) return;
+      void restart();
+    });
+    return unsubscribe;
+  }, [restart]);
 
   // ─────────────────────────────────────────────────────────────────────────
   // Cleanup on unmount

--- a/frontend/src/components/voice/useVoiceChat.ts
+++ b/frontend/src/components/voice/useVoiceChat.ts
@@ -409,6 +409,9 @@ export function useVoiceChat({
 
   // Prewarm: précharge le SDK ElevenLabs côté client pour économiser ~200-300ms au clic
   const prewarmedRef = useRef(false);
+  // Guard contre les démarrages concurrents — closure-safe (les refs ne sont
+  // jamais capturées de façon obsolète, contrairement à la valeur de `status`).
+  const isStartingRef = useRef(false);
   const prewarm = useCallback(() => {
     if (prewarmedRef.current) return;
     prewarmedRef.current = true;
@@ -419,15 +422,15 @@ export function useVoiceChat({
   }, []);
 
   const start = useCallback(async () => {
-    // Empêcher les démarrages multiples
-    if (
-      status === "connecting" ||
-      status === "listening" ||
-      status === "speaking"
-    ) {
+    // Empêcher les démarrages multiples (ref-based pour éviter le closure trap :
+    // une useCallback qui dépend de `status` capture une valeur obsolète quand
+    // restart() relance start() depuis le bus listener).
+    if (isStartingRef.current || conversationRef.current) {
       return;
     }
+    isStartingRef.current = true;
 
+    try {
     setError(null);
     setMessages([]);
     setElapsedSeconds(0);
@@ -662,8 +665,10 @@ export function useVoiceChat({
       releaseMediaStream();
       reportError(ERROR_MESSAGES.SDK_LOAD_FAILED);
     }
+    } finally {
+      isStartingRef.current = false;
+    }
   }, [
-    status,
     summaryId,
     debateId,
     agentType,

--- a/frontend/src/components/voice/voicePrefsBus.ts
+++ b/frontend/src/components/voice/voicePrefsBus.ts
@@ -14,7 +14,9 @@
 
 export type VoicePrefsEvent =
   | { type: "playback_rate_changed"; value: number }
-  | { type: "restart_required"; reason: string };
+  | { type: "restart_required"; reason: string }
+  | { type: "apply_with_restart" }
+  | { type: "call_status_changed"; active: boolean };
 
 type Listener = (event: VoicePrefsEvent) => void;
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1753,7 +1753,6 @@ export const DashboardPage: React.FC = () => {
             error={voiceChat.error ?? undefined}
             playbackRate={voiceChat.playbackRate}
             micLevel={micLevel}
-            onRestart={voiceChat.restart}
           />
         </>
       )}

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -1833,7 +1833,6 @@ export const History: React.FC = () => {
                       error={voiceChat.error ?? undefined}
                       playbackRate={voiceChat.playbackRate}
                       micLevel={micLevel}
-                      onRestart={voiceChat.restart}
                     />
                   </>
                 )}

--- a/mobile/src/components/analysis/StreamingOverlay.tsx
+++ b/mobile/src/components/analysis/StreamingOverlay.tsx
@@ -6,7 +6,6 @@ import Animated, {
   useAnimatedProps,
   withRepeat,
   withTiming,
-  withSequence,
   runOnJS,
   Easing,
 } from "react-native-reanimated";
@@ -21,8 +20,7 @@ import { useAnalysisStore } from "../../stores/analysisStore";
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
-// DeepSight spinner assets
-const SPINNER_COSMIC = require("../../../assets/images/spinner-cosmic.jpg");
+// DeepSight spinner assets — wheel only (cosmic background removed to avoid double-logo overlay)
 const SPINNER_WHEEL = require("../../../assets/images/spinner-wheel.jpg");
 
 interface StreamingOverlayProps {
@@ -64,7 +62,7 @@ const RING_STROKE = 3;
 const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
-// Fake progress curve — fast at start, slows down, never reaches 95% until real completion
+// Fake progress curve — fast at start, slows down, climbs to 98% before real completion lands
 const FAKE_PROGRESS_TIMELINE = [
   { time: 0, progress: 2 },
   { time: 1500, progress: 8 },
@@ -78,8 +76,11 @@ const FAKE_PROGRESS_TIMELINE = [
   { time: 50000, progress: 80 },
   { time: 70000, progress: 85 },
   { time: 90000, progress: 88 },
-  { time: 120000, progress: 90 },
-  { time: 180000, progress: 92 },
+  { time: 110000, progress: 91 },
+  { time: 130000, progress: 93 },
+  { time: 160000, progress: 95 },
+  { time: 200000, progress: 97 },
+  { time: 260000, progress: 98 },
 ];
 
 function getFakeProgress(elapsedMs: number): number {
@@ -125,7 +126,6 @@ export const StreamingOverlay: React.FC<StreamingOverlayProps> = ({
   const fadeAnim = useSharedValue(1);
   const scaleAnim = useSharedValue(1);
   const wheelRotation = useSharedValue(0);
-  const cosmicPulse = useSharedValue(1);
 
   const [displayProgress, setDisplayProgress] = useState(0);
   const [messageIndex, setMessageIndex] = useState(0);
@@ -147,15 +147,7 @@ export const StreamingOverlay: React.FC<StreamingOverlayProps> = ({
       -1,
       false,
     );
-    cosmicPulse.value = withRepeat(
-      withSequence(
-        withTiming(1.03, { duration: 1200, easing: Easing.inOut(Easing.ease) }),
-        withTiming(0.97, { duration: 1200, easing: Easing.inOut(Easing.ease) }),
-      ),
-      -1,
-      true,
-    );
-  }, [wheelRotation, cosmicPulse]);
+  }, [wheelRotation]);
 
   // Rotate motivational messages
   useEffect(() => {
@@ -178,6 +170,11 @@ export const StreamingOverlay: React.FC<StreamingOverlayProps> = ({
   );
 
   // Handle completion animation
+  // ⚠️ Ne PAS appeler store.completeAnalysis() ici : ça mettrait status="completed",
+  // ce qui ferait disparaître l'overlay immédiatement (showStreamingOverlay devient false)
+  // et démontrerait ce composant avant que le setTimeout/onComplete s'exécute.
+  // Résultat : onComplete jamais appelé, summary_id jamais transmis à l'écran parent.
+  // C'est handleStreamingComplete (parent) qui fera resetAnalysis() après réception du summaryId.
   const handleComplete = useCallback(() => {
     if (completedRef.current) return;
     completedRef.current = true;
@@ -185,9 +182,8 @@ export const StreamingOverlay: React.FC<StreamingOverlayProps> = ({
 
     // Animate to 100%
     updateProgress(100);
-    store.completeAnalysis();
 
-    // Fade out after celebration
+    // Fade out after celebration, then propagate summary_id to parent
     const timer = setTimeout(() => {
       fadeAnim.value = withTiming(0, { duration: 400 });
       scaleAnim.value = withTiming(0.9, { duration: 400 }, () => {
@@ -196,7 +192,7 @@ export const StreamingOverlay: React.FC<StreamingOverlayProps> = ({
     }, 1200);
 
     return () => clearTimeout(timer);
-  }, [updateProgress, store, fadeAnim, scaleAnim, onComplete]);
+  }, [updateProgress, fadeAnim, scaleAnim, onComplete]);
 
   // Poll backend for real status
   useEffect(() => {
@@ -317,8 +313,8 @@ export const StreamingOverlay: React.FC<StreamingOverlayProps> = ({
       // Use whichever is higher: fake or real
       const effectiveProgress = Math.max(fakeProgress, realProgress);
 
-      // Cap at 94% until real completion
-      const cappedProgress = Math.min(effectiveProgress, 94);
+      // Cap at 98% until real completion (backend posts progress=100 only at the very end)
+      const cappedProgress = Math.min(effectiveProgress, 98);
       updateProgress(cappedProgress);
     }, 500);
 
@@ -340,10 +336,6 @@ export const StreamingOverlay: React.FC<StreamingOverlayProps> = ({
 
   const wheelStyle = useAnimatedStyle(() => ({
     transform: [{ rotate: `${wheelRotation.value}deg` }],
-  }));
-
-  const cosmicStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: cosmicPulse.value }],
   }));
 
   // ── Écran d'erreur définitif (après 3 sondages 'failed') ──────────────────
@@ -414,16 +406,7 @@ export const StreamingOverlay: React.FC<StreamingOverlayProps> = ({
           />
         </Svg>
 
-        {/* Cosmic background (fixed, pulsing) */}
-        <Animated.View style={[styles.spinnerImageWrapper, cosmicStyle]}>
-          <Image
-            source={SPINNER_COSMIC}
-            style={styles.spinnerCosmic}
-            resizeMode="cover"
-          />
-        </Animated.View>
-
-        {/* Wheel overlay (rotating) */}
+        {/* Wheel (rotating) — single layer, no static background overlay */}
         <Animated.View style={[styles.spinnerImageWrapper, wheelStyle]}>
           <Image
             source={SPINNER_WHEEL}
@@ -535,16 +518,11 @@ const styles = StyleSheet.create({
     borderRadius: SPINNER_SIZE / 2,
     overflow: "hidden",
   },
-  spinnerCosmic: {
-    width: SPINNER_SIZE,
-    height: SPINNER_SIZE,
-    borderRadius: SPINNER_SIZE / 2,
-  },
   spinnerWheel: {
     width: SPINNER_SIZE,
     height: SPINNER_SIZE,
     borderRadius: SPINNER_SIZE / 2,
-    opacity: 0.7,
+    opacity: 1,
   },
   percentageContainer: {
     position: "absolute",


### PR DESCRIPTION
## Contexte

Récupération du chantier orphelin `feat/voice-prefs-apply-button` (21 patches uniques, 0 PR), extrait par audit cross-session le 2026-04-28. La branche source date de ~36h et avait été abandonnée sans PR.

## Summary

Remplacement du flush instantané des préférences voice par un système **staging + Apply button**. Les changements qui nécessitent un restart de la conversation ElevenLabs (voice_id, language, agent_type…) sont mis en queue ; l'utilisateur revoit les changements en attente et les applique en un clic via une toolbar flottante, ce qui déclenche un restart contrôlé de la session.

### Architecture
- **`VoicePrefsStagingProvider`** (nouveau) — context React qui collecte les changements `stage(field, value)` au lieu de PATCH instantanément
- **`StagedPrefsToolbar`** (nouveau) — toolbar flottante visible quand des changements sont stagés, propose Apply / Discard
- **`restartRequiredFields`** — liste des champs qui force un restart vs flush direct
- **Event bus** `apply_with_restart` + `call_status_changed` — pilote le restart de la session ElevenLabs sans casser l'UI
- Routage de `VoiceSettings` et `VoiceLiveSettings` via `stage()` au lieu de PATCH direct
- Suppression de la bannière `restart_required` (remplacée par la toolbar)

### Fichiers principaux
- `frontend/src/components/voice/staging/` (nouveau dossier : Provider + Toolbar + restartRequiredFields + tests)
- `frontend/src/components/voice/VoiceSettings.tsx` & `VoiceLiveSettings.tsx`
- `frontend/src/components/voice/useVoiceChat.ts`
- `frontend/src/components/voice/VoiceModal.tsx`
- `frontend/e2e/voice-apply-flow.spec.ts` (E2E happy path Playwright)
- `frontend/src/App.tsx` (wire provider — repositionné dans `AmbientLightingProvider` après merge avec main)

## Stats

26 files changed, +8682 / -375 (le gros volume vient de docs/plans `docs/superpowers/` empilés sur la branche source ; le code applicatif fait ~1900 lignes incluant tests).

## Test plan

- [ ] `npm run typecheck` passe
- [ ] `npm run test` — suite voice/staging verte
- [ ] `npx playwright test voice-apply-flow.spec.ts`
- [ ] Smoke manuel : changer `voice_id` mid-call → toolbar apparaît → Apply déclenche restart sans perdre transcript ni timer

## Notes pour la review

- 3 conflits triviaux résolus en gardant la version main (formatting docs + saving indicator de `VoiceSettings.tsx` + wrapping `AmbientLightingProvider` de `App.tsx`)
- 2 commits docs skippés (déjà absorbés sur main via la série QVC)
- Branche source `feat/voice-prefs-apply-button` (35h) peut être supprimée après merge

🤖 Découpé via audit cross-session — branche orpheline rescue

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAgyCKAjmQJiYVqejfSnWT)_