### PR TITLE
feat(deploy): automate alembic migrations on backend container start

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -100,6 +100,11 @@ jobs:
               backend
 
             # Recreate the backend container.
+            # RUN_MIGRATIONS=true makes entrypoint.sh run `alembic upgrade head`
+            # before launching uvicorn. Idempotent + safe-by-default. Without
+            # this, a PR shipping a new alembic revision would put the backend
+            # in unhealthy state until migrations were applied manually
+            # (cf. incident 2026-04-26, PR #152, see deploy/hetzner/RUNBOOK.md).
             docker stop repo-backend-1 || true
             docker rm repo-backend-1 || true
             docker run -d \
@@ -107,6 +112,7 @@ jobs:
               --network repo_deepsight \
               --network-alias backend \
               --env-file /opt/deepsight/repo/.env.production \
+              -e RUN_MIGRATIONS=true \
               --restart unless-stopped \
               -p 127.0.0.1:8080:8080 \
               deepsight-backend:latest
@@ -154,6 +160,12 @@ jobs:
             echo "Rolling back to deepsight-backend:previous"
             docker tag deepsight-backend:previous deepsight-backend:latest
 
+            # RUN_MIGRATIONS=false on rollback: the previous image may correspond
+            # to the previous schema, and the new code's migration has potentially
+            # already been applied to the live DB. Re-running `alembic upgrade head`
+            # against an old image whose migration files don't match the live state
+            # is risky. Schema-level rollback is a separate manual procedure
+            # (alembic downgrade) — cf. deploy/hetzner/RUNBOOK.md section 3.
             docker stop repo-backend-1 || true
             docker rm repo-backend-1 || true
             docker run -d \
@@ -161,6 +173,7 @@ jobs:
               --network repo_deepsight \
               --network-alias backend \
               --env-file /opt/deepsight/repo/.env.production \
+              -e RUN_MIGRATIONS=false \
               --restart unless-stopped \
               -p 127.0.0.1:8080:8080 \
               deepsight-backend:latest

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Backend container entrypoint.
+# Optionally runs alembic migrations before launching uvicorn.
+#
+# Set RUN_MIGRATIONS=true to apply pending migrations on container start.
+# Defaults to false so local dev / staging containers don't surprise-migrate
+# a shared database. Production sets RUN_MIGRATIONS=true via the deploy workflow.
+
+set -e
+
+if [ "${RUN_MIGRATIONS:-false}" = "true" ]; then
+  echo "[entrypoint] RUN_MIGRATIONS=true — running alembic upgrade head"
+  cd /app && alembic upgrade head
+  echo "[entrypoint] alembic upgrade head done"
+fi
+
+cd /app/src
+exec "$@"

--- a/deploy/hetzner/Dockerfile
+++ b/deploy/hetzner/Dockerfile
@@ -41,12 +41,19 @@ COPY static/ ./static/
 COPY alembic.ini ./alembic.ini
 COPY alembic/ ./alembic/
 
+# Entrypoint runs alembic upgrade head before uvicorn when RUN_MIGRATIONS=true.
+# Build context is `backend/` so this picks up backend/entrypoint.sh.
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 WORKDIR /app/src
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=30s \
     CMD curl -f http://localhost:8080/health || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
 
 # 4 workers pour 8 vCPU (I/O bound async → 1 worker / 2 vCPU)
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", \

