### PR TITLE
feat(voice): auto-analyse Mistral on V1 Quick Voice Call cache miss

### DIFF
--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -970,32 +970,32 @@ async def get_voice_catalog():
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-async def _run_main_analysis_for_v3(
+async def _run_main_analysis_for_video(
     url: str,
     video_id: str,
     lang: str,
     user_id: int,
     user_plan: str,
 ) -> None:
-    """Trigger the main analysis pipeline for the Quick Voice Call mobile V3 path.
+    """Trigger the main analysis pipeline for a Quick Voice Call session.
+
+    Used by both the mobile V3 path (``video_url`` entry point) and the V1
+    extension path when no Summary is cached for the YouTube ``video_id``.
 
     Wraps ``videos/router._analyze_video_background_v6`` with sane defaults so
-    the placeholder Summary created for ``video_url`` eventually gets a sibling
-    row with ``full_digest`` populated. The orchestrator's ``run_for_video``
-    polls by ``(video_id, user_id) DESC`` and picks up the freshest row, so
-    whichever of the two ends up with content first wins.
+    a Summary row eventually gets ``full_digest`` populated. The orchestrator's
+    ``run_for_video`` polls by ``(video_id, user_id) DESC`` and picks up the
+    freshest row.
 
     Credit reservation is intentionally bypassed here: the v6 pipeline is
     invoked without a prior reservation, which the function tolerates (it
     only releases credits when ``SECURITY_AVAILABLE`` and a reservation
-    exists). PR2/PR3 may add explicit credit accounting for the V3 entry
-    point — out of scope for Task 7 (foundation only).
+    exists).
     """
     try:
         from videos.router import _analyze_video_background_v6
 
-        # Use a v3-specific task_id prefix so logs are easy to correlate.
-        task_id = f"v3voice_{uuid.uuid4()}"
+        task_id = f"voice_{uuid.uuid4()}"
         platform = "tiktok" if "tiktok.com" in url else "youtube"
         await _analyze_video_background_v6(
             task_id=task_id,
@@ -1013,7 +1013,7 @@ async def _run_main_analysis_for_v3(
         )
     except Exception as exc:  # noqa: BLE001 — best-effort, voice still works
         logger.exception(
-            "Quick Voice Call mobile V3: main analysis pipeline failed (non-fatal)",
+            "Quick Voice Call: main analysis pipeline failed (non-fatal)",
             extra={
                 "url": url[:80],
                 "video_id": video_id,
@@ -1336,7 +1336,7 @@ async def create_voice_session(
             # populated and the orchestrator's polling fetchers eventually
             # see something to publish as ``analysis_partial`` events.
             background_tasks.add_task(
-                _run_main_analysis_for_v3,
+                _run_main_analysis_for_video,
                 url=request.video_url,
                 video_id=v3_video_id,
                 lang=request.language or "fr",
@@ -1354,33 +1354,92 @@ async def create_voice_session(
                 },
             )
         else:
-            # V1 extension path (Quick Voice Call V1.1 fix Agent A) :
-            # use the production orchestrator wrapping ultra_resilient transcript
-            # extraction + cached Summary analysis fetchers, instead of the no-op
-            # default factory that left the agent without context.
-            #
-            # Note for V3 mobile path: see the ``if v3_url_path`` branch above —
-            # it wires StreamingOrchestrator directly with ``fetch_for_video_url``
-            # (voice/transcript_fetcher.py) and ``run_for_video`` /
-            # ``final_digest_for_video`` (voice/analysis_runner.py) because V3
-            # already has a Summary placeholder row and a parallel main analysis
-            # pipeline running. V1 has no such placeholder yet, so the production
-            # orchestrator polls/falls back as needed.
-            orchestrator = create_production_orchestrator(redis=redis)
-            background_tasks.add_task(
-                orchestrator.run,
-                session_id=voice_session.id,
-                video_id=request.video_id,
-                user_id=current_user.id,
+            # V1 extension path. Two sub-branches:
+            #   (a) Cache hit OR free plan → ``create_production_orchestrator``
+            #       reads the cached Summary (no Mistral spend, no auto-analysis).
+            #   (b) Cache miss AND plan != free → fire the main analysis pipeline
+            #       in background and use the V3-style polling fetchers
+            #       (``run_for_video`` / ``final_digest_for_video``) so the
+            #       agent gets a real ``analysis_partial`` stream as the Mistral
+            #       sections land in the DB. Free is excluded to avoid burning
+            #       Mistral tokens outside the explicit "Analyser" funnel.
+            cached_analysis_result = await db.execute(
+                select(Summary)
+                .where(Summary.video_id == request.video_id)
+                .where(Summary.full_digest.is_not(None))
+                .order_by(Summary.id.desc())
+                .limit(1)
             )
-            logger.info(
-                "Quick Voice Call orchestrator scheduled",
-                extra={
-                    "session_id": voice_session.id,
-                    "video_id": request.video_id,
-                    "user_id": current_user.id,
-                },
-            )
+            has_cached_analysis = cached_analysis_result.scalar_one_or_none() is not None
+
+            should_auto_analyze = (not has_cached_analysis) and plan != "free"
+
+            if should_auto_analyze:
+                # Reconstruct YouTube URL — V1 extension only sees YouTube IDs.
+                youtube_url = f"https://www.youtube.com/watch?v={request.video_id}"
+                background_tasks.add_task(
+                    _run_main_analysis_for_video,
+                    url=youtube_url,
+                    video_id=request.video_id,
+                    lang=request.language or "fr",
+                    user_id=current_user.id,
+                    user_plan=plan,
+                )
+
+                # Capture video_id for closures so the orchestrator's run() can
+                # pass any string as the first arg (it's the same video_id here,
+                # but the closure keeps the signature compatible with V3's URL).
+                _v1_video_id = request.video_id
+
+                async def _v1_run_analysis(_video_arg: str, user_id: int) -> dict:
+                    return await run_for_video(_v1_video_id, user_id)
+
+                async def _v1_final_digest(_video_arg: str, user_id: int) -> str:
+                    return await final_digest_for_video(_v1_video_id, user_id)
+
+                # Reuse the V1 transcript fetcher (video_id-based, ultra_resilient
+                # chain) — it already works with the bare YouTube ID.
+                from voice.streaming_orchestrator import _make_transcript_fetcher
+
+                orchestrator = StreamingOrchestrator(
+                    redis=redis,
+                    fetch_transcript=_make_transcript_fetcher(),
+                    run_analysis=_v1_run_analysis,
+                    final_digest=_v1_final_digest,
+                )
+                background_tasks.add_task(
+                    orchestrator.run,
+                    session_id=voice_session.id,
+                    video_id=request.video_id,
+                    user_id=current_user.id,
+                )
+                logger.info(
+                    "Quick Voice Call V1 orchestrator scheduled (auto-analysis)",
+                    extra={
+                        "session_id": voice_session.id,
+                        "video_id": request.video_id,
+                        "user_id": current_user.id,
+                        "plan": plan,
+                    },
+                )
+            else:
+                orchestrator = create_production_orchestrator(redis=redis)
+                background_tasks.add_task(
+                    orchestrator.run,
+                    session_id=voice_session.id,
+                    video_id=request.video_id,
+                    user_id=current_user.id,
+                )
+                logger.info(
+                    "Quick Voice Call V1 orchestrator scheduled",
+                    extra={
+                        "session_id": voice_session.id,
+                        "video_id": request.video_id,
+                        "user_id": current_user.id,
+                        "plan": plan,
+                        "has_cached_analysis": has_cached_analysis,
+                    },
+                )
 
     # Generate signed URL via ElevenLabs Conversational AI API
     try:

--- a/backend/tests/voice/test_voice_session_v1_auto_analysis.py
+++ b/backend/tests/voice/test_voice_session_v1_auto_analysis.py
@@ -1,0 +1,277 @@
+"""Tests for the V1 (extension) auto-analysis branch in POST /api/voice/session.
+
+Verifies the cache-miss + plan-aware behaviour added to the V1 path:
+
+  1. cache miss + plan != "free" → ``_run_main_analysis_for_video`` is
+     scheduled as a background task and the orchestrator wired with the
+     V3-style polling fetchers (``run_for_video`` / ``final_digest_for_video``).
+  2. cache miss + plan == "free"  → no auto-analysis; the production
+     orchestrator (cached-Summary fetcher) is used as before.
+  3. cache hit  + plan != "free"  → no auto-analysis; production orchestrator.
+
+Each test exercises the route ``create_voice_session`` directly with mocked
+ElevenLabs / oEmbed / quota dependencies, mirroring the pattern used in
+``test_voice_session_streaming.py`` and ``test_voice_session_video_url.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import BackgroundTasks
+
+
+def _make_voice_prefs() -> MagicMock:
+    prefs = MagicMock()
+    prefs.voice_id = None
+    prefs.input_mode = "ptt"
+    prefs.ptt_key = " "
+    prefs.turn_timeout = 15
+    prefs.turn_eagerness = "normal"
+    prefs.voice_chat_model = "eleven_turbo_v2_5"
+    prefs.voice_chat_speed_preset = "1x"
+    prefs.to_voice_settings = MagicMock(return_value={"speed": 1.0})
+    return prefs
+
+
+def _build_eleven_cm():
+    client = AsyncMock()
+    client.create_conversation_agent = AsyncMock(return_value="agent_v1_auto_001")
+    client.get_signed_url = AsyncMock(
+        return_value=("wss://signed.example.test", "2026-04-29T12:00:00Z")
+    )
+    client.get_conversation_token = AsyncMock(
+        return_value=("livekit_token_v1", "2026-04-29T12:00:00Z")
+    )
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm, client
+
+
+class _FakeOembedClient:
+    """Async-context-manager that returns a benign oEmbed response."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, params=None):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json = MagicMock(return_value={"title": "Test video", "author_name": "Test channel"})
+        return resp
+
+
+def _configure_db_for_cache(mock_db_session, *, cache_hit: bool):
+    """Configure mock_db_session.execute to return cache-hit/miss Summary lookups.
+
+    The V1 path performs ONE Summary cache lookup (full_digest is_not None).
+    No request.summary_id is provided in these tests, so no other db.execute
+    calls precede the cache lookup.
+    """
+    fake_summary = MagicMock()
+    fake_summary.id = 42
+    fake_summary.full_digest = '{"summary": "cached"}' if cache_hit else None
+
+    scalar_result = MagicMock()
+    scalar_result.scalar_one_or_none = MagicMock(
+        return_value=(fake_summary if cache_hit else None)
+    )
+    mock_db_session.execute = AsyncMock(return_value=scalar_result)
+    mock_db_session.add = MagicMock()
+    mock_db_session.commit = AsyncMock()
+
+    async def _refresh(obj):
+        if getattr(obj, "id", None) is None:
+            import uuid as _uuid
+            obj.id = str(_uuid.uuid4())
+
+    mock_db_session.refresh = AsyncMock(side_effect=_refresh)
+
+
+def _make_v1_user(plan: str, user_id: int = 50):
+    user = MagicMock()
+    user.id = user_id
+    user.email = f"v1user_{plan}@deepsight.test"
+    user.plan = plan
+    user.is_admin = True  # bypass quota gating for focus on auto-analysis logic
+    user.voice_bonus_seconds = 0
+    user.stripe_customer_id = None
+    user.username = f"v1_{plan}"
+    return user
+
+
+def _make_v1_request():
+    from voice.schemas import VoiceSessionRequest
+
+    return VoiceSessionRequest(
+        agent_type="explorer_streaming",
+        video_id="dQw4w9WgXcQ",
+        is_streaming=True,
+        language="fr",
+    )
+
+
+def _patch_common(monkeypatch=None):
+    """Yield the common patches used by every test in this module."""
+    eleven_cm, _ = _build_eleven_cm()
+    return [
+        patch(
+            "voice.router.check_voice_quota",
+            new=AsyncMock(return_value={"can_use": True, "seconds_remaining": 600}),
+        ),
+        patch(
+            "voice.router.get_elevenlabs_client",
+            return_value=eleven_cm,
+        ),
+        patch(
+            "voice.preferences.get_user_voice_preferences",
+            new=AsyncMock(return_value=_make_voice_prefs()),
+        ),
+        patch(
+            "voice.router.httpx.AsyncClient",
+            return_value=_FakeOembedClient(),
+        ),
+        # Prevent the orchestrator's run() from actually firing — we only
+        # care that it was scheduled.
+        patch(
+            "voice.router.create_production_orchestrator",
+            return_value=MagicMock(run=AsyncMock()),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v1_cache_miss_plan_pro_schedules_auto_analysis(mock_db_session):
+    """V1 + plan pro + no cached analysis → main analysis pipeline is scheduled."""
+    from voice.router import create_voice_session
+
+    _configure_db_for_cache(mock_db_session, cache_hit=False)
+
+    user = _make_v1_user("pro")
+    request = _make_v1_request()
+    bg_tasks = BackgroundTasks()
+
+    patches = _patch_common()
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "voice.router._run_main_analysis_for_video",
+            new=AsyncMock(),
+        ) as mock_main_analysis:
+            response = await create_voice_session(
+                request,
+                background_tasks=bg_tasks,
+                current_user=user,
+                db=mock_db_session,
+                redis=AsyncMock(),
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert response is not None
+    assert response.is_streaming is True
+
+    # Two background tasks scheduled: orchestrator.run + _run_main_analysis_for_video.
+    assert len(bg_tasks.tasks) == 2
+
+    # Verify _run_main_analysis_for_video was one of them, with the YouTube URL
+    # rebuilt from video_id.
+    main_analysis_task = next(
+        (t for t in bg_tasks.tasks if t.func is mock_main_analysis), None
+    )
+    assert main_analysis_task is not None, (
+        "Expected _run_main_analysis_for_video to be scheduled for V1 cache miss + plan pro"
+    )
+    assert main_analysis_task.kwargs["url"] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert main_analysis_task.kwargs["video_id"] == "dQw4w9WgXcQ"
+    assert main_analysis_task.kwargs["user_id"] == user.id
+    assert main_analysis_task.kwargs["user_plan"] == "pro"
+
+
+@pytest.mark.asyncio
+async def test_v1_cache_miss_plan_free_does_not_schedule_auto_analysis(mock_db_session):
+    """V1 + plan free + no cached analysis → no auto-analysis (fallback to production orchestrator)."""
+    from voice.router import create_voice_session
+
+    _configure_db_for_cache(mock_db_session, cache_hit=False)
+
+    user = _make_v1_user("free")
+    request = _make_v1_request()
+    bg_tasks = BackgroundTasks()
+
+    patches = _patch_common()
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "voice.router._run_main_analysis_for_video",
+            new=AsyncMock(),
+        ) as mock_main_analysis:
+            response = await create_voice_session(
+                request,
+                background_tasks=bg_tasks,
+                current_user=user,
+                db=mock_db_session,
+                redis=AsyncMock(),
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert response is not None
+
+    # Free plan must not pay for an auto-generated Mistral analysis.
+    main_analysis_tasks = [t for t in bg_tasks.tasks if t.func is mock_main_analysis]
+    assert main_analysis_tasks == [], (
+        "Free plan must not schedule _run_main_analysis_for_video on cache miss"
+    )
+
+    # The orchestrator IS still scheduled (transcript-only fallback).
+    assert len(bg_tasks.tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_v1_cache_hit_plan_pro_does_not_schedule_auto_analysis(mock_db_session):
+    """V1 + plan pro + cached Summary with full_digest → no auto-analysis."""
+    from voice.router import create_voice_session
+
+    _configure_db_for_cache(mock_db_session, cache_hit=True)
+
+    user = _make_v1_user("pro")
+    request = _make_v1_request()
+    bg_tasks = BackgroundTasks()
+
+    patches = _patch_common()
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "voice.router._run_main_analysis_for_video",
+            new=AsyncMock(),
+        ) as mock_main_analysis:
+            response = await create_voice_session(
+                request,
+                background_tasks=bg_tasks,
+                current_user=user,
+                db=mock_db_session,
+                redis=AsyncMock(),
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert response is not None
+
+    main_analysis_tasks = [t for t in bg_tasks.tasks if t.func is mock_main_analysis]
+    assert main_analysis_tasks == [], (
+        "Cache hit must not re-trigger Mistral analysis"
+    )
+
+    # Production orchestrator scheduled (cache fetcher will read the summary).
+    assert len(bg_tasks.tasks) == 1


### PR DESCRIPTION
## Summary

When the extension launches a Quick Voice Call on a video the user hasn't previously analysed in DeepSight, the agent only received `transcript_chunk` events and replied *"analyse non disponible"*. This PR wires the same pattern already used by the V3 mobile path.

- On **cache miss + plan != \"free\"**, schedule `_run_main_analysis_for_video` in background (the v6 Mistral pipeline) and use the polling fetchers `run_for_video` / `final_digest_for_video` so `analysis_partial` events are published as `Summary.full_digest` sections land in the DB.
- **Free plan** and **cache hit** keep the existing `create_production_orchestrator` path — no extra Mistral spend, behaviour unchanged.
- Renames `_run_main_analysis_for_v3` → `_run_main_analysis_for_video` since the function is now used by both V1 extension and V3 mobile paths.

## Decision matrix (V1 path)

| Cache | Plan      | Action                                   |
| ----- | --------- | ---------------------------------------- |
| miss  | non-free  | trigger main analysis + V3-style polling |
| miss  | free      | transcript-only fallback (no Mistral)    |
| hit   | any       | cached Summary fetcher (unchanged)       |

## Test plan

- [x] `tests/voice/test_voice_session_v1_auto_analysis.py` — 3 new unit tests covering the matrix above (cache miss/hit × plan pro/free).
- [x] `tests/voice/test_voice_session_streaming.py` (existing) — still green, no regression on the V1 streaming flow.
- [x] `tests/voice/test_voice_session_video_url.py` (existing) — V3 mobile path unaffected by the rename.
- [x] `tests/voice/test_streaming_orchestrator.py` + `test_quick_voice_call_e2e.py` + `test_analysis_runner.py` — all green (23 tests total in voice module).

```
============================== 23 passed, 3 warnings in 4.75s ==============================
```

## Deploy

Merging this triggers `deploy-backend.yml` → SSH Hetzner → `git pull` → rebuild container with auto-migrations (PR #189 mechanism). No new env vars, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)