### PR TITLE
fix(transcripts): YOUTUBE_PROXY for Whisper STT + youtube-transcript-api 1.x compat

### DIFF
--- a/backend/src/transcripts/ultra_resilient.py
+++ b/backend/src/transcripts/ultra_resilient.py
@@ -31,6 +31,7 @@ from core.config import (
     get_deepgram_key,
     get_openai_key,
     get_assemblyai_key,
+    get_youtube_proxy,
     TRANSCRIPT_CONFIG,
 )
 
@@ -321,7 +322,14 @@ class UltraResilientTranscriptExtractor:
             raise Exception("youtube-transcript-api not installed")
 
         def _fetch_sync():
-            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+            # youtube-transcript-api 1.x changed list_transcripts (classmethod)
+            # → list (instance method). Try new API first, fall back to legacy
+            # so the same code works across versions.
+            try:
+                ytt_api = YouTubeTranscriptApi()
+                transcript_list = ytt_api.list(video_id)
+            except AttributeError:
+                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
 
             # Try manual transcripts first
             for lang in languages:
@@ -353,7 +361,11 @@ class UltraResilientTranscriptExtractor:
         loop = asyncio.get_event_loop()
         segments, lang, is_auto = await loop.run_in_executor(None, _fetch_sync)
 
-        text = " ".join([s["text"] for s in segments])
+        # Snippet shape changed in 1.x: dict → FetchedTranscriptSnippet object
+        # with .text attribute. Support both.
+        text = " ".join(
+            [s.text if hasattr(s, "text") else s["text"] for s in segments]
+        )
 
         return TranscriptResult(
             text=text,
@@ -1015,8 +1027,13 @@ class UltraResilientTranscriptExtractor:
                 self._get_random_user_agent(),
                 "-o",
                 audio_path,
-                f"https://www.youtube.com/watch?v={video_id}",
             ]
+            # Route through YOUTUBE_PROXY when available — Hetzner IP is banned
+            # by YouTube so the direct download from the audio host fails too.
+            proxy = get_youtube_proxy()
+            if proxy:
+                cmd.extend(["--proxy", proxy])
+            cmd.append(f"https://www.youtube.com/watch?v={video_id}")
 
             process = await asyncio.create_subprocess_exec(
                 *cmd,


### PR DESCRIPTION
## Bug en prod

Quick Voice Call sur YouTube Shorts reste bloqué à \"0% du transcript reçu\". Logs Hetzner montrent que les 10 méthodes d'extraction échouent en cascade :

\`\`\`
youtube_transcript_api: type object 'YouTubeTranscriptApi' has no attribute 'list_transcripts'
innertube/invidious/piped/yt-dlp/timedtext: All instances failed (= IP Hetzner ban)
supadata_api: 404 (Shorts pas indexés)
whisper_fallback: Failed to download audio (yt-dlp pas wired sur le proxy)
\`\`\`

Les Shorts n'ont quasi jamais de captions → Whisper STT est le seul recours, mais il fail au download audio depuis IP Hetzner banned, ET il n'utilisait pas \`YOUTUBE_PROXY\` pourtant déjà configuré côté .env.production.

## Fix

1. **\`_method_whisper_fallback\`** : ajoute \`--proxy <YOUTUBE_PROXY>\` à la commande yt-dlp quand la var d'env est set.
2. **\`_method_youtube_transcript_api\`** : compat lib v1.x — \`YouTubeTranscriptApi.list_transcripts()\` (classmethod, retiré) → \`YouTubeTranscriptApi().list()\` (instance). Snippets passent de \`dict[\"text\"]\` à \`FetchedTranscriptSnippet.text\`. Try new API puis fallback legacy → même code marche cross-versions.

## Test plan

- [ ] Merge → workflow \`deploy-backend.yml\` redéploie container
- [ ] Re-tester Quick Voice Call sur Short \`qdFTrj4LwY4\` (le cas qui a échoué dans les logs)
- [ ] Vérifier que \`whisper_fallback\` produit du texte transcript
- [ ] Vérifier que \`youtube_transcript_api\` n'est plus le premier point d'échec systématique

## Hors scope (follow-up)

- Wire le proxy dans toutes les autres méthodes yt-dlp (\`_method_yt_dlp_native\`, \`_method_yt_dlp_auto_subs\`) — pas critique car Whisper suffit pour Shorts
- Audit Webshare proxy quotas

🤖 Generated with [Claude Code](https://claude.com/claude-code)