### PR TITLE
fix(docker): include alembic.ini + alembic/ in backend image

### DIFF
--- a/deploy/hetzner/Dockerfile
+++ b/deploy/hetzner/Dockerfile
@@ -35,6 +35,12 @@ COPY src/ ./src/
 # Without this COPY, isdir() checks in main.py fail silently and mounts never activate.
 COPY static/ ./static/
 
+# Alembic migrations — required to run `alembic upgrade head` inside the container
+# before/after backend rebuild. Without these files we had to `docker cp` them in
+# manually (cf. deployment 2026-04-28 migration 009).
+COPY alembic.ini ./alembic.ini
+COPY alembic/ ./alembic/
+
 WORKDIR /app/src
 
 EXPOSE 8080


### PR DESCRIPTION
## Contexte

Issue rencontrée pendant le déploiement de la migration `009_add_user_preferences_json` (PR #152) sur Hetzner le 2026-04-28 : le Dockerfile ne copie pas `alembic.ini` ni le dossier `alembic/` dans l'image. Pour appliquer la migration, l'utilisateur a dû `docker cp` ces fichiers manuellement dans le container avant de pouvoir lancer `alembic upgrade head`.

## Fix

```diff
+ # Alembic migrations — required to run `alembic upgrade head` inside the container
+ # before/after backend rebuild.
+ COPY alembic.ini ./alembic.ini
+ COPY alembic/ ./alembic/
```

## Impact

- **Taille image** : +~50 KB (`alembic/` est léger : `env.py` + 9 migrations versions)
- **Procédure de déploiement post-merge** simplifiée — l'agent peut désormais faire :
  ```bash
  ssh root@89.167.23.214
  cd /opt/deepsight/repo && git pull
  docker compose -f deploy/hetzner/docker-compose.yml up -d --no-deps --build backend
  docker exec repo-backend-1 alembic upgrade head    # ← marche directement
  ```
- **Pas de rupture** sur le code applicatif (le code reste sous `/app/src/`)

## Ordre de migration (rappel pour futures PRs avec migration)

L'utilisateur a noté qu'entre 14:56 et 14:59 (déploiement de PR #152), le backend a démarré `unhealthy` parce que le nouveau code attendait la colonne `users.preferences` qui n'existait pas encore. **Procédure correcte** :
1. Build nouvelle image
2. **Lancer `alembic upgrade head` AVANT** le swap du container (sur l'ancienne image, ou une image transitoire)
3. Swap container

Idéalement on automatise ça — issue de suivi possible.

## Test plan

- [ ] `docker build -f deploy/hetzner/Dockerfile -t deepsight-backend:test backend/` → image build OK
- [ ] `docker run --rm deepsight-backend:test ls /app/alembic/versions/` → 9 fichiers `*.py` listés
- [ ] `docker run --rm deepsight-backend:test alembic --config /app/alembic.ini current` → pas d'erreur "no such file"

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAgyCKAjmQJiYVqejfSnWT)_