### PR TITLE
fix(transcripts): max coverage YOUTUBE_PROXY + YTDLP_COOKIES_PATH (yt-dlp + ytt-api)

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -725,6 +725,10 @@ def get_youtube_proxy() -> str:
     return YOUTUBE_PROXY
 
 
+def get_ytdlp_cookies_path() -> str:
+    return _settings.YTDLP_COOKIES_PATH
+
+
 def get_perplexity_key() -> str:
     return PERPLEXITY_API_KEY
 

--- a/backend/src/transcripts/ultra_resilient.py
+++ b/backend/src/transcripts/ultra_resilient.py
@@ -32,8 +32,25 @@ from core.config import (
     get_openai_key,
     get_assemblyai_key,
     get_youtube_proxy,
+    get_ytdlp_cookies_path,
     TRANSCRIPT_CONFIG,
 )
+
+
+def _yt_dlp_extra_args() -> list:
+    """Common yt-dlp flags for IP-banned environments: proxy + cookies.
+
+    Both are no-ops when their env vars are unset, so this is safe to call
+    from every yt-dlp wrapper unconditionally.
+    """
+    extra = []
+    proxy = get_youtube_proxy()
+    if proxy:
+        extra.extend(["--proxy", proxy])
+    cookies = get_ytdlp_cookies_path()
+    if cookies and os.path.exists(cookies):
+        extra.extend(["--cookies", cookies])
+    return extra
 
 
 class ExtractionMethod(Enum):
@@ -323,13 +340,28 @@ class UltraResilientTranscriptExtractor:
 
         def _fetch_sync():
             # youtube-transcript-api 1.x changed list_transcripts (classmethod)
-            # → list (instance method). Try new API first, fall back to legacy
-            # so the same code works across versions.
+            # → list (instance method). Wire YOUTUBE_PROXY when set so the
+            # call doesn't hit the (banned) Hetzner IP directly.
+            proxy = get_youtube_proxy()
             try:
-                ytt_api = YouTubeTranscriptApi()
+                kwargs = {}
+                if proxy:
+                    try:
+                        from youtube_transcript_api.proxies import GenericProxyConfig
+                        kwargs["proxy_config"] = GenericProxyConfig(
+                            http_url=proxy, https_url=proxy
+                        )
+                    except ImportError:
+                        # ytt 0.x — proxies passed differently below
+                        pass
+                ytt_api = YouTubeTranscriptApi(**kwargs)
                 transcript_list = ytt_api.list(video_id)
             except AttributeError:
-                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+                # Legacy 0.x classmethod path. Pass proxies dict if available.
+                proxies = {"http": proxy, "https": proxy} if proxy else None
+                transcript_list = YouTubeTranscriptApi.list_transcripts(
+                    video_id, proxies=proxies
+                ) if proxies else YouTubeTranscriptApi.list_transcripts(video_id)
 
             # Try manual transcripts first
             for lang in languages:
@@ -398,6 +430,7 @@ class UltraResilientTranscriptExtractor:
                 self._get_random_user_agent(),
                 "--extractor-args",
                 "youtube:player_client=android",
+                *_yt_dlp_extra_args(),
                 "-o",
                 output_template,
                 f"https://www.youtube.com/watch?v={video_id}",
@@ -455,6 +488,7 @@ class UltraResilientTranscriptExtractor:
                 "youtube:player_client=mweb",
                 "--sleep-requests",
                 "1",
+                *_yt_dlp_extra_args(),
                 "-o",
                 output_template,
                 f"https://www.youtube.com/watch?v={video_id}",
@@ -1025,15 +1059,11 @@ class UltraResilientTranscriptExtractor:
                 "5",
                 "--user-agent",
                 self._get_random_user_agent(),
+                *_yt_dlp_extra_args(),
                 "-o",
                 audio_path,
+                f"https://www.youtube.com/watch?v={video_id}",
             ]
-            # Route through YOUTUBE_PROXY when available — Hetzner IP is banned
-            # by YouTube so the direct download from the audio host fails too.
-            proxy = get_youtube_proxy()
-            if proxy:
-                cmd.extend(["--proxy", proxy])
-            cmd.append(f"https://www.youtube.com/watch?v={video_id}")
 
             process = await asyncio.create_subprocess_exec(
                 *cmd,


### PR DESCRIPTION
## Goal

Maximum coverage transcript extraction sur Hetzner IP banned. Wire YOUTUBE_PROXY (déjà set) et YTDLP_COOKIES_PATH (à configurer) dans toutes les méthodes yt-dlp + youtube-transcript-api lib.

## Changes

- New `_yt_dlp_extra_args()` helper → returns `[--proxy, X, --cookies, Y]` based on env
- Wired into `_method_yt_dlp_native` + `_method_yt_dlp_auto_subs` + `_method_whisper_fallback`
- `_method_youtube_transcript_api` wired with `GenericProxyConfig` (lib 1.x) + legacy proxies dict (0.x)
- New `get_ytdlp_cookies_path()` in core.config

## Coverage

| Type | Avant | Après |
|---|---|---|
| Vidéos avec captions | bloquées (IP ban) | OK via proxy |
| Shorts sans captions | bloquées | OK si `YTDLP_COOKIES_PATH` set + cookies valides |
| TikTok | inchangé (chain séparée) | inchangé |

## Action Hetzner après merge

1. Sur Chrome connecté à YouTube, exporter cookies via extension "Get cookies.txt LOCALLY"
2. SCP le fichier sur Hetzner : `scp cookies.txt root@hetzner:/opt/deepsight/cookies.txt`
3. Ajouter à .env.production : `YTDLP_COOKIES_PATH=/opt/deepsight/cookies.txt`
4. `docker rm -f repo-backend-1 && docker run -d --env-file ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)