### PR TITLE
chore(backfill): scripts for historical voice + chat text digests

### DIFF
--- a/scripts/backfill_chat_text_digests.py
+++ b/scripts/backfill_chat_text_digests.py
@@ -1,0 +1,61 @@
+"""Backfill digests for chat texte buckets accumulated before the bucket hook
+was deployed.
+
+Iterates per (summary_id, user_id) tuple and calls maybe_generate_chat_text_digest
+in a loop until no more buckets are produced.
+
+Run: cd backend && python -m scripts.backfill_chat_text_digests
+"""
+import asyncio
+import logging
+from sqlalchemy import select, distinct
+
+from db.database import ChatMessage, ChatTextDigest, async_session_factory
+from voice.context_digest import maybe_generate_chat_text_digest, CHAT_TEXT_BUCKET_SIZE
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("backfill_chat_text")
+
+
+async def main():
+    async with async_session_factory() as db:
+        pairs = (
+            await db.execute(
+                select(distinct(ChatMessage.summary_id), ChatMessage.user_id)
+                .where(ChatMessage.source == "text")
+            )
+        ).all()
+    logger.info("Found %d (summary_id, user_id) pairs to inspect", len(pairs))
+
+    for summary_id, user_id in pairs:
+        async with async_session_factory() as db:
+            # Loop while buckets are produced
+            while True:
+                count_before = (
+                    await db.execute(
+                        select(ChatTextDigest)
+                        .where(
+                            ChatTextDigest.summary_id == summary_id,
+                            ChatTextDigest.user_id == user_id,
+                        )
+                    )
+                ).scalars().all()
+                await maybe_generate_chat_text_digest(db, summary_id, user_id)
+                count_after = (
+                    await db.execute(
+                        select(ChatTextDigest)
+                        .where(
+                            ChatTextDigest.summary_id == summary_id,
+                            ChatTextDigest.user_id == user_id,
+                        )
+                    )
+                ).scalars().all()
+                if len(count_after) == len(count_before):
+                    break
+        await asyncio.sleep(0.5)
+
+    logger.info("Backfill chat text digests complete.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/backfill_voice_session_digests.py
+++ b/scripts/backfill_voice_session_digests.py
@@ -1,0 +1,54 @@
+"""Backfill digests for voice_sessions that ended before the digest hook
+was deployed (digest_text IS NULL but messages exist).
+
+Run: cd backend && python -m scripts.backfill_voice_session_digests
+
+Batch by 50 sessions, sleep 1s between batches to respect Mistral rate limit.
+"""
+import asyncio
+import logging
+from sqlalchemy import select
+
+from db.database import VoiceSession, async_session_factory, ChatMessage
+from voice.context_digest import generate_voice_session_digest
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("backfill_voice")
+
+BATCH_SIZE = 50
+SLEEP_BETWEEN_BATCHES_S = 1.0
+
+
+async def main():
+    async with async_session_factory() as db:
+        sessions_to_process = (
+            await db.execute(
+                select(VoiceSession.id)
+                .where(VoiceSession.digest_text.is_(None))
+                .where(
+                    VoiceSession.id.in_(
+                        select(ChatMessage.voice_session_id)
+                        .where(ChatMessage.voice_session_id.isnot(None))
+                        .distinct()
+                    )
+                )
+            )
+        ).scalars().all()
+    logger.info("Found %d voice sessions to backfill", len(sessions_to_process))
+
+    for i in range(0, len(sessions_to_process), BATCH_SIZE):
+        batch = sessions_to_process[i : i + BATCH_SIZE]
+        async with async_session_factory() as db:
+            for sid in batch:
+                try:
+                    await generate_voice_session_digest(db, sid)
+                except Exception as exc:
+                    logger.warning("backfill skipped sid=%s err=%s", sid, exc)
+        logger.info("Batch %d/%d done", i // BATCH_SIZE + 1, (len(sessions_to_process) + BATCH_SIZE - 1) // BATCH_SIZE)
+        await asyncio.sleep(SLEEP_BETWEEN_BATCHES_S)
+
+    logger.info("Backfill voice digests complete.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Optional one-shot backfill scripts (Task 13 of merge-voice-chat-context-implementation.md). Idempotent, batched. To run post-deploy on existing voice_sessions and chat texte without digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)