--- a/deploy/hetzner/RUNBOOK.md
+++ b/deploy/hetzner/RUNBOOK.md
@@ -1,0 +1,194 @@
+# Backend Deploy RUNBOOK — Hetzner
+
+> Procédure officielle pour déployer le backend DeepSight, en particulier quand la PR contient une migration de schéma. **Empêche le bug PR #152** (downtime 3min : nouveau code attendait `users.preferences` avant que la migration 009 soit jouée).
+
+---
+
+## TL;DR — ordre canonique
+
+```
+1. git pull (récupère le code + les migrations alembic)
+2. alembic upgrade head sur l'ANCIEN container (DB migrée AVANT swap)
+3. docker build + docker run (le nouveau container démarre avec un schema déjà à jour)
+4. healthcheck /health, vérifier qu'il vire au vert en <60s
+```
+
+L'**entrypoint.sh** du Dockerfile fait étape (2) automatiquement si `RUN_MIGRATIONS=true` est passé. Le workflow GitHub Actions `.github/workflows/deploy-backend.yml` active cette option par défaut. **En CI, la procédure est donc transparente**. Le RUNBOOK ci-dessous reste utile pour les déploiements manuels ou les hotfixes hors-CI.
+
+---
+
+## 0. Pré-checks
+
+```bash
+# SSH OK ?
+ssh -i ~/.ssh/id_hetzner root@89.167.23.214 'hostname && uptime'
+
+# Container actuel healthy ?
+ssh -i ~/.ssh/id_hetzner root@89.167.23.214 'docker ps --format "{{.Names}} {{.Status}}"'
+# repo-backend-1 doit être "Up X (healthy)"
+
+# Branche prod sur main ?
+ssh -i ~/.ssh/id_hetzner root@89.167.23.214 'cd /opt/deepsight/repo && git status -sb'
+```
+
+Si pas healthy → **ne pas déployer**, diagnostiquer d'abord (cf. section "Diagnostic" plus bas).
+
+---
+
+## 1. Procédure step-by-step
+
+```bash
+ssh -i ~/.ssh/id_hetzner root@89.167.23.214
+
+cd /opt/deepsight/repo
+
+# 1a — Sync code (apporte les nouveaux fichiers alembic dans le repo VPS)
+git fetch origin main
+git reset --hard origin/main
+
+# 1b — Run alembic upgrade head sur l'ancien container
+# L'image actuelle a alembic.ini + alembic/ depuis PR #185, et le repo VPS
+# contient maintenant les nouveaux fichiers de migration grâce au git pull.
+# MAIS l'image n'a pas encore les nouveaux fichiers : on monte le repo dans le container :
+docker exec repo-backend-1 sh -c 'cd /app && alembic upgrade head' || {
+  # Si ça échoue parce que l'image n'a pas le nouveau fichier de migration,
+  # le copier dedans manuellement :
+  docker cp backend/alembic/versions repo-backend-1:/app/alembic/
+  docker exec repo-backend-1 sh -c 'cd /app && alembic upgrade head'
+}
+
+# 1c — Tag rollback anchor
+docker tag deepsight-backend:latest deepsight-backend:previous
+
+# 1d — Build new image
+docker build \
+  -t deepsight-backend:latest \
+  -f deploy/hetzner/Dockerfile \
+  backend
+
+# 1e — Stop + recreate container
+docker stop repo-backend-1
+docker rm repo-backend-1
+docker run -d \
+  --name repo-backend-1 \
+  --network repo_deepsight \
+  --env-file /opt/deepsight/repo/.env.production \
+  -e RUN_MIGRATIONS=true \
+  --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  deepsight-backend:latest
+
+# 1f — Vérifier que l'entrypoint a bien tourné
+sleep 5
+docker logs repo-backend-1 --tail 20 | grep -i entrypoint
+# Attendu : "[entrypoint] RUN_MIGRATIONS=true — running alembic upgrade head"
+#           "[entrypoint] alembic upgrade head done"
+# Si DB déjà à jour, alembic dira juste "Context impl PostgresqlImpl. INFO  Will assume transactional DDL."
+```
+
+---
+
+## 2. Healthcheck post-swap
+
+```bash
+# Attendre que le start_period (30s) + premier healthcheck passe
+sleep 35
+
+docker exec repo-backend-1 curl -s http://localhost:8080/health
+# Attendu : {"status":"ok","database":"connected","redis":"connected",...}
+
+docker ps --filter name=repo-backend-1 --format '{{.Names}} {{.Status}}'
+# Attendu : repo-backend-1   Up X seconds (healthy)
+
+# Health publique via Caddy
+curl -s https://api.deepsightsynthesis.com/health
+```
+
+Si le healthcheck reste rouge >2min → **rollback** (section 3).
+
+---
+
+## 3. Rollback manuel
+
+Le workflow GitHub fait un rollback automatique si le smoke test post-deploy échoue. Pour un rollback manuel hors-CI :
+
+```bash
+ssh -i ~/.ssh/id_hetzner root@89.167.23.214
+
+# 3a — Vérifier qu'on a bien une image previous
+docker image inspect deepsight-backend:previous >/dev/null 2>&1 || echo "PAS DE PREVIOUS — rollback impossible"
+
+# 3b — Restaurer
+docker tag deepsight-backend:previous deepsight-backend:latest
+docker stop repo-backend-1
+docker rm repo-backend-1
+
+# IMPORTANT : RUN_MIGRATIONS=false sur le rollback !
+# La DB peut avoir été migrée vers le nouveau schema. L'ancienne image
+# pourrait re-tenter la migration et échouer en boucle. Si on doit aussi
+# revenir en arrière sur la DB, c'est une procédure séparée (alembic downgrade).
+docker run -d \
+  --name repo-backend-1 \
+  --network repo_deepsight \
+  --env-file /opt/deepsight/repo/.env.production \
+  -e RUN_MIGRATIONS=false \
+  --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  deepsight-backend:latest
+
+sleep 15
+docker exec repo-backend-1 curl -s http://localhost:8080/health
+```
+
+⚠️ **Cas critique** : si la nouvelle migration alembic a modifié le schema de manière non rétro-compatible (drop column, altération de type), l'ancien code peut crasher au runtime. Dans ce cas il faut soit :
+- Faire un `alembic downgrade -1` AVANT le rollback du container (downtime accepté)
+- Ou patcher l'ancien code pour qu'il tolère les deux schemas (deploy 2 fois en pré-migration)
+
+---
+
+## 4. Diagnostic
+
+```bash
+# Logs récents
+docker logs repo-backend-1 --tail 100 2>&1 | grep -iE 'error|traceback|exception|critical|failed'
+
+# Logs entrypoint (vérifier que la migration a tourné)
+docker logs repo-backend-1 2>&1 | grep -i 'entrypoint\|alembic'
+
+# État containers
+docker ps --format '{{.Names}} {{.Status}} {{.Ports}}'
+
+# Image actuelle
+docker inspect repo-backend-1 --format '{{.Image}} {{.Config.Image}}'
+docker images deepsight-backend
+
+# Suivi live
+docker logs repo-backend-1 -f --tail 50
+
+# Healthcheck depuis Caddy
+curl -i https://api.deepsightsynthesis.com/health
+```
+
+---
+
+## 5. Annexe — Incident 2026-04-26 (PR #152)
+
+**Timeline** :
+- 14:56 — PR #152 mergée sur main, workflow démarre
+- 14:57 — Image rebuilt + container swap, nouveau code attend la colonne `users.preferences`
+- 14:57 → 14:59 — `repo-backend-1` `unhealthy`, retours 500 sur `/api/auth/me` et `/api/auth/preferences`
+- 14:59 — Migration 009 appliquée manuellement via `docker cp` + `alembic upgrade head`, container redevient healthy
+
+**Root cause** : workflow `docker run` direct sans `alembic upgrade head` préalable. Migration 009 (`add_user_preferences_json`) jamais jouée par le pipeline. Image PR #185 a depuis ajouté `alembic.ini` + `alembic/` dans `/app/`, mais sans entrypoint pour les jouer automatiquement.
+
+**Fix permanent** (cette PR) : `entrypoint.sh` qui exécute `alembic upgrade head` au démarrage si `RUN_MIGRATIONS=true`. Workflow GitHub passe `-e RUN_MIGRATIONS=true` au `docker run`. Le rollback path passe `RUN_MIGRATIONS=false` pour ne pas re-tenter une migration potentiellement cassée.
+
+---
+
+## 6. Checklist mentale avant de push une PR avec migration
+
+- [ ] Migration alembic présente dans `backend/alembic/versions/`
+- [ ] Migration testée en local (`alembic upgrade head` puis `alembic downgrade -1`)
+- [ ] Rétrocompatibilité du schema vérifiée (ancien code peut-il vivre avec le nouveau schema ?)
+- [ ] Si non rétrocompatible → plan de déploiement en 2 phases documenté dans la PR
+- [ ] Smoke test prévu post-deploy (route qui consomme les nouveaux champs)


