### PR TITLE
fix(deploy): document real auto-deploy mechanism

### DIFF
--- a/deploy/hetzner/AUTODEPLOY.md
+++ b/deploy/hetzner/AUTODEPLOY.md
@@ -1,0 +1,149 @@
+# Auto-Deploy Backend — Mécanisme réel
+
+> **TL;DR** : push to `main` → GitHub Actions (`.github/workflows/deploy-backend.yml`) → SSH au VPS Hetzner → `docker build` + `docker run` direct (PAS `docker compose`). Container backend recréé en ~30s.
+
+---
+
+## Vue d'ensemble
+
+```
+Push to main          GitHub Actions          Hetzner VPS
+─────────────         ──────────────          ────────────
+git push          ──► Workflow trigger    ──► SSH appleboy/ssh-action@v1.2.0
+                      (paths filter)            │
+                                                ├─► tag :latest → :previous
+                                                ├─► git fetch + reset --hard origin/main
+                                                ├─► docker build deepsight-backend:latest
+                                                ├─► docker stop + rm repo-backend-1
+                                                └─► docker run repo-backend-1
+                                                    │
+                          curl /health         ◄───┘
+                          (rollback si KO)
+```
+
+## Pourquoi `docker run` direct et pas `docker compose` ?
+
+Historiquement les 4 containers prod (`repo-backend-1`, `repo-postgres-1`, `repo-redis-1`, `repo-caddy-1`) ont été créés à la main via `docker run` au moment de la migration Railway → Hetzner. Aucun n'a les labels `com.docker.compose.project` ni `com.docker.compose.service`.
+
+Migrer vers `docker compose up -d` aujourd'hui implique :
+- Renommer les containers (collision sur `container_name` existant)
+- Réassocier les volumes nommés (`repo_postgres_data`, `repo_redis_data`, `repo_caddy_data`, `repo_caddy_config`)
+- Reprendre la main sur le réseau `repo_deepsight` (créé manuellement, marqué `external: true` dans le compose)
+- Risque d'un "container name already in use" pendant la bascule (cf. memo `reference_deepsight-hetzner-auto-deploy.md`)
+
+Le workflow `docker run` est éprouvé (~30s par déploiement, plusieurs centaines de cycles) → **on garde, on documente, on n'orchestre pas une migration risquée pour un gain cosmétique**.
+
+`deploy/hetzner/docker-compose.yml` est conservé comme **référence** (valeurs canoniques des services + healthchecks) et **fallback** pour une éventuelle migration future ou une stack de staging — mais **n'est pas utilisé en prod**.
+
+## Commande exacte exécutée par le workflow
+
+Extrait fidèle de `.github/workflows/deploy-backend.yml` (étape `Build and deploy on Hetzner VPS`) :
+
+```bash
+cd /opt/deepsight/repo
+
+# Tag rollback anchor
+docker tag deepsight-backend:latest deepsight-backend:previous
+
+# Sync code
+git fetch origin main
+git reset --hard origin/main
+
+# Build (context = backend/)
+docker build \
+  -t deepsight-backend:latest \
+  -f deploy/hetzner/Dockerfile \
+  backend
+
+# Recreate container
+docker stop repo-backend-1 || true
+docker rm repo-backend-1 || true
+docker run -d \
+  --name repo-backend-1 \
+  --network repo_deepsight \
+  --env-file /opt/deepsight/repo/.env.production \
+  --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  deepsight-backend:latest
+```
+
+Suivi par un smoke test `curl https://api.deepsightsynthesis.com/health` (5 retries, 30s timeout). En cas d'échec, rollback automatique vers `deepsight-backend:previous`.
+
+## Trigger
+
+Le workflow se déclenche sur :
+- `push` sur `main` qui touche `backend/**`, `deploy/hetzner/**`, ou le workflow lui-même
+- `workflow_dispatch` (déclenchement manuel via l'onglet Actions de GitHub)
+
+Concurrence : `concurrency: { group: deploy-backend, cancel-in-progress: false }` → 2 deploys consécutifs sont sérialisés.
+
+## Migrations alembic
+
+Voir [`RUNBOOK.md`](./RUNBOOK.md). En résumé :
+- Une migration alembic doit toujours tourner **avant** le swap de container, sur l'ancien container (qui a déjà les fichiers de migration grâce au `git pull`) — sinon downtime tant que le nouveau code attend un schema absent.
+- L'image embarque depuis PR #185 `alembic.ini` + `alembic/` à `/app/`. Le container peut donc se migrer lui-même via `docker exec ... alembic upgrade head`.
+- Depuis cette PR, l'`entrypoint.sh` du Dockerfile peut faire `alembic upgrade head` au démarrage si `RUN_MIGRATIONS=true` est passé. Le workflow active cette option.
+
+## Procédure de remédiation manuelle
+
+Si le workflow GitHub est cassé ou si on veut déployer hors-CI :
+
+```bash
+ssh -i ~/.ssh/id_hetzner root@89.167.23.214
+
+cd /opt/deepsight/repo
+git fetch origin main && git reset --hard origin/main
+
+# Si la PR contient une migration alembic, la jouer AVANT le swap :
+docker exec repo-backend-1 alembic --config /app/alembic.ini upgrade head
+
+docker tag deepsight-backend:latest deepsight-backend:previous 2>/dev/null || true
+docker build -t deepsight-backend:latest -f deploy/hetzner/Dockerfile backend
+docker stop repo-backend-1 || true
+docker rm repo-backend-1 || true
+docker run -d \
+  --name repo-backend-1 \
+  --network repo_deepsight \
+  --env-file /opt/deepsight/repo/.env.production \
+  -e RUN_MIGRATIONS=true \
+  --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  deepsight-backend:latest
+
+sleep 15 && docker exec repo-backend-1 curl -s http://localhost:8080/health
+```
+
+## Rollback manuel
+
+```bash
+ssh -i ~/.ssh/id_hetzner root@89.167.23.214
+docker tag deepsight-backend:previous deepsight-backend:latest
+docker stop repo-backend-1 && docker rm repo-backend-1
+# Note : RUN_MIGRATIONS=false en rollback — on revient à l'ancien schema, pas besoin de re-migrer
+docker run -d \
+  --name repo-backend-1 \
+  --network repo_deepsight \
+  --env-file /opt/deepsight/repo/.env.production \
+  -e RUN_MIGRATIONS=false \
+  --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  deepsight-backend:latest
+```
+
+## Diagnostic
+
+```bash
+docker ps --format '{{.Names}} {{.Status}}'
+docker logs repo-backend-1 --tail 100 2>&1 | grep -iE 'error|traceback|exception'
+docker exec repo-backend-1 curl -s http://localhost:8080/health
+docker inspect repo-backend-1 --format '{{.State.StartedAt}}'
+
+# Vérifier que l'entrypoint a bien tourné
+docker logs repo-backend-1 2>&1 | grep -i 'entrypoint\|alembic'
+```
+
+## TODO / améliorations futures
+
+- Versionner le webhook listener (`/opt/junglefarmz/deploy-api.py` sur le VPS) — actuellement non versionné
+- Healthcheck pre-swap (rouler l'image en standby et tester `/health` avant de swap, cf. blue-green)
+- Migration vers `docker compose` lors d'une fenêtre de maintenance dédiée

--- a/deploy/hetzner/CLAUDE.md
+++ b/deploy/hetzner/CLAUDE.md
@@ -21,27 +21,26 @@ Réseau Docker : `repo_deepsight` (créé manuellement, déclaré `external: tru
 ## Fichiers ici
 
 - `Dockerfile` : Python 3.11 + ffmpeg + WeasyPrint deps. Build context = `../../backend`
-- `docker-compose.yml` : Stack complète. Usage : `docker compose -f deploy/hetzner/docker-compose.yml up -d`
+- `docker-compose.yml` : **DORMANT** — référence/fallback uniquement. La prod n'utilise PAS compose (cf. `AUTODEPLOY.md`).
 - `caddy/Caddyfile` : Reverse proxy api.deepsightsynthesis.com → backend:8080. Timeouts SSE 300s, HSTS, security headers.
+- `AUTODEPLOY.md` : mécanisme exact du déploiement automatique (GitHub Actions → SSH → `docker run`).
+- `RUNBOOK.md` : procédure manuelle, gestion des migrations alembic, rollback.
 
-## Déploiement backend (procédure standard)
+## Déploiement backend
 
-```bash
-# Depuis le VPS
-cd /opt/deepsight/repo
-git pull
-docker compose -f deploy/hetzner/docker-compose.yml up -d --build backend
-# Ou rebuild complet :
-docker compose -f deploy/hetzner/docker-compose.yml up -d --no-deps --build backend
-```
+Le déploiement est **automatique** via GitHub Actions (`.github/workflows/deploy-backend.yml`) → SSH au VPS → `docker build` + `docker run`. **Pas `docker compose`** : la prod tourne en `docker run` direct depuis la migration Railway → Hetzner. Voir [`AUTODEPLOY.md`](./AUTODEPLOY.md) pour le détail.
+
+**Push to main** touchant `backend/**`, `deploy/hetzner/**` ou le workflow lui-même = build + swap container backend en ~30s.
+
+**Pour une PR avec migration de schéma**, suivre [`RUNBOOK.md`](./RUNBOOK.md). Ordre canonique : `git pull` → `docker exec repo-backend-1 alembic upgrade head` → build + swap. Depuis l'`entrypoint.sh` (PR fix anomaly #5), le container exécute `alembic upgrade head` automatiquement au démarrage si `RUN_MIGRATIONS=true` est passé (le workflow l'active par défaut).
 
 ## ⚠️ Points critiques
 
-- Le réseau `repo_deepsight` est `external: true` → il doit exister AVANT le compose (`docker network create repo_deepsight`)
-- Les containers se réfèrent entre eux par leur `container_name` (pas le nom du service compose)
-- `env_file: ../../.env.production` + variables `environment:` dans le compose (ces dernières overrident)
-- Le Dockerfile copie `backend/src/` → le code tourne depuis `/app/src/`
-- HealthCheck backend = `curl -f http://localhost:8080/health`
+- Le réseau `repo_deepsight` est créé manuellement — `docker network create repo_deepsight` côté VPS, et `external: true` dans `docker-compose.yml` (qui n'est pas utilisé mais reste cohérent).
+- Les containers se réfèrent entre eux par leur `container_name`.
+- `--env-file /opt/deepsight/repo/.env.production` au `docker run`.
+- Le Dockerfile copie `backend/src/` → le code tourne depuis `/app/src/`. `alembic.ini` + `alembic/` sont à `/app/` (cf. PR #185).
+- HealthCheck backend = `curl -f http://localhost:8080/health` (Caddy repasse en `https://api.deepsightsynthesis.com/health`).
 
 ## Diagnostic rapide
 

--- a/deploy/hetzner/docker-compose.yml
+++ b/deploy/hetzner/docker-compose.yml
@@ -1,14 +1,20 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 # DeepSight Production Stack — Hetzner VPS
 #
-# Usage depuis /opt/deepsight/repo :
-#   docker compose -f deploy/hetzner/docker-compose.yml up -d
+# ⚠️ DORMANT — non utilisé en production (au 2026-04-28).
 #
-# Rebuild backend après changement de code :
-#   docker compose -f deploy/hetzner/docker-compose.yml up -d --build backend
+# La prod tourne en `docker run` direct depuis le webhook
+# `junglefarmz-deploy.service` (cf. AUTODEPLOY.md). Aucun container actuel
+# ne porte les labels `com.docker.compose.*`.
 #
-# ⚠️ Les noms de containers (container_name) et le réseau correspondent
-#    exactement à la config de production existante pour éviter toute casse.
+# Ce fichier est conservé pour :
+#   - servir de référence (services/healthchecks/volumes canoniques)
+#   - servir de fallback si on migre vers `docker compose up -d` plus tard
+#   - démarrer une stack de staging locale
+#
+# NE PAS lancer `docker compose up` sur la prod tant que les containers
+# existants (repo-backend-1, repo-postgres-1, repo-redis-1, repo-caddy-1)
+# n'ont pas été décommissionnés proprement.
 # ═══════════════════════════════════════════════════════════════════════════════
 
 networks:


### PR DESCRIPTION
## Context

Audit cross-session DeepSight 2026-04-28 has surfaced a documentation drift on `deploy/hetzner/CLAUDE.md`:

- The file claims the backend is deployed via `docker compose -f deploy/hetzner/docker-compose.yml up -d --build backend`.
- In reality, production runs on `docker run` direct, triggered by the `junglefarmz-deploy.service` systemd webhook on the VPS, itself called from `.github/workflows/deploy-backend.yml`.
- None of the live containers (`repo-backend-1`, `repo-postgres-1`, `repo-redis-1`, `repo-caddy-1`) carry `com.docker.compose.*` labels.

This drift caused the audit to assume `docker-compose.yml` was the deploy entrypoint when investigating recent prod incidents. We fix it without migrating prod (option C of the brief — out of scope, ops risk too high for cosmetic gain).

## What changes

- **NEW** `deploy/hetzner/AUTODEPLOY.md` — documents the actual flow: push → GitHub Actions → SSH → `docker build` + `docker run`. Includes the exact command, manual-remediation procedure, rollback path, diagnostics, and TODOs (versioning the `/opt/junglefarmz/deploy-api.py` listener, migrating to compose during a maintenance window).
- **MODIFIED** `deploy/hetzner/CLAUDE.md` — "Déploiement backend" section rewritten to reference `AUTODEPLOY.md` (and `RUNBOOK.md` shipped by the migration-automation PR). The `docker-compose.yml` entry is annotated as DORMANT.
- **MODIFIED** `deploy/hetzner/docker-compose.yml` — top-of-file comment updated: file is dormant, not used in prod, kept as reference + fallback for future migration.

## Decisions documented in the audit plan

- **Versioning the deploy-api.py listener** — out of scope. Code lives on the VPS at `/opt/junglefarmz/deploy-api.py`, shared with another project, contains secrets. Listed as a TODO in AUTODEPLOY.md.
- **Migrating prod to docker compose** — explicitly NOT done in this PR. Risk of "container name already in use" + volume re-association during the swap. Documented as a maintenance-window candidate.

## Test plan

- [ ] Visual review of `deploy/hetzner/AUTODEPLOY.md` content vs the actual workflow file
- [ ] Cross-check the recommended manual-remediation `docker run` block against `docker inspect repo-backend-1` output
- [ ] Confirm `deploy/hetzner/CLAUDE.md` no longer references `docker compose up` as the prod path
- [ ] Once merged, reflect the change in the local memory `reference_deepsight-hetzner-auto-deploy.md`

## Related

- Pairs with the migration-automation PR (anomaly #5) which ships `RUNBOOK.md` and the `entrypoint.sh` referenced in this CLAUDE.md update.
- Audit log: `C:\Users\33667\.claude\plans\crispy-snuggling-starlight.md`