### PR TITLE
feat(voice): wire real Tournesol + Trending into companion initial recos

### DIFF
--- a/backend/src/voice/companion_external.py
+++ b/backend/src/voice/companion_external.py
@@ -1,0 +1,136 @@
+"""External-source services for the COMPANION agent's reco fetchers.
+
+These thin wrappers expose `recommend(theme, limit)` and `get_trending(
+theme, limit)` async methods consumed by `companion_recos.fetch_*_reco`.
+
+Tournesol → public API at api.tournesol.app/polls/videos/recommendations/
+Trending  → in-house DeepSight aggregate (Summary table) via the existing
+            trending router helper.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class TournesolService:
+    """Async client for Tournesol's public recommendations endpoint.
+
+    No auth, public read-only API. Timeouts at 5s to keep the COMPANION
+    pre-fetch parallel gather within its 2s envelope (we let it occasionally
+    miss the wider gather rather than block it).
+    """
+
+    BASE_URL = "https://api.tournesol.app/polls/videos/recommendations/"
+    TIMEOUT_SECONDS = 5.0
+
+    @staticmethod
+    async def recommend(theme: str, limit: int = 5) -> list[dict[str, Any]]:
+        """Return up to `limit` Tournesol videos matching the given theme.
+
+        Items are shaped for `companion_recos.fetch_tournesol_reco`:
+            {video_id, title, channel, duration, thumbnail}
+        Returns [] on any error or empty payload — callers should fall
+        through gracefully.
+        """
+        if not theme:
+            return []
+
+        params = {
+            "search": theme,
+            "limit": min(int(limit), 20),
+            "unsafe": "false",
+        }
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "DeepSight/1.0 (companion-agent)",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=TournesolService.TIMEOUT_SECONDS) as client:
+                response = await client.get(TournesolService.BASE_URL, params=params, headers=headers)
+        except (httpx.TimeoutException, httpx.HTTPError) as exc:
+            logger.warning("tournesol companion recommend timeout/error: %s", exc)
+            return []
+
+        if response.status_code != 200:
+            logger.warning("tournesol companion recommend non-200: %s", response.status_code)
+            return []
+
+        try:
+            payload = response.json()
+        except (ValueError, TypeError) as exc:
+            logger.warning("tournesol companion recommend decode failed: %s", exc)
+            return []
+
+        results: list[dict[str, Any]] = []
+        for item in payload.get("results", []):
+            entity = item.get("entity", item)
+            uid = entity.get("uid", "")
+            video_id = uid.replace("yt:", "") if uid else None
+            if not video_id:
+                continue
+            metadata = entity.get("metadata", {}) or {}
+            results.append(
+                {
+                    "video_id": video_id,
+                    "title": metadata.get("name") or entity.get("name") or "Untitled",
+                    "channel": (metadata.get("uploader") or entity.get("uploader") or "Unknown"),
+                    "duration": metadata.get("duration") or 0,
+                    "thumbnail": f"https://img.youtube.com/vi/{video_id}/mqdefault.jpg",
+                }
+            )
+
+        return results
+
+
+class TrendingService:
+    """Adapter around the in-house trending helper.
+
+    Filters by Summary.category when available — the COMPANION builder
+    passes the user's primary theme, which often (but not always) matches
+    the category column. Empty result is fine; the orchestrator drops it.
+    """
+
+    @staticmethod
+    async def get_trending(theme: str, limit: int = 5) -> list[dict[str, Any]]:
+        """Return up to `limit` trending DeepSight videos for the given theme.
+
+        Tries category-filtered first, then falls back to no-filter (period 7d).
+        """
+        from trending.router import _query_trending_from_db
+
+        async def _query(category: Optional[str]) -> list[dict[str, Any]]:
+            try:
+                resp = await _query_trending_from_db(period="7d", category=category, limit=limit)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "trending companion get_trending failed (category=%s): %s",
+                    category,
+                    exc,
+                )
+                return []
+
+            return [
+                {
+                    "video_id": v.video_id,
+                    "title": v.title,
+                    "channel": v.channel,
+                    "duration": v.duration or 0,
+                    "thumbnail": v.thumbnail_url,
+                }
+                for v in resp.videos
+            ]
+
+        # First try with the theme as a category filter
+        items = await _query(theme.lower() if theme else None)
+        if items:
+            return items
+
+        # Fall back to top trending overall (no category filter)
+        return await _query(None)

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -3421,24 +3421,62 @@ class _CompanionServicesBundle:
     - themes_fn: extract_top3_themes via Summary.category fallback (no LLM
       in V1 wiring; LLM path is a follow-up once mistral-small client is
       threaded through).
-    - initial_recos_fn: V1 returns []. Real Tournesol / Trending /
-      history-similarity orchestration is a follow-up task. The agent stays
-      useful in V1 because the system prompt instructs it to call
-      get_more_recos(topic) directly when it has no pre-fetched recos.
+    - initial_recos_fn: orchestrates the parallel pre-fetch of up to 3 recos
+      (Tournesol + Trending). History-similarity stays disabled until the
+      embedding service is wired through — the orchestrator simply drops it.
     """
 
