### PR TITLE
feat(voice): V1 Quick Voice Call — create Summary placeholder for cross-platform history sync

### DIFF
--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -1273,10 +1273,63 @@ async def create_voice_session(
             },
         )
 
+    # ── Quick Voice Call (V1) — create Summary placeholder ───────────────
+    # When the extension launches a Quick Voice Call on YouTube, the V1
+    # path (``video_id`` set, ``video_url`` absent) must surface the video
+    # in the user's history right away — exactly like the V3 mobile path
+    # does for Summary deep-linking. Without this, the auto-analysis
+    # pipeline (Mistral) creates the row asynchronously and the video is
+    # invisible from web/mobile/extension history until ``full_digest``
+    # lands. We pre-create a placeholder if (and only if) no Summary
+    # already exists for ``(video_id, user_id)`` so we don't shadow a
+    # cached analysis the orchestrator could re-use.
+    v1_summary: Optional[Summary] = None
+    if request.is_streaming and request.video_id and not v3_url_path:
+        existing_summary_result = await db.execute(
+            select(Summary)
+            .where(Summary.user_id == current_user.id)
+            .where(Summary.video_id == request.video_id)
+            .order_by(Summary.id.desc())
+            .limit(1)
+        )
+        existing_summary = existing_summary_result.scalar_one_or_none()
+        if existing_summary is None:
+            v1_video_title = (
+                request.video_title
+                if request.video_title
+                else f"[En cours] YT {request.video_id}"
+            )
+            v1_summary = Summary(
+                user_id=current_user.id,
+                video_id=request.video_id,
+                video_title=v1_video_title,
+                video_url=f"https://www.youtube.com/watch?v={request.video_id}",
+                platform="youtube",
+                mode="standard",
+                lang=request.language or "fr",
+            )
+            db.add(v1_summary)
+            await db.commit()
+            await db.refresh(v1_summary)
+            logger.info(
+                "Quick Voice Call V1: Summary placeholder created",
+                extra={
+                    "user_id": current_user.id,
+                    "summary_id": v1_summary.id,
+                    "video_id": request.video_id,
+                },
+            )
+
     # Create voice session in DB
     voice_session = VoiceSession(
         user_id=current_user.id,
-        summary_id=v3_summary.id if v3_summary is not None else request.summary_id,
+        summary_id=(
+            v3_summary.id
+            if v3_summary is not None
+            else v1_summary.id
+            if v1_summary is not None
+            else request.summary_id
+        ),
         debate_id=request.debate_id,
         agent_type=agent_config.agent_type,
         is_streaming_session=bool(request.is_streaming),

--- a/backend/tests/voice/test_voice_session_v1_auto_analysis.py
+++ b/backend/tests/voice/test_voice_session_v1_auto_analysis.py
@@ -65,12 +65,21 @@ class _FakeOembedClient:
         return resp
 
 
-def _configure_db_for_cache(mock_db_session, *, cache_hit: bool):
+def _configure_db_for_cache(mock_db_session, *, cache_hit: bool, captured: list | None = None):
     """Configure mock_db_session.execute to return cache-hit/miss Summary lookups.
 
-    The V1 path performs ONE Summary cache lookup (full_digest is_not None).
-    No request.summary_id is provided in these tests, so no other db.execute
-    calls precede the cache lookup.
+    The V1 path performs TWO Summary lookups :
+
+      1. Existing-summary check by ``(user_id, video_id)`` — used to decide
+         whether to create a Summary placeholder for the history sync.
+      2. Cached-analysis check by ``(video_id, full_digest is_not None)`` —
+         used to decide whether to schedule auto-analysis (Mistral).
+
+    Both lookups use the same ``scalar_one_or_none`` shape, so we return the
+    same fake Summary on every call: it has ``full_digest`` populated only
+    when ``cache_hit=True``, which matches the production semantics for both
+    branches simultaneously (cache hit ⇒ existing summary present + already
+    analyzed; cache miss ⇒ no summary at all → placeholder created).
     """
     fake_summary = MagicMock()
     fake_summary.id = 42
@@ -81,7 +90,14 @@ def _configure_db_for_cache(mock_db_session, *, cache_hit: bool):
         return_value=(fake_summary if cache_hit else None)
     )
     mock_db_session.execute = AsyncMock(return_value=scalar_result)
-    mock_db_session.add = MagicMock()
+
+    if captured is not None:
+        def _fake_add(obj):
+            captured.append(obj)
+        mock_db_session.add = MagicMock(side_effect=_fake_add)
+    else:
+        mock_db_session.add = MagicMock()
+
     mock_db_session.commit = AsyncMock()
 
     async def _refresh(obj):
