### PR TITLE
fix(transcripts): TikTok yt-dlp proxy + cookies coverage (parity with #200)

### DIFF
--- a/backend/src/transcripts/audio_utils.py
+++ b/backend/src/transcripts/audio_utils.py
@@ -6,6 +6,7 @@
 """
 
 import asyncio
+import os
 import subprocess
 import tempfile
 import time
@@ -15,7 +16,28 @@ from concurrent.futures import ThreadPoolExecutor
 
 import httpx
 
-from core.config import get_groq_key
+from core.config import get_groq_key, get_youtube_proxy, get_ytdlp_cookies_path
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 YT-DLP EXTRA ARGS — proxy + cookies (partagé YouTube + TikTok)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _yt_dlp_extra_args() -> list:
+    """Common yt-dlp flags for IP-banned environments: proxy + cookies.
+
+    Both are no-ops when their env vars are unset, so this is safe to call
+    from every yt-dlp wrapper unconditionally (YouTube ET TikTok).
+    """
+    extra = []
+    proxy = get_youtube_proxy()
+    if proxy:
+        extra.extend(["--proxy", proxy])
+    cookies = get_ytdlp_cookies_path()
+    if cookies and os.path.exists(cookies):
+        extra.extend(["--cookies", cookies])
+    return extra
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 📊 CONFIGURATION
@@ -314,6 +336,7 @@ async def download_audio_ytdlp(
 
                 cmd = [
                     "yt-dlp",
+                    *_yt_dlp_extra_args(),
                     "-x",
                     "--audio-format",
                     "mp3",

--- a/backend/src/transcripts/tiktok.py
+++ b/backend/src/transcripts/tiktok.py
@@ -29,6 +29,7 @@ from transcripts.audio_utils import (
     transcribe_audio_voxtral,
     compress_audio,
     executor as audio_executor,
+    _yt_dlp_extra_args,
 )
 from core.config import get_supadata_key, get_mistral_key
 
@@ -296,6 +297,7 @@ async def get_tiktok_video_info(url: str) -> Optional[Dict[str, Any]]:
             def _get_info():
                 cmd = [
                     "yt-dlp",
+                    *_yt_dlp_extra_args(),
                     "--dump-json",
                     "--no-warnings",
                     "--skip-download",
@@ -903,6 +905,7 @@ async def _download_video_bytes(url: str, video_id: str) -> Optional[bytes]:
                 video_path = f"{tmpdir}/video.mp4"
                 cmd = [
                     "yt-dlp",
+                    *_yt_dlp_extra_args(),
                     "-f",
                     "best[ext=mp4]/best",
                     "-o",

--- a/backend/src/transcripts/ultra_resilient.py
+++ b/backend/src/transcripts/ultra_resilient.py
@@ -36,21 +36,9 @@ from core.config import (
     TRANSCRIPT_CONFIG,
 )
 
-
-def _yt_dlp_extra_args() -> list:
-    """Common yt-dlp flags for IP-banned environments: proxy + cookies.
-
-    Both are no-ops when their env vars are unset, so this is safe to call
-    from every yt-dlp wrapper unconditionally.
-    """
-    extra = []
-    proxy = get_youtube_proxy()
-    if proxy:
-        extra.extend(["--proxy", proxy])
-    cookies = get_ytdlp_cookies_path()
-    if cookies and os.path.exists(cookies):
-        extra.extend(["--cookies", cookies])
-    return extra
+# Helper partagé YouTube + TikTok — défini dans audio_utils pour ré-utilisation.
+# Re-export pour compat avec d'éventuels imports existants.
+from transcripts.audio_utils import _yt_dlp_extra_args  # noqa: F401
 
 
 class ExtractionMethod(Enum):

--- a/backend/tests/transcripts/test_yt_dlp_extra_args.py
+++ b/backend/tests/transcripts/test_yt_dlp_extra_args.py
@@ -1,0 +1,77 @@
+"""
+Tests for _yt_dlp_extra_args() helper from transcripts/audio_utils.py.
+
+Verifies that the proxy/cookies wiring used by YouTube AND TikTok yt-dlp
+invocations behaves correctly across env var combinations.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+class TestYtDlpExtraArgs:
+    def test_returns_empty_when_no_env(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        assert audio_utils._yt_dlp_extra_args() == []
+
+    def test_includes_proxy_when_set(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://user:pass@proxy:1080")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        args = audio_utils._yt_dlp_extra_args()
+        assert args == ["--proxy", "http://user:pass@proxy:1080"]
+
+    def test_includes_cookies_when_file_exists(self, monkeypatch, tmp_path):
+        from transcripts import audio_utils
+
+        cookies_file = tmp_path / "cookies.txt"
+        cookies_file.write_text("# Netscape cookies file")
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: str(cookies_file))
+
+        args = audio_utils._yt_dlp_extra_args()
+        assert args == ["--cookies", str(cookies_file)]
+
+    def test_skips_cookies_when_path_does_not_exist(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "/nonexistent/cookies.txt")
+
+        assert audio_utils._yt_dlp_extra_args() == []
+
+    def test_proxy_and_cookies_together(self, monkeypatch, tmp_path):
+        from transcripts import audio_utils
+
+        cookies_file = tmp_path / "cookies.txt"
+        cookies_file.write_text("# cookies")
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://proxy:1080")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: str(cookies_file))
+
+        args = audio_utils._yt_dlp_extra_args()
+        assert args == ["--proxy", "http://proxy:1080", "--cookies", str(cookies_file)]
+
+    def test_re_export_from_ultra_resilient(self):
+        """Backward-compat: ultra_resilient still exposes _yt_dlp_extra_args."""
+        from transcripts.ultra_resilient import _yt_dlp_extra_args as ur_helper
+        from transcripts.audio_utils import _yt_dlp_extra_args as au_helper
+
+        assert ur_helper is au_helper
+
+    def test_tiktok_imports_helper(self):
+        """tiktok module imports the shared helper."""
+        from transcripts import tiktok
+
+        assert hasattr(tiktok, "_yt_dlp_extra_args")


### PR DESCRIPTION
## Why

PR #200 wired \`YOUTUBE_PROXY\` + \`YTDLP_COOKIES_PATH\` into every yt-dlp invocation of \`ultra_resilient.py\` (YouTube path). But Quick Voice Call on **TikTok** public videos still failed from Hetzner because \`tiktok.py\` had three uncovered call sites that hit the banned host IP directly:

1. \`get_tiktok_video_info\` — yt-dlp \`--dump-json\` (metadata, with \`ALT_HEADERS\` rotation)
2. \`_download_video_bytes\` — yt-dlp video fallback (visual-OCR phase)
3. \`audio_utils.download_audio_ytdlp\` — Phases 1/2/3 of the TikTok transcript pipeline (and YouTube audio downloads too)

This PR mirrors the #200 wiring to fix all three.

## What

- **Move** \`_yt_dlp_extra_args()\` from \`ultra_resilient.py\` to \`audio_utils.py\` (already imported by both YouTube + TikTok). Re-export from \`ultra_resilient\` so existing imports keep working.
- **Wire** the helper into \`download_audio_ytdlp\` (one splat — benefits YouTube AND TikTok audio downloads).
- **Wire** the helper into the two direct \`subprocess.run([\"yt-dlp\", ...])\` calls in \`tiktok.py\`.
- \`ALT_HEADERS\` (Chrome/Safari User-Agent + Referer rotation) preserved unchanged — the helper only **prepends** \`--proxy\`/\`--cookies\` flags before the existing args.
- No new env var: \`YTDLP_COOKIES_PATH\` is reused (cookies don't apply to TikTok public videos in practice but the helper stays consistent).

## Diff is minimal

\`\`\`
backend/src/transcripts/audio_utils.py            | +25 -1
backend/src/transcripts/tiktok.py                 |  +3 -0
backend/src/transcripts/ultra_resilient.py        |  +3 -15
backend/tests/transcripts/test_yt_dlp_extra_args.py | +75 (new)
\`\`\`

## Tests

7 new unit tests covering: empty env, proxy only, cookies file exists, cookies path missing (skipped), combined proxy+cookies, re-export compat from \`ultra_resilient\`, and \`tiktok\` import.

\`\`\`
backend $ python -m pytest tests/transcripts/ -x -q
27 passed in 6.06s
\`\`\`

## Out of scope (noted, not touched)

- \`_circuit_breaker\` initialization patterns, \`oEmbed\` fallback, \`Supadata\` priority — all left intact.
- The third-party APIs (\`tikwm\`) in \`_download_audio_direct\` / \`_download_video_bytes\` Phase-1 are NOT proxied. They go through their own host so don't suffer the YouTube/TikTok IP ban. Helper only applies to yt-dlp.

## Deploy

\`deploy-backend.yml\` will redeploy the container on Hetzner automatically after merge. No new env vars required (\`YOUTUBE_PROXY\` is already set in production for #200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)