-    @staticmethod
-    async def themes_fn(*, user_id, db):
-        # db here is the CompanionDBAdapter passed by the builder.
+    def __init__(self, *, user: User, db_adapter):
+        self._user = user
+        self._db_adapter = db_adapter
+
+    async def themes_fn(self, *, user_id, db):
         from voice.companion_themes import extract_top3_themes
 
         return await extract_top3_themes(user_id=user_id, db=db, llm_client=None)
 
-    @staticmethod
-    async def initial_recos_fn(*, primary_theme):  # noqa: ARG004
-        return []
+    async def initial_recos_fn(self, *, primary_theme: str):
+        from voice.companion_external import TournesolService, TrendingService
+        from voice.companion_recos import (
+            build_initial_recos,
+            fetch_tournesol_reco,
+            fetch_trending_reco,
+        )
+
+        excluded = await self._db_adapter.fetch_user_analyzed_video_ids(user_id=self._user.id)
+
+        async def _history_fn():
+            # History-similarity requires an embedding service — disabled in
+            # this wiring. The orchestrator drops None and continues.
+            return None
+
+        async def _trending_fn():
+            return await fetch_trending_reco(
+                theme=primary_theme,
+                trending_service=TrendingService(),
+                excluded_video_ids=excluded,
+            )
+
+        async def _tournesol_fn():
+            return await fetch_tournesol_reco(
+                theme=primary_theme,
+                tournesol_service=TournesolService(),
+                excluded_video_ids=excluded,
+            )
+
+        return await build_initial_recos(
+            primary_theme=primary_theme,
+            history_fn=_history_fn,
+            trending_fn=_trending_fn,
+            tournesol_fn=_tournesol_fn,
+        )
 
 
 def _build_companion_services(*, db, redis, user):  # noqa: ARG001
-    """Return the services bundle consumed by build_companion_context."""
-    return _CompanionServicesBundle()
+    """Return the services bundle consumed by build_companion_context.
+
+    `db` is the raw AsyncSession; we wrap it in CompanionDBAdapter so the
+    bundle can call fetch_user_analyzed_video_ids() to compute the
+    excluded set for parallel reco pre-fetches.
+    """
+    return _CompanionServicesBundle(user=user, db_adapter=CompanionDBAdapter(db))


### PR DESCRIPTION
## Summary

Replaces the V1 placeholder `_CompanionServicesBundle.initial_recos_fn` (returned `[]`) with a real orchestration over two production sources, run in parallel via the existing `build_initial_recos` helper.

## Changes

- **NEW** `backend/src/voice/companion_external.py`
  - `TournesolService.recommend(theme, limit)` — public API call to `api.tournesol.app/polls/videos/recommendations/?search=<theme>`. 5s timeout, graceful fallback to `[]` on any error / non-200 / decode failure.
  - `TrendingService.get_trending(theme, limit)` — wraps the existing `trending/router._query_trending_from_db`. Tries `category=<theme>` first, falls back to no-filter trending if empty.
- **MODIFIED** `backend/src/voice/router.py`
  - `_CompanionServicesBundle` becomes an instance with `(user, db_adapter)` baked in via `__init__` so `initial_recos_fn` can compute the user's excluded video_id set on each call.
  - `initial_recos_fn(primary_theme)` orchestrates a parallel `gather` over `_history_fn` (returns None — embedding service not wired yet), `_trending_fn` (TrendingService), `_tournesol_fn` (TournesolService).

## Result

COMPANION agent now greets the user with up to 2 pre-fetched recos (1 trending, 1 tournesol) on the resolved primary theme, matching the design spec. The agent stops needing to immediately call `get_more_recos` at session start.

## Hors-scope (still follow-up)

- History+similarity pre-fetch — needs the embedding service threaded through. Today returns `None` and the orchestrator drops it.
- Mistral-small fallback in `themes_fn` for users whose `Summary.category` coverage is < 70%.

## Test plan

- [x] `pytest backend/tests/voice -q` → 140/140 PASS
- [x] `ruff check backend/src/voice/` → clean
- [x] `ruff format backend/src/voice/ --check` → clean
- [ ] Smoke prod : Login Pro → GET `/api/voice/companion-context` → vérifier que `initial_recos` n'est plus `[]` (selon le `Summary.category` du user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)