@@ -275,3 +291,65 @@ async def test_v1_cache_hit_plan_pro_does_not_schedule_auto_analysis(mock_db_ses
 
     # Production orchestrator scheduled (cache fetcher will read the summary).
     assert len(bg_tasks.tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_v1_cache_miss_plan_pro_creates_summary_placeholder(mock_db_session):
+    """V1 + plan pro + cache miss → Summary placeholder row persisted for history sync.
+
+    Regression guard for the cross-platform history sync feature
+    (feat/voice-v1-summary-placeholder): when the extension launches a
+    Quick Voice Call on YouTube and no Summary exists yet for
+    ``(video_id, user_id)``, the router must persist a placeholder row
+    with ``mode="standard"`` and the canonical YouTube ``video_id`` so
+    the video shows up immediately in web/mobile/extension history.
+    """
+    from voice.router import create_voice_session
+    from db.database import Summary, VoiceSession
+
+    captured: list = []
+    _configure_db_for_cache(mock_db_session, cache_hit=False, captured=captured)
+
+    user = _make_v1_user("pro")
+    request = _make_v1_request()
+    bg_tasks = BackgroundTasks()
+
+    patches = _patch_common()
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "voice.router._run_main_analysis_for_video",
+            new=AsyncMock(),
+        ):
+            response = await create_voice_session(
+                request,
+                background_tasks=bg_tasks,
+                current_user=user,
+                db=mock_db_session,
+                redis=AsyncMock(),
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert response is not None
+
+    # Exactly one Summary row was added (the V1 placeholder).
+    summaries = [c for c in captured if isinstance(c, Summary)]
+    assert len(summaries) == 1, (
+        f"Expected 1 Summary placeholder for V1 cache miss, got {len(summaries)}"
+    )
+
+    placeholder = summaries[0]
+    assert placeholder.user_id == user.id
+    assert placeholder.video_id == "dQw4w9WgXcQ"
+    assert placeholder.mode == "standard"
+    assert placeholder.platform == "youtube"
+    assert placeholder.video_url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert placeholder.lang == "fr"
+
+    # The VoiceSession links to the placeholder so the client deep-link works.
+    sessions = [c for c in captured if isinstance(c, VoiceSession)]
+    assert len(sessions) == 1
+    assert sessions[0].summary_id == placeholder.id


### PR DESCRIPTION
## Pourquoi

Quand l'utilisateur lance un Quick Voice Call sur YouTube **depuis l'extension Chrome** (path V1 = `video_id`), aucune ligne `Summary` n'était créée immédiatement. La vidéo n'apparaissait donc PAS dans l'historique web / mobile / extension tant que l'auto-analyse Mistral n'avait pas encore terminé d'écrire `full_digest` — soit plusieurs secondes à plusieurs minutes plus tard.

À l'inverse, le path V3 mobile (`video_url`) crée déjà un placeholder `Summary` au début de la session pour permettre au client de deep-link sur `/analysis/[id]` immédiatement (cf. lignes 1247-1274 du router avant ce PR).

Ce PR aligne le path V1 sur le comportement V3 → **un seul historique cohérent sur les 3 plateformes**.

## Ce qui change

### `backend/src/voice/router.py` (+55 lignes)

Dans `create_voice_session`, après la branche V3 placeholder et avant la création de la `VoiceSession` :

- Si `request.is_streaming + request.video_id + pas v3_url_path` :
  - On vérifie qu'aucun `Summary` n'existe déjà pour `(video_id, user_id)` via un `SELECT ... ORDER BY id DESC LIMIT 1`.
  - Si aucun → on crée un placeholder `Summary` avec :
    - `user_id`, `video_id`
    - `video_title = request.video_title or f"[En cours] YT {video_id}"`
    - `video_url = f"https://www.youtube.com/watch?v={video_id}"`
    - `platform = "youtube"`, `mode = "standard"`, `lang = request.language or "fr"`
  - `db.add` + `commit` + `refresh`
- La `VoiceSession.summary_id` est calculée en cascade : `v3_summary.id ?? v1_summary.id ?? request.summary_id`.

### `backend/tests/voice/test_voice_session_v1_auto_analysis.py` (+88 lignes)

- Nouveau test `test_v1_cache_miss_plan_pro_creates_summary_placeholder` qui vérifie :
  - Exactement **1** `Summary` row ajouté.
  - `placeholder.video_id == "dQw4w9WgXcQ"`, `mode == "standard"`, `platform == "youtube"`, `video_url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"`, `lang == "fr"`.
  - La `VoiceSession.summary_id` pointe sur le placeholder.
- Le helper `_configure_db_for_cache` accepte un paramètre optionnel `captured: list` pour récupérer les rows passés à `db.add`.
- Docstring du helper mise à jour pour refléter les **deux** db.execute désormais (existing-summary check + cache check).

## Tests

Toute la suite voice reste verte :

```
backend/tests/voice/test_voice_session_v1_auto_analysis.py   ........  4/4
backend/tests/voice/test_voice_session_video_url.py          ........  5/5
backend/tests/voice/                                         ........ 144/144
```

En particulier :
- `test_voice_session_video_url.py::test_valid_youtube_url_creates_summary_and_session` (path V3, ne crée toujours qu'**1** Summary) reste green grâce au garde `not v3_url_path`.
- Les 3 tests V1 préexistants (`test_v1_cache_*`) restent green parce que le mock `mock_db_session.execute` retourne le même résultat pour les deux appels — sémantique cohérente avec la prod.

## Hors scope

- Pas de migration DB (le placeholder utilise les colonnes Summary existantes).
- Pas de touche au front extension (le `summary_id` était déjà retourné dans `VoiceSessionResponse`).
- Pas de gestion de la collision `(video_id, user_id)` au-delà du `LIMIT 1` (l'utilisateur qui re-clic sur la même vidéo n'aura pas de doublon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)