### PR TITLE
feat(voice): wire COMPANION → EXPLORER transfer in VoiceCallPage

### DIFF
--- a/frontend/src/pages/VoiceCallPage.tsx
+++ b/frontend/src/pages/VoiceCallPage.tsx
@@ -6,8 +6,8 @@
  * floating panel). Plan-gated to Pro tier — free users see an upgrade CTA.
  */
 
-import React, { useEffect, useState, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Phone,
@@ -40,6 +40,7 @@ const formatTime = (seconds: number): string => {
 const VoiceCallPage: React.FC = () => {
   const { language } = useTranslation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { voiceEnabled } = useVoiceEnabled();
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -50,9 +51,35 @@ const VoiceCallPage: React.FC = () => {
     [language],
   );
 
+  // Dual-mode driven by URL: ?summary=<id>&autostart=1 switches the page from
+  // free-form COMPANION to a video-bound EXPLORER session. The companion
+  // agent's `transfer_to_video` tool produces this URL via onTransferRequest.
+  const targetSummaryId = useMemo(() => {
+    const raw = searchParams.get("summary");
+    if (!raw) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  }, [searchParams]);
+
+  const shouldAutoStart = searchParams.get("autostart") === "1";
+
+  // Companion → Explorer transfer: navigate so the page re-mounts with the
+  // ?summary= URL, which tears down the companion session and provisions a
+  // fresh explorer session via the standard /api/voice/session flow.
+  const handleTransferRequest = useCallback(
+    (payload: { summary_id: number; video_title: string }) => {
+      navigate(`/voice-call?summary=${payload.summary_id}&autostart=1`, {
+        replace: false,
+      });
+    },
+    [navigate],
+  );
+
   const voice = useVoiceChat({
-    agentType: "companion",
+    agentType: targetSummaryId ? "explorer" : "companion",
+    summaryId: targetSummaryId ?? undefined,
     language,
+    onTransferRequest: targetSummaryId ? undefined : handleTransferRequest,
   });
 
   const isActive =
@@ -71,6 +98,17 @@ const VoiceCallPage: React.FC = () => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Auto-start the explorer session when arriving via a transfer URL
+  // (?summary=<id>&autostart=1). We only auto-start once per mount and
+  // only when the call is idle to avoid double-starting after a reload.
+  useEffect(() => {
+    if (!voiceEnabled) return;
+    if (!targetSummaryId || !shouldAutoStart) return;
+    if (voice.status !== "idle") return;
+    Promise.resolve(voice.start()).catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [voiceEnabled, targetSummaryId, shouldAutoStart]);
 
   const safeStart = useCallback(() => {
     Promise.resolve(voice.start()).catch(() => {});
@@ -255,13 +293,20 @@ const VoiceCallPage: React.FC = () => {
                 </div>
                 <div>
                   <h1 className="text-xl sm:text-2xl font-semibold text-text-primary">
-                    {tr("Appel vocal", "Voice call")}
+                    {targetSummaryId
+                      ? tr("Appel sur ta vidéo", "Call on your video")
+                      : tr("Appel vocal", "Voice call")}
                   </h1>
                   <p className="text-sm text-text-secondary">
-                    {tr(
-                      "Compagnon de réflexion — discutez librement avec DeepSight",
-                      "Reflection companion — talk freely with DeepSight",
-                    )}
+                    {targetSummaryId
+                      ? tr(
+                          `Session vocale ciblée sur l'analyse #${targetSummaryId}`,
+                          `Voice session focused on analysis #${targetSummaryId}`,
+                        )
+                      : tr(
+                          "Compagnon de réflexion — discutez librement avec DeepSight",
+                          "Reflection companion — talk freely with DeepSight",
+                        )}
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Frontend half of the call-transfer feature shipped in PR #172. The `/voice-call` page becomes **dual-mode** driven by URL query string — when the COMPANION agent calls `transfer_to_video`, the page navigates with `?summary=<id>&autostart=1`, the previous session tears down, and a fresh EXPLORER session auto-starts on the target video.

Single file changed: `frontend/src/pages/VoiceCallPage.tsx` (+53 / -8).

## Flow end-to-end

```
COMPANION call (/voice-call)
   │ user: "discutons de ma vidéo sur l'IA"
   ▼
Agent calls transfer_to_video(query="IA")
   │
   ▼
Backend POST /tools/transfer-to-video (PR #172)
   ├ resolve Summary
   └ stash payload in Redis (TTL 60s)
   │
   ▼
useVoiceChat detects tool_name → GET /companion-pending-transfer/<id>
   └ bubbles onTransferRequest({summary_id, video_title, ...})
   │
   ▼
VoiceCallPage.handleTransferRequest
   └ navigate("/voice-call?summary=42&autostart=1")
   │
   ▼
Page re-mount with summary param
   ├ useSearchParams reads summary
   ├ useVoiceChat({agentType:"explorer", summaryId:42})
   └ useEffect auto-starts session (standard /api/voice/session flow)
```

## Changes

- `useSearchParams` + `useMemo` imports
- `targetSummaryId` computed from URL (`?summary=<id>` parsed as Number)
- `shouldAutoStart` flag from `?autostart=1`
- `useVoiceChat` agentType / summaryId switch based on `targetSummaryId`
- `onTransferRequest` passed only in companion mode (avoid transfer-loop on target page)
- New `useEffect` auto-starts the explorer session once when URL params present and status is idle
- Header title/subtitle adapts to the mode (companion vs analysis #N)

## Hors-scope (follow-ups)

- E2E Playwright spec for the transfer flow (env-gated)
- Mobile equivalent (mobile/src/components/voice doesn't yet consume `onTransferRequest`)
- `start_analysis` real wiring + auto-transfer post-analysis

## Test plan

- [ ] Login Pro → `/voice-call` → click Appeler → companion starts
- [ ] Say "discutons de ma vidéo sur [titre récent]"
- [ ] Agent says "Je te bascule, deux secondes" then URL flips to `/voice-call?summary=X&autostart=1`
- [ ] New EXPLORER session auto-starts on the target summary
- [ ] Header shows "Appel sur ta vidéo · Session vocale ciblée sur l'analyse #X"
- [ ] No regression on plain `/voice-call` companion mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)