### PR DESCRIPTION
## Context

Production incident on 2026-04-26 (PR #152, 14:56-14:59 UTC, ~3 min downtime): the new backend image expected `users.preferences` (column added by alembic 009), but the deploy pipeline rebuilt the image and swapped the container **before** running `alembic upgrade head`. The container went unhealthy; recovery required a manual `docker cp` of the migration files + `alembic upgrade head` on the running container.

PR #185 partially addressed this by copying `alembic.ini` + `alembic/` into the image. This PR adds the missing piece: the image now applies pending migrations on its own at start time when `RUN_MIGRATIONS=true` is passed.

## What changes

### New files

- **`backend/entrypoint.sh`** — opt-in migration runner. If `RUN_MIGRATIONS=true`, `cd /app && alembic upgrade head`, otherwise no-op. Then `cd /app/src` and `exec "$@"` to launch the original CMD (uvicorn). Idempotent. `set -e` so a failing migration prevents container start (fails fast, triggers healthcheck alert).
- **`deploy/hetzner/RUNBOOK.md`** — manual deploy procedure for hotfixes / hors-CI deploys. Includes pre-checks, step-by-step, healthcheck, rollback (with the schema-aware caveat), diagnostics, and the 2026-04-26 incident annex.

### Modified files

- **`deploy/hetzner/Dockerfile`** — `COPY entrypoint.sh /entrypoint.sh` + `RUN chmod +x /entrypoint.sh` + `ENTRYPOINT ["/entrypoint.sh"]`. CMD unchanged (becomes the entrypoint's `"$@"`). Build context is `backend/` (per the workflow), so the script lives at `backend/entrypoint.sh`, not `deploy/hetzner/`.
- **`.github/workflows/deploy-backend.yml`** —
  - Deploy step: `docker run` now passes `-e RUN_MIGRATIONS=true`, so prod auto-migrates on every deploy.
  - Rollback step: passes `-e RUN_MIGRATIONS=false` instead. Re-running an old image's migration set against a DB that may already be migrated is not safe; schema-level rollback is a separate manual procedure (cf. RUNBOOK section 3).

## Migration safety properties

- **Idempotent** — `alembic upgrade head` is a no-op when DB is already at HEAD.
- **Race-resistant** — only one worker / container runs the entrypoint; uvicorn's 4 child workers don't re-trigger it.
- **Failure-visible** — if migration fails, container exits non-zero before uvicorn starts; healthcheck stays red, workflow's smoke test fails, automatic rollback kicks in.

## Test plan

- [ ] **Local** `docker build -t deepsight-backend-test -f deploy/hetzner/Dockerfile backend` succeeds (deferred — docker not available on the dev machine where this PR was authored).
- [ ] **Local** `docker run --rm -e RUN_MIGRATIONS=false deepsight-backend-test uvicorn --version` prints uvicorn version (entrypoint passes through, no migration).
- [ ] **Staging / first prod deploy of this branch**: tail `docker logs repo-backend-1` after deploy and confirm the entrypoint logs `[entrypoint] RUN_MIGRATIONS=true — running alembic upgrade head` and `[entrypoint] alembic upgrade head done`.
- [ ] **First prod PR with a new alembic revision after merge**: confirm zero downtime and that the new column / table is queryable from the new code immediately after the swap.

## Related

- Pairs with the doc PR (anomaly #2) which references `RUNBOOK.md`.
- Audit log: `C:\Users\33667\.claude\plans\crispy-snuggling-starlight.md`