### PR TITLE
feat(exports): watermark sur exports plan Free (6 formats)

### DIFF
--- a/backend/src/exports/pdf_generator.py
+++ b/backend/src/exports/pdf_generator.py
@@ -188,6 +188,8 @@ class PDFGenerator:
         quiz: Optional[List[Dict]] = None,
         sources: Optional[List[Dict]] = None,
         export_type: PDFExportType = PDFExportType.FULL,
+        user_plan: Optional[str] = None,
+        user_language: str = "fr",
     ) -> Optional[bytes]:
         """
         Génère un PDF professionnel.
@@ -238,6 +240,8 @@ class PDFGenerator:
                 quiz=quiz,
                 sources=sources,
                 export_type=export_type,
+                user_plan=user_plan,
+                user_language=user_language,
             )
 
             # Charger et rendre le template
@@ -277,8 +281,24 @@ class PDFGenerator:
         quiz: Optional[List[Dict]],
         sources: Optional[List[Dict]],
         export_type: PDFExportType,
+        user_plan: Optional[str] = None,
+        user_language: str = "fr",
     ) -> Dict[str, Any]:
         """Prépare toutes les données pour le template"""
+
+        # Watermark gating (Free vs payant) — utilise add_watermark helper
+        from .watermark import add_watermark
+
+        watermark_marker = add_watermark(
+            content="placeholder",
+            format="pdf",
+            user_plan=user_plan,
+            user_language=user_language,
+        )
+        # add_watermark pour 'pdf' retourne toujours un dict marqueur
+        show_watermark = watermark_marker["needs_watermark"]
+        watermark_text = watermark_marker["text"]
+        watermark_url = watermark_marker["url"]
 
         # Date formatting
         date_str = (created_at or datetime.now()).strftime("%d %B %Y à %H:%M")
@@ -338,6 +358,10 @@ class PDFGenerator:
             "show_timestamps": show_timestamps,
             "show_flashcards": show_flashcards,
             "show_quiz": show_quiz,
+            # Watermark gating (Free uniquement)
+            "show_watermark": show_watermark,
+            "watermark_text": watermark_text,
+            "watermark_url": watermark_url,
             # Theme
             "theme": DEEP_SIGHT_THEME,
         }
@@ -360,7 +384,15 @@ def get_pdf_generator() -> PDFGenerator:
 
 
 def generate_pdf(
-    title: str, channel: str, category: str, mode: str, summary: str, export_type: str = "full", **kwargs
+    title: str,
+    channel: str,
+    category: str,
+    mode: str,
+    summary: str,
+    export_type: str = "full",
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
+    **kwargs,
 ) -> Optional[bytes]:
     """
     Fonction de convenance pour générer un PDF.
@@ -368,6 +400,8 @@ def generate_pdf(
     Args:
         title, channel, category, mode, summary: Données de base
         export_type: "full" | "summary" | "flashcards" | "study"
+        user_plan: plan id (free, plus, pro, expert, ...) — controle l'affichage du watermark
+        user_language: "fr" | "en" — langue du watermark
         **kwargs: Données additionnelles (entities, flashcards, etc.)
 
     Returns:
@@ -385,7 +419,15 @@ def generate_pdf(
     pdf_type = type_map.get(export_type, PDFExportType.FULL)
 
     return generator.generate(
-        title=title, channel=channel, category=category, mode=mode, summary=summary, export_type=pdf_type, **kwargs
+        title=title,
+        channel=channel,
+        category=category,
+        mode=mode,
+        summary=summary,
+        export_type=pdf_type,
+        user_plan=user_plan,
+        user_language=user_language,
+        **kwargs,
     )
 
 

--- a/backend/src/exports/router.py
+++ b/backend/src/exports/router.py
@@ -154,7 +154,7 @@ async def export_analysis(
         except (json.JSONDecodeError, TypeError) as e:
             logger.warning(f"Failed to parse fact_check_result for summary {request.summary_id}: {e}")
 
-    # Générer l'export
+    # Générer l'export — propager user.plan + user.default_lang pour le watermark
     content, filename, mimetype = export_summary(
         format=request.format,
         title=summary.video_title,
@@ -171,6 +171,8 @@ async def export_analysis(
         flashcards=flashcards,
         sources=sources,
         pdf_export_type=request.pdf_type or "full",
+        user_plan=current_user.plan,
+        user_language=current_user.default_lang or "fr",
     )
 
     if content is None:

--- a/backend/src/exports/service.py
+++ b/backend/src/exports/service.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from typing import Optional, Dict, Any, List, Tuple
 
 from core.http_client import shared_http_client
+from .watermark import add_watermark
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 📦 IMPORTS LAZY — Chargés uniquement quand nécessaire (économie ~80MB RAM)
@@ -209,6 +210,8 @@ def export_to_txt(
     video_url: str = "",
     duration: int = 0,
     created_at: datetime = None,
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
 ) -> str:
     """Exporte l'analyse en format texte brut"""
 
@@ -238,7 +241,8 @@ Analysé  : {date_str}
                     Généré par Deep Sight — deepsightsynthesis.com
 ═══════════════════════════════════════════════════════════════════════════
 """
-    return content
+    # Watermark plan-aware (Free seulement)
+    return add_watermark(content, "txt", user_plan, user_language)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -259,6 +263,8 @@ def export_to_markdown(
     reliability_score: float = None,
     created_at: datetime = None,
     flashcards: List[Dict] = None,
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
 ) -> str:
     """Exporte l'analyse en format Markdown"""
 
@@ -331,7 +337,8 @@ def export_to_markdown(
 *Généré par [Deep Sight](https://deepsightsynthesis.com) — Analyse intelligente de vidéos YouTube*
 """
 
-    return content
+    # Watermark plan-aware (Free seulement) -- ajoute la mention "Analyse avec DeepSight" sous Free
+    return add_watermark(content, "md", user_plan, user_language)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -351,6 +358,8 @@ def export_to_docx(
     reliability_score: float = None,
     created_at: datetime = None,
     flashcards: List[Dict] = None,
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
 ) -> Optional[bytes]:
     """Exporte l'analyse en format DOCX"""
 
@@ -456,11 +465,19 @@ def export_to_docx(
             p.add_run("Réponse: ").bold = True
             p.add_run(card.get("back", card.get("answer", "")))
 
-    # Footer
+    # Footer (mention brand origin — toujours présente)
     doc.add_paragraph()
     footer = doc.add_paragraph()
     footer.add_run("Généré par Deep Sight — deepsightsynthesis.com").italic = True
     footer.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    # Watermark gating (Free seulement)
+    marker = add_watermark("placeholder", "docx", user_plan, user_language)
+    if isinstance(marker, dict) and marker.get("needs_watermark"):
+        wm = doc.add_paragraph()
+        run = wm.add_run(f"{marker['text']} — {marker['url']}")
+        run.italic = True
+        wm.alignment = WD_ALIGN_PARAGRAPH.CENTER
 
     # Sauvegarder en bytes
     buffer = io.BytesIO()
@@ -485,6 +502,8 @@ def export_to_pdf_reportlab(
     entities: Dict = None,
     reliability_score: float = None,
     created_at: datetime = None,
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
 ) -> Optional[bytes]:
     """Export PDF de fallback avec ReportLab (moins stylé)"""
 
@@ -575,12 +594,26 @@ def export_to_pdf_reportlab(
         emoji = "✅" if reliability_score >= 70 else "⚖️" if reliability_score >= 50 else "⚠️"
         story.append(Paragraph(f"<b>{emoji} {reliability_score}/100</b>", body_style))
 
-    # Footer
+    # Footer (mention brand origin — toujours présente)
     story.append(Spacer(1, 30))
     footer_style = ParagraphStyle(
         "Footer", parent=styles["Normal"], fontSize=8, textColor=HexColor("#999999"), alignment=1
     )
     story.append(Paragraph("Généré par Deep Sight — deepsightsynthesis.com", footer_style))
+
+    # Watermark gating (Free seulement)
+    marker = add_watermark("placeholder", "pdf", user_plan, user_language)
+    if isinstance(marker, dict) and marker.get("needs_watermark"):
+        watermark_style = ParagraphStyle(
+            "Watermark",
+            parent=styles["Normal"],
+            fontSize=8,
+            textColor=HexColor("#94a3b8"),
+            alignment=1,
+            fontName="Helvetica-Oblique",
+        )
+        story.append(Spacer(1, 0.3 * cm))
+        story.append(Paragraph(f"{marker['text']} — {marker['url']}", watermark_style))
 
     # Build PDF
     doc.build(story)
@@ -608,6 +641,8 @@ def export_to_pdf(
     flashcards: List[Dict] = None,
     sources: List[Dict] = None,
     export_type: str = "full",
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
 ) -> Optional[bytes]:
     """
     Exporte l'analyse en format PDF.
@@ -615,6 +650,8 @@ def export_to_pdf(
 
     Args:
         export_type: "full" | "summary" | "flashcards" | "study"
+        user_plan: plan id (free/plus/pro/expert/...) — controle l'affichage du watermark
+        user_language: "fr" | "en" — langue du watermark
     """
 
     # Try WeasyPrint first (beautiful HTML→PDF)
@@ -634,6 +671,8 @@ def export_to_pdf(
             flashcards=flashcards,
             sources=sources,
             export_type=export_type,
+            user_plan=user_plan,
+            user_language=user_language,
         )
         if pdf:
             return pdf
@@ -652,6 +691,8 @@ def export_to_pdf(
             entities=entities,
             reliability_score=reliability_score,
             created_at=created_at,
+            user_plan=user_plan,
+            user_language=user_language,
         )
 
     return None
@@ -673,6 +714,8 @@ def export_to_csv(
     entities: Dict = None,
     reliability_score: float = None,
     created_at: datetime = None,
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
 ) -> str:
     """Exporte l'analyse en format CSV (structured data)"""
 
@@ -738,7 +781,9 @@ def export_to_csv(
     writer.writerow([])
     writer.writerow(["Généré par Deep Sight - deepsightsynthesis.com"])
 
-    return buffer.getvalue()
+    csv_content = buffer.getvalue()
+    # Watermark plan-aware (Free seulement) -- ajoute une ligne commentaire '#'
+    return add_watermark(csv_content, "csv", user_plan, user_language)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -757,6 +802,8 @@ def export_to_excel(
     entities: Dict = None,
     reliability_score: float = None,
     created_at: datetime = None,
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
 ) -> Optional[bytes]:
     """Exporte l'analyse en format Excel (.xlsx)"""
 
@@ -893,12 +940,22 @@ def export_to_excel(
 
         row += 17
 
-    # Footer
+    # Footer (mention brand origin — toujours présente)
     ws.merge_cells(f"A{row}:D{row}")
     cell = ws[f"A{row}"]
     cell.value = "Généré par Deep Sight — deepsightsynthesis.com"
     cell.font = Font(name="Arial", size=8, italic=True, color="999999")
     cell.alignment = Alignment(horizontal="center")
+
+    # Watermark gating (Free seulement) -- cellule supplémentaire en dessous
+    marker = add_watermark("placeholder", "xlsx", user_plan, user_language)
+    if isinstance(marker, dict) and marker.get("needs_watermark"):
+        row += 1
+        ws.merge_cells(f"A{row}:D{row}")
+        wm_cell = ws[f"A{row}"]
+        wm_cell.value = f"{marker['text']} — {marker['url']}"
+        wm_cell.font = Font(name="Arial", size=8, italic=True, color="94A3B8")
+        wm_cell.alignment = Alignment(horizontal="center")
 
     # Ajuster largeur des colonnes
     ws.column_dimensions["A"].width = 20
@@ -934,13 +991,17 @@ def export_summary(
     flashcards: List[Dict] = None,
     sources: List[Dict] = None,
     pdf_export_type: str = "full",
+    user_plan: Optional[str] = None,
+    user_language: str = "fr",
 ) -> Tuple[Optional[bytes | str], str, str]:
     """
     Exporte un résumé dans le format demandé.
 
     Args:
-        format: txt, md, docx, pdf
+        format: txt, md, docx, pdf, csv, xlsx
         pdf_export_type: full, summary, flashcards, study (pour PDF uniquement)
+        user_plan: plan id (free/plus/pro/expert/...) — controle l'affichage du watermark
+        user_language: "fr" | "en" — langue du watermark
 
     Returns:
         Tuple (content, filename, mimetype)
@@ -951,7 +1012,11 @@ def export_summary(
     base_filename = clean_filename(title, timestamp)
 
     if format == "txt":
-        content = export_to_txt(title, channel, category, mode, summary, video_url, duration, created_at)
+        content = export_to_txt(
+            title, channel, category, mode, summary, video_url, duration, created_at,
+            user_plan=user_plan,
+            user_language=user_language,
+        )
         return content, f"{base_filename}.txt", "text/plain"
 
     elif format == "md":
@@ -968,6 +1033,8 @@ def export_summary(
             reliability_score,
             created_at,
             flashcards,
+            user_plan=user_plan,
+            user_language=user_language,
         )
         return content, f"{base_filename}.md", "text/markdown"
 
@@ -986,6 +1053,8 @@ def export_summary(
             reliability_score,
             created_at,
             flashcards,
+            user_plan=user_plan,
+            user_language=user_language,
         )
         return (
             content,
@@ -1009,6 +1078,8 @@ def export_summary(
             flashcards=flashcards,
             sources=sources,
             export_type=pdf_export_type,
+            user_plan=user_plan,
+            user_language=user_language,
         )
         if content is None:
             return None, "", ""
@@ -1016,23 +1087,26 @@ def export_summary(
         # Ajouter le type dans le nom de fichier
         type_suffix = "" if pdf_export_type == "full" else f"_{pdf_export_type}"
         return content, f"{base_filename}{type_suffix}.pdf", "application/pdf"
-        return content, f"deepsight_{safe_title}_{timestamp}.pdf", "application/pdf"
 
     elif format == "csv":
         content = export_to_csv(
-            title, channel, category, mode, summary, video_url, duration, entities, reliability_score, created_at
+            title, channel, category, mode, summary, video_url, duration, entities, reliability_score, created_at,
+            user_plan=user_plan,
+            user_language=user_language,
         )
-        return content, f"deepsight_{safe_title}_{timestamp}.csv", "text/csv"
+        return content, f"{base_filename}.csv", "text/csv"
 
     elif format == "xlsx":
         if not EXCEL_AVAILABLE:
             return None, "", ""
         content = export_to_excel(
-            title, channel, category, mode, summary, video_url, duration, entities, reliability_score, created_at
+            title, channel, category, mode, summary, video_url, duration, entities, reliability_score, created_at,
+            user_plan=user_plan,
+            user_language=user_language,
         )
         return (
             content,
-            f"deepsight_{safe_title}_{timestamp}.xlsx",
+            f"{base_filename}.xlsx",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         )
     else:

--- a/backend/src/exports/templates/pdf_template.html
+++ b/backend/src/exports/templates/pdf_template.html
@@ -738,6 +738,27 @@
         margin-top: 0.1cm;
       }
 
+      /* ═══════════════════ WATERMARK (Free plan only) ═══════════════════ */
+
+      .cover-watermark {
+        margin-top: 1cm;
+        text-align: center;
+        font-size: 8pt;
+        color: rgba(255, 255, 255, 0.45);
+        font-style: italic;
+        letter-spacing: 0.3px;
+      }
+
+      .last-page-watermark {
+        margin-top: 0.6cm;
+        text-align: center;
+        font-size: 8pt;
+        color: #94a3b8;
+        font-style: italic;
+        letter-spacing: 0.3px;
+        page-break-before: avoid;
+      }
+
       /* ═══════════════════ UTILITIES ═══════════════════ */
 
       .page-break {
@@ -807,6 +828,11 @@
           {% endif %}
           <div class="cover-footer-date">Exporté le {{ date }}</div>
         </div>
+        {% if show_watermark %}
+        <div class="cover-watermark">
+          <em>{{ watermark_text }} — {{ watermark_url }}</em>
+        </div>
+        {% endif %}
       </div>
     </div>
 
@@ -1038,6 +1064,13 @@
           {% endfor %}
         </ul>
       </div>
+    </div>
+    {% endif %}
+
+    <!-- ═══════════════════ WATERMARK (Free plan only) ═══════════════════ -->
+    {% if show_watermark %}
+    <div class="last-page-watermark">
+      <em>{{ watermark_text }} — {{ watermark_url }}</em>
     </div>
     {% endif %}
 

--- a/backend/src/exports/watermark.py
+++ b/backend/src/exports/watermark.py
@@ -1,0 +1,154 @@
+"""
+DeepSight - Watermark helper for free-plan exports.
+
+Centralise le gating Free vs payant + i18n FR/EN + dispatch par format.
+
+Pour les formats texte (txt/md/csv) : retourne directement le contenu modifie.
+Pour les formats binaires (docx/xlsx/pdf) : retourne un dict marqueur que le
+caller utilisera pour injecter le watermark via la lib appropriee
+(python-docx / openpyxl / Jinja2 template).
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from billing.plan_config import normalize_plan_id
+
+
+# ============================================================================
+# CONSTANTS
+# ============================================================================
+
+# Pendant la transition v0 -> v2 (cf. plan pricing-v2 separe), les plans payants
+# couvrent les trois IDs possibles. Quand pricing-v2 sera merge ET la migration
+# 011 appliquee en prod, retirer "plus" de la set.
+PAID_PLANS: frozenset[str] = frozenset({"plus", "pro", "expert"})
+
+WATERMARK_URL = "www.deepsightsynthesis.com"
+WATERMARK_URL_HTTPS = "https://www.deepsightsynthesis.com"
+
+# Texte i18n
+WATERMARK_TEXTS: dict[str, dict[str, str]] = {
+    "fr": {
+        "tagline": "Analyse avec DeepSight - IA souveraine europeenne",
+        "tagline_display": "Analysé avec DeepSight — IA souveraine européenne",
+        "short": "Analysé avec DeepSight",
+        "name": "DeepSight",
+    },
+    "en": {
+        "tagline": "Analyzed with DeepSight - European sovereign AI",
+        "tagline_display": "Analyzed with DeepSight — European sovereign AI",
+        "short": "Analyzed with DeepSight",
+        "name": "DeepSight",
+    },
+}
+
+
+# ============================================================================
+# CORE
+# ============================================================================
+
+
+def _resolve_language(user_language: Optional[str]) -> str:
+    """Resout la langue : fr par defaut, en si 'en', sinon fallback fr."""
+    if not user_language:
+        return "fr"
+    lang = user_language.lower().strip()
+    if lang in WATERMARK_TEXTS:
+        return lang
+    return "fr"
+
+
+def _should_apply_watermark(user_plan: Optional[str]) -> bool:
+    """Determine si le watermark doit etre applique.
+
+    Regle : watermark si plan normalise NOT in PAID_PLANS (donc Free + plans inconnus).
+    """
+    if not user_plan:
+        return True  # Free fallback
+    normalized = normalize_plan_id(user_plan)
+    return normalized not in PAID_PLANS
+
+
+def add_watermark(
+    content: Union[str, bytes, dict, None],
+    format: str,
+    user_plan: Optional[str],
+    user_language: str = "fr",
+) -> Union[str, dict]:
+    """
+    Ajoute un watermark de branding sur un export en plan Free.
+
+    Pour les formats texte (txt, md, csv), retourne le contenu modifie directement.
+    Pour les formats binaires (docx, xlsx, pdf), retourne un dict marqueur :
+
+        {
+            "needs_watermark": bool,
+            "text": str,           # Texte tagline (display, avec accents)
+            "short": str,          # Texte court ("Analysé avec DeepSight")
+            "url": str,            # "www.deepsightsynthesis.com"
+            "url_https": str,      # "https://www.deepsightsynthesis.com"
+            "language": str,       # "fr" | "en"
+        }
+
+    Le caller utilisera ce dict pour injecter le watermark via la lib appropriee
+    (python-docx footer, openpyxl cell, Jinja2 template var).
+
+    Args:
+        content: contenu original (texte ou marqueur dict pour binaires)
+        format: "txt" | "md" | "csv" | "docx" | "xlsx" | "pdf"
+        user_plan: plan id (free, plus, pro, expert, etudiant, team, ...) -- sera normalise
+        user_language: "fr" | "en" (defaut: "fr"), tout autre code -> fallback "fr"
+
+    Returns:
+        Le contenu modifie (str) pour txt/md/csv, ou un dict marqueur pour docx/xlsx/pdf.
+    """
+    apply = _should_apply_watermark(user_plan)
+    lang = _resolve_language(user_language)
+    texts = WATERMARK_TEXTS[lang]
+
+    # Format binaire : dict marqueur (toujours retourne -- needs_watermark decide)
+    if format in ("docx", "xlsx", "pdf"):
+        return {
+            "needs_watermark": apply,
+            "text": texts["tagline_display"],
+            "short": texts["short"],
+            "url": WATERMARK_URL,
+            "url_https": WATERMARK_URL_HTTPS,
+            "language": lang,
+        }
+
+    # Pas de watermark pour les payants -> contenu inchange
+    if not apply:
+        return content if content is not None else ""
+
+    # Format texte : injection du marqueur en fin de contenu
+    if format == "txt":
+        return (
+            f"{content}\n\n"
+            f"---\n"
+            f"{texts['tagline_display']} ({WATERMARK_URL})\n"
+        )
+
+    if format == "md":
+        # Tagline avec lien markdown : remplace "DeepSight" par "[DeepSight](url)"
+        tagline_with_link = texts["tagline_display"].replace(
+            "DeepSight",
+            f"[DeepSight]({WATERMARK_URL_HTTPS})",
+            1,
+        )
+        return (
+            f"{content}\n\n"
+            f"---\n"
+            f"*{tagline_with_link}*\n"
+        )
+
+    if format == "csv":
+        # Commentaire en derniere ligne (les parsers CSV standards ignorent les '#')
+        return (
+            f"{str(content).rstrip()}\n"
+            f"# {texts['tagline_display']} ({WATERMARK_URL})\n"
+        )
+
+    # Format inconnu : passthrough sans modification (securite)
+    return content if content is not None else ""

--- a/backend/tests/test_exports_watermark.py
+++ b/backend/tests/test_exports_watermark.py
@@ -1,0 +1,180 @@
+"""Tests du helper watermark - gating Free vs payant + i18n FR/EN + 6 formats."""
+import pytest
+from exports.watermark import add_watermark, PAID_PLANS
+
+
+# --- Constantes attendues ----------------------------------------------------
+
+EXPECTED_FR_TEXT = "Analysé avec DeepSight"
+EXPECTED_FR_TAGLINE = "IA souveraine européenne"
+EXPECTED_EN_TEXT = "Analyzed with DeepSight"
+EXPECTED_EN_TAGLINE = "European sovereign AI"
+EXPECTED_URL = "www.deepsightsynthesis.com"
+
+
+# --- Set PAID_PLANS ----------------------------------------------------------
+
+def test_paid_plans_contains_v0_and_v2_during_transition():
+    """PAID_PLANS doit couvrir 'plus' (v0), 'pro' (v0+v2), 'expert' (v2) pendant la transition."""
+    assert "plus" in PAID_PLANS
+    assert "pro" in PAID_PLANS
+    assert "expert" in PAID_PLANS
+    assert "free" not in PAID_PLANS
+
+
+# --- Gating Free vs payant ---------------------------------------------------
+
+@pytest.mark.parametrize("paid_plan", ["plus", "pro", "expert"])
+@pytest.mark.parametrize("fmt", ["txt", "md", "csv"])
+def test_watermark_not_applied_for_paid_plans_text(paid_plan: str, fmt: str):
+    """Aucun watermark sur les plans payants, formats texte."""
+    original = "Contenu test"
+    result = add_watermark(original, fmt, user_plan=paid_plan, user_language="fr")
+    assert result == original
+
+
+@pytest.mark.parametrize("paid_plan", ["plus", "pro", "expert"])
+@pytest.mark.parametrize("fmt", ["docx", "xlsx", "pdf"])
+def test_watermark_not_applied_for_paid_plans_binary(paid_plan: str, fmt: str):
+    """Plans payants : binary returns marker dict avec needs_watermark=False."""
+    result = add_watermark("placeholder", fmt, user_plan=paid_plan, user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is False
+
+
+@pytest.mark.parametrize("fmt", ["txt", "csv"])
+def test_watermark_applied_for_free_plan_text(fmt: str):
+    """Watermark present sur formats texte (txt/csv) pour Free."""
+    original = "Contenu test"
+    result = add_watermark(original, fmt, user_plan="free", user_language="fr")
+    assert result != original
+    assert EXPECTED_FR_TEXT in result
+    assert EXPECTED_URL in result
+
+
+def test_watermark_applied_for_free_plan_md():
+    """MD : watermark present mais format different (lien markdown casse 'Analyse avec DeepSight')."""
+    original = "Contenu test"
+    result = add_watermark(original, "md", user_plan="free", user_language="fr")
+    assert result != original
+    # Lien markdown contient DeepSight
+    assert "[DeepSight](https://www.deepsightsynthesis.com)" in result
+    # Tagline complete contient les autres mots-cles
+    assert "IA souveraine européenne" in result
+    assert "Analysé avec" in result
+
+
+def test_watermark_applied_for_unknown_plan_defaults_to_free():
+    """Plan inconnu -> fallback Free -> watermark applique."""
+    result = add_watermark("X", "txt", user_plan="bogus_plan", user_language="fr")
+    assert EXPECTED_FR_TEXT in result
+
+
+def test_watermark_applied_for_empty_plan():
+    """Plan vide ou None -> fallback Free."""
+    result_empty = add_watermark("X", "txt", user_plan="", user_language="fr")
+    result_none = add_watermark("X", "txt", user_plan=None, user_language="fr")
+    assert EXPECTED_FR_TEXT in result_empty
+    assert EXPECTED_FR_TEXT in result_none
+
+
+# --- i18n FR / EN ------------------------------------------------------------
+
+def test_watermark_french_default():
+    """Langue FR par defaut."""
+    result = add_watermark("X", "txt", user_plan="free", user_language="fr")
+    assert EXPECTED_FR_TEXT in result
+    assert EXPECTED_FR_TAGLINE in result
+    assert EXPECTED_EN_TEXT not in result
+
+
+def test_watermark_english():
+    """Langue EN si user_language='en'."""
+    result = add_watermark("X", "txt", user_plan="free", user_language="en")
+    assert EXPECTED_EN_TEXT in result
+    assert EXPECTED_EN_TAGLINE in result
+    assert EXPECTED_FR_TEXT not in result
+
+
+def test_watermark_unknown_language_defaults_to_fr():
+    """Langue inconnue (es, de, etc.) -> fallback FR."""
+    result = add_watermark("X", "txt", user_plan="free", user_language="es")
+    assert EXPECTED_FR_TEXT in result
+
+
+# --- Format-specific shape ---------------------------------------------------
+
+def test_watermark_txt_format():
+    """TXT : separateur '---' + ligne plain."""
+    result = add_watermark("Hello", "txt", user_plan="free", user_language="fr")
+    assert "Hello" in result
+    assert "---" in result
+
+
+def test_watermark_md_format():
+    """MD : separateur '---' + lien markdown."""
+    result = add_watermark("Hello", "md", user_plan="free", user_language="fr")
+    assert "Hello" in result
+    assert "---" in result
+    assert "[DeepSight](https://www.deepsightsynthesis.com)" in result
+    # Italic
+    assert "*" in result.split("Hello", 1)[1]
+
+
+def test_watermark_csv_format():
+    """CSV : commentaire derniere ligne prefixe par '#'."""
+    result = add_watermark("a,b,c", "csv", user_plan="free", user_language="fr")
+    assert "a,b,c" in result
+    last_line = result.strip().split("\n")[-1]
+    assert last_line.startswith("#")
+    assert EXPECTED_FR_TEXT in last_line
+
+
+# --- Format binaires (DOCX/XLSX/PDF) -- passthrough --------------------------
+
+def test_watermark_docx_returns_marker_dict():
+    """DOCX : helper retourne dict {needs_watermark, text, url} pour que service.py l'injecte via python-docx."""
+    result = add_watermark("placeholder", "docx", user_plan="free", user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is True
+    assert EXPECTED_FR_TEXT in result["text"]
+    assert result["url"] == EXPECTED_URL
+
+
+def test_watermark_docx_no_marker_for_paid():
+    """DOCX : payant -> dict avec needs_watermark=False."""
+    result = add_watermark("placeholder", "docx", user_plan="pro", user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is False
+
+
+def test_watermark_xlsx_returns_marker_dict():
+    """XLSX : idem DOCX, dict marqueur."""
+    result = add_watermark("placeholder", "xlsx", user_plan="free", user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is True
+    assert EXPECTED_FR_TEXT in result["text"]
+
+
+def test_watermark_pdf_returns_marker_dict():
+    """PDF : idem, dict pour propagation au template Jinja2."""
+    result = add_watermark("placeholder", "pdf", user_plan="free", user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is True
+    assert EXPECTED_FR_TEXT in result["text"]
+    assert result["url"] == EXPECTED_URL
+
+
+# --- Normalize via plan_config ----------------------------------------------
+
+def test_watermark_normalize_legacy_aliases():
+    """Plans legacy (etudiant, starter, student, equipe, team, unlimited) sont mappes via normalize_plan_id."""
+    # 'etudiant' -> 'plus' (in PAID_PLANS) -> no watermark
+    result_etudiant = add_watermark("X", "txt", user_plan="etudiant", user_language="fr")
+    assert result_etudiant == "X"
+    # 'team' -> 'pro' (in PAID_PLANS) -> no watermark
+    result_team = add_watermark("X", "txt", user_plan="team", user_language="fr")
+    assert result_team == "X"
+    # 'unlimited' -> 'pro' -> no watermark
+    result_unlim = add_watermark("X", "txt", user_plan="unlimited", user_language="fr")
+    assert result_unlim == "X"

--- a/backend/tests/test_exports_watermark.py
+++ b/backend/tests/test_exports_watermark.py
@@ -178,3 +178,251 @@ def test_watermark_normalize_legacy_aliases():
     # 'unlimited' -> 'pro' -> no watermark
     result_unlim = add_watermark("X", "txt", user_plan="unlimited", user_language="fr")
     assert result_unlim == "X"
+
+
+# ============================================================================
+# INTEGRATION TESTS -- appel reel a export_to_*
+# ============================================================================
+from datetime import datetime  # noqa: E402
+
+from exports.service import (  # noqa: E402
+    export_to_txt,
+    export_to_markdown,
+    export_to_docx,
+    export_to_csv,
+    export_to_excel,
+    export_summary,
+    DOCX_AVAILABLE,
+    EXCEL_AVAILABLE,
+)
+
+
+SAMPLE_KWARGS = dict(
+    title="Test Video",
+    channel="Test Channel",
+    category="Tech",
+    mode="Standard",
+    summary="# Test\n\nContenu de synthese de test.",
+    video_url="https://youtube.com/watch?v=test",
+    duration=600,
+    created_at=datetime(2026, 4, 29, 12, 0, 0),
+)
+
+
+# --- TXT ---------------------------------------------------------------------
+
+def test_integration_txt_free_has_watermark():
+    out = export_to_txt(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    assert "Analysé avec DeepSight" in out
+    assert "IA souveraine européenne" in out
+    # Mention brand origin existante reste
+    assert "deepsightsynthesis.com" in out
+
+
+def test_integration_txt_pro_no_watermark():
+    out = export_to_txt(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    assert "Analysé avec DeepSight" not in out
+    # Mention brand origin existante reste
+    assert "deepsightsynthesis.com" in out
+
+
+def test_integration_txt_expert_no_watermark():
+    out = export_to_txt(**SAMPLE_KWARGS, user_plan="expert", user_language="fr")
+    assert "Analysé avec DeepSight" not in out
+
+
+def test_integration_txt_plus_no_watermark_during_v0_v2_transition():
+    """v0 'plus' = payant, doit pas avoir de watermark pendant la transition."""
+    out = export_to_txt(**SAMPLE_KWARGS, user_plan="plus", user_language="fr")
+    assert "Analysé avec DeepSight" not in out
+
+
+# --- MD ----------------------------------------------------------------------
+
+def test_integration_md_free_has_watermark_link():
+    out = export_to_markdown(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    assert "[DeepSight](https://www.deepsightsynthesis.com)" in out
+    assert "IA souveraine européenne" in out
+
+
+def test_integration_md_pro_no_watermark():
+    out = export_to_markdown(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    assert "Analysé avec DeepSight" not in out
+    assert "IA souveraine européenne" not in out
+
+
+def test_integration_md_english():
+    out = export_to_markdown(**SAMPLE_KWARGS, user_plan="free", user_language="en")
+    assert "Analyzed with" in out
+    assert "European sovereign AI" in out
+
+
+# --- DOCX --------------------------------------------------------------------
+
+@pytest.mark.skipif(not DOCX_AVAILABLE, reason="python-docx not installed")
+def test_integration_docx_free_has_watermark_paragraph():
+    """DOCX Free contient un paragraphe avec le texte watermark."""
+    from docx import Document
+    import io
+
+    blob = export_to_docx(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    assert blob is not None
+    doc = Document(io.BytesIO(blob))
+    full_text = "\n".join(p.text for p in doc.paragraphs)
+    assert "Analysé avec DeepSight" in full_text
+    assert "IA souveraine européenne" in full_text
+
+
+@pytest.mark.skipif(not DOCX_AVAILABLE, reason="python-docx not installed")
+def test_integration_docx_pro_no_watermark_paragraph():
+    from docx import Document
+    import io
+
+    blob = export_to_docx(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    doc = Document(io.BytesIO(blob))
+    full_text = "\n".join(p.text for p in doc.paragraphs)
+    assert "Analysé avec DeepSight" not in full_text
+    # Mention brand existante reste
+    assert "Généré par Deep Sight" in full_text
+
+
+# --- CSV ---------------------------------------------------------------------
+
+def test_integration_csv_free_has_watermark_comment():
+    out = export_to_csv(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    last_line = out.strip().split("\n")[-1]
+    assert last_line.startswith("#")
+    assert "Analysé avec DeepSight" in last_line
+
+
+def test_integration_csv_pro_no_watermark_comment():
+    out = export_to_csv(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    last_line = out.strip().split("\n")[-1]
+    assert "Analysé avec DeepSight" not in last_line
+
+
+# --- XLSX --------------------------------------------------------------------
+
+@pytest.mark.skipif(not EXCEL_AVAILABLE, reason="openpyxl not installed")
+def test_integration_xlsx_free_has_watermark_cell():
+    from openpyxl import load_workbook
+    import io
+
+    blob = export_to_excel(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    assert blob is not None
+    wb = load_workbook(io.BytesIO(blob))
+    ws = wb.active
+    all_values = []
+    for row in ws.iter_rows(values_only=True):
+        for v in row:
+            if v:
+                all_values.append(str(v))
+    full_text = " ".join(all_values)
+    assert "Analysé avec DeepSight" in full_text
+
+
+@pytest.mark.skipif(not EXCEL_AVAILABLE, reason="openpyxl not installed")
+def test_integration_xlsx_pro_no_watermark_cell():
+    from openpyxl import load_workbook
+    import io
+
+    blob = export_to_excel(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    wb = load_workbook(io.BytesIO(blob))
+    ws = wb.active
+    all_values = []
+    for row in ws.iter_rows(values_only=True):
+        for v in row:
+            if v:
+                all_values.append(str(v))
+    full_text = " ".join(all_values)
+    assert "Analysé avec DeepSight" not in full_text
+    assert "Deep Sight" in full_text  # Brand mention existante reste
+
+
+# --- PDF (smoke -- verifie generer sans crash si WeasyPrint dispo) ----------
+
+def _pdf_engine_available():
+    """Check si au moins WeasyPrint OU ReportLab est dispo."""
+    try:
+        from exports.service import weasyprint_available, REPORTLAB_AVAILABLE
+        return weasyprint_available() or bool(REPORTLAB_AVAILABLE)
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _pdf_engine_available(), reason="No PDF engine available")
+def test_integration_pdf_free_smoke():
+    """Smoke test : PDF Free genere sans crash, taille > 1KB.
+
+    Utilise WeasyPrint si dispo, sinon ReportLab fallback.
+    Le watermark est verifie de facon binary -- byte search dans le PDF.
+    """
+    content, filename, mimetype = export_summary(
+        format="pdf",
+        **SAMPLE_KWARGS,
+        user_plan="free",
+        user_language="fr",
+    )
+    assert content is not None
+    assert len(content) > 1024  # PDF non trivial
+    assert filename.endswith(".pdf")
+    assert mimetype == "application/pdf"
+    # Verify watermark text appears in PDF bytes (best-effort -- ReportLab encodes plain text)
+    # WeasyPrint may compress so this is a smoke check only
+    if isinstance(content, bytes) and b"DeepSight" in content:
+        # Some chance the watermark text leaks visibly
+        pass  # OK
+
+
+@pytest.mark.skipif(not _pdf_engine_available(), reason="No PDF engine available")
+def test_integration_pdf_pro_smoke():
+    content, _, _ = export_summary(
+        format="pdf",
+        **SAMPLE_KWARGS,
+        user_plan="pro",
+        user_language="fr",
+    )
+    assert content is not None
+    assert len(content) > 1024
+
+
+# --- export_summary dispatcher ----------------------------------------------
+
+@pytest.mark.parametrize("fmt", ["txt", "csv"])
+def test_integration_export_summary_free_has_watermark(fmt: str):
+    """Le dispatcher principal applique le watermark pour Free sur les formats texte."""
+    content, _, _ = export_summary(
+        format=fmt,
+        **SAMPLE_KWARGS,
+        user_plan="free",
+        user_language="fr",
+    )
+    assert isinstance(content, str)
+    assert "Analysé avec DeepSight" in content
+
+
+def test_integration_export_summary_md_free_has_watermark():
+    """MD: lien markdown (DeepSight remplace par [DeepSight](url)) -- check mots-cle."""
+    content, _, _ = export_summary(
+        format="md",
+        **SAMPLE_KWARGS,
+        user_plan="free",
+        user_language="fr",
+    )
+    assert isinstance(content, str)
+    assert "[DeepSight](https://www.deepsightsynthesis.com)" in content
+    assert "IA souveraine européenne" in content
+
+
+@pytest.mark.parametrize("fmt", ["txt", "md", "csv"])
+def test_integration_export_summary_pro_no_watermark(fmt: str):
+    """Le dispatcher principal n'applique PAS le watermark pour Pro sur les formats texte."""
+    content, _, _ = export_summary(
+        format=fmt,
+        **SAMPLE_KWARGS,
+        user_plan="pro",
+        user_language="fr",
+    )
+    assert isinstance(content, str)
+    assert "Analysé avec DeepSight" not in content
+    assert "IA souveraine européenne" not in content

--- a/docs/superpowers/plans/2026-04-29-RELEASE-ORCHESTRATION.md
+++ b/docs/superpowers/plans/2026-04-29-RELEASE-ORCHESTRATION.md
@@ -1,0 +1,685 @@
+# Release Orchestration — DeepSight Audit Kimi 2026-04-29
+
+> **Statut :** Document méta-cohérence (PAS un plan d'implémentation). Audit transversal des **9 plans datés 2026-04-29** pour identifier conflits, dépendances cycliques et produire la roadmap d'exécution.
+>
+> **Périmètre audité** (par ordre alphabétique de slug) :
+>
+> 1. `audit-kimi-phase-0-seo-securite` — SEO + headers Vercel + ProductJsonLd + prix v2
+> 2. `dashboard-onboarding-empty-states` — Sidebar rename + Onboarding 3 étapes + EmptyState
+> 3. `edge-tts-gratuit` — Provider TTS gratuit (Microsoft Edge) + table `voice_edge_quota`
+> 4. `elevenlabs-voice-packs` — Top-up minutes ElevenLabs + table `voice_credit_packs`
+> 5. `homepage-testimonials` — Testimonials + TrustBadges + SocialProofCounter + endpoint public
+> 6. `posthog-events-complets` — 18 events PostHog typés + `EventPayloadMap`
+> 7. `pricing-v2-stripe-grandfathering` — Renaming plus→pro, pro→expert + Stripe + grandfathering
+> 8. `programme-parrainage` — Table `referrals` + endpoints `/api/referral/*` + ReferralWidget
+> 9. `watermark-exports-gratuits` — Watermark sur 6 formats d'export Free
+>
+> Le 10ᵉ plan présent (`merge-voice-chat-context-implementation`) n'est PAS dans le périmètre demandé et est ignoré.
+
+---
+
+## Executive summary
+
+- **Conflit Alembic critique résolu** : 3 plans revendiquent simultanément la migration `010` (voice-packs, edge-tts, parrainage). Le plan edge-tts est le seul à anticiper le conflit. **Renumérotation imposée** : voice-packs reste `010`, pricing-v2 reste `011`, parrainage devient `012`, edge-tts devient `013`.
+- **Couplage atomique obligatoire** : `audit-kimi-phase-0-seo-securite` (#1) et `pricing-v2-stripe-grandfathering` (#7) **DOIVENT merger ensemble** via release-train, sinon incohérence publique annoncée 8,99 € / facturée 5,99 €. Les deux plans le mentionnent explicitement.
+- **Drift business value** : la grille de prix utilisée par les plans diverge — v0 (Plus 4,99 € / Pro 9,99 €), v1 (Pro 5,99 € / Expert 14,99 €), v2 (Pro 8,99 € / Expert 19,99 €) cohabitent dans la base de code. Les plans v2 uniformisent vers Pro 8,99 € / Expert 19,99 € — alignement complet.
+- **Dépendances PostHog** : 4 events sur 18 sont **bloqués** par d'autres plans (`pricing_toggle_changed`, `plan_selected.is_annual`, `trial_started.expert`, voice packs E18/E19). Le plan #6 le documente et déclare quand même les constantes pour éviter les conflits de PR ultérieurs.
+- **Quick wins indépendants identifiés** : #5 testimonials (autonome côté front, mini route backend), #2 dashboard onboarding (front-only), #9 watermark (back-only avec normalisation `plus|pro` legacy → compatible v1 et v2).
+
+**Recommandation top-line** : démarrer Sprint A (quick wins) en parallèle pendant que Sprint B (release-train pricing) est préparé. Sprint B est le bottleneck — sans lui, #6 #8 #9 sont bloqués sur des type changes.
+
+---
+
+## A — Alembic migration order
+
+### Conflits revendiqués (lecture des plans)
+
+| Plan           | Migration revendiquée           | `down_revision` revendiqué        | Anticipe le conflit ?                                     |
+| -------------- | ------------------------------- | --------------------------------- | --------------------------------------------------------- |
+| #4 voice-packs | `010_add_voice_credit_packs.py` | `"009"`                           | Non (revendique 010 first-come)                           |
+| #7 pricing-v2  | `011_pricing_v2_rename.py`      | `"010"` (avec note "vérifier")    | Partiellement (mention "010 ou 009")                      |
+| #8 parrainage  | `010_add_referrals.py`          | `"009_add_user_preferences_json"` | Non (utilise revision_id `"010_add_referrals"`)           |
+| #3 edge-tts    | `010_add_voice_edge_quota.py`   | `"009"` (avec note "ou 011")      | Oui — explicite : « si voice-packs mergé : utiliser 011 » |
+
+État prod actuel (vérifié `backend/alembic/versions/`) : dernière migration **`009_add_user_preferences_json.py`**.
+
+### Renumérotation imposée
+
+L'ordre de merge optimal (justifié en section E) implique la séquence suivante :
+
+```
+009 (prod actuel)
+ └─→ 010_add_voice_credit_packs       ← plan #4 voice-packs (mergeable seul, indépendant)
+      └─→ 011_pricing_v2_rename       ← plan #7 pricing-v2 (release-train avec #1)
+           └─→ 012_add_referrals      ← plan #8 parrainage (renumérotation : 010 → 012)
+                └─→ 013_add_voice_edge_quota  ← plan #3 edge-tts (renumérotation : 010 → 013)
+```
+
+### Actions concrètes par plan
+
+| Plan           | Action requise dans le fichier de migration                                                                                                                                                                                                          |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #4 voice-packs | **Aucune** — garde `revision = "010"`, `down_revision = "009"`. Premier mergé.                                                                                                                                                                       |
+| #7 pricing-v2  | **Aucune** si #4 mergé avant — garde `revision = "011"`, `down_revision = "010"`. Le plan inclut déjà la directive « vérifier 010 ou 009 ».                                                                                                          |
+| #8 parrainage  | **Renommer fichier** `010_add_referrals.py` → `012_add_referrals.py`. **Modifier** `revision = "012_add_referrals"`, `down_revision = "011"`.                                                                                                        |
+| #3 edge-tts    | **Renommer fichier** `010_add_voice_edge_quota.py` → `013_add_voice_edge_quota.py`. **Modifier** `revision = "013"`, `down_revision = "012_add_referrals"`. La directive « si voice-packs mergé : 011 » devient obsolète — utiliser 013 directement. |
+
+### Tables / colonnes touchées (récap)
+
+| Migration         | Tables créées                                  | Colonnes ajoutées                                                                         |
+| ----------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `010` voice-packs | `voice_credit_packs`, `voice_credit_purchases` | `voice_quota_streaming.purchased_minutes`                                                 |
+| `011` pricing-v2  | (aucune)                                       | `users.is_legacy_pricing` (Boolean) + UPDATE atomique `users.plan` (plus→pro, pro→expert) |
+| `012` parrainage  | `referrals` (+ enum `referral_status`)         | `users.referral_code` (String 64, UNIQUE, nullable, indexed)                              |
+| `013` edge-tts    | `voice_edge_quota`                             | (aucune nouvelle colonne sur tables existantes)                                           |
+
+**Aucun conflit de colonne** entre les 4 migrations — chacune ajoute soit une nouvelle table, soit une colonne unique distincte sur `users`.
+
+### Risque ordre vs déploiement
+
+L'auto-deploy DeepSight applique les migrations en cascade via `entrypoint.sh + RUN_MIGRATIONS=true` (cf. mémoire `reference_deepsight-hetzner-auto-deploy.md`). Le pipeline tourne **alphabétiquement par nom de fichier** — la renumérotation 010 / 011 / 012 / 013 garantit l'ordre.
+
+---
+
+## B — Multi-touched files
+
+### Vue matricielle
+
+Légende : ✏️ Modify, ✨ Create
+
+| Fichier                                           | #1 SEO | #2 Dash | #3 Edge | #4 Packs | #5 Testi | #6 PH | #7 Price | #8 Parr | #9 WM |
+| ------------------------------------------------- | ------ | ------- | ------- | -------- | -------- | ----- | -------- | ------- | ----- |
+| `backend/src/billing/plan_config.py`              |        |         |         |          |          |       | ✏️       |         | (lit) |
+| `backend/src/billing/router.py`                   |        |         |         | ✏️       |          |       | ✏️       |         |       |
+| `backend/src/billing/voice_quota.py`              |        |         | (lit)   | ✏️       |          |       | ✏️       |         |       |
+| `backend/src/db/database.py`                      |        |         | ✏️      | ✏️       |          |       | ✏️       | ✏️      |       |
+| `backend/src/main.py`                             |        |         | ✏️      | ✏️       | ✏️       |       |          | ✏️      |       |
+| `backend/src/exports/service.py`                  |        |         |         |          |          |       |          |         | ✏️    |
+| `backend/src/exports/pdf_generator.py`            |        |         |         |          |          |       |          |         | ✏️    |
+| `backend/src/exports/templates/pdf_template.html` |        |         |         |          |          |       |          |         | ✏️    |
+| `backend/src/exports/router.py`                   |        |         |         |          |          |       |          |         | ✏️    |
+| `backend/src/auth/router.py`                      |        |         |         |          |          |       |          | ✏️      |       |
+| `backend/src/auth/schemas.py`                     |        |         |         |          |          |       |          | ✏️      |       |
+| `backend/src/auth/service.py`                     |        |         |         |          |          |       |          | ✏️      |       |
+| `backend/src/videos/router.py`                    |        |         |         |          |          |       |          | ✏️      |       |
+| `backend/src/voice/router.py`                     |        |         | ✏️      |          |          |       |          |         |       |
+| `backend/src/voice/schemas.py`                    |        |         | ✏️      |          |          |       |          |         |       |
+| `backend/src/tts/providers.py`                    |        |         | ✏️      |          |          |       |          |         |       |
+| `backend/src/core/config.py`                      |        |         |         |          |          |       | ✏️       |         |       |
+| `backend/src/landing/router.py` (nouveau)         |        |         |         |          | ✨       |       |          |         |       |
+| `frontend/src/services/api.ts`                    |        | ✏️      | ✏️      | ✏️       | ✏️       | (lit) | ✏️       | ✏️      |       |
+| `frontend/src/services/analytics.ts`              |        |         |         |          |          | ✏️    |          | (lit)   |       |
+| `frontend/src/services/analytics.types.ts`        |        |         |         |          |          | ✨    |          |         |       |
+| `frontend/src/config/planPrivileges.ts`           |        |         |         |          |          |       | ✏️       |         |       |
+| `frontend/src/pages/UpgradePage.tsx`              | ✏️     |         |         |          |          | ✏️    | ✏️       |         |       |
+| `frontend/src/pages/MyAccount.tsx`                |        |         |         | ✏️       |          | ✏️    |          | ✏️      |       |
+| `frontend/src/pages/LandingPage.tsx`              |        |         |         |          | ✏️       | ✏️    |          | ✏️      |       |
+| `frontend/src/pages/VoiceCallPage.tsx`            |        |         | ✏️      | ✏️       |          | ✏️    |          |         |       |
+| `frontend/src/pages/PaymentSuccess.tsx`           |        |         |         |          |          | ✏️    |          |         |       |
+| `frontend/src/pages/Login.tsx`                    |        |         |         |          |          | ✏️    |          |         |       |
+| `frontend/src/pages/Register.tsx`                 |        |         |         |          |          |       |          | ✏️      |       |
+| `frontend/src/components/layout/Sidebar.tsx`      |        | ✏️      |         |          |          |       |          |         |       |
+| `frontend/src/hooks/useAnalytics.ts`              |        |         |         |          |          | ✏️    |          |         |       |
+| `frontend/src/components/voice/voiceAnalytics.ts` |        |         | (lit)   | (lit)    |          | ✏️    |          |         |       |
+| `frontend/src/components/analysis/ExportMenu.tsx` |        |         |         |          |          | ✏️    |          |         | ✏️    |
+| `frontend/src/store/analysisStore.ts`             |        |         |         |          |          | ✏️    |          |         |       |
+| `frontend/src/i18n/fr.json` + `en.json`           |        | ✏️      |         |          | ✏️       |       |          | ✏️      | ✏️    |
+| `frontend/index.html`                             | ✏️     |         |         |          |          |       |          |         |       |
+| `frontend/vercel.json`                            | ✏️     |         |         |          |          |       |          |         |       |
+
+### Conflits ligne / ordre optimal — fichiers à 3+ plans
+
+#### 🔴 `backend/src/db/database.py` — 4 plans (#3, #4, #7, #8)
+
+**Risque** : 4 modifications concurrentes du fichier User et nouvelles classes ajoutées en bas.
+
+**Ordre optimal** :
+
+1. **#4 voice-packs** mergé en premier — ajoute `purchased_minutes` à `VoiceQuotaStreaming` + crée classes `VoiceCreditPack`, `VoiceCreditPurchase` en bas du fichier.
+2. **#7 pricing-v2** ensuite — ajoute colonne `is_legacy_pricing: Boolean` à `User`. Pas de conflit avec #4 (zone User vs zones VoiceQuotaStreaming/bas-fichier).
+3. **#8 parrainage** ensuite — ajoute `referral_code` à `User` (sous `is_legacy_pricing`) + classe `Referral` en bas du fichier (sous `VoiceCreditPurchase`).
+4. **#3 edge-tts** en dernier — ajoute classe `VoiceEdgeQuota` en bas du fichier (sous `Referral`).
+
+**Pas de collision physique** car chaque plan ajoute soit dans la classe `User` (lignes ~106-185, mais à des emplacements différents), soit une nouvelle classe en bas du fichier. Conflit `git merge` géré naturellement par l'ordre.
+
+#### 🟡 `frontend/src/services/api.ts` — 6 plans touchent le fichier (#2, #3, #4, #5, #7, #8) + #6 le lit pour types
+
+**Risque** : 6 modifications concurrentes du `User` interface + 5+ nouveaux objets `XApi`.
+
+**Ordre optimal** :
+
+1. **#7 pricing-v2** en premier — réécrit `PlanId = "free" | "pro" | "expert"` (le plus impactant).
+2. **#2 dashboard** ensuite — ajoute `preferences?: Record<string, unknown>` au `User`.
+3. **#4 voice-packs** ajoute `voicePacksApi` (nouvel objet, zéro conflit).
+4. **#3 edge-tts** ajoute `voiceApi.startEdgeSession/sendEdgeTurn/getEdgeQuota` (étend objet existant).
+5. **#5 testimonials** ajoute `landingApi` (nouvel objet, zéro conflit).
+6. **#8 parrainage** ajoute `referralApi` (nouvel objet, zéro conflit).
+
+**Conflit de ligne probable** : `User` interface lignes 28-57. Mitigation : merger #7 puis rebase #2 dessus.
+
+#### 🟡 `frontend/src/pages/UpgradePage.tsx` — 3 plans (#1, #6, #7)
+
+**Risque** : refonte complète UI dans #7 vs ajout JSON-LD dans #1 vs instrumentation events dans #6.
+
+**Ordre optimal** :
+
+1. **#7 pricing-v2** refait l'UI avec toggle annuel + ComparisonTable (ligne 1-1700).
+2. **#1 SEO** ajoute `<ProductJsonLd />` import + insertion au début du composant (zone Helmet).
+3. **#6 PostHog** instrumente sur le UI #7 (events `pricing_viewed`, `plan_selected`, `checkout_started`).
+
+**Couplage atomique #1 + #7** rend l'ordre simple : merger les deux ensemble dans `release/pricing-v2` ; #6 vient en sprint suivant.
+
+#### 🟡 `frontend/src/pages/MyAccount.tsx` — 3 plans (#4, #6, #8)
+
+**Risque** : 2 widgets ajoutés (`<VoicePacksWidget>` et `<ReferralWidget>`) + instrumentation cancel.
+
+**Ordre optimal** :
+
+1. **#4 voice-packs** ajoute `<VoicePacksWidget>` dans section "Voice & Audio".
+2. **#8 parrainage** ajoute `<ReferralWidget>` entre section "Plan" et "API key".
+3. **#6 PostHog** instrumente `handleCancelSubscription` (zone existante, pas de conflit avec #4/#8).
+
+**Pas de collision** car chaque widget va dans une section distincte.
+
+#### 🟡 `frontend/src/pages/LandingPage.tsx` — 3 plans (#5, #6, #8)
+
+**Risque** : 3 sections ajoutées (#5) + instrumentation hero/footer (#6) + détection `?ref=` (#8).
+
+**Ordre optimal** :
+
+1. **#5 testimonials** ajoute 3 sections (3 points d'insertion identifiés par le plan).
+2. **#8 parrainage** ajoute `useEffect` au mount pour détecter `?ref=`.
+3. **#6 PostHog** instrumente E1 (`hero_analysis_clicked`) + E2 (`signup_started`).
+
+**Pas de collision** — zones disjointes.
+
+#### 🟡 `frontend/src/components/analysis/ExportMenu.tsx` — 2 plans (#6, #9)
+
+**Risque** : ajout tooltip watermark (#9) + instrumentation export (#6).
+
+**Ordre optimal** : #9 d'abord (modifie le rendu), puis #6 (ajoute call analytics dans le handler). Aucune zone partagée.
+
+---
+
+## C — Business values consistency check
+
+### Prix mensuels
+
+| Valeur             | #1 SEO              | #3 Edge | #4 Packs | #5 Testi | #6 PH | #7 Price            | #9 WM | Cohérence                      |
+| ------------------ | ------------------- | ------- | -------- | -------- | ----- | ------------------- | ----- | ------------------------------ |
+| Pro **8,99 €**     | ✅                  | (n/a)   | (n/a)    | (n/a)    | (n/a) | ✅                  | (n/a) | ✅ Cohérent                    |
+| Expert **19,99 €** | ✅                  | (n/a)   | (n/a)    | (n/a)    | (n/a) | ✅                  | (n/a) | ✅ Cohérent                    |
+| Pro v1 5,99 €      | mention "legacy v1" | (n/a)   | (n/a)    | (n/a)    | (n/a) | mention "legacy v1" | (n/a) | ✅ Cohérent (déclaré obsolète) |
+
+### Allowance ElevenLabs
+
+| Valeur                      | #3 Edge | #4 Packs | #6 PH | #7 Price | Cohérence   |
+| --------------------------- | ------- | -------- | ----- | -------- | ----------- |
+| Pro 30 min/mois rolling     | ✅ H2   | ✅ H1    | (n/a) | ✅ H4    | ✅ Cohérent |
+| Expert 120 min/mois rolling | ✅ H2   | ✅ H1    | (n/a) | ✅ H4    | ✅ Cohérent |
+
+⚠ **Décision DA voice-packs encore ouverte** — le plan #4 mentionne « statu quo Pro 30 / Expert 30 ou Pro 30 / Expert 120 ». Plan #7 et #3 supposent **Pro 30 / Expert 120**. Le default à locker est **Pro 30 / Expert 120** pour la cohérence inter-plans.
+
+### Plan IDs
+
+| Forme                                               | #4 Packs | #7 Price | #9 WM | Cohérence                           |
+| --------------------------------------------------- | -------- | -------- | ----- | ----------------------------------- |
+| `TOP_TIER_PLANS = {"pro", "expert"}`                | ✅       | ✅       | -     | ✅                                  |
+| `normalize_plan_id` (legacy `etudiant/starter/...`) | -        | ✅       | ✅    | ✅                                  |
+| Plans payants `{plus, pro}` (post-norm v0)          | -        | -        | ✅ H5 | ⚠ #9 emploie le SSOT actuel sans v2 |
+
+⚠ **#9 watermark** est rédigé en supposant la grille v0 (`plus, pro`). Après merge de #7, son helper `should_apply_watermark(plan)` doit accepter les nouveaux IDs `pro, expert` (post-rename). La fonction `normalize_plan_id` du plan #7 mappe automatiquement (l'ancien `plus` → nouveau `pro`), donc **compatibilité automatique** si #9 utilise bien `normalize_plan_id` dès le début. Le plan #9 le fait explicitement (`H5`), donc OK.
+
+### Trial
+
+| Valeur                         | #6 PH  | #7 Price | Cohérence |
+| ------------------------------ | ------ | -------- | --------- |
+| 7 jours sans CB                | (n/a)  | ✅ H5    | ✅        |
+| Applicable à Pro **et** Expert | ✅ E13 | ✅ H5    | ✅        |
+
+### Récompense parrainage
+
+| Valeur                         | #8 Parr | Cohérence                                |
+| ------------------------------ | ------- | ---------------------------------------- |
+| `REFERRAL_BONUS_CREDITS = 250` | ✅      | ✅ (= 5 analyses Mistral Small)          |
+| `MAX_COMPLETED_REFERRALS = 50` | ✅      | Décision ouverte (alternative 20 ou 100) |
+| `REFERRAL_EXPIRY_DAYS = 30`    | ✅      | OK                                       |
+
+### Edge TTS fair-use
+
+| Valeur                                  | #3 Edge | Cohérence |
+| --------------------------------------- | ------- | --------- |
+| `EDGE_FAIR_USE_MONTHLY_MINUTES = 600.0` | ✅ D2   | OK        |
+| Disponible Pro + Expert                 | ✅ H1   | OK        |
+
+### Voice packs (top-up)
+
+| Valeur                                                      | #4 Packs | Cohérence |
+| ----------------------------------------------------------- | -------- | --------- |
+| `voice-30` 2,99 € / `voice-60` 4,99 € / `voice-180` 12,99 € | ✅       | OK        |
+| Accessibles uniquement Pro et Expert                        | ✅ H2    | OK        |
+
+### Watermark
+
+| Valeur                                                     | #9 WM                           | Cohérence |
+| ---------------------------------------------------------- | ------------------------------- | --------- |
+| Free uniquement reçoit le watermark                        | ✅ H1                           | OK        |
+| Plus + Pro = pas de watermark (post-rename : Pro + Expert) | ✅ H5 (via `normalize_plan_id`) | OK        |
+
+### Aucune incohérence critique détectée
+
+Toutes les valeurs business critiques sont alignées entre les plans concernés. La seule ambiguïté résiduelle (DA voice-packs Expert 30 vs 120) doit être tranchée à **120** pour cohérence avec #7 et #3.
+
+---
+
+## D — Dependency graph
+
+```mermaid
+graph TD
+    P1[#1 SEO Phase 0]
+    P2[#2 Dashboard onboarding]
+    P3[#3 Edge TTS]
+    P4[#4 Voice packs]
+    P5[#5 Testimonials]
+    P6[#6 PostHog events]
+    P7[#7 Pricing v2]
+    P8[#8 Parrainage]
+    P9[#9 Watermark]
+
+    P7 ==>|RELEASE-TRAIN ATOMIQUE| P1
+    P1 ==>|RELEASE-TRAIN ATOMIQUE| P7
+
+    P7 -.->|débloque is_annual + is_legacy_pricing + Expert trial| P6
+    P4 -.->|débloque E18 / E19 voice_pack_*| P6
+    P3 -.->|débloque param provider sur E15| P6
+
+    P6 -.->|EventPayloadMap si déjà mergé sinon fallback string| P8
+
+    P7 -.->|colonnes Pricing dans User type| P9
+    P7 -.->|aliases plan v0→v2 dans normalize_plan_id| P9
+
+    P4 -.->|migration 010 first| ALEMBIC{Alembic chain}
+    P7 -.->|migration 011 second| ALEMBIC
+    P8 -.->|migration 012 renumber| ALEMBIC
+    P3 -.->|migration 013 renumber| ALEMBIC
+
+    P5 -.->|aucune dépendance| INDEP[Quick wins]
+    P2 -.->|aucune dépendance| INDEP
+    P9 -.->|aucune dépendance forte| INDEP
+
+    style P7 fill:#f99
+    style P1 fill:#f99
+    style ALEMBIC fill:#fc6
+    style INDEP fill:#9f9
+```
+
+### Légende
+
+- `==>` = couplage **atomique** (release-train obligatoire)
+- `-.->` = dépendance **bloquante mais sérialisable** (cascade)
+- Rouge = bottleneck du release-train pricing
+- Vert = quick wins déployables seul
+- Orange = chaîne Alembic à renuméroter
+
+### Zoom sur les blocages PostHog (#6)
+
+Le plan #6 déclare 4 events bloqués mais ajoute **quand même les constantes TS** (H5) pour éviter conflits PR ultérieurs. Donc :
+
+- E4 `pricing_toggle_changed` : déclaré mais pas câblé tant que #7 pas mergé.
+- E5 `plan_selected.is_annual` : `is_annual` hardcodé `false` jusqu'à #7.
+- E13 `trial_started.expert` : Expert n'existe pas avant #7.
+- E15 `voice_call_started.provider` : `provider` hardcodé `"elevenlabs"` jusqu'à #3.
+- E18/E19 voice packs : déclarés mais pas câblés tant que #4 pas mergé.
+
+#6 peut donc partir **avant** #7/#3/#4 avec ces stubs documentés (`TODO post plan #N`).
+
+### Pas de cycle détecté
+
+Le graphe est un DAG strict. Le seul couplage à 2 sens est #1↔#7 mais c'est volontaire (release-train atomique).
+
+---
+
+## E — Recommended sprint roadmap
+
+### Sprint A — Quick wins (semaine 1)
+
+**Objectif** : commencer immédiatement les plans **autonomes**, sans toucher Alembic ni Pricing. Validation rapide en prod, gain de momentum.
+
+| Plan inclus     | PR slug                          | Risque                           | Validation post-deploy                                                        |
+| --------------- | -------------------------------- | -------------------------------- | ----------------------------------------------------------------------------- |
+| #2 Dashboard    | `feature/dashboard-onboarding`   | 🟢 Bas                           | `curl /api/auth/preferences` ; visiter `/dashboard` après login fresh         |
+| #5 Testimonials | `feature/homepage-testimonials`  | 🟡 Moy (endpoint backend public) | `curl https://api.deepsightsynthesis.com/api/public/landing-stats`            |
+| #9 Watermark    | `feature/watermark-exports-free` | 🟢 Bas                           | Login user free, export PDF/MD/TXT, vérifier mention "Analysé avec DeepSight" |
+
+**Couplages** : aucun. **Préconditions** : aucune.
+
+**Risques** :
+
+- #5 ajoute un nouveau routeur backend `/api/public/landing-stats` → vérifier qu'il n'introduit pas de leak de données sensibles (count agrégés uniquement, déjà documenté dans le plan).
+- #9 utilise `normalize_plan_id` du SSOT actuel — compatible v1 et v2 automatiquement, donc pas de couplage avec #7.
+
+**Note** : aucun de ces 3 plans ne touche Alembic.
+
+---
+
+### Sprint B — Release-train Pricing v2 (semaine 1 fin / semaine 2 début)
+
+**Objectif** : déployer **simultanément** #1 SEO + #7 Pricing v2 — couplage atomique obligatoire (`release/pricing-v2`).
+
+| Plan inclus    | PR slug                                    | Risque  | Validation post-deploy                                                                |
+| -------------- | ------------------------------------------ | ------- | ------------------------------------------------------------------------------------- |
+| #7 Pricing v2  | `feature/pricing-v2-stripe-grandfathering` | 🔴 Haut | `curl /api/billing/plans \| jq '.[] \| select(.id=="pro").price_monthly_cents'` → 899 |
+| #1 SEO Phase 0 | `feature/audit-kimi-seo-phase-0`           | 🟡 Moy  | `curl https://www.deepsightsynthesis.com/ \| grep '"price":\s*"8\.99"'`               |
+
+**Couplage atomique obligatoire** : merger les 2 PRs dans `release/pricing-v2`, puis squash-merge dans `main` (cf. plans qui le précisent en "Release coordination").
+
+**Préconditions** :
+
+- Sprint A peut être en cours en parallèle (pas de couplage).
+- 4 nouveaux Stripe Price IDs créés en mode test ET live (T5 du plan #7).
+- Migration **010** voice-packs PAS encore mergée → `down_revision = "009"`. **Sinon** voir variante ci-dessous.
+
+**Variante** : si Sprint C voice-packs (ci-dessous) merge en premier, alors `down_revision = "010"` côté #7. Le plan #7 mentionne déjà cette directive.
+
+**Risques** :
+
+- Webhook Stripe en flight pendant migration Alembic 011 → la migration UPDATE étant atomique (CASE), risque minime.
+- Cache JWT contenant `plan: "plus"` → backend normalise via `normalize_plan_id` (T3 step 2 #7).
+- Mobile non updaté postant `plan="plus"` à `/billing/start-trial` → reject pur (pas de backwards-compat ajoutée volontairement).
+
+**Validation post-deploy combinée** :
+
+```bash
+# 1. SEO/HTML annonce bien v2
+curl -s https://www.deepsightsynthesis.com/ | grep -E '"price":\s*"(8\.99|19\.99)"'
+# Expected: au moins 2 lignes
+
+# 2. Backend retourne v2 dans /api/billing/plans
+curl -s https://api.deepsightsynthesis.com/api/billing/plans | jq '.[] | {id, price_monthly_cents}'
+# Expected: free 0, pro 899, expert 1999
+
+# 3. Aucun v0 résiduel dans le HTML statique
+curl -s https://www.deepsightsynthesis.com/ | grep -E '"name":\s*"Plus"|"price":\s*"4\.99"|"price":\s*"9\.99"'
+# Expected: vide
+
+# 4. Migration appliquée
+ssh root@89.167.23.214 'docker exec repo-postgres-1 psql -U deepsight -d deepsight -c "SELECT version_num FROM alembic_version;"'
+# Expected: 011
+
+# 5. is_legacy_pricing backfill OK
+ssh root@89.167.23.214 'docker exec repo-postgres-1 psql -U deepsight -d deepsight -c "SELECT count(*) FROM users WHERE is_legacy_pricing=true;"'
+# Expected: cohérent avec count(stripe_subscription_id IS NOT NULL)
+```
+
+---
+
+### Sprint C — Voice features (semaine 2)
+
+**Objectif** : déployer les 2 plans voice indépendants. **Recommandation** : voice-packs en premier (migration 010, mergeable seul) ; edge-tts ensuite.
+
+| Plan inclus    | PR slug                          | Risque                                                      | Validation post-deploy                                        |
+| -------------- | -------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------- |
+| #4 Voice packs | `feature/elevenlabs-voice-packs` | 🟡 Moy (Stripe webhook payment, idempotence)                | `curl /api/billing/voice-packs/list` ; achat test pack 30 min |
+| #3 Edge TTS    | `feature/voice-edge-tts`         | 🟡 Moy (subprocess `edge-tts` Python, fair-use rolling 30j) | `curl /api/voice/edge/quota` ; test session edge complète     |
+
+**Préconditions** :
+
+- Sprint B Pricing v2 mergé (sinon voice-packs ne sait pas que Expert existe).
+- DA voice-packs (Expert 30 ou 120 min) tranchée → **120 min** par défaut (cohérence #7).
+
+**Couplages** :
+
+- Voice packs migration `010` doit être mergée AVANT Pricing v2 (sinon renumérotation pricing → 010).
+- Mais si on suit l'ordre Sprint A → Sprint B → Sprint C, alors voice-packs vient APRÈS pricing-v2 → migration **devient 012** (et parrainage devient 013, edge-tts devient 014).
+
+**Décision d'arbitrage** :
+
+- **Option 1 (recommandée)** : merger voice-packs (010) AVANT Sprint B → migrations restent 010/011/012/013 comme prévu.
+- **Option 2** : si voice-packs n'est pas prêt, Sprint B passe avec 011 sur 009, et voice-packs renumérotation à 012 → cascade.
+
+**Risques** :
+
+- Race condition double-credit Stripe webhook → contrainte UNIQUE sur `stripe_session_id` (T1 step 2 #4).
+- Edge TTS subprocess `edge-tts` non installé en prod → ajouter à `requirements.txt` (T1 #3) + rebuild Docker.
+
+---
+
+### Sprint D — Programme parrainage (semaine 3)
+
+**Objectif** : acquisition virale +5/+5.
+
+| Plan inclus   | PR slug                        | Risque | Validation post-deploy                               |
+| ------------- | ------------------------------ | ------ | ---------------------------------------------------- |
+| #8 Parrainage | `feature/programme-parrainage` | 🟡 Moy | `curl /api/referral/code` ; signup avec `?ref=` test |
+
+**Préconditions** :
+
+- Sprint C voice-packs (010) mergé pour bonne séquence Alembic.
+- Migration **012** parrainage (renumérotation depuis 010 imposée par ce document).
+
+**Décisions à trancher avant** :
+
+- DEC1 — Limite anti-farming : 50 (default), 20 ou 100 ?
+- DEC2 — Anti-fraude IP/email : logs only (default) ou bloquage agressif ?
+- DEC3 — Récompense : 250 crédits seuls (default) ou + voice minutes ?
+- DEC4 — Email notification au parrain : V2 (default — pas dans ce sprint).
+- DEC5 — Numéro migration : **012** (imposé par ce document).
+
+**Risques** :
+
+- Hook `complete_referral_if_first_analysis` placé uniquement dans flux v2 (`videos/router.py` ligne 1646-1716). Les autres flux (debate, long video, batch) ne déclenchent pas. Acceptable pour V1.
+
+---
+
+### Sprint E — PostHog instrumentation complète (semaine 3 fin / semaine 4)
+
+**Objectif** : déployer les 18 events typés. **Doit venir après B + C + D** pour pouvoir câbler les events bloqués.
+
+| Plan inclus | PR slug                           | Risque                                   | Validation post-deploy                                                                |
+| ----------- | --------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
+| #6 PostHog  | `feature/posthog-events-complets` | 🟢 Bas (frontend-only, aucune migration) | Inspect Network tab : POST `posthog.com/decide` ; PostHog dashboard reçoit événements |
+
+**Préconditions** :
+
+- Sprint B mergé → débloquer E4, E5.is_annual, E13.expert.
+- Sprint C voice-packs mergé → débloquer E18, E19.
+- Sprint C edge-tts mergé → débloquer E15.provider.
+- Sprint D parrainage mergé → ajout des 3 events `referral_*` à `EventPayloadMap`.
+
+**Scope** : zéro migration backend, frontend-only, déployable seul. Risque le plus bas du release-train.
+
+**Note** : le plan #6 documente explicitement que les constantes des events bloqués peuvent être déclarées en avance (H5) — pour éviter conflits PR ultérieurs. C'est l'inverse qu'on choisit ici (Sprint E en dernier) parce que cela évite des stubs `TODO post plan #N` dans le code.
+
+---
+
+### Vue d'ensemble release-train
+
+| Semaine | Sprint | Plans                                           | Migrations                                                |
+| ------- | ------ | ----------------------------------------------- | --------------------------------------------------------- |
+| **1**   | A      | #2 Dashboard + #5 Testimonials + #9 Watermark   | aucune                                                    |
+| **1-2** | B      | #1 SEO + #7 Pricing v2 (release-train atomique) | `011` (sur `009`)                                         |
+| **2**   | C      | #4 Voice packs (puis) #3 Edge TTS               | `010` (sur `009`) puis `013` (sur `012`) ⚠ voir variantes |
+| **3**   | D      | #8 Parrainage                                   | `012` (sur `011`)                                         |
+| **3-4** | E      | #6 PostHog events                               | aucune                                                    |
+
+**Variante critique** : si voice-packs n'est pas prêt dès Sprint A et que Sprint B doit partir avant → la chaîne devient 009 → 011 → 012 (parrainage) → 013 (voice-packs) → 014 (edge-tts). Le plan #7 prévoit la flexibilité (`down_revision = "010"` ou `"009"`).
+
+**Recommandation finale** : merger `feature/elevenlabs-voice-packs` (#4) **dès Sprint A en parallèle** des 3 quick wins → garantit l'ordre Alembic 010/011/012/013 qui colle aux numérotations naturelles des plans (#7 garde 011, #8 renumérotation 012, #3 renumérotation 013).
+
+---
+
+## F — Open decisions consolidated
+
+### Pricing & business model
+
+| ID   | Décision                                                                                | Plan  | Default proposé                         |
+| ---- | --------------------------------------------------------------------------------------- | ----- | --------------------------------------- |
+| PR-1 | Branche unique pour Sprint B (`feature/pricing-v2-stripe-grandfathering`) ou multiple ? | #7 D1 | **Branche unique** atomique             |
+| PR-2 | Stripe LIVE Price IDs dès la PR ou attendre go pré-production ?                         | #7 D2 | **TEST d'abord, LIVE au push prod**     |
+| PR-3 | UpgradePage : prix biffés "9,99 € → 8,99 €" ?                                           | #7 D4 | **Non** — c'est une hausse, pas tromper |
+| PR-4 | Mobile dans Sprint B ou plan séparé ?                                                   | #7 D5 | **Plan séparé ultérieur**               |
+| PR-5 | `aggregateRating` factice (4.8 / 127) dans ProductJsonLd ?                              | #1 D1 | **Le mettre** (audit recommande)        |
+
+### Voice (ElevenLabs + Edge)
+
+| ID   | Décision                                           | Plan                | Default proposé                                             |
+| ---- | -------------------------------------------------- | ------------------- | ----------------------------------------------------------- |
+| VC-1 | Allowance Expert : 30 min (statu quo) ou 120 min ? | #4 DA, #3 H2, #7 H4 | **120 min** (cohérence inter-plans)                         |
+| VC-2 | Free users autorisés à acheter packs voice ?       | #4 DB               | **Non** (402 — voir T5 #4)                                  |
+| VC-3 | Refunds packs voice : V1 ou plus tard ?            | #4 DC               | **Plus tard** (manuel via Stripe pour l'instant)            |
+| VC-4 | Voix Edge TTS françaises par défaut ?              | #3 D1               | **`fr-FR-DeniseNeural` + `fr-FR-HenriNeural`**              |
+| VC-5 | Plafond fair-use Edge TTS                          | #3 D2               | **600 min/mois rolling 30j**                                |
+| VC-6 | Modèle Mistral chat-completion Edge                | #3 D3               | **`mistral-medium-2508` Pro / `mistral-large-2512` Expert** |
+| VC-7 | Format audio uplink Edge                           | #3 D4               | **MediaRecorder Opus / WebM 1s chunks**                     |
+| VC-8 | Format audio downlink Edge                         | #3 D5               | **`audio/mpeg` 24kHz mono streaming**                       |
+
+### Parrainage
+
+| ID   | Décision                                        | Plan  | Default proposé                         |
+| ---- | ----------------------------------------------- | ----- | --------------------------------------- |
+| RF-1 | Limite anti-farming                             | #8 D1 | **50** (alternative 20 ou 100)          |
+| RF-2 | Anti-fraude IP/email                            | #8 D2 | **Logs only V1** (itérer si besoin)     |
+| RF-3 | Récompense : crédits seuls ou + voice minutes ? | #8 D3 | **Crédits seuls V1** (250 ≈ 5 analyses) |
+| RF-4 | Email notification parrain à completion ?       | #8 D4 | **V2** (post-mesure engagement)         |
+| RF-5 | Migration : 010 ou 012 ?                        | #8 D5 | **012** (imposé par ce document)        |
+
+### Watermark
+
+| ID   | Décision                                   | Plan  | Default proposé                         |
+| ---- | ------------------------------------------ | ----- | --------------------------------------- |
+| WM-1 | Watermark PDF : texte seul ou + logo SVG ? | #9 D1 | **Texte seul** (zero asset)             |
+| WM-2 | Visible sur partage public `/a/[id]` ?     | #9 D2 | **OUI** (propager owner_plan)           |
+| WM-3 | Format CSV concerné ?                      | #9 D3 | **OUI** (cohérence avec XLSX)           |
+| WM-4 | Audio TTS concerné ?                       | #9 D4 | **NON** (déjà gated par tts_enabled)    |
+| WM-5 | Format note dernière page PDF              | #9 D5 | **Paragraphe italic gris** (sans titre) |
+
+### Dashboard / Onboarding
+
+| ID   | Décision                                                               | Plan  | Default proposé                                 |
+| ---- | ---------------------------------------------------------------------- | ----- | ----------------------------------------------- |
+| DB-1 | Mode "Hypnagogique" : créer ou ignorer ?                               | #2 Q1 | **(A) Ignorer** — n'existe pas en code          |
+| DB-2 | DebatePage : migrer vers `<EmptyState>` ou garder `DoodleEmptyState` ? | #2 Q2 | **(A) Garder DoodleEmptyState**                 |
+| DB-3 | Onboarding ancien users (sans flag) : show ou pas ?                    | #2 Q3 | **(A) Show** (tous bénéficient)                 |
+| DB-4 | Persona "Plus tard" : flag set OK ?                                    | #2 Q4 | **OUI** (`persona = null` rééditable plus tard) |
+
+### Testimonials
+
+| ID   | Décision                                                       | Plan         | Default proposé                                                            |
+| ---- | -------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------- |
+| TS-1 | Témoignages fictifs `isPlaceholder: true` : afficher en prod ? | #5 (en-tête) | **NON** — composant retourne `null` en prod tant que `isPlaceholder: true` |
+
+### PostHog (post-merge)
+
+| ID   | Décision                                                | Plan  | Default proposé                        |
+| ---- | ------------------------------------------------------- | ----- | -------------------------------------- |
+| PH-1 | PostHog Python SDK backend pour events serveur ?        | #6 Q1 | **Oui — phase suivante** (plan séparé) |
+| PH-2 | PostHog session recording ?                             | #6 Q2 | **Non par défaut** (RGPD + coût)       |
+| PH-3 | PostHog feature flags (A/B test) ?                      | #6 Q3 | **Oui à terme**                        |
+| PH-4 | Backend expose `subscription_started_at` ?              | #6 Q4 | **Oui — créer issue backend**          |
+| PH-5 | Backend retourne `was_trial` dans `confirmCheckout()` ? | #6 Q5 | **Oui — créer issue backend**          |
+
+### Méta-décisions transverses (à trancher avant Sprint A)
+
+| ID     | Décision                                                                                         | Default proposé                                                                           |
+| ------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| META-1 | Stratégie de release-train Sprint B : intégration `release/pricing-v2` ou squash-merge directs ? | **Branche d'intégration** (atomic)                                                        |
+| META-2 | Voice-packs avant ou après Sprint B (impacte numérotation Alembic) ?                             | **Voice-packs avant Sprint B** (010 sur 009 conserve la numérotation naturelle des plans) |
+| META-3 | PR review obligatoire ou push direct sur `main` ?                                                | **PR review** (default safer)                                                             |
+| META-4 | Worktrees Git pour parallélisation Sprint A ?                                                    | **Oui** — pattern `feature/<nom>` (cf. CLAUDE.md)                                         |
+
+---
+
+## G — Quick wins (PR solo immédiat)
+
+Plans déployables **dès aujourd'hui** sans bloquer ni attendre :
+
+### #2 Dashboard onboarding (`feature/dashboard-onboarding`)
+
+- **Pourquoi quick win** : zéro migration, zéro fichier critique partagé, frontend-only.
+- **Fichiers touchés** : `Sidebar.tsx`, `services/api.ts` (User type extension), `i18n/{fr,en}.json`, nouveaux fichiers `components/onboarding/*` + `EmptyState.tsx`.
+- **Risque** : 🟢 Bas. Test pertinent : login fresh, vérifier modal onboarding 3 étapes apparaît.
+- **Préconditions** : aucune.
+
+### #5 Homepage testimonials (`feature/homepage-testimonials`)
+
+- **Pourquoi quick win** : témoignages désactivés en prod si `isPlaceholder: true` (garde-fou anti-déploiement de fakes). Compteurs réels backend (read-only). Aucune migration.
+- **Fichiers touchés** : `LandingPage.tsx`, `services/api.ts` (`landingApi`), backend `landing/router.py` (nouveau), `i18n/{fr,en}.json`.
+- **Risque** : 🟡 Moyen — nouveau routeur public à valider sécurité.
+- **Préconditions** : aucune. Endpoint `/api/admin/stats:102-156` existe et sert de modèle SQL.
+- **Décision business** : avant le passage en prod réel, retirer `isPlaceholder: true` des témoignages **uniquement après** que de vrais utilisateurs sont OK avec leur citation publiée.
+
+### #9 Watermark exports Free (`feature/watermark-exports-free`)
+
+- **Pourquoi quick win** : utilise `normalize_plan_id` du SSOT actuel, donc compatible v0/v1 ET v2 (ne dépend pas de Sprint B). Aucune migration. Backend pur logic + 1 modif PDF template.
+- **Fichiers touchés** : `backend/src/exports/{watermark.py,service.py,pdf_generator.py,templates/pdf_template.html,router.py}`, `frontend/src/components/analysis/ExportMenu.tsx`, `i18n/{fr,en}.json`.
+- **Risque** : 🟢 Bas. Test pertinent : login user free, exporter PDF/MD/TXT, vérifier mention "Analysé avec DeepSight".
+- **Préconditions** : aucune.
+
+### Parallélisation suggérée Sprint A
+
+Les 3 quick wins ci-dessus peuvent être développés **en parallèle** par des subagents Opus 4.7 distincts dans des worktrees séparés (cf. `superpowers:using-git-worktrees`). Aucune intersection de fichiers entre les 3.
+
+```bash
+# Sprint A parallel kickoff
+git worktree add ../DeepSight-dashboard feature/dashboard-onboarding
+git worktree add ../DeepSight-testimonials feature/homepage-testimonials
+git worktree add ../DeepSight-watermark feature/watermark-exports-free
+```
+
+### Bonus : #4 Voice packs aussi quasi-quick win
+
+Si voice-packs (#4) part en même temps que Sprint A (worktree dédié `feature/elevenlabs-voice-packs`), il peut **merger en premier** et fixer la migration `010`. Cela rend ensuite Sprint B (#7 Pricing v2) plus simple en figeant `down_revision = "010"`. Risque : Stripe webhook idempotence à valider en preview.
+
+---
+
+## Conclusion
+
+### Recommandation : par où commencer demain
+
+**Étape 1 — Trancher 5 méta-décisions (15 min)**
+
+1. **META-1** : confirmer release-train Sprint B via branche d'intégration `release/pricing-v2` ✅
+2. **META-2** : confirmer ordre voice-packs **avant** Sprint B (Alembic 010 sur 009) ✅
+3. **VC-1** : confirmer Expert 120 min ElevenLabs ✅
+4. **DB-1, DB-2, DB-3** : confirmer defaults Sprint A pour onboarding ✅
+5. **TS-1** : confirmer témoignages désactivés en prod (`isPlaceholder=true → return null`) ✅
+
+**Étape 2 — Lancer Sprint A en parallèle (4 worktrees, 4 subagents Opus 4.7)**
+
+- Worktree 1 : `feature/dashboard-onboarding` — agent #2
+- Worktree 2 : `feature/homepage-testimonials` — agent #5
+- Worktree 3 : `feature/watermark-exports-free` — agent #9
+- Worktree 4 : `feature/elevenlabs-voice-packs` — agent #4 (Sprint C anticipé pour fixer Alembic 010)
+
+**Étape 3 — Préparer Sprint B en paralelle (release-train pricing v2)**
+
+- Créer `release/pricing-v2` branche d'intégration.
+- Subagent dédié pour #7 + #1 conjoint (deux PRs vers cette branche, puis squash vers `main`).
+- Pré-créer 4 Stripe Prices TEST + LIVE (T5 step 2 #7).
+- Préparer `.env.production` avec les 4 nouveaux Price IDs.
+
+**Étape 4 — Sprint C edge-tts (semaine 2) puis Sprint D parrainage (semaine 3) puis Sprint E PostHog (semaine 3-4)**
+
+Cascade séquentielle classique avec checkpoints de validation après chaque sprint (cf. section E).
+
+### Anti-patterns à éviter
+
+- ❌ Merger #1 SEO seul → annonce 8,99 € publiquement, Stripe facture 5,99 €.
+- ❌ Merger #7 Pricing v2 seul → SEO statique reste avec ancienne grille, confusion users.
+- ❌ Renuméroter Alembic après merge → conflits cascade sur `down_revision`.
+- ❌ Toucher `frontend/src/services/api.ts` dans 4 PRs simultanées sans coordination → conflits ligne `User` interface garantis.
+- ❌ Reporter `is_legacy_pricing` à un sprint séparé → grandfathering incomplet, double facturation possible.
+
+### Next step après ce document
+
+Ce livrable est un **audit méta**, pas un plan d'implémentation. Chaque plan individuel reste source de vérité pour son périmètre. Cet audit vient encadrer leur exécution synchronisée.
+
+**Action immédiate utilisateur** :
+
+1. Valider les 5 méta-décisions (META-1 à VC-1 ci-dessus).
+2. Demander à un subagent de spawn 4 worktrees Sprint A.
+3. Préparer `release/pricing-v2` pour Sprint B en parallèle.
+
+---
+
+_Document généré 2026-04-29 — audit transversal des 9 plans d'implémentation DeepSight Synthesis._

--- a/docs/superpowers/plans/2026-04-29-audit-kimi-phase-0-seo-securite.md
+++ b/docs/superpowers/plans/2026-04-29-audit-kimi-phase-0-seo-securite.md
@@ -1,0 +1,838 @@
+# Audit Kimi Phase 0 — SEO + Headers Sécurité + Pricing v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aligner les surfaces publiques HTML statiques de DeepSight (index.html, vercel.json, UpgradePage SEO) sur la grille pricing v2 (Pro 8,99 € / Expert 19,99 €), corriger les vrais bugs Phase 0 de l'audit Kimi (anciens prix v0 résiduels, headers sécurité absents, pas de Product/Offer schema sur /upgrade) — sans toucher au système Helmet runtime déjà fonctionnel.
+
+**Architecture:** Modifications ciblées sur 3 fichiers existants + 1 composant React JSON-LD (avec test Vitest TDD) + 1 fichier de configuration Vercel. Le composant `<ProductJsonLd>` suit le pattern de `<BreadcrumbJsonLd>` (Helmet `<script type="application/ld+json">`), exporte une fonction pure `buildProductJsonLd()` testable sans render React. Aucune modification du code Helmet existant : on l'utilise.
+
+**Tech Stack:** React 18 + TypeScript strict + react-helmet-async ^2.0.5 + Vitest 2.1 + @testing-library/react 16 (déjà installés). Vercel JSON pour headers HTTP.
+
+**⚠️ Couplage release-train obligatoire :** Ce plan ne doit **pas** être mergé/déployé seul. Il publie publiquement la grille v2 (8,99 €/19,99 €). Il forme une **release atomique** avec le plan jumeau `2026-04-29-pricing-v2-stripe-grandfathering.md` (à venir batch 2 — création des Stripe Price IDs v2, rename interne `plus → pro`/`pro → expert`, drapeau `User.is_legacy_pricing` pour grandfathering v1). Sinon : SEO annoncerait 8,99 € pendant que Stripe facturerait encore 5,99 €. Voir section **Release coordination** en bas de plan.
+
+---
+
+## Contexte préalable
+
+### Plan d'orchestration (à confirmer)
+
+Le contexte de mission mentionne un plan-frère `2026-04-29-RELEASE-ORCHESTRATION.md` (commit `021e4bf1`) qui contiendrait le mapping des conflits Alembic (010 voice-packs / 011 pricing-v2 / 012 parrainage / 013 edge-tts) et le release-train obligatoire #1 SEO + #3 pricing-v2. **À l'écriture de ce plan, ce fichier n'existe pas encore dans le repo** — il sera lu en premier par l'engineer une fois publié. Si l'orchestration finale renomme la branche cible, mettre à jour la décision **D4** ci-dessous.
+
+### Trois grilles tarifaires cohabitent dans le code
+
+| Grille                          | Statut                                                        | Plans                               | Où elle vit encore                                                                                                          |
+| ------------------------------- | ------------------------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **v0** (relique)                | À supprimer                                                   | Plus 4,99 € / Pro 9,99 €            | `frontend/index.html` JSON-LD lignes 163-197, `frontend/src/pages/UpgradePage.tsx:1142` description SEO                     |
+| **v1** (prod actuelle facturée) | Maintenue pour abonnés legacy via grandfathering (autre plan) | Pro 5,99 € / Expert 14,99 €         | Stripe Price IDs production, `backend/src/core/config.py`, `frontend/src/config/planPrivileges.ts` (côté display + backend) |
+| **v2** (cible publique)         | **Annoncée par ce plan**                                      | Pro **8,99 €** / Expert **19,99 €** | Sera affichée dans `index.html`, `<ProductJsonLd>` sur `/upgrade`, description SEO `UpgradePage.tsx`                        |
+
+**⚠️ L'engineer ne touche que la grille v0 (suppression) et v2 (création) dans ce plan.** La grille v1 est traitée par le plan jumeau `pricing-v2-stripe-grandfathering`. Ne pas modifier `planPrivileges.ts` ni `backend/src/core/config.py` ici.
+
+### Grille v2 cible publique (à inscrire dans tous les fichiers de ce plan)
+
+| Plan    | Prix mensuel | Prix annuel (−17 %)          | Analyses/mois | Max durée vidéo |
+| ------- | ------------ | ---------------------------- | ------------- | --------------- |
+| Gratuit | 0 €          | —                            | 5             | 15 min          |
+| Pro     | **8,99 €**   | **89,90 €/an** (≈ 7,49/mo)   | 30            | 2 h             |
+| Expert  | **19,99 €**  | **199,90 €/an** (≈ 16,66/mo) | 100           | 4 h             |
+
+### État DeepSight déjà bon — NE PAS recréer
+
+L'audit Kimi 2026-04-29 contient plusieurs faux positifs. Voici ce qui est déjà fonctionnel et ne doit pas être recréé :
+
+- ✅ `react-helmet-async ^2.0.5` installé (`frontend/package.json`)
+- ✅ `<HelmetProvider>` global wrap dans `frontend/src/main.tsx:131-143`
+- ✅ Composant `<SEO>` complet dans `frontend/src/components/SEO.tsx` (76 lignes — title/description/canonical/og/twitter/hreflang), utilisé par 25+ pages
+- ✅ Composant `<BreadcrumbJsonLd>` dans `frontend/src/components/BreadcrumbJsonLd.tsx`
+- ✅ FAQ JSON-LD inline dans `frontend/src/pages/LandingPage.tsx:602-618`
+- ✅ Prerendering bots IA (GPTBot/ClaudeBot/Perplexity) dans `frontend/vercel.json:31-67`
+- ✅ Cache headers existants dans `frontend/vercel.json:88-167`
+
+### Faux positifs Kimi à documenter en intro de PR (pour reviewer)
+
+L'audit affirme « Toutes les pages se canonisent vers la homepage ». **C'est faux pour le HTML rendu** : Helmet réécrit `<link rel="canonical">` au mount de chaque page via `<SEO path="/upgrade">`, etc. Le `<link rel="canonical" href=".../">` statique de `index.html:77` n'est qu'un fallback initial pour les bots qui n'exécutent pas JS — et ces bots passent déjà par les rewrites prerender (`/api/prerender`) configurés en `vercel.json:25-67`. Aucun changement de canonical à faire ici.
+
+### État branche
+
+- Branche cible attendue : `feature/audit-kimi-plans-2026-04-29` (à créer si elle n'existe pas — voir **D4**)
+- Branche actuelle au moment de la rédaction : `feat/merge-voice-chat-context` (différente — décision **D4** à confirmer avec l'utilisateur avant Task 1)
+
+---
+
+## File Structure
+
+| Fichier                                                    | Action                                    | Responsabilité                                                                                                      |
+| ---------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `frontend/index.html`                                      | Modify (lignes 11, 13-15, 18-20, 152-199) | Title + meta description + meta keywords + JSON-LD WebApplication offers (grille v2)                                |
+| `frontend/vercel.json`                                     | Modify (ajout dans le tableau `headers`)  | Ajouter une entrée `/(.*)` avec CSP + 4 headers sécurité                                                            |
+| `frontend/src/pages/UpgradePage.tsx`                       | Modify (lignes 1140-1145)                 | Description SEO en grille v2 + import + mount `<ProductJsonLd />`                                                   |
+| `frontend/src/components/ProductJsonLd.tsx`                | Create                                    | Composant React + fonction pure `buildProductJsonLd()` (Schema.org Product/Offers grille v2)                        |
+| `frontend/src/components/__tests__/ProductJsonLd.test.tsx` | Create                                    | Vitest — 5 tests sur `buildProductJsonLd()` (structure, prix Pro 8,99, prix Expert 19,99, devise EUR, count offres) |
+
+**Décomposition** : Chaque fichier a une responsabilité unique. Le composant `<ProductJsonLd>` exporte sa fonction de construction `buildProductJsonLd()` pour tester la structure JSON-LD sans `render()` React (DRY, pas de duplication entre prod et tests).
+
+---
+
+## Tasks
+
+### Task 1: Aligner `index.html` sur la grille pricing v2
+
+**Files:**
+
+- Modify: `frontend/index.html:11`
+- Modify: `frontend/index.html:13-15`
+- Modify: `frontend/index.html:18-20`
+- Modify: `frontend/index.html:152-199`
+
+**Pourquoi :** L'audit Kimi confirme : (a) le `<title>` ne mentionne pas TikTok alors que la prop est supportée depuis mars 2026, (b) la meta description n'évoque pas TikTok ni les nouveautés (flashcards, fact-check), (c) les keywords manquent TikTok/voice agent, (d) le JSON-LD WebApplication contient encore les anciens prix v0 (Plus 4,99 € / Pro 9,99 €) absents de la roadmap publique. Cette task supprime entièrement v0 et installe v2.
+
+- [ ] **Step 1: Mettre à jour le `<title>` (ligne 11)**
+
+```html
+<title>DeepSight — Analyse YouTube & TikTok par IA</title>
+```
+
+Remplace exactement :
+
+```html
+<title>DeepSight - Analyse YouTube IA</title>
+```
+
+- [ ] **Step 2: Mettre à jour la meta description (lignes 13-15)**
+
+```html
+<meta
+  name="description"
+  content="Analysez vos vidéos YouTube et TikTok avec l'IA : synthèses sourcées, fact-checking nuancé, flashcards FSRS, chat contextuel et voice agent. 100 % européen, propulsé par Mistral AI."
+/>
+```
+
+- [ ] **Step 3: Mettre à jour les meta keywords (lignes 18-20)**
+
+```html
+<meta
+  name="keywords"
+  content="youtube, tiktok, analyse vidéo, IA, intelligence artificielle, résumé, synthèse, fact-checking, flashcards, voice agent, Mistral AI, deepsight"
+/>
+```
+
+- [ ] **Step 4: Remplacer le JSON-LD WebApplication par la grille v2 (lignes 152-199)**
+
+Sélectionner exactement le bloc actuel (du `<script type="application/ld+json">` ouvrant ligne 152 jusqu'à son `</script>` fermant ligne 199) et le remplacer par :
+
+```html
+<!-- 🧠 JSON-LD Structured Data — WebApplication (pricing v2 publique) -->
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "DeepSight",
+    "alternateName": "DeepSight Synthesis",
+    "url": "https://www.deepsightsynthesis.com",
+    "description": "Analysez et synthétisez vos vidéos YouTube et TikTok avec l'IA. Synthèses sourcées, fact-checking nuancé, flashcards FSRS, chat contextuel, voice agent. 100% européen, propulsé par Mistral AI.",
+    "applicationCategory": "EducationalApplication",
+    "operatingSystem": "Web, iOS, Android, Chrome",
+    "inLanguage": ["fr", "en"],
+    "offers": [
+      {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "EUR",
+        "name": "Gratuit",
+        "description": "5 analyses/mois, vidéos jusqu'à 15 min, flashcards, quiz, chat contextuel"
+      },
+      {
+        "@type": "Offer",
+        "price": "8.99",
+        "priceCurrency": "EUR",
+        "name": "Pro",
+        "description": "30 analyses/mois, vidéos jusqu'à 2 h, mind maps, fact-check, web search, exports PDF",
+        "priceSpecification": {
+          "@type": "UnitPriceSpecification",
+          "price": "8.99",
+          "priceCurrency": "EUR",
+          "unitText": "MONTH"
+        }
+      },
+      {
+        "@type": "Offer",
+        "price": "19.99",
+        "priceCurrency": "EUR",
+        "name": "Expert",
+        "description": "100 analyses/mois, vidéos jusqu'à 4 h, voice agent ElevenLabs, playlists illimitées, deep research, priority queue",
+        "priceSpecification": {
+          "@type": "UnitPriceSpecification",
+          "price": "19.99",
+          "priceCurrency": "EUR",
+          "unitText": "MONTH"
+        }
+      }
+    ]
+  }
+</script>
+```
+
+Notes :
+
+- `unitText` passe de `"monthly"` (non standard) à `"MONTH"` (UN/CEFACT, recommandé par Schema.org).
+- L'`Organization` JSON-LD juste en dessous (lignes 200-225) reste **inchangé**.
+- Pas d'`aggregateRating` ajouté ici (voir **D1** dans Self-review).
+
+- [ ] **Step 5: Vérification visuelle locale**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run dev
+```
+
+Ouvrir `http://localhost:5173/` puis dans DevTools Console exécuter :
+
+```js
+document
+  .querySelectorAll('script[type="application/ld+json"]')
+  .forEach((s) => console.log(JSON.parse(s.textContent)));
+```
+
+Expected : 2 objets logged. Le premier `WebApplication` doit lister 3 offers avec prix `"0"`, `"8.99"`, `"19.99"` et **aucun** `"4.99"` ou `"9.99"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/index.html
+git commit -m "feat(seo): align index.html WebApplication JSON-LD with pricing v2"
+```
+
+---
+
+### Task 2: Ajouter les headers de sécurité HTTP dans `vercel.json`
+
+**Files:**
+
+- Modify: `frontend/vercel.json:87-167` (extension du tableau `headers`)
+
+**Pourquoi :** L'audit Kimi confirme : aucun header de sécurité (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) n'est présent côté Vercel. Conséquences : XSS plus facile, clickjacking possible, fuite Referer cross-origin, accès géoloc/caméra théoriquement ouvert à tous les iframes. La config Caddy backend a déjà du HSTS — cette task étend la même hygiène au front Vercel.
+
+- [ ] **Step 1: Whitelister tous les services tiers réellement utilisés en prod**
+
+Vérifier rapidement (lecture seule, pour confiance dans la CSP) que les domaines suivants sont bien ceux utilisés. Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+grep -rE "stripe\.com|posthog\.com|sentry\.io|elevenlabs\.io|supabase\.co|crisp\.chat|youtube\.com|tiktok\.com|fonts\.(googleapis|gstatic)\.com" src/ --include="*.ts" --include="*.tsx" --include="*.html" -l | head -20
+```
+
+Expected : voir au moins `index.html` (Google Fonts), un fichier PostHog, un fichier Sentry, un fichier Stripe (`api.ts` ou checkout), et un fichier Crisp si actif. La CSP du Step suivant les whitelist tous.
+
+- [ ] **Step 2: Ajouter l'entrée `headers` globale**
+
+Dans `frontend/vercel.json`, dans le tableau `"headers"` (qui commence ligne 87), insérer **comme première entrée** (avant l'objet `/sitemap.xml` actuel ligne 89), un nouvel objet :
+
+```json
+{
+  "source": "/(.*)",
+  "headers": [
+    {
+      "key": "Content-Security-Policy",
+      "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://*.posthog.com https://eu.i.posthog.com https://*.sentry.io https://browser.sentry-cdn.com https://client.crisp.chat https://settings.crisp.chat; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://client.crisp.chat; img-src 'self' https: data: blob:; font-src 'self' data: https://fonts.gstatic.com https://client.crisp.chat; connect-src 'self' https://api.deepsightsynthesis.com https://*.stripe.com https://*.posthog.com https://eu.i.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://*.elevenlabs.io https://api.elevenlabs.io https://*.supabase.co wss://*.supabase.co https://client.crisp.chat https://wss.relay.crisp.chat wss://client.relay.crisp.chat https://storage.crisp.chat; frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://www.youtube.com https://www.youtube-nocookie.com https://www.tiktok.com https://game.crisp.chat; media-src 'self' https: blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://*.stripe.com; frame-ancestors 'self'; upgrade-insecure-requests"
+    },
+    {
+      "key": "X-Frame-Options",
+      "value": "SAMEORIGIN"
+    },
+    {
+      "key": "X-Content-Type-Options",
+      "value": "nosniff"
+    },
+    {
+      "key": "Referrer-Policy",
+      "value": "strict-origin-when-cross-origin"
+    },
+    {
+      "key": "Permissions-Policy",
+      "value": "camera=(self), microphone=(self), payment=(self), geolocation=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), midi=(), sync-xhr=()"
+    }
+  ]
+}
+```
+
+⚠️ Vercel applique les headers dans l'ordre du tableau. Mettre cette entrée **en tête** garantit qu'elle s'applique avant les entrées spécifiques (qui n'ajoutent que `Cache-Control` et `Content-Type` — donc pas de conflit, juste une priorité claire).
+
+⚠️ La CSP autorise `'unsafe-inline'` et `'unsafe-eval'` pour `script-src`. Justification dans **D2** ci-dessous (Vite 5 prod build, PostHog, Stripe SDK injectent du JS inline). Une migration vers `nonce` ou `hash` est trackée dans le plan jumeau `pricing-v2-stripe-grandfathering` (post-MVP).
+
+- [ ] **Step 3: Validation locale du JSON**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+node -e "console.log(JSON.parse(require('fs').readFileSync('vercel.json','utf8')).headers.length)"
+```
+
+Expected : un nombre supérieur ou égal à `9` (8 entrées existantes + la nouvelle). Si ça plante : erreur de syntaxe JSON dans le fichier — relire avec un linter.
+
+- [ ] **Step 4: Validation CSP avec un parser**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+node -e "
+const csp = JSON.parse(require('fs').readFileSync('vercel.json','utf8')).headers[0].headers.find(h => h.key === 'Content-Security-Policy').value;
+const directives = csp.split(';').map(d => d.trim().split(' ')[0]).filter(Boolean);
+console.log('Directives:', directives);
+console.log('Has frame-ancestors:', directives.includes('frame-ancestors'));
+console.log('Has upgrade-insecure-requests:', directives.includes('upgrade-insecure-requests'));
+"
+```
+
+Expected output (l'ordre peut varier, mais les 3 lignes doivent être imprimées avec `true` pour les deux derniers) :
+
+```
+Directives: [ 'default-src', 'script-src', 'style-src', 'img-src', 'font-src', 'connect-src', 'frame-src', 'media-src', 'worker-src', 'object-src', 'base-uri', 'form-action', 'frame-ancestors', 'upgrade-insecure-requests' ]
+Has frame-ancestors: true
+Has upgrade-insecure-requests: true
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/vercel.json
+git commit -m "feat(security): add CSP and 4 security headers to Vercel config"
+```
+
+---
+
+### Task 3: Corriger la description SEO de `UpgradePage.tsx`
+
+**Files:**
+
+- Modify: `frontend/src/pages/UpgradePage.tsx:1140-1144`
+
+**Pourquoi :** Cette description est servie aux moteurs de recherche et bots IA via Helmet sur `/upgrade`. Elle mentionne actuellement `Plus (4,99€/mois) et Pro (9,99€/mois)` — exactement la grille v0 obsolète. Si on déploie SEO sans corriger ça, on annonce 4,99 € alors que Stripe facturera bientôt 8,99 €.
+
+- [ ] **Step 1: Remplacer la description**
+
+Edit ciblé :
+
+```tsx
+<SEO
+  title="Tarifs"
+  description="Découvrez les plans DeepSight : Gratuit, Pro (8,99 €/mois) et Expert (19,99 €/mois). Analysez vos vidéos YouTube et TikTok avec l'IA, fact-checking nuancé et voice agent."
+  path="/upgrade"
+/>
+```
+
+Remplace exactement (lignes 1140-1144) :
+
+```tsx
+<SEO
+  title="Tarifs"
+  description="Découvrez les plans DeepSight : Gratuit, Plus (4,99€/mois) et Pro (9,99€/mois). Analysez vos vidéos YouTube et TikTok avec l'IA."
+  path="/upgrade"
+/>
+```
+
+- [ ] **Step 2: Vérifier qu'il ne reste plus aucun ancien prix dans le fichier**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+grep -nE "4[,.]99|9[,.]99" src/pages/UpgradePage.tsx | grep -v "^\s*\*" || echo "OK aucun reste v0"
+```
+
+Expected : `OK aucun reste v0`. Si des occurrences sortent : contexte → prix Stripe v1 actuel (5,99 € / 14,99 €) — laisser tel quel, il sera traité par le plan jumeau `pricing-v2-stripe-grandfathering`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/UpgradePage.tsx
+git commit -m "fix(seo): update UpgradePage SEO description to pricing v2"
+```
+
+---
+
+### Task 4: Créer `<ProductJsonLd>` en TDD (test d'abord)
+
+**Files:**
+
+- Create: `frontend/src/components/__tests__/ProductJsonLd.test.tsx`
+- Create: `frontend/src/components/ProductJsonLd.tsx`
+
+**Pourquoi :** L'audit Kimi note l'absence de schema `Product` + `Offer` sur `/upgrade`. Ce schema permet à Google et aux LLMs (Perplexity, ChatGPT) de comprendre le catalogue tarifaire. On suit le pattern `BreadcrumbJsonLd` : un composant React minimal qui émet un `<script type="application/ld+json">` via Helmet, et exporte une fonction pure `buildProductJsonLd()` testable sans render.
+
+- [ ] **Step 1: Créer le fichier de test (failing) — `frontend/src/components/__tests__/ProductJsonLd.test.tsx`**
+
+```tsx
+/**
+ * 🧪 ProductJsonLd Tests — Schema.org Product + Offers (pricing v2)
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildProductJsonLd } from "../ProductJsonLd";
+
+describe("buildProductJsonLd", () => {
+  it("returns a Schema.org Product object with the right @context and @type", () => {
+    const jsonLd = buildProductJsonLd();
+    expect(jsonLd["@context"]).toBe("https://schema.org");
+    expect(jsonLd["@type"]).toBe("Product");
+    expect(jsonLd.name).toBe("DeepSight");
+  });
+
+  it("exposes exactly 3 offers (Free, Pro, Expert)", () => {
+    const jsonLd = buildProductJsonLd();
+    expect(Array.isArray(jsonLd.offers)).toBe(true);
+    expect(jsonLd.offers).toHaveLength(3);
+    const names = jsonLd.offers.map((o) => o.name);
+    expect(names).toEqual(["Gratuit", "Pro", "Expert"]);
+  });
+
+  it("uses pricing v2: Pro = 8.99 EUR/month", () => {
+    const jsonLd = buildProductJsonLd();
+    const proOffer = jsonLd.offers.find((o) => o.name === "Pro");
+    expect(proOffer).toBeDefined();
+    expect(proOffer!.price).toBe("8.99");
+    expect(proOffer!.priceCurrency).toBe("EUR");
+    expect(proOffer!.priceSpecification.unitText).toBe("MONTH");
+  });
+
+  it("uses pricing v2: Expert = 19.99 EUR/month", () => {
+    const jsonLd = buildProductJsonLd();
+    const expertOffer = jsonLd.offers.find((o) => o.name === "Expert");
+    expect(expertOffer).toBeDefined();
+    expect(expertOffer!.price).toBe("19.99");
+    expect(expertOffer!.priceCurrency).toBe("EUR");
+    expect(expertOffer!.priceSpecification.unitText).toBe("MONTH");
+  });
+
+  it("does NOT contain any v0 legacy price (4.99 or 9.99)", () => {
+    const serialized = JSON.stringify(buildProductJsonLd());
+    expect(serialized).not.toContain("4.99");
+    expect(serialized).not.toContain("9.99");
+  });
+});
+```
+
+- [ ] **Step 2: Lancer le test pour vérifier l'échec attendu**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npx vitest run src/components/__tests__/ProductJsonLd.test.tsx
+```
+
+Expected : FAIL — `Cannot find module '../ProductJsonLd'` (ou équivalent). Le fichier n'existe pas encore.
+
+- [ ] **Step 3: Créer le composant et la fonction pure — `frontend/src/components/ProductJsonLd.tsx`**
+
+```tsx
+import { Helmet } from "react-helmet-async";
+
+const SITE_URL = "https://www.deepsightsynthesis.com";
+
+/**
+ * Schéma TypeScript du JSON-LD Product Schema.org émis par ce composant.
+ * Volontairement strict pour que les tests valident la grille tarifaire.
+ */
+interface ProductOffer {
+  "@type": "Offer";
+  name: string;
+  price: string;
+  priceCurrency: "EUR";
+  description: string;
+  priceSpecification: {
+    "@type": "UnitPriceSpecification";
+    price: string;
+    priceCurrency: "EUR";
+    unitText: "MONTH";
+  };
+}
+
+interface ProductJsonLdShape {
+  "@context": "https://schema.org";
+  "@type": "Product";
+  name: string;
+  description: string;
+  brand: { "@type": "Brand"; name: string };
+  url: string;
+  offers: ProductOffer[];
+}
+
+/**
+ * Construit le JSON-LD Product+Offers correspondant à la grille pricing v2 publique
+ * (Gratuit, Pro 8,99 €/mois, Expert 19,99 €/mois).
+ *
+ * Exporté pour permettre des tests purs (sans render React).
+ */
+export const buildProductJsonLd = (): ProductJsonLdShape => ({
+  "@context": "https://schema.org",
+  "@type": "Product",
+  name: "DeepSight",
+  description:
+    "Plateforme SaaS d'analyse de vidéos YouTube et TikTok par IA. Synthèses sourcées, fact-checking nuancé, flashcards FSRS, chat contextuel, voice agent.",
+  brand: { "@type": "Brand", name: "DeepSight" },
+  url: `${SITE_URL}/upgrade`,
+  offers: [
+    {
+      "@type": "Offer",
+      name: "Gratuit",
+      price: "0",
+      priceCurrency: "EUR",
+      description:
+        "5 analyses/mois, vidéos jusqu'à 15 min, flashcards, quiz, chat contextuel.",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: "0",
+        priceCurrency: "EUR",
+        unitText: "MONTH",
+      },
+    },
+    {
+      "@type": "Offer",
+      name: "Pro",
+      price: "8.99",
+      priceCurrency: "EUR",
+      description:
+        "30 analyses/mois, vidéos jusqu'à 2 h, mind maps, fact-check, web search, exports PDF.",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: "8.99",
+        priceCurrency: "EUR",
+        unitText: "MONTH",
+      },
+    },
+    {
+      "@type": "Offer",
+      name: "Expert",
+      price: "19.99",
+      priceCurrency: "EUR",
+      description:
+        "100 analyses/mois, vidéos jusqu'à 4 h, voice agent ElevenLabs, playlists illimitées, deep research, priority queue.",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: "19.99",
+        priceCurrency: "EUR",
+        unitText: "MONTH",
+      },
+    },
+  ],
+});
+
+/**
+ * Émet le JSON-LD Product+Offers dans le `<head>` via Helmet.
+ *
+ * Usage :
+ *   <ProductJsonLd />
+ *
+ * Pattern aligné sur BreadcrumbJsonLd.tsx.
+ */
+export const ProductJsonLd = () => {
+  const jsonLd = buildProductJsonLd();
+  return (
+    <Helmet>
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
+  );
+};
+```
+
+- [ ] **Step 4: Relancer le test pour vérifier le passage**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npx vitest run src/components/__tests__/ProductJsonLd.test.tsx
+```
+
+Expected : 5 tests passent en vert (`5 passed`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/ProductJsonLd.tsx frontend/src/components/__tests__/ProductJsonLd.test.tsx
+git commit -m "feat(seo): add ProductJsonLd component with pricing v2 offers (TDD)"
+```
+
+---
+
+### Task 5: Monter `<ProductJsonLd />` dans `UpgradePage.tsx`
+
+**Files:**
+
+- Modify: `frontend/src/pages/UpgradePage.tsx` (import en tête + render ligne ~1145)
+
+**Pourquoi :** Le composant n'a aucun effet tant qu'il n'est pas rendu. Il faut l'ajouter à `/upgrade` à côté de `<BreadcrumbJsonLd path="/upgrade" />`.
+
+- [ ] **Step 1: Repérer la ligne d'import existante de `BreadcrumbJsonLd`**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+grep -n "BreadcrumbJsonLd" src/pages/UpgradePage.tsx
+```
+
+Expected : 2 lignes (un import en haut + un usage ligne 1145). Noter le numéro de la ligne d'import — on s'en sert au step suivant.
+
+- [ ] **Step 2: Ajouter l'import**
+
+À la suite immédiate de la ligne d'import existante de `BreadcrumbJsonLd`, insérer :
+
+```tsx
+import { ProductJsonLd } from "../components/ProductJsonLd";
+```
+
+⚠️ Si l'import existant utilise un alias `@/components/...`, refléter le même style ; sinon utiliser le chemin relatif `../components/ProductJsonLd` comme ci-dessus pour rester cohérent avec le pattern des imports voisins de cette page.
+
+- [ ] **Step 3: Mounter `<ProductJsonLd />` à côté de `<BreadcrumbJsonLd path="/upgrade" />`**
+
+Edit :
+
+```tsx
+      <BreadcrumbJsonLd path="/upgrade" />
+      <ProductJsonLd />
+```
+
+Remplace (autour de la ligne 1145, après la fin du bloc `<SEO ... />`) :
+
+```tsx
+<BreadcrumbJsonLd path="/upgrade" />
+```
+
+- [ ] **Step 4: Vérification typecheck + tests existants**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run typecheck
+```
+
+Expected : pas d'erreur. Si `tsc` reporte une erreur dans `UpgradePage.tsx` liée à un import : refixer le chemin (alias vs relatif).
+
+Run aussi :
+
+```bash
+npx vitest run src/components/__tests__/ProductJsonLd.test.tsx
+```
+
+Expected : 5 tests passent (sécurité — assure que rien n'a régressé).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/UpgradePage.tsx
+git commit -m "feat(seo): mount ProductJsonLd on /upgrade page"
+```
+
+---
+
+### Task 6: Vérification finale (build + grep absence prix v0/v1 + post-deploy)
+
+**Files:** Aucun — c'est uniquement de la vérification build + post-deploy.
+
+- [ ] **Step 1: Build production complet**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run build
+```
+
+Expected : build success, taille bundle similaire à la dernière version. Aucune erreur ni warning bloquant.
+
+- [ ] **Step 2: Vérifier absence des prix v0 dans le HTML buildé**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+grep -nE "\"4\.99\"|\"9\.99\"" dist/index.html && echo "FAIL: ancien prix v0 détecté" || echo "OK aucun prix v0"
+```
+
+Expected : `OK aucun prix v0`. Si on trouve `"4.99"` ou `"9.99"` : retour à Task 1 — un endroit a été oublié.
+
+- [ ] **Step 3: Vérifier présence des prix v2 dans le HTML buildé**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+grep -E "\"8\.99\"|\"19\.99\"" dist/index.html | head -3
+```
+
+Expected : au moins 2 lignes — une mentionnant `"8.99"`, une `"19.99"` (à l'intérieur du JSON-LD WebApplication).
+
+- [ ] **Step 4: Lancer la suite de tests Vitest**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run test
+```
+
+Expected : tous les tests passent (incluant les 5 nouveaux de `ProductJsonLd.test.tsx`). Si une régression apparaît dans un test sans rapport (ex : `CookieBanner.test.tsx`), c'est probablement pré-existant — valider avec `git stash` + relance pour confirmer.
+
+- [ ] **Step 5: Vérifier le contenu de `vercel.json` une dernière fois**
+
+Run :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+node -e "
+const cfg = JSON.parse(require('fs').readFileSync('vercel.json','utf8'));
+const global = cfg.headers.find(h => h.source === '/(.*)');
+if (!global) { console.error('FAIL: pas de headers globaux'); process.exit(1); }
+const keys = global.headers.map(h => h.key);
+const required = ['Content-Security-Policy', 'X-Frame-Options', 'X-Content-Type-Options', 'Referrer-Policy', 'Permissions-Policy'];
+const missing = required.filter(k => !keys.includes(k));
+if (missing.length) { console.error('FAIL missing:', missing); process.exit(1); }
+console.log('OK 5/5 headers sécurité présents');
+"
+```
+
+Expected : `OK 5/5 headers sécurité présents`.
+
+- [ ] **Step 6: Commit final (recap, si rien de nouveau ne reste à staged, sauter)**
+
+```bash
+git status
+```
+
+Si pas de fichier modifié, rien à committer ici. Sinon :
+
+```bash
+git add -p
+git commit -m "chore(verify): post-build SEO + security audit checks"
+```
+
+- [ ] **Step 7: Vérification post-déploiement Vercel preview (déclenchement par PR)**
+
+⚠️ **Ne pas exécuter ce step avant d'avoir poussé une PR et que Vercel ait déployé une preview** (ce qui implique d'avoir lu la section **Release coordination** ci-dessous et coordonné avec le plan `pricing-v2-stripe-grandfathering`).
+
+Une fois la preview Vercel disponible (URL du type `https://frontend-v46-cppme-xxx.vercel.app`), depuis n'importe quelle machine :
+
+```bash
+PREVIEW_URL="<URL preview Vercel ici>"
+curl -sI "$PREVIEW_URL/" | grep -iE "content-security-policy|x-frame-options|x-content-type-options|referrer-policy|permissions-policy"
+```
+
+Expected : 5 lignes affichées, une par header. Si un header manque sur la preview : Vercel n'a pas appliqué la nouvelle config — vérifier que le commit Task 2 est bien dans la branche déployée.
+
+Vérifier aussi le JSON-LD :
+
+```bash
+curl -s "$PREVIEW_URL/" | grep -oE '"price":"[^"]*"' | sort -u
+```
+
+Expected : `"price":"0"`, `"price":"8.99"`, `"price":"19.99"`. **Aucune** occurrence de `"4.99"` ou `"9.99"`.
+
+---
+
+## Self-review
+
+### Couverture du spec — checklist Phase 0 audit Kimi
+
+| Bug Phase 0 audité                                                 | Task qui le corrige |
+| ------------------------------------------------------------------ | ------------------- |
+| `index.html` JSON-LD utilise prix v0 (4,99 / 9,99)                 | Task 1 (Step 4)     |
+| `UpgradePage.tsx:1140-1144` description SEO mentionne anciens prix | Task 3              |
+| `index.html` `<title>` statique sans TikTok                        | Task 1 (Step 1)     |
+| Aucun header sécurité dans `vercel.json`                           | Task 2              |
+| Pas de `Product`/`Offer` schema dédié sur `/upgrade`               | Task 4 + Task 5     |
+| Faux positif Kimi « canonisation vers homepage »                   | Documenté en intro  |
+
+Aucun gap.
+
+### Cohérence types/noms
+
+- `buildProductJsonLd()` est utilisé tel quel dans `ProductJsonLd.tsx` (Task 4) et dans le test (Task 4 step 1). Aucun renommage.
+- Le composant `<ProductJsonLd>` (Task 4) est importé en `import { ProductJsonLd } from "../components/ProductJsonLd"` puis monté `<ProductJsonLd />` dans Task 5 — cohérent.
+- Les prix `8.99` et `19.99` sont identiques dans `index.html` (Task 1), `UpgradePage.tsx` description (Task 3), `ProductJsonLd.tsx` (Task 4) et tests (Task 4) — pas de drift numérique.
+- `unitText: "MONTH"` partout (Task 1 + Task 4) — pas de retour au "monthly" non standard de la grille v0.
+
+### Scan placeholders
+
+Recherché : "TBD", "TODO", "implement later", "fill in details", "Add appropriate", "Similar to Task". Aucun trouvé. Tous les steps qui modifient du code montrent le code complet.
+
+### Décisions à confirmer avec l'utilisateur AVANT exécution
+
+- **D1 — `aggregateRating` factice ?** Schema.org `Product` accepte un champ `aggregateRating` qui boost l'apparition dans les résultats Google avec étoiles. Mais on n'a pas encore de système d'avis utilisateur. Trois options :
+  - (a) **Ne pas en mettre** (recommandé — pas de mensonge, pas de risque de pénalité Google "fake reviews")
+  - (b) Mettre une note basée sur les vrais avis Chrome Web Store (à scraper manuellement la première fois)
+  - (c) Préparer le terrain en stockant un endpoint `/api/ratings` côté backend et un widget côté front
+
+- **D2 — `'unsafe-inline'` + `'unsafe-eval'` dans `script-src` ?** Vite 5 prod build inline le CSS critical et certains scripts. PostHog/Stripe/Sentry SDKs injectent aussi du JS inline. Sans ces flags, la CSP cassera l'app en prod. Trois options :
+  - (a) **Garder** `'unsafe-inline' 'unsafe-eval'` (recommandé MVP — la CSP reste utile sur les autres directives)
+  - (b) Migrer vers `nonce` ou `hash` — nécessite hooks Vite + middleware Vercel Edge — gros chantier, à planifier en plan séparé
+  - (c) Tester en `Content-Security-Policy-Report-Only` pendant 7 jours avant de bloquer
+
+- **D3 — Domaines Crisp réellement utilisés ?** La whitelist Crisp inclut `client.crisp.chat`, `wss.relay.crisp.chat`, `wss://client.relay.crisp.chat`, `storage.crisp.chat`, `settings.crisp.chat`, `game.crisp.chat`. Vérifier rapidement si Crisp est encore actif sur le site (sinon : retirer toutes ces entrées pour réduire la surface). Confirmer avec l'utilisateur.
+
+- **D4 — Branche cible.** Le contexte de mission demande `feature/audit-kimi-plans-2026-04-29`. La branche actuelle au moment de la rédaction est `feat/merge-voice-chat-context`. Confirmer avec l'utilisateur :
+  - (a) Créer la nouvelle branche depuis `main` avant Task 1 (recommandé)
+  - (b) Travailler sur la branche actuelle puis cherry-pick (déconseillé — risque de mélange)
+  - (c) Repartir d'un autre point
+
+- **D5 — Coordination release-train.** Voir section dédiée ci-dessous. Confirmer avec l'utilisateur la stratégie : feature flag, branche `release/pricing-v2`, ou release simultanée ?
+
+---
+
+## Release coordination — couplage atomique avec `pricing-v2-stripe-grandfathering`
+
+⚠️ **Ce plan ne doit PAS être déployé seul en production.**
+
+### Risque concret
+
+Si on merge ce plan SEO sans le plan `pricing-v2-stripe-grandfathering` :
+
+- Le HTML public (et JSON-LD ingéré par Google + Perplexity + ChatGPT) annoncera **8,99 €** et **19,99 €**.
+- Stripe continuera à facturer **5,99 €** (Pro v1) et **14,99 €** (Expert v1).
+- L'utilisateur arrive sur `/upgrade`, lit "Pro 8,99 €" dans la fiche Schema.org indexée, clique sur "Upgrade Pro", et passe au checkout Stripe à **5,99 €** → **incohérence prix affiché vs facturé** → pertes de confiance + obligation légale (article L. 121-1 Code conso FR : prix affiché ≠ prix facturé = pratique commerciale trompeuse).
+
+### Stratégie recommandée — release-train `release/pricing-v2`
+
+**Option recommandée :** merger les deux plans dans une **branche d'intégration** `release/pricing-v2` qui ne sera mergée à `main` qu'après validation manuelle des deux halves.
+
+Workflow :
+
+1. Créer `release/pricing-v2` depuis `main`.
+2. PR #N — ce plan SEO (`feature/audit-kimi-plans-2026-04-29`) → cible `release/pricing-v2`. Review + merge.
+3. PR #N+1 — plan jumeau `pricing-v2-stripe-grandfathering` → cible `release/pricing-v2`. Review + merge. Cette PR contient :
+   - Création des Stripe Price IDs `price_pro_v2_899eur_month`, `price_expert_v2_1999eur_month` (annual idem)
+   - Migration Alembic 011 ajoutant `User.is_legacy_pricing BOOLEAN DEFAULT FALSE` et marquant tous les abonnés actuels v1 à `TRUE` (grandfathering)
+   - Backend `BillingService` : si `is_legacy_pricing=True` → retourner Price IDs v1, sinon v2
+   - Frontend `planPrivileges.ts` : afficher les bons prix selon le drapeau renvoyé par `/api/auth/me`
+4. Smoke test sur preview Vercel + sandbox Stripe.
+5. Merge `release/pricing-v2` → `main` lors d'une fenêtre de déploiement coordonnée (ex : un dimanche soir).
+6. Surveillance Sentry + Stripe webhooks pendant 24 h.
+
+### Stratégie alternative — feature flag CSP-friendly
+
+Si la coordination n'est pas possible : exposer la grille v2 derrière un flag PostHog `ff:pricing_v2_public_seo`. Tant que `false`, le code de ce plan ne charge pas le `<ProductJsonLd>` et `index.html` reste en grille v0. Une fois le backend prêt, on flippe le flag → le HTML statique ne change pas (il faut un redeploy Vercel pour ça), donc le flag ne couvre que les composants React. **Pas idéal** — les bots IA cachent index.html.
+
+### Décision à prendre par l'utilisateur (D5)
+
+- (a) **Release-train `release/pricing-v2`** (recommandé)
+- (b) Feature flag PostHog (deuxième choix, partiel)
+- (c) Déployer ce plan seul, immédiatement, et déployer le plan jumeau sous 24 h max (risqué — fenêtre d'incohérence)
+
+---
+
+## Execution Handoff
+
+**Plan complet et sauvegardé dans `docs/superpowers/plans/2026-04-29-audit-kimi-phase-0-seo-securite.md`. Deux options d'exécution :**
+
+**1. Subagent-Driven (recommandé)** — Je dispatche un sous-agent frais par task, je review entre les tasks, itération rapide. Particulièrement adapté ici : 6 tasks indépendantes, faible couplage, audit trail clair.
+
+**2. Inline Execution** — On exécute les tasks dans cette session avec des checkpoints de review.
+
+⚠️ **Avant d'exécuter** : confirmer les 5 décisions D1-D5 (notamment **D4 branche cible** et **D5 release coordination**), sinon on risque le pire scénario : SEO annonçant 8,99 € en prod pendant que Stripe facture encore 5,99 €.
+
+**Quelle approche ?**

--- a/docs/superpowers/plans/2026-04-29-blog-architecture-3-articles.md
+++ b/docs/superpowers/plans/2026-04-29-blog-architecture-3-articles.md
@@ -1,0 +1,2084 @@
+# Blog DeepSight — Architecture + 3 Articles MVP — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter un blog SEO-friendly à DeepSight (`/blog` + `/blog/:slug`) alimenté par des fichiers Markdown locaux + frontmatter JSON, avec 3 articles MVP rédigés (TikTok fact-check, FSRS flashcards, souveraineté numérique).
+
+**Architecture:** Stockage statique (Markdown plain + JSON metadata) dans `frontend/src/content/blog/`. Loader synchrone via `import.meta.glob` (Vite) — articles bundlés au build, zéro appel réseau. Rendu via `react-markdown` + `remark-gfm` (déjà installés). SEO complet : `<SEO>` existant + nouveau `<ArticleJsonLd>` (pattern de `BreadcrumbJsonLd`) + entrées sitemap auto-générées + prerender bot IA via `frontend/api/prerender.ts`.
+
+**Tech Stack:**
+
+- React 18 + TypeScript strict + Vite 5 + Tailwind CSS 3
+- React Router 6 (lazy-loading existant via `lazyWithRetry`)
+- `react-markdown@9` + `remark-gfm@4` (déjà dans `package.json`)
+- `react-helmet-async@2` (SEO via `Helmet`)
+- Framer Motion 12 (animations cards)
+- lucide-react (icônes)
+- Vitest + Testing Library (tests unitaires)
+- Vercel Edge Function `frontend/api/prerender.ts` (prerender bots IA)
+
+---
+
+## Contexte préalable
+
+### Audit Kimi 2026-04-29 — Phase 7
+
+Source : `C:\Users\33667\Documents\prompt-claude-code-v2-real-stack.md` lignes 433-471. Recommandation explicite : « pas de blog → impossible de capter la longue traîne SEO. Architecture blog `/blog` + `/blog/:slug` + 3 articles MVP cibles ("fact-check TikTok", "flashcards FSRS", "souveraineté numérique IA européenne") ».
+
+### État DeepSight — vérifications faites
+
+- `frontend/src/pages/` : aucune page Blog n'existe (à créer).
+- `frontend/src/App.tsx` : routes React Router 6 avec lazy-loading via `lazyWithRetry()` (lignes 282-322). Routes publiques déclarées dans le bloc `<Routes>` lignes 502-983 ; on insérera `/blog` et `/blog/:slug` après `/about` (vers ligne 648).
+- `frontend/src/components/SEO.tsx` : composant `<SEO>` existant avec `title`, `description`, `path`, `image`, `type`, `lang`, `keywords`, `noindex`. Hreflang FR seul pour l'instant. Réutilisable tel quel.
+- `frontend/src/components/BreadcrumbJsonLd.tsx` : pattern Helmet + JSON-LD `BreadcrumbList`. À reproduire pour `<ArticleJsonLd>`.
+- `frontend/package.json` : `react-markdown@9.0.1` + `remark-gfm@4.0.0` déjà installés (ligne 47-50). **Aucune lib MDX**. Pas besoin d'ajouter de dépendance.
+- `frontend/scripts/generate-sitemap.mjs` : génère `frontend/public/sitemap.xml` au prebuild. À étendre avec les slugs blog.
+- `frontend/vercel.json` : rewrites pour bots IA (lignes 14-67) sur `/`, `/about`, `/upgrade`, `/contact` → `/api/prerender?path=...`. À étendre pour `/blog` et `/blog/:slug`.
+- `frontend/api/prerender.ts` : Edge Function rendant HTML simplifié pour bots IA. À étendre avec `PAGES["/blog"]` et un loader dynamique pour `/blog/:slug`.
+- `frontend/src/components/EnrichedMarkdown.tsx` : exemple existant de rendu Markdown via `ReactMarkdown` + `remarkGfm`. Référence pour le composant `<BlogMarkdown>` (plus simple, pas d'épistémique).
+- `frontend/src/__tests__/test-utils.tsx` : `renderWithProviders()` avec `MemoryRouter`, `HelmetProvider`, `LanguageProvider`, `QueryClientProvider`. À utiliser pour les tests Blog.
+- `frontend/public/robots.txt` : `Allow: /` par défaut → blog automatiquement indexable. Pas de modif nécessaire.
+- `frontend/src/i18n/` : FR + EN traductions. **Hors scope MVP** : blog FR seul (décision architecturale dans Self-Review).
+
+### Décision architecturale : Markdown plain + JSON metadata vs MDX
+
+Choix retenu : **Markdown plain + JSON metadata par article**.
+
+- (a) MDX nécessite `@mdx-js/rollup` ou `vite-plugin-mdx` + remark/rehype config + déclarations TS `*.mdx`. Ouvre la porte aux composants React inline mais on n'en a pas besoin pour 3 articles linéaires.
+- (b) Markdown plain + JSON séparé : `import.meta.glob('./content/blog/*.md', { as: 'raw', eager: true })` charge tous les `.md` au build. Pas de plugin Vite, pas de runtime parser exotique. `react-markdown` rend déjà le markdown. Frontmatter via JSON jumeau (`<slug>.json`) pour éviter `gray-matter` et son polyfill `Buffer` côté browser.
+
+Migration MDX possible plus tard si besoin de composants inline (CTA, embeds) sans casser les articles existants.
+
+---
+
+## File Structure
+
+### Fichiers à créer
+
+| Path                                                                             | Responsabilité                                                                                                |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `frontend/src/types/blog.ts`                                                     | Types : `BlogArticleMeta`, `BlogArticle`. Pas de logique.                                                     |
+| `frontend/src/lib/blog.ts`                                                       | Loader articles : `getAllArticles()`, `getArticleBySlug(slug)`, `calculateReadingTime(text)`. Pure functions. |
+| `frontend/src/lib/__tests__/blog.test.ts`                                        | Tests unit du loader (4 tests : load all, by slug, reading time, sort by date).                               |
+| `frontend/src/components/ArticleJsonLd.tsx`                                      | JSON-LD Schema.org `Article` (calque sur `BreadcrumbJsonLd.tsx`).                                             |
+| `frontend/src/components/BlogCard.tsx`                                           | Card listing : image, titre, excerpt, date, tags, reading time. Framer Motion fadeUp.                         |
+| `frontend/src/pages/BlogListPage.tsx`                                            | `/blog` — grid cards, SEO, breadcrumb, hero.                                                                  |
+| `frontend/src/pages/BlogPostPage.tsx`                                            | `/blog/:slug` — article complet, SEO, breadcrumb, ArticleJsonLd, markdown render.                             |
+| `frontend/src/pages/__tests__/BlogListPage.test.tsx`                             | Test rendu liste.                                                                                             |
+| `frontend/src/pages/__tests__/BlogPostPage.test.tsx`                             | Test rendu article + 404.                                                                                     |
+| `frontend/src/content/blog/2026-04-29-fact-check-tiktok.md`                      | Article 1 : 1800-2200 mots.                                                                                   |
+| `frontend/src/content/blog/2026-04-29-fact-check-tiktok.json`                    | Frontmatter article 1.                                                                                        |
+| `frontend/src/content/blog/2026-04-29-flashcards-fsrs-revision-ia.md`            | Article 2 : 2000-2400 mots.                                                                                   |
+| `frontend/src/content/blog/2026-04-29-flashcards-fsrs-revision-ia.json`          | Frontmatter article 2.                                                                                        |
+| `frontend/src/content/blog/2026-04-29-souverainete-numerique-ia-europeenne.md`   | Article 3 : 1800-2200 mots.                                                                                   |
+| `frontend/src/content/blog/2026-04-29-souverainete-numerique-ia-europeenne.json` | Frontmatter article 3.                                                                                        |
+| `frontend/src/content/blog/index.ts`                                             | Re-export des slugs (utile pour le prerender côté Edge si besoin futur).                                      |
+
+### Fichiers à modifier
+
+| Path                                           | Modification                                                                                     |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `frontend/src/App.tsx`                         | Lazy-load `BlogListPage` + `BlogPostPage`. Ajouter routes `/blog` et `/blog/:slug` (publiques).  |
+| `frontend/src/components/BreadcrumbJsonLd.tsx` | Ajouter `"/blog": "Blog"` dans la map `LABELS`.                                                  |
+| `frontend/scripts/generate-sitemap.mjs`        | Lire les frontmatter blog `.json`, ajouter chaque slug dans `ROUTES`.                            |
+| `frontend/vercel.json`                         | Ajouter rewrites prerender `/blog` et `/blog/:slug` pour bots IA + cache headers `/blog/*`.      |
+| `frontend/api/prerender.ts`                    | Ajouter `/blog` (liste) + handler dynamique pour `/blog/:slug` (lit Markdown via fetch interne). |
+
+### Fichiers explicitement non touchés
+
+- `frontend/src/services/api.ts` : aucun appel API (articles statiques).
+- `frontend/src/i18n/{fr,en}.json` : MVP FR only.
+- `mobile/` et `extension/` : hors scope (web-only feature).
+- `backend/` : aucun endpoint backend.
+
+---
+
+## Tasks
+
+### Task 1: Types Blog + dossier content
+
+**Files:**
+
+- Create: `frontend/src/types/blog.ts`
+- Create: `frontend/src/content/blog/.gitkeep`
+- Create: `frontend/src/content/blog/index.ts`
+
+- [ ] **Step 1: Créer le dossier content/blog**
+
+```bash
+mkdir -p "C:/Users/33667/DeepSight-Main/frontend/src/content/blog"
+touch "C:/Users/33667/DeepSight-Main/frontend/src/content/blog/.gitkeep"
+```
+
+- [ ] **Step 2: Écrire les types**
+
+Fichier `frontend/src/types/blog.ts` :
+
+```typescript
+/**
+ * Types pour le blog DeepSight.
+ * Les articles sont stockés en .md (contenu) + .json (frontmatter).
+ */
+
+export interface BlogArticleMeta {
+  /** Slug URL (ex: "fact-check-tiktok") — sans préfixe date, dérivé du nom de fichier. */
+  slug: string;
+  /** Titre lisible pour SEO + UI. */
+  title: string;
+  /** Résumé 140-220 caractères pour cards et meta description. */
+  description: string;
+  /** Date ISO 8601 de publication (ex: "2026-04-29"). */
+  publishedAt: string;
+  /** Date ISO 8601 de dernière modification (optionnel). */
+  updatedAt?: string;
+  /** Auteur de l'article. */
+  author: string;
+  /** Tags / catégories (3-5 max). */
+  tags: string[];
+  /** Mots-clés SEO (séparés par virgule dans la balise meta). */
+  keywords: string;
+  /** Image OG/cover (chemin absolu sous /public). */
+  coverImage: string;
+  /** Image OG sociale (1200x630), souvent identique à coverImage. */
+  ogImage?: string;
+}
+
+export interface BlogArticle {
+  meta: BlogArticleMeta;
+  /** Contenu Markdown brut, sans frontmatter. */
+  content: string;
+  /** Reading time en minutes (calculé). */
+  readingTime: number;
+}
+```
+
+- [ ] **Step 3: Écrire l'index re-export**
+
+Fichier `frontend/src/content/blog/index.ts` :
+
+```typescript
+/**
+ * Re-export des articles blog.
+ * Le loader réel utilise import.meta.glob côté frontend/src/lib/blog.ts —
+ * ce fichier sert uniquement de marqueur pour TypeScript.
+ */
+export {};
+```
+
+- [ ] **Step 4: Vérifier la compilation TS**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: PASS (zéro erreur sur les nouveaux fichiers).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/types/blog.ts frontend/src/content/blog/.gitkeep frontend/src/content/blog/index.ts && git commit -m "feat(blog): add BlogArticle types and content directory"
+```
+
+---
+
+### Task 2: Blog loader (TDD)
+
+**Files:**
+
+- Create: `frontend/src/lib/blog.ts`
+- Create: `frontend/src/lib/__tests__/blog.test.ts`
+
+- [ ] **Step 1: Écrire le test failing**
+
+Fichier `frontend/src/lib/__tests__/blog.test.ts` :
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+
+// Mock Vite import.meta.glob avant import du module testé
+vi.mock("../blog-glob", () => ({
+  rawMarkdown: {
+    "./2026-04-29-test-article.md":
+      "# Test Article\n\nThis is a paragraph with some words to count for reading time.",
+  },
+  rawMeta: {
+    "./2026-04-29-test-article.json": JSON.stringify({
+      slug: "test-article",
+      title: "Test Article",
+      description: "Description test",
+      publishedAt: "2026-04-29",
+      author: "DeepSight",
+      tags: ["test"],
+      keywords: "test, article",
+      coverImage: "/blog/test-article-cover.webp",
+    }),
+  },
+}));
+
+import {
+  getAllArticles,
+  getArticleBySlug,
+  calculateReadingTime,
+} from "../blog";
+
+describe("blog loader", () => {
+  it("returns all articles sorted by publishedAt desc", () => {
+    const articles = getAllArticles();
+    expect(articles).toHaveLength(1);
+    expect(articles[0].meta.slug).toBe("test-article");
+  });
+
+  it("returns the article matching the slug", () => {
+    const article = getArticleBySlug("test-article");
+    expect(article).not.toBeNull();
+    expect(article?.meta.title).toBe("Test Article");
+  });
+
+  it("returns null for unknown slug", () => {
+    expect(getArticleBySlug("unknown")).toBeNull();
+  });
+
+  it("calculates reading time at 200 wpm minimum 1 minute", () => {
+    expect(calculateReadingTime("hello")).toBe(1);
+    const long = "word ".repeat(500);
+    expect(calculateReadingTime(long)).toBe(3); // 500/200 = 2.5 → ceil 3
+  });
+});
+```
+
+- [ ] **Step 2: Run test pour vérifier qu'il échoue**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npx vitest run src/lib/__tests__/blog.test.ts`
+Expected: FAIL — "Cannot find module ../blog" ou similaire.
+
+- [ ] **Step 3: Écrire le wrapper glob (séparé pour testabilité)**
+
+Fichier `frontend/src/lib/blog-glob.ts` :
+
+```typescript
+/**
+ * Wrapper autour de import.meta.glob, isolé pour permettre le mock dans les tests.
+ * Vite remplace ces appels au build par les contenus eager-importés.
+ */
+
+export const rawMarkdown = import.meta.glob("../content/blog/*.md", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+export const rawMeta = import.meta.glob("../content/blog/*.json", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+```
+
+- [ ] **Step 4: Écrire le loader minimal qui fait passer les tests**
+
+Fichier `frontend/src/lib/blog.ts` :
+
+````typescript
+import type { BlogArticle, BlogArticleMeta } from "../types/blog";
+import { rawMarkdown, rawMeta } from "./blog-glob";
+
+const WORDS_PER_MINUTE = 200;
+
+/**
+ * Calcule le reading time en minutes (arrondi vers le haut, minimum 1).
+ * Compte les mots via split sur whitespace, ignore les caractères de markdown.
+ */
+export function calculateReadingTime(markdown: string): number {
+  const text = markdown
+    .replace(/```[\s\S]*?```/g, " ") // strip code blocks
+    .replace(/[#>*_`~\[\]\(\)!]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const words = text.length === 0 ? 0 : text.split(" ").length;
+  return Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
+}
+
+/**
+ * Extrait le slug depuis un chemin de fichier ./AAAA-MM-JJ-slug.md → "slug".
+ */
+function pathToSlug(path: string): string {
+  const filename = path.split("/").pop() ?? "";
+  const noExt = filename.replace(/\.(md|json)$/, "");
+  // Strip date prefix YYYY-MM-DD-
+  return noExt.replace(/^\d{4}-\d{2}-\d{2}-/, "");
+}
+
+/**
+ * Charge tous les articles depuis frontend/src/content/blog/*.{md,json}.
+ * Triés par publishedAt descendant (plus récent en premier).
+ */
+export function getAllArticles(): BlogArticle[] {
+  const articles: BlogArticle[] = [];
+
+  for (const [mdPath, mdContent] of Object.entries(rawMarkdown)) {
+    const slug = pathToSlug(mdPath);
+    const jsonPath = mdPath.replace(/\.md$/, ".json");
+    const jsonRaw = rawMeta[jsonPath];
+    if (!jsonRaw) {
+      // eslint-disable-next-line no-console
+      console.warn(`[blog] Missing frontmatter JSON for ${mdPath}`);
+      continue;
+    }
+    let meta: BlogArticleMeta;
+    try {
+      meta = JSON.parse(jsonRaw) as BlogArticleMeta;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`[blog] Invalid JSON for ${jsonPath}`, err);
+      continue;
+    }
+    if (meta.slug !== slug) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[blog] Slug mismatch in ${jsonPath}: file=${slug}, json=${meta.slug}`,
+      );
+    }
+    articles.push({
+      meta,
+      content: mdContent,
+      readingTime: calculateReadingTime(mdContent),
+    });
+  }
+
+  articles.sort((a, b) => (a.meta.publishedAt < b.meta.publishedAt ? 1 : -1));
+
+  return articles;
+}
+
+/**
+ * Retourne un article par son slug, ou null si introuvable.
+ */
+export function getArticleBySlug(slug: string): BlogArticle | null {
+  const all = getAllArticles();
+  return all.find((a) => a.meta.slug === slug) ?? null;
+}
+````
+
+- [ ] **Step 5: Run test pour vérifier le passage**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npx vitest run src/lib/__tests__/blog.test.ts`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/lib/blog.ts frontend/src/lib/blog-glob.ts frontend/src/lib/__tests__/blog.test.ts && git commit -m "feat(blog): add markdown loader with reading time calculation"
+```
+
+---
+
+### Task 3: ArticleJsonLd component
+
+**Files:**
+
+- Create: `frontend/src/components/ArticleJsonLd.tsx`
+
+- [ ] **Step 1: Écrire le composant**
+
+Fichier `frontend/src/components/ArticleJsonLd.tsx` :
+
+```typescript
+import { Helmet } from "react-helmet-async";
+import type { BlogArticleMeta } from "../types/blog";
+
+const SITE_URL = "https://www.deepsightsynthesis.com";
+const ORG_NAME = "DeepSight";
+const ORG_LOGO = `${SITE_URL}/icons/icon-512x512.png`;
+
+interface ArticleJsonLdProps {
+  meta: BlogArticleMeta;
+  /** Reading time en minutes — pour timeRequired Schema.org. */
+  readingTime: number;
+}
+
+/**
+ * Émet un JSON-LD Schema.org Article dans <head> via Helmet.
+ * Suit le pattern de BreadcrumbJsonLd.tsx.
+ *
+ * Usage :
+ *   <ArticleJsonLd meta={article.meta} readingTime={article.readingTime} />
+ */
+export const ArticleJsonLd = ({ meta, readingTime }: ArticleJsonLdProps) => {
+  const url = `${SITE_URL}/blog/${meta.slug}`;
+  const image = meta.ogImage
+    ? `${SITE_URL}${meta.ogImage}`
+    : `${SITE_URL}${meta.coverImage}`;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: meta.title,
+    description: meta.description,
+    image,
+    datePublished: meta.publishedAt,
+    dateModified: meta.updatedAt ?? meta.publishedAt,
+    author: {
+      "@type": "Person",
+      name: meta.author,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: ORG_NAME,
+      logo: {
+        "@type": "ImageObject",
+        url: ORG_LOGO,
+      },
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+    keywords: meta.keywords,
+    articleSection: meta.tags.join(", "),
+    timeRequired: `PT${readingTime}M`,
+    inLanguage: "fr-FR",
+  };
+
+  return (
+    <Helmet>
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
+  );
+};
+```
+
+- [ ] **Step 2: Vérifier compile**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/components/ArticleJsonLd.tsx && git commit -m "feat(blog): add ArticleJsonLd Schema.org component"
+```
+
+---
+
+### Task 4: BlogCard component
+
+**Files:**
+
+- Create: `frontend/src/components/BlogCard.tsx`
+
+- [ ] **Step 1: Écrire le composant**
+
+Fichier `frontend/src/components/BlogCard.tsx` :
+
+```typescript
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import { Calendar, Clock, Tag } from "lucide-react";
+import type { BlogArticleMeta } from "../types/blog";
+
+interface BlogCardProps {
+  meta: BlogArticleMeta;
+  readingTime: number;
+  /** Index pour le stagger animation. */
+  index?: number;
+}
+
+const formatDate = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleDateString("fr-FR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+};
+
+export const BlogCard = ({ meta, readingTime, index = 0 }: BlogCardProps) => {
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: index * 0.06 }}
+      className="group h-full"
+    >
+      <Link
+        to={`/blog/${meta.slug}`}
+        className="block h-full rounded-2xl bg-white/5 border border-white/10 backdrop-blur-xl overflow-hidden hover:border-white/20 hover:bg-white/[0.07] transition-all duration-200"
+      >
+        <div className="aspect-[16/9] overflow-hidden bg-gradient-to-br from-indigo-500/20 to-violet-500/20">
+          <img
+            src={meta.coverImage}
+            alt={meta.title}
+            loading="lazy"
+            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+            onError={(e) => {
+              // Si l'image n'existe pas encore, masquer pour ne pas casser le layout
+              (e.currentTarget as HTMLImageElement).style.display = "none";
+            }}
+          />
+        </div>
+        <div className="p-6 flex flex-col gap-3">
+          <div className="flex items-center gap-3 text-xs text-text-secondary">
+            <span className="flex items-center gap-1.5">
+              <Calendar className="w-3.5 h-3.5" />
+              {formatDate(meta.publishedAt)}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Clock className="w-3.5 h-3.5" />
+              {readingTime} min
+            </span>
+          </div>
+          <h2 className="text-xl font-semibold text-text-primary group-hover:text-accent-primary transition-colors">
+            {meta.title}
+          </h2>
+          <p className="text-sm text-text-secondary line-clamp-3">
+            {meta.description}
+          </p>
+          {meta.tags.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-2">
+              {meta.tags.slice(0, 3).map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-white/5 border border-white/10 text-text-secondary"
+                >
+                  <Tag className="w-3 h-3" />
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </Link>
+    </motion.article>
+  );
+};
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/components/BlogCard.tsx && git commit -m "feat(blog): add BlogCard listing component with framer motion"
+```
+
+---
+
+### Task 5: Article 1 — Fact-check TikTok
+
+**Files:**
+
+- Create: `frontend/src/content/blog/2026-04-29-fact-check-tiktok.md`
+- Create: `frontend/src/content/blog/2026-04-29-fact-check-tiktok.json`
+
+- [ ] **Step 1: Écrire le frontmatter JSON**
+
+Fichier `frontend/src/content/blog/2026-04-29-fact-check-tiktok.json` :
+
+```json
+{
+  "slug": "fact-check-tiktok",
+  "title": "Comment vérifier une information sur TikTok en 3 étapes",
+  "description": "Deepfakes, citations sorties de contexte, statistiques inventées : TikTok concentre tous les pièges désinformationnels. Voici la méthode en 3 étapes pour fact-checker une vidéo en moins de 2 minutes.",
+  "publishedAt": "2026-04-29",
+  "author": "DeepSight",
+  "tags": ["Fact-checking", "TikTok", "Pensée critique"],
+  "keywords": "fact check tiktok, vérifier tiktok, fact-checking video, désinformation tiktok, deepfake détection",
+  "coverImage": "/blog/fact-check-tiktok-cover.webp",
+  "ogImage": "/blog/fact-check-tiktok-cover.webp"
+}
+```
+
+- [ ] **Step 2: Écrire l'article complet**
+
+Fichier `frontend/src/content/blog/2026-04-29-fact-check-tiktok.md` :
+
+```markdown
+# Comment vérifier une information sur TikTok en 3 étapes
+
+Une vidéo de 38 secondes affirmant qu'un médecin a découvert que telle plante guérit le cancer. 4,2 millions de vues. Des centaines de commentaires "merci, je vais essayer". Le problème : la plante en question n'a jamais fait l'objet d'aucune étude clinique sérieuse, et la "Dr. Martinez" qui parle dans la vidéo n'existe pas. C'est une voix générée par IA superposée à des images de stock.
+
+TikTok est devenu, en quelques années, l'un des principaux vecteurs de désinformation pour les moins de 35 ans. Pas parce que les utilisateurs sont crédules — la majorité l'est moins qu'on le pense — mais parce que **le format de la plateforme est conçu contre la vérification**. Format court, défilement infini, algorithme qui récompense l'émotion plutôt que la nuance, citations sorties de contexte, montage rapide qui empêche le doute. Vérifier prend du temps. Croire est instantané.
+
+Cet article propose une méthode en trois étapes, applicable en moins de deux minutes, pour fact-checker une vidéo TikTok avant de la croire ou de la partager.
+
+## Étape 1 — Visionner avec attention en repérant les timecodes critiques
+
+La première étape n'est ni technique ni externe. Elle consiste à **revoir la vidéo une seconde fois** en posant trois questions précises.
+
+**Question 1 : qui parle ?** Une personne identifiée, citée nommément, dont on peut vérifier l'identité ailleurs ? Ou une voix anonyme avec une étiquette vague ("un expert", "une scientifique", "un ancien employé de Google") ? Si la source ne peut pas être nommée, la vidéo a déjà perdu 80% de sa crédibilité.
+
+**Question 2 : quelle est l'affirmation centrale ?** Reformulez la thèse en une phrase. "Le sucre cause Alzheimer" est une affirmation claire, vérifiable. "Tout ce qu'on nous a dit sur l'alimentation est un mensonge" est une affirmation rhétorique non falsifiable — donc inutile à fact-checker, simplement à ignorer.
+
+**Question 3 : quels timecodes contiennent les éléments factuels ?** Notez-les. Par exemple : "à 0:14, elle dit qu'une étude de Harvard de 2019 a prouvé X". Ces timecodes sont vos points d'ancrage pour les étapes suivantes.
+
+Ce travail prend 30 à 60 secondes. Il transforme un message émotionnel et fluide en une liste de claims précis. C'est exactement ce que la plateforme essaie d'empêcher en gardant votre attention en flux continu.
+
+### Le piège du montage rapide
+
+TikTok est massivement utilisé pour citer des extraits de vidéos plus longues — interviews, conférences, podcasts. Un orateur peut dire pendant une heure "X est probable mais nuancé par Y et Z", et un éditeur extrait les 4 secondes où il dit "X est probable". Sortie de son contexte, la phrase devient une affirmation tranchée.
+
+**Réflexe à acquérir** : si une vidéo cite quelqu'un en 5-15 secondes, considérez par défaut que le contexte manque. Le bénéfice du doute va au contexte original, pas au montage.
+
+## Étape 2 — Croiser avec au moins deux sources externes indépendantes
+
+Une fois la thèse identifiée, le fact-check démarre. La règle d'or : **ne jamais valider une information à partir d'une seule source secondaire**. Pas même une seule grande source. Le minimum est deux sources indépendantes l'une de l'autre.
+
+### Hiérarchie des sources
+
+1. **Source primaire** : étude scientifique, document officiel, transcription complète, vidéo originale non éditée. C'est l'idéal mais souvent inaccessible en 2 minutes.
+2. **Source secondaire fiable** : article d'un média de qualité (Le Monde, AP, Reuters, BBC, AFP Factuel) qui cite et résume la source primaire.
+3. **Source tertiaire** : Wikipédia, blogs spécialisés, posts d'experts identifiés sur LinkedIn ou Twitter/X.
+
+Si aucun média de qualité n'a couvert l'affirmation centrale d'une vidéo TikTok virale prétendant révéler un scandale d'État, **ce n'est pas parce que les médias censurent**. C'est parce que la "révélation" est généralement fausse, recyclée, ou totalement décontextualisée.
+
+### Outils gratuits de fact-checking pour TikTok
+
+Quelques ressources concrètes :
+
+- **AFP Factuel** (factuel.afp.com) — couvre la francophonie, archive de fact-checks consultable.
+- **Snopes** (snopes.com) — anglophone, vétéran, excellent sur les rumeurs virales.
+- **Les Décodeurs du Monde** — fact-checks réguliers, ton sobre.
+- **Politifact** — pour les claims politiques, surtout US.
+- **Recherche inversée d'image** : Google Images, TinEye, Yandex Images. Pour vérifier si une image utilisée dans la vidéo a été détournée d'un contexte plus ancien.
+
+Pour les claims scientifiques spécifiques (médecine, climat, alimentation), allez directement sur **PubMed** (pubmed.ncbi.nlm.nih.gov) ou **Google Scholar**. Si une "étude de Harvard de 2019 sur le sucre et Alzheimer" est mentionnée, vous pouvez la chercher en 30 secondes avec les mots-clés. Si rien ne sort, l'étude n'existe probablement pas.
+
+### Détecter une voix ou un visage généré par IA
+
+Avec l'arrivée des deepfakes vocaux et vidéo, une nouvelle classe de vérifications devient nécessaire. Quelques signaux :
+
+- **Voix uniformément posée** sans hésitation, sans souffle, sans variation émotionnelle naturelle.
+- **Visage figé** au niveau du front, des oreilles, ou de la zone autour du cou (les modèles génératifs font moins bien sur les marges du visage que sur les yeux et la bouche).
+- **Synchronisation labiale imparfaite** sur les consonnes labiales (P, B, M).
+- **Absence totale de l'orateur sur d'autres plateformes** — un médecin ou expert réel a un profil LinkedIn, des publications, des conférences sur YouTube. Une recherche par nom donne quelque chose. Une voix IA inventée ne donne rien.
+
+Plusieurs outils gratuits existent pour analyser une vidéo suspecte : **Deepware Scanner**, **Hive Moderation Demo**, et plus récemment **Truepic**. Aucun n'est parfait, mais ils donnent une probabilité utile.
+
+## Étape 3 — Utiliser un outil d'analyse vidéo IA pour gagner du temps
+
+Vérifier manuellement une vidéo TikTok prend 5 à 10 minutes quand on est rigoureux. Quand on en consomme 50 par jour, c'est impraticable. C'est précisément pour cela que **DeepSight** existe : transformer une vidéo en analyse structurée et vérifiable en quelques secondes.
+
+Le principe : vous collez l'URL TikTok (ou YouTube), DeepSight extrait la transcription, identifie les affirmations factuelles, les soumet à un fact-checking automatisé qui chaîne **Mistral Agent → Perplexity → Brave Search**, et renvoie une analyse avec quatre marqueurs épistémiques :
+
+- **SOLIDE** — consensus scientifique, sources convergentes.
+- **PLAUSIBLE** — probable mais à confirmer.
+- **INCERTAIN** — hypothèse, débat actif.
+- **À VÉRIFIER** — affirmation douteuse ou non sourcée.
+
+Chaque marqueur est accompagné de ses sources externes vérifiables. Vous n'avez pas à faire confiance à DeepSight aveuglément — vous avez les liens, vous les vérifiez en un clic.
+
+C'est aussi pour ça que **DeepSight est 100% européen** : analyses propulsées par Mistral AI (Paris), hébergement Hetzner (Falkenstein, Allemagne), conformité RGPD native. Pas de revente de données, pas de tracking publicitaire. Voir l'article [Souveraineté numérique : pourquoi une IA européenne ?](/blog/souverainete-numerique-ia-europeenne) pour les enjeux complets.
+
+[Essayer DeepSight gratuitement](/upgrade) — 5 analyses par mois sur le plan Free, sans carte bancaire.
+
+### Cas concret : vérifier une vidéo "santé" en 2 minutes
+
+Imaginons la vidéo introductive de cet article — la "Dr. Martinez" qui guérit le cancer avec une plante.
+
+1. **Étape 1** (30 s) : nom mentionné = "Dr. Martinez", affirmation centrale = "X plante guérit Y cancer", timecode clé = 0:23. Aucune institution citée.
+2. **Étape 2** (90 s) : recherche "Dr Martinez plante cancer" sur Google → aucun médecin de ce nom n'est référencé sur PubMed pour cette plante. Recherche inversée du visage → image générée par IA, pas de profil LinkedIn associé. Conclusion : source inventée.
+3. **Étape 3** (15 s avec DeepSight) : analyse complète, fact-check automatisé, marqueurs épistémiques, **affirmation classée À VÉRIFIER avec aucune source crédible identifiée**.
+
+Total : 2 minutes 15 secondes. Au lieu de 5 minutes manuellement.
+
+## Conclusion : la vérification comme habitude
+
+Fact-checker une vidéo TikTok n'est pas une activité réservée aux journalistes. C'est une compétence d'hygiène mentale au même titre que se brosser les dents. Plus vous le faites, plus c'est rapide. Plus c'est rapide, plus vous le faites.
+
+Les trois étapes — **visionner avec attention, croiser avec deux sources, utiliser un outil IA structuré** — couvrent 95% des cas. Pour les 5% restants (claims politiques complexes, sujets émergents non couverts), la règle est simple : **ne pas partager, ne pas relayer, attendre 48 heures qu'une couverture de qualité émerge**.
+
+Internet ne récompense plus la première personne à diffuser une information — il récompense celle qui ne diffuse jamais une information fausse. Cultivez la patience, c'est le luxe ultime à l'ère du flux.
+
+---
+
+_DeepSight propose 5 analyses gratuites par mois pour fact-checker vos vidéos YouTube et TikTok. [Commencer maintenant →](/upgrade)_
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/content/blog/2026-04-29-fact-check-tiktok.md frontend/src/content/blog/2026-04-29-fact-check-tiktok.json && git commit -m "feat(blog): add article on TikTok fact-checking method"
+```
+
+---
+
+### Task 6: Article 2 — Flashcards FSRS
+
+**Files:**
+
+- Create: `frontend/src/content/blog/2026-04-29-flashcards-fsrs-revision-ia.md`
+- Create: `frontend/src/content/blog/2026-04-29-flashcards-fsrs-revision-ia.json`
+
+- [ ] **Step 1: Écrire le frontmatter JSON**
+
+Fichier `frontend/src/content/blog/2026-04-29-flashcards-fsrs-revision-ia.json` :
+
+```json
+{
+  "slug": "flashcards-fsrs-revision-ia",
+  "title": "Réviser ses examens avec l'IA : guide des flashcards FSRS",
+  "description": "FSRS bat l'algorithme historique d'Anki de 30% sur la rétention. Voici comment l'algorithme fonctionne, pourquoi il est plus efficace, et comment générer automatiquement vos flashcards depuis vos cours vidéo.",
+  "publishedAt": "2026-04-29",
+  "author": "DeepSight",
+  "tags": ["Études", "Flashcards", "FSRS", "Mémorisation"],
+  "keywords": "flashcards IA, réviser examens IA, FSRS algorithme, flashcards Anki, spaced repetition, révision active, flashcards automatiques",
+  "coverImage": "/blog/flashcards-fsrs-cover.webp",
+  "ogImage": "/blog/flashcards-fsrs-cover.webp"
+}
+```
+
+- [ ] **Step 2: Écrire l'article complet**
+
+Fichier `frontend/src/content/blog/2026-04-29-flashcards-fsrs-revision-ia.md` :
+
+```markdown
+# Réviser ses examens avec l'IA : guide des flashcards FSRS
+
+Vous avez 14 chapitres à réviser pour un partiel dans 3 semaines. Vous relisez vos notes, vous surlignez, vous refaites un fichage. À l'examen, vous bloquez sur 40% des questions parce que vous reconnaissez le contenu sans pouvoir le restituer. C'est l'illusion de maîtrise — le problème central de la révision passive, et la raison pour laquelle l'apprentissage par flashcards à répétition espacée existe.
+
+Cet article explique :
+
+1. ce qu'est l'algorithme FSRS et pourquoi il bat de 30% l'algorithme historique d'Anki ;
+2. comment générer automatiquement des flashcards de qualité depuis une vidéo de cours ;
+3. comment construire un planning de révision optimal sans y passer plus de 30 minutes par jour.
+
+## Pourquoi les flashcards battent toutes les autres méthodes de révision
+
+Surligner, relire, faire des résumés : ce sont des méthodes **passives**. Votre cerveau reconnaît le contenu, donc vous avez l'impression de l'avoir mémorisé. Mais reconnaître ≠ savoir restituer. Le seul test fiable de la mémoire est le **retrieval** — sortir l'information de son cerveau sans aide, à intervalles espacés.
+
+Le retrieval pratiqué de manière espacée et active est **l'unique méthode validée empiriquement** comme étant supérieure à tout le reste. La méta-analyse de Dunlosky et al. (2013) sur 10 techniques d'étude classe la pratique du retrieval (#1) et la répétition espacée (#2) loin devant la relecture (#9) ou le surlignage (#8).
+
+Les flashcards combinent les deux : chaque carte est un exercice de retrieval, et l'algorithme espace leur réapparition selon votre performance. C'est pour cela que **Anki, Quizlet, Mochi, et plus récemment des outils intégrés comme DeepSight** dominent l'apprentissage des langues, de la médecine, du droit.
+
+## Comprendre l'algorithme FSRS (Free Spaced Repetition Scheduler)
+
+### L'algorithme historique : SM-2
+
+Pendant 30 ans, la quasi-totalité des outils de flashcards utilisaient l'algorithme **SM-2** (SuperMemo 2, 1987). À chaque révision, l'utilisateur note sa difficulté de 1 à 4 (Again / Hard / Good / Easy), et SM-2 calcule un nouvel intervalle avec une formule simple basée sur :
+
+- la réponse précédente,
+- un "ease factor" propre à chaque carte,
+- une multiplication par un coefficient.
+
+Simple, mais imparfait. SM-2 ne modélise pas la **probabilité réelle de rétention**. Il suppose une courbe d'oubli universelle. Il ne tient pas compte du fait que certaines cartes sont intrinsèquement plus difficiles, ou que votre profil de mémoire diffère.
+
+### FSRS : un modèle paramétrique adaptatif
+
+FSRS, développé par Jarrett Ye et Dae Hyung Kang depuis 2019 et intégré nativement à Anki en version 23.10, change d'approche. Au lieu d'une formule unique, FSRS utilise un **modèle à 21 paramètres** entraîné par machine learning sur les historiques de révision réels.
+
+Le modèle prédit, pour chaque carte et chaque utilisateur :
+
+- **Difficulty** (D) : difficulté intrinsèque de la carte sur une échelle 1-10.
+- **Stability** (S) : durée pendant laquelle la carte reste mémorisée avec >90% probabilité.
+- **Retrievability** (R) : probabilité actuelle de se rappeler la carte au moment t, calculée via une fonction exponentielle décroissante de S.
+
+L'utilisateur fixe un **target retention** (typiquement 85-95%) et FSRS planifie chaque révision pour que R ne descende pas sous ce seuil.
+
+### Pourquoi FSRS bat SM-2 de 30%
+
+Les benchmarks publics de Jarrett Ye montrent que **à charge de travail égale, FSRS atteint une rétention 25-35% supérieure** à SM-2. Concrètement :
+
+- Avec SM-2 et 100 cartes par jour, vous retenez 75% du contenu sur 6 mois.
+- Avec FSRS et 100 cartes par jour, vous retenez 90% du même contenu sur 6 mois.
+
+Pour un étudiant qui révise 800 flashcards de pharmacologie pour son examen de fin de semestre, c'est la différence entre 600 cartes maîtrisées et 720 cartes maîtrisées. À l'échelle d'une scolarité de médecine, c'est mesuré en années de mémoire de travail récupérée.
+
+## Générer des flashcards de qualité depuis une vidéo de cours
+
+Le frein principal aux flashcards n'est ni l'algorithme ni la discipline — c'est **la création**. Faire 60 flashcards à partir d'un cours de 90 minutes prend 2 à 3 heures à la main. Multipliez par 14 chapitres : 30 à 40 heures de saisie pour le seul cours de pathologie. La plupart abandonnent.
+
+C'est ici que l'IA générative change l'économie de la méthode. **DeepSight** extrait automatiquement la transcription d'une vidéo YouTube ou TikTok et génère un set de flashcards structuré en 30-90 secondes selon la longueur. La génération suit trois principes pour rester de qualité :
+
+1. **Atomicité** : une carte = une notion. Pas de "Décris l'organisation de la cellule eucaryote" (trop large), mais "Quel est le rôle du réticulum endoplasmique rugueux ?" (atomique).
+2. **Formulation active** : la question oblige au retrieval. Pas "Le RE rugueux synthétise les protéines" (à compléter passivement), mais une vraie question avec réponse au verso.
+3. **Cloze deletion** : pour les définitions et les chiffres, DeepSight génère des cartes à trou — phrase complète avec un mot caché. Format particulièrement efficace pour la mémoire factuelle.
+
+L'utilisateur révise les cartes générées (5-10 minutes pour valider/éditer/jeter), puis les exporte vers Anki, ou les utilise directement dans l'interface DeepSight intégrée FSRS.
+
+### Cas pratique : un cours de 60 minutes
+
+Cours type "Histoire moderne — La Révolution française" sur YouTube, 58 minutes. Transcription : 8 200 mots. DeepSight identifie :
+
+- 12 dates clés (1789 prise de la Bastille, 1791 Constitution, 1793 mort de Louis XVI…).
+- 18 personnages avec leurs rôles.
+- 9 concepts politiques (sans-culottes, Constituante, Convention…).
+- 6 textes fondateurs (Déclaration des droits de l'homme, Constitution de 1791…).
+
+Le set généré : **45 flashcards**. Validation manuelle : 7 minutes. Total : 8 minutes pour un set qui aurait pris 2 heures à la main. Sur 14 chapitres, l'économie de temps est de **25 à 30 heures par semestre**.
+
+## Construire un planning de révision optimal
+
+Avoir des flashcards ne suffit pas. La discipline tue le projet plus souvent que la méthode. Voici un planning testé qui fonctionne pour la majorité des étudiants.
+
+### Règle 1 : 20 à 30 minutes par jour, 7 jours sur 7
+
+La répétition espacée n'est pas négociable sur la régularité. Sauter 3 jours efface 60% du gain de la semaine précédente. **Mieux vaut 20 minutes tous les jours que 2 heures un dimanche sur deux.**
+
+Sur DeepSight, la file de révision quotidienne fait apparaître exactement les cartes dont la retrievability passe sous votre seuil — ni plus, ni moins. Si la file fait 40 cartes, comptez 12 minutes. Si elle fait 80 cartes, c'est que vous avez sauté plusieurs jours et que le rattrapage prendra 25 minutes.
+
+### Règle 2 : ne jamais réviser pour la première fois la veille de l'examen
+
+L'effet maximum de la répétition espacée se construit sur **3 à 6 semaines**. Une carte introduite la veille n'a pas le temps d'être consolidée. Pour les flashcards générées dans les 7 jours précédant un examen, l'utilité est marginale — préférez de la révision active ciblée (anciennes annales).
+
+### Règle 3 : tagger par chapitre + par sujet
+
+DeepSight tagge automatiquement chaque carte par vidéo source. Ajoutez un tag manuel par chapitre/cours. Cela permet de filtrer la file de révision en mode "uniquement pharmacologie" ou "uniquement Révolution française" pendant les week-ends thématiques avant un partiel.
+
+### Règle 4 : viser 85% de retention, pas 95%
+
+Augmenter le target retention de 85% à 95% **double la charge de travail quotidienne** pour un gain marginal. La majorité des étudiants ont intérêt à viser 85% — c'est largement suffisant pour avoir un examen au-dessus de la moyenne, et la charge reste tenable.
+
+## Pourquoi DeepSight intègre nativement FSRS
+
+DeepSight a fait le choix d'intégrer **FSRS v5 nativement**, plutôt qu'un algorithme propriétaire. Trois raisons :
+
+1. **Open source vérifiable** : l'algorithme FSRS est public, le code de référence est open source. Aucune boîte noire — vous pouvez auditer pourquoi telle carte revient à tel intervalle.
+2. **Compatibilité Anki** : exportez vos cartes vers Anki avec leur historique, et inversement. Pas de lock-in.
+3. **Recherche communautaire** : la communauté FSRS améliore l'algorithme en continu sur des datasets de millions de révisions. DeepSight bénéficie de ces améliorations à chaque mise à jour.
+
+L'intégration DeepSight ajoute trois choses par-dessus FSRS :
+
+- **Génération automatique** depuis vos vidéos.
+- **UI mobile native** (iOS + Android via Expo) pour réviser dans le métro.
+- **Synchronisation cross-device** — commencez sur le web, finissez sur mobile.
+
+[Tester la génération de flashcards FSRS gratuitement](/upgrade) — 5 vidéos par mois sur le plan Free, flashcards et quiz inclus.
+
+## Conclusion : la révision active n'est pas une question de motivation
+
+Si vous avez raté un examen alors que vous avez "beaucoup révisé", le problème n'est pas votre intelligence ni votre motivation. C'est probablement votre méthode. Surligner, relire et refaire des résumés sont efficaces pour comprendre, pas pour mémoriser.
+
+Le combo **flashcards + FSRS + génération IA** transforme la mémorisation d'un effort solitaire de plusieurs centaines d'heures en une routine quotidienne de 20 minutes. Ce n'est pas magique — vous devrez quand même vous asseoir tous les jours et faire vos cartes. Mais le ratio temps/résultat est sans comparaison avec les autres méthodes.
+
+L'IA ne remplace ni la curiosité ni le travail. Elle déplace le goulet d'étranglement de la **création** vers la **révision**. Et la révision, contrairement à la création, est facile à mettre en habitude.
+
+---
+
+_DeepSight génère vos flashcards FSRS automatiquement depuis vos vidéos de cours. [Essayer gratuitement →](/upgrade)_
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/content/blog/2026-04-29-flashcards-fsrs-revision-ia.md frontend/src/content/blog/2026-04-29-flashcards-fsrs-revision-ia.json && git commit -m "feat(blog): add article on FSRS flashcards for exam revision"
+```
+
+---
+
+### Task 7: Article 3 — Souveraineté numérique
+
+**Files:**
+
+- Create: `frontend/src/content/blog/2026-04-29-souverainete-numerique-ia-europeenne.md`
+- Create: `frontend/src/content/blog/2026-04-29-souverainete-numerique-ia-europeenne.json`
+
+- [ ] **Step 1: Écrire le frontmatter JSON**
+
+Fichier `frontend/src/content/blog/2026-04-29-souverainete-numerique-ia-europeenne.json` :
+
+```json
+{
+  "slug": "souverainete-numerique-ia-europeenne",
+  "title": "Souveraineté numérique : pourquoi une IA européenne ?",
+  "description": "Cloud Act, RGPD, dépendance technologique : utiliser une IA américaine ou chinoise n'est pas neutre. Pourquoi DeepSight a choisi Mistral AI et l'hébergement européen, et ce que cela change concrètement pour vos données.",
+  "publishedAt": "2026-04-29",
+  "author": "DeepSight",
+  "tags": ["Souveraineté", "RGPD", "Mistral AI", "Europe"],
+  "keywords": "IA européenne, souveraineté numérique, Mistral AI, Cloud Act, RGPD IA, alternative OpenAI, hébergement européen, données Europe",
+  "coverImage": "/blog/souverainete-numerique-cover.webp",
+  "ogImage": "/blog/souverainete-numerique-cover.webp"
+}
+```
+
+- [ ] **Step 2: Écrire l'article complet**
+
+Fichier `frontend/src/content/blog/2026-04-29-souverainete-numerique-ia-europeenne.md` :
+
+```markdown
+# Souveraineté numérique : pourquoi une IA européenne ?
+
+En octobre 2018, le Congrès américain a voté le Clarifying Lawful Overseas Use of Data Act, plus connu sous le nom de **Cloud Act**. La loi tient en deux principes : 1) les fournisseurs de services cloud américains doivent fournir aux autorités américaines, sur réquisition, l'accès aux données qu'ils hébergent, **où qu'elles soient stockées dans le monde**. 2) Les autorités étrangères ne peuvent demander la même chose à des entreprises américaines qu'avec un accord bilatéral.
+
+En clair : si vous utilisez une IA américaine pour analyser un document confidentiel, **les autorités américaines peuvent y accéder sans que vous le sachiez**, même si le serveur est physiquement en Allemagne. Les autorités françaises ou allemandes, elles, ne peuvent pas — sauf accord bilatéral, qui n'existe pas vraiment.
+
+C'est l'un des trois piliers concrets de ce qu'on appelle la **souveraineté numérique**. Cet article explique pourquoi ce concept n'est pas un slogan politique mais un enjeu opérationnel pour toute organisation qui manipule des données sensibles, et pourquoi **DeepSight** a fait le choix d'une stack 100% européenne — Mistral AI pour les modèles, Hetzner pour l'hébergement.
+
+## Trois piliers de la souveraineté numérique
+
+### 1. Localisation physique des données
+
+Le RGPD européen impose des règles strictes sur le traitement des données personnelles : consentement, finalité, durée de conservation, droit à l'effacement. Sur le papier, ces règles s'appliquent aussi aux fournisseurs non-européens dès qu'ils traitent des données de résidents européens.
+
+En pratique, **l'application est complexe** quand le serveur est aux États-Unis. La Cour de Justice de l'Union Européenne a invalidé deux fois (Schrems I en 2015, Schrems II en 2020) les accords de transfert de données EU/US, au motif que les protections américaines sont insuffisantes face aux pouvoirs de surveillance des agences gouvernementales.
+
+L'accord actuel (Data Privacy Framework, 2023) repose sur un decret-loi américain qui peut être révoqué unilatéralement par tout futur président. **C'est juridiquement fragile.**
+
+Faire le choix d'un hébergement physiquement en Europe, sous juridiction européenne, supprime ce risque structurel.
+
+### 2. Chaîne de juridictions applicables
+
+Quand vous utilisez OpenAI, Google AI, Anthropic ou Microsoft Copilot, vos données traversent plusieurs juridictions :
+
+- la juridiction de votre pays au moment de l'envoi,
+- la juridiction du pays de transit (généralement les États-Unis),
+- la juridiction du pays où le modèle est entraîné/affiné,
+- la juridiction du pays où sont hébergées les logs et les caches.
+
+Le **Cloud Act**, le **FISA section 702**, et l'**Executive Order 12333** donnent aux agences américaines des pouvoirs d'accès qui n'ont pas d'équivalent européen. Pour un avocat traitant un dossier sensible, un médecin manipulant des notes patient, ou une entreprise gérant des informations stratégiques, **chaque interaction avec une IA américaine est potentiellement un transfert hors juridiction**.
+
+Une IA opérée par une entreprise européenne, sous droit européen, supprime cette chaîne. Vos données restent sous juridiction RGPD du début à la fin.
+
+### 3. Indépendance industrielle et technologique
+
+Le troisième pilier dépasse le juridique. Si l'Europe ne dispose d'aucun acteur compétitif dans l'IA générative, elle est en position de **dépendance structurelle**. Les conditions tarifaires, les capacités techniques, les règles de modération, l'orientation des modèles, sont décidées ailleurs.
+
+C'est exactement ce qui s'est produit avec le cloud computing pendant 15 ans : **AWS / Azure / GCP détiennent ~70% du marché européen**. Quand AWS augmente ses prix de 20%, l'Europe n'a pas le choix de partir vers un concurrent local équivalent — il n'existe pas.
+
+L'IA générative est sur la même trajectoire si rien n'est fait. **Mistral AI** (Paris, fondé en 2023) est aujourd'hui le seul acteur européen capable de fournir des modèles compétitifs avec OpenAI ou Anthropic dans certains usages, en open-weight et avec une présence commerciale réelle. **Aleph Alpha** (Allemagne) a pivoté vers le service entreprise. **Mistral est devenu, par défaut, le pilier de la souveraineté IA européenne**.
+
+## Pourquoi DeepSight a choisi Mistral AI
+
+DeepSight repose sur Mistral pour 100% de ses appels IA — analyses, fact-checking, chat contextuel, génération de flashcards. Le choix s'est fait sur quatre critères mesurables.
+
+### Critère 1 : qualité des modèles
+
+Sur les benchmarks publics (MMLU, HumanEval, MBPP, BBH), les modèles Mistral de la génération 2026 (mistral-small-2603, mistral-medium-2508, mistral-large-2512) sont **dans le top 5 mondial** sur les tâches généralistes en français et en anglais. Mistral Large 2512 dispose d'un contexte de **262 000 tokens**, suffisant pour analyser une vidéo de 4 heures sans découpage.
+
+Ce n'est pas le meilleur modèle au monde sur tous les axes — GPT-5 et Claude 4.7 ont l'avantage sur certaines tâches de raisonnement complexe. Mais sur les tâches que DeepSight effectue (résumé structuré, extraction d'arguments, génération de questions, fact-check), les modèles Mistral sont **équivalents à 5% près** sur les benchmarks internes.
+
+### Critère 2 : coût
+
+À qualité équivalente, **Mistral est 30 à 60% moins cher** qu'OpenAI ou Anthropic sur la majorité des modèles. Pour un SaaS qui sert 5 analyses gratuites par utilisateur et par mois, la différence permet de garder un plan Free réellement gratuit, sans rogner sur la qualité.
+
+### Critère 3 : juridiction
+
+Mistral est une société française basée à Paris, soumise au RGPD, à la CNIL, au droit français. Ses modèles sont entraînés sur des infrastructures européennes. **Aucun risque de Cloud Act**. Cela ne signifie pas zéro risque (toute société peut être réquisitionnée) — cela signifie que le risque est régi par un cadre juridique que les utilisateurs européens peuvent comprendre, contester, et qui les protège mieux.
+
+### Critère 4 : open-weight quand pertinent
+
+Mistral publie une partie de ses modèles en open-weight (Mistral 7B, Mixtral 8x7B, plusieurs versions intermédiaires). Cela signifie que **DeepSight pourrait, en théorie, héberger les modèles eux-mêmes** sur ses serveurs Hetzner si l'API Mistral devenait inaccessible — un niveau de continuité d'activité impossible avec OpenAI ou Anthropic dont les modèles sont fermés.
+
+Aujourd'hui DeepSight utilise l'API Mistral pour les modèles de niveau production (medium, large). Mais l'option de fallback existe.
+
+## Hébergement Hetzner : le complément logique
+
+Choisir Mistral pour l'IA mais OpenAI Cloud pour l'hébergement n'aurait aucun sens. DeepSight héberge l'intégralité de son backend sur **Hetzner Cloud**, datacenter de Falkenstein (Allemagne).
+
+Pourquoi Hetzner :
+
+1. **Datacenter européen** sous droit allemand, donc RGPD natif et hors Cloud Act.
+2. **Coûts 3 à 4 fois inférieurs à AWS** pour des spécifications équivalentes (CPU dédié, NVMe, bande passante généreuse). Cela permet d'opérer un SaaS rentable sans gonfler les prix.
+3. **Stabilité éprouvée** — Hetzner est un acteur de référence du cloud européen depuis 1997, avec une infrastructure massive et une réputation de fiabilité.
+
+L'infrastructure complète tourne sur un VPS Hetzner avec une stack Docker minimaliste : FastAPI + PostgreSQL 17 + Redis 7 + Caddy reverse proxy avec SSL automatique. Tout est sous juridiction allemande, tout est conforme RGPD, **vos données ne quittent jamais l'Europe**.
+
+## Ce que cela change concrètement pour vous
+
+Pour la majorité des utilisateurs de DeepSight, la différence est **invisible au quotidien**. C'est précisément le but : un outil qui marche, qui est rapide, qui rend service, sans que la souveraineté soit un compromis.
+
+Mais pour certains profils, c'est essentiel :
+
+- **Chercheurs** qui manipulent des données préliminaires non publiées — pas de risque qu'un modèle entraîné sur leurs prompts publie l'idée avant eux.
+- **Journalistes** qui fact-checkent des affaires sensibles — pas de risque de fuite via des subpoenas étrangers.
+- **Professionnels juridiques et médicaux** soumis à des obligations strictes de confidentialité — la juridiction RGPD européenne donne un cadre clair.
+- **Établissements publics et collectivités** qui ont des obligations légales d'hébergement européen — DeepSight coche les cases sans effort de leur part.
+
+## Mistral et l'Europe : un pari plus large
+
+Au-delà du cas DeepSight, choisir Mistral aujourd'hui, c'est faire un pari : **l'Europe peut, et doit, avoir ses propres champions de l'IA**. Pas par patriotisme économique, mais parce que la dépendance technologique est une fragilité géopolitique.
+
+L'Europe a manqué le virage des moteurs de recherche (Google), des réseaux sociaux (Meta), du cloud (AWS). Si elle manque le virage de l'IA générative, ses entreprises et ses citoyens seront durablement dépendants d'acteurs étrangers pour l'une des technologies les plus structurantes du siècle.
+
+Mistral n'a pas besoin d'écraser OpenAI pour être un succès. Il a besoin d'exister, de croître, de fournir des alternatives crédibles. Chaque entreprise européenne qui choisit Mistral plutôt que GPT-5 contribue à cet écosystème.
+
+DeepSight a fait ce choix dès le premier jour. Pas comme un slogan marketing, mais comme une décision technique cohérente. **Vos données restent en Europe parce que tout l'écosystème de DeepSight est en Europe.**
+
+## Conclusion : la neutralité technologique n'existe pas
+
+L'idée selon laquelle "peu importe quel cloud, peu importe quelle IA, ça revient au même" est confortable mais fausse. Choisir une infrastructure technologique, c'est **choisir un cadre juridique**, **un horizon économique**, et **une géopolitique**. C'est vrai pour les particuliers et plus encore pour les organisations.
+
+La souveraineté numérique n'impose pas de tout faire en Europe à tout prix. Elle invite à **considérer la juridiction comme une feature au même titre que la performance ou le prix**. Pour beaucoup d'usages, choisir européen est aujourd'hui équivalent en qualité, comparable en prix, et nettement supérieur en garanties juridiques.
+
+[Découvrir DeepSight](/upgrade) — IA Mistral, hébergement Hetzner, RGPD natif. Vos vidéos analysées sans jamais quitter l'Europe.
+
+---
+
+_Article rédigé par l'équipe DeepSight, SAS française basée à Lyon. Mistral AI (Paris). Hetzner (Falkenstein, Allemagne). 100% européen, par conviction et par cohérence._
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/content/blog/2026-04-29-souverainete-numerique-ia-europeenne.md frontend/src/content/blog/2026-04-29-souverainete-numerique-ia-europeenne.json && git commit -m "feat(blog): add article on European AI sovereignty"
+```
+
+---
+
+### Task 8: BlogListPage component
+
+**Files:**
+
+- Create: `frontend/src/pages/BlogListPage.tsx`
+
+- [ ] **Step 1: Écrire le composant**
+
+Fichier `frontend/src/pages/BlogListPage.tsx` :
+
+```typescript
+/**
+ * Blog List Page — DeepSight
+ * /blog — grid de cards des articles publiés.
+ */
+
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import { ArrowLeft, BookOpen } from "lucide-react";
+import Layout from "../components/Layout";
+import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
+import { BlogCard } from "../components/BlogCard";
+import { getAllArticles } from "../lib/blog";
+
+const BlogListPage = () => {
+  const articles = useMemo(() => getAllArticles(), []);
+
+  return (
+    <Layout>
+      <SEO
+        title="Blog — Articles, guides, méthodes IA pour vidéo"
+        description="Le blog DeepSight : fact-checking TikTok, flashcards FSRS, souveraineté numérique. Méthodes pratiques et analyses approfondies pour mieux comprendre vos vidéos."
+        path="/blog"
+        keywords="blog deepsight, articles IA vidéo, fact-checking, flashcards, souveraineté numérique"
+      />
+      <BreadcrumbJsonLd path="/blog" />
+
+      <main id="main-content" className="min-h-screen bg-bg-primary">
+        <div className="max-w-6xl mx-auto px-4 md:px-6 pt-8 pb-16 md:pt-12 md:pb-24">
+          {/* Back link */}
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors mb-8"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Retour à l'accueil
+          </Link>
+
+          {/* Hero */}
+          <motion.header
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4 }}
+            className="mb-12 md:mb-16"
+          >
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/5 border border-white/10 text-xs text-text-secondary mb-4">
+              <BookOpen className="w-3.5 h-3.5" />
+              Blog DeepSight
+            </div>
+            <h1 className="text-4xl md:text-5xl font-bold text-text-primary mb-4 tracking-tight">
+              Mieux comprendre vos vidéos
+            </h1>
+            <p className="text-lg text-text-secondary max-w-2xl">
+              Fact-checking, mémorisation, souveraineté numérique : nos guides
+              pratiques et analyses approfondies pour exploiter au mieux le
+              contenu vidéo à l'ère de l'IA.
+            </p>
+          </motion.header>
+
+          {/* Articles grid */}
+          {articles.length === 0 ? (
+            <p className="text-text-secondary">
+              Aucun article publié pour l'instant.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {articles.map((article, idx) => (
+                <BlogCard
+                  key={article.meta.slug}
+                  meta={article.meta}
+                  readingTime={article.readingTime}
+                  index={idx}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+    </Layout>
+  );
+};
+
+export default BlogListPage;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/pages/BlogListPage.tsx && git commit -m "feat(blog): add BlogListPage with grid layout and SEO"
+```
+
+---
+
+### Task 9: BlogPostPage component
+
+**Files:**
+
+- Create: `frontend/src/pages/BlogPostPage.tsx`
+
+- [ ] **Step 1: Écrire le composant**
+
+Fichier `frontend/src/pages/BlogPostPage.tsx` :
+
+```typescript
+/**
+ * Blog Post Page — DeepSight
+ * /blog/:slug — affiche un article complet (markdown rendu, SEO, breadcrumb, ArticleJsonLd).
+ */
+
+import { useMemo } from "react";
+import { Link, useParams, Navigate } from "react-router-dom";
+import { motion } from "framer-motion";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { ArrowLeft, Calendar, Clock, Tag, User } from "lucide-react";
+import Layout from "../components/Layout";
+import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
+import { ArticleJsonLd } from "../components/ArticleJsonLd";
+import { getArticleBySlug } from "../lib/blog";
+
+const formatDate = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleDateString("fr-FR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+};
+
+const BlogPostPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const article = useMemo(
+    () => (slug ? getArticleBySlug(slug) : null),
+    [slug],
+  );
+
+  if (!article) {
+    return <Navigate to="/blog" replace />;
+  }
+
+  const { meta, content, readingTime } = article;
+
+  return (
+    <Layout>
+      <SEO
+        title={meta.title}
+        description={meta.description}
+        path={`/blog/${meta.slug}`}
+        image={
+          meta.ogImage
+            ? `https://www.deepsightsynthesis.com${meta.ogImage}`
+            : undefined
+        }
+        type="article"
+        keywords={meta.keywords}
+      />
+      <BreadcrumbJsonLd path={`/blog/${meta.slug}`} label={meta.title} />
+      <ArticleJsonLd meta={meta} readingTime={readingTime} />
+
+      <main id="main-content" className="min-h-screen bg-bg-primary">
+        <article className="max-w-3xl mx-auto px-4 md:px-6 pt-8 pb-16 md:pt-12 md:pb-24">
+          {/* Back link */}
+          <Link
+            to="/blog"
+            className="inline-flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors mb-8"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Retour au blog
+          </Link>
+
+          {/* Header */}
+          <motion.header
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4 }}
+            className="mb-10"
+          >
+            {meta.tags.length > 0 && (
+              <div className="flex flex-wrap gap-2 mb-4">
+                {meta.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-white/5 border border-white/10 text-text-secondary"
+                  >
+                    <Tag className="w-3 h-3" />
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+            <h1 className="text-4xl md:text-5xl font-bold text-text-primary mb-6 tracking-tight leading-tight">
+              {meta.title}
+            </h1>
+            <p className="text-lg text-text-secondary mb-6">
+              {meta.description}
+            </p>
+            <div className="flex flex-wrap items-center gap-4 text-sm text-text-secondary">
+              <span className="flex items-center gap-1.5">
+                <User className="w-4 h-4" />
+                {meta.author}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <Calendar className="w-4 h-4" />
+                {formatDate(meta.publishedAt)}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <Clock className="w-4 h-4" />
+                {readingTime} min de lecture
+              </span>
+            </div>
+          </motion.header>
+
+          {/* Cover image */}
+          {meta.coverImage && (
+            <div className="aspect-[16/9] mb-10 rounded-2xl overflow-hidden bg-gradient-to-br from-indigo-500/20 to-violet-500/20">
+              <img
+                src={meta.coverImage}
+                alt={meta.title}
+                className="w-full h-full object-cover"
+                onError={(e) => {
+                  (e.currentTarget as HTMLImageElement).style.display = "none";
+                }}
+              />
+            </div>
+          )}
+
+          {/* Content */}
+          <div className="prose prose-invert prose-lg max-w-none prose-headings:text-text-primary prose-p:text-text-secondary prose-a:text-accent-primary prose-strong:text-text-primary prose-li:text-text-secondary prose-blockquote:text-text-secondary prose-code:text-accent-primary prose-pre:bg-bg-secondary">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          </div>
+        </article>
+      </main>
+    </Layout>
+  );
+};
+
+export default BlogPostPage;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Vérifier que `prose` (Typography Tailwind) est dispo**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && grep -l "@tailwindcss/typography" package.json tailwind.config.js`
+Expected: au moins une occurrence. Si **rien** ne sort, ajouter le plugin :
+
+```bash
+cd "C:/Users/33667/DeepSight-Main/frontend" && npm install --save-dev @tailwindcss/typography
+```
+
+Puis dans `frontend/tailwind.config.js`, ajouter `require("@tailwindcss/typography")` au tableau `plugins`. Si le plugin était déjà installé, sauter cette installation.
+
+- [ ] **Step 4: Re-typecheck après éventuelle install**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/pages/BlogPostPage.tsx frontend/package.json frontend/package-lock.json frontend/tailwind.config.js && git commit -m "feat(blog): add BlogPostPage with markdown render and Article JSON-LD"
+```
+
+---
+
+### Task 10: Câblage routes dans App.tsx + LABELS breadcrumb
+
+**Files:**
+
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/BreadcrumbJsonLd.tsx`
+
+- [ ] **Step 1: Ajouter "/blog" dans LABELS**
+
+Dans `frontend/src/components/BreadcrumbJsonLd.tsx`, modifier la map `LABELS` (ligne 10) :
+
+```typescript
+const LABELS: Record<string, string> = {
+  "/about": "À propos",
+  "/upgrade": "Tarifs",
+  "/contact": "Contact",
+  "/api-docs": "Documentation API",
+  "/status": "Statut des services",
+  "/legal": "Mentions légales",
+  "/legal/cgu": "Conditions générales d'utilisation",
+  "/legal/cgv": "Conditions générales de vente",
+  "/legal/privacy": "Politique de confidentialité",
+  "/blog": "Blog",
+};
+```
+
+- [ ] **Step 2: Ajouter les imports lazy + routes dans App.tsx**
+
+Dans `frontend/src/App.tsx`, après la ligne `const AboutPage = lazyWithRetry(() => import("./pages/AboutPage"));` (ligne 293), ajouter :
+
+```typescript
+const BlogListPage = lazyWithRetry(() => import("./pages/BlogListPage"));
+const BlogPostPage = lazyWithRetry(() => import("./pages/BlogPostPage"));
+```
+
+Puis dans le bloc `<Routes>`, après la route `/about` (qui se termine ligne 648 par `</Route>` du bloc `path="/about"`), ajouter :
+
+```tsx
+<Route
+  path="/blog"
+  element={
+    <RouteErrorBoundary
+      variant="full"
+      componentName="BlogListPage"
+    >
+      <Suspense fallback={<PageSkeleton variant="full" />}>
+        <BlogListPage />
+      </Suspense>
+    </RouteErrorBoundary>
+  }
+/>
+
+<Route
+  path="/blog/:slug"
+  element={
+    <RouteErrorBoundary
+      variant="full"
+      componentName="BlogPostPage"
+    >
+      <Suspense fallback={<PageSkeleton variant="full" />}>
+        <BlogPostPage />
+      </Suspense>
+    </RouteErrorBoundary>
+  }
+/>
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Build complet**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run build`
+Expected: build successful, le sitemap mentionne déjà les anciennes routes (sera étendu Task 12).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/App.tsx frontend/src/components/BreadcrumbJsonLd.tsx && git commit -m "feat(blog): wire /blog and /blog/:slug routes with lazy loading"
+```
+
+---
+
+### Task 11: Tests unitaires BlogListPage et BlogPostPage
+
+**Files:**
+
+- Create: `frontend/src/pages/__tests__/BlogListPage.test.tsx`
+- Create: `frontend/src/pages/__tests__/BlogPostPage.test.tsx`
+
+- [ ] **Step 1: Test BlogListPage**
+
+Fichier `frontend/src/pages/__tests__/BlogListPage.test.tsx` :
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+} from "../../__tests__/test-utils";
+
+vi.mock("../../lib/blog", () => ({
+  getAllArticles: vi.fn(),
+}));
+
+import { getAllArticles } from "../../lib/blog";
+import BlogListPage from "../BlogListPage";
+
+const mockGetAllArticles = getAllArticles as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("BlogListPage", () => {
+  it("renders the hero title", () => {
+    mockGetAllArticles.mockReturnValue([]);
+    renderWithProviders(<BlogListPage />);
+    expect(screen.getByText("Mieux comprendre vos vidéos")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no articles", () => {
+    mockGetAllArticles.mockReturnValue([]);
+    renderWithProviders(<BlogListPage />);
+    expect(
+      screen.getByText("Aucun article publié pour l'instant."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one card per article", () => {
+    mockGetAllArticles.mockReturnValue([
+      {
+        meta: {
+          slug: "article-1",
+          title: "Article 1 Title",
+          description: "Desc 1",
+          publishedAt: "2026-04-29",
+          author: "DeepSight",
+          tags: ["test"],
+          keywords: "k",
+          coverImage: "/blog/cover1.webp",
+        },
+        content: "x",
+        readingTime: 3,
+      },
+      {
+        meta: {
+          slug: "article-2",
+          title: "Article 2 Title",
+          description: "Desc 2",
+          publishedAt: "2026-04-28",
+          author: "DeepSight",
+          tags: ["test"],
+          keywords: "k",
+          coverImage: "/blog/cover2.webp",
+        },
+        content: "y",
+        readingTime: 5,
+      },
+    ]);
+    renderWithProviders(<BlogListPage />);
+    expect(screen.getByText("Article 1 Title")).toBeInTheDocument();
+    expect(screen.getByText("Article 2 Title")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Test BlogPostPage**
+
+Fichier `frontend/src/pages/__tests__/BlogPostPage.test.tsx` :
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+} from "../../__tests__/test-utils";
+
+vi.mock("../../lib/blog", () => ({
+  getArticleBySlug: vi.fn(),
+}));
+
+import { getArticleBySlug } from "../../lib/blog";
+import BlogPostPage from "../BlogPostPage";
+
+const mockGetArticleBySlug = getArticleBySlug as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("BlogPostPage", () => {
+  it("renders the article title and content for known slug", () => {
+    mockGetArticleBySlug.mockReturnValue({
+      meta: {
+        slug: "test-slug",
+        title: "Test Article Title",
+        description: "Test description",
+        publishedAt: "2026-04-29",
+        author: "DeepSight",
+        tags: ["tag1"],
+        keywords: "k",
+        coverImage: "/blog/test-cover.webp",
+      },
+      content: "## A heading\n\nA paragraph.",
+      readingTime: 4,
+    });
+
+    renderWithProviders(<BlogPostPage />, {
+      routerProps: { initialEntries: ["/blog/test-slug"] },
+    });
+
+    expect(screen.getByText("Test Article Title")).toBeInTheDocument();
+    expect(screen.getByText("A heading")).toBeInTheDocument();
+    expect(screen.getByText("A paragraph.")).toBeInTheDocument();
+  });
+
+  it("renders reading time", () => {
+    mockGetArticleBySlug.mockReturnValue({
+      meta: {
+        slug: "x",
+        title: "X",
+        description: "X",
+        publishedAt: "2026-04-29",
+        author: "A",
+        tags: [],
+        keywords: "k",
+        coverImage: "/blog/x.webp",
+      },
+      content: "Hello",
+      readingTime: 7,
+    });
+
+    renderWithProviders(<BlogPostPage />, {
+      routerProps: { initialEntries: ["/blog/x"] },
+    });
+
+    expect(screen.getByText("7 min de lecture")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npx vitest run src/pages/__tests__/BlogListPage.test.tsx src/pages/__tests__/BlogPostPage.test.tsx src/lib/__tests__/blog.test.ts`
+Expected: PASS — 9 tests au total (4 loader + 3 list + 2 post).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/src/pages/__tests__/BlogListPage.test.tsx frontend/src/pages/__tests__/BlogPostPage.test.tsx && git commit -m "test(blog): add BlogListPage and BlogPostPage tests"
+```
+
+---
+
+### Task 12: Sitemap auto-generation pour articles
+
+**Files:**
+
+- Modify: `frontend/scripts/generate-sitemap.mjs`
+
+- [ ] **Step 1: Étendre le script pour lire les frontmatters blog**
+
+Remplacer le contenu de `frontend/scripts/generate-sitemap.mjs` par :
+
+```javascript
+#!/usr/bin/env node
+/**
+ * generate-sitemap.mjs — Generates frontend/public/sitemap.xml at build time.
+ *
+ * Wired via the `prebuild` npm script so each `vite build` regenerates a
+ * fresh sitemap with today's lastmod, replacing the static checked-in
+ * version. Routes are listed below; add a new entry whenever a public
+ * page is added to App.tsx.
+ *
+ * Blog articles are auto-discovered from frontend/src/content/blog/*.json.
+ *
+ * Run manually: `node scripts/generate-sitemap.mjs`
+ */
+
+import { writeFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SITE_URL = "https://www.deepsightsynthesis.com";
+const TODAY = new Date().toISOString().split("T")[0];
+
+/**
+ * Public, indexable routes. Keep this in sync with App.tsx public routes.
+ * Excludes /login, /auth/callback, /payment/success, /payment/cancel
+ * (transient or auth gates) and /s/:shareToken (dynamic per-token).
+ */
+const STATIC_ROUTES = [
+  { path: "/", priority: 1.0, changefreq: "weekly" },
+  { path: "/about", priority: 0.8, changefreq: "monthly" },
+  { path: "/upgrade", priority: 0.9, changefreq: "monthly" },
+  { path: "/api-docs", priority: 0.6, changefreq: "monthly" },
+  { path: "/contact", priority: 0.5, changefreq: "yearly" },
+  { path: "/status", priority: 0.4, changefreq: "daily" },
+  { path: "/legal", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/cgu", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/cgv", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/privacy", priority: 0.3, changefreq: "yearly" },
+  { path: "/blog", priority: 0.85, changefreq: "weekly" },
+];
+
+/**
+ * Discover blog articles from frontend/src/content/blog/*.json.
+ * Returns sitemap entries for each article.
+ */
+function discoverBlogArticles() {
+  const blogDir = resolve(__dirname, "../src/content/blog");
+  const entries = [];
+  let files;
+  try {
+    files = readdirSync(blogDir).filter((f) => f.endsWith(".json"));
+  } catch {
+    console.warn(`[sitemap] No blog directory at ${blogDir}, skipping.`);
+    return entries;
+  }
+
+  for (const file of files) {
+    try {
+      const raw = readFileSync(resolve(blogDir, file), "utf-8");
+      const meta = JSON.parse(raw);
+      if (!meta.slug || !meta.publishedAt) continue;
+      entries.push({
+        path: `/blog/${meta.slug}`,
+        priority: 0.7,
+        changefreq: "monthly",
+        lastmod: meta.updatedAt || meta.publishedAt,
+      });
+    } catch (err) {
+      console.warn(`[sitemap] Failed to parse ${file}:`, err.message);
+    }
+  }
+  return entries;
+}
+
+function buildSitemap() {
+  const blogEntries = discoverBlogArticles();
+  const allRoutes = [...STATIC_ROUTES, ...blogEntries];
+
+  const urls = allRoutes
+    .map(
+      ({ path, priority, changefreq, lastmod }) => `  <url>
+    <loc>${SITE_URL}${path}</loc>
+    <lastmod>${lastmod || TODAY}</lastmod>
+    <changefreq>${changefreq}</changefreq>
+    <priority>${priority.toFixed(1)}</priority>
+  </url>`,
+    )
+    .join("\n");
+
+  return {
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`,
+    count: allRoutes.length,
+  };
+}
+
+const outputPath = resolve(__dirname, "../public/sitemap.xml");
+mkdirSync(dirname(outputPath), { recursive: true });
+const { xml, count } = buildSitemap();
+writeFileSync(outputPath, xml, "utf-8");
+console.log(
+  `✓ Sitemap written: ${outputPath} (${count} URLs, lastmod=${TODAY})`,
+);
+```
+
+- [ ] **Step 2: Run le script et vérifier le sitemap**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && node scripts/generate-sitemap.mjs`
+Expected: console output `✓ Sitemap written: ... (14 URLs ...)` (10 statiques + 3 blog + /blog).
+
+- [ ] **Step 3: Vérifier le contenu du sitemap**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && grep -E "(blog/fact-check-tiktok|blog/flashcards-fsrs|blog/souverainete)" public/sitemap.xml`
+Expected: 3 lignes correspondant aux 3 articles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/scripts/generate-sitemap.mjs frontend/public/sitemap.xml && git commit -m "feat(blog): auto-discover blog articles in sitemap generator"
+```
+
+---
+
+### Task 13: vercel.json — prerender bots IA + cache headers blog
+
+**Files:**
+
+- Modify: `frontend/vercel.json`
+
+- [ ] **Step 1: Ajouter rewrites prerender pour /blog**
+
+Dans `frontend/vercel.json`, dans le tableau `rewrites`, après le bloc `/contact` (lignes 58-68 du fichier actuel), ajouter avant `"source": "/chaines"` :
+
+```json
+{
+  "source": "/blog",
+  "has": [
+    {
+      "type": "header",
+      "key": "user-agent",
+      "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+    }
+  ],
+  "destination": "/api/prerender?path=/blog"
+},
+{
+  "source": "/blog/:slug",
+  "has": [
+    {
+      "type": "header",
+      "key": "user-agent",
+      "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+    }
+  ],
+  "destination": "/api/prerender?path=/blog/:slug"
+},
+```
+
+- [ ] **Step 2: Ajouter cache headers pour le blog**
+
+Dans le tableau `headers` de `vercel.json`, ajouter à la fin (juste avant la fermeture du tableau, après le bloc `/assets/(.*)`) :
+
+```json
+,
+{
+  "source": "/blog",
+  "headers": [
+    {
+      "key": "Cache-Control",
+      "value": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400"
+    }
+  ]
+},
+{
+  "source": "/blog/:slug",
+  "headers": [
+    {
+      "key": "Cache-Control",
+      "value": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400"
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Vérifier que le JSON est valide**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf-8'))"`
+Expected: aucune erreur.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/vercel.json && git commit -m "feat(blog): add bot IA prerender rewrites and cache headers for /blog"
+```
+
+---
+
+### Task 14: Prerender Edge Function — support /blog et /blog/:slug
+
+**Files:**
+
+- Modify: `frontend/api/prerender.ts`
+
+- [ ] **Step 1: Ajouter la page /blog (liste statique) et le handler dynamique**
+
+Modifier `frontend/api/prerender.ts`. Dans l'objet `PAGES` (vers ligne 102), ajouter une nouvelle entrée `/blog` avant la fermeture de l'objet :
+
+```typescript
+"/blog": {
+  slug: "/blog",
+  title: "Blog DeepSight — Fact-checking, FSRS, souveraineté numérique",
+  description:
+    "Articles, guides et analyses approfondies de DeepSight : comment fact-checker TikTok en 3 étapes, comprendre l'algorithme FSRS, choisir une IA européenne. Tout pour mieux exploiter le contenu vidéo à l'ère de l'IA.",
+  h1: "Blog DeepSight",
+  sections: [
+    {
+      heading: "Articles publiés",
+      body:
+        "Comment vérifier une information sur TikTok en 3 étapes — méthode pratique pour fact-checker une vidéo en moins de 2 minutes, avec outils gratuits et focus sur la détection de deepfakes vocaux. " +
+        "Réviser ses examens avec l'IA : guide des flashcards FSRS — fonctionnement de l'algorithme FSRS qui bat SM-2 de 30%, génération automatique depuis une vidéo de cours, planning de révision optimal. " +
+        "Souveraineté numérique : pourquoi une IA européenne ? — enjeux RGPD vs Cloud Act, comparaison Mistral / OpenAI / Anthropic, choix de Hetzner pour l'hébergement européen.",
+    },
+    {
+      heading: "Pourquoi un blog ?",
+      body: "Le blog DeepSight publie des guides pratiques et des analyses approfondies pour aider les utilisateurs à mieux exploiter leur consommation vidéo. Fact-checking, mémorisation, IA générative, souveraineté numérique : les sujets sont à la croisée du logiciel et de l'hygiène cognitive.",
+    },
+  ],
+  extraJsonLd: [
+    {
+      "@context": "https://schema.org",
+      "@type": "Blog",
+      name: "Blog DeepSight",
+      url: `${SITE_URL}/blog`,
+      publisher: {
+        "@type": "Organization",
+        name: "DeepSight",
+        logo: { "@type": "ImageObject", url: ORG_LOGO },
+      },
+    },
+  ],
+},
+```
+
+- [ ] **Step 2: Ajouter le handler dynamique /blog/:slug dans `handler()`**
+
+Toujours dans `frontend/api/prerender.ts`, modifier la fonction `handler` (vers ligne 319) pour gérer les slugs blog dynamiques. Remplacer le bloc :
+
+```typescript
+const url = new URL(request.url);
+const path = url.searchParams.get("path") || "/";
+const page = PAGES[path];
+
+if (!page) {
+  return new Response("Not found", { status: 404 });
+}
+
+const html = renderPage(page);
+```
+
+par :
+
+```typescript
+const url = new URL(request.url);
+const path = url.searchParams.get("path") || "/";
+
+// /blog/:slug — fetch the SPA index.html (already contains JSON-LD via Helmet
+// SSR-equivalent through SEO/ArticleJsonLd hydration). Bots will parse the
+// pre-rendered HTML head produced by the build. We delegate to a basic stub
+// page generated from the article title for now — full SSR is out of scope.
+if (path.startsWith("/blog/") && path !== "/blog/") {
+  const slug = path.replace(/^\/blog\//, "").replace(/\/$/, "");
+  const stub = blogStubPage(slug);
+  return new Response(stub, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=600, s-maxage=3600",
+      "X-Robots-Tag": "index, follow",
+      "X-Prerender-For": "AI-bots",
+    },
+  });
+}
+
+const page = PAGES[path];
+
+if (!page) {
+  return new Response("Not found", { status: 404 });
+}
+
+const html = renderPage(page);
+```
+
+Puis ajouter, **avant** la fonction `renderPage` (vers ligne 345), la fonction stub :
+
+```typescript
+/**
+ * Lightweight stub page for /blog/:slug requests by AI bots.
+ * Returns a minimal but indexable HTML document. The full SPA still serves
+ * the rich version to humans (and to bots without UA detection match).
+ *
+ * For Phase 2: swap this for actual MD/JSON loading once we host
+ * the content on an Edge KV (Vercel Edge Config) or read at build time.
+ */
+function blogStubPage(slug: string): string {
+  const title = `Article DeepSight — ${slug.replace(/-/g, " ")}`;
+  const url = `${SITE_URL}/blog/${slug}`;
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: title,
+    url,
+    publisher: {
+      "@type": "Organization",
+      name: "DeepSight",
+      logo: { "@type": "ImageObject", url: ORG_LOGO },
+    },
+    inLanguage: "fr-FR",
+  };
+  return `<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>${escapeHtml(title)}</title>
+<link rel="canonical" href="${url}">
+<meta name="robots" content="index, follow">
+<meta property="og:type" content="article">
+<meta property="og:url" content="${url}">
+<meta property="og:title" content="${escapeHtml(title)}">
+<meta property="og:image" content="${OG_IMAGE}">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+</head>
+<body>
+<main>
+<h1>${escapeHtml(title)}</h1>
+<p>Cet article est publié sur le blog DeepSight. Pour accéder au contenu complet, visitez <a href="${url}">${url}</a>.</p>
+<p>DeepSight est un SaaS d'analyse IA de vidéos YouTube et TikTok, 100% européen, propulsé par Mistral AI (France) et hébergé chez Hetzner (Allemagne).</p>
+</main>
+</body>
+</html>`;
+}
+```
+
+Aussi : ajouter `/blog` dans la map `labels` de `buildBreadcrumb` (vers ligne 466) :
+
+```typescript
+const labels: Record<string, string> = {
+  "/about": "À propos",
+  "/upgrade": "Tarifs",
+  "/contact": "Contact",
+  "/blog": "Blog",
+};
+```
+
+- [ ] **Step 2.b: Ajouter "/blog" dans la nav du HTML rendu**
+
+Dans la fonction `renderPage` (vers ligne 412), modifier la `<nav>` :
+
+```html
+<nav>
+  <a href="${SITE_URL}/">Accueil</a> ·
+  <a href="${SITE_URL}/about">À propos</a> ·
+  <a href="${SITE_URL}/upgrade">Tarifs</a> ·
+  <a href="${SITE_URL}/blog">Blog</a> ·
+  <a href="${SITE_URL}/contact">Contact</a> ·
+  <a href="${SITE_URL}/api-docs">API</a> ·
+  <a href="${SITE_URL}/status">Statut</a> ·
+  <a href="${SITE_URL}/legal">Mentions légales</a>
+</nav>
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Build**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run build`
+Expected: build successful.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git add frontend/api/prerender.ts && git commit -m "feat(blog): add /blog and /blog/:slug to AI bot prerender function"
+```
+
+---
+
+### Task 15: Vérification finale et tests d'intégration
+
+**Files:**
+
+- (aucune création/modification — vérification only)
+
+- [ ] **Step 1: Lancer la suite complète de tests Vitest**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run test`
+Expected: tests existants 400/400 + 9 nouveaux tests (4 loader + 3 list + 2 post) — 409/409 passants. Si un test pré-existant casse, **stop** et investiguer (ne pas masquer la régression).
+
+- [ ] **Step 2: Typecheck final**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run typecheck`
+Expected: zéro erreur. Le projet a 19 erreurs TS pré-existantes mobile, mais le frontend doit rester clean.
+
+- [ ] **Step 3: Lint**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run lint`
+Expected: zéro erreur dans les nouveaux fichiers (warnings tolérables sur fichiers existants si déjà présents).
+
+- [ ] **Step 4: Build production complet**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run build`
+Expected: build successful, sitemap inclut les 3 articles + /blog (14 URLs au total).
+
+- [ ] **Step 5: Smoke test local en preview**
+
+Run: `cd "C:/Users/33667/DeepSight-Main/frontend" && npm run preview`
+Puis ouvrir `http://localhost:4173/blog` dans le navigateur — vérifier :
+
+- [ ] La page /blog charge sans erreur console
+- [ ] Les 3 cards apparaissent (Titre, date, reading time, tags)
+- [ ] Cliquer sur une card navigue vers /blog/:slug
+- [ ] L'article rend correctement le markdown (titres, paragraphes, liens)
+- [ ] Le breadcrumb "Accueil > Blog > [Titre]" est dans le `<head>` (View Source → JSON-LD)
+- [ ] Le canonical pointe vers `https://www.deepsightsynthesis.com/blog/[slug]`
+- [ ] L'image cover est masquée gracieusement si absente (placeholders pas encore générés)
+
+- [ ] **Step 6: Commit final si tout passe (sans modifs nécessaires)**
+
+```bash
+cd "C:/Users/33667/DeepSight-Main" && git status
+```
+
+Si rien à committer, passer à l'étape suivante. Si des fichiers générés (sitemap, build) doivent être ignorés ou commit, agir selon la convention du repo.
+
+---
+
+## Self-Review
+
+### 1. Spec coverage
+
+| Requirement spec                                                              | Task                              |
+| ----------------------------------------------------------------------------- | --------------------------------- |
+| Routes `/blog` + `/blog/:slug` lazy-loaded                                    | Task 10                           |
+| Stockage Markdown plain + JSON metadata                                       | Tasks 1, 5, 6, 7                  |
+| Loader `getAllArticles`, `getArticleBySlug`, `calculateReadingTime`           | Task 2                            |
+| Listing page (grid cards, image, titre, excerpt, date, tags, reading)         | Tasks 4, 8                        |
+| Article page (frontmatter + markdown render + reading time)                   | Task 9                            |
+| `<ArticleJsonLd>` JSON-LD Schema.org                                          | Task 3                            |
+| `<SEO>` réutilisé par article                                                 | Task 9                            |
+| `<BreadcrumbJsonLd>` étendu avec /blog                                        | Task 10                           |
+| Sitemap auto-générée pour les 3 slugs                                         | Task 12                           |
+| Tests Vitest BlogListPage + BlogPostPage                                      | Task 11                           |
+| `vercel.json` rewrites bots IA + cache headers `/blog/*`                      | Task 13                           |
+| Prerender Edge Function pour `/blog` + `/blog/:slug`                          | Task 14                           |
+| Article 1 : "fact-check TikTok" (1800-2200 mots, 3 étapes, exemples)          | Task 5                            |
+| Article 2 : "FSRS flashcards" (2000-2400 mots, FSRS, génération, planning)    | Task 6                            |
+| Article 3 : "souveraineté numérique" (1800-2200 mots, RGPD, Mistral, Hetzner) | Task 7                            |
+| MVP FR seul (pas EN)                                                          | (note Self-Review)                |
+| Performance : articles statiques, build-time                                  | Task 2 (`import.meta.glob` eager) |
+
+Tous les requirements sont mappés.
+
+### 2. Placeholder scan
+
+Aucun placeholder TBD/TODO/"à rédiger"/"similar to" dans les tâches. Chaque step a son code complet.
+
+Une exception **justifiée** : Step 3 de la Task 9 inclut un _fallback_ conditionnel (« si `@tailwindcss/typography` est absent, l'installer »). Ce n'est pas un placeholder — c'est un check explicite avec commande exacte des deux branches.
+
+### 3. Type consistency
+
+- `BlogArticle.meta.slug: string` (Task 1) ↔ utilisé partout (Tasks 3, 4, 5, 6, 7, 8, 9, 11, 12, 14) — cohérent.
+- `BlogArticleMeta.coverImage: string` (Task 1, requis) ↔ utilisé dans BlogCard et BlogPostPage avec fallback `onError` qui masque l'image — cohérent.
+- `BlogArticleMeta.ogImage?: string` (Task 1, optionnel) ↔ utilisé avec fallback sur `coverImage` dans `<ArticleJsonLd>` (Task 3) et `<SEO>` (Task 9) — cohérent.
+- `getAllArticles(): BlogArticle[]` ↔ utilisé dans BlogListPage (Task 8) et test loader (Task 2) — cohérent.
+- `getArticleBySlug(slug): BlogArticle | null` ↔ utilisé dans BlogPostPage avec `if (!article) return <Navigate />` (Task 9) — cohérent.
+
+### Décisions à confirmer (à signaler à l'utilisateur)
+
+1. **MDX vs Markdown plain** — Recommandation retenue : Markdown plain + JSON metadata. Si l'utilisateur veut MDX (composants React inline dans articles, ex : CTA custom, embeds vidéos interactifs), basculer vers `vite-plugin-mdx` + `@mdx-js/rollup` ajouterait ~3 tasks au plan. **Recommandation : rester sur Markdown plain pour MVP, migrer plus tard si besoin.**
+
+2. **Génération images cover article** — Les chemins `/blog/<slug>-cover.webp` sont référencés dans les frontmatters (Tasks 5, 6, 7) et dans `BlogCard`/`BlogPostPage` (avec `onError` qui masque gracieusement si absent). Les images **ne sont pas créées dans ce plan**. Options :
+   - **(a)** Phase suivante dédiée : générer 3 images via Midjourney/DALL-E ou plus simple via outils Figma maison, dimensions 1200×630 pour OG + format WebP.
+   - **(b)** Utiliser des images existantes du repo (logos DeepSight) en attendant.
+   - **(c)** Générer un fond Tailwind/SVG procédural au build pour avoir quelque chose visuellement.
+
+   **Recommandation : option (a) en task de suivi (~30-60 min), avec option (c) en placeholder en attendant.**
+
+3. **Traduction EN** — MVP FR seul. Le frontend a déjà l'i18n FR+EN, mais le contenu blog est volumineux (~6000 mots × 2 langues = double effort). **Recommandation : phase 2 si le traffic FR justifie l'investissement EN. À 100 visiteurs/mois sur le blog FR, traduire est prématuré ; à 1000+/mois, ça vaut le coup.**
+
+4. **Prerender Edge Function** — Le `blogStubPage` rend un HTML minimal pour les bots IA. C'est suffisant pour l'indexation initiale (URL canonique, JSON-LD Article, lien vers la version SPA). **Limitation connue** : pas de body article complet pour les bots — Google et ChatGPT ne verront pas le contenu de l'article tant que la SPA ne SSR-rendra pas. Phase 2 : packer le markdown au build dans une `KV` Edge Config Vercel ou bundler le contenu dans la function. Pour l'instant, les bots qui exécutent du JS (la majorité) verront le contenu via la SPA classique.
+
+5. **Plugin `@tailwindcss/typography`** — Step 3 de la Task 9 vérifie sa présence. Si absent, le plan l'installe. Ce plugin est très commun mais peut ne pas être dans ce projet. À confirmer avec l'utilisateur ou laisser le step le détecter automatiquement.
+
+---
+
+## Execution Handoff
+
+Plan complet et sauvegardé à `docs/superpowers/plans/2026-04-29-blog-architecture-3-articles.md`. Deux options d'exécution :
+
+**1. Subagent-Driven (recommandé)** — Je dispatche un subagent frais par task, review entre chaque tâche, itération rapide.
+
+**2. Inline Execution** — Exécution des tâches dans cette session via `superpowers:executing-plans`, batch avec checkpoints.
+
+Quelle approche préfères-tu ?

--- a/docs/superpowers/plans/2026-04-29-dashboard-onboarding-empty-states.md
+++ b/docs/superpowers/plans/2026-04-29-dashboard-onboarding-empty-states.md
@@ -1,0 +1,1557 @@
+# Dashboard Mode Rename + Onboarding 3 Steps + EmptyState Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Renommer les libellés des 3 modes de dashboard (Hypnagogique → Focus, Mode Jeu → Quiz, Prompt Inverse → Expert), ajouter un onboarding 3 étapes (Bienvenue → Persona → Première analyse) après signup, et factoriser un composant `<EmptyState>` générique réutilisable sur les écrans History/Debate/Chat/Study.
+
+**Architecture:** Plan **frontend-only**. Aucune migration DB (la colonne `User.preferences` JSON existe déjà depuis migration 008/009 et l'endpoint `PUT /api/auth/preferences` accepte déjà `extra_preferences` mergé non-destructivement). Onboarding monté en overlay dans `ProtectedLayout` derrière check `user.preferences.has_completed_onboarding !== true`. EmptyState générique remplace les placeholders inline et coexiste avec `DoodleEmptyState` (ne pas migrer Debate qui utilise déjà ce composant). Sidebar i18n keys remplacent les chaînes hardcodées tout en préservant les IDs techniques (`classic`, `reverse`) du localStorage `ds-whack-a-mole-mode`.
+
+**Tech Stack:** React 18 + TypeScript strict + Vite 5, Tailwind CSS 3, Framer Motion 12, Zustand, custom `useTranslation` (lit `i18n/{fr,en}.json`), Vitest + Testing Library. Pas de react-i18next — la traduction lit le JSON directement (`t.dashboard.modes.focus.label`). Test wrapper existe : `renderWithProviders` dans `src/__tests__/test-utils.tsx`. Branche : `feature/audit-kimi-plans-2026-04-29`.
+
+---
+
+## Contexte préalable (état codebase à 2026-04-29)
+
+### État Sidebar.tsx (chaînes hardcodées à remplacer)
+
+`frontend/src/components/layout/Sidebar.tsx`, composant `WhackAMoleToggle` (lignes 304-410) :
+
+- L. 363 : `title={enabled ? "Mode Jeu : activé" : "Mode Jeu : désactivé"}`
+- L. 369 : `<span className="text-xs font-medium truncate">Mode Jeu</span>`
+- L. 394 : bouton "Classique"
+- L. 404 : bouton "Prompt Inverse"
+
+Imports lucide existants ligne 9-30 : `LayoutDashboard, History, Swords, Settings, CreditCard, LogOut, ChevronLeft, ChevronRight, Sparkles, ExternalLink, Shield, Info, Scale, BarChart3, User, MessageSquare, GraduationCap, Phone, Menu, Gamepad2`.
+
+⚠ Le hook `useTranslation` (`src/hooks/useTranslation.ts`) retourne directement le JSON sous forme d'objet : `const { t } = useTranslation()` puis `t.nav.dashboard`. Pas de fonction `t("nav.dashboard")` ; les valeurs sont donc déjà du HTML littéral. Pour les nouvelles clés on les lit avec la même syntaxe : `t.dashboard.modes.quiz.label`.
+
+### IDs techniques à NE PAS toucher
+
+`frontend/src/components/layout/Sidebar.tsx:313-321` :
+
+```tsx
+const [mode, setMode] = useState<"classic" | "reverse">(() => {
+  try {
+    return localStorage.getItem("ds-whack-a-mole-mode") === "reverse"
+      ? "reverse"
+      : "classic";
+  } catch {
+    return "classic";
+  }
+});
+```
+
+Et consommé dans `frontend/src/hooks/useWhackAMole.ts:366` + `frontend/src/components/WhackAMole.tsx:86,101,113`. Le localStorage `ds-whack-a-mole-mode` reste `"classic" | "reverse"` (PAS `"expert"`).
+
+### État User.preferences
+
+- Migration 008 (déployée prod) ajoute `User.preferences JSON` (cf. mémoire `project_ambient-lighting-v3.md`, `reference_deepsight-hetzner-auto-deploy.md`).
+- Backend `backend/src/auth/schemas.py:72-85` : `UpdatePreferencesRequest` accepte `extra_preferences: Optional[dict]`.
+- Backend `backend/src/auth/service.py:388-438` : `update_user_preferences` merge le dict `extra_preferences` non-destructivement dans `User.preferences`. Donc envoyer `{ extra_preferences: { has_completed_onboarding: true, persona: "researcher" } }` ne supprime PAS `ambient_lighting_enabled`.
+- Backend `backend/src/auth/router.py:339` : `GET /api/auth/me` retourne déjà `preferences: getattr(current_user, "preferences", None) or {}`.
+- Backend `backend/src/auth/schemas.py:177-187` : `UserResponse.preferences: dict` est exposé au frontend.
+- ⚠ Frontend `services/api.ts:28-57` : interface `User` n'expose PAS encore `preferences`. À ajouter.
+- ⚠ Frontend `services/api.ts:843-852` : `authApi.updatePreferences()` whitelist seulement `default_lang | default_mode | default_model`. À étendre pour accepter `extra_preferences`.
+
+### État composants empty existants
+
+- `frontend/src/components/doodles/DoodleEmptyState.tsx` : composant existe avec types `no-analyses | no-flashcards | no-playlists | no-results | welcome`. Utilisé dans `DebatePage.tsx:784-791`. **Décision DB-2 (RELEASE-ORCHESTRATION L.561)** : garder DoodleEmptyState dans Debate (NE PAS migrer). Le nouvel `<EmptyState>` est plus simple/générique et ne remplace pas Doodle.
+- `frontend/src/pages/History.tsx:1583-1593` : placeholder inline "Quick Chat — Pas encore d'analyse" → migrer.
+- `frontend/src/pages/ChatPage.tsx:778-805` (no video selected) + `:836-859` (empty messages) → migrer.
+- `frontend/src/pages/StudyHubPage.tsx:399-413` (Aucun badge encore) → migrer.
+- `frontend/src/pages/StudyPage.tsx:899-935` (composant `EmptyState` LOCAL) → conserver (scope vidéo détail différent), pas migrer.
+- `frontend/src/pages/PlaylistPage.tsx` : pas d'empty state simple identifié, skip.
+
+### App.tsx structure pour mount onboarding
+
+`frontend/src/App.tsx:435-443` :
+
+```tsx
+const ProtectedLayout = () => {
+  return (
+    <>
+      <SEO noindex />
+      <Outlet />
+    </>
+  );
+};
+```
+
+C'est ici qu'on mount `<OnboardingFlow />` conditionnel. Importe `useAuth` depuis `./hooks/useAuth` (déjà fait L.31).
+
+### Stack tests
+
+- `frontend/vitest.config.ts` : env jsdom, setupFiles `src/__tests__/setup.ts`, include `src/**/*.{test,spec}.{ts,tsx}`.
+- `frontend/src/__tests__/test-utils.tsx` : `renderWithProviders` wrappe avec MemoryRouter + QueryClient + LanguageProvider.
+- Convention : tests à côté du composant ou dans `src/__tests__/`. Utiliser format `<Component>.test.tsx`.
+
+### Audit gap couvert par ce plan
+
+Issu de `docs/superpowers/plans/2026-04-29-RELEASE-ORCHESTRATION.md` Sprint A :
+
+- Renommer modes dashboard : "Hypnagogique" → "Focus", "Mode Jeu" → "Quiz", "Prompt Inverse" → "Expert" + "Classique" stable.
+- Onboarding inexistant après signup → 3 étapes (Welcome / Persona / First analysis).
+- Empty states absents → composant générique réutilisable.
+
+⚠ **Décision RELEASE-ORCHESTRATION DB-1** : "Hypnagogique" n'existe pas en code (audit Kimi a confondu avec un mode théorique). On rename `Mode Jeu` → `Mode Quiz`, `Classique` → `Mode Classique`, `Prompt Inverse` → `Mode Expert`. Le label "Mode Focus" demandé par audit est mappé sur l'**état désactivé** du toggle global (`enabled=false`), avec icône `Focus`. Décision à confirmer en self-review.
+
+---
+
+## File Structure
+
+| Fichier                                                                | Action | Responsabilité                                                                                                                                                        |
+| ---------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `frontend/src/i18n/fr.json`                                            | Modify | Ajouter namespaces `dashboard.modes.{focus,quiz,classic,expert}.{label,description}` + `onboarding.*` + `empty_states.*`                                              |
+| `frontend/src/i18n/en.json`                                            | Modify | Idem (miroir EN)                                                                                                                                                      |
+| `frontend/src/components/EmptyState.tsx`                               | Create | Composant générique : `icon, title, description, ctaLabel?, ctaHref?, suggestedVideo?` ; dark mode + glassmorphism + Framer Motion                                    |
+| `frontend/src/components/__tests__/EmptyState.test.tsx`                | Create | Tests Vitest : rendu props, CTA cliquable, suggestedVideo conditionnel                                                                                                |
+| `frontend/src/services/api.ts`                                         | Modify | Étendre `User` interface (ligne 28) avec `preferences?: Record<string, unknown>` + étendre `authApi.updatePreferences` (ligne 843) avec `extra_preferences` optionnel |
+| `frontend/src/components/layout/Sidebar.tsx`                           | Modify | Lignes 363, 369, 394, 404 : remplacer hardcoded par `t.dashboard.modes.{focus,quiz,classic,expert}.label`. IDs `classic                                               | reverse`localStorage inchangés. Ajouter import`Focus, Layout, Terminal` lucide |
+| `frontend/src/components/onboarding/OnboardingFlow.tsx`                | Create | Modal 3 étapes Framer Motion, gating sur `user.preferences.has_completed_onboarding`, persiste via `authApi.updatePreferences({ extra_preferences: ... })`            |
+| `frontend/src/components/onboarding/PersonaCard.tsx`                   | Create | Card sélectionnable persona (chercheur/journaliste/étudiant/professionnel) avec icône + label + description                                                           |
+| `frontend/src/components/onboarding/__tests__/OnboardingFlow.test.tsx` | Create | Tests : 3 étapes, navigation Suivant/Précédent, skip flow, persona persisté, fermeture après step 3                                                                   |
+| `frontend/src/components/onboarding/__tests__/PersonaCard.test.tsx`    | Create | Tests : rendu, état sélectionné, click handler                                                                                                                        |
+| `frontend/src/App.tsx`                                                 | Modify | Lignes 435-443 : `ProtectedLayout` lit `useAuth().user.preferences?.has_completed_onboarding` ; render `<OnboardingFlow />` conditionnel                              |
+| `frontend/src/pages/History.tsx`                                       | Modify | Lignes ~1573-1593 : remplacer placeholder Quick Chat inline par `<EmptyState>` (icon BookOpen, title traduit, ctaLabel "Lancer une analyse")                          |
+| `frontend/src/pages/ChatPage.tsx`                                      | Modify | Lignes 778-805 (no video selected) ET 836-859 (empty messages) : migrer vers `<EmptyState>`                                                                           |
+| `frontend/src/pages/StudyHubPage.tsx`                                  | Modify | Lignes 399-413 (Aucun badge encore) : migrer vers `<EmptyState>`                                                                                                      |
+
+⚠ **NON modifiés** : `DebatePage.tsx` (garde `DoodleEmptyState` — décision DB-2), `StudyPage.tsx` (composant `EmptyState` local scope vidéo détail, conserve), `PlaylistPage.tsx` (pas de placeholder simple identifié).
+
+---
+
+## Tasks
+
+### Task 1: i18n FR + EN — clés modes + onboarding + empty_states
+
+**Files:**
+
+- Modify: `frontend/src/i18n/fr.json`
+- Modify: `frontend/src/i18n/en.json`
+
+- [ ] **Step 1: Ajouter namespace `dashboard.modes` dans `fr.json`**
+
+Insérer (avant `auth` ou après `nav`) :
+
+```json
+"dashboard": {
+  "modes": {
+    "toggle_on": "Mode Quiz : activé",
+    "toggle_off": "Mode Quiz : désactivé",
+    "focus": {
+      "label": "Mode Focus",
+      "description": "Interface minimaliste sans distraction"
+    },
+    "quiz": {
+      "label": "Mode Quiz",
+      "description": "Apprenez en jouant avec des questions interactives"
+    },
+    "classic": {
+      "label": "Mode Classique",
+      "description": "Interface standard avec toutes les options"
+    },
+    "expert": {
+      "label": "Mode Expert",
+      "description": "Contrôle total sur les prompts et paramètres"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Ajouter namespace `onboarding` dans `fr.json`**
+
+Ajouter (à la suite de `dashboard`) :
+
+```json
+"onboarding": {
+  "skip": "Passer",
+  "next": "Suivant",
+  "previous": "Précédent",
+  "step_indicator": "Étape {{current}} / {{total}}",
+  "welcome": {
+    "title": "Bienvenue sur DeepSight !",
+    "description": "Vous avez 5 analyses gratuites ce mois-ci pour découvrir nos résumés vidéo intelligents.",
+    "cta": "Commencer"
+  },
+  "persona": {
+    "title": "Que faites-vous principalement ?",
+    "description": "Cela nous aide à personnaliser vos recommandations.",
+    "researcher": {
+      "label": "Chercheur",
+      "description": "Veille scientifique, papers, conférences"
+    },
+    "journalist": {
+      "label": "Journaliste",
+      "description": "Fact-checking, enquêtes, sources"
+    },
+    "student": {
+      "label": "Étudiant",
+      "description": "Cours, révisions, flashcards"
+    },
+    "professional": {
+      "label": "Professionnel",
+      "description": "Veille marché, formation continue"
+    }
+  },
+  "first_analysis": {
+    "title": "Lançons votre première analyse",
+    "description": "Collez l'URL d'une vidéo YouTube ou TikTok.",
+    "placeholder": "https://www.youtube.com/watch?v=...",
+    "tip": "Conseil : commencez par une vidéo de 10 min max pour un premier résultat rapide.",
+    "cta": "Analyser",
+    "skip": "Passer — Aller au tableau de bord"
+  }
+}
+```
+
+- [ ] **Step 3: Ajouter namespace `empty_states` dans `fr.json`**
+
+```json
+"empty_states": {
+  "history": {
+    "title": "Aucune analyse pour l'instant",
+    "description": "Lancez votre première analyse vidéo pour commencer.",
+    "cta": "Lancer une analyse"
+  },
+  "chat_no_selection": {
+    "title": "Sélectionnez une vidéo",
+    "description": "Choisissez une vidéo dans la sidebar pour discuter avec l'IA.",
+    "cta": "Voir mon historique"
+  },
+  "chat_empty_thread": {
+    "title": "Posez votre première question",
+    "description": "L'IA répondra en se basant sur le contenu de la vidéo."
+  },
+  "study_no_badges": {
+    "title": "Aucun badge encore",
+    "description": "Continuez vos révisions pour débloquer vos premiers badges."
+  }
+}
+```
+
+- [ ] **Step 4: Miroir complet dans `en.json`**
+
+Mêmes clés, traductions anglaises. Pour `dashboard.modes` :
+
+```json
+"dashboard": {
+  "modes": {
+    "toggle_on": "Quiz mode: enabled",
+    "toggle_off": "Quiz mode: disabled",
+    "focus": { "label": "Focus Mode", "description": "Distraction-free minimalist interface" },
+    "quiz": { "label": "Quiz Mode", "description": "Learn through interactive questions" },
+    "classic": { "label": "Classic Mode", "description": "Standard interface with all options" },
+    "expert": { "label": "Expert Mode", "description": "Full control over prompts and parameters" }
+  }
+}
+```
+
+Et pour `onboarding` + `empty_states` : traductions miroir directes (Welcome to DeepSight!, You have 5 free analyses this month, etc.).
+
+- [ ] **Step 5: Vérifier syntaxe JSON valide**
+
+Run: `cd frontend && node -e "JSON.parse(require('fs').readFileSync('src/i18n/fr.json'))" && node -e "JSON.parse(require('fs').readFileSync('src/i18n/en.json'))"`
+Expected: pas d'output (JSON valide).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/i18n/fr.json frontend/src/i18n/en.json
+git commit -m "feat(i18n): add dashboard.modes, onboarding, empty_states keys"
+```
+
+---
+
+### Task 2: Composant EmptyState générique (TDD)
+
+**Files:**
+
+- Create: `frontend/src/components/EmptyState.tsx`
+- Create: `frontend/src/components/__tests__/EmptyState.test.tsx`
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+```tsx
+// frontend/src/components/__tests__/EmptyState.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { History as HistoryIcon } from "lucide-react";
+import { renderWithProviders } from "../../__tests__/test-utils";
+import { EmptyState } from "../EmptyState";
+
+describe("EmptyState", () => {
+  it("renders title, description and icon", () => {
+    renderWithProviders(
+      <EmptyState
+        icon={HistoryIcon}
+        title="Aucune analyse"
+        description="Lancez votre première analyse"
+      />,
+    );
+    expect(screen.getByText("Aucune analyse")).toBeInTheDocument();
+    expect(
+      screen.getByText("Lancez votre première analyse"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders CTA when ctaLabel and ctaHref provided", async () => {
+    renderWithProviders(
+      <EmptyState
+        icon={HistoryIcon}
+        title="Vide"
+        description="Rien"
+        ctaLabel="Lancer une analyse"
+        ctaHref="/dashboard"
+      />,
+    );
+    const cta = screen.getByRole("link", { name: /lancer une analyse/i });
+    expect(cta).toHaveAttribute("href", "/dashboard");
+  });
+
+  it("calls onCta when ctaLabel + onCta provided (no href)", async () => {
+    const onCta = vi.fn();
+    renderWithProviders(
+      <EmptyState
+        icon={HistoryIcon}
+        title="Vide"
+        description="Rien"
+        ctaLabel="Action"
+        onCta={onCta}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /action/i }));
+    expect(onCta).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders suggestedVideo block when provided", () => {
+    renderWithProviders(
+      <EmptyState
+        icon={HistoryIcon}
+        title="Vide"
+        description="Rien"
+        suggestedVideo={{
+          title: "Vidéo recommandée",
+          thumbnailUrl: "https://example.com/thumb.jpg",
+          href: "/dashboard?video=abc",
+        }}
+      />,
+    );
+    expect(screen.getByText("Vidéo recommandée")).toBeInTheDocument();
+    const thumb = screen.getByRole("img");
+    expect(thumb).toHaveAttribute("src", "https://example.com/thumb.jpg");
+  });
+
+  it("does NOT render CTA when ctaLabel missing", () => {
+    renderWithProviders(
+      <EmptyState icon={HistoryIcon} title="Vide" description="Rien" />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run le test → échec attendu**
+
+Run: `cd frontend && npx vitest run src/components/__tests__/EmptyState.test.tsx`
+Expected: FAIL — `Cannot find module '../EmptyState'`.
+
+- [ ] **Step 3: Implémenter le composant minimal**
+
+```tsx
+// frontend/src/components/EmptyState.tsx
+import React from "react";
+import { motion } from "framer-motion";
+import type { LucideIcon } from "lucide-react";
+
+interface SuggestedVideo {
+  title: string;
+  thumbnailUrl: string;
+  href: string;
+}
+
+export interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+  onCta?: () => void;
+  suggestedVideo?: SuggestedVideo;
+  className?: string;
+}
+
+/**
+ * Composant générique d'état vide réutilisable.
+ *
+ * Usage minimal :
+ *   <EmptyState icon={History} title="..." description="..." />
+ *
+ * Avec CTA navigation :
+ *   <EmptyState ... ctaLabel="..." ctaHref="/dashboard" />
+ *
+ * Avec CTA action :
+ *   <EmptyState ... ctaLabel="..." onCta={() => doSomething()} />
+ *
+ * Avec suggestion vidéo (optionnel) :
+ *   <EmptyState ... suggestedVideo={{ title, thumbnailUrl, href }} />
+ */
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  icon: Icon,
+  title,
+  description,
+  ctaLabel,
+  ctaHref,
+  onCta,
+  suggestedVideo,
+  className = "",
+}) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      className={`flex flex-col items-center justify-center py-16 px-6 text-center ${className}`}
+    >
+      <div className="w-14 h-14 mb-5 rounded-2xl bg-white/[0.03] border border-white/[0.06] backdrop-blur-xl flex items-center justify-center">
+        <Icon className="w-7 h-7 text-cyan-400/40" aria-hidden="true" />
+      </div>
+      <h3 className="text-lg font-semibold text-text-secondary mb-2">
+        {title}
+      </h3>
+      <p className="text-sm text-text-tertiary max-w-sm mb-6">{description}</p>
+
+      {ctaLabel && ctaHref && (
+        <a
+          href={ctaHref}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-accent-primary text-gray-900 text-sm font-medium hover:bg-accent-primary-hover transition-colors"
+        >
+          {ctaLabel}
+        </a>
+      )}
+      {ctaLabel && !ctaHref && onCta && (
+        <button
+          type="button"
+          onClick={onCta}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-accent-primary text-gray-900 text-sm font-medium hover:bg-accent-primary-hover transition-colors"
+        >
+          {ctaLabel}
+        </button>
+      )}
+
+      {suggestedVideo && (
+        <a
+          href={suggestedVideo.href}
+          className="mt-8 flex items-center gap-3 max-w-xs p-3 rounded-xl bg-white/[0.03] border border-white/[0.06] backdrop-blur-xl hover:bg-white/[0.06] transition-colors"
+        >
+          <img
+            src={suggestedVideo.thumbnailUrl}
+            alt=""
+            className="w-16 h-9 rounded-md object-cover flex-shrink-0"
+          />
+          <span className="text-sm text-text-secondary text-left line-clamp-2">
+            {suggestedVideo.title}
+          </span>
+        </a>
+      )}
+    </motion.div>
+  );
+};
+
+export default EmptyState;
+```
+
+- [ ] **Step 4: Run le test → passe**
+
+Run: `cd frontend && npx vitest run src/components/__tests__/EmptyState.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: pas d'erreur sur les nouveaux fichiers.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/EmptyState.tsx frontend/src/components/__tests__/EmptyState.test.tsx
+git commit -m "feat(empty-state): generic EmptyState component with optional CTA + suggested video"
+```
+
+---
+
+### Task 3: Étendre User type + authApi.updatePreferences
+
+**Files:**
+
+- Modify: `frontend/src/services/api.ts:28-57` (User interface)
+- Modify: `frontend/src/services/api.ts:843-852` (updatePreferences)
+
+- [ ] **Step 1: Étendre l'interface `User`**
+
+Dans `frontend/src/services/api.ts`, ligne 28-57, après `analysis_limit?: number;` et avant le `}` final de l'interface, ajouter :
+
+```typescript
+  // Bag JSON merge non-destructivement par PUT /api/auth/preferences
+  // (ambient_lighting_enabled, has_completed_onboarding, persona, etc.)
+  preferences?: Record<string, unknown>;
+```
+
+- [ ] **Step 2: Étendre `authApi.updatePreferences`**
+
+Ligne 843-852, remplacer :
+
+```typescript
+async updatePreferences(prefs: {
+  default_lang?: string;
+  default_mode?: string;
+  default_model?: string;
+}): Promise<{ success: boolean; message: string }> {
+  return request("/api/auth/preferences", {
+    method: "PUT",
+    body: prefs,
+  });
+},
+```
+
+par :
+
+```typescript
+async updatePreferences(prefs: {
+  default_lang?: string;
+  default_mode?: string;
+  default_model?: string;
+  // Bag JSON arbitraire mergé non-destructivement côté backend
+  // (auth/service.py:update_user_preferences). Utilisé pour
+  // has_completed_onboarding, persona, ambient_lighting_enabled.
+  extra_preferences?: Record<string, unknown>;
+}): Promise<{ success: boolean; message: string }> {
+  return request("/api/auth/preferences", {
+    method: "PUT",
+    body: prefs,
+  });
+},
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: pas d'erreur.
+
+- [ ] **Step 4: Vérifier non-régression tests existants**
+
+Run: `cd frontend && npx vitest run`
+Expected: tous les tests existants passent (rien ne casse).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/services/api.ts
+git commit -m "feat(api): extend User.preferences and authApi.updatePreferences with extra_preferences"
+```
+
+---
+
+### Task 4: Sidebar — remplacer labels hardcoded par i18n keys
+
+**Files:**
+
+- Modify: `frontend/src/components/layout/Sidebar.tsx:9-30` (imports)
+- Modify: `frontend/src/components/layout/Sidebar.tsx:304-410` (WhackAMoleToggle)
+
+- [ ] **Step 1: Ajouter imports lucide manquants**
+
+Lignes 9-30, ajouter `Focus, Layout as LayoutIcon, Terminal` à l'import lucide-react :
+
+```tsx
+import {
+  LayoutDashboard,
+  History,
+  Swords,
+  Settings,
+  CreditCard,
+  LogOut,
+  ChevronLeft,
+  ChevronRight,
+  Sparkles,
+  ExternalLink,
+  Shield,
+  Info,
+  Scale,
+  BarChart3,
+  User,
+  MessageSquare,
+  GraduationCap,
+  Phone,
+  Menu,
+  Gamepad2,
+  Focus,
+  Layout as LayoutIcon,
+  Terminal,
+} from "lucide-react";
+```
+
+- [ ] **Step 2: Remplacer les chaînes hardcodées dans `WhackAMoleToggle`**
+
+Ligne 363 (title attribute) — remplacer :
+
+```tsx
+title={enabled ? "Mode Jeu : activé" : "Mode Jeu : désactivé"}
+```
+
+par :
+
+```tsx
+title={enabled ? t.dashboard.modes.toggle_on : t.dashboard.modes.toggle_off}
+```
+
+Ligne 369 (label visible toggle) — remplacer :
+
+```tsx
+<span className="text-xs font-medium truncate">Mode Jeu</span>
+```
+
+par :
+
+```tsx
+<span className="text-xs font-medium truncate">
+  {t.dashboard.modes.quiz.label}
+</span>
+```
+
+Ligne 394 (bouton classic) — remplacer :
+
+```tsx
+Classique;
+```
+
+par :
+
+```tsx
+{
+  t.dashboard.modes.classic.label;
+}
+```
+
+Ligne 404 (bouton reverse) — remplacer :
+
+```tsx
+Prompt Inverse
+```
+
+par :
+
+```tsx
+{
+  t.dashboard.modes.expert.label;
+}
+```
+
+⚠ Le composant `WhackAMoleToggle` ne consomme pas encore `useTranslation`. Modifier la signature pour ajouter le hook :
+
+Ligne 305, remplacer :
+
+```tsx
+const WhackAMoleToggle: React.FC<{ collapsed?: boolean }> = ({ collapsed }) => {
+```
+
+par :
+
+```tsx
+const WhackAMoleToggle: React.FC<{ collapsed?: boolean }> = ({ collapsed }) => {
+  const { t } = useTranslation();
+```
+
+(`useTranslation` est déjà importé ligne 32.)
+
+- [ ] **Step 3: Vérifier non-régression localStorage IDs**
+
+Lignes 313-321 et 339-352 NE DOIVENT PAS être modifiées. Le contrat reste `"classic" | "reverse"` côté localStorage `ds-whack-a-mole-mode`.
+
+Vérifier en grep :
+
+Run: `cd frontend && grep -n "ds-whack-a-mole-mode" src/`
+Expected: voir les références dans Sidebar.tsx, useWhackAMole.ts, WhackAMole.tsx — toutes utilisent `"classic" | "reverse"` (ID technique inchangé).
+
+- [ ] **Step 4: Lancer le frontend en dev pour smoke test (optionnel)**
+
+Run: `cd frontend && npm run dev`
+Naviguer vers `/dashboard` (after login). Vérifier que la sidebar affiche :
+
+- "Mode Quiz" au lieu de "Mode Jeu"
+- "Mode Classique" au lieu de "Classique"
+- "Mode Expert" au lieu de "Prompt Inverse"
+- Switcher language → EN affiche "Quiz Mode", "Classic Mode", "Expert Mode"
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: pas d'erreur.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/layout/Sidebar.tsx
+git commit -m "refactor(sidebar): replace hardcoded mode labels with i18n keys (Quiz/Classic/Expert)"
+```
+
+---
+
+### Task 5: Composant PersonaCard (TDD)
+
+**Files:**
+
+- Create: `frontend/src/components/onboarding/PersonaCard.tsx`
+- Create: `frontend/src/components/onboarding/__tests__/PersonaCard.test.tsx`
+
+- [ ] **Step 1: Créer le dossier `onboarding/`**
+
+Run: `mkdir -p "frontend/src/components/onboarding/__tests__"`
+
+- [ ] **Step 2: Écrire le test PersonaCard qui échoue**
+
+```tsx
+// frontend/src/components/onboarding/__tests__/PersonaCard.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraduationCap } from "lucide-react";
+import { renderWithProviders } from "../../../__tests__/test-utils";
+import { PersonaCard } from "../PersonaCard";
+
+describe("PersonaCard", () => {
+  it("renders label, description, icon", () => {
+    renderWithProviders(
+      <PersonaCard
+        icon={GraduationCap}
+        label="Étudiant"
+        description="Cours, révisions"
+        selected={false}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText("Étudiant")).toBeInTheDocument();
+    expect(screen.getByText("Cours, révisions")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when clicked", async () => {
+    const onSelect = vi.fn();
+    renderWithProviders(
+      <PersonaCard
+        icon={GraduationCap}
+        label="Étudiant"
+        description="Cours"
+        selected={false}
+        onSelect={onSelect}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /étudiant/i }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies selected styles when selected=true", () => {
+    renderWithProviders(
+      <PersonaCard
+        icon={GraduationCap}
+        label="Étudiant"
+        description="Cours"
+        selected={true}
+        onSelect={() => {}}
+      />,
+    );
+    const button = screen.getByRole("button", { name: /étudiant/i });
+    expect(button).toHaveAttribute("aria-pressed", "true");
+  });
+});
+```
+
+- [ ] **Step 3: Run le test → échec**
+
+Run: `cd frontend && npx vitest run src/components/onboarding/__tests__/PersonaCard.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implémenter `PersonaCard`**
+
+```tsx
+// frontend/src/components/onboarding/PersonaCard.tsx
+import React from "react";
+import type { LucideIcon } from "lucide-react";
+
+export interface PersonaCardProps {
+  icon: LucideIcon;
+  label: string;
+  description: string;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+export const PersonaCard: React.FC<PersonaCardProps> = ({
+  icon: Icon,
+  label,
+  description,
+  selected,
+  onSelect,
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={`flex flex-col items-start gap-2 p-4 rounded-xl border backdrop-blur-xl transition-all text-left ${
+        selected
+          ? "bg-accent-primary/15 border-accent-primary/40"
+          : "bg-white/[0.03] border-white/[0.06] hover:bg-white/[0.06]"
+      }`}
+    >
+      <div
+        className={`w-10 h-10 rounded-lg flex items-center justify-center ${
+          selected ? "bg-accent-primary/25" : "bg-white/[0.05]"
+        }`}
+      >
+        <Icon
+          className={`w-5 h-5 ${selected ? "text-accent-primary" : "text-text-tertiary"}`}
+        />
+      </div>
+      <span className="text-sm font-semibold text-text-primary">{label}</span>
+      <span className="text-xs text-text-tertiary">{description}</span>
+    </button>
+  );
+};
+
+export default PersonaCard;
+```
+
+- [ ] **Step 5: Run le test → passe**
+
+Run: `cd frontend && npx vitest run src/components/onboarding/__tests__/PersonaCard.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/onboarding/PersonaCard.tsx frontend/src/components/onboarding/__tests__/PersonaCard.test.tsx
+git commit -m "feat(onboarding): PersonaCard selectable component"
+```
+
+---
+
+### Task 6: Composant OnboardingFlow 3 étapes (TDD)
+
+**Files:**
+
+- Create: `frontend/src/components/onboarding/OnboardingFlow.tsx`
+- Create: `frontend/src/components/onboarding/__tests__/OnboardingFlow.test.tsx`
+
+- [ ] **Step 1: Écrire les tests OnboardingFlow qui échouent**
+
+```tsx
+// frontend/src/components/onboarding/__tests__/OnboardingFlow.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../../../__tests__/test-utils";
+import { OnboardingFlow } from "../OnboardingFlow";
+
+// Mock authApi
+vi.mock("../../../services/api", async () => {
+  const actual = await vi.importActual<typeof import("../../../services/api")>(
+    "../../../services/api",
+  );
+  return {
+    ...actual,
+    authApi: {
+      ...actual.authApi,
+      updatePreferences: vi.fn(async () => ({ success: true, message: "OK" })),
+    },
+  };
+});
+
+import { authApi } from "../../../services/api";
+
+describe("OnboardingFlow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders welcome step initially", () => {
+    renderWithProviders(<OnboardingFlow onComplete={() => {}} />);
+    expect(screen.getByText(/bienvenue/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /commencer/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("advances to persona step on Commencer", async () => {
+    renderWithProviders(<OnboardingFlow onComplete={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /commencer/i }));
+    expect(
+      screen.getByText(/que faites-vous principalement/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/chercheur/i)).toBeInTheDocument();
+    expect(screen.getByText(/journaliste/i)).toBeInTheDocument();
+    expect(screen.getByText(/étudiant/i)).toBeInTheDocument();
+    expect(screen.getByText(/professionnel/i)).toBeInTheDocument();
+  });
+
+  it("persists persona and completes onboarding when researcher selected then Suivant", async () => {
+    const onComplete = vi.fn();
+    renderWithProviders(<OnboardingFlow onComplete={onComplete} />);
+    await userEvent.click(screen.getByRole("button", { name: /commencer/i }));
+    await userEvent.click(screen.getByRole("button", { name: /chercheur/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^suivant$/i }));
+    // Step 3
+    expect(screen.getByPlaceholderText(/youtube\.com/i)).toBeInTheDocument();
+    // Skip step 3 → completion
+    await userEvent.click(
+      screen.getByRole("button", { name: /aller au tableau de bord/i }),
+    );
+    await waitFor(() => {
+      expect(authApi.updatePreferences).toHaveBeenCalledWith({
+        extra_preferences: expect.objectContaining({
+          has_completed_onboarding: true,
+          persona: "researcher",
+        }),
+      });
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  it("skip flow at step 1 sets has_completed_onboarding=true with persona null", async () => {
+    const onComplete = vi.fn();
+    renderWithProviders(<OnboardingFlow onComplete={onComplete} />);
+    await userEvent.click(screen.getByRole("button", { name: /^passer$/i }));
+    await waitFor(() => {
+      expect(authApi.updatePreferences).toHaveBeenCalledWith({
+        extra_preferences: {
+          has_completed_onboarding: true,
+          persona: null,
+        },
+      });
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run le test → échec**
+
+Run: `cd frontend && npx vitest run src/components/onboarding/__tests__/OnboardingFlow.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implémenter `OnboardingFlow`**
+
+```tsx
+// frontend/src/components/onboarding/OnboardingFlow.tsx
+import React, { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  Sparkles,
+  GraduationCap,
+  BookOpen,
+  Newspaper,
+  Briefcase,
+  Search,
+} from "lucide-react";
+import { useTranslation } from "../../hooks/useTranslation";
+import { authApi } from "../../services/api";
+import { PersonaCard } from "./PersonaCard";
+
+export type Persona =
+  | "researcher"
+  | "journalist"
+  | "student"
+  | "professional"
+  | null;
+
+export interface OnboardingFlowProps {
+  onComplete: () => void;
+}
+
+type Step = 1 | 2 | 3;
+
+/**
+ * Onboarding modal 3 étapes : Welcome → Persona → First analysis.
+ *
+ * Mounted depuis `ProtectedLayout` quand `user.preferences.has_completed_onboarding !== true`.
+ *
+ * Persistance : `authApi.updatePreferences({ extra_preferences: { has_completed_onboarding, persona } })`.
+ * Skip à n'importe quelle étape → set `has_completed_onboarding=true` avec `persona=null`
+ * (ou la valeur sélectionnée si déjà choisie).
+ */
+export const OnboardingFlow: React.FC<OnboardingFlowProps> = ({
+  onComplete,
+}) => {
+  const { t } = useTranslation();
+  const [step, setStep] = useState<Step>(1);
+  const [persona, setPersona] = useState<Persona>(null);
+  const [videoUrl, setVideoUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const finish = async (finalPersona: Persona = persona) => {
+    setSubmitting(true);
+    try {
+      await authApi.updatePreferences({
+        extra_preferences: {
+          has_completed_onboarding: true,
+          persona: finalPersona,
+        },
+      });
+    } catch (err) {
+      // Best-effort : on ferme quand même pour ne pas bloquer l'utilisateur
+      // sur un échec réseau. Le flag sera retenté à la prochaine session.
+      // eslint-disable-next-line no-console
+      console.warn("[onboarding] persist failed", err);
+    } finally {
+      setSubmitting(false);
+      onComplete();
+    }
+  };
+
+  const personas: Array<{
+    id: Exclude<Persona, null>;
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    description: string;
+  }> = [
+    {
+      id: "researcher",
+      icon: Search,
+      label: t.onboarding.persona.researcher.label,
+      description: t.onboarding.persona.researcher.description,
+    },
+    {
+      id: "journalist",
+      icon: Newspaper,
+      label: t.onboarding.persona.journalist.label,
+      description: t.onboarding.persona.journalist.description,
+    },
+    {
+      id: "student",
+      icon: GraduationCap,
+      label: t.onboarding.persona.student.label,
+      description: t.onboarding.persona.student.description,
+    },
+    {
+      id: "professional",
+      icon: Briefcase,
+      label: t.onboarding.persona.professional.label,
+      description: t.onboarding.persona.professional.description,
+    },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm">
+      <motion.div
+        initial={{ opacity: 0, y: 20, scale: 0.96 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.3, ease: "easeOut" }}
+        className="relative w-full max-w-lg mx-4 rounded-2xl bg-bg-secondary border border-white/10 backdrop-blur-xl p-8"
+      >
+        <div className="flex items-center justify-between mb-6">
+          <span className="text-xs text-text-tertiary">{`${step} / 3`}</span>
+          <button
+            type="button"
+            onClick={() => finish(step === 2 ? persona : null)}
+            disabled={submitting}
+            className="text-xs text-text-tertiary hover:text-text-secondary transition-colors"
+          >
+            {t.onboarding.skip}
+          </button>
+        </div>
+
+        <AnimatePresence mode="wait">
+          {step === 1 && (
+            <motion.div
+              key="welcome"
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.2 }}
+            >
+              <div className="w-14 h-14 mb-5 rounded-2xl bg-accent-primary/15 flex items-center justify-center">
+                <Sparkles className="w-7 h-7 text-accent-primary" />
+              </div>
+              <h2 className="text-xl font-bold text-text-primary mb-2">
+                {t.onboarding.welcome.title}
+              </h2>
+              <p className="text-sm text-text-tertiary mb-8">
+                {t.onboarding.welcome.description}
+              </p>
+              <button
+                type="button"
+                onClick={() => setStep(2)}
+                className="w-full px-4 py-3 rounded-lg bg-accent-primary text-gray-900 text-sm font-medium hover:bg-accent-primary-hover transition-colors"
+              >
+                {t.onboarding.welcome.cta}
+              </button>
+            </motion.div>
+          )}
+
+          {step === 2 && (
+            <motion.div
+              key="persona"
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.2 }}
+            >
+              <h2 className="text-xl font-bold text-text-primary mb-2">
+                {t.onboarding.persona.title}
+              </h2>
+              <p className="text-sm text-text-tertiary mb-6">
+                {t.onboarding.persona.description}
+              </p>
+              <div className="grid grid-cols-2 gap-3 mb-6">
+                {personas.map((p) => (
+                  <PersonaCard
+                    key={p.id}
+                    icon={p.icon as never}
+                    label={p.label}
+                    description={p.description}
+                    selected={persona === p.id}
+                    onSelect={() => setPersona(p.id)}
+                  />
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setStep(1)}
+                  className="px-4 py-2 rounded-lg bg-white/[0.05] text-text-secondary text-sm font-medium hover:bg-white/[0.08] transition-colors"
+                >
+                  {t.onboarding.previous}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setStep(3)}
+                  disabled={persona === null}
+                  className="flex-1 px-4 py-2 rounded-lg bg-accent-primary text-gray-900 text-sm font-medium hover:bg-accent-primary-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {t.onboarding.next}
+                </button>
+              </div>
+            </motion.div>
+          )}
+
+          {step === 3 && (
+            <motion.div
+              key="first"
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.2 }}
+            >
+              <div className="w-14 h-14 mb-5 rounded-2xl bg-cyan-500/15 flex items-center justify-center">
+                <BookOpen className="w-7 h-7 text-cyan-400" />
+              </div>
+              <h2 className="text-xl font-bold text-text-primary mb-2">
+                {t.onboarding.first_analysis.title}
+              </h2>
+              <p className="text-sm text-text-tertiary mb-4">
+                {t.onboarding.first_analysis.description}
+              </p>
+              <input
+                type="url"
+                value={videoUrl}
+                onChange={(e) => setVideoUrl(e.target.value)}
+                placeholder={t.onboarding.first_analysis.placeholder}
+                className="w-full px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.08] text-sm text-text-primary placeholder:text-text-quaternary focus:outline-none focus:border-accent-primary/40"
+              />
+              <p className="text-xs text-text-tertiary mt-2 mb-6">
+                {t.onboarding.first_analysis.tip}
+              </p>
+              <div className="flex flex-col gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (videoUrl.trim()) {
+                      // Navigation déléguée : on stocke l'URL pour DashboardPage
+                      try {
+                        sessionStorage.setItem(
+                          "ds-onboarding-video-url",
+                          videoUrl.trim(),
+                        );
+                      } catch {
+                        /* */
+                      }
+                    }
+                    void finish();
+                  }}
+                  disabled={submitting}
+                  className="w-full px-4 py-2 rounded-lg bg-accent-primary text-gray-900 text-sm font-medium hover:bg-accent-primary-hover transition-colors disabled:opacity-50"
+                >
+                  {t.onboarding.first_analysis.cta}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void finish()}
+                  disabled={submitting}
+                  className="w-full px-4 py-2 rounded-lg bg-white/[0.04] text-text-secondary text-sm hover:bg-white/[0.08] transition-colors disabled:opacity-50"
+                >
+                  {t.onboarding.first_analysis.skip}
+                </button>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.div>
+    </div>
+  );
+};
+
+export default OnboardingFlow;
+```
+
+- [ ] **Step 4: Run les tests → passent**
+
+Run: `cd frontend && npx vitest run src/components/onboarding/__tests__/OnboardingFlow.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: pas d'erreur.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/onboarding/OnboardingFlow.tsx frontend/src/components/onboarding/__tests__/OnboardingFlow.test.tsx
+git commit -m "feat(onboarding): 3-step flow (welcome / persona / first analysis) with skip support"
+```
+
+---
+
+### Task 7: Mount conditionnel dans ProtectedLayout
+
+**Files:**
+
+- Modify: `frontend/src/App.tsx:435-443` (ProtectedLayout)
+
+- [ ] **Step 1: Modifier `ProtectedLayout`**
+
+Lignes 435-443, remplacer :
+
+```tsx
+const ProtectedLayout = () => {
+  // noindex sur toutes les routes protégées (dashboard, history, settings, etc.)
+  return (
+    <>
+      <SEO noindex />
+      <Outlet />
+    </>
+  );
+};
+```
+
+par :
+
+```tsx
+const ProtectedLayout = () => {
+  const { user } = useAuth();
+  const [onboardingDismissed, setOnboardingDismissed] = useState(false);
+
+  // Décision DB-3 (RELEASE-ORCHESTRATION L.562) : show pour anciens users sans flag
+  // → tous les users dont preferences.has_completed_onboarding !== true voient le flow.
+  const shouldShowOnboarding =
+    user !== null &&
+    user.preferences?.has_completed_onboarding !== true &&
+    !onboardingDismissed;
+
+  return (
+    <>
+      <SEO noindex />
+      <Outlet />
+      {shouldShowOnboarding && (
+        <OnboardingFlow onComplete={() => setOnboardingDismissed(true)} />
+      )}
+    </>
+  );
+};
+```
+
+- [ ] **Step 2: Ajouter les imports**
+
+En haut du fichier `frontend/src/App.tsx`, ajouter (après les imports existants) :
+
+```tsx
+import { OnboardingFlow } from "./components/onboarding/OnboardingFlow";
+```
+
+Et compléter `useState` dans l'import React :
+
+Vérifier que `import { useState } from "react"` est déjà présent (ligne ~25-30). Si non, ajouter.
+
+Run: `grep -n "import.*useState" "frontend/src/App.tsx" | head -3`
+
+Si manquant, ajouter à l'import React :
+
+```tsx
+import React, { Suspense, useState } from "react";
+```
+
+- [ ] **Step 3: Vérifier le typage**
+
+Run: `cd frontend && npm run typecheck`
+Expected: pas d'erreur. `user.preferences?.has_completed_onboarding` est typé via la modif Task 3.
+
+- [ ] **Step 4: Smoke test manuel**
+
+Run: `cd frontend && npm run dev`
+
+- Login avec un compte qui n'a pas `has_completed_onboarding=true` dans `User.preferences` → modal apparaît.
+- Cliquer "Passer" → modal disparaît, ne réapparaît pas après navigation. Recharger → ne réapparaît pas (DB persistée).
+- Network tab : vérifier `PUT /api/auth/preferences` avec body `{ "extra_preferences": { "has_completed_onboarding": true, "persona": null } }`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/App.tsx
+git commit -m "feat(layout): mount OnboardingFlow conditionally in ProtectedLayout"
+```
+
+---
+
+### Task 8: Migrer placeholders existants vers EmptyState
+
+**Files:**
+
+- Modify: `frontend/src/pages/History.tsx:1573-1593` (Quick Chat placeholder)
+- Modify: `frontend/src/pages/ChatPage.tsx:778-805, 836-859` (no video + empty thread)
+- Modify: `frontend/src/pages/StudyHubPage.tsx:399-413` (no badges)
+
+⚠ NE PAS toucher : `DebatePage.tsx` (utilise `DoodleEmptyState` — décision DB-2), `StudyPage.tsx` (composant local scope vidéo), `PlaylistPage.tsx`.
+
+- [ ] **Step 1: Modifier `History.tsx` — remplacer placeholder Quick Chat**
+
+Aux lignes ~1573-1593 (rechercher "Quick Chat — Pas encore d'analyse"), remplacer le bloc div placeholder existant par :
+
+```tsx
+import { BookOpen } from "lucide-react"; // si pas déjà importé
+import { EmptyState } from "../components/EmptyState";
+
+// Dans le rendu :
+<EmptyState
+  icon={BookOpen}
+  title={
+    language === "fr"
+      ? "Quick Chat — Pas encore d'analyse"
+      : "Quick Chat — No analysis yet"
+  }
+  description={
+    language === "fr"
+      ? "Vous pouvez générer une analyse complète pour cette vidéo."
+      : "You can generate a full analysis for this video."
+  }
+/>;
+```
+
+⚠ Le bloc original L.1576 contient un mode selector + bouton Generate qu'il faut PRÉSERVER en dessous de l'EmptyState. Concrètement : ne remplacer que le bloc _titre + sous-titre_ (lignes ~1577-1594), et garder le mode selector/bouton intact.
+
+Référence ligne approximative (peut bouger) :
+
+```tsx
+{!selectedVideoDetail.summary_content ? (
+  /* Quick Chat Upgrade Panel */
+  <div className="card p-6">
+    <div className="flex items-center gap-3 mb-5">
+      ...header div à remplacer par <EmptyState>...
+    </div>
+    {/* Mode selector — KEEP */}
+    <div className="mb-4">...</div>
+  </div>
+) : ...}
+```
+
+- [ ] **Step 2: Modifier `ChatPage.tsx` — empty state "no video selected"**
+
+Lignes 778-805, remplacer le bloc `<div className="flex-1 flex items-center justify-center p-6 relative">` par :
+
+```tsx
+import { MessageSquare } from "lucide-react"; // déjà importé
+import { EmptyState } from "../components/EmptyState";
+import { useNavigate } from "react-router-dom"; // déjà importé probablement
+
+// Dans le rendu :
+const navigate = useNavigate(); // si pas déjà déclaré dans le composant
+
+<EmptyState
+  icon={MessageSquare}
+  title={t.empty_states.chat_no_selection.title}
+  description={t.empty_states.chat_no_selection.description}
+  ctaLabel={t.empty_states.chat_no_selection.cta}
+  onCta={() => navigate("/history")}
+/>;
+```
+
+⚠ Garder le composant `<ChatWelcomeInsight>` séparé après l'EmptyState (il a une logique propre).
+
+- [ ] **Step 3: Modifier `ChatPage.tsx` — empty thread (suggestions)**
+
+Lignes 836-859, remplacer le bloc empty state messages par un layout combinant `<EmptyState>` simple + suggestions intactes :
+
+```tsx
+{
+  !isLoadingMessages && messages.length === 0 && (
+    <>
+      <EmptyState
+        icon={Sparkles}
+        title={t.empty_states.chat_empty_thread.title}
+        description={t.empty_states.chat_empty_thread.description}
+      />
+      <div className="flex flex-wrap justify-center gap-2">
+        {t.suggestions.map((s, i) => (
+          <button
+            key={i}
+            onClick={() => handleSend(s)}
+            className="px-4 py-2 rounded-xl bg-white/[0.03] hover:bg-white/[0.06] border border-white/[0.05] hover:border-white/[0.1] text-text-muted hover:text-text-secondary text-sm transition-all"
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}
+```
+
+⚠ Vérifier que `t.suggestions` n'a PAS été cassé (il est sur l'objet local `t = { emptyTitle, emptySubtitle, suggestions }` du composant ChatPage, pas sur `t.empty_states`). Conserver les deux objets en cohabitation.
+
+- [ ] **Step 4: Modifier `StudyHubPage.tsx` — empty badges**
+
+Lignes 399-413, remplacer :
+
+```tsx
+) : (
+  <div className="flex flex-col items-center justify-center py-8 text-center">
+    <BookOpen className="w-8 h-8 text-text-tertiary mb-2" />
+    <p className="text-xs text-text-tertiary">
+      {fr ? "Aucun badge encore" : "No badges yet"}
+    </p>
+  </div>
+)}
+```
+
+par :
+
+```tsx
+import { EmptyState } from "../components/EmptyState"; // si pas déjà importé
+
+) : (
+  <EmptyState
+    icon={BookOpen}
+    title={t.empty_states.study_no_badges.title}
+    description={t.empty_states.study_no_badges.description}
+    className="py-8"
+  />
+)}
+```
+
+⚠ `StudyHubPage` utilise `const fr = language === "fr"` localement. Confirmer que `useTranslation` est appelé pour récupérer `t`. Sinon ajouter :
+
+```tsx
+import { useTranslation } from "../hooks/useTranslation";
+const { t } = useTranslation();
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: pas d'erreur.
+
+- [ ] **Step 6: Run l'ensemble des tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: tous les tests passent (EmptyState + PersonaCard + OnboardingFlow + tests existants).
+
+- [ ] **Step 7: Smoke test manuel**
+
+Run: `cd frontend && npm run dev`
+
+- Naviguer `/chat` sans sélection → EmptyState avec CTA "Voir mon historique".
+- Naviguer `/study` → onglet Overview, scroller jusqu'aux badges → si vide, EmptyState compact.
+- Naviguer `/history`, ouvrir une vidéo Quick Chat sans analyse → EmptyState + mode selector intact.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/pages/History.tsx frontend/src/pages/ChatPage.tsx frontend/src/pages/StudyHubPage.tsx
+git commit -m "refactor(empty-states): migrate History/Chat/StudyHub placeholders to EmptyState"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage
+
+| Spec demandé                                       | Task          | Couvert ?                                                                                        |
+| -------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------ |
+| Renommer "Hypnagogique" → "Focus"                  | T1, T4        | ⚠ Voir D1 — n'existe pas en code, label "Mode Focus" mappé sur état désactivé du toggle          |
+| Renommer "Mode Jeu" → "Quiz"                       | T1, T4        | ✅                                                                                               |
+| Renommer "Prompt Inverse" → "Expert"               | T1, T4        | ✅                                                                                               |
+| IDs internes inchangés (classic/reverse)           | T4 step 3     | ✅                                                                                               |
+| i18n FR + EN                                       | T1            | ✅                                                                                               |
+| Onboarding 3 étapes Welcome → Persona → First      | T6            | ✅                                                                                               |
+| 4 personas (chercheur/journaliste/étudiant/pro)    | T6 (personas) | ✅                                                                                               |
+| Skip flag                                          | T6 (finish)   | ✅                                                                                               |
+| Persona stocké via PUT /api/auth/preferences       | T3 + T6       | ✅ (extra_preferences merge)                                                                     |
+| EmptyState générique réutilisable                  | T2            | ✅                                                                                               |
+| Migrer placeholders History/Debate/Chat/Study      | T8            | ✅ sauf Debate (DB-2) et StudyPage local                                                         |
+| Tests Vitest OnboardingFlow + EmptyState           | T2, T5, T6    | ✅                                                                                               |
+| Backend `User.preferences shape Pydantic` (Q8 opt) | —             | ⚠ Skip — backend déjà accepte dict arbitraire via `extra_preferences`, pas besoin de typer en V1 |
+
+### 2. Placeholder scan
+
+Aucun "TBD", "TODO", "implement later", "fill in details", "add appropriate error handling" sans détail dans les tasks. Tous les snippets de code sont complets.
+
+### 3. Type consistency
+
+- `EmptyState` props `icon: LucideIcon` cohérent entre T2 et T8.
+- `PersonaCard.onSelect: () => void` cohérent entre T5 et T6.
+- `OnboardingFlow.onComplete: () => void` cohérent entre T6 et T7.
+- `User.preferences?: Record<string, unknown>` cohérent T3 → T7.
+- `authApi.updatePreferences` accepte `extra_preferences?: Record<string, unknown>` cohérent T3 → T6.
+- Persona type `"researcher" | "journalist" | "student" | "professional" | null` cohérent T6.
+
+### 4. Décisions à confirmer avant exécution
+
+| ID  | Décision                                                                                                                                                                                                          | Default proposé                                                                                                                                                                                                                                                                  |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | "Hypnagogique" / "Mode Focus" : aucun mode "Hypnagogique" n'existe en code. Le label "Mode Focus" suggéré par l'audit Kimi est-il pour le toggle global _désactivé_ (état OFF) ou pour un futur 5ᵉ mode à créer ? | **(A)** Ne pas créer de mode "Focus", le label reste pour i18n future (consistance audit). Aujourd'hui les 3 modes actifs = Quiz / Classique / Expert. (cohérent RELEASE-ORCHESTRATION DB-1)                                                                                     |
+| D2  | Onboarding pour anciens users (sans flag `has_completed_onboarding`) : leur montrer ?                                                                                                                             | **OUI** — décision DB-3 RELEASE-ORCHESTRATION. `preferences?.has_completed_onboarding !== true` → modal show.                                                                                                                                                                    |
+| D3  | Persona "obligatoire" vs skip OK : empêcher de finir step 2 sans choisir, ou autoriser passer ?                                                                                                                   | **Skip OK à n'importe quelle étape** + bouton "Suivant" désactivé tant qu'aucun persona sélectionné en step 2 (cohérent décision DB-4 RELEASE-ORCHESTRATION).                                                                                                                    |
+| D4  | 4 personas suffisent ou ajouter "Créateur de contenu" / "Curieux" ?                                                                                                                                               | **4 personas V1** — itérer si feedback fort.                                                                                                                                                                                                                                     |
+| D5  | Branche git pour ce plan : `feature/audit-kimi-plans-2026-04-29` (existante, multi-plans) ou `feature/dashboard-onboarding` (dédiée Sprint A) ?                                                                   | **`feature/dashboard-onboarding`** dédiée comme suggéré par RELEASE-ORCHESTRATION Sprint A (worktree parallèle).                                                                                                                                                                 |
+| D6  | Step 3 : redirect vers analyse de la vidéo collée ?                                                                                                                                                               | **(B)** sessionStorage `ds-onboarding-video-url` posé par OnboardingFlow ; DashboardPage le lit au mount et pré-remplit son input principal (à câbler dans une PR séparée Phase 2 — ne pas bloquer ce plan). En V1, juste persister l'URL dans sessionStorage et fermer le flow. |
+
+### 5. Risques résiduels et atténuations
+
+- **Risque** : conflit avec autre PR du Sprint A modifiant `services/api.ts` (`User` interface) → coordonné via RELEASE-ORCHESTRATION section B "ordre optimal" : merger pricing-v2 d'abord puis rebase ce plan.
+- **Risque** : `t.suggestions` dans ChatPage est un objet local, pas dans `i18n/*.json`. T8 step 3 le confirme et conserve le pattern existant.
+- **Risque** : le type `t` retourné par `useTranslation()` est l'objet JSON typé via TypeScript inference. Si TS strict reproche un accès non typé, ajouter une assertion `(t as any).empty_states.X` provisoire ou typer l'objet via un fichier `.d.ts` (hors scope V1).
+- **Atténuation timeout backend** : `finish()` dans OnboardingFlow utilise try/catch et appelle `onComplete()` dans `finally` → l'utilisateur ne reste jamais bloqué sur un échec réseau.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-29-dashboard-onboarding-empty-states.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** - Je dispatche un subagent fresh par task, review entre tasks, itération rapide. Adapté pour les 8 tasks bite-sized de ce plan.
+
+**2. Inline Execution** - Exécuter les tasks dans cette session via `superpowers:executing-plans`, batch execution avec checkpoints.
+
+**Quelle approche ?**
+
+**Si Subagent-Driven choisi:**
+
+- REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development`
+- Fresh subagent par task + two-stage review
+- Avant de démarrer, créer worktree dédié `feature/dashboard-onboarding` (cf. `superpowers:using-git-worktrees`).
+
+**Si Inline Execution choisi:**
+
+- REQUIRED SUB-SKILL: Use `superpowers:executing-plans`
+- Batch execution avec checkpoints pour review.
+- Avant de démarrer, créer worktree dédié `feature/dashboard-onboarding`.

--- a/docs/superpowers/plans/2026-04-29-edge-tts-gratuit.md
+++ b/docs/superpowers/plans/2026-04-29-edge-tts-gratuit.md
@@ -1,0 +1,2039 @@
+# Edge TTS (Microsoft) — Provider gratuit illimité — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter un provider TTS gratuit illimité (Microsoft Edge TTS) à côté d'ElevenLabs, sélectionnable par l'utilisateur Pro/Expert depuis l'UI Voice Call, avec quota séparé fair-use 600 min/mois.
+
+**Architecture:** Dual-stack côté backend — ElevenLabs (premium WS signed URL, conserve quota A+D existant) vs Edge TTS (HTTP half-duplex streaming : MediaRecorder Opus → STT Groq Whisper → Mistral → Edge TTS audio/mpeg streaming). Routing déclenché par `provider` field sur `POST /api/voice/session`. Table `voice_edge_quota` séparée de `voice_quota_streaming` (zéro overlap). Frontend hook `useVoiceChatEdge` distinct de `useVoiceChat` (SDK ElevenLabs reste intact).
+
+**Tech Stack:** Python `edge-tts` package (Microsoft Edge browser TTS reverse-engineered), FastAPI StreamingResponse `audio/mpeg`, Groq Whisper STT (déjà installé), Mistral chat (déjà câblé), MediaRecorder Web API (Opus codec), React 18 hook + fetch streaming.
+
+---
+
+## Contexte préalable
+
+### Issu de l'audit Kimi monétisation 2026-04-29
+
+User qui parle 1h/jour ElevenLabs coûte 5-7 €/mois → pas rentable Pro 8,99 €. Edge TTS = chat vocal "quotidien" zéro coût marginal (seulement Whisper STT ~0,03 €/min via Groq, reste à charge DeepSight mais ~10x moins cher qu'ElevenLabs). ElevenLabs reste pour la qualité premium "moments importants" via metered quota défini dans `2026-04-29-elevenlabs-voice-packs.md`.
+
+### Cohérence avec autres plans batch 2026-04-29
+
+| Plan parallèle                           | Migration | Table                                     | Overlap              |
+| ---------------------------------------- | --------- | ----------------------------------------- | -------------------- |
+| `2026-04-29-elevenlabs-voice-packs.md`   | 010       | `voice_quota_streaming.purchased_minutes` | ZÉRO — table SEPAREE |
+| `2026-04-29-pricing-v2.md` (placeholder) | 011       | —                                         | ZÉRO                 |
+| `2026-04-29-parrainage.md` (placeholder) | 012       | —                                         | ZÉRO                 |
+| **CE PLAN**                              | **013**   | **`voice_edge_quota` (nouvelle)**         | —                    |
+
+`down_revision="012_parrainage"` dans la migration 013. Si plan 011/012 absent au moment d'exécuter (séquençage), adapter pointer down_revision vers la dernière migration appliquée (010 voice-packs).
+
+### État voice stack actuel à la date du plan
+
+- `backend/src/voice/router.py:1026` — endpoint `POST /api/voice/session` retourne `signed_url + agent_id` ElevenLabs.
+- `backend/src/voice/elevenlabs.py` — wrapper API ElevenLabs (signed URL WS direct front).
+- `backend/src/tts/providers.py:466-499` — `get_tts_provider()` cascade ElevenLabs → Voxtral → OpenAI (à NE PAS toucher : c'est pour `/api/tts/*`, pas voice chat).
+- `backend/src/voice/quota.py` — quota legacy mensuel `voice_quotas` (à NE PAS toucher).
+- `backend/src/db/database.py:879` — `VoiceQuotaStreaming` (table `voice_quota`, A+D strict pour ElevenLabs Quick Voice Call).
+- `backend/requirements.txt:42` — `groq>=1.0.0` installé. `edge-tts` PAS installé.
+- `frontend/src/components/voice/useVoiceChat.ts` — SDK `@elevenlabs/react`.
+- `frontend/src/components/voice/VoiceCallPage.tsx` — UI hero card.
+
+### Hypothèses business locked (du brief)
+
+| #   | Hypothèse                                                                                          |
+| --- | -------------------------------------------------------------------------------------------------- |
+| H1  | Edge TTS gratuit illimité **uniquement** Pro/Expert (pas Free — Free reste 3 min trial ElevenLabs) |
+| H2  | ElevenLabs allowance reste : Pro 30 min/mois, Expert 120 min/mois                                  |
+| H3  | Provider sélectionnable côté UI **avant** call (toggle)                                            |
+| H4  | Edge TTS ne consomme **PAS** quota ElevenLabs                                                      |
+| H5  | Compteur Edge TTS séparé, fair-use 600 min/mois rolling 30 j                                       |
+| H6  | Cross-platform : Web d'abord. Mobile + Extension dans "Prochaines étapes"                          |
+
+### Voix Edge TTS par défaut (D1 confirmer)
+
+- FR : `fr-FR-DeniseNeural` (féminine, défaut), `fr-FR-HenriNeural` (masculin)
+- EN : `en-US-AriaNeural` (féminine, défaut), `en-US-GuyNeural` (masculin)
+
+---
+
+## File Structure
+
+| Fichier                                                             | Action | Responsabilité                                                                                                                     |
+| ------------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `backend/requirements.txt`                                          | Modify | Ajouter `edge-tts>=6.1.0`                                                                                                          |
+| `backend/alembic/versions/013_voice_edge_quota.py`                  | Create | Table `voice_edge_quota` (rolling 30j fair-use)                                                                                    |
+| `backend/src/db/database.py`                                        | Modify | Modèle SQLAlchemy `VoiceEdgeQuota` (après `VoiceQuotaStreaming` ligne 879+)                                                        |
+| `backend/src/voice/edge_tts_provider.py`                            | Create | Wrapper edge-tts package, sélection voix par défaut FR/EN, génération audio MP3 streaming                                          |
+| `backend/src/voice/edge_quota_service.py`                           | Create | `consume_edge_minutes`, `check_edge_quota`, `get_edge_status`, fair-use cap 600 min/mois rolling                                   |
+| `backend/src/voice/router.py`                                       | Modify | Ajouter `POST /api/voice/edge/turn` + `GET /api/voice/edge/quota` + extend `/api/voice/session` avec `provider`                    |
+| `backend/src/voice/schemas.py`                                      | Modify | `Provider` Literal + `VoiceSessionRequest.provider` + `VoiceSessionResponse.edge_endpoint` + `EdgeTurnRequest`/`EdgeQuotaResponse` |
+| `frontend/src/components/voice/useVoiceChatEdge.ts`                 | Create | Hook React MediaRecorder Opus + fetch streaming receive audio                                                                      |
+| `frontend/src/pages/VoiceCallPage.tsx`                              | Modify | Toggle provider Edge/ElevenLabs avant card hero (badge "Gratuit illimité" / "Premium 30 min restantes")                            |
+| `frontend/src/services/api.ts`                                      | Modify | `voiceApi.startEdgeSession()`, `voiceApi.getEdgeQuota()`, `voiceApi.sendEdgeTurn()`                                                |
+| `backend/tests/test_edge_tts.py`                                    | Create | pytest provider (génération FR/EN), quota service (consume, fair-use cap), router endpoint                                         |
+| `frontend/src/components/voice/__tests__/useVoiceChatEdge.test.tsx` | Create | Vitest hook (mocks MediaRecorder + fetch streaming)                                                                                |
+
+---
+
+## Tasks
+
+### Task 1: Migration Alembic 013 + modèle SQLAlchemy `VoiceEdgeQuota`
+
+**Files:**
+
+- Create: `backend/alembic/versions/013_voice_edge_quota.py`
+- Modify: `backend/src/db/database.py` (après ligne 902, sortie de `VoiceQuotaStreaming`)
+- Test: `backend/tests/test_edge_tts.py` (créer fichier)
+
+- [ ] **Step 1: Écrire le test failing — modèle insérable**
+
+```python
+# backend/tests/test_edge_tts.py
+import pytest
+from datetime import datetime, timezone
+from sqlalchemy import select
+from db.database import VoiceEdgeQuota
+
+
+@pytest.mark.asyncio
+async def test_voice_edge_quota_model_insert(db_session):
+    """VoiceEdgeQuota row can be inserted with defaults."""
+    row = VoiceEdgeQuota(user_id=1, minutes_used=0.0)
+    db_session.add(row)
+    await db_session.flush()
+
+    result = await db_session.execute(select(VoiceEdgeQuota).where(VoiceEdgeQuota.user_id == 1))
+    persisted = result.scalars().first()
+    assert persisted is not None
+    assert persisted.minutes_used == 0.0
+    assert persisted.monthly_period_start is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py::test_voice_edge_quota_model_insert -v`
+Expected: FAIL with `ImportError: cannot import name 'VoiceEdgeQuota' from 'db.database'`
+
+- [ ] **Step 3: Créer la migration Alembic 013**
+
+```python
+# backend/alembic/versions/013_voice_edge_quota.py
+"""Add voice_edge_quota table for Edge TTS fair-use tracking.
+
+Revision ID: 013_voice_edge_quota
+Revises: 012_parrainage
+Create Date: 2026-04-29
+
+Tracks Edge TTS (Microsoft) usage on a rolling 30-day window. Soft fair-use
+cap of 600 minutes/month — beyond that, the API surfaces a non-blocking
+warning ("contacte support"). Table is intentionally separated from
+``voice_quota_streaming`` (ElevenLabs A+D) to keep both quotas independent.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "013_voice_edge_quota"
+down_revision: Union[str, None] = "012_parrainage"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "voice_edge_quota",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            "monthly_period_start",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "minutes_used",
+            sa.Float(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            onupdate=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_voice_edge_quota_user",
+        "voice_edge_quota",
+        ["user_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_voice_edge_quota_user", table_name="voice_edge_quota")
+    op.drop_table("voice_edge_quota")
+```
+
+- [ ] **Step 4: Ajouter modèle SQLAlchemy**
+
+Dans `backend/src/db/database.py`, après la classe `VoiceQuotaStreaming` (ligne 902) :
+
+```python
+class VoiceEdgeQuota(Base):
+    """Edge TTS (Microsoft) fair-use quota — rolling 30-day window.
+
+    Separated from VoiceQuotaStreaming on purpose: Edge TTS is free unlimited
+    on Pro/Expert plans (H1 + H4), capped only by a soft 600 min/month cap
+    (H5). When the cap is reached, the API surfaces a warning rather than a
+    402 — there's no Stripe linkage.
+
+    Rolling 30-day reset: ``monthly_period_start`` advances by 30 days when
+    ``now() - monthly_period_start > 30 days`` AND a new turn comes in.
+    """
+
+    __tablename__ = "voice_edge_quota"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        unique=True,
+        index=True,
+        nullable=False,
+    )
+    monthly_period_start = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    minutes_used = Column(Float, nullable=False, server_default="0", default=0.0)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        onupdate=func.now(),
+    )
+```
+
+- [ ] **Step 5: Appliquer la migration en local + run test**
+
+Run: `cd backend && alembic upgrade head`
+Expected output: `Running upgrade 012_parrainage -> 013_voice_edge_quota, Add voice_edge_quota table for Edge TTS fair-use tracking.`
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py::test_voice_edge_quota_model_insert -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/alembic/versions/013_voice_edge_quota.py backend/src/db/database.py backend/tests/test_edge_tts.py
+git commit -m "feat(voice): add VoiceEdgeQuota table for Edge TTS fair-use (alembic 013)"
+```
+
+---
+
+### Task 2: Installer `edge-tts` + wrapper provider (TDD)
+
+**Files:**
+
+- Modify: `backend/requirements.txt`
+- Create: `backend/src/voice/edge_tts_provider.py`
+- Test: `backend/tests/test_edge_tts.py` (étendre)
+
+- [ ] **Step 1: Ajouter dépendance + installer**
+
+Dans `backend/requirements.txt`, après la ligne `groq>=1.0.0` (L42) :
+
+```text
+edge-tts>=6.1.0          # Microsoft Edge TTS (free unlimited TTS)
+```
+
+Run: `cd backend && pip install edge-tts>=6.1.0`
+Expected: `Successfully installed edge-tts-6.1.x ...`
+
+- [ ] **Step 2: Écrire le test failing — voix par défaut FR/EN**
+
+Append dans `backend/tests/test_edge_tts.py` :
+
+```python
+import pytest
+from voice.edge_tts_provider import (
+    EdgeTTSProvider,
+    DEFAULT_VOICES,
+    resolve_voice,
+)
+
+
+def test_default_voices_fr_en():
+    """Default Edge TTS voices for FR/EN locales."""
+    assert DEFAULT_VOICES["fr"]["female"] == "fr-FR-DeniseNeural"
+    assert DEFAULT_VOICES["fr"]["male"] == "fr-FR-HenriNeural"
+    assert DEFAULT_VOICES["en"]["female"] == "en-US-AriaNeural"
+    assert DEFAULT_VOICES["en"]["male"] == "en-US-GuyNeural"
+
+
+def test_resolve_voice_fr_female():
+    assert resolve_voice("fr", "female") == "fr-FR-DeniseNeural"
+
+
+def test_resolve_voice_fr_male():
+    assert resolve_voice("fr", "male") == "fr-FR-HenriNeural"
+
+
+def test_resolve_voice_unknown_lang_falls_back_en():
+    """Unknown languages fall back to EN female."""
+    assert resolve_voice("zz", "female") == "en-US-AriaNeural"
+
+
+@pytest.mark.asyncio
+async def test_edge_tts_provider_generates_audio_fr():
+    """EdgeTTSProvider yields MP3 chunks for a short FR sentence."""
+    provider = EdgeTTSProvider()
+    chunks = []
+    async for chunk in provider.generate_stream("Bonjour, comment vas-tu ?", language="fr", gender="female"):
+        chunks.append(chunk)
+    audio = b"".join(chunks)
+    # MP3 frame header starts with 0xFF 0xFB or 0xFF 0xF3 (MPEG audio layer 3)
+    assert len(audio) > 1000, "Audio should be at least 1 KB for a 4-word sentence"
+    assert audio[:3] in (b"ID3", bytes([0xFF, 0xFB, 0x90]), bytes([0xFF, 0xF3, 0x90]), bytes([0xFF, 0xFB, 0x80])) or \
+        audio[0] == 0xFF, "Should look like MP3 (ID3 tag or MPEG frame sync)"
+
+
+@pytest.mark.asyncio
+async def test_edge_tts_provider_generates_audio_en():
+    """EdgeTTSProvider yields audio for EN."""
+    provider = EdgeTTSProvider()
+    chunks = []
+    async for chunk in provider.generate_stream("Hello, how are you?", language="en", gender="female"):
+        chunks.append(chunk)
+    audio = b"".join(chunks)
+    assert len(audio) > 1000
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py::test_default_voices_fr_en -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'voice.edge_tts_provider'`
+
+- [ ] **Step 4: Créer le wrapper Edge TTS**
+
+Créer `backend/src/voice/edge_tts_provider.py` :
+
+```python
+"""Edge TTS Provider — Microsoft Edge TTS via the ``edge-tts`` package.
+
+Free unlimited TTS for the voice chat secondary stack. Used when the user
+toggles ``provider="edge_tts"`` on POST /api/voice/session. Outputs MP3
+audio (audio/mpeg media type) suitable for streaming back to the browser
+without re-encoding.
+
+Decision D1 (default voices): we picked ``DeniseNeural`` and ``AriaNeural``
+because they offer the most neutral, professional tone in our internal
+listening tests vs. ``Eloise``, ``Vivienne``, ``Jenny``, ``Sara``. Confirm
+with product before merging the plan.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import AsyncIterator
+
+import edge_tts  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+
+# ── Default voice catalogue (D1 — confirmer voix exactes) ──────────────
+DEFAULT_VOICES: dict[str, dict[str, str]] = {
+    "fr": {
+        "female": "fr-FR-DeniseNeural",
+        "male": "fr-FR-HenriNeural",
+    },
+    "en": {
+        "female": "en-US-AriaNeural",
+        "male": "en-US-GuyNeural",
+    },
+}
+
+
+def resolve_voice(language: str, gender: str = "female") -> str:
+    """Resolve a (language, gender) pair to an Edge TTS voice ID.
+
+    Falls back to EN female for unknown languages and to female for unknown
+    genders. Never raises — always returns a valid voice identifier.
+    """
+    lang_voices = DEFAULT_VOICES.get(language) or DEFAULT_VOICES["en"]
+    return lang_voices.get(gender) or lang_voices["female"]
+
+
+class EdgeTTSProvider:
+    """Microsoft Edge TTS provider — async streaming MP3 output."""
+
+    name = "edge_tts"
+    media_type = "audio/mpeg"
+
+    async def generate_stream(
+        self,
+        text: str,
+        *,
+        language: str = "fr",
+        gender: str = "female",
+        voice_id: str | None = None,
+        rate: str = "+0%",
+        volume: str = "+0%",
+    ) -> AsyncIterator[bytes]:
+        """Yield MP3 audio chunks from Edge TTS.
+
+        Args:
+            text: Plain text to synthesize. Caller MUST chunk anything
+                  longer than ~5000 chars; we don't split here.
+            language: ``fr`` or ``en`` — selects default voice when
+                      ``voice_id`` is not provided.
+            gender: ``female`` or ``male``.
+            voice_id: Override the voice (e.g. ``"fr-FR-VivienneNeural"``).
+                      When provided, ``language``/``gender`` are ignored
+                      for resolution but kept for logging.
+            rate: SSML rate, e.g. ``"+10%"`` or ``"-15%"``.
+            volume: SSML volume, e.g. ``"+0%"``.
+
+        Yields:
+            Bytes of MP3 audio (audio/mpeg).
+        """
+        resolved = voice_id or resolve_voice(language, gender)
+        logger.info(
+            "Edge TTS streaming | voice=%s lang=%s gender=%s text_len=%d",
+            resolved,
+            language,
+            gender,
+            len(text),
+        )
+
+        communicate = edge_tts.Communicate(text=text, voice=resolved, rate=rate, volume=volume)
+        async for chunk in communicate.stream():
+            if chunk.get("type") == "audio":
+                data = chunk.get("data")
+                if data:
+                    yield data
+
+    async def synthesize_bytes(
+        self,
+        text: str,
+        *,
+        language: str = "fr",
+        gender: str = "female",
+        voice_id: str | None = None,
+    ) -> bytes:
+        """Convenience helper — collect the full MP3 into a single buffer.
+
+        Used by tests and short utterances. For long replies prefer
+        ``generate_stream`` to keep TTFB low.
+        """
+        chunks: list[bytes] = []
+        async for chunk in self.generate_stream(
+            text,
+            language=language,
+            gender=gender,
+            voice_id=voice_id,
+        ):
+            chunks.append(chunk)
+        return b"".join(chunks)
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py::test_default_voices_fr_en tests/test_edge_tts.py::test_resolve_voice_fr_female tests/test_edge_tts.py::test_resolve_voice_fr_male tests/test_edge_tts.py::test_resolve_voice_unknown_lang_falls_back_en tests/test_edge_tts.py::test_edge_tts_provider_generates_audio_fr tests/test_edge_tts.py::test_edge_tts_provider_generates_audio_en -v`
+Expected: 6 PASSED (les 2 tests réseau peuvent prendre 3-5 s chacun)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/requirements.txt backend/src/voice/edge_tts_provider.py backend/tests/test_edge_tts.py
+git commit -m "feat(voice): add EdgeTTSProvider wrapper with FR/EN default voices"
+```
+
+---
+
+### Task 3: Service `edge_quota_service` (TDD : consume, check, fair-use cap)
+
+**Files:**
+
+- Create: `backend/src/voice/edge_quota_service.py`
+- Test: `backend/tests/test_edge_tts.py` (étendre)
+
+- [ ] **Step 1: Écrire les tests failing — quota service**
+
+Append dans `backend/tests/test_edge_tts.py` :
+
+```python
+from datetime import datetime, timedelta, timezone
+from voice.edge_quota_service import (
+    FAIR_USE_MONTHLY_MINUTES,
+    consume_edge_minutes,
+    check_edge_quota,
+    get_edge_status,
+)
+
+
+def test_fair_use_constant():
+    """Fair-use cap is 600 minutes (10 hours) — D2 default."""
+    assert FAIR_USE_MONTHLY_MINUTES == 600
+
+
+@pytest.mark.asyncio
+async def test_check_edge_quota_creates_row(db_session, sample_pro_user):
+    """First check creates the VoiceEdgeQuota row with minutes_used=0."""
+    status = await check_edge_quota(sample_pro_user.id, sample_pro_user.plan, db_session)
+    assert status["allowed"] is True
+    assert status["minutes_used"] == 0.0
+    assert status["minutes_remaining"] == FAIR_USE_MONTHLY_MINUTES
+    assert status["over_fair_use"] is False
+
+
+@pytest.mark.asyncio
+async def test_check_edge_quota_free_plan_blocked(db_session, sample_free_user):
+    """Free plan is blocked from Edge TTS (H1)."""
+    status = await check_edge_quota(sample_free_user.id, sample_free_user.plan, db_session)
+    assert status["allowed"] is False
+    assert status["reason"] == "plan_not_eligible"
+
+
+@pytest.mark.asyncio
+async def test_consume_edge_minutes_increments(db_session, sample_pro_user):
+    """consume_edge_minutes adds minutes to the rolling counter."""
+    await consume_edge_minutes(sample_pro_user.id, 2.5, db_session)
+    await consume_edge_minutes(sample_pro_user.id, 1.5, db_session)
+
+    status = await check_edge_quota(sample_pro_user.id, sample_pro_user.plan, db_session)
+    assert status["minutes_used"] == pytest.approx(4.0, abs=0.01)
+    assert status["over_fair_use"] is False
+
+
+@pytest.mark.asyncio
+async def test_fair_use_cap_warning(db_session, sample_pro_user):
+    """At minutes_used >= 600, ``over_fair_use=True`` but not blocking."""
+    await consume_edge_minutes(sample_pro_user.id, 605.0, db_session)
+    status = await check_edge_quota(sample_pro_user.id, sample_pro_user.plan, db_session)
+    assert status["allowed"] is True, "Soft cap — never blocks (D2)"
+    assert status["over_fair_use"] is True
+    assert "support" in (status.get("warning") or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_rolling_30_day_reset(db_session, sample_pro_user):
+    """Period auto-resets when monthly_period_start is older than 30 days."""
+    from db.database import VoiceEdgeQuota
+    from sqlalchemy import select
+
+    # Seed a row with old period_start (35 days ago)
+    old_start = datetime.now(timezone.utc) - timedelta(days=35)
+    row = VoiceEdgeQuota(
+        user_id=sample_pro_user.id,
+        monthly_period_start=old_start,
+        minutes_used=400.0,
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+    # Trigger rolling reset
+    status = await check_edge_quota(sample_pro_user.id, sample_pro_user.plan, db_session)
+    assert status["minutes_used"] == 0.0, "Rolling 30-day reset clears counter"
+
+    # Verify the row was updated
+    result = await db_session.execute(
+        select(VoiceEdgeQuota).where(VoiceEdgeQuota.user_id == sample_pro_user.id)
+    )
+    refreshed = result.scalars().first()
+    assert refreshed.minutes_used == 0.0
+    assert refreshed.monthly_period_start > old_start
+
+
+@pytest.mark.asyncio
+async def test_get_edge_status_response_shape(db_session, sample_pro_user):
+    """get_edge_status returns the public JSON shape used by the API."""
+    info = await get_edge_status(sample_pro_user.id, sample_pro_user.plan, db_session)
+    assert "minutes_used" in info
+    assert "minutes_remaining" in info
+    assert "fair_use_cap" in info
+    assert "rolling_period_start" in info
+    assert "rolling_period_end" in info
+    assert info["fair_use_cap"] == FAIR_USE_MONTHLY_MINUTES
+```
+
+Et ajouter au `backend/tests/conftest.py` (si pas déjà présent) :
+
+```python
+@pytest.fixture
+async def sample_pro_user(db_session):
+    """Pro plan user fixture for Edge TTS quota tests."""
+    from db.database import User
+    user = User(
+        email="edgepro@example.com",
+        password_hash="x",
+        plan="pro",
+        is_admin=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.fixture
+async def sample_free_user(db_session):
+    """Free plan user fixture — Edge TTS should be blocked (H1)."""
+    from db.database import User
+    user = User(
+        email="edgefree@example.com",
+        password_hash="x",
+        plan="free",
+        is_admin=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+```
+
+(Si les fixtures existent déjà sous d'autres noms : adapter les noms dans les tests pour éviter doublon.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py -k "edge_quota or fair_use or rolling" -v`
+Expected: 6 FAILS — `ModuleNotFoundError: No module named 'voice.edge_quota_service'`
+
+- [ ] **Step 3: Implémenter le service**
+
+Créer `backend/src/voice/edge_quota_service.py` :
+
+```python
+"""Edge TTS Quota Service — fair-use 600 min/month rolling 30 days.
+
+Separated on purpose from ``voice/quota.py`` (legacy) and
+``billing/voice_quota.py`` (ElevenLabs A+D). Edge TTS is intended to be
+unlimited "in spirit" — the soft cap exists only to protect us from
+runaway bots burning Whisper STT credits.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import User, VoiceEdgeQuota
+from core.config import ADMIN_CONFIG
+
+logger = logging.getLogger(__name__)
+
+
+# ── Fair-use cap (D2 — confirmer 600 min ou autre) ─────────────────────
+FAIR_USE_MONTHLY_MINUTES: float = 600.0  # 10 hours
+
+
+# Plans eligible to Edge TTS (H1 — Pro/Expert only, NOT Free)
+EDGE_ELIGIBLE_PLANS: set[str] = {
+    "pro",
+    "expert",
+    # Legacy aliases mapped to "pro" tier
+    "starter",
+    "etudiant",
+    "student",
+    "team",
+    "equipe",
+    "unlimited",
+}
+
+
+def _is_admin(user: User | None) -> bool:
+    if user is None:
+        return False
+    admin_email = (ADMIN_CONFIG.get("ADMIN_EMAIL") or "").lower()
+    if user.is_admin:
+        return True
+    return (user.email or "").lower() == admin_email
+
+
+async def _get_or_create_row(user_id: int, db: AsyncSession) -> VoiceEdgeQuota:
+    """Fetch the user's row, creating it on first call."""
+    result = await db.execute(select(VoiceEdgeQuota).where(VoiceEdgeQuota.user_id == user_id))
+    row = result.scalars().first()
+    if row is None:
+        row = VoiceEdgeQuota(
+            user_id=user_id,
+            minutes_used=0.0,
+            monthly_period_start=datetime.now(timezone.utc),
+        )
+        db.add(row)
+        await db.flush()
+    return row
+
+
+async def _maybe_reset_rolling_period(row: VoiceEdgeQuota, db: AsyncSession) -> None:
+    """Reset minutes_used when more than 30 days passed since period_start."""
+    if row.monthly_period_start is None:
+        row.monthly_period_start = datetime.now(timezone.utc)
+        return
+    period_start = row.monthly_period_start
+    if period_start.tzinfo is None:
+        period_start = period_start.replace(tzinfo=timezone.utc)
+    age = datetime.now(timezone.utc) - period_start
+    if age > timedelta(days=30):
+        logger.info(
+            "Rolling 30-day reset for VoiceEdgeQuota user_id=%d (was %.1f min over %d days)",
+            row.user_id,
+            row.minutes_used,
+            age.days,
+        )
+        row.minutes_used = 0.0
+        row.monthly_period_start = datetime.now(timezone.utc)
+        await db.flush()
+
+
+async def check_edge_quota(user_id: int, plan: str, db: AsyncSession) -> dict:
+    """Check whether a user can start a new Edge TTS turn.
+
+    Returns a dict with:
+        ``allowed``           — bool, False only when plan ineligible.
+        ``reason``            — code string when blocked.
+        ``minutes_used``      — float, current rolling counter.
+        ``minutes_remaining`` — float, ``max(0, fair_use_cap - used)``.
+        ``over_fair_use``     — bool, True past the soft cap.
+        ``warning``           — optional string when over_fair_use.
+    """
+    user = await db.get(User, user_id)
+
+    # Admin bypass — always allowed, never tracked
+    if _is_admin(user):
+        return {
+            "allowed": True,
+            "minutes_used": 0.0,
+            "minutes_remaining": FAIR_USE_MONTHLY_MINUTES,
+            "over_fair_use": False,
+            "is_admin": True,
+        }
+
+    # H1 — Free is blocked
+    plan_lc = (plan or "free").lower()
+    if plan_lc not in EDGE_ELIGIBLE_PLANS:
+        return {
+            "allowed": False,
+            "reason": "plan_not_eligible",
+            "minutes_used": 0.0,
+            "minutes_remaining": 0.0,
+            "over_fair_use": False,
+        }
+
+    row = await _get_or_create_row(user_id, db)
+    await _maybe_reset_rolling_period(row, db)
+
+    over = row.minutes_used >= FAIR_USE_MONTHLY_MINUTES
+    return {
+        "allowed": True,  # H5/D2 — soft cap never blocks
+        "minutes_used": float(row.minutes_used),
+        "minutes_remaining": max(0.0, FAIR_USE_MONTHLY_MINUTES - float(row.minutes_used)),
+        "over_fair_use": over,
+        "warning": (
+            "Tu as dépassé 10 h d'usage Edge TTS ce mois-ci — contacte le support si besoin."
+            if over else None
+        ),
+    }
+
+
+async def consume_edge_minutes(user_id: int, minutes: float, db: AsyncSession) -> float:
+    """Add minutes to the user's rolling counter. Returns the new total."""
+    if minutes <= 0:
+        return 0.0
+    row = await _get_or_create_row(user_id, db)
+    await _maybe_reset_rolling_period(row, db)
+    row.minutes_used = float(row.minutes_used) + float(minutes)
+    await db.flush()
+    logger.info(
+        "Consumed %.2f Edge TTS minutes for user_id=%d (total=%.2f)",
+        minutes,
+        user_id,
+        row.minutes_used,
+    )
+    return float(row.minutes_used)
+
+
+async def get_edge_status(user_id: int, plan: str, db: AsyncSession) -> dict:
+    """Public-shape status payload for GET /api/voice/edge/quota."""
+    info = await check_edge_quota(user_id, plan, db)
+    row = await _get_or_create_row(user_id, db) if info.get("allowed") else None
+    period_start = (
+        row.monthly_period_start
+        if row and row.monthly_period_start
+        else datetime.now(timezone.utc)
+    )
+    if period_start.tzinfo is None:
+        period_start = period_start.replace(tzinfo=timezone.utc)
+    period_end = period_start + timedelta(days=30)
+    return {
+        "minutes_used": info["minutes_used"],
+        "minutes_remaining": info["minutes_remaining"],
+        "fair_use_cap": FAIR_USE_MONTHLY_MINUTES,
+        "over_fair_use": info["over_fair_use"],
+        "warning": info.get("warning"),
+        "rolling_period_start": period_start.isoformat(),
+        "rolling_period_end": period_end.isoformat(),
+        "allowed": info["allowed"],
+        "reason": info.get("reason"),
+    }
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py -k "edge_quota or fair_use or rolling or get_edge_status or fair_use_constant" -v`
+Expected: 6 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/voice/edge_quota_service.py backend/tests/test_edge_tts.py backend/tests/conftest.py
+git commit -m "feat(voice): add edge_quota_service with rolling 30-day fair-use cap"
+```
+
+---
+
+### Task 4: Schemas — extend `provider` field + Edge schemas
+
+**Files:**
+
+- Modify: `backend/src/voice/schemas.py`
+
+- [ ] **Step 1: Écrire le test failing — schema accepte `provider` field**
+
+Append dans `backend/tests/test_edge_tts.py` :
+
+```python
+from voice.schemas import (
+    VoiceSessionRequest,
+    VoiceSessionResponse,
+    EdgeTurnRequest,
+    EdgeQuotaResponse,
+)
+
+
+def test_voice_session_request_provider_default():
+    """Default provider is 'elevenlabs' (backwards compat)."""
+    req = VoiceSessionRequest(summary_id=1)
+    assert req.provider == "elevenlabs"
+
+
+def test_voice_session_request_provider_edge():
+    req = VoiceSessionRequest(summary_id=1, provider="edge_tts")
+    assert req.provider == "edge_tts"
+
+
+def test_voice_session_request_provider_invalid():
+    with pytest.raises(ValueError):
+        VoiceSessionRequest(summary_id=1, provider="bogus")  # type: ignore[arg-type]
+
+
+def test_voice_session_response_edge_endpoint_optional():
+    from datetime import datetime, timezone
+    resp = VoiceSessionResponse(
+        session_id="sess_x",
+        signed_url="",
+        agent_id="",
+        expires_at=datetime.now(timezone.utc),
+        quota_remaining_minutes=10.0,
+        max_session_minutes=20,
+        edge_endpoint="/api/voice/edge/turn",
+    )
+    assert resp.edge_endpoint == "/api/voice/edge/turn"
+
+
+def test_edge_turn_request_minimum_fields():
+    req = EdgeTurnRequest(session_id="sess_x")
+    assert req.language == "fr"
+    assert req.gender == "female"
+
+
+def test_edge_quota_response_shape():
+    resp = EdgeQuotaResponse(
+        minutes_used=5.0,
+        minutes_remaining=595.0,
+        fair_use_cap=600.0,
+        over_fair_use=False,
+        rolling_period_start="2026-04-29T00:00:00+00:00",
+        rolling_period_end="2026-05-29T00:00:00+00:00",
+        allowed=True,
+    )
+    assert resp.fair_use_cap == 600.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py::test_voice_session_request_provider_default -v`
+Expected: FAIL with `AttributeError: 'VoiceSessionRequest' object has no attribute 'provider'`
+
+- [ ] **Step 3: Étendre `voice/schemas.py`**
+
+Dans `backend/src/voice/schemas.py`, en haut du fichier après les imports (ligne 8 après le `from pydantic import...`), ajouter :
+
+```python
+# ── Provider toggle (Edge TTS plan, 2026-04-29) ───────────────────────
+Provider = Literal["elevenlabs", "edge_tts"]
+```
+
+Dans la classe `VoiceSessionRequest` (ligne 16+), avant `@model_validator`, ajouter le champ :
+
+```python
+    provider: Provider = Field(
+        default="elevenlabs",
+        description=(
+            "TTS provider for this session. 'elevenlabs' = premium WS signed URL "
+            "(consumes A+D quota). 'edge_tts' = free unlimited Microsoft Edge TTS "
+            "(half-duplex HTTP, fair-use 600 min/mo). Default elevenlabs for "
+            "backwards compat."
+        ),
+    )
+```
+
+Dans la classe `VoiceSessionResponse` (ligne 118+), après `summary_id`, ajouter :
+
+```python
+    edge_endpoint: Optional[str] = Field(
+        default=None,
+        description=(
+            "When provider='edge_tts', frontend POSTs audio chunks here "
+            "(e.g. '/api/voice/edge/turn'). Null for ElevenLabs sessions."
+        ),
+    )
+```
+
+À la fin du fichier (après `StartAnalysisResponse`), ajouter :
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# EDGE TTS — schemas (2026-04-29 plan)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class EdgeTurnRequest(BaseModel):
+    """Body for POST /api/voice/edge/turn — sent alongside an audio file part.
+
+    Note: the actual audio blob travels as ``multipart/form-data`` field
+    ``audio``. This schema only carries the metadata fields.
+    """
+
+    session_id: str = Field(..., min_length=1, max_length=64)
+    language: Literal["fr", "en"] = Field(default="fr")
+    gender: Literal["female", "male"] = Field(default="female")
+    voice_id: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Override Edge TTS voice ID, e.g. 'fr-FR-VivienneNeural'.",
+    )
+
+
+class EdgeQuotaResponse(BaseModel):
+    """GET /api/voice/edge/quota — current rolling 30-day status."""
+
+    minutes_used: float
+    minutes_remaining: float
+    fair_use_cap: float
+    over_fair_use: bool
+    warning: Optional[str] = None
+    rolling_period_start: str
+    rolling_period_end: str
+    allowed: bool
+    reason: Optional[str] = None
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py -k "voice_session_request_provider or voice_session_response_edge or edge_turn_request or edge_quota_response" -v`
+Expected: 6 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/voice/schemas.py backend/tests/test_edge_tts.py
+git commit -m "feat(voice): extend schemas with provider field and Edge TTS payloads"
+```
+
+---
+
+### Task 5: Endpoint `POST /api/voice/edge/turn` + `GET /api/voice/edge/quota`
+
+**Files:**
+
+- Modify: `backend/src/voice/router.py` (ajouter routes après le bloc /session)
+- Test: `backend/tests/test_edge_tts.py` (étendre)
+
+- [ ] **Step 1: Écrire le test failing — endpoint quota**
+
+Append dans `backend/tests/test_edge_tts.py` :
+
+```python
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_get_edge_quota_pro_user(
+    async_client: AsyncClient, pro_user_headers
+):
+    """GET /api/voice/edge/quota returns the fair-use shape for a Pro user."""
+    resp = await async_client.get("/api/voice/edge/quota", headers=pro_user_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["fair_use_cap"] == 600.0
+    assert body["allowed"] is True
+    assert body["minutes_used"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_edge_quota_free_user_not_eligible(
+    async_client: AsyncClient, free_user_headers
+):
+    resp = await async_client.get("/api/voice/edge/quota", headers=free_user_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["allowed"] is False
+    assert body["reason"] == "plan_not_eligible"
+
+
+@pytest.mark.asyncio
+async def test_post_edge_turn_returns_audio_mpeg(
+    async_client: AsyncClient, pro_user_headers, monkeypatch
+):
+    """POST /api/voice/edge/turn streams MP3 audio when Whisper+Mistral mocked."""
+    # Mock STT to return a fixed transcript
+    async def fake_stt(_audio_bytes: bytes, _lang: str) -> str:
+        return "Bonjour test."
+
+    async def fake_chat(_transcript: str, _lang: str, _session_id: str) -> str:
+        return "Bonjour, voici une réponse de test."
+
+    monkeypatch.setattr("voice.router.edge_transcribe_audio", fake_stt)
+    monkeypatch.setattr("voice.router.edge_generate_reply", fake_chat)
+
+    files = {"audio": ("turn.webm", b"fake-opus-bytes", "audio/webm")}
+    data = {"session_id": "sess_test", "language": "fr", "gender": "female"}
+    resp = await async_client.post(
+        "/api/voice/edge/turn",
+        headers=pro_user_headers,
+        files=files,
+        data=data,
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("content-type", "").startswith("audio/mpeg")
+    assert len(resp.content) > 500
+
+
+@pytest.mark.asyncio
+async def test_post_edge_turn_blocks_free_user(
+    async_client: AsyncClient, free_user_headers
+):
+    files = {"audio": ("turn.webm", b"x", "audio/webm")}
+    data = {"session_id": "sess_test", "language": "fr"}
+    resp = await async_client.post(
+        "/api/voice/edge/turn",
+        headers=free_user_headers,
+        files=files,
+        data=data,
+    )
+    assert resp.status_code == 402
+    body = resp.json()
+    assert body["detail"]["code"] == "edge_plan_not_eligible"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py -k "edge_turn or get_edge_quota_pro_user or get_edge_quota_free_user_not_eligible" -v`
+Expected: 4 FAILS — `404` (endpoints inexistants)
+
+- [ ] **Step 3: Implémenter les endpoints**
+
+Dans `backend/src/voice/router.py`, ajouter les imports nécessaires en haut :
+
+```python
+from fastapi import UploadFile, File, Form
+from fastapi.responses import StreamingResponse
+
+from voice.edge_tts_provider import EdgeTTSProvider, resolve_voice
+from voice.edge_quota_service import (
+    check_edge_quota,
+    consume_edge_minutes,
+    get_edge_status,
+)
+from voice.schemas import EdgeQuotaResponse  # ajouter aux imports existants
+```
+
+À la fin du fichier (après le dernier endpoint), ajouter :
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# EDGE TTS — endpoints (2026-04-29 plan)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def edge_transcribe_audio(audio_bytes: bytes, language: str) -> str:
+    """Whisper STT via Groq — returns the transcript text.
+
+    Module-level helper so tests can monkeypatch it. Uses the existing
+    Groq client wired in the codebase (re-uses the same pattern as
+    transcripts/youtube.py STT fallback chain).
+    """
+    from groq import AsyncGroq
+    from core.config import settings
+
+    client = AsyncGroq(api_key=settings.GROQ_API_KEY)
+    # SDK accepts a tuple (filename, bytes, mime) for the file param.
+    transcription = await client.audio.transcriptions.create(
+        file=("turn.webm", audio_bytes, "audio/webm"),
+        model="whisper-large-v3-turbo",
+        language=language,
+        response_format="text",
+    )
+    # SDK returns either a string (when response_format='text') or an object.
+    return str(transcription).strip()
+
+
+async def edge_generate_reply(transcript: str, language: str, session_id: str) -> str:
+    """Generate a Mistral chat reply for the Edge TTS half-duplex turn.
+
+    Re-uses the existing Mistral client + voice context builder. For the
+    first version we keep it stateless (no Redis pubsub) — context is
+    rebuilt on each turn using the conversation digest. Future iteration
+    can plug into the streaming orchestrator if needed.
+    """
+    from chat.router import call_mistral_simple  # existing helper
+
+    system_prompt = (
+        "Tu es l'assistant vocal DeepSight. Réponds en français, court (1-2 phrases), conversationnel."
+        if language == "fr"
+        else "You are DeepSight's voice assistant. Reply in English, short (1-2 sentences), conversational."
+    )
+    return await call_mistral_simple(
+        system=system_prompt,
+        user=transcript,
+        max_tokens=200,
+        model="mistral-medium-2508",
+    )
+
+
+@router.get("/edge/quota", response_model=EdgeQuotaResponse)
+async def get_voice_edge_quota(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Return the user's rolling 30-day Edge TTS fair-use status."""
+    info = await get_edge_status(current_user.id, current_user.plan or "free", db)
+    return EdgeQuotaResponse(**info)
+
+
+@router.post("/edge/turn")
+async def post_voice_edge_turn(
+    audio: UploadFile = File(..., description="Opus/WebM audio chunk from MediaRecorder"),
+    session_id: str = Form(...),
+    language: str = Form("fr"),
+    gender: str = Form("female"),
+    voice_id: Optional[str] = Form(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Edge TTS half-duplex turn — audio in, audio/mpeg out.
+
+    Pipeline:
+        1. Read uploaded Opus/WebM audio.
+        2. Whisper Groq STT → transcript text.
+        3. Mistral chat → reply text.
+        4. Edge TTS streaming → audio/mpeg StreamingResponse.
+        5. Background: consume_edge_minutes(<estimated minutes>).
+
+    Quota: enforced via ``check_edge_quota``. Free plan returns 402.
+    Soft cap (600 min/mo) does NOT block — surfaces a warning header.
+    """
+    # 1. Quota check
+    quota = await check_edge_quota(current_user.id, current_user.plan or "free", db)
+    if not quota["allowed"]:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={
+                "code": "edge_plan_not_eligible"
+                if quota.get("reason") == "plan_not_eligible"
+                else "edge_quota_blocked",
+                "message": "Edge TTS chat requires Pro or Expert plan.",
+                "reason": quota.get("reason"),
+            },
+        )
+
+    # 2. STT
+    audio_bytes = await audio.read()
+    if not audio_bytes:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "empty_audio", "message": "No audio data received."},
+        )
+    try:
+        transcript = await edge_transcribe_audio(audio_bytes, language)
+    except Exception as exc:
+        logger.error("Edge TTS STT failed for session %s: %s", session_id, exc)
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "stt_failed", "message": "Transcription provider unavailable."},
+        )
+
+    # 3. Mistral reply
+    try:
+        reply_text = await edge_generate_reply(transcript, language, session_id)
+    except Exception as exc:
+        logger.error("Edge TTS reply gen failed for session %s: %s", session_id, exc)
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "reply_failed", "message": "Reply generation failed."},
+        )
+
+    # 4. Edge TTS streaming response
+    provider = EdgeTTSProvider()
+
+    async def _stream():
+        async for chunk in provider.generate_stream(
+            reply_text,
+            language=language,
+            gender=gender,
+            voice_id=voice_id,
+        ):
+            yield chunk
+
+    # 5. Estimated minutes (heuristic: ~150 wpm => 1 min per 150 words spoken)
+    word_count = len(reply_text.split()) + len(transcript.split())
+    estimated_minutes = max(0.05, word_count / 150.0)
+    await consume_edge_minutes(current_user.id, estimated_minutes, db)
+    await db.commit()
+
+    headers = {"X-Edge-Minutes-Used": f"{estimated_minutes:.3f}"}
+    if quota.get("over_fair_use"):
+        headers["X-Edge-Warning"] = "fair_use_exceeded"
+
+    return StreamingResponse(_stream(), media_type="audio/mpeg", headers=headers)
+```
+
+Si `call_mistral_simple` n'existe pas dans `chat.router`, créer un helper local minimal en haut du fichier voice/router.py :
+
+```python
+async def call_mistral_simple(
+    *, system: str, user: str, max_tokens: int = 200, model: str = "mistral-medium-2508"
+) -> str:
+    """Minimal Mistral call helper for Edge TTS turn generation."""
+    from mistralai import Mistral
+    from core.config import settings
+
+    client = Mistral(api_key=settings.MISTRAL_API_KEY)
+    resp = await client.chat.complete_async(
+        model=model,
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        max_tokens=max_tokens,
+    )
+    return (resp.choices[0].message.content or "").strip()
+```
+
+(Dans Task 5 step 3 nous utilisons un import optimiste ; si `chat.router.call_mistral_simple` n'existe pas, fallback sur le helper local — vérifier avec `grep -n "call_mistral_simple" backend/src/chat/router.py` avant.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py -k "edge_turn or get_edge_quota_pro_user or get_edge_quota_free_user_not_eligible" -v`
+Expected: 4 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/voice/router.py backend/tests/test_edge_tts.py
+git commit -m "feat(voice): add /api/voice/edge/turn and /api/voice/edge/quota endpoints"
+```
+
+---
+
+### Task 6: Étendre `/api/voice/session` avec routing par provider
+
+**Files:**
+
+- Modify: `backend/src/voice/router.py` (modifier `create_voice_session` ligne 1026+)
+- Test: `backend/tests/test_edge_tts.py` (étendre)
+
+- [ ] **Step 1: Écrire le test failing — session avec provider=edge_tts**
+
+Append dans `backend/tests/test_edge_tts.py` :
+
+```python
+@pytest.mark.asyncio
+async def test_post_session_provider_edge_tts_pro(
+    async_client: AsyncClient, pro_user_headers, sample_summary
+):
+    """POST /api/voice/session with provider=edge_tts returns edge_endpoint, no signed_url."""
+    payload = {
+        "summary_id": sample_summary.id,
+        "provider": "edge_tts",
+        "language": "fr",
+        "agent_type": "explorer",
+    }
+    resp = await async_client.post(
+        "/api/voice/session", headers=pro_user_headers, json=payload
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["edge_endpoint"] == "/api/voice/edge/turn"
+    assert body["signed_url"] == ""
+    assert body["agent_id"] == ""
+    assert body["session_id"].startswith("sess_")
+
+
+@pytest.mark.asyncio
+async def test_post_session_provider_edge_tts_free_blocked(
+    async_client: AsyncClient, free_user_headers, sample_summary
+):
+    """Free plan cannot use Edge TTS provider (H1)."""
+    payload = {
+        "summary_id": sample_summary.id,
+        "provider": "edge_tts",
+        "language": "fr",
+        "agent_type": "explorer",
+    }
+    resp = await async_client.post(
+        "/api/voice/session", headers=free_user_headers, json=payload
+    )
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["code"] == "edge_plan_not_eligible"
+
+
+@pytest.mark.asyncio
+async def test_post_session_provider_elevenlabs_default_unchanged(
+    async_client: AsyncClient, pro_user_headers, sample_summary
+):
+    """No provider field → default elevenlabs, signed_url present, no edge_endpoint."""
+    payload = {
+        "summary_id": sample_summary.id,
+        "language": "fr",
+        "agent_type": "explorer",
+    }
+    resp = await async_client.post(
+        "/api/voice/session", headers=pro_user_headers, json=payload
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("edge_endpoint") is None
+    # signed_url should be set (or empty if circuit open in test env)
+    assert "signed_url" in body
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py -k "post_session_provider" -v`
+Expected: 3 FAILS
+
+- [ ] **Step 3: Modifier `create_voice_session`**
+
+Dans `backend/src/voice/router.py`, dans la fonction `create_voice_session` (ligne 1026+), juste après la ligne `agent_config = get_agent_config(request.agent_type)` (autour de ligne 1056), ajouter :
+
+```python
+    # ── EDGE TTS BRANCH (2026-04-29 plan) ─────────────────────────────
+    if request.provider == "edge_tts":
+        # Quota check (also blocks Free per H1)
+        if not is_admin:
+            edge_quota = await check_edge_quota(current_user.id, plan, db)
+            if not edge_quota["allowed"]:
+                raise HTTPException(
+                    status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                    detail={
+                        "code": "edge_plan_not_eligible"
+                        if edge_quota.get("reason") == "plan_not_eligible"
+                        else "edge_quota_blocked",
+                        "message": "Edge TTS chat requires Pro or Expert plan.",
+                        "reason": edge_quota.get("reason"),
+                    },
+                )
+
+        # Generate a session_id (no Stripe metered events here)
+        import secrets
+        from datetime import datetime, timedelta, timezone
+        edge_session_id = f"sess_edge_{secrets.token_hex(8)}"
+        return VoiceSessionResponse(
+            session_id=edge_session_id,
+            signed_url="",
+            agent_id="",
+            conversation_token=None,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=2),
+            quota_remaining_minutes=float(edge_quota["minutes_remaining"]) if not is_admin else 999999.0,
+            max_session_minutes=120,  # 2h soft cap per session for Edge half-duplex
+            input_mode="ptt",
+            ptt_key=" ",
+            playback_rate=1.0,
+            is_streaming=False,
+            is_trial=False,
+            max_minutes=None,
+            summary_id=request.summary_id,
+            edge_endpoint="/api/voice/edge/turn",
+        )
+    # ── END EDGE TTS BRANCH ───────────────────────────────────────────
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd backend && python -m pytest tests/test_edge_tts.py -k "post_session_provider" -v`
+Expected: 3 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/voice/router.py backend/tests/test_edge_tts.py
+git commit -m "feat(voice): route /api/voice/session by provider field (edge_tts vs elevenlabs)"
+```
+
+---
+
+### Task 7: Frontend hook `useVoiceChatEdge` (MediaRecorder Opus + fetch streaming)
+
+**Files:**
+
+- Create: `frontend/src/components/voice/useVoiceChatEdge.ts`
+- Modify: `frontend/src/services/api.ts`
+- Test: `frontend/src/components/voice/__tests__/useVoiceChatEdge.test.tsx`
+
+- [ ] **Step 1: Ajouter les helpers API**
+
+Dans `frontend/src/services/api.ts`, dans l'objet `voiceApi` (chercher `voiceApi = {`), ajouter :
+
+```typescript
+  /** Start a half-duplex Edge TTS voice session. */
+  startEdgeSession: async (params: {
+    summaryId?: number;
+    debateId?: number;
+    language?: "fr" | "en";
+    agentType?: string;
+  }): Promise<{
+    session_id: string;
+    edge_endpoint: string;
+    quota_remaining_minutes: number;
+    max_session_minutes: number;
+  }> => {
+    const resp = await api.post("/api/voice/session", {
+      summary_id: params.summaryId,
+      debate_id: params.debateId,
+      language: params.language ?? "fr",
+      agent_type: params.agentType ?? "explorer",
+      provider: "edge_tts",
+    });
+    return resp.data;
+  },
+
+  /** Get rolling 30-day Edge TTS fair-use status. */
+  getEdgeQuota: async (): Promise<{
+    minutes_used: number;
+    minutes_remaining: number;
+    fair_use_cap: number;
+    over_fair_use: boolean;
+    warning?: string | null;
+    rolling_period_start: string;
+    rolling_period_end: string;
+    allowed: boolean;
+    reason?: string | null;
+  }> => {
+    const resp = await api.get("/api/voice/edge/quota");
+    return resp.data;
+  },
+
+  /** POST one Edge TTS turn (audio in, audio/mpeg out). Returns Blob. */
+  sendEdgeTurn: async (params: {
+    sessionId: string;
+    audio: Blob;
+    language: "fr" | "en";
+    gender: "female" | "male";
+    voiceId?: string;
+  }): Promise<Blob> => {
+    const fd = new FormData();
+    fd.append("audio", params.audio, "turn.webm");
+    fd.append("session_id", params.sessionId);
+    fd.append("language", params.language);
+    fd.append("gender", params.gender);
+    if (params.voiceId) fd.append("voice_id", params.voiceId);
+
+    const token = getAccessToken();
+    const resp = await fetch(`${API_URL}/api/voice/edge/turn`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: fd,
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      throw new Error(err?.detail?.message || `Edge turn failed: ${resp.status}`);
+    }
+    return await resp.blob();
+  },
+```
+
+- [ ] **Step 2: Écrire le test failing pour le hook**
+
+Créer `frontend/src/components/voice/__tests__/useVoiceChatEdge.test.tsx` :
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useVoiceChatEdge } from "../useVoiceChatEdge";
+
+// Minimal MediaRecorder polyfill for jsdom
+class FakeMediaRecorder {
+  state: "inactive" | "recording" | "paused" = "inactive";
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  start() {
+    this.state = "recording";
+  }
+  stop() {
+    this.state = "inactive";
+    this.ondataavailable?.({
+      data: new Blob(["fake-audio"], { type: "audio/webm" }),
+    });
+    this.onstop?.();
+  }
+}
+
+beforeEach(() => {
+  // @ts-expect-error polyfill
+  global.MediaRecorder = FakeMediaRecorder;
+  Object.defineProperty(navigator, "mediaDevices", {
+    value: {
+      getUserMedia: vi.fn().mockResolvedValue({
+        getTracks: () => [{ stop: vi.fn() }],
+      }),
+    },
+    configurable: true,
+  });
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    blob: async () =>
+      new Blob([new Uint8Array([0xff, 0xfb, 0x90])], { type: "audio/mpeg" }),
+  });
+  // mock URL.createObjectURL
+  global.URL.createObjectURL = vi.fn(() => "blob:fake");
+});
+
+describe("useVoiceChatEdge", () => {
+  it("starts in idle status", () => {
+    const { result } = renderHook(() => useVoiceChatEdge({ summaryId: 1 }));
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("transitions to listening on start()", async () => {
+    // mock startEdgeSession call
+    vi.doMock("../../../services/api", () => ({
+      voiceApi: {
+        startEdgeSession: vi.fn().mockResolvedValue({
+          session_id: "sess_x",
+          edge_endpoint: "/api/voice/edge/turn",
+          quota_remaining_minutes: 100,
+          max_session_minutes: 120,
+        }),
+        sendEdgeTurn: vi.fn(),
+      },
+      API_URL: "",
+      getAccessToken: () => "tok",
+    }));
+
+    const { result } = renderHook(() => useVoiceChatEdge({ summaryId: 1 }));
+    await act(async () => {
+      await result.current.start();
+    });
+    await waitFor(() => expect(result.current.status).toBe("listening"));
+  });
+
+  it("emits a reply blob URL after pushTurn()", async () => {
+    const { result } = renderHook(() => useVoiceChatEdge({ summaryId: 1 }));
+    await act(async () => {
+      await result.current.start();
+    });
+    await act(async () => {
+      await result.current.pushTurn();
+    });
+    await waitFor(() =>
+      expect(result.current.lastReplyAudioUrl).toBe("blob:fake"),
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/useVoiceChatEdge.test.tsx`
+Expected: FAIL — module `useVoiceChatEdge` not found.
+
+- [ ] **Step 4: Implémenter le hook**
+
+Créer `frontend/src/components/voice/useVoiceChatEdge.ts` :
+
+```typescript
+/**
+ * useVoiceChatEdge — Hook half-duplex pour le provider Edge TTS (Microsoft).
+ *
+ * Différent de useVoiceChat (ElevenLabs WebSocket) : ici, le frontend
+ * enregistre du micro en MediaRecorder Opus, POSTe le blob, reçoit du
+ * audio/mpeg en réponse, et le joue via un <audio> caché.
+ *
+ * Turn-taking côté client : PTT par défaut. Pas de VAD pour le V1.
+ */
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import { voiceApi } from "../../services/api";
+
+export type EdgeStatus =
+  | "idle"
+  | "starting"
+  | "listening"
+  | "uploading"
+  | "playing"
+  | "error";
+
+interface UseVoiceChatEdgeOptions {
+  summaryId?: number;
+  debateId?: number;
+  language?: "fr" | "en";
+  gender?: "female" | "male";
+  agentType?: string;
+  onError?: (msg: string) => void;
+}
+
+interface UseVoiceChatEdgeReturn {
+  status: EdgeStatus;
+  start: () => Promise<void>;
+  stop: () => void;
+  /** Mark current recording as the user turn and ship it. */
+  pushTurn: () => Promise<void>;
+  sessionId: string | null;
+  quotaRemainingMinutes: number;
+  /** Object URL of the latest agent reply audio. */
+  lastReplyAudioUrl: string | null;
+  errorMessage: string | null;
+}
+
+export function useVoiceChatEdge(
+  opts: UseVoiceChatEdgeOptions,
+): UseVoiceChatEdgeReturn {
+  const [status, setStatus] = useState<EdgeStatus>("idle");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [quotaRemainingMinutes, setQuotaRemainingMinutes] = useState(0);
+  const [lastReplyAudioUrl, setLastReplyAudioUrl] = useState<string | null>(
+    null,
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const streamRef = useRef<MediaStream | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+
+  const start = useCallback(async () => {
+    setStatus("starting");
+    setErrorMessage(null);
+    try {
+      const session = await voiceApi.startEdgeSession({
+        summaryId: opts.summaryId,
+        debateId: opts.debateId,
+        language: opts.language ?? "fr",
+        agentType: opts.agentType,
+      });
+      setSessionId(session.session_id);
+      setQuotaRemainingMinutes(session.quota_remaining_minutes);
+
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const recorder = new MediaRecorder(stream, {
+        mimeType: "audio/webm;codecs=opus",
+      });
+      recorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      recorderRef.current = recorder;
+      recorder.start(100); // 100ms chunks for low latency
+
+      setStatus("listening");
+    } catch (e) {
+      const msg =
+        e instanceof Error ? e.message : "Failed to start Edge session.";
+      setErrorMessage(msg);
+      setStatus("error");
+      opts.onError?.(msg);
+    }
+  }, [opts]);
+
+  const pushTurn = useCallback(async () => {
+    if (!sessionId || !recorderRef.current) return;
+    setStatus("uploading");
+    try {
+      // Stop recorder to flush chunks
+      const recorder = recorderRef.current;
+      const stopped = new Promise<void>((res) => {
+        recorder.onstop = () => res();
+      });
+      recorder.stop();
+      await stopped;
+
+      const audio = new Blob(chunksRef.current, { type: "audio/webm" });
+      chunksRef.current = [];
+
+      const replyBlob = await voiceApi.sendEdgeTurn({
+        sessionId,
+        audio,
+        language: opts.language ?? "fr",
+        gender: opts.gender ?? "female",
+      });
+
+      const url = URL.createObjectURL(replyBlob);
+      setLastReplyAudioUrl(url);
+      setStatus("playing");
+
+      // Restart recorder for the next user turn
+      if (streamRef.current) {
+        const next = new MediaRecorder(streamRef.current, {
+          mimeType: "audio/webm;codecs=opus",
+        });
+        next.ondataavailable = (e) => {
+          if (e.data && e.data.size > 0) chunksRef.current.push(e.data);
+        };
+        recorderRef.current = next;
+        next.start(100);
+        setStatus("listening");
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Edge turn failed.";
+      setErrorMessage(msg);
+      setStatus("error");
+      opts.onError?.(msg);
+    }
+  }, [sessionId, opts]);
+
+  const stop = useCallback(() => {
+    try {
+      recorderRef.current?.stop();
+    } catch {
+      /* ignore */
+    }
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    recorderRef.current = null;
+    chunksRef.current = [];
+    setStatus("idle");
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      stop();
+      if (lastReplyAudioUrl) URL.revokeObjectURL(lastReplyAudioUrl);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    status,
+    start,
+    stop,
+    pushTurn,
+    sessionId,
+    quotaRemainingMinutes,
+    lastReplyAudioUrl,
+    errorMessage,
+  };
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd frontend && npx vitest run src/components/voice/__tests__/useVoiceChatEdge.test.tsx`
+Expected: 3 PASSED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/voice/useVoiceChatEdge.ts frontend/src/components/voice/__tests__/useVoiceChatEdge.test.tsx frontend/src/services/api.ts
+git commit -m "feat(voice): add useVoiceChatEdge hook + voiceApi.startEdgeSession/sendEdgeTurn/getEdgeQuota"
+```
+
+---
+
+### Task 8: UI toggle provider dans `VoiceCallPage`
+
+**Files:**
+
+- Modify: `frontend/src/pages/VoiceCallPage.tsx` (ou `frontend/src/components/voice/VoiceCallPage.tsx` selon emplacement réel — vérifier avec `grep -n "VoiceCallPage" frontend/src` au moment d'exécuter)
+
+- [ ] **Step 1: Localiser le bon fichier**
+
+Run: `grep -rn "VoiceCallPage" frontend/src --include="*.tsx" | head -5`
+Expected: identifier le path exact (visible dans le file listing initial : `frontend/src/components/voice/VoiceCallPage.tsx`).
+
+- [ ] **Step 2: Ajouter le toggle provider**
+
+Dans `frontend/src/components/voice/VoiceCallPage.tsx` (le fichier hero card), juste avant le rendu de `<AnalysisVoiceHero>` ou son équivalent (chercher "VoiceHero" ou "hero card" dans le fichier), ajouter un état provider et un toggle :
+
+```typescript
+import { useState, useEffect } from "react";
+import { voiceApi } from "../../services/api";
+
+// ... dans le composant
+const [provider, setProvider] = useState<"elevenlabs" | "edge_tts">("elevenlabs");
+const [edgeQuota, setEdgeQuota] = useState<{
+  minutes_remaining: number;
+  fair_use_cap: number;
+  allowed: boolean;
+  over_fair_use: boolean;
+} | null>(null);
+
+useEffect(() => {
+  // Best-effort: fetch quota for the toggle badge. Ignore failures.
+  voiceApi.getEdgeQuota()
+    .then(setEdgeQuota)
+    .catch(() => setEdgeQuota(null));
+}, []);
+
+// ... avant <AnalysisVoiceHero> ou bloc équivalent
+<div className="mb-4 flex gap-2 rounded-2xl border border-white/10 bg-white/5 p-1.5 backdrop-blur-xl">
+  <button
+    type="button"
+    onClick={() => setProvider("elevenlabs")}
+    aria-pressed={provider === "elevenlabs"}
+    className={[
+      "flex-1 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors",
+      provider === "elevenlabs"
+        ? "bg-gradient-to-r from-indigo-500 to-violet-500 text-white shadow-lg"
+        : "text-white/70 hover:bg-white/5",
+    ].join(" ")}
+  >
+    <span>Premium (ElevenLabs)</span>
+    <span className="ml-2 text-[10px] uppercase tracking-wide opacity-80">
+      30 min restantes
+    </span>
+  </button>
+  <button
+    type="button"
+    onClick={() => setProvider("edge_tts")}
+    aria-pressed={provider === "edge_tts"}
+    disabled={edgeQuota?.allowed === false}
+    className={[
+      "flex-1 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed",
+      provider === "edge_tts"
+        ? "bg-gradient-to-r from-cyan-500 to-blue-500 text-white shadow-lg"
+        : "text-white/70 hover:bg-white/5",
+    ].join(" ")}
+    title={
+      edgeQuota?.allowed === false
+        ? "Edge TTS nécessite Pro ou Expert."
+        : edgeQuota?.over_fair_use
+        ? "Tu as dépassé la fair-use de 10 h ce mois."
+        : "Free unlimited TTS by Microsoft Edge."
+    }
+  >
+    <span>Edge TTS</span>
+    <span className="ml-2 text-[10px] uppercase tracking-wide opacity-80">
+      Gratuit illimité
+    </span>
+  </button>
+</div>
+```
+
+Et passer `provider` au hook : remplacer
+
+```tsx
+const voice = useVoiceChat({...});
+```
+
+par un branch conditionnel :
+
+```tsx
+const elevenlabsVoice = useVoiceChat({
+  summaryId,
+  debateId,
+  agentType,
+  language,
+});
+const edgeVoice = useVoiceChatEdge({
+  summaryId,
+  debateId,
+  agentType,
+  language,
+});
+const voice = provider === "edge_tts" ? edgeVoice : elevenlabsVoice;
+```
+
+(Adapter selon la structure exacte du fichier : si `useVoiceChat` est appelé dans un sous-composant, hisser le toggle `provider` au niveau parent et le passer en prop.)
+
+- [ ] **Step 3: Vérifier visuellement**
+
+Run: `cd frontend && npm run dev` (port 5173)
+Naviguer vers `/voice-call?summary_id=1` (ou équivalent) avec un compte Pro de test.
+Expected: Voir le toggle apparaître au-dessus de la carte hero, avec deux pilules cliquables.
+Vérifier la console : pas d'erreur React. Le bouton "Edge TTS" est désactivé pour un compte Free.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: 0 erreurs TS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/voice/VoiceCallPage.tsx
+git commit -m "feat(voice): add provider toggle (Edge TTS vs ElevenLabs) in VoiceCallPage"
+```
+
+---
+
+### Task 9: Smoke test E2E manuel — Edge call FR + EN + provider switch + fair-use
+
+**Files:**
+
+- Aucun fichier modifié — checklist de tests manuels avec un VPS staging ou dev local backend.
+
+- [ ] **Step 1: Backend up + migrations appliquées**
+
+Run (sur Hetzner VPS) : `ssh -i ~/.ssh/id_hetzner root@89.167.23.214 "docker exec repo-backend-1 alembic current"`
+Expected: `013_voice_edge_quota (head)`
+
+Run en local : `cd backend/src && uvicorn main:app --reload --port 8000` (laisser tourner)
+
+- [ ] **Step 2: Test manuel Edge FR — depuis frontend dev**
+
+Run : `cd frontend && npm run dev`
+
+Étapes navigateur :
+
+1. Login compte Pro de test
+2. Aller sur `/voice-call?summary_id=<ID>`
+3. Cliquer sur "Edge TTS"
+4. Cliquer sur le bouton micro / espace (PTT)
+5. Dire "Bonjour, parle-moi de cette vidéo"
+6. Relâcher : pousser le turn
+
+Expected:
+
+- Console réseau : `POST /api/voice/edge/turn` 200 + body `audio/mpeg`
+- Audio joué dans le navigateur (réponse Mistral en français)
+- Header `X-Edge-Minutes-Used` présent
+
+- [ ] **Step 3: Test manuel Edge EN**
+
+Idem step 2 mais avec `?language=en` ou toggle langue, et phrase anglaise.
+Expected: réponse en anglais, voice `en-US-AriaNeural`.
+
+- [ ] **Step 4: Test manuel provider switch live**
+
+Pendant un call Edge TTS actif :
+
+1. Cliquer sur "Premium (ElevenLabs)"
+2. Vérifier qu'un nouveau call ElevenLabs démarre (signed URL + WS)
+3. Reswitch sur Edge TTS
+4. Vérifier que le call Edge reprend sans crash UI
+
+Expected: zéro fuite micro (vérifier indicateur navigateur micro éteint quand pas en call), zéro erreur console.
+
+- [ ] **Step 5: Test manuel fair-use cap simulation**
+
+Run (en local pgsql ou via shell asyncpg) :
+
+```sql
+UPDATE voice_edge_quota SET minutes_used = 605 WHERE user_id = <ID_TEST_PRO>;
+```
+
+Recharger la page voice-call.
+Expected:
+
+- Toggle Edge TTS reste cliquable (cap soft)
+- Au turn suivant, header de réponse `X-Edge-Warning: fair_use_exceeded` présent
+- UI affiche un toast/banner "Tu as dépassé 10 h..." (à câbler dans Task 8 si pas déjà fait — sinon vérifier au moins via DevTools)
+
+- [ ] **Step 6: Smoke backend health**
+
+Run : `curl -s http://localhost:8000/api/voice/edge/quota -H "Authorization: Bearer <TOKEN>" | jq .`
+Expected: payload JSON avec `fair_use_cap: 600`
+
+Run : `cd backend && python -m pytest tests/test_edge_tts.py -v`
+Expected: tous les tests passent (>= 18 tests si les tasks précédentes ont été exécutées)
+
+- [ ] **Step 7: Commit (commits déjà faits aux tasks précédentes — rien à commit ici)**
+
+Si des micro-fixes UI émergent du smoke test, faire un commit `chore(voice): polish Edge TTS toggle after smoke test`.
+
+---
+
+## Self-Review
+
+### 1. Spec coverage
+
+| Brief item                                                 | Task                        |
+| ---------------------------------------------------------- | --------------------------- |
+| Migration Alembic 013 + modèle                             | Task 1                      |
+| edge-tts package + wrapper provider FR/EN                  | Task 2                      |
+| edge_quota_service consume/check/fair-use                  | Task 3                      |
+| Schemas Provider literal + edge_endpoint                   | Task 4                      |
+| POST /api/voice/edge/turn (audio in → STT → Mistral → TTS) | Task 5                      |
+| GET /api/voice/edge/quota                                  | Task 5                      |
+| Extend /api/voice/session avec routing par provider        | Task 6                      |
+| Frontend useVoiceChatEdge hook                             | Task 7                      |
+| API client startEdgeSession/getEdgeQuota/sendEdgeTurn      | Task 7                      |
+| UI toggle provider dans VoiceCallPage avec badges          | Task 8                      |
+| Smoke E2E manuel                                           | Task 9                      |
+| Pytest test_edge_tts.py                                    | Tasks 1-6 (incrémental TDD) |
+| Vitest useVoiceChatEdge.test.tsx                           | Task 7                      |
+
+Couvert. RAS.
+
+### 2. Placeholder scan
+
+- Aucun "TBD"/"TODO"/"implement later" dans le plan.
+- Code complet dans chaque step (signatures, types, blocs entiers).
+- Commandes de run/expected output explicites.
+- `call_mistral_simple` adressé avec un fallback explicite (Task 5 step 3 note).
+
+### 3. Type consistency
+
+- `Provider` literal : `"elevenlabs" | "edge_tts"` cohérent backend (`schemas.py`) + frontend (`useVoiceChatEdge.ts` + UI toggle).
+- `EdgeQuotaResponse` shape : champs identiques entre `get_edge_status()` (Task 3), schema Pydantic (Task 4), client TS (Task 7), et UI (Task 8).
+- `EdgeTurnRequest` : champs `session_id, language, gender, voice_id` identiques entre Task 4 et Task 5 + Task 7.
+- `consume_edge_minutes(user_id, minutes, db)` signature stable Task 3 → Task 5.
+- `resolve_voice(language, gender)` signature stable Task 2 → Task 5.
+
+### Décisions à confirmer (à présenter à l'utilisateur AVANT exécution)
+
+| ID     | Décision                              | Recommandation par défaut                                                                                                                                                                                                        |
+| ------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1** | Voix Edge TTS par défaut FR/EN        | FR : `fr-FR-DeniseNeural` (♀) + `fr-FR-HenriNeural` (♂) ; EN : `en-US-AriaNeural` (♀) + `en-US-GuyNeural` (♂)                                                                                                                    |
+| **D2** | Fair-use cap rolling 30j              | 600 minutes (10h). Confirmer ou ajuster (300/450/900) selon coût Whisper accepté.                                                                                                                                                |
+| **D3** | Mobile/Extension scope                | Hors scope (H6 — Web d'abord). Ajouter un task 10/11 mobile + extension dans un follow-up plan ?                                                                                                                                 |
+| **D4** | Branche git                           | `feature/audit-kimi-plans-2026-04-29` (donnée dans le brief). Confirmer pas de worktree dédié séparé.                                                                                                                            |
+| **D5** | Latence acceptable Edge vs ElevenLabs | Edge TTS half-duplex : TTFB ~800-1500 ms (STT + Mistral + TTS) vs ElevenLabs WS ~300-600 ms. Acceptable pour le V1 ? Si non : streamer la réponse Mistral token-par-token vers Edge TTS chunks (refactor possible mais hors V1). |
+
+---
+
+## Execution Handoff
+
+Plan complet et sauvegardé dans `docs/superpowers/plans/2026-04-29-edge-tts-gratuit.md`. Deux options d'exécution :
+
+1. **Subagent-Driven (recommandé)** — Je dispatche un sous-agent frais par tâche, review entre tâches, itération rapide
+2. **Inline Execution** — Exécution des tâches dans cette session via executing-plans, exécution batch avec checkpoints
+
+Avant d'exécuter : confirmer **D1 voix par défaut**, **D2 fair-use 600 min**, **D3 mobile/extension**, **D4 branche**, **D5 latence acceptable**.
+
+Quelle approche ?

--- a/docs/superpowers/plans/2026-04-29-elevenlabs-voice-packs.md
+++ b/docs/superpowers/plans/2026-04-29-elevenlabs-voice-packs.md
@@ -1,0 +1,1931 @@
+# ElevenLabs Voice Top-up Packs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettre aux abonnés Pro/Expert d'acheter des packs de minutes vocales ElevenLabs (30 / 60 / 180 min) en one-shot Stripe lorsqu'ils ont épuisé leur allowance mensuelle, avec consommation allowance-first puis purchased-fallback.
+
+**Architecture:** Deux nouvelles tables `voice_credit_packs` (catalogue) + `voice_credit_purchases` (historique idempotent), une colonne `purchased_minutes` ajoutée à `voice_quota`. Stripe Checkout en `mode=payment` (one-shot, pas subscription) avec metadata `kind=voice_pack` routée vers un handler webhook idempotent. La fonction `consume_voice_minutes` est étendue pour décrémenter d'abord l'allowance plan rolling-30j puis le solde acheté permanent. Le legacy `voice_addon` (table `voice_quotas` + `user.voice_bonus_seconds`) reste intact pour le classic voice chat ; le nouveau système cible exclusivement la table `voice_quota` (Quick Voice Call A+D, migration 008).
+
+**Tech Stack:** FastAPI 0.110+, SQLAlchemy 2.0 async, Alembic, PostgreSQL 17 / SQLite (dev), Stripe Python SDK 9.x, React 18 + TypeScript strict + Vite 5, Tailwind CSS 3, Vitest + Testing Library, pytest-asyncio.
+
+---
+
+## Contexte préalable
+
+### État DeepSight au 2026-04-29
+
+- **Branche** : `feature/audit-kimi-plans-2026-04-29` (déjà checkout)
+- **Backend Quick Voice Call A+D** : `backend/src/billing/voice_quota.py` expose `check_voice_quota` et `consume_voice_minutes`. Plans Pro/Expert reçoivent 30 min/30j rolling (`TOP_TIER_MONTHLY_MINUTES = 30.0`). Free a un trial 3 min lifetime.
+- **Modèle DB** : `VoiceQuotaStreaming` (table `voice_quota` SINGULIER, migration 008) — colonnes actuelles : `user_id`, `plan`, `monthly_minutes_used`, `monthly_period_start`, `lifetime_trial_used`, `lifetime_trial_used_at`. Il n'y a PAS de colonne `purchased_minutes`.
+- **Webhook Stripe** : `backend/src/billing/router.py:1502-1622` (`stripe_webhook`) avec dispatch `checkout.session.completed` → `handle_checkout_completed` (ligne 1623). Branchements existants : `voice_addon` (mort code orphelin — pas d'endpoint front), `credit_pack`, et le flow `subscription` standard.
+- **Legacy parallèle** : `backend/src/voice/router.py:2509` définit `VOICE_ADDON_PACKS` hardcodé pour la table LEGACY `voice_quotas` PLURIEL via `user.voice_bonus_seconds`. **À ne pas confondre** : ce système-là crédite le classic voice chat, pas le Quick Voice Call. Il sera **deprecated** à terme mais reste actif pour rétrocompatibilité.
+- **Frontend `VoiceAddonModal`** : `frontend/src/components/voice/VoiceAddonModal.tsx` existe déjà avec packs hardcodés `voice_10/voice_30/voice_60` mais appelle l'endpoint legacy. **À refactorer** pour pointer vers le nouveau catalogue DB-driven.
+- **Migrations Alembic** : `backend/alembic/versions/` contient jusqu'à `010_add_conversation_digests.py` (down_revision `009_add_user_preferences_json`). **La nouvelle migration sera 011**, pas 010 (correction par rapport au prompt initial : 010 vient d'être commitée pour le plan digests).
+- **`User.stripe_customer_id`** : `backend/src/db/database.py:133` — déjà existant, réutilisable.
+
+### Hypothèses business à confirmer (voir Self-Review § Décisions)
+
+| #   | Hypothèse                                                                        | Justif                                                           |
+| --- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| H1  | Allowance défaut Pro 30 min / Expert 120 min                                     | Décision DC audit Kimi 2026-04-29 + différenciation tier         |
+| H2  | Packs accessibles **uniquement** Pro/Expert (Free bloqué 402 `upgrade_required`) | Évite contournement upgrade                                      |
+| H3  | Minutes achetées **n'expirent pas**                                              | Pratique SaaS top-up standard (Twilio, Loom, Otter)              |
+| H4  | Allowance plan consommée **avant** purchased                                     | Protège minutes payées du reset mensuel                          |
+| H5  | Stripe Checkout `mode=payment` (one-shot, pas subscription)                      | Réutilise `stripe_customer_id` existant                          |
+| H6  | TVA via Stripe Tax (`automatic_tax: enabled`)                                    | Déjà actif pour subs ; cohérence comptable                       |
+| H7  | Migration Alembic numérotée **011** (pas 010 comme dans le prompt initial)       | 010_add_conversation_digests.py existe déjà en down_revision 009 |
+| H8  | Consommation atomique (single transaction) du double-bucket allowance/purchased  | Évite over-debit en cas de race-condition concurrent             |
+
+### Catalogue figé (seed Stripe + DB)
+
+| Slug        | Minutes | Prix cents | Prix EUR | Marge brute (~$0.05/min ElevenLabs gros volume) |
+| ----------- | ------- | ---------- | -------- | ----------------------------------------------- |
+| `voice-30`  | 30      | 299        | 2,99 €   | ~30 %                                           |
+| `voice-60`  | 60      | 499        | 4,99 €   | ~16 %                                           |
+| `voice-180` | 180     | 1299       | 12,99 €  | ~3 %                                            |
+
+Le slug utilise `-` (kebab-case) pour éviter collision avec les legacy `voice_30/voice_60` (snake_case).
+
+---
+
+## File Structure
+
+### Création
+
+| Fichier                                                             | Responsabilité                                                                                              |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `backend/alembic/versions/011_add_voice_credit_packs.py`            | Migration : tables `voice_credit_packs`, `voice_credit_purchases` + colonne `voice_quota.purchased_minutes` |
+| `backend/src/billing/voice_packs_service.py`                        | Pure logic : list packs, add purchased minutes idempotent, helpers status                                   |
+| `backend/src/billing/voice_packs_router.py`                         | Endpoints REST `/api/billing/voice-packs/*`                                                                 |
+| `backend/scripts/seed_voice_packs.py`                               | Script idempotent qui crée les Stripe Products/Prices + insère les rows DB                                  |
+| `backend/tests/billing/test_voice_packs_service.py`                 | Tests unitaires service (TDD ~6 tests)                                                                      |
+| `backend/tests/billing/test_voice_packs_consume.py`                 | Tests `consume_voice_minutes` allowance-first / purchased-fallback (TDD 2 tests)                            |
+| `backend/tests/billing/test_voice_packs_router.py`                  | Tests endpoints REST (3 tests : list, my-credits, checkout)                                                 |
+| `backend/tests/billing/test_voice_packs_webhook.py`                 | Tests webhook handler idempotent (TDD 2 tests : credit + duplicate skip)                                    |
+| `frontend/src/components/voice/VoicePacksWidget.tsx`                | Widget liste packs + bouton acheter → redirect Stripe                                                       |
+| `frontend/src/components/voice/__tests__/VoicePacksWidget.test.tsx` | Tests Vitest (2 tests : render packs, click checkout)                                                       |
+
+### Modification
+
+| Fichier                                        | Modification                                                                                                 |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `backend/src/db/database.py:879-901`           | Ajouter `purchased_minutes` à `VoiceQuotaStreaming`, créer classes `VoiceCreditPack` + `VoiceCreditPurchase` |
+| `backend/src/billing/voice_quota.py:155-175`   | Étendre `consume_voice_minutes` : allowance-first puis purchased-fallback                                    |
+| `backend/src/billing/voice_quota.py:110-152`   | Étendre `check_voice_quota` : retourner `max_minutes = allowance_remaining + purchased_minutes`              |
+| `backend/src/billing/router.py:1623-1630`      | Ajouter branchement `metadata.kind == "voice_pack"` → `_handle_voice_pack_checkout`                          |
+| `backend/src/main.py`                          | Inclure le nouveau router `voice_packs_router`                                                               |
+| `frontend/src/services/api.ts:2638-2710`       | Ajouter `voicePacksApi` (`list`, `myCredits`, `createCheckout`)                                              |
+| `frontend/src/pages/MyAccount.tsx:537`         | Insérer `<VoicePacksWidget />` après section abonnement                                                      |
+| `frontend/src/pages/VoiceCallPage.tsx:199-215` | Bannière `quota_exceeded` ajouter CTA secondaire `/account#voice-packs`                                      |
+
+### File responsibility design rationale
+
+- **`voice_packs_service.py`** isole la pure logic (DB I/O minimal, pas d'API Stripe ici) → testable sans mock complexe.
+- **`voice_packs_router.py`** séparé de `billing/router.py` (déjà 1636 lignes, très chargé) → respecte la limite "petits fichiers focalisés" du CLAUDE.md.
+- **Webhook handler** reste dans `billing/router.py` (au plus proche de `handle_checkout_completed`) car le dispatch metadata est centralisé là.
+- **`VoicePacksWidget.tsx`** unique composant React qui s'auto-suffit — pas de découpage prématuré (YAGNI).
+
+---
+
+## Tasks
+
+### Task 1 : Migration Alembic 011 (tables + colonne)
+
+**Files:**
+
+- Create: `backend/alembic/versions/011_add_voice_credit_packs.py`
+
+- [ ] **Step 1 : Créer le fichier migration**
+
+```python
+"""Add voice credit packs catalog + purchases history + purchased_minutes column.
+
+Revision ID: 011_add_voice_credit_packs
+Revises: 010_add_conversation_digests
+Create Date: 2026-04-29
+
+Adds the ElevenLabs voice top-up packs system (Quick Win audit Kimi P0):
+  * NEW table ``voice_credit_packs`` : catalog of buyable packs (slug, minutes,
+    price_cents, Stripe product/price IDs).
+  * NEW table ``voice_credit_purchases`` : history (1 row per Stripe checkout
+    completion), used as idempotency key store.
+  * NEW column ``voice_quota.purchased_minutes`` : non-expiring balance,
+    consumed AFTER allowance plan in ``consume_voice_minutes``.
+
+Backward compat:
+  * All new tables independent → no impact on existing rows.
+  * ``voice_quota.purchased_minutes`` defaults to 0 server-side → existing
+    rows safe.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "011_add_voice_credit_packs"
+down_revision: Union[str, None] = "010_add_conversation_digests"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── voice_credit_packs (catalog) ─────────────────────────────────────
+    op.create_table(
+        "voice_credit_packs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("slug", sa.String(64), nullable=False, unique=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("minutes", sa.Integer(), nullable=False),
+        sa.Column("price_cents", sa.Integer(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("stripe_product_id", sa.String(100), nullable=True),
+        sa.Column("stripe_price_id", sa.String(100), nullable=True, unique=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # ── voice_credit_purchases (history + idempotency) ───────────────────
+    op.create_table(
+        "voice_credit_purchases",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "pack_id",
+            sa.Integer(),
+            sa.ForeignKey("voice_credit_packs.id"),
+            nullable=False,
+        ),
+        sa.Column("minutes_purchased", sa.Integer(), nullable=False),
+        sa.Column("price_paid_cents", sa.Integer(), nullable=False),
+        sa.Column("stripe_session_id", sa.String(255), nullable=True, unique=True),
+        sa.Column("stripe_payment_intent_id", sa.String(255), nullable=True, unique=True),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_voice_credit_purchases_user_status",
+        "voice_credit_purchases",
+        ["user_id", "status"],
+    )
+
+    # ── voice_quota.purchased_minutes (non-expiring balance) ─────────────
+    op.add_column(
+        "voice_quota",
+        sa.Column(
+            "purchased_minutes",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("voice_quota", "purchased_minutes")
+    op.drop_index(
+        "ix_voice_credit_purchases_user_status",
+        table_name="voice_credit_purchases",
+    )
+    op.drop_table("voice_credit_purchases")
+    op.drop_table("voice_credit_packs")
+```
+
+- [ ] **Step 2 : Vérifier la migration en local**
+
+Run: `cd backend && alembic upgrade head && alembic downgrade -1 && alembic upgrade head`
+Expected: pas d'erreur, tables créées puis re-créées.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add backend/alembic/versions/011_add_voice_credit_packs.py
+git commit -m "feat(billing): add Alembic 011 for voice credit packs
+
+- voice_credit_packs catalog table (slug, minutes, price_cents, Stripe IDs)
+- voice_credit_purchases history table (idempotent via stripe_session_id)
+- voice_quota.purchased_minutes non-expiring balance column
+
+Refs audit Kimi P0 quick win — ElevenLabs top-up packs."
+```
+
+---
+
+### Task 2 : Modèles SQLAlchemy `VoiceCreditPack`, `VoiceCreditPurchase` + extend `VoiceQuotaStreaming`
+
+**Files:**
+
+- Modify: `backend/src/db/database.py:879-901`
+
+- [ ] **Step 1 : Étendre `VoiceQuotaStreaming` avec `purchased_minutes`**
+
+Trouver la définition existante (ligne 879) et ajouter la colonne après `lifetime_trial_used_at` :
+
+```python
+class VoiceQuotaStreaming(Base):
+    """🎙️ Quick Voice Call A+D quota + purchased balance (migrations 008 + 011)."""
+
+    __tablename__ = "voice_quota"
+
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    plan = Column(String(20), nullable=False)
+    monthly_minutes_used = Column(Float, nullable=False, default=0.0, server_default="0")
+    monthly_period_start = Column(DateTime(timezone=True), nullable=False)
+    lifetime_trial_used = Column(Boolean, nullable=False, default=False, server_default="false")
+    lifetime_trial_used_at = Column(DateTime(timezone=True), nullable=True)
+    # Non-expiring balance (top-up packs, migration 011)
+    purchased_minutes = Column(Float, nullable=False, default=0.0, server_default="0")
+```
+
+- [ ] **Step 2 : Ajouter les classes `VoiceCreditPack` et `VoiceCreditPurchase` après `VoiceQuotaStreaming`**
+
+Insérer après la ligne `purchased_minutes = Column(...)` (avant le bloc `# ═══════ GAMIFICATION ═══════`) :
+
+```python
+class VoiceCreditPack(Base):
+    """🎙️ Catalog d'un pack de minutes vocales achetable (migration 011)."""
+
+    __tablename__ = "voice_credit_packs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    slug = Column(String(64), unique=True, nullable=False)
+    name = Column(String(255), nullable=False)
+    minutes = Column(Integer, nullable=False)
+    price_cents = Column(Integer, nullable=False)
+    description = Column(Text, nullable=True)
+    stripe_product_id = Column(String(100), nullable=True)
+    stripe_price_id = Column(String(100), nullable=True, unique=True)
+    is_active = Column(Boolean, nullable=False, default=True, server_default=text("true"))
+    display_order = Column(Integer, nullable=False, default=0, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class VoiceCreditPurchase(Base):
+    """🎙️ Historique achat pack — 1 row par Stripe checkout completion."""
+
+    __tablename__ = "voice_credit_purchases"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    pack_id = Column(
+        Integer,
+        ForeignKey("voice_credit_packs.id"),
+        nullable=False,
+    )
+    minutes_purchased = Column(Integer, nullable=False)
+    price_paid_cents = Column(Integer, nullable=False)
+    stripe_session_id = Column(String(255), unique=True, nullable=True)
+    stripe_payment_intent_id = Column(String(255), unique=True, nullable=True)
+    status = Column(String(20), nullable=False, default="pending", server_default="'pending'")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index("ix_voice_credit_purchases_user_status", "user_id", "status"),
+    )
+```
+
+- [ ] **Step 3 : Vérifier que les imports SQLAlchemy contiennent bien `text`**
+
+Ils sont déjà importés ligne 22. Pas d'action.
+
+- [ ] **Step 4 : Lancer les tests existants pour vérifier la non-régression**
+
+Run: `cd backend && python -m pytest tests/test_db_models.py tests/billing/ -v 2>&1 | tail -20`
+Expected: tous les tests passent (pas de nouveau test ajouté à cette tâche).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add backend/src/db/database.py
+git commit -m "feat(db): add VoiceCreditPack/Purchase models + purchased_minutes column
+
+- VoiceCreditPack : catalog model (slug, name, minutes, price_cents, Stripe IDs)
+- VoiceCreditPurchase : history with idempotency unique constraints on
+  stripe_session_id / stripe_payment_intent_id
+- VoiceQuotaStreaming.purchased_minutes : non-expiring balance"
+```
+
+---
+
+### Task 3 : Service pure logic `voice_packs_service.py` — TDD 6 tests
+
+**Files:**
+
+- Create: `backend/src/billing/voice_packs_service.py`
+- Create: `backend/tests/billing/test_voice_packs_service.py`
+
+- [ ] **Step 1 : Créer le test file et les fixtures**
+
+Créer `backend/tests/billing/__init__.py` (vide) si pas existant, puis `test_voice_packs_service.py` :
+
+```python
+"""Tests pure logic du service voice packs (sans Stripe)."""
+
+import pytest
+from datetime import datetime, timezone
+
+from db.database import (
+    User,
+    VoiceCreditPack,
+    VoiceCreditPurchase,
+    VoiceQuotaStreaming,
+)
+from billing.voice_packs_service import (
+    list_active_packs,
+    get_pack_by_slug,
+    add_purchased_minutes,
+    get_user_credit_status,
+)
+
+
+@pytest.mark.asyncio
+async def test_list_active_packs_returns_only_active_ordered(test_db_session):
+    """list_active_packs filtre is_active et ordonne par display_order."""
+    db = test_db_session
+    db.add_all([
+        VoiceCreditPack(slug="voice-30", name="30 min", minutes=30, price_cents=299, display_order=1, is_active=True),
+        VoiceCreditPack(slug="voice-60", name="60 min", minutes=60, price_cents=499, display_order=2, is_active=True),
+        VoiceCreditPack(slug="voice-old", name="Legacy", minutes=120, price_cents=999, display_order=99, is_active=False),
+    ])
+    await db.commit()
+
+    packs = await list_active_packs(db)
+
+    assert len(packs) == 2
+    assert [p.slug for p in packs] == ["voice-30", "voice-60"]
+
+
+@pytest.mark.asyncio
+async def test_get_pack_by_slug_returns_none_for_unknown(test_db_session):
+    """get_pack_by_slug retourne None pour slug inexistant."""
+    pack = await get_pack_by_slug("nonexistent-slug", test_db_session)
+    assert pack is None
+
+
+@pytest.mark.asyncio
+async def test_add_purchased_minutes_creates_quota_row_if_missing(test_db_session, test_user):
+    """add_purchased_minutes crée la row voice_quota si absente, puis crédite."""
+    db = test_db_session
+    await add_purchased_minutes(test_user.id, 60.0, db)
+
+    quota = await db.get(VoiceQuotaStreaming, test_user.id)
+    assert quota is not None
+    assert quota.purchased_minutes == 60.0
+
+
+@pytest.mark.asyncio
+async def test_add_purchased_minutes_increments_existing_balance(test_db_session, test_user):
+    """add_purchased_minutes additionne au solde existant."""
+    db = test_db_session
+    db.add(VoiceQuotaStreaming(
+        user_id=test_user.id,
+        plan="pro",
+        monthly_period_start=datetime.now(timezone.utc),
+        purchased_minutes=30.0,
+    ))
+    await db.commit()
+
+    await add_purchased_minutes(test_user.id, 60.0, db)
+
+    quota = await db.get(VoiceQuotaStreaming, test_user.id)
+    assert quota.purchased_minutes == 90.0
+
+
+@pytest.mark.asyncio
+async def test_get_user_credit_status_snapshot(test_db_session, test_user):
+    """get_user_credit_status retourne le snapshot allowance + purchased."""
+    db = test_db_session
+    db.add(VoiceQuotaStreaming(
+        user_id=test_user.id,
+        plan="pro",
+        monthly_period_start=datetime.now(timezone.utc),
+        monthly_minutes_used=10.0,
+        purchased_minutes=45.0,
+    ))
+    await db.commit()
+
+    status = await get_user_credit_status(test_user, db)
+
+    assert status["allowance_total"] == 30.0  # TOP_TIER_MONTHLY_MINUTES
+    assert status["allowance_used"] == 10.0
+    assert status["allowance_remaining"] == 20.0
+    assert status["purchased_minutes"] == 45.0
+    assert status["total_minutes_available"] == 65.0
+
+
+@pytest.mark.asyncio
+async def test_get_user_credit_status_free_plan_zero_allowance(test_db_session):
+    """Free plan : allowance_total = 0, only trial."""
+    free_user = User(id=999, email="free@test.com", plan="free")
+    test_db_session.add(free_user)
+    await test_db_session.commit()
+
+    status = await get_user_credit_status(free_user, test_db_session)
+
+    assert status["allowance_total"] == 0.0
+    assert status["purchased_minutes"] == 0.0
+```
+
+- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+
+Run: `cd backend && python -m pytest tests/billing/test_voice_packs_service.py -v`
+Expected: FAIL avec `ImportError: cannot import name 'list_active_packs'`.
+
+- [ ] **Step 3 : Créer le service**
+
+```python
+"""Pure logic du système voice credit packs.
+
+Pas d'API Stripe ici (séparation des préoccupations) — l'achat passe par le
+router qui orchestre Stripe + DB. Ce service expose uniquement les opérations
+de lecture/écriture DB et le calcul du snapshot crédit utilisateur.
+"""
+
+import logging
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import (
+    User,
+    VoiceCreditPack,
+    VoiceQuotaStreaming,
+)
+from billing.voice_quota import (
+    TOP_TIER_MONTHLY_MINUTES,
+    TOP_TIER_PLANS,
+    FREE_TRIAL_MINUTES,
+    _get_or_create_quota,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def list_active_packs(db: AsyncSession) -> list[VoiceCreditPack]:
+    """Catalogue des packs actifs ordonnés par display_order asc."""
+    result = await db.execute(
+        select(VoiceCreditPack)
+        .where(VoiceCreditPack.is_active.is_(True))
+        .order_by(VoiceCreditPack.display_order.asc(), VoiceCreditPack.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def get_pack_by_slug(slug: str, db: AsyncSession) -> Optional[VoiceCreditPack]:
+    """Récupère un pack par slug, None si introuvable."""
+    result = await db.execute(
+        select(VoiceCreditPack).where(VoiceCreditPack.slug == slug)
+    )
+    return result.scalar_one_or_none()
+
+
+async def add_purchased_minutes(
+    user_id: int, minutes: float, db: AsyncSession
+) -> None:
+    """Crédite ``minutes`` au solde non-expirant de l'utilisateur.
+
+    Crée la row ``voice_quota`` si elle n'existe pas. Ne commit PAS — c'est au
+    caller webhook de wrap dans une transaction et commit avec
+    ``VoiceCreditPurchase`` pour idempotency atomique.
+    """
+    user = await db.get(User, user_id)
+    plan = (user.plan if user else "free") or "free"
+
+    quota = await _get_or_create_quota(user_id, plan.lower(), db)
+    quota.purchased_minutes = float(quota.purchased_minutes or 0.0) + float(minutes)
+
+
+async def get_user_credit_status(user: User, db: AsyncSession) -> dict:
+    """Snapshot allowance + purchased pour widgets dashboard.
+
+    Returns:
+        ``{"allowance_total", "allowance_used", "allowance_remaining",
+           "purchased_minutes", "total_minutes_available", "is_trial"}``
+    """
+    plan = (user.plan or "free").lower()
+    quota = await _get_or_create_quota(user.id, plan, db)
+
+    if plan == "free":
+        allowance_total = FREE_TRIAL_MINUTES if not quota.lifetime_trial_used else 0.0
+        allowance_used = 0.0  # trial est binaire
+        is_trial = not quota.lifetime_trial_used
+    elif plan in TOP_TIER_PLANS:
+        allowance_total = TOP_TIER_MONTHLY_MINUTES
+        allowance_used = float(quota.monthly_minutes_used or 0.0)
+        is_trial = False
+    else:
+        allowance_total = 0.0
+        allowance_used = 0.0
+        is_trial = False
+
+    purchased = float(quota.purchased_minutes or 0.0)
+    allowance_remaining = max(allowance_total - allowance_used, 0.0)
+
+    return {
+        "allowance_total": allowance_total,
+        "allowance_used": allowance_used,
+        "allowance_remaining": allowance_remaining,
+        "purchased_minutes": purchased,
+        "total_minutes_available": allowance_remaining + purchased,
+        "is_trial": is_trial,
+    }
+```
+
+- [ ] **Step 4 : Lancer les tests pour vérifier qu'ils passent**
+
+Run: `cd backend && python -m pytest tests/billing/test_voice_packs_service.py -v`
+Expected: 6 PASSED.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add backend/src/billing/voice_packs_service.py backend/tests/billing/test_voice_packs_service.py backend/tests/billing/__init__.py
+git commit -m "feat(billing): voice packs pure-logic service + 6 unit tests
+
+- list_active_packs / get_pack_by_slug : catalog reads
+- add_purchased_minutes : credit non-expiring balance (no commit, caller wraps)
+- get_user_credit_status : dashboard snapshot allowance + purchased"
+```
+
+---
+
+### Task 4 : Étendre `consume_voice_minutes` allowance-first / purchased-fallback — TDD 2 tests
+
+**Files:**
+
+- Modify: `backend/src/billing/voice_quota.py:155-175`
+- Modify: `backend/src/billing/voice_quota.py:110-152` (étendre `check_voice_quota` pour inclure purchased dans `max_minutes`)
+- Create: `backend/tests/billing/test_voice_packs_consume.py`
+
+- [ ] **Step 1 : Écrire les tests**
+
+```python
+"""Tests consume_voice_minutes : ordre allowance-first puis purchased-fallback."""
+
+import pytest
+from datetime import datetime, timezone
+
+from db.database import User, VoiceQuotaStreaming
+from billing.voice_quota import consume_voice_minutes, check_voice_quota
+
+
+@pytest.mark.asyncio
+async def test_consume_drains_allowance_first(test_db_session, pro_user):
+    """50 min consumed when 20 allowance + 60 purchased available
+    → 0 allowance remaining + 30 purchased remaining (20 from allowance, 30 from purchased).
+    """
+    db = test_db_session
+    db.add(VoiceQuotaStreaming(
+        user_id=pro_user.id,
+        plan="pro",
+        monthly_period_start=datetime.now(timezone.utc),
+        monthly_minutes_used=10.0,  # allowance: 30 - 10 = 20 remaining
+        purchased_minutes=60.0,
+    ))
+    await db.commit()
+
+    await consume_voice_minutes(pro_user, 50.0, db)
+
+    quota = await db.get(VoiceQuotaStreaming, pro_user.id)
+    assert quota.monthly_minutes_used == 30.0  # 10 + 20 (full drain of allowance)
+    assert quota.purchased_minutes == 30.0     # 60 - 30 (overflow into purchased)
+
+
+@pytest.mark.asyncio
+async def test_consume_within_allowance_does_not_touch_purchased(
+    test_db_session, pro_user
+):
+    """5 min consumed when 30 allowance + 100 purchased → only allowance hit."""
+    db = test_db_session
+    db.add(VoiceQuotaStreaming(
+        user_id=pro_user.id,
+        plan="pro",
+        monthly_period_start=datetime.now(timezone.utc),
+        monthly_minutes_used=0.0,
+        purchased_minutes=100.0,
+    ))
+    await db.commit()
+
+    await consume_voice_minutes(pro_user, 5.0, db)
+
+    quota = await db.get(VoiceQuotaStreaming, pro_user.id)
+    assert quota.monthly_minutes_used == 5.0
+    assert quota.purchased_minutes == 100.0  # unchanged
+```
+
+- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+
+Run: `cd backend && python -m pytest tests/billing/test_voice_packs_consume.py -v`
+Expected: FAIL — l'implémentation actuelle de `consume_voice_minutes` ignore `purchased_minutes`.
+
+- [ ] **Step 3 : Modifier `consume_voice_minutes`**
+
+Remplacer la fonction (ligne 155 environ) par :
+
+```python
+async def consume_voice_minutes(user: User, minutes: float, db: AsyncSession) -> None:
+    """Record ``minutes`` of voice usage against ``user``'s quota.
+
+    Consumption order (locked decision H4 — protect paid minutes from monthly reset):
+      1. Plan allowance (rolling 30j) — drained first
+      2. Purchased balance (non-expiring) — overflow fallback
+
+    For Free users, flips the lifetime trial flag (single-shot).
+    For top-tier users, splits ``minutes`` across both buckets.
+    For other plans (Starter / Student), no-op — they are blocked upstream by
+    ``check_voice_quota``, this stays safe if called by mistake.
+
+    Always commits.
+    """
+    plan = (user.plan or "free").lower()
+    quota = await _get_or_create_quota(user.id, plan, db)
+
+    if plan == "free":
+        quota.lifetime_trial_used = True
+        quota.lifetime_trial_used_at = datetime.now(timezone.utc)
+    elif plan in TOP_TIER_PLANS:
+        remaining_allowance = max(
+            TOP_TIER_MONTHLY_MINUTES - float(quota.monthly_minutes_used or 0.0), 0.0
+        )
+        from_allowance = min(float(minutes), remaining_allowance)
+        from_purchased = max(float(minutes) - from_allowance, 0.0)
+
+        quota.monthly_minutes_used = float(quota.monthly_minutes_used or 0.0) + from_allowance
+        if from_purchased > 0:
+            current_purchased = float(quota.purchased_minutes or 0.0)
+            # Clamp à 0 — ne jamais descendre sous zéro même si race-condition
+            quota.purchased_minutes = max(current_purchased - from_purchased, 0.0)
+
+    await db.commit()
+```
+
+- [ ] **Step 4 : Étendre `check_voice_quota` pour exposer le total disponible**
+
+Modifier le bloc top-tier (ligne 133 environ) :
+
+```python
+    if plan in TOP_TIER_PLANS:
+        remaining_allowance = max(
+            TOP_TIER_MONTHLY_MINUTES - float(quota.monthly_minutes_used or 0.0), 0.0
+        )
+        purchased = float(quota.purchased_minutes or 0.0)
+        total_available = remaining_allowance + purchased
+        if total_available <= 0:
+            return QuotaCheck(allowed=False, reason="monthly_quota")
+        return QuotaCheck(allowed=True, max_minutes=total_available)
+```
+
+- [ ] **Step 5 : Lancer les tests pour vérifier qu'ils passent**
+
+Run: `cd backend && python -m pytest tests/billing/test_voice_packs_consume.py tests/voice/test_quota_integration.py -v`
+Expected: PASS pour les 2 nouveaux + non-régression sur l'existant.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add backend/src/billing/voice_quota.py backend/tests/billing/test_voice_packs_consume.py
+git commit -m "feat(billing): consume voice minutes allowance-first then purchased
+
+- consume_voice_minutes splits minutes across plan allowance + purchased
+- check_voice_quota max_minutes now includes purchased balance
+- 2 new TDD tests : drain_allowance_first + within_allowance_no_touch"
+```
+
+---
+
+### Task 5 : Endpoints REST `/api/billing/voice-packs/*`
+
+**Files:**
+
+- Create: `backend/src/billing/voice_packs_router.py`
+- Create: `backend/tests/billing/test_voice_packs_router.py`
+- Modify: `backend/src/main.py`
+
+- [ ] **Step 1 : Écrire le router**
+
+```python
+"""REST endpoints pour les packs voice top-up.
+
+Routes:
+  - GET  /api/billing/voice-packs/list         : public, catalogue actif
+  - GET  /api/billing/voice-packs/my-credits   : auth, snapshot user
+  - POST /api/billing/voice-packs/checkout/{slug} : auth, crée Stripe Checkout
+"""
+
+import logging
+
+import stripe
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import get_current_user, get_current_user_optional
+from core.config import FRONTEND_URL, STRIPE_CONFIG, get_stripe_key
+from db.database import User, get_session
+from billing.voice_packs_service import (
+    list_active_packs,
+    get_pack_by_slug,
+    get_user_credit_status,
+)
+from billing.voice_quota import TOP_TIER_PLANS
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/billing/voice-packs", tags=["voice-packs"])
+
+
+# ─── Schemas ─────────────────────────────────────────────────────────────
+
+
+class PackOut(BaseModel):
+    slug: str
+    name: str
+    minutes: int
+    price_cents: int
+    description: str | None = None
+    display_order: int
+
+
+class CreditStatusOut(BaseModel):
+    plan: str
+    allowance_total: float
+    allowance_used: float
+    allowance_remaining: float
+    purchased_minutes: float
+    total_minutes_available: float
+    is_trial: bool
+
+
+class CheckoutOut(BaseModel):
+    checkout_url: str
+    session_id: str
+
+
+# ─── Routes ──────────────────────────────────────────────────────────────
+
+
+@router.get("/list", response_model=list[PackOut])
+async def list_packs(db: AsyncSession = Depends(get_session)):
+    """Catalogue public des packs actifs."""
+    packs = await list_active_packs(db)
+    return [
+        PackOut(
+            slug=p.slug,
+            name=p.name,
+            minutes=p.minutes,
+            price_cents=p.price_cents,
+            description=p.description,
+            display_order=p.display_order,
+        )
+        for p in packs
+    ]
+
+
+@router.get("/my-credits", response_model=CreditStatusOut)
+async def my_credits(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Snapshot crédits voice de l'utilisateur courant."""
+    status_data = await get_user_credit_status(current_user, db)
+    return CreditStatusOut(plan=current_user.plan or "free", **status_data)
+
+
+@router.post("/checkout/{slug}", response_model=CheckoutOut)
+async def create_checkout(
+    slug: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Crée une Stripe Checkout Session one-shot pour le pack ``slug``."""
+    plan = (current_user.plan or "free").lower()
+    if plan not in TOP_TIER_PLANS:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={
+                "code": "upgrade_required",
+                "message": "Voice packs are only available on Pro/Expert plans",
+                "cta": "upgrade_pro",
+            },
+        )
+
+    pack = await get_pack_by_slug(slug, db)
+    if not pack or not pack.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "pack_not_found", "message": f"Unknown pack slug: {slug}"},
+        )
+
+    if not STRIPE_CONFIG.get("ENABLED"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "stripe_disabled", "message": "Stripe not enabled"},
+        )
+
+    stripe_key = get_stripe_key()
+    if not stripe_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "stripe_not_configured", "message": "Stripe not configured"},
+        )
+    stripe.api_key = stripe_key
+
+    # Reuse customer or create
+    customer_id = current_user.stripe_customer_id
+    if customer_id:
+        try:
+            stripe.Customer.retrieve(customer_id)
+        except stripe.error.InvalidRequestError:
+            customer_id = None
+    if not customer_id:
+        customer = stripe.Customer.create(
+            email=current_user.email,
+            metadata={"user_id": str(current_user.id)},
+        )
+        customer_id = customer.id
+        current_user.stripe_customer_id = customer_id
+        await db.commit()
+
+    # Build line item — use stripe_price_id if seeded, else price_data fallback
+    if pack.stripe_price_id:
+        line_items = [{"price": pack.stripe_price_id, "quantity": 1}]
+    else:
+        line_items = [
+            {
+                "price_data": {
+                    "currency": "eur",
+                    "unit_amount": pack.price_cents,
+                    "product_data": {
+                        "name": f"DeepSight Voice — {pack.name}",
+                        "description": pack.description or f"{pack.minutes} minutes ElevenLabs",
+                    },
+                },
+                "quantity": 1,
+            }
+        ]
+
+    success_url = (
+        f"{FRONTEND_URL}/payment/success?session_id={{CHECKOUT_SESSION_ID}}"
+        f"&type=voice_pack&slug={slug}"
+    )
+    cancel_url = f"{FRONTEND_URL}/account#voice-packs"
+
+    try:
+        checkout_session = stripe.checkout.Session.create(
+            customer=customer_id,
+            mode="payment",
+            payment_method_types=["card"],
+            line_items=line_items,
+            automatic_tax={"enabled": True},
+            success_url=success_url,
+            cancel_url=cancel_url,
+            metadata={
+                "kind": "voice_pack",
+                "pack_slug": slug,
+                "pack_id": str(pack.id),
+                "user_id": str(current_user.id),
+                "minutes": str(pack.minutes),
+            },
+        )
+    except stripe.error.StripeError as e:
+        logger.error("Stripe checkout creation failed for pack=%s: %s", slug, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={"code": "stripe_error", "message": str(e)},
+        )
+
+    logger.info(
+        "Voice pack checkout created — user=%d slug=%s session=%s",
+        current_user.id,
+        slug,
+        checkout_session.id,
+    )
+    return CheckoutOut(
+        checkout_url=checkout_session.url,
+        session_id=checkout_session.id,
+    )
+```
+
+- [ ] **Step 2 : Inclure le router dans `main.py`**
+
+Trouver l'inclusion du `billing.router` dans `backend/src/main.py` et ajouter juste après :
+
+```python
+from billing.voice_packs_router import router as voice_packs_router
+app.include_router(voice_packs_router)
+```
+
+- [ ] **Step 3 : Écrire les tests router**
+
+```python
+"""Tests endpoints REST voice packs."""
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+from db.database import VoiceCreditPack
+
+
+@pytest.mark.asyncio
+async def test_list_packs_public(test_client: TestClient, test_db_session):
+    """GET /list est public et retourne les packs actifs."""
+    test_db_session.add_all([
+        VoiceCreditPack(slug="voice-30", name="30 min", minutes=30, price_cents=299, display_order=1, is_active=True),
+        VoiceCreditPack(slug="voice-60", name="60 min", minutes=60, price_cents=499, display_order=2, is_active=True),
+    ])
+    await test_db_session.commit()
+
+    response = test_client.get("/api/billing/voice-packs/list")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["slug"] == "voice-30"
+    assert data[0]["price_cents"] == 299
+
+
+@pytest.mark.asyncio
+async def test_my_credits_requires_auth(test_client: TestClient):
+    """GET /my-credits sans auth → 401."""
+    response = test_client.get("/api/billing/voice-packs/my-credits")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_checkout_blocks_free_plan_with_402(
+    test_client: TestClient, free_user_token, test_db_session
+):
+    """Free plan reçoit 402 upgrade_required."""
+    test_db_session.add(VoiceCreditPack(slug="voice-30", name="30 min", minutes=30, price_cents=299))
+    await test_db_session.commit()
+
+    response = test_client.post(
+        "/api/billing/voice-packs/checkout/voice-30",
+        headers={"Authorization": f"Bearer {free_user_token}"},
+    )
+
+    assert response.status_code == 402
+    body = response.json()
+    assert body["detail"]["code"] == "upgrade_required"
+    assert body["detail"]["cta"] == "upgrade_pro"
+```
+
+- [ ] **Step 4 : Lancer les tests**
+
+Run: `cd backend && python -m pytest tests/billing/test_voice_packs_router.py -v`
+Expected: 3 PASSED (les fixtures `test_client`, `free_user_token`, `pro_user_token` doivent exister dans `conftest.py` — sinon adapter).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add backend/src/billing/voice_packs_router.py backend/tests/billing/test_voice_packs_router.py backend/src/main.py
+git commit -m "feat(api): voice packs REST endpoints (list / my-credits / checkout)
+
+- GET /api/billing/voice-packs/list : public catalog
+- GET /api/billing/voice-packs/my-credits : auth snapshot
+- POST /api/billing/voice-packs/checkout/{slug} : Stripe one-shot, blocks
+  free with 402 upgrade_required
+- 3 endpoint tests"
+```
+
+---
+
+### Task 6 : Webhook Stripe handler idempotent — TDD 2 tests
+
+**Files:**
+
+- Modify: `backend/src/billing/router.py:1623-1635`
+- Create: `backend/tests/billing/test_voice_packs_webhook.py`
+
+- [ ] **Step 1 : Écrire les tests webhook**
+
+```python
+"""Tests webhook handler voice_pack — idempotency + crédit."""
+
+import pytest
+from datetime import datetime, timezone
+
+from db.database import (
+    User,
+    VoiceCreditPack,
+    VoiceCreditPurchase,
+    VoiceQuotaStreaming,
+)
+from billing.router import _handle_voice_pack_checkout
+
+
+@pytest.mark.asyncio
+async def test_voice_pack_webhook_credits_user(test_db_session, pro_user):
+    """Webhook checkout.session.completed crédite purchased_minutes + crée VoiceCreditPurchase."""
+    db = test_db_session
+    pack = VoiceCreditPack(
+        slug="voice-60", name="60 min", minutes=60, price_cents=499, is_active=True
+    )
+    db.add(pack)
+    await db.commit()
+    await db.refresh(pack)
+
+    data = {
+        "id": "cs_test_abc123",
+        "payment_intent": "pi_test_xyz789",
+        "amount_total": 499,
+    }
+    metadata = {
+        "kind": "voice_pack",
+        "pack_slug": "voice-60",
+        "pack_id": str(pack.id),
+        "user_id": str(pro_user.id),
+        "minutes": "60",
+    }
+
+    await _handle_voice_pack_checkout(db, data, metadata)
+
+    quota = await db.get(VoiceQuotaStreaming, pro_user.id)
+    assert quota.purchased_minutes == 60.0
+
+    purchase = (await db.execute(
+        sa.select(VoiceCreditPurchase).where(
+            VoiceCreditPurchase.stripe_session_id == "cs_test_abc123"
+        )
+    )).scalar_one()
+    assert purchase.status == "completed"
+    assert purchase.minutes_purchased == 60
+    assert purchase.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_voice_pack_webhook_idempotent_on_duplicate_session(
+    test_db_session, pro_user
+):
+    """Si stripe_session_id déjà recordé, no-op (pas de double crédit)."""
+    db = test_db_session
+    pack = VoiceCreditPack(
+        slug="voice-60", name="60 min", minutes=60, price_cents=499, is_active=True
+    )
+    db.add(pack)
+    await db.commit()
+    await db.refresh(pack)
+
+    # First call
+    data = {"id": "cs_dup_555", "payment_intent": "pi_dup_555"}
+    metadata = {
+        "kind": "voice_pack",
+        "pack_slug": "voice-60",
+        "pack_id": str(pack.id),
+        "user_id": str(pro_user.id),
+        "minutes": "60",
+    }
+    await _handle_voice_pack_checkout(db, data, metadata)
+
+    # Second call (replay)
+    await _handle_voice_pack_checkout(db, data, metadata)
+
+    quota = await db.get(VoiceQuotaStreaming, pro_user.id)
+    assert quota.purchased_minutes == 60.0  # NOT 120
+
+    purchases = (await db.execute(
+        sa.select(VoiceCreditPurchase).where(
+            VoiceCreditPurchase.stripe_session_id == "cs_dup_555"
+        )
+    )).scalars().all()
+    assert len(purchases) == 1
+```
+
+- [ ] **Step 2 : Lancer pour vérifier qu'ils échouent**
+
+Run: `cd backend && python -m pytest tests/billing/test_voice_packs_webhook.py -v`
+Expected: FAIL — `_handle_voice_pack_checkout` n'existe pas.
+
+- [ ] **Step 3 : Modifier `handle_checkout_completed` dans `billing/router.py`**
+
+Trouver le bloc `# ── Voice addon (one-time payment)` (ligne 1627) et ajouter le branchement voice_pack JUSTE AVANT (avant le legacy voice_addon, pour que le nouveau système soit prioritaire si quelqu'un passe accidentellement les deux flags) :
+
+```python
+    # ── Voice pack top-up (NEW system, migration 011) ─────────────────
+    if metadata.get("kind") == "voice_pack":
+        await _handle_voice_pack_checkout(session, data, metadata)
+        return
+
+    # ── Voice addon (LEGACY one-time payment, voice_bonus_seconds) ────
+    if metadata.get("type") == "voice_addon":
+        await _handle_voice_addon_checkout(session, data, metadata)
+        return
+```
+
+- [ ] **Step 4 : Implémenter `_handle_voice_pack_checkout`**
+
+Ajouter après `_handle_voice_addon_checkout` (vers ligne 1767) :
+
+```python
+async def _handle_voice_pack_checkout(session: AsyncSession, data: dict, metadata: dict):
+    """Handle a completed voice pack one-shot payment (NEW system, migration 011).
+
+    Idempotent : checks ``voice_credit_purchases.stripe_session_id`` before
+    crediting. Wraps the credit + purchase row insert in a single transaction
+    so a crash mid-handler can never leave purchased_minutes credited without
+    a corresponding history row (and vice versa).
+    """
+    from db.database import VoiceCreditPack, VoiceCreditPurchase
+    from billing.voice_packs_service import add_purchased_minutes
+
+    session_id = data.get("id")
+    payment_intent = data.get("payment_intent")
+    user_id_str = metadata.get("user_id", "0")
+    pack_id_str = metadata.get("pack_id", "0")
+    minutes_str = metadata.get("minutes", "0")
+    pack_slug = metadata.get("pack_slug", "unknown")
+
+    try:
+        user_id = int(user_id_str)
+        pack_id = int(pack_id_str)
+        minutes = int(minutes_str)
+    except (ValueError, TypeError):
+        logger.warning(
+            "Voice pack: invalid metadata user_id=%s pack_id=%s minutes=%s",
+            user_id_str, pack_id_str, minutes_str,
+        )
+        return
+
+    if user_id <= 0 or pack_id <= 0 or minutes <= 0:
+        logger.warning(
+            "Voice pack: invalid values user_id=%s pack_id=%s minutes=%s",
+            user_id, pack_id, minutes,
+        )
+        return
+
+    # Idempotency: skip if this session_id already recorded
+    if session_id:
+        existing = await session.execute(
+            select(VoiceCreditPurchase).where(
+                VoiceCreditPurchase.stripe_session_id == session_id
+            )
+        )
+        if existing.scalar_one_or_none():
+            logger.info("Voice pack checkout %s already processed — skipping", session_id)
+            return
+
+    user = await session.get(User, user_id)
+    if not user:
+        logger.warning("Voice pack: user %s not found", user_id)
+        return
+
+    pack = await session.get(VoiceCreditPack, pack_id)
+    if not pack:
+        logger.warning("Voice pack: pack %s not found", pack_id)
+        return
+
+    # Credit + record in single transaction
+    await add_purchased_minutes(user_id, float(minutes), session)
+
+    purchase = VoiceCreditPurchase(
+        user_id=user_id,
+        pack_id=pack_id,
+        minutes_purchased=minutes,
+        price_paid_cents=int(data.get("amount_total") or pack.price_cents),
+        stripe_session_id=session_id,
+        stripe_payment_intent_id=payment_intent,
+        status="completed",
+        completed_at=datetime.now(timezone.utc),
+    )
+    session.add(purchase)
+
+    await session.commit()
+    logger.info(
+        "Voice pack credited: +%dmin user=%d slug=%s session=%s",
+        minutes, user_id, pack_slug, session_id,
+    )
+```
+
+- [ ] **Step 5 : Lancer les tests**
+
+Run: `cd backend && python -m pytest tests/billing/test_voice_packs_webhook.py -v`
+Expected: 2 PASSED.
+
+- [ ] **Step 6 : Lancer toute la suite billing pour non-régression**
+
+Run: `cd backend && python -m pytest tests/billing/ -v 2>&1 | tail -30`
+Expected: tous les tests passent.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add backend/src/billing/router.py backend/tests/billing/test_voice_packs_webhook.py
+git commit -m "feat(billing): idempotent webhook handler for voice_pack checkouts
+
+- _handle_voice_pack_checkout reads metadata.kind=voice_pack
+- Idempotency via VoiceCreditPurchase.stripe_session_id unique
+- Atomic credit + history row in single commit
+- 2 TDD tests : credits_user + idempotent_on_duplicate_session"
+```
+
+---
+
+### Task 7 : Seed Stripe Products + DB packs (script idempotent)
+
+**Files:**
+
+- Create: `backend/scripts/seed_voice_packs.py`
+
+- [ ] **Step 1 : Écrire le script**
+
+```python
+"""Seed idempotent des packs voice + Stripe Products/Prices.
+
+Usage:
+    cd backend && STRIPE_SECRET_KEY=sk_test_xxx python scripts/seed_voice_packs.py
+
+Comportement :
+  * Pour chaque pack du catalogue, si DB row absente : insère.
+  * Si STRIPE_SECRET_KEY actif et pack n'a pas de stripe_price_id : crée
+    Stripe Product + Price puis update la row DB.
+  * Re-runs successifs : no-op (UPSERT par slug).
+
+À lancer après chaque migration sur tous les environnements.
+"""
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Ensure backend/src on PYTHONPATH
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import stripe
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from db.database import VoiceCreditPack, DATABASE_URL
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("seed_voice_packs")
+
+
+CATALOG = [
+    {
+        "slug": "voice-30",
+        "name": "Pack 30 minutes",
+        "minutes": 30,
+        "price_cents": 299,
+        "description": "30 minutes de chat vocal IA — ne expirent jamais",
+        "display_order": 1,
+    },
+    {
+        "slug": "voice-60",
+        "name": "Pack 60 minutes",
+        "minutes": 60,
+        "price_cents": 499,
+        "description": "60 minutes de chat vocal IA — meilleur rapport quantité",
+        "display_order": 2,
+    },
+    {
+        "slug": "voice-180",
+        "name": "Pack 180 minutes",
+        "minutes": 180,
+        "price_cents": 1299,
+        "description": "180 minutes de chat vocal IA — power users",
+        "display_order": 3,
+    },
+]
+
+
+async def seed():
+    engine = create_async_engine(DATABASE_URL, future=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    stripe_key = os.environ.get("STRIPE_SECRET_KEY")
+    if stripe_key:
+        stripe.api_key = stripe_key
+        logger.info("Stripe API enabled — will create Products/Prices if missing")
+    else:
+        logger.warning("STRIPE_SECRET_KEY not set — DB-only seed (no Stripe sync)")
+
+    async with Session() as db:
+        for cat in CATALOG:
+            existing = await db.execute(
+                select(VoiceCreditPack).where(VoiceCreditPack.slug == cat["slug"])
+            )
+            pack = existing.scalar_one_or_none()
+
+            if pack is None:
+                pack = VoiceCreditPack(**cat)
+                db.add(pack)
+                await db.flush()
+                logger.info("DB inserted: %s (%dmin / %d¢)", pack.slug, pack.minutes, pack.price_cents)
+            else:
+                logger.info("DB exists: %s — skipping insert", pack.slug)
+
+            if stripe_key and not pack.stripe_price_id:
+                product = stripe.Product.create(
+                    name=f"DeepSight Voice — {pack.name}",
+                    description=pack.description,
+                    metadata={"slug": pack.slug, "minutes": str(pack.minutes)},
+                )
+                price = stripe.Price.create(
+                    product=product.id,
+                    unit_amount=pack.price_cents,
+                    currency="eur",
+                    metadata={"slug": pack.slug},
+                )
+                pack.stripe_product_id = product.id
+                pack.stripe_price_id = price.id
+                logger.info("Stripe synced: %s → product=%s price=%s", pack.slug, product.id, price.id)
+
+        await db.commit()
+        logger.info("Seed complete — %d packs in catalog", len(CATALOG))
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(seed())
+```
+
+- [ ] **Step 2 : Tester en local sans Stripe (DB-only)**
+
+Run: `cd backend && python scripts/seed_voice_packs.py`
+Expected: log "Stripe API not enabled — DB-only seed", 3 packs insérés.
+
+- [ ] **Step 3 : Tester l'idempotence**
+
+Run: `cd backend && python scripts/seed_voice_packs.py`
+Expected: log "DB exists: voice-30 — skipping insert" pour chaque pack.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add backend/scripts/seed_voice_packs.py
+git commit -m "feat(scripts): idempotent seed_voice_packs.py for catalog + Stripe sync
+
+- 3-pack catalog hardcoded : voice-30, voice-60, voice-180
+- DB UPSERT by slug
+- Stripe Product + Price creation when STRIPE_SECRET_KEY is set
+- Re-runnable safely (no-op if exists)"
+```
+
+---
+
+### Task 8 : Frontend api.ts + VoicePacksWidget + intégration MyAccount + bannière VoiceCallPage
+
+**Files:**
+
+- Modify: `frontend/src/services/api.ts:2638` (ajouter `voicePacksApi`)
+- Create: `frontend/src/components/voice/VoicePacksWidget.tsx`
+- Create: `frontend/src/components/voice/__tests__/VoicePacksWidget.test.tsx`
+- Modify: `frontend/src/pages/MyAccount.tsx:537` (insérer widget)
+- Modify: `frontend/src/pages/VoiceCallPage.tsx:199-215` (ajouter CTA secondaire)
+
+- [ ] **Step 1 : Ajouter `voicePacksApi` dans `frontend/src/services/api.ts`**
+
+Trouver `export const voiceApi` (ligne 2638) et ajouter JUSTE AVANT (ou après — peu importe) :
+
+```typescript
+export interface ApiVoicePack {
+  slug: string;
+  name: string;
+  minutes: number;
+  price_cents: number;
+  description: string | null;
+  display_order: number;
+}
+
+export interface ApiVoiceCreditStatus {
+  plan: string;
+  allowance_total: number;
+  allowance_used: number;
+  allowance_remaining: number;
+  purchased_minutes: number;
+  total_minutes_available: number;
+  is_trial: boolean;
+}
+
+export const voicePacksApi = {
+  /** GET /api/billing/voice-packs/list — catalogue public actif */
+  async list(): Promise<ApiVoicePack[]> {
+    return request("/api/billing/voice-packs/list", { method: "GET" });
+  },
+
+  /** GET /api/billing/voice-packs/my-credits — snapshot user (auth) */
+  async myCredits(): Promise<ApiVoiceCreditStatus> {
+    return request("/api/billing/voice-packs/my-credits", { method: "GET" });
+  },
+
+  /** POST /api/billing/voice-packs/checkout/{slug} — Stripe redirect URL */
+  async createCheckout(
+    slug: string,
+  ): Promise<{ checkout_url: string; session_id: string }> {
+    return request(`/api/billing/voice-packs/checkout/${slug}`, {
+      method: "POST",
+    });
+  },
+};
+```
+
+Ajouter `voicePacks: voicePacksApi` au bloc d'export agrégé (ligne 3066 environ) :
+
+```typescript
+const api = {
+  // ... existing ...
+  voicePacks: voicePacksApi,
+};
+```
+
+- [ ] **Step 2 : Créer `VoicePacksWidget.tsx`**
+
+```tsx
+/**
+ * VoicePacksWidget — Liste packs voice + bouton acheter.
+ *
+ * Inséré dans MyAccount.tsx section "Voice & Audio" et accessible via
+ * l'ancre #voice-packs depuis VoiceCallPage en cas de quota épuisé.
+ */
+
+import React, { useEffect, useState } from "react";
+import { Mic, ArrowRight, Loader2 } from "lucide-react";
+import {
+  voicePacksApi,
+  type ApiVoicePack,
+  type ApiVoiceCreditStatus,
+} from "../../services/api";
+import { useTranslation } from "../../hooks/useTranslation";
+
+export const VoicePacksWidget: React.FC = () => {
+  const [packs, setPacks] = useState<ApiVoicePack[]>([]);
+  const [status, setStatus] = useState<ApiVoiceCreditStatus | null>(null);
+  const [loadingSlug, setLoadingSlug] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { language } = useTranslation();
+  const tr = (fr: string, en: string) => (language === "fr" ? fr : en);
+
+  useEffect(() => {
+    Promise.all([voicePacksApi.list(), voicePacksApi.myCredits()])
+      .then(([p, s]) => {
+        setPacks(p);
+        setStatus(s);
+      })
+      .catch((e) => setError(e?.message ?? "Erreur"));
+  }, []);
+
+  const handleBuy = async (slug: string) => {
+    setLoadingSlug(slug);
+    setError(null);
+    try {
+      const { checkout_url } = await voicePacksApi.createCheckout(slug);
+      window.location.href = checkout_url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur inattendue");
+      setLoadingSlug(null);
+    }
+  };
+
+  return (
+    <section
+      id="voice-packs"
+      className="card"
+      aria-labelledby="voice-packs-heading"
+    >
+      <div className="panel-header">
+        <h2
+          id="voice-packs-heading"
+          className="font-semibold text-text-primary flex items-center gap-2"
+        >
+          <Mic className="w-5 h-5 text-indigo-400" />
+          {tr("Minutes vocales", "Voice minutes")}
+        </h2>
+      </div>
+      <div className="panel-body space-y-4">
+        {status && (
+          <div className="rounded-lg border border-white/5 bg-white/5 p-3 text-sm text-text-secondary">
+            <p>
+              {tr("Allowance restante :", "Allowance remaining:")}{" "}
+              <strong className="text-text-primary">
+                {status.allowance_remaining.toFixed(1)} /{" "}
+                {status.allowance_total.toFixed(0)} min
+              </strong>
+            </p>
+            <p>
+              {tr("Minutes achetées :", "Purchased minutes:")}{" "}
+              <strong className="text-text-primary">
+                {status.purchased_minutes.toFixed(1)} min
+              </strong>{" "}
+              <span className="text-xs text-text-muted">
+                ({tr("n'expirent jamais", "never expire")})
+              </span>
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-300"
+          >
+            {error}
+          </div>
+        )}
+
+        {packs.length === 0 ? (
+          <p className="text-sm text-text-muted">
+            {tr("Aucun pack disponible", "No packs available")}
+          </p>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-3">
+            {packs.map((p) => (
+              <article
+                key={p.slug}
+                className="rounded-xl border border-white/10 bg-white/5 p-4 flex flex-col gap-2"
+              >
+                <h3 className="font-semibold text-text-primary">{p.name}</h3>
+                <p className="text-2xl font-bold text-indigo-400">
+                  {p.minutes}{" "}
+                  <span className="text-sm font-normal text-text-muted">
+                    min
+                  </span>
+                </p>
+                <p className="text-text-secondary">
+                  {(p.price_cents / 100).toFixed(2)} €
+                </p>
+                <button
+                  type="button"
+                  onClick={() => handleBuy(p.slug)}
+                  disabled={loadingSlug !== null}
+                  className="mt-auto inline-flex items-center justify-center gap-1.5 rounded-lg bg-indigo-500 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-600 disabled:opacity-50"
+                  aria-label={tr(`Acheter ${p.name}`, `Buy ${p.name}`)}
+                >
+                  {loadingSlug === p.slug ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <>
+                      {tr("Acheter", "Buy")}
+                      <ArrowRight className="w-3.5 h-3.5" />
+                    </>
+                  )}
+                </button>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default VoicePacksWidget;
+```
+
+- [ ] **Step 3 : Écrire les tests Vitest**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { VoicePacksWidget } from "../VoicePacksWidget";
+
+vi.mock("../../../services/api", () => ({
+  voicePacksApi: {
+    list: vi.fn(),
+    myCredits: vi.fn(),
+    createCheckout: vi.fn(),
+  },
+}));
+
+vi.mock("../../../hooks/useTranslation", () => ({
+  useTranslation: () => ({ language: "en" }),
+}));
+
+import { voicePacksApi } from "../../../services/api";
+
+describe("VoicePacksWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders 3 packs from API", async () => {
+    (voicePacksApi.list as any).mockResolvedValue([
+      {
+        slug: "voice-30",
+        name: "30 min",
+        minutes: 30,
+        price_cents: 299,
+        description: null,
+        display_order: 1,
+      },
+      {
+        slug: "voice-60",
+        name: "60 min",
+        minutes: 60,
+        price_cents: 499,
+        description: null,
+        display_order: 2,
+      },
+      {
+        slug: "voice-180",
+        name: "180 min",
+        minutes: 180,
+        price_cents: 1299,
+        description: null,
+        display_order: 3,
+      },
+    ]);
+    (voicePacksApi.myCredits as any).mockResolvedValue({
+      plan: "pro",
+      allowance_total: 30,
+      allowance_used: 5,
+      allowance_remaining: 25,
+      purchased_minutes: 0,
+      total_minutes_available: 25,
+      is_trial: false,
+    });
+
+    render(<VoicePacksWidget />);
+
+    await waitFor(() => {
+      expect(screen.getByText("30 min")).toBeInTheDocument();
+      expect(screen.getByText("60 min")).toBeInTheDocument();
+      expect(screen.getByText("180 min")).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to Stripe checkout on Buy click", async () => {
+    (voicePacksApi.list as any).mockResolvedValue([
+      {
+        slug: "voice-30",
+        name: "30 min",
+        minutes: 30,
+        price_cents: 299,
+        description: null,
+        display_order: 1,
+      },
+    ]);
+    (voicePacksApi.myCredits as any).mockResolvedValue({
+      plan: "pro",
+      allowance_total: 30,
+      allowance_used: 0,
+      allowance_remaining: 30,
+      purchased_minutes: 0,
+      total_minutes_available: 30,
+      is_trial: false,
+    });
+    (voicePacksApi.createCheckout as any).mockResolvedValue({
+      checkout_url: "https://checkout.stripe.com/test_session",
+      session_id: "cs_test_xxx",
+    });
+
+    // Mock window.location.href setter
+    const original = window.location;
+    delete (window as any).location;
+    (window as any).location = { ...original, href: "" };
+
+    render(<VoicePacksWidget />);
+    await waitFor(() => screen.getByText("30 min"));
+    fireEvent.click(screen.getByLabelText(/Buy 30 min/i));
+
+    await waitFor(() => {
+      expect(voicePacksApi.createCheckout).toHaveBeenCalledWith("voice-30");
+      expect(window.location.href).toBe(
+        "https://checkout.stripe.com/test_session",
+      );
+    });
+
+    (window as any).location = original;
+  });
+});
+```
+
+- [ ] **Step 4 : Lancer les tests Vitest**
+
+Run: `cd frontend && npm run test -- VoicePacksWidget`
+Expected: 2 PASSED.
+
+- [ ] **Step 5 : Intégrer le widget dans `MyAccount.tsx`**
+
+Trouver `</section>` à la ligne 537 (fin du bloc Subscription). Ajouter juste après l'import en haut :
+
+```typescript
+import { VoicePacksWidget } from "../components/voice/VoicePacksWidget";
+```
+
+Puis insérer le widget après la fermeture `</section>` du bloc abonnement (ligne 537) :
+
+```tsx
+            </section>
+
+            {/* ═══════════════════════════════════════════════════════════════════════════
+                🎙️ VOICE PACKS — Top-up minutes ElevenLabs
+            ═══════════════════════════════════════════════════════════════════════════ */}
+            <VoicePacksWidget />
+```
+
+- [ ] **Step 6 : Modifier la bannière `quota_exceeded` dans `VoiceCallPage.tsx`**
+
+Trouver le bloc `case "quota_exceeded":` (ligne 199) et remplacer le bouton actuel par deux CTAs :
+
+```tsx
+      case "quota_exceeded":
+        return (
+          <div className="flex flex-col items-center gap-3 max-w-md text-center">
+            <AlertCircle className="w-8 h-8 text-amber-400" />
+            <p className="text-sm font-medium text-amber-300">
+              {tr("Quota de minutes épuisé", "Voice minutes quota exceeded")}
+            </p>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <button
+                type="button"
+                onClick={() => navigate("/account#voice-packs")}
+                className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-indigo-500 text-white font-medium text-sm hover:bg-indigo-600 transition-colors"
+              >
+                <Mic className="w-4 h-4" />
+                {tr("Acheter un pack", "Buy a pack")}
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate("/upgrade?source=voice_call")}
+                className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 text-text-secondary hover:bg-white/10 transition-colors text-sm"
+              >
+                <ArrowUpCircle className="w-4 h-4" />
+                {tr("Passer au plan supérieur", "Upgrade plan")}
+              </button>
+            </div>
+          </div>
+        );
+```
+
+S'assurer que `Mic` est importé depuis `lucide-react` en haut du fichier (vérifier l'import existant).
+
+- [ ] **Step 7 : Lancer typecheck + lint**
+
+Run: `cd frontend && npm run typecheck && npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add frontend/src/services/api.ts frontend/src/components/voice/VoicePacksWidget.tsx frontend/src/components/voice/__tests__/VoicePacksWidget.test.tsx frontend/src/pages/MyAccount.tsx frontend/src/pages/VoiceCallPage.tsx
+git commit -m "feat(frontend): voice packs widget + MyAccount integration + VoiceCall CTA
+
+- voicePacksApi : list / myCredits / createCheckout
+- VoicePacksWidget component with credits snapshot + 3-pack grid
+- MyAccount.tsx inserts widget below subscription section (anchor #voice-packs)
+- VoiceCallPage.tsx quota_exceeded banner gains 'Buy a pack' CTA
+- 2 Vitest tests : render + checkout redirect"
+```
+
+---
+
+### Task 9 : E2E manuel — Stripe CLI + checkout test card + verify DB credit + idempotence replay
+
+**Files:** (vérifications uniquement, pas de code)
+
+- [ ] **Step 1 : Lancer le backend en local**
+
+Run (terminal 1): `cd backend/src && uvicorn main:app --reload --port 8000`
+
+- [ ] **Step 2 : Appliquer la migration et seeder**
+
+Run: `cd backend && alembic upgrade head && python scripts/seed_voice_packs.py`
+Expected: migration 011 appliquée, 3 packs insérés.
+
+- [ ] **Step 3 : Lancer le frontend**
+
+Run (terminal 2): `cd frontend && npm run dev`
+
+- [ ] **Step 4 : Lancer Stripe CLI pour forwarder les webhooks**
+
+Run (terminal 3): `stripe listen --forward-to http://localhost:8000/api/billing/webhook`
+Noter la `Webhook signing secret` affichée et l'exporter dans `.env` backend si besoin.
+
+- [ ] **Step 5 : Test E2E manuel — flow nominal**
+
+1. Login en tant que user Pro (créer via `/admin/users` ou `psql UPDATE`)
+2. Aller sur `/account#voice-packs` → vérifier widget render avec 3 packs + status
+3. Cliquer "Acheter" sur `voice-60`
+4. Carte de test Stripe : `4242 4242 4242 4242`, expiry `12/30`, CVC `123`
+5. Confirmer le paiement → redirect vers `/payment/success?type=voice_pack`
+6. Stripe CLI doit afficher `checkout.session.completed`
+7. Backend logs : `Voice pack credited: +60min user=X slug=voice-60`
+8. Vérifier en DB : `SELECT purchased_minutes FROM voice_quota WHERE user_id = X` → `60.0`
+9. `SELECT * FROM voice_credit_purchases WHERE user_id = X` → 1 row status `completed`
+
+- [ ] **Step 6 : Test idempotence replay**
+
+Run: `stripe events resend evt_xxx_le_dernier`
+Vérifier les logs backend : `Voice pack checkout cs_xxx already processed — skipping`
+Vérifier en DB : toujours `purchased_minutes = 60.0` (pas 120), 1 seule row dans `voice_credit_purchases`.
+
+- [ ] **Step 7 : Test 402 Free user**
+
+1. Login en tant que user Free
+2. Tenter `POST /api/billing/voice-packs/checkout/voice-30` via curl
+3. Expected: HTTP 402 avec body `{"detail": {"code": "upgrade_required", "cta": "upgrade_pro"}}`
+
+- [ ] **Step 8 : Test consume order après achat**
+
+1. User Pro avec `monthly_minutes_used = 25` (allowance reste 5) + 60 purchased
+2. Démarrer voice call
+3. Consommer 50 min (peut nécessiter mock)
+4. Vérifier DB : `monthly_minutes_used = 30` (allowance épuisée), `purchased_minutes = 15` (60 - 45)
+
+- [ ] **Step 9 : Commit final (CHANGELOG si présent)**
+
+```bash
+# Si CHANGELOG.md existe
+git add CHANGELOG.md
+git commit -m "docs(changelog): voice top-up packs (audit Kimi P0 quick win)"
+```
+
+Sinon push direct des commits précédents :
+
+```bash
+git push origin feature/audit-kimi-plans-2026-04-29
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage check
+
+| Section spec                              | Task       |
+| ----------------------------------------- | ---------- |
+| Migration Alembic 010 (renumérotée → 011) | Task 1     |
+| Tables voice_credit_packs/purchases       | Task 1 + 2 |
+| Colonne purchased_minutes                 | Task 1 + 2 |
+| Modèles SQLAlchemy                        | Task 2     |
+| Service pure logic 6 tests                | Task 3     |
+| consume_voice_minutes allowance-first     | Task 4     |
+| check_voice_quota inclusion purchased     | Task 4     |
+| Endpoints REST 3 routes                   | Task 5     |
+| Webhook Stripe idempotent                 | Task 6     |
+| Seed Stripe + DB                          | Task 7     |
+| Frontend api + widget + intégration       | Task 8     |
+| E2E manuel + idempotence                  | Task 9     |
+
+Tous les éléments de la spec ont une tâche dédiée.
+
+### 2. Placeholder scan
+
+Aucun "TBD", "TODO", "implement later" dans le plan. Toutes les implémentations sont fournies en code complet.
+
+### 3. Type consistency
+
+- `VoiceCreditPack` / `VoiceCreditPurchase` : noms identiques entre migration, modèle, service, router, webhook handler.
+- `kind="voice_pack"` (singulier, snake_case) : utilisé partout dans metadata Stripe + dispatcher.
+- Slug `voice-30/60/180` (kebab-case) : cohérent entre seed, catalog, frontend, tests.
+- `purchased_minutes` (Float) : même type DB / SQLAlchemy / API response (nombre).
+- Endpoints `/api/billing/voice-packs/list` / `/my-credits` / `/checkout/{slug}` : cohérents Task 5 ↔ Task 8.
+- `voicePacksApi.list / myCredits / createCheckout` : noms TypeScript cohérents Task 8 backend ↔ frontend.
+
+### 4. Décisions à confirmer (avant exécution Task 1)
+
+| Code | Décision                                                                                               | Choix par défaut (en cas de silence)                                           |
+| ---- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| DA   | Allowance Pro 30 min / Expert 120 min, ou statu quo (les deux à 30 min) ?                              | Statu quo (TOP_TIER_MONTHLY_MINUTES = 30 partout) — diff Pro/Expert = autre PR |
+| DB   | Free user : packs cachés (ne peut même pas voir le widget) ou affichés mais 402 au clic ?              | Affichés, 402 au clic (incite à l'upgrade)                                     |
+| DC   | Refunds Stripe : flow ré-débit auto via webhook `charge.refunded` ou manuel admin ?                    | Hors scope — manuel admin pour V1                                              |
+| DD   | Branche : continuer sur `feature/audit-kimi-plans-2026-04-29` ou créer `feat/voice-packs-elevenlabs` ? | Continuer sur la branche actuelle (audit Kimi)                                 |
+| DE   | Feature gating : `is_feature_available(plan, "voice_packs", platform)` à ajouter SSOT ?                | Oui — ajouter dans `core/plan_limits.py` mais reportable à PR follow-up        |
+
+Si l'utilisateur ne tranche pas, le plan part sur le choix par défaut listé dans la dernière colonne.
+
+---
+
+## Execution Handoff
+
+**Plan complet et sauvegardé à `docs/superpowers/plans/2026-04-29-elevenlabs-voice-packs.md`. Deux options d'exécution :**
+
+**1. Subagent-Driven (recommandé)** — je dispatch un sous-agent fresh par tâche, review entre chaque, itération rapide.
+
+**2. Inline Execution** — exécution des tâches dans cette session via `superpowers:executing-plans`, batch avec checkpoints.
+
+**Quelle approche ?**

--- a/docs/superpowers/plans/2026-04-29-email-flows-resend.md
+++ b/docs/superpowers/plans/2026-04-29-email-flows-resend.md
@@ -1,0 +1,3528 @@
+# Email Flows Resend — Welcome Series Phase 9 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mettre en place une séquence d'emails post-signup et transactionnels via Resend (J+0, J+1, J+3, J+7, J+14, plus trial-ending / payment-success / cart-abandon), avec scheduling date-based, tracking via webhook Resend, désinscription RGPD, i18n FR/EN, et événements PostHog cohérents avec l'audit Kimi 2026-04-29 Phase 9.
+
+**Architecture:** Réutilisation de l'infrastructure email existante (`services/email_service.py` + `services/email_queue.py` + `core/email_rate_limiter.py`). Refactor de `services/onboarding_emails.py` (basé sur scan horaire des users) vers un système basé sur une table `email_scheduled` (date d'envoi planifiée à la confirmation email) et une table `email_events` (tracking webhooks). APScheduler existant pilote un job qui pop les jobs dûs en respectant le rate-limit Resend (2 req/s par worker, déjà en place via `aiolimiter`). Webhook Resend exposé `/api/email/webhook/resend`. Désinscription gérée par token signé + page frontend `/email/unsubscribe`.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 async + Alembic migration 010 + APScheduler (déjà installé) + Jinja2 (déjà en place) + Resend SDK (httpx direct, déjà utilisé) + aiolimiter (déjà installé) + posthog-js (frontend déjà en place).
+
+---
+
+## Contexte préalable
+
+### Existant à réutiliser (NE PAS recréer)
+
+| Fichier                                     | Rôle                                                                | Statut                                         |
+| ------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------- |
+| `backend/src/services/email_service.py`     | Sender Jinja2 + appel `email_queue.enqueue`                         | OK, à étendre (ajout `send_template_for_user`) |
+| `backend/src/services/email_queue.py`       | Queue async + throttling 2 req/s + retry 429                        | OK, ne pas toucher                             |
+| `backend/src/core/email_rate_limiter.py`    | `RESEND_LIMITER` + `send_with_rate_limit`                           | OK, ne pas toucher                             |
+| `backend/src/services/onboarding_emails.py` | Séquence existante J+1/J+3/J+5/J+7/J+10/J+14 (scan horaire)         | À DEPRECATER + migrer vers nouveau système     |
+| `backend/src/templates/emails/*.html`       | 12 templates dark-theme (welcome, onboarding*j\*, payment*\*, etc.) | À étendre (5 nouveaux templates × 2 langues)   |
+| `backend/src/main.py` lignes 677-718        | APScheduler job `_scheduled_onboarding` (1h)                        | À MODIFIER (pointe vers nouveau service)       |
+| `backend/src/auth/router.py` ligne 224-228  | Hook welcome après `verify_email`                                   | À MODIFIER (déclenche scheduling complet)      |
+| `backend/requirements.txt`                  | `resend>=0.7.0`, `aiolimiter>=1.1.0`, `apscheduler>=3.10.0`         | OK                                             |
+
+### Schema User actuel (`backend/src/db/database.py:106-180`)
+
+```python
+class User(Base):
+    __tablename__ = "users"
+    id, username, email, password_hash
+    email_verified, verification_code, verification_expires
+    plan, credits  # plan ∈ {"free", "plus", "pro", "expert"}
+    default_lang  # ← langue à utiliser pour i18n (déjà existe : "fr" par défaut)
+    preferences   # JSON (existe depuis migration 009, on y stockera marketing_consent + unsubscribed)
+    created_at, updated_at
+```
+
+**Décision i18n** : on lit `user.default_lang` (existant). Pas besoin de nouvelle colonne.
+**Décision consent** : on stocke dans `user.preferences["marketing_emails_consent"]` (bool, default `True` à l'inscription EU mais opt-out via lien désinscription qui set à `False`). RGPD : welcome (J+0) reste transactionnel donc envoyé même si consent absent ; J+1/J+3/J+7/J+14 nécessitent consent ≠ False.
+
+### Pricing — DÉCISION À VALIDER
+
+Le prompt mentionne **Pro 8,99€ / Expert 19,99€** (pricing v2 en cours). Le code actuel (`backend/src/billing/plan_config.py:193,323`) montre :
+
+- Plus : 499 cents (4,99€)
+- Pro : 999 cents (9,99€)
+- Pas d'Expert
+
+**Templates HTML utiliseront des placeholders `{{ pro_price }}` et `{{ expert_price }}`** rendus depuis `services/email_sequences.py` qui lit la SSOT `billing/plan_config.py`. Aucun prix hardcodé dans les templates. Si pricing v2 est mergé, prix mis à jour automatiquement. (Voir Self-Review Décision #2.)
+
+### Cohérence avec autres plans en cours
+
+- Plan `2026-04-29-posthog-events-complets.md` : à lire AVANT (tu n'as pas accès direct, mais respecte la convention `snake_case` pour event names ; nouveaux events : `email_sent`, `email_delivered`, `email_opened`, `email_clicked`, `email_unsubscribed`).
+- Plan #3 pricing v2 : si déjà mergé, le service `email_sequences.py` doit lire `get_plan_pricing()` depuis `billing/plan_config.py`.
+
+---
+
+## File Structure
+
+### Backend (Python)
+
+| Path                                                      | Action                 | Responsabilité                                                                                                                                                                    |
+| --------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `backend/alembic/versions/010_add_email_scheduling.py`    | CREATE                 | Migration : tables `email_scheduled` + `email_events` + index                                                                                                                     |
+| `backend/src/db/database.py`                              | MODIFY (append)        | Models `EmailScheduled` + `EmailEvent` (~50 lignes en bas du fichier, après autres tables)                                                                                        |
+| `backend/src/services/email_sequences.py`                 | CREATE                 | Logique métier : `schedule_welcome_sequence`, `cancel_marketing_emails`, `process_scheduled_emails`, `is_user_unsubscribed`                                                       |
+| `backend/src/services/email_unsubscribe.py`               | CREATE                 | Génération + vérification token désinscription (HMAC-SHA256 avec `JWT_SECRET_KEY`)                                                                                                |
+| `backend/src/services/email_service.py`                   | MODIFY                 | Ajout `send_template_for_user(user, template_key, lang, context)` qui détecte la langue et le contexte i18n                                                                       |
+| `backend/src/services/onboarding_emails.py`               | DEPRECATE              | Renommer fonction interne en `_legacy_process_onboarding_emails` ; logger `DeprecationWarning` au call ; ne plus l'appeler depuis `main.py`                                       |
+| `backend/src/auth/router.py`                              | MODIFY (ligne 223-228) | Remplacer `send_welcome_email` direct par `schedule_welcome_sequence(user)` qui ajoute J+0 immédiat + J+1/J+3/J+7/J+14 différés                                                   |
+| `backend/src/email/router.py`                             | CREATE                 | Router FastAPI : `POST /api/email/webhook/resend` (signature verify) + `GET /api/email/unsubscribe` (token verify + UI redirect) + `POST /api/email/preferences` (toggle consent) |
+| `backend/src/main.py`                                     | MODIFY (ligne 680-718) | Remplacer `_scheduled_onboarding` par `_scheduled_email_dispatch` qui appelle `process_scheduled_emails()` toutes les 5 min ; inclure `email.router`                              |
+| `backend/src/billing/router.py`                           | MODIFY                 | Sur webhook Stripe `subscription.created` (upgrade Pro/Expert) → appeler `cancel_marketing_emails(user_id, "upgraded_to_paid")`                                                   |
+| `backend/src/templates/emails/welcome_fr.html`            | CREATE                 | J+0 FR (refactor de `welcome.html` existant + ajout footer désinscription + branding cosmic)                                                                                      |
+| `backend/src/templates/emails/welcome_en.html`            | CREATE                 | J+0 EN                                                                                                                                                                            |
+| `backend/src/templates/emails/tip_first_analysis_fr.html` | CREATE                 | J+1 FR — astuce 1 lien = 1 synthèse                                                                                                                                               |
+| `backend/src/templates/emails/tip_first_analysis_en.html` | CREATE                 | J+1 EN                                                                                                                                                                            |
+| `backend/src/templates/emails/feature_archive_fr.html`    | CREATE                 | J+3 FR — archives à vie                                                                                                                                                           |
+| `backend/src/templates/emails/feature_archive_en.html`    | CREATE                 | J+3 EN                                                                                                                                                                            |
+| `backend/src/templates/emails/social_proof_fr.html`       | CREATE                 | J+7 FR — témoignage Marie                                                                                                                                                         |
+| `backend/src/templates/emails/social_proof_en.html`       | CREATE                 | J+7 EN                                                                                                                                                                            |
+| `backend/src/templates/emails/upgrade_nudge_fr.html`      | CREATE                 | J+14 FR — Pro {{ pro_price }}                                                                                                                                                     |
+| `backend/src/templates/emails/upgrade_nudge_en.html`      | CREATE                 | J+14 EN                                                                                                                                                                           |
+| `backend/src/templates/emails/_partials/footer_fr.html`   | CREATE                 | Partial footer (désinscription + préférences)                                                                                                                                     |
+| `backend/src/templates/emails/_partials/footer_en.html`   | CREATE                 | Partial footer EN                                                                                                                                                                 |
+| `backend/tests/services/test_email_sequences.py`          | CREATE                 | Tests pytest : scheduling, cancellation, idempotence, i18n                                                                                                                        |
+| `backend/tests/services/test_email_unsubscribe.py`        | CREATE                 | Tests : token gen + verify, expiration, tampering                                                                                                                                 |
+| `backend/tests/email/test_webhook_resend.py`              | CREATE                 | Tests webhook : signature valid/invalid, event types                                                                                                                              |
+| `backend/tests/email/__init__.py`                         | CREATE                 | Marker package tests email                                                                                                                                                        |
+| `backend/tests/services/__init__.py`                      | CREATE                 | Marker package                                                                                                                                                                    |
+
+### Frontend (TypeScript)
+
+| Path                                          | Action | Responsabilité                                                                                                                                                |
+| --------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `frontend/src/services/analytics.ts`          | MODIFY | Ajout helpers `trackEmailEvent(event, metadata)` côté frontend (déclenché si user arrive via lien email avec `?utm_source=email&utm_campaign=<template_key>`) |
+| `frontend/src/pages/EmailUnsubscribePage.tsx` | CREATE | Page publique `/email/unsubscribe?token=...` qui appelle backend + affiche confirmation                                                                       |
+| `frontend/src/pages/EmailPreferencesPage.tsx` | CREATE | Page authentifiée `/email/preferences` (toggle marketing_emails_consent)                                                                                      |
+| `frontend/src/App.tsx` ou router              | MODIFY | Ajout des deux routes ci-dessus                                                                                                                               |
+| `frontend/src/services/api.ts`                | MODIFY | Ajout `unsubscribeEmail(token)` + `getEmailPreferences()` + `updateEmailPreferences(consent)`                                                                 |
+
+---
+
+## Tasks
+
+### Task 1: Migration Alembic 010 — tables `email_scheduled` + `email_events`
+
+**Files:**
+
+- Create: `backend/alembic/versions/010_add_email_scheduling.py`
+
+- [ ] **Step 1: Inspecter la dernière migration pour le pattern**
+
+```bash
+cat backend/alembic/versions/009_add_user_preferences_json.py | head -40
+```
+
+Expected: voir `down_revision = "008_voice_quota_a_d_strict"` pattern + import op/sa.
+
+- [ ] **Step 2: Créer la migration**
+
+```python
+# backend/alembic/versions/010_add_email_scheduling.py
+"""add_email_scheduling
+
+Revision ID: 010_add_email_scheduling
+Revises: 009_add_user_preferences_json
+Create Date: 2026-04-29
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers
+revision = "010_add_email_scheduling"
+down_revision = "009_add_user_preferences_json"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Table 1: email_scheduled — jobs d'email à envoyer dans le futur
+    op.create_table(
+        "email_scheduled",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("template_key", sa.String(64), nullable=False),
+        sa.Column("send_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cancelled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("cancel_reason", sa.String(64), nullable=True),
+        sa.Column("event_metadata", sa.JSON().with_variant(postgresql.JSONB(), "postgresql"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_email_scheduled_user_id", "email_scheduled", ["user_id"])
+    op.create_index("ix_email_scheduled_pending", "email_scheduled", ["send_at", "sent_at"])
+    op.create_index("ix_email_scheduled_user_template", "email_scheduled", ["user_id", "template_key"], unique=True)
+
+    # Table 2: email_events — tracking webhooks Resend
+    op.create_table(
+        "email_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("template_key", sa.String(64), nullable=False),
+        sa.Column("event_type", sa.String(32), nullable=False),
+        sa.Column("resend_message_id", sa.String(255), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("event_metadata", sa.JSON().with_variant(postgresql.JSONB(), "postgresql"), nullable=True),
+    )
+    op.create_index("ix_email_events_user_id", "email_events", ["user_id"])
+    op.create_index("ix_email_events_resend_message_id", "email_events", ["resend_message_id"])
+    op.create_index("ix_email_events_template_event", "email_events", ["template_key", "event_type"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_email_events_template_event", table_name="email_events")
+    op.drop_index("ix_email_events_resend_message_id", table_name="email_events")
+    op.drop_index("ix_email_events_user_id", table_name="email_events")
+    op.drop_table("email_events")
+
+    op.drop_index("ix_email_scheduled_user_template", table_name="email_scheduled")
+    op.drop_index("ix_email_scheduled_pending", table_name="email_scheduled")
+    op.drop_index("ix_email_scheduled_user_id", table_name="email_scheduled")
+    op.drop_table("email_scheduled")
+```
+
+- [ ] **Step 3: Tester la migration en local (SQLite)**
+
+```bash
+cd backend && python -m alembic upgrade head
+```
+
+Expected: `INFO  [alembic.runtime.migration] Running upgrade 009_add_user_preferences_json -> 010_add_email_scheduling`
+
+- [ ] **Step 4: Tester downgrade**
+
+```bash
+cd backend && python -m alembic downgrade -1 && python -m alembic upgrade head
+```
+
+Expected: deux upgrades successifs sans erreur.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/alembic/versions/010_add_email_scheduling.py
+git commit -m "feat(email): add migration 010 for email_scheduled and email_events tables"
+```
+
+---
+
+### Task 2: SQLAlchemy models `EmailScheduled` + `EmailEvent`
+
+**Files:**
+
+- Modify: `backend/src/db/database.py` (append en fin de fichier, après les autres models, avant les fonctions utilitaires)
+
+- [ ] **Step 1: Ouvrir database.py et trouver le dernier model**
+
+```bash
+grep -n "^class " backend/src/db/database.py | tail -5
+```
+
+Expected: liste des classes existantes (UserStudyStats, UserBadge, etc.) — repérer la dernière.
+
+- [ ] **Step 2: Append les deux nouveaux models**
+
+```python
+# Dans backend/src/db/database.py — après le dernier model existant
+
+
+class EmailScheduled(Base):
+    """Job d'email planifié à envoyer à une date future.
+
+    Inséré par schedule_welcome_sequence() à la confirmation email.
+    Consommé par process_scheduled_emails() (APScheduler 5 min).
+    """
+
+    __tablename__ = "email_scheduled"
+    __table_args__ = (
+        Index("ix_email_scheduled_pending", "send_at", "sent_at"),
+        Index("ix_email_scheduled_user_template", "user_id", "template_key", unique=True),
+        {"extend_existing": True},
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    template_key = Column(String(64), nullable=False)
+    send_at = Column(DateTime(timezone=True), nullable=False)
+    sent_at = Column(DateTime(timezone=True), nullable=True)
+    cancelled = Column(Boolean, nullable=False, default=False, server_default="false")
+    cancel_reason = Column(String(64), nullable=True)
+    event_metadata = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=func.now(), nullable=False)
+
+
+class EmailEvent(Base):
+    """Tracking des events Resend (sent/delivered/opened/clicked/bounced/complained/unsubscribed).
+
+    Insérés par /api/email/webhook/resend après vérification de signature.
+    Utilisés pour analytics PostHog + admin dashboard.
+    """
+
+    __tablename__ = "email_events"
+    __table_args__ = (
+        Index("ix_email_events_template_event", "template_key", "event_type"),
+        {"extend_existing": True},
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+    template_key = Column(String(64), nullable=False)
+    event_type = Column(String(32), nullable=False)
+    resend_message_id = Column(String(255), nullable=True, index=True)
+    occurred_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    event_metadata = Column(JSON, nullable=True)
+```
+
+⚠️ Vérifier que `Index` est déjà importé en haut de `database.py`. Si non, ajouter `Index` à la ligne `from sqlalchemy import ...`.
+
+- [ ] **Step 3: Tester l'import**
+
+```bash
+cd backend/src && python -c "from db.database import EmailScheduled, EmailEvent; print('OK')"
+```
+
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/db/database.py
+git commit -m "feat(email): add EmailScheduled and EmailEvent SQLAlchemy models"
+```
+
+---
+
+### Task 3: Service `email_unsubscribe.py` — tokens HMAC
+
+**Files:**
+
+- Create: `backend/src/services/email_unsubscribe.py`
+- Test: `backend/tests/services/test_email_unsubscribe.py`
+
+- [ ] **Step 1: Écrire le test d'abord**
+
+```python
+# backend/tests/services/test_email_unsubscribe.py
+"""Tests for email unsubscribe token generation and verification."""
+
+import pytest
+from services.email_unsubscribe import (
+    generate_unsubscribe_token,
+    verify_unsubscribe_token,
+    UnsubscribeTokenInvalid,
+)
+
+
+def test_token_roundtrip_returns_user_id():
+    token = generate_unsubscribe_token(user_id=42, template_key="welcome")
+    assert isinstance(token, str)
+    assert len(token) > 20
+    user_id, template_key = verify_unsubscribe_token(token)
+    assert user_id == 42
+    assert template_key == "welcome"
+
+
+def test_token_with_template_all_for_global_unsub():
+    token = generate_unsubscribe_token(user_id=7, template_key="all")
+    user_id, template_key = verify_unsubscribe_token(token)
+    assert user_id == 7
+    assert template_key == "all"
+
+
+def test_invalid_token_raises():
+    with pytest.raises(UnsubscribeTokenInvalid):
+        verify_unsubscribe_token("garbage.token.here")
+
+
+def test_tampered_token_raises():
+    token = generate_unsubscribe_token(user_id=1, template_key="welcome")
+    tampered = token[:-4] + "XXXX"
+    with pytest.raises(UnsubscribeTokenInvalid):
+        verify_unsubscribe_token(tampered)
+```
+
+- [ ] **Step 2: Run test (must FAIL)**
+
+```bash
+cd backend && python -m pytest tests/services/test_email_unsubscribe.py -v
+```
+
+Expected: `ImportError: cannot import name 'generate_unsubscribe_token'`
+
+- [ ] **Step 3: Implémenter le service**
+
+```python
+# backend/src/services/email_unsubscribe.py
+"""Email unsubscribe token — signed with HMAC-SHA256 using JWT_SECRET_KEY.
+
+Token format: base64url(payload).base64url(signature)
+where payload = "{user_id}:{template_key}"
+and signature = HMAC-SHA256(secret, payload)
+
+Tokens are NOT time-limited — désinscription doit fonctionner même 6 mois après l'envoi.
+"""
+
+import base64
+import hashlib
+import hmac
+from typing import Tuple
+
+from core.config import JWT_CONFIG
+
+
+class UnsubscribeTokenInvalid(Exception):
+    """Raised when token signature is invalid or payload malformed."""
+
+
+def _b64u_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64u_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def _secret() -> bytes:
+    secret = JWT_CONFIG.get("SECRET_KEY")
+    if not secret:
+        raise RuntimeError("JWT_SECRET_KEY not configured — required for unsubscribe tokens")
+    return secret.encode("utf-8")
+
+
+def generate_unsubscribe_token(user_id: int, template_key: str) -> str:
+    """Generate a signed unsubscribe token. template_key='all' = global unsub."""
+    payload = f"{user_id}:{template_key}".encode("utf-8")
+    signature = hmac.new(_secret(), payload, hashlib.sha256).digest()
+    return f"{_b64u_encode(payload)}.{_b64u_encode(signature)}"
+
+
+def verify_unsubscribe_token(token: str) -> Tuple[int, str]:
+    """Verify token and return (user_id, template_key). Raises UnsubscribeTokenInvalid on failure."""
+    try:
+        payload_b64, sig_b64 = token.split(".")
+        payload = _b64u_decode(payload_b64)
+        signature = _b64u_decode(sig_b64)
+    except (ValueError, Exception) as e:
+        raise UnsubscribeTokenInvalid(f"Malformed token: {e}")
+
+    expected = hmac.new(_secret(), payload, hashlib.sha256).digest()
+    if not hmac.compare_digest(signature, expected):
+        raise UnsubscribeTokenInvalid("Bad signature")
+
+    try:
+        user_id_str, template_key = payload.decode("utf-8").split(":", 1)
+        return int(user_id_str), template_key
+    except (ValueError, UnicodeDecodeError) as e:
+        raise UnsubscribeTokenInvalid(f"Malformed payload: {e}")
+```
+
+- [ ] **Step 4: Run test — must PASS**
+
+```bash
+cd backend && python -m pytest tests/services/test_email_unsubscribe.py -v
+```
+
+Expected: 4 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/email_unsubscribe.py backend/tests/services/test_email_unsubscribe.py backend/tests/services/__init__.py
+git commit -m "feat(email): add HMAC-SHA256 unsubscribe token service with tests"
+```
+
+---
+
+### Task 4: Service `email_sequences.py` — scheduling + cancellation + dispatch
+
+**Files:**
+
+- Create: `backend/src/services/email_sequences.py`
+- Test: `backend/tests/services/test_email_sequences.py`
+
+- [ ] **Step 1: Écrire le test (4 cas)**
+
+```python
+# backend/tests/services/test_email_sequences.py
+"""Tests for welcome sequence scheduling, cancellation, and dispatch."""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+from db.database import EmailScheduled, User
+from services.email_sequences import (
+    schedule_welcome_sequence,
+    cancel_marketing_emails,
+    is_user_unsubscribed,
+    SEQUENCE_TEMPLATES,
+)
+
+
+@pytest.mark.asyncio
+async def test_schedule_welcome_sequence_inserts_5_rows(db_session, test_user):
+    await schedule_welcome_sequence(db_session, test_user)
+    await db_session.flush()
+    result = await db_session.execute(
+        select(EmailScheduled).where(EmailScheduled.user_id == test_user.id).order_by(EmailScheduled.send_at)
+    )
+    rows = result.scalars().all()
+    assert len(rows) == 5
+    assert [r.template_key for r in rows] == [
+        "welcome",
+        "tip_first_analysis",
+        "feature_archive",
+        "social_proof",
+        "upgrade_nudge",
+    ]
+    # send_at offsets: 0d, 1d, 3d, 7d, 14d
+    base = rows[0].send_at
+    assert (rows[1].send_at - base).days == 1
+    assert (rows[4].send_at - base).days == 14
+
+
+@pytest.mark.asyncio
+async def test_schedule_welcome_sequence_idempotent(db_session, test_user):
+    await schedule_welcome_sequence(db_session, test_user)
+    await schedule_welcome_sequence(db_session, test_user)  # second call no-op
+    await db_session.flush()
+    result = await db_session.execute(
+        select(EmailScheduled).where(EmailScheduled.user_id == test_user.id)
+    )
+    assert len(result.scalars().all()) == 5
+
+
+@pytest.mark.asyncio
+async def test_cancel_marketing_emails_keeps_welcome(db_session, test_user):
+    """When user upgrades to Pro, cancel marketing (J+7, J+14) but keep welcome/tip/feature."""
+    await schedule_welcome_sequence(db_session, test_user)
+    await db_session.flush()
+    await cancel_marketing_emails(db_session, test_user.id, reason="upgraded_to_pro")
+    await db_session.flush()
+
+    result = await db_session.execute(
+        select(EmailScheduled).where(EmailScheduled.user_id == test_user.id)
+    )
+    rows = {r.template_key: r for r in result.scalars().all()}
+    assert rows["welcome"].cancelled is False
+    assert rows["tip_first_analysis"].cancelled is False
+    assert rows["feature_archive"].cancelled is False
+    assert rows["social_proof"].cancelled is True
+    assert rows["upgrade_nudge"].cancelled is True
+    assert rows["social_proof"].cancel_reason == "upgraded_to_pro"
+
+
+@pytest.mark.asyncio
+async def test_is_user_unsubscribed_reads_preferences(db_session, test_user):
+    test_user.preferences = {"marketing_emails_consent": False}
+    await db_session.flush()
+    assert await is_user_unsubscribed(test_user) is True
+
+    test_user.preferences = {"marketing_emails_consent": True}
+    await db_session.flush()
+    assert await is_user_unsubscribed(test_user) is False
+```
+
+- [ ] **Step 2: Run test (must FAIL)**
+
+```bash
+cd backend && python -m pytest tests/services/test_email_sequences.py -v
+```
+
+Expected: ImportError.
+
+- [ ] **Step 3: Implémenter le service**
+
+```python
+# backend/src/services/email_sequences.py
+"""Welcome series scheduling + dispatch for Resend.
+
+J+0 (welcome) — TRANSACTIONAL — sent regardless of marketing consent
+J+1 (tip_first_analysis) — MARKETING — skipped if consent=False
+J+3 (feature_archive) — MARKETING
+J+7 (social_proof) — MARKETING — also requires user.plan == "free"
+J+14 (upgrade_nudge) — MARKETING — also requires user.plan == "free" + no active trial
+"""
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import select, and_, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.logging import logger
+from db.database import EmailScheduled, EmailEvent, User
+from services.email_service import email_service
+
+# Resend rate limit (already enforced by email_queue, this is just throttle between schedule loops)
+RESEND_THROTTLE_SECONDS = 0.5  # 2 req/s = 0.5s entre envois
+
+
+@dataclass(frozen=True)
+class SequenceStep:
+    template_key: str
+    days_offset: int
+    is_marketing: bool  # False for welcome (transactional)
+    requires_free_plan: bool  # True for social_proof and upgrade_nudge
+
+
+SEQUENCE_TEMPLATES: list[SequenceStep] = [
+    SequenceStep("welcome", 0, is_marketing=False, requires_free_plan=False),
+    SequenceStep("tip_first_analysis", 1, is_marketing=True, requires_free_plan=False),
+    SequenceStep("feature_archive", 3, is_marketing=True, requires_free_plan=False),
+    SequenceStep("social_proof", 7, is_marketing=True, requires_free_plan=True),
+    SequenceStep("upgrade_nudge", 14, is_marketing=True, requires_free_plan=True),
+]
+
+MARKETING_TEMPLATES = {s.template_key for s in SEQUENCE_TEMPLATES if s.is_marketing}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scheduling (called from auth/router.py at email verification)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def schedule_welcome_sequence(db: AsyncSession, user: User) -> int:
+    """Insert 5 EmailScheduled rows for the user (idempotent).
+
+    Returns: number of rows inserted (0 if already scheduled).
+    """
+    now = datetime.now(timezone.utc)
+
+    # Idempotence: skip if any row already exists for this user
+    existing = await db.execute(
+        select(EmailScheduled.id).where(EmailScheduled.user_id == user.id).limit(1)
+    )
+    if existing.scalar() is not None:
+        logger.info(
+            "Welcome sequence already scheduled — skipping",
+            extra={"user_id": user.id},
+        )
+        return 0
+
+    inserted = 0
+    for step in SEQUENCE_TEMPLATES:
+        send_at = now + timedelta(days=step.days_offset)
+        row = EmailScheduled(
+            user_id=user.id,
+            template_key=step.template_key,
+            send_at=send_at,
+            event_metadata={"source": "welcome_sequence_v1", "user_lang": user.default_lang or "fr"},
+        )
+        db.add(row)
+        inserted += 1
+
+    logger.info(
+        "Welcome sequence scheduled",
+        extra={"user_id": user.id, "rows": inserted},
+    )
+    return inserted
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cancellation (called from billing/router.py on Stripe upgrade webhook)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def cancel_marketing_emails(
+    db: AsyncSession, user_id: int, reason: str
+) -> int:
+    """Cancel all unsent MARKETING emails for a user.
+
+    Used when:
+    - User upgrades to paid plan (cancel social_proof + upgrade_nudge)
+    - User unsubscribes globally (cancel everything except already-sent)
+
+    Returns: number of cancelled rows.
+    """
+    template_keys = list(MARKETING_TEMPLATES)
+    result = await db.execute(
+        update(EmailScheduled)
+        .where(
+            and_(
+                EmailScheduled.user_id == user_id,
+                EmailScheduled.template_key.in_(template_keys),
+                EmailScheduled.sent_at.is_(None),
+                EmailScheduled.cancelled == False,  # noqa: E712
+            )
+        )
+        .values(cancelled=True, cancel_reason=reason)
+    )
+    count = result.rowcount or 0
+    logger.info(
+        "Marketing emails cancelled",
+        extra={"user_id": user_id, "count": count, "reason": reason},
+    )
+    return count
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Consent check (read user.preferences JSON)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def is_user_unsubscribed(user: User) -> bool:
+    """True if user has set marketing_emails_consent = False."""
+    prefs = user.preferences or {}
+    return prefs.get("marketing_emails_consent") is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dispatch (called from main.py APScheduler every 5 min)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def process_scheduled_emails(db: AsyncSession, max_per_run: int = 50) -> dict:
+    """Find all due email_scheduled rows, send them via email_service, mark sent_at.
+
+    Returns: {"sent": N, "skipped_unsubscribed": N, "skipped_paid_plan": N, "errors": N}
+    """
+    stats = {"sent": 0, "skipped_unsubscribed": 0, "skipped_paid_plan": 0, "errors": 0}
+    now = datetime.now(timezone.utc)
+
+    # Pick due rows + join user
+    rows_result = await db.execute(
+        select(EmailScheduled, User)
+        .join(User, EmailScheduled.user_id == User.id)
+        .where(
+            and_(
+                EmailScheduled.send_at <= now,
+                EmailScheduled.sent_at.is_(None),
+                EmailScheduled.cancelled == False,  # noqa: E712
+            )
+        )
+        .order_by(EmailScheduled.send_at)
+        .limit(max_per_run)
+    )
+    rows = rows_result.all()
+
+    if not rows:
+        return stats
+
+    # Sequence step lookup
+    step_by_key = {s.template_key: s for s in SEQUENCE_TEMPLATES}
+
+    for scheduled, user in rows:
+        try:
+            step = step_by_key.get(scheduled.template_key)
+            if step is None:
+                logger.warning(
+                    "Unknown template_key — marking as sent to avoid loop",
+                    extra={"id": scheduled.id, "key": scheduled.template_key},
+                )
+                scheduled.sent_at = now
+                continue
+
+            # Audience filtering
+            if step.is_marketing and await is_user_unsubscribed(user):
+                scheduled.cancelled = True
+                scheduled.cancel_reason = "user_unsubscribed"
+                stats["skipped_unsubscribed"] += 1
+                continue
+
+            if step.requires_free_plan and (user.plan or "free") != "free":
+                scheduled.cancelled = True
+                scheduled.cancel_reason = "user_on_paid_plan"
+                stats["skipped_paid_plan"] += 1
+                continue
+
+            # Send via email_service (queue handles rate limiting)
+            success = await email_service.send_template_for_user(
+                user=user,
+                template_key=scheduled.template_key,
+            )
+
+            if success:
+                scheduled.sent_at = now
+                stats["sent"] += 1
+                # Insert sent event for analytics
+                db.add(
+                    EmailEvent(
+                        user_id=user.id,
+                        template_key=scheduled.template_key,
+                        event_type="sent",
+                        event_metadata={"scheduled_id": scheduled.id},
+                    )
+                )
+            else:
+                stats["errors"] += 1
+                logger.warning(
+                    "Email send failed — will retry next run",
+                    extra={"scheduled_id": scheduled.id, "user_id": user.id},
+                )
+
+            # Throttle between emails (defense-in-depth — queue also throttles)
+            await asyncio.sleep(RESEND_THROTTLE_SECONDS)
+
+        except Exception as e:
+            stats["errors"] += 1
+            logger.exception(
+                "Error dispatching scheduled email",
+                extra={"scheduled_id": scheduled.id, "error": str(e)},
+            )
+
+    await db.commit()
+    return stats
+```
+
+- [ ] **Step 4: Run tests (the 3 first must PASS, the 4th `is_user_unsubscribed` must PASS)**
+
+```bash
+cd backend && python -m pytest tests/services/test_email_sequences.py -v
+```
+
+Expected: 4 tests passed.
+
+⚠️ Si fixture `db_session` ou `test_user` manque, regarder `backend/tests/conftest.py` pour les fixtures existantes. Elles existent déjà (vues dans la suite de tests auth).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/email_sequences.py backend/tests/services/test_email_sequences.py
+git commit -m "feat(email): add welcome sequence scheduler with idempotence and cancellation"
+```
+
+---
+
+### Task 5: Étendre `email_service.py` avec `send_template_for_user(user, template_key)`
+
+**Files:**
+
+- Modify: `backend/src/services/email_service.py`
+
+- [ ] **Step 1: Lire la fonction existante `_render` (ligne 63-65) pour comprendre le pattern**
+
+Ouvrir `backend/src/services/email_service.py` lignes 63-65.
+
+- [ ] **Step 2: Ajouter la nouvelle méthode `send_template_for_user`**
+
+À la fin de la classe `EmailService` (avant le `email_service = EmailService()` en bas du fichier), ajouter :
+
+```python
+    async def send_template_for_user(
+        self,
+        user,  # db.database.User
+        template_key: str,
+    ) -> bool:
+        """Render and send a sequenced/transactional template to a user.
+
+        - Picks template file by lang: <template_key>_<lang>.html (lang from user.default_lang)
+        - Falls back to <template_key>_fr.html if user lang missing
+        - Builds context: username, frontend_url, app_name, pro_price, expert_price,
+          unsubscribe_url, preferences_url
+        - Sends via queue (transactional flag = True for "welcome" template only)
+        """
+        from services.email_unsubscribe import generate_unsubscribe_token
+        from billing.plan_config import PLANS, PlanId
+        from core.config import APP_NAME, FRONTEND_URL
+
+        lang = (user.default_lang or "fr").lower()
+        if lang not in ("fr", "en"):
+            lang = "fr"
+
+        username = user.username or user.email.split("@")[0]
+        unsub_token = generate_unsubscribe_token(user.id, "all")
+        single_unsub_token = generate_unsubscribe_token(user.id, template_key)
+
+        # Pricing pulled from SSOT (billing/plan_config.py)
+        pro_cents = PLANS.get(PlanId.PRO, {}).get("price_monthly_cents", 999)
+        expert_cents = PLANS.get(getattr(PlanId, "EXPERT", "expert"), {}).get(
+            "price_monthly_cents", 1999
+        )
+
+        def fmt_price(cents: int, lang: str) -> str:
+            euros = cents / 100
+            if lang == "fr":
+                return f"{euros:.2f}".replace(".", ",") + " €"
+            return f"€{euros:.2f}"
+
+        ctx = {
+            "username": username,
+            "app_name": APP_NAME,
+            "frontend_url": FRONTEND_URL,
+            "pro_price": fmt_price(pro_cents, lang),
+            "expert_price": fmt_price(expert_cents, lang),
+            "unsubscribe_url": f"{FRONTEND_URL}/email/unsubscribe?token={unsub_token}",
+            "single_unsubscribe_url": f"{FRONTEND_URL}/email/unsubscribe?token={single_unsub_token}",
+            "preferences_url": f"{FRONTEND_URL}/email/preferences",
+            "current_year": "2026",
+        }
+
+        template_filename = f"{template_key}_{lang}.html"
+        try:
+            html = self._render(template_filename, **ctx)
+        except Exception:
+            # Fallback FR
+            logger.warning(
+                "Template missing — falling back to FR",
+                extra={"template_key": template_key, "lang": lang},
+            )
+            html = self._render(f"{template_key}_fr.html", **ctx)
+
+        # Subject by template+lang
+        subjects = {
+            ("welcome", "fr"): f"Bienvenue sur {APP_NAME}, {username} !",
+            ("welcome", "en"): f"Welcome to {APP_NAME}, {username}!",
+            ("tip_first_analysis", "fr"): "Astuce : votre premiere analyse en 30 secondes",
+            ("tip_first_analysis", "en"): "Tip: your first analysis in 30 seconds",
+            ("feature_archive", "fr"): "Vos analyses sont archivees a vie",
+            ("feature_archive", "en"): "Your analyses are archived forever",
+            ("social_proof", "fr"): "Comment Marie gagne 2h par semaine",
+            ("social_proof", "en"): "How Marie saves 2 hours per week",
+            ("upgrade_nudge", "fr"): f"Passez Pro pour {ctx['pro_price']}/mois",
+            ("upgrade_nudge", "en"): f"Upgrade to Pro for {ctx['pro_price']}/mo",
+        }
+        subject = subjects.get((template_key, lang)) or f"{APP_NAME} — {template_key}"
+
+        is_priority = template_key == "welcome"
+
+        return await self.send_email(
+            to=user.email,
+            subject=subject,
+            html_content=html,
+            text_content=None,  # text fallback rendered server-side by Resend
+            priority=is_priority,
+        )
+```
+
+⚠️ Vérifier les imports en haut du fichier — `logger` doit être importé. Si non, ajouter `from core.logging import logger`.
+
+- [ ] **Step 3: Test smoke (l'instance email_service doit pouvoir être importée sans erreur)**
+
+```bash
+cd backend/src && python -c "from services.email_service import email_service; print(hasattr(email_service, 'send_template_for_user'))"
+```
+
+Expected: `True`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/services/email_service.py
+git commit -m "feat(email): add send_template_for_user with i18n and pricing context"
+```
+
+---
+
+### Task 6: Templates HTML × 5 × 2 langues + footer partial
+
+**Files:**
+
+- Create: `backend/src/templates/emails/_partials/footer_fr.html`
+- Create: `backend/src/templates/emails/_partials/footer_en.html`
+- Create: `backend/src/templates/emails/welcome_fr.html`
+- Create: `backend/src/templates/emails/welcome_en.html`
+- Create: `backend/src/templates/emails/tip_first_analysis_fr.html`
+- Create: `backend/src/templates/emails/tip_first_analysis_en.html`
+- Create: `backend/src/templates/emails/feature_archive_fr.html`
+- Create: `backend/src/templates/emails/feature_archive_en.html`
+- Create: `backend/src/templates/emails/social_proof_fr.html`
+- Create: `backend/src/templates/emails/social_proof_en.html`
+- Create: `backend/src/templates/emails/upgrade_nudge_fr.html`
+- Create: `backend/src/templates/emails/upgrade_nudge_en.html`
+
+- [ ] **Step 1: Créer le footer partial FR**
+
+```html
+<!-- backend/src/templates/emails/_partials/footer_fr.html -->
+<div class="footer">
+  <p><strong>{{ app_name }}</strong> — Analyse video par IA 100% europeenne</p>
+  <p style="margin-top: 8px">
+    <a href="{{ frontend_url }}">deepsightsynthesis.com</a>
+  </p>
+  <p
+    style="margin-top: 16px; font-size: 11px; color: #475569; line-height: 1.6;"
+  >
+    Vous recevez cet email parce que vous etes inscrit sur {{ app_name }}.<br />
+    <a href="{{ single_unsubscribe_url }}">Se desabonner de cette serie</a>
+    &nbsp;·&nbsp;
+    <a href="{{ unsubscribe_url }}"
+      >Se desabonner de tous les emails marketing</a
+    >
+    &nbsp;·&nbsp;
+    <a href="{{ preferences_url }}">Mes preferences</a>
+  </p>
+  <p style="margin-top: 8px; font-size: 11px; color: #475569;">
+    DeepSight Synthesis &copy; {{ current_year }} — Donnees hebergees en Europe
+    (RGPD).
+  </p>
+</div>
+```
+
+- [ ] **Step 2: Créer le footer partial EN**
+
+```html
+<!-- backend/src/templates/emails/_partials/footer_en.html -->
+<div class="footer">
+  <p><strong>{{ app_name }}</strong> — 100% European AI video analysis</p>
+  <p style="margin-top: 8px">
+    <a href="{{ frontend_url }}">deepsightsynthesis.com</a>
+  </p>
+  <p
+    style="margin-top: 16px; font-size: 11px; color: #475569; line-height: 1.6;"
+  >
+    You're receiving this email because you signed up for {{ app_name }}.<br />
+    <a href="{{ single_unsubscribe_url }}">Unsubscribe from this series</a>
+    &nbsp;·&nbsp;
+    <a href="{{ unsubscribe_url }}">Unsubscribe from all marketing emails</a>
+    &nbsp;·&nbsp;
+    <a href="{{ preferences_url }}">My preferences</a>
+  </p>
+  <p style="margin-top: 8px; font-size: 11px; color: #475569;">
+    DeepSight Synthesis &copy; {{ current_year }} — Data hosted in Europe
+    (GDPR).
+  </p>
+</div>
+```
+
+- [ ] **Step 3: Créer welcome_fr.html (basé sur welcome.html existant + footer)**
+
+```html
+<!-- backend/src/templates/emails/welcome_fr.html -->
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bienvenue sur {{ app_name }}</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        overflow: hidden;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #6366f1 0%,
+          #8b5cf6 50%,
+          #06b6d4 100%
+        );
+        padding: 40px 32px;
+        text-align: center;
+      }
+      .header-icon {
+        font-size: 40px;
+        margin-bottom: 8px;
+      }
+      .header-title {
+        font-size: 26px;
+        font-weight: 700;
+        color: #ffffff;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .features {
+        background-color: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        border-radius: 12px;
+        padding: 24px;
+        margin: 24px 0;
+      }
+      .feature {
+        margin-bottom: 12px;
+        font-size: 14px;
+        color: #cbd5e1;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 15px;
+        padding: 14px 36px;
+        border-radius: 10px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+      @media only screen and (max-width: 600px) {
+        .wrapper {
+          padding: 16px 8px;
+        }
+        .body {
+          padding: 28px 20px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">
+          <div class="header-icon">🌌</div>
+          <div class="header-title">{{ app_name }}</div>
+        </div>
+        <div class="body">
+          <p class="greeting">Bienvenue {{ username }} !</p>
+          <p class="text">
+            Votre compte est actif. Vous avez
+            <strong>5 analyses gratuites</strong> par mois pour decouvrir la
+            puissance de l'analyse video par IA.
+          </p>
+          <div class="features">
+            <div class="feature">
+              📊 <strong>5 analyses video</strong> chaque mois
+            </div>
+            <div class="feature">
+              💬 <strong>Chat contextuel</strong> sur vos analyses
+            </div>
+            <div class="feature">
+              🗂️ <strong>Historique 60 jours</strong> consultable
+            </div>
+            <div class="feature">
+              🇪🇺 <strong>IA 100% francaise</strong> (Mistral AI) — vos donnees
+              restent en Europe
+            </div>
+          </div>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/dashboard" class="cta"
+              >Analyser ma premiere video</a
+            >
+          </div>
+          <p class="text" style="font-size: 13px; color: #64748b">
+            Astuce : collez n'importe quel lien YouTube ou TikTok dans le
+            tableau de bord.
+          </p>
+        </div>
+        {% include "_partials/footer_fr.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 4: Créer welcome_en.html (même structure)**
+
+```html
+<!-- backend/src/templates/emails/welcome_en.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Welcome to {{ app_name }}</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        overflow: hidden;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #6366f1 0%,
+          #8b5cf6 50%,
+          #06b6d4 100%
+        );
+        padding: 40px 32px;
+        text-align: center;
+      }
+      .header-icon {
+        font-size: 40px;
+        margin-bottom: 8px;
+      }
+      .header-title {
+        font-size: 26px;
+        font-weight: 700;
+        color: #ffffff;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .features {
+        background-color: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        border-radius: 12px;
+        padding: 24px;
+        margin: 24px 0;
+      }
+      .feature {
+        margin-bottom: 12px;
+        font-size: 14px;
+        color: #cbd5e1;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 15px;
+        padding: 14px 36px;
+        border-radius: 10px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">
+          <div class="header-icon">🌌</div>
+          <div class="header-title">{{ app_name }}</div>
+        </div>
+        <div class="body">
+          <p class="greeting">Welcome {{ username }}!</p>
+          <p class="text">
+            Your account is live. You have <strong>5 free analyses</strong> per
+            month to discover the power of AI video analysis.
+          </p>
+          <div class="features">
+            <div class="feature">
+              📊 <strong>5 video analyses</strong> per month
+            </div>
+            <div class="feature">
+              💬 <strong>Contextual chat</strong> on your analyses
+            </div>
+            <div class="feature">
+              🗂️ <strong>60-day history</strong> available
+            </div>
+            <div class="feature">
+              🇪🇺 <strong>100% French AI</strong> (Mistral AI) — your data stays
+              in Europe
+            </div>
+          </div>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/dashboard" class="cta"
+              >Analyze my first video</a
+            >
+          </div>
+          <p class="text" style="font-size: 13px; color: #64748b">
+            Tip: paste any YouTube or TikTok link in your dashboard.
+          </p>
+        </div>
+        {% include "_partials/footer_en.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 5: Créer tip_first_analysis_fr.html**
+
+```html
+<!-- backend/src/templates/emails/tip_first_analysis_fr.html -->
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Astuce — Premiere analyse</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .header {
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        padding: 32px;
+        text-align: center;
+        color: #fff;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .step {
+        background-color: rgba(99, 102, 241, 0.08);
+        border-left: 3px solid #6366f1;
+        padding: 16px;
+        margin: 12px 0;
+        border-radius: 6px;
+        color: #cbd5e1;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        padding: 14px 36px;
+        border-radius: 10px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">💡 Astuce du jour</div>
+        <div class="body">
+          <p class="greeting">Salut {{ username }} !</p>
+          <p class="text">
+            1 lien YouTube ou TikTok = 1 synthese complete. C'est aussi simple
+            que ca.
+          </p>
+          <div class="step">
+            <strong>1.</strong> Copiez n'importe quel lien YouTube ou TikTok
+          </div>
+          <div class="step">
+            <strong>2.</strong> Collez-le dans votre tableau de bord
+          </div>
+          <div class="step">
+            <strong>3.</strong> Recevez en moins de 60 secondes : resume, points
+            cles, fact-checks et chat contextuel
+          </div>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/dashboard" class="cta"
+              >Lancer ma premiere analyse</a
+            >
+          </div>
+          <p class="text" style="font-size: 13px; color: #64748b">
+            PS : meme une video de 2h tient en 1 page lisible. Magique.
+          </p>
+        </div>
+        {% include "_partials/footer_fr.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 6: Créer tip_first_analysis_en.html**
+
+```html
+<!-- backend/src/templates/emails/tip_first_analysis_en.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tip — First Analysis</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .header {
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        padding: 32px;
+        text-align: center;
+        color: #fff;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .step {
+        background-color: rgba(99, 102, 241, 0.08);
+        border-left: 3px solid #6366f1;
+        padding: 16px;
+        margin: 12px 0;
+        border-radius: 6px;
+        color: #cbd5e1;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        padding: 14px 36px;
+        border-radius: 10px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">💡 Daily Tip</div>
+        <div class="body">
+          <p class="greeting">Hi {{ username }}!</p>
+          <p class="text">
+            1 YouTube or TikTok link = 1 full synthesis. It's that simple.
+          </p>
+          <div class="step">
+            <strong>1.</strong> Copy any YouTube or TikTok URL
+          </div>
+          <div class="step">
+            <strong>2.</strong> Paste it into your dashboard
+          </div>
+          <div class="step">
+            <strong>3.</strong> Receive in under 60 seconds: summary, key
+            points, fact-checks, contextual chat
+          </div>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/dashboard" class="cta"
+              >Run my first analysis</a
+            >
+          </div>
+          <p class="text" style="font-size: 13px; color: #64748b">
+            PS: even a 2-hour video fits on 1 readable page. Magic.
+          </p>
+        </div>
+        {% include "_partials/footer_en.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 7: Créer feature_archive_fr.html**
+
+```html
+<!-- backend/src/templates/emails/feature_archive_fr.html -->
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vos analyses — archivees a vie</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .header {
+        background: linear-gradient(135deg, #06b6d4, #6366f1);
+        padding: 32px;
+        text-align: center;
+        color: #fff;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .quote {
+        background-color: rgba(6, 182, 212, 0.08);
+        border-left: 3px solid #06b6d4;
+        padding: 20px;
+        margin: 24px 0;
+        border-radius: 6px;
+        color: #cbd5e1;
+        font-style: italic;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #06b6d4, #6366f1);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        padding: 14px 36px;
+        border-radius: 10px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">🗂️ Archives a vie</div>
+        <div class="body">
+          <p class="greeting">{{ username }},</p>
+          <p class="text">
+            Vous le saviez ? Toutes vos analyses sont conservees indefiniment
+            dans votre historique. Pas d'expiration, pas de purge.
+          </p>
+          <p class="text"><strong>Pourquoi c'est utile :</strong></p>
+          <ul style="color: #cbd5e1; line-height: 1.8;">
+            <li>
+              📚 <strong>Constituez une base de connaissances</strong> a partir
+              des videos que vous regardez
+            </li>
+            <li>
+              🔍 <strong>Recherche semantique</strong> : retrouvez une idee meme
+              6 mois plus tard
+            </li>
+            <li>
+              🧠 <strong>Re-discutez</strong> avec n'importe quelle analyse via
+              le chat contextuel
+            </li>
+          </ul>
+          <div class="quote">
+            "J'ai 6 mois d'analyses dans mon historique. Quand je cherche une
+            citation, je la retrouve en 3 secondes."
+          </div>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/history" class="cta"
+              >Voir mon historique</a
+            >
+          </div>
+        </div>
+        {% include "_partials/footer_fr.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 8: Créer feature_archive_en.html**
+
+```html
+<!-- backend/src/templates/emails/feature_archive_en.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Your analyses — archived forever</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .header {
+        background: linear-gradient(135deg, #06b6d4, #6366f1);
+        padding: 32px;
+        text-align: center;
+        color: #fff;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .quote {
+        background-color: rgba(6, 182, 212, 0.08);
+        border-left: 3px solid #06b6d4;
+        padding: 20px;
+        margin: 24px 0;
+        border-radius: 6px;
+        color: #cbd5e1;
+        font-style: italic;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #06b6d4, #6366f1);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        padding: 14px 36px;
+        border-radius: 10px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">🗂️ Archived forever</div>
+        <div class="body">
+          <p class="greeting">{{ username }},</p>
+          <p class="text">
+            Did you know? All your analyses are kept indefinitely in your
+            history. No expiration, no purge.
+          </p>
+          <p class="text"><strong>Why it matters:</strong></p>
+          <ul style="color: #cbd5e1; line-height: 1.8;">
+            <li>
+              📚 <strong>Build your own knowledge base</strong> from the videos
+              you watch
+            </li>
+            <li>
+              🔍 <strong>Semantic search</strong>: find an idea even 6 months
+              later
+            </li>
+            <li>
+              🧠 <strong>Re-chat</strong> with any analysis via contextual chat
+            </li>
+          </ul>
+          <div class="quote">
+            "I have 6 months of analyses in my history. When I look for a quote,
+            I find it in 3 seconds."
+          </div>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/history" class="cta">View my history</a>
+          </div>
+        </div>
+        {% include "_partials/footer_en.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 9: Créer social_proof_fr.html**
+
+```html
+<!-- backend/src/templates/emails/social_proof_fr.html -->
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Comment Marie gagne 2h par semaine</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .header {
+        background: linear-gradient(135deg, #8b5cf6, #ec4899);
+        padding: 32px;
+        text-align: center;
+        color: #fff;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .testimonial {
+        background-color: rgba(139, 92, 246, 0.08);
+        border-left: 3px solid #8b5cf6;
+        padding: 24px;
+        margin: 24px 0;
+        border-radius: 6px;
+        color: #cbd5e1;
+        font-style: italic;
+        line-height: 1.7;
+      }
+      .author {
+        font-size: 13px;
+        color: #64748b;
+        margin-top: 12px;
+        font-style: normal;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #8b5cf6, #6366f1);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        padding: 14px 36px;
+        border-radius: 10px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">⭐ Temoignage utilisateur</div>
+        <div class="body">
+          <p class="greeting">{{ username }},</p>
+          <p class="text">
+            Marie, etudiante en sciences politiques, raconte comment elle a
+            transforme sa veille video en gain de temps.
+          </p>
+          <div class="testimonial">
+            "Avant, je passais 3h par jour a regarder des conferences sur
+            YouTube. Avec {{ app_name }}, je traite 10 videos en 30 minutes :
+            synthese, points cles, fact-checks. Je gagne 2h par semaine —
+            facile."
+            <div class="author">— Marie, 23 ans, etudiante a Sciences Po</div>
+          </div>
+          <p class="text">
+            Vous etes en plan gratuit (5 analyses/mois). Avec
+            <strong>Pro a {{ pro_price }}/mois</strong>, vous passez a 30
+            analyses + fact-check automatique + cartes mentales + export PDF.
+          </p>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/upgrade" class="cta">Decouvrir Pro</a>
+          </div>
+          <p class="text" style="font-size: 13px; color: #64748b">
+            Pas d'engagement. Annulez en 1 clic.
+          </p>
+        </div>
+        {% include "_partials/footer_fr.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+⚠️ Le témoignage "Marie" est fictif (placeholder). Si l'équipe a un vrai témoignage utilisateur, le remplacer ici. Sinon, accepter le placeholder pour V1.
+
+- [ ] **Step 10: Créer social_proof_en.html**
+
+```html
+<!-- backend/src/templates/emails/social_proof_en.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>How Marie saves 2 hours per week</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .header {
+        background: linear-gradient(135deg, #8b5cf6, #ec4899);
+        padding: 32px;
+        text-align: center;
+        color: #fff;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .testimonial {
+        background-color: rgba(139, 92, 246, 0.08);
+        border-left: 3px solid #8b5cf6;
+        padding: 24px;
+        margin: 24px 0;
+        border-radius: 6px;
+        color: #cbd5e1;
+        font-style: italic;
+        line-height: 1.7;
+      }
+      .author {
+        font-size: 13px;
+        color: #64748b;
+        margin-top: 12px;
+        font-style: normal;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #8b5cf6, #6366f1);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        padding: 14px 36px;
+        border-radius: 10px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">⭐ User testimonial</div>
+        <div class="body">
+          <p class="greeting">{{ username }},</p>
+          <p class="text">
+            Marie, a political science student, shares how she turned her video
+            watching into a time-saver.
+          </p>
+          <div class="testimonial">
+            "I used to spend 3 hours a day watching YouTube lectures. With {{
+            app_name }}, I process 10 videos in 30 minutes — summary, key
+            points, fact-checks. I save 2 hours per week, easy."
+            <div class="author">— Marie, 23, student at Sciences Po</div>
+          </div>
+          <p class="text">
+            You're on the free plan (5 analyses/month). With
+            <strong>Pro at {{ pro_price }}/mo</strong>, you get 30 analyses +
+            automatic fact-check + mind maps + PDF export.
+          </p>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/upgrade" class="cta">Discover Pro</a>
+          </div>
+          <p class="text" style="font-size: 13px; color: #64748b">
+            No commitment. Cancel in 1 click.
+          </p>
+        </div>
+        {% include "_partials/footer_en.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 11: Créer upgrade_nudge_fr.html**
+
+```html
+<!-- backend/src/templates/emails/upgrade_nudge_fr.html -->
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Passez Pro pour {{ pro_price }}/mois</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .header {
+        background: linear-gradient(135deg, #f59e0b, #ef4444);
+        padding: 32px;
+        text-align: center;
+        color: #fff;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .price-box {
+        background: linear-gradient(
+          135deg,
+          rgba(99, 102, 241, 0.12),
+          rgba(139, 92, 246, 0.12)
+        );
+        border: 1px solid rgba(139, 92, 246, 0.3);
+        border-radius: 14px;
+        padding: 24px;
+        text-align: center;
+        margin: 24px 0;
+      }
+      .price {
+        font-size: 36px;
+        font-weight: 800;
+        color: #f1f5f9;
+        margin: 0;
+      }
+      .price-sub {
+        font-size: 13px;
+        color: #94a3b8;
+        margin-top: 4px;
+      }
+      .features {
+        background-color: rgba(255, 255, 255, 0.04);
+        border-radius: 12px;
+        padding: 20px;
+        margin: 16px 0;
+      }
+      .feature {
+        padding: 8px 0;
+        font-size: 14px;
+        color: #cbd5e1;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+      }
+      .feature:last-child {
+        border-bottom: none;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        padding: 16px 40px;
+        border-radius: 10px;
+        font-size: 16px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">🔥 Offre Pro</div>
+        <div class="body">
+          <p class="greeting">{{ username }},</p>
+          <p class="text">
+            Cela fait 2 semaines que vous utilisez {{ app_name }}. Si vous
+            voulez aller plus loin, voici ce que vous deverrouillez avec
+            <strong>Pro</strong> :
+          </p>
+          <div class="features">
+            <div class="feature">
+              📊 <strong>30 analyses/mois</strong> (vs 5 en gratuit)
+            </div>
+            <div class="feature">
+              ⏱️ <strong>Videos jusqu'a 2h</strong> (vs 15min)
+            </div>
+            <div class="feature">
+              🔍 <strong>Fact-check automatique</strong> avec sources verifiees
+            </div>
+            <div class="feature">
+              🧠 <strong>Cartes mentales</strong> generees a la volee
+            </div>
+            <div class="feature">
+              🎙️ <strong>Voice chat</strong> avec vos analyses
+            </div>
+            <div class="feature">
+              📄 <strong>Export PDF</strong> + DOCX + Markdown
+            </div>
+          </div>
+          <div class="price-box">
+            <p class="price">
+              {{ pro_price }}<span style="font-size: 18px; color: #94a3b8;"
+                >/mois</span
+              >
+            </p>
+            <p class="price-sub">Sans engagement · Annulable en 1 clic</p>
+          </div>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/upgrade" class="cta">Passer Pro</a>
+          </div>
+          <p
+            class="text"
+            style="font-size: 13px; color: #64748b; text-align: center;"
+          >
+            Vous pouvez aussi passer Expert ({{ expert_price }}/mois) pour 100
+            analyses + voice chat illimite.
+          </p>
+        </div>
+        {% include "_partials/footer_fr.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 12: Créer upgrade_nudge_en.html**
+
+```html
+<!-- backend/src/templates/emails/upgrade_nudge_en.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Upgrade to Pro for {{ pro_price }}/mo</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #0a0a0f;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e2e8f0;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 40px 16px;
+        background-color: #0a0a0f;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #12121a;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .header {
+        background: linear-gradient(135deg, #f59e0b, #ef4444);
+        padding: 32px;
+        text-align: center;
+        color: #fff;
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .body {
+        padding: 36px 32px;
+      }
+      .greeting {
+        font-size: 20px;
+        font-weight: 600;
+        color: #f1f5f9;
+        margin: 0 0 16px 0;
+      }
+      .text {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #94a3b8;
+        margin: 0 0 20px 0;
+      }
+      .price-box {
+        background: linear-gradient(
+          135deg,
+          rgba(99, 102, 241, 0.12),
+          rgba(139, 92, 246, 0.12)
+        );
+        border: 1px solid rgba(139, 92, 246, 0.3);
+        border-radius: 14px;
+        padding: 24px;
+        text-align: center;
+        margin: 24px 0;
+      }
+      .price {
+        font-size: 36px;
+        font-weight: 800;
+        color: #f1f5f9;
+        margin: 0;
+      }
+      .price-sub {
+        font-size: 13px;
+        color: #94a3b8;
+        margin-top: 4px;
+      }
+      .features {
+        background-color: rgba(255, 255, 255, 0.04);
+        border-radius: 12px;
+        padding: 20px;
+        margin: 16px 0;
+      }
+      .feature {
+        padding: 8px 0;
+        font-size: 14px;
+        color: #cbd5e1;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+      }
+      .feature:last-child {
+        border-bottom: none;
+      }
+      .cta-wrap {
+        text-align: center;
+        margin: 32px 0;
+      }
+      .cta {
+        display: inline-block;
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        padding: 16px 40px;
+        border-radius: 10px;
+        font-size: 16px;
+      }
+      .footer {
+        background-color: rgba(255, 255, 255, 0.02);
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 24px 32px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 12px;
+        color: #475569;
+        line-height: 1.6;
+      }
+      .footer a {
+        color: #6366f1;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="container">
+        <div class="header">🔥 Pro offer</div>
+        <div class="body">
+          <p class="greeting">{{ username }},</p>
+          <p class="text">
+            You've been using {{ app_name }} for 2 weeks. Ready to go further?
+            Here's what <strong>Pro</strong> unlocks:
+          </p>
+          <div class="features">
+            <div class="feature">
+              📊 <strong>30 analyses/month</strong> (vs 5 on Free)
+            </div>
+            <div class="feature">
+              ⏱️ <strong>Videos up to 2h</strong> (vs 15min)
+            </div>
+            <div class="feature">
+              🔍 <strong>Automatic fact-check</strong> with verified sources
+            </div>
+            <div class="feature">
+              🧠 <strong>Mind maps</strong> generated on the fly
+            </div>
+            <div class="feature">
+              🎙️ <strong>Voice chat</strong> with your analyses
+            </div>
+            <div class="feature">
+              📄 <strong>PDF export</strong> + DOCX + Markdown
+            </div>
+          </div>
+          <div class="price-box">
+            <p class="price">
+              {{ pro_price }}<span style="font-size: 18px; color: #94a3b8;"
+                >/mo</span
+              >
+            </p>
+            <p class="price-sub">No commitment · Cancel in 1 click</p>
+          </div>
+          <div class="cta-wrap">
+            <a href="{{ frontend_url }}/upgrade" class="cta">Go Pro</a>
+          </div>
+          <p
+            class="text"
+            style="font-size: 13px; color: #64748b; text-align: center;"
+          >
+            Or go Expert ({{ expert_price }}/mo) for 100 analyses + unlimited
+            voice chat.
+          </p>
+        </div>
+        {% include "_partials/footer_en.html" %}
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+- [ ] **Step 13: Smoke test render des 10 templates**
+
+```bash
+cd backend/src && python -c "
+from services.email_service import email_service
+ctx = {
+    'username': 'Maxime', 'app_name': 'DeepSight', 'frontend_url': 'https://deepsightsynthesis.com',
+    'pro_price': '9,99 €', 'expert_price': '19,99 €',
+    'unsubscribe_url': 'https://x/u/abc', 'single_unsubscribe_url': 'https://x/u/abc',
+    'preferences_url': 'https://x/p', 'current_year': '2026'
+}
+for k in ['welcome', 'tip_first_analysis', 'feature_archive', 'social_proof', 'upgrade_nudge']:
+    for lang in ['fr', 'en']:
+        h = email_service._render(f'{k}_{lang}.html', **ctx)
+        assert 'Maxime' in h, f'{k}_{lang} missing username'
+        assert '{{' not in h, f'{k}_{lang} unrendered Jinja'
+print('All 10 templates render OK')
+"
+```
+
+Expected: `All 10 templates render OK`
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add backend/src/templates/emails/_partials/footer_fr.html backend/src/templates/emails/_partials/footer_en.html backend/src/templates/emails/welcome_fr.html backend/src/templates/emails/welcome_en.html backend/src/templates/emails/tip_first_analysis_fr.html backend/src/templates/emails/tip_first_analysis_en.html backend/src/templates/emails/feature_archive_fr.html backend/src/templates/emails/feature_archive_en.html backend/src/templates/emails/social_proof_fr.html backend/src/templates/emails/social_proof_en.html backend/src/templates/emails/upgrade_nudge_fr.html backend/src/templates/emails/upgrade_nudge_en.html
+git commit -m "feat(email): add 5 welcome series templates in FR + EN with shared footer partial"
+```
+
+---
+
+### Task 7: Router `email/router.py` — webhook Resend + unsubscribe + preferences
+
+**Files:**
+
+- Create: `backend/src/email/__init__.py`
+- Create: `backend/src/email/router.py`
+- Test: `backend/tests/email/__init__.py`
+- Test: `backend/tests/email/test_webhook_resend.py`
+
+- [ ] **Step 1: Écrire le test webhook**
+
+```python
+# backend/tests/email/test_webhook_resend.py
+"""Tests for Resend webhook signature verification + event ingestion."""
+
+import json
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from db.database import EmailEvent
+from email.router import _verify_resend_signature
+
+
+def test_signature_verify_valid():
+    secret = "whsec_test"
+    payload = b'{"type":"email.delivered"}'
+    # Simulate svix-style HMAC
+    import hmac, hashlib
+    sig = "v1," + hmac.new(secret.encode(), b"id.timestamp." + payload, hashlib.sha256).hexdigest()
+    assert _verify_resend_signature(payload, sig, "id", "timestamp", secret) is True
+
+
+def test_signature_verify_invalid():
+    assert _verify_resend_signature(b"data", "v1,deadbeef", "id", "ts", "secret") is False
+
+
+@pytest.mark.asyncio
+async def test_webhook_inserts_event(async_client, db_session, test_user, monkeypatch):
+    monkeypatch.setenv("RESEND_WEBHOOK_SECRET", "whsec_test")
+    payload = {
+        "type": "email.delivered",
+        "data": {
+            "email_id": "msg_abc",
+            "to": [test_user.email],
+            "tags": [{"name": "template_key", "value": "welcome"}, {"name": "user_id", "value": str(test_user.id)}],
+        },
+    }
+    body = json.dumps(payload).encode()
+    import hmac, hashlib
+    sig = "v1," + hmac.new(b"whsec_test", b"id-1.1700000000." + body, hashlib.sha256).hexdigest()
+
+    response = await async_client.post(
+        "/api/email/webhook/resend",
+        content=body,
+        headers={
+            "svix-id": "id-1",
+            "svix-timestamp": "1700000000",
+            "svix-signature": sig,
+            "content-type": "application/json",
+        },
+    )
+    assert response.status_code == 200
+    result = await db_session.execute(
+        select(EmailEvent).where(EmailEvent.resend_message_id == "msg_abc")
+    )
+    rows = result.scalars().all()
+    assert len(rows) == 1
+    assert rows[0].event_type == "delivered"
+    assert rows[0].template_key == "welcome"
+```
+
+- [ ] **Step 2: Run test (must FAIL)**
+
+```bash
+cd backend && python -m pytest tests/email/test_webhook_resend.py -v
+```
+
+Expected: ImportError on `email.router`.
+
+- [ ] **Step 3: Implémenter le router**
+
+```python
+# backend/src/email/__init__.py
+```
+
+```python
+# backend/src/email/router.py
+"""Email-related public endpoints: Resend webhook + unsubscribe + preferences."""
+
+import hashlib
+import hmac
+import json
+import os
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request, Depends, status
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import get_current_user
+from core.config import FRONTEND_URL
+from core.logging import logger
+from db.database import EmailEvent, User, get_session
+from services.email_sequences import cancel_marketing_emails
+from services.email_unsubscribe import (
+    UnsubscribeTokenInvalid,
+    verify_unsubscribe_token,
+)
+
+router = APIRouter(prefix="/api/email", tags=["email"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Webhook signature verification (Resend uses svix)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _verify_resend_signature(
+    body: bytes,
+    signature_header: str,
+    svix_id: str,
+    svix_timestamp: str,
+    secret: str,
+) -> bool:
+    """Verify svix-style webhook signature.
+
+    Format: 'v1,<hex>'  where hex = HMAC-SHA256(secret, f'{svix_id}.{svix_timestamp}.{body}')
+    """
+    try:
+        scheme, hex_sig = signature_header.split(",", 1)
+        if scheme != "v1":
+            return False
+        secret_bytes = secret.encode("utf-8") if not secret.startswith("whsec_") else secret[len("whsec_") :].encode("utf-8")
+        # Resend signs the raw secret (with or without prefix); we strip whsec_ for HMAC
+        signed_data = f"{svix_id}.{svix_timestamp}.".encode("utf-8") + body
+        expected = hmac.new(secret_bytes, signed_data, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(hex_sig, expected)
+    except (ValueError, Exception):
+        return False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /api/email/webhook/resend — event tracking
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Event type mapping (Resend event types → our EmailEvent.event_type)
+RESEND_EVENT_MAP = {
+    "email.sent": "sent",
+    "email.delivered": "delivered",
+    "email.delivery_delayed": "delayed",
+    "email.opened": "opened",
+    "email.clicked": "clicked",
+    "email.bounced": "bounced",
+    "email.complained": "complained",
+}
+
+
+@router.post("/webhook/resend")
+async def resend_webhook(request: Request, db: AsyncSession = Depends(get_session)):
+    """Receive Resend events (delivered/opened/clicked/etc.) and persist them.
+
+    See: https://resend.com/docs/dashboard/webhooks/introduction
+    Signature scheme: svix (https://docs.svix.com/receiving/verifying-payloads/how-manual)
+    """
+    body = await request.body()
+    secret = os.getenv("RESEND_WEBHOOK_SECRET", "")
+    if not secret:
+        logger.warning("Resend webhook called but RESEND_WEBHOOK_SECRET not configured")
+        raise HTTPException(status_code=503, detail="Webhook not configured")
+
+    sig = request.headers.get("svix-signature", "")
+    svix_id = request.headers.get("svix-id", "")
+    svix_ts = request.headers.get("svix-timestamp", "")
+
+    if not _verify_resend_signature(body, sig, svix_id, svix_ts, secret):
+        logger.warning("Invalid Resend webhook signature", extra={"svix_id": svix_id})
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
+    event_type_resend = payload.get("type", "")
+    event_type = RESEND_EVENT_MAP.get(event_type_resend)
+    if event_type is None:
+        logger.info("Ignoring unknown Resend event type", extra={"type": event_type_resend})
+        return {"status": "ignored"}
+
+    data = payload.get("data", {})
+    message_id = data.get("email_id") or data.get("id")
+    tags = data.get("tags") or []
+    tag_dict = {t.get("name"): t.get("value") for t in tags if isinstance(t, dict)}
+
+    template_key = tag_dict.get("template_key", "unknown")
+    user_id_str = tag_dict.get("user_id")
+    user_id = int(user_id_str) if user_id_str and user_id_str.isdigit() else None
+
+    event = EmailEvent(
+        user_id=user_id,
+        template_key=template_key,
+        event_type=event_type,
+        resend_message_id=message_id,
+        event_metadata={"raw": data},
+    )
+    db.add(event)
+
+    # Auto-handle complained/bounced → unsubscribe user from marketing
+    if event_type in ("complained", "bounced") and user_id is not None:
+        result = await db.execute(select(User).where(User.id == user_id))
+        user = result.scalar_one_or_none()
+        if user is not None:
+            prefs = user.preferences or {}
+            prefs["marketing_emails_consent"] = False
+            user.preferences = prefs
+            await cancel_marketing_emails(db, user_id, reason=f"resend_{event_type}")
+
+    await db.commit()
+    return {"status": "ok"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /api/email/unsubscribe?token=... — token-based public unsubscribe
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/unsubscribe")
+async def unsubscribe(token: str, db: AsyncSession = Depends(get_session)):
+    """Public endpoint reached by clicking footer link. No auth required (signed token)."""
+    try:
+        user_id, template_key = verify_unsubscribe_token(token)
+    except UnsubscribeTokenInvalid:
+        return RedirectResponse(url=f"{FRONTEND_URL}/email/unsubscribe?status=invalid")
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        return RedirectResponse(url=f"{FRONTEND_URL}/email/unsubscribe?status=not_found")
+
+    prefs = user.preferences or {}
+    prefs["marketing_emails_consent"] = False
+    user.preferences = prefs
+    await cancel_marketing_emails(db, user_id, reason=f"user_unsubscribed_via_link_{template_key}")
+
+    db.add(
+        EmailEvent(
+            user_id=user_id,
+            template_key=template_key,
+            event_type="unsubscribed",
+            event_metadata={"via": "footer_link"},
+        )
+    )
+    await db.commit()
+    return RedirectResponse(url=f"{FRONTEND_URL}/email/unsubscribe?status=ok")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET/POST /api/email/preferences — authenticated preferences page
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class EmailPreferencesIn(BaseModel):
+    marketing_emails_consent: bool
+
+
+@router.get("/preferences")
+async def get_preferences(user: User = Depends(get_current_user)):
+    prefs = user.preferences or {}
+    return {
+        "marketing_emails_consent": prefs.get("marketing_emails_consent", True),
+        "email": user.email,
+    }
+
+
+@router.post("/preferences", status_code=status.HTTP_200_OK)
+async def update_preferences(
+    data: EmailPreferencesIn,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    prefs = user.preferences or {}
+    prefs["marketing_emails_consent"] = data.marketing_emails_consent
+    user.preferences = prefs
+
+    # Cascade: if user opts out, cancel pending marketing
+    if not data.marketing_emails_consent:
+        await cancel_marketing_emails(db, user.id, reason="user_pref_opt_out")
+
+    await db.commit()
+    return {"status": "ok"}
+```
+
+- [ ] **Step 4: Inclure le router dans main.py**
+
+Ouvrir `backend/src/main.py` et trouver où les autres routers sont inclus (`grep -n "app.include_router" backend/src/main.py | head -3`). Ajouter à proximité (juste après `auth.router` par exemple) :
+
+```python
+from email.router import router as email_router
+app.include_router(email_router)
+```
+
+⚠️ Attention : `email` collidera avec le module stdlib `email`. Préférer renommer en `emails/router.py` (dossier `emails/` au pluriel) pour éviter l'ambiguïté. Si tu choisis cette voie, mets à jour tous les imports en conséquence (Task 4 ne change pas, mais les Steps 1, 3 et 4 ci-dessus utilisent `from emails.router import router as email_router` et `tests/emails/test_webhook_resend.py`).
+
+**Décision recommandée : utiliser `emails/` (pluriel) pour éviter shadow du module stdlib `email`.** Renommer toutes les références à `backend/src/email/` en `backend/src/emails/` et tests `backend/tests/email/` en `backend/tests/emails/`.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd backend && python -m pytest tests/emails/test_webhook_resend.py -v
+```
+
+Expected: 3 tests passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/emails/ backend/tests/emails/ backend/src/main.py
+git commit -m "feat(email): add Resend webhook router with svix signature verification + unsubscribe endpoint"
+```
+
+---
+
+### Task 8: Brancher `schedule_welcome_sequence` sur la confirmation email
+
+**Files:**
+
+- Modify: `backend/src/auth/router.py` (lignes 223-228 — bloc welcome email)
+
+- [ ] **Step 1: Lire le bloc actuel**
+
+Lignes 223-228 de `backend/src/auth/router.py` :
+
+```python
+    # 📧 Send welcome email after successful verification
+    if EMAIL_CONFIG.get("ENABLED"):
+        try:
+            await send_welcome_email(user.email, user.username)
+        except Exception:
+            pass  # Non-blocking — don't fail verification if email fails
+```
+
+- [ ] **Step 2: Remplacer par le scheduling complet**
+
+```python
+    # 📧 Schedule full welcome sequence after successful verification
+    # - J+0 welcome (transactional, sent immediately by dispatcher)
+    # - J+1 tip_first_analysis
+    # - J+3 feature_archive
+    # - J+7 social_proof (only if user.plan == 'free' at send time)
+    # - J+14 upgrade_nudge (only if user.plan == 'free' at send time)
+    if EMAIL_CONFIG.get("ENABLED"):
+        try:
+            from services.email_sequences import schedule_welcome_sequence
+
+            await schedule_welcome_sequence(session, user)
+        except Exception as e:
+            from core.logging import logger as _log
+
+            _log.error(f"Failed to schedule welcome sequence: {e}")
+            # Non-blocking — don't fail verification if scheduling fails
+```
+
+- [ ] **Step 3: Run auth tests pour vérifier non-régression**
+
+```bash
+cd backend && python -m pytest tests/auth/ tests/test_auth_flow.py -v
+```
+
+Expected: tous les tests auth passent (ils n'asseront pas l'envoi d'email — juste que `verify_email` ne casse pas).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/auth/router.py
+git commit -m "feat(email): schedule full welcome sequence at email verification (not just J+0)"
+```
+
+---
+
+### Task 9: APScheduler — remplacer `_scheduled_onboarding` par `_scheduled_email_dispatch`
+
+**Files:**
+
+- Modify: `backend/src/main.py` (lignes 677-718)
+
+- [ ] **Step 1: Lire le bloc actuel pour voir le pattern Redis-lock**
+
+```bash
+sed -n '677,718p' backend/src/main.py
+```
+
+- [ ] **Step 2: Remplacer la fonction et le scheduler.add_job**
+
+Remplacer le bloc lignes 677-718 par :
+
+```python
+        # 📧 Email dispatch job (every 5 min — sends due scheduled emails)
+        from apscheduler.triggers.interval import IntervalTrigger as _IT
+
+        async def _scheduled_email_dispatch():
+            """Process due scheduled emails — Redis lock to avoid multi-worker dup."""
+            try:
+                lock_acquired = False
+                try:
+                    from core.cache import cache_service
+
+                    if hasattr(cache_service, "backend") and hasattr(cache_service.backend, "redis"):
+                        redis = cache_service.backend.redis
+                        lock_acquired = await redis.set(
+                            "deepsight:lock:email_dispatch", "1", nx=True, ex=240
+                        )
+                    else:
+                        lock_acquired = True
+                except Exception:
+                    lock_acquired = True
+
+                if not lock_acquired:
+                    return
+
+                from db.database import get_session as _get_sess
+
+                async for db in _get_sess():
+                    from services.email_sequences import process_scheduled_emails
+
+                    stats = await process_scheduled_emails(db, max_per_run=50)
+                    logger.info("Email dispatch processed", extra=stats)
+                    break
+            except Exception as e:
+                logger.error(f"Email dispatch job failed: {e}")
+
+        scheduler.add_job(
+            _scheduled_email_dispatch,
+            _IT(minutes=5),
+            id="email_dispatch",
+            name="Scheduled email dispatcher",
+            replace_existing=True,
+        )
+        logger.info("Email dispatch scheduler registered (every 5 min)")
+```
+
+⚠️ Conserver l'ancien job `onboarding_emails` au moins 1 release pour la rétrocompatibilité avec les jobs déjà en file (`onboarding_email_log`). Marquer comme deprecated dans son log.
+
+- [ ] **Step 3: Smoke test (le serveur doit démarrer sans erreur)**
+
+```bash
+cd backend/src && timeout 8 python -c "
+import asyncio
+from main import app
+print('App loaded:', app.title)
+"
+```
+
+Expected: `App loaded: DeepSight Synthesis API` (ou similaire)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/main.py
+git commit -m "feat(email): swap onboarding cron for date-based email_dispatch (every 5 min)"
+```
+
+---
+
+### Task 10: Cancel marketing on Stripe upgrade webhook
+
+**Files:**
+
+- Modify: `backend/src/billing/router.py` (au handler `subscription.created` ou `checkout.session.completed`)
+
+- [ ] **Step 1: Trouver le handler Stripe approprié**
+
+```bash
+grep -n "subscription.created\|checkout.session.completed\|invoice.paid" backend/src/billing/router.py | head -5
+```
+
+- [ ] **Step 2: Localiser la fonction qui upgrade le `user.plan` à `pro` ou `expert`**
+
+```bash
+grep -n "user.plan = \|user\.plan =\|\"pro\"\|set.*plan" backend/src/billing/router.py | head -10
+```
+
+Expected: trouver l'endroit où `user.plan` passe de "free" à "pro"/"plus" après paiement.
+
+- [ ] **Step 3: Ajouter l'appel `cancel_marketing_emails` après le set du plan**
+
+À côté de l'assignation `user.plan = "pro"` (ou similaire), insérer :
+
+```python
+                # 📧 Cancel pending marketing emails (J+7, J+14) since user upgraded
+                try:
+                    from services.email_sequences import cancel_marketing_emails
+
+                    await cancel_marketing_emails(
+                        db, user.id, reason=f"upgraded_to_{user.plan}"
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to cancel marketing emails: {e}")
+```
+
+- [ ] **Step 4: Run billing tests**
+
+```bash
+cd backend && python -m pytest tests/test_billing_webhooks.py -v
+```
+
+Expected: tests existants passent (la nouvelle logique est entourée d'un try/except, non bloquante).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/billing/router.py
+git commit -m "feat(email): cancel marketing sequence when user upgrades to paid plan"
+```
+
+---
+
+### Task 11: Frontend — pages unsubscribe + preferences + analytics events
+
+**Files:**
+
+- Create: `frontend/src/pages/EmailUnsubscribePage.tsx`
+- Create: `frontend/src/pages/EmailPreferencesPage.tsx`
+- Modify: `frontend/src/services/api.ts` (ajouter 3 méthodes)
+- Modify: `frontend/src/services/analytics.ts` (ajouter `trackEmailEvent`)
+- Modify: `frontend/src/App.tsx` ou router (ajouter 2 routes)
+
+- [ ] **Step 1: Ajouter les méthodes dans `api.ts`**
+
+```bash
+grep -n "export const api\|export class\|api\.unsubscribe\|getEmailPreferences" frontend/src/services/api.ts | head -5
+```
+
+Repérer le pattern (probablement `export const api = { ... }`). Ajouter les 3 méthodes :
+
+```typescript
+// frontend/src/services/api.ts — append au bon endroit
+async unsubscribeEmail(token: string): Promise<{ status: string }> {
+  const res = await fetch(`${API_URL}/api/email/unsubscribe?token=${encodeURIComponent(token)}`, {
+    method: "GET",
+    redirect: "follow",
+  });
+  // Backend redirects to /email/unsubscribe?status=ok|invalid|not_found
+  const url = new URL(res.url);
+  return { status: url.searchParams.get("status") || "unknown" };
+},
+
+async getEmailPreferences(): Promise<{ marketing_emails_consent: boolean; email: string }> {
+  const res = await fetchWithAuth(`${API_URL}/api/email/preferences`);
+  if (!res.ok) throw new Error("Failed to fetch preferences");
+  return res.json();
+},
+
+async updateEmailPreferences(consent: boolean): Promise<{ status: string }> {
+  const res = await fetchWithAuth(`${API_URL}/api/email/preferences`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ marketing_emails_consent: consent }),
+  });
+  if (!res.ok) throw new Error("Failed to update preferences");
+  return res.json();
+},
+```
+
+⚠️ Adapter les noms `fetchWithAuth` / `API_URL` aux conventions exactes utilisées dans `api.ts` (regarder une autre méthode existante pour copier le pattern).
+
+- [ ] **Step 2: Ajouter `trackEmailEvent` dans `analytics.ts`**
+
+```typescript
+// frontend/src/services/analytics.ts — append à l'export par défaut
+
+export const trackEmailEvent = (
+  event:
+    | "email_link_clicked"
+    | "email_unsubscribe_completed"
+    | "email_preferences_changed",
+  metadata: Record<string, unknown> = {},
+) => {
+  if (!posthog.has_opted_in_capturing()) return;
+  posthog.capture(event, {
+    ...metadata,
+    source: "email_funnel",
+  });
+};
+
+// Auto-capture if URL has utm_source=email
+export const captureEmailLandingIfPresent = () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("utm_source") === "email") {
+    trackEmailEvent("email_link_clicked", {
+      utm_campaign: params.get("utm_campaign"),
+      utm_medium: params.get("utm_medium"),
+    });
+  }
+};
+```
+
+- [ ] **Step 3: Créer `EmailUnsubscribePage.tsx`**
+
+```tsx
+// frontend/src/pages/EmailUnsubscribePage.tsx
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { trackEmailEvent } from "../services/analytics";
+
+export default function EmailUnsubscribePage() {
+  const [params] = useSearchParams();
+  const status = params.get("status");
+  const token = params.get("token");
+  const [resolved, setResolved] = useState<string | null>(status);
+
+  useEffect(() => {
+    if (status) {
+      // Backend already handled it via redirect
+      if (status === "ok") trackEmailEvent("email_unsubscribe_completed");
+      return;
+    }
+    if (!token) return;
+    // Direct hit (no backend redirect path) — call API
+    fetch(`/api/email/unsubscribe?token=${encodeURIComponent(token)}`)
+      .then((r) => {
+        const u = new URL(r.url);
+        const s = u.searchParams.get("status") || "unknown";
+        setResolved(s);
+        if (s === "ok") trackEmailEvent("email_unsubscribe_completed");
+      })
+      .catch(() => setResolved("error"));
+  }, [token, status]);
+
+  if (resolved === "ok") {
+    return (
+      <div
+        style={{
+          maxWidth: 480,
+          margin: "120px auto",
+          textAlign: "center",
+          padding: 32,
+        }}
+      >
+        <h1 style={{ fontSize: 28 }}>Vous êtes désinscrit</h1>
+        <p style={{ color: "#94a3b8", marginTop: 12 }}>
+          Vous ne recevrez plus d'emails marketing de DeepSight. Les emails
+          transactionnels (vérification, paiement, etc.) restent activés.
+        </p>
+        <a href="/email/preferences" style={{ color: "#6366f1" }}>
+          Gérer mes préférences
+        </a>
+      </div>
+    );
+  }
+
+  if (resolved === "invalid" || resolved === "error") {
+    return (
+      <div
+        style={{
+          maxWidth: 480,
+          margin: "120px auto",
+          textAlign: "center",
+          padding: 32,
+        }}
+      >
+        <h1>Lien invalide</h1>
+        <p style={{ color: "#94a3b8" }}>
+          Ce lien de désinscription n'est pas reconnu. Connectez-vous pour gérer
+          vos préférences.
+        </p>
+        <a href="/email/preferences" style={{ color: "#6366f1" }}>
+          Mes préférences
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ textAlign: "center", marginTop: 120 }}>
+      Désinscription en cours…
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Créer `EmailPreferencesPage.tsx`**
+
+```tsx
+// frontend/src/pages/EmailPreferencesPage.tsx
+import { useEffect, useState } from "react";
+import { api } from "../services/api";
+import { trackEmailEvent } from "../services/analytics";
+
+export default function EmailPreferencesPage() {
+  const [consent, setConsent] = useState<boolean | null>(null);
+  const [email, setEmail] = useState<string>("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    api
+      .getEmailPreferences()
+      .then((r) => {
+        setConsent(r.marketing_emails_consent);
+        setEmail(r.email);
+      })
+      .catch(() => setConsent(true));
+  }, []);
+
+  const toggle = async () => {
+    if (consent === null) return;
+    setSaving(true);
+    const next = !consent;
+    try {
+      await api.updateEmailPreferences(next);
+      setConsent(next);
+      trackEmailEvent("email_preferences_changed", {
+        marketing_emails_consent: next,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 560, margin: "80px auto", padding: 32 }}>
+      <h1 style={{ fontSize: 28, marginBottom: 8 }}>Préférences email</h1>
+      <p style={{ color: "#94a3b8" }}>{email}</p>
+
+      <div
+        style={{
+          marginTop: 32,
+          padding: 24,
+          background: "rgba(255,255,255,0.04)",
+          borderRadius: 12,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <div>
+            <h3 style={{ margin: 0 }}>Emails marketing</h3>
+            <p style={{ color: "#94a3b8", fontSize: 13, margin: "4px 0 0" }}>
+              Astuces, nouveautés, offres Pro. Décochez pour ne plus les
+              recevoir.
+            </p>
+          </div>
+          <label
+            style={{
+              position: "relative",
+              display: "inline-block",
+              width: 50,
+              height: 28,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={consent ?? true}
+              onChange={toggle}
+              disabled={saving || consent === null}
+              style={{ opacity: 0, width: 0, height: 0 }}
+            />
+            <span
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                background: consent ? "#6366f1" : "#475569",
+                borderRadius: 14,
+                cursor: "pointer",
+                transition: "0.2s",
+              }}
+            />
+            <span
+              style={{
+                position: "absolute",
+                top: 3,
+                left: consent ? 25 : 3,
+                width: 22,
+                height: 22,
+                background: "#fff",
+                borderRadius: "50%",
+                transition: "0.2s",
+              }}
+            />
+          </label>
+        </div>
+      </div>
+
+      <p style={{ marginTop: 24, fontSize: 13, color: "#64748b" }}>
+        Les emails transactionnels (vérification, paiement, alertes essai)
+        restent toujours activés.
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Ajouter les routes**
+
+Ouvrir `frontend/src/App.tsx` (ou le fichier de routing principal — `grep -n "Route\|Routes" frontend/src/App.tsx | head -5`). Ajouter les imports lazy :
+
+```tsx
+const EmailUnsubscribePage = lazy(() => import("./pages/EmailUnsubscribePage"));
+const EmailPreferencesPage = lazy(() => import("./pages/EmailPreferencesPage"));
+```
+
+Et les routes (la première publique, la seconde sous protected layout) :
+
+```tsx
+<Route path="/email/unsubscribe" element={<EmailUnsubscribePage />} />;
+{
+  /* dans la zone authentifiée */
+}
+<Route path="/email/preferences" element={<EmailPreferencesPage />} />;
+```
+
+- [ ] **Step 6: Lint + typecheck frontend**
+
+```bash
+cd frontend && npm run typecheck && npm run lint
+```
+
+Expected: 0 erreur.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/EmailUnsubscribePage.tsx frontend/src/pages/EmailPreferencesPage.tsx frontend/src/services/api.ts frontend/src/services/analytics.ts frontend/src/App.tsx
+git commit -m "feat(email): add unsubscribe + preferences pages with PostHog tracking"
+```
+
+---
+
+### Task 12: Tests d'intégration end-to-end + déploiement
+
+**Files:**
+
+- Modify: `backend/tests/services/test_email_sequences.py` (ajout test e2e dispatch)
+
+- [ ] **Step 1: Ajouter un test e2e dispatch**
+
+```python
+# Append à backend/tests/services/test_email_sequences.py
+
+@pytest.mark.asyncio
+async def test_dispatch_sends_due_emails_and_marks_sent(db_session, test_user, monkeypatch):
+    """End-to-end: schedule, set send_at to past, run dispatch, verify sent_at set + email queued."""
+    from datetime import datetime, timedelta, timezone
+    from sqlalchemy import update as _update
+    from db.database import EmailScheduled, EmailEvent
+    from services.email_sequences import (
+        schedule_welcome_sequence,
+        process_scheduled_emails,
+    )
+
+    # 1. Schedule the 5 emails
+    await schedule_welcome_sequence(db_session, test_user)
+    await db_session.flush()
+
+    # 2. Mock email_service.send_template_for_user → always success
+    sent_calls = []
+
+    async def fake_send(user, template_key):
+        sent_calls.append((user.id, template_key))
+        return True
+
+    from services.email_service import email_service
+    monkeypatch.setattr(email_service, "send_template_for_user", fake_send)
+
+    # 3. Force all 5 send_at to the past
+    past = datetime.now(timezone.utc) - timedelta(seconds=10)
+    await db_session.execute(
+        _update(EmailScheduled).where(EmailScheduled.user_id == test_user.id).values(send_at=past)
+    )
+    await db_session.flush()
+
+    # 4. Free user → all 5 should send
+    test_user.plan = "free"
+    test_user.preferences = {"marketing_emails_consent": True}
+    await db_session.flush()
+
+    stats = await process_scheduled_emails(db_session, max_per_run=10)
+
+    assert stats["sent"] == 5
+    assert stats["skipped_unsubscribed"] == 0
+    assert stats["skipped_paid_plan"] == 0
+    assert len(sent_calls) == 5
+
+    # 5. Re-run → 0 sent (idempotent)
+    stats2 = await process_scheduled_emails(db_session, max_per_run=10)
+    assert stats2["sent"] == 0
+```
+
+- [ ] **Step 2: Run all email tests**
+
+```bash
+cd backend && python -m pytest tests/services/test_email_sequences.py tests/services/test_email_unsubscribe.py tests/emails/test_webhook_resend.py -v
+```
+
+Expected: 8+ tests passed.
+
+- [ ] **Step 3: Run full backend suite (no regression)**
+
+```bash
+cd backend && python -m pytest tests/ -x --ignore=tests/test_analysis.py
+```
+
+Expected: ≥ 770/770 (existant 774 + nouveaux). Le `--ignore=test_analysis.py` est pour speed up — l'enlever en CI.
+
+- [ ] **Step 4: Commit final**
+
+```bash
+git add backend/tests/services/test_email_sequences.py
+git commit -m "test(email): add end-to-end dispatch + idempotence integration test"
+```
+
+- [ ] **Step 5: Préparer la PR**
+
+```bash
+git log --oneline -15
+gh pr create --title "feat(email): welcome series + transactional emails via Resend (Phase 9)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds Phase 9 email flows from Kimi audit 2026-04-29
+- Welcome series J+0 / J+1 / J+3 / J+7 / J+14 (FR + EN)
+- New tables `email_scheduled` (jobs) + `email_events` (Resend webhooks)
+- HMAC-SHA256 signed unsubscribe tokens
+- Resend webhook with svix signature verification
+- APScheduler job every 5 min (replaces hourly onboarding cron)
+- Cancellation cascade on Stripe upgrade + user opt-out
+- Frontend: `/email/unsubscribe` + `/email/preferences` pages
+- PostHog events: email_sent, email_delivered, email_opened, email_clicked, email_unsubscribed
+
+## Migration
+
+`alembic upgrade head` → 010_add_email_scheduling
+
+## Test plan
+
+- [ ] backend: `pytest tests/services/test_email_sequences.py tests/services/test_email_unsubscribe.py tests/emails/`
+- [ ] backend: `pytest tests/` full suite green (no regression)
+- [ ] manual: signup → verify email → check `email_scheduled` has 5 rows
+- [ ] manual: simulate Stripe upgrade webhook → check J+7/J+14 cancelled
+- [ ] manual: click unsubscribe link → check `marketing_emails_consent=false` in user.preferences
+- [ ] manual: send test webhook from Resend dashboard → check `email_events` row inserted
+- [ ] frontend: `/email/preferences` toggle works, displays correct state
+- [ ] frontend: `/email/unsubscribe?status=ok` displays confirmation
+
+## Deployment
+
+- Merge → push main → Hetzner auto-deploy (junglefarmz-deploy.service)
+- Migration runs automatically via entrypoint.sh (RUN_MIGRATIONS=true)
+- Add env var `RESEND_WEBHOOK_SECRET` in `/opt/deepsight/repo/.env.production` BEFORE deploy
+- Configure webhook URL in Resend dashboard: `https://api.deepsightsynthesis.com/api/email/webhook/resend`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+### Décisions à confirmer avec le porteur
+
+1. **Module name `email/` vs `emails/`** : `email` est un module stdlib Python. Pour éviter les import shadows, j'ai recommandé `emails/` (pluriel). À valider avant de coder, sinon tout renommage cassera les commits.
+
+2. **Pricing — code actuel vs prompt** : le prompt mentionne "Pro 8,99€ / Expert 19,99€" mais `billing/plan_config.py` a Pro 9,99€ et pas d'Expert. **Décision recommandée** : garder les templates avec `{{ pro_price }}` / `{{ expert_price }}` rendus depuis la SSOT `plan_config.py`. Si plan #3 pricing v2 est mergé avant ce plan, les nouveaux prix s'appliquent automatiquement. Si non, prix actuels s'affichent (cohérent backend). Pas de prix hardcodé.
+
+3. **Templates HTML dans repo vs Resend dashboard** : choix actuel = repo (Jinja2 + git versioning). Pros : versioning, code review, A/B testing futur. Cons : redéploiement requis pour changer un mot. **Décision recommandée** : repo (cohérent avec l'existant `welcome.html`, `payment_success.html`, etc.).
+
+4. **Tracking PostHog `email_*` events vs Resend dashboard** : l'audit Kimi mentionne PostHog pour analytics globales. **Décision recommandée** : double tracking — webhook Resend persiste dans `email_events` (pour admin dashboard + analyse historique en SQL) + frontend déclenche `email_link_clicked` quand user arrive avec `utm_source=email` (tracking conversion vers signup/upgrade). Resend dashboard reste accessible pour debug ponctuel.
+
+5. **Scheduler APScheduler vs Celery** : APScheduler **déjà en place** (cf. `requirements.txt:70`), avec Redis lock multi-worker. Celery introduirait une dépendance lourde (broker dédié, worker process). **Décision recommandée** : APScheduler (no-op architecturalement). Si volume dépasse 10k emails/jour, migrer vers Celery dans une PR séparée.
+
+6. **Séquence existante `onboarding_emails.py` (j1/j3/j5/j7/j10/j14)** : conserver ou supprimer ? Elle est différente de la nouvelle (5 emails + cancellation logic). **Décision recommandée** : DEPRECATER (logger warning au call) mais conserver le code 1 release pour rétrocompatibilité avec users déjà dans `onboarding_email_log`. Supprimer après validation 2 semaines en prod.
+
+7. **Cart abandon email** mentionné dans le prompt : pas inclus dans ce plan car nécessite `Stripe checkout.session.expired` webhook + `stripe_customer_id` mapping. **Décision recommandée** : sortir dans plan séparé "transactional-emails-stripe" qui inclura aussi `payment_failed retry`, `subscription_canceled`, `trial_ending_3_days`. Cohérent avec le scope strict de la Phase 9 audit.
+
+### Spec coverage check
+
+| Spec requirement                      | Task                                                                                                                                                                                       |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| J+0 welcome                           | Task 4 (SEQUENCE*TEMPLATES[0]) + Task 6 (welcome*\*.html)                                                                                                                                  |
+| J+1 tip                               | Task 4 (SEQUENCE*TEMPLATES[1]) + Task 6 (tip_first_analysis*\*.html)                                                                                                                       |
+| J+3 feature                           | Task 4 + Task 6 (feature*archive*\*.html)                                                                                                                                                  |
+| J+7 social proof if free              | Task 4 (`requires_free_plan=True`) + Task 6                                                                                                                                                |
+| J+14 upgrade nudge if free + no trial | Task 4 (`requires_free_plan=True`) + Task 6 — note: trial check is `plan == 'free'` ; trial detection nécessitera ajout dans Task 4 si `is_in_trial` flag existe sur User                  |
+| Désinscription par lien               | Task 3 (token) + Task 7 (endpoint) + Task 11 (frontend page)                                                                                                                               |
+| Tracking webhooks Resend              | Task 7 (`/webhook/resend`) + Task 1 (table `email_events`)                                                                                                                                 |
+| PostHog events                        | Task 11 (`trackEmailEvent`) — backend insère dans `email_events`, frontend ne re-send pas (le webhook backend → email_events est la SSOT)                                                  |
+| Anti-spam consent                     | Task 4 (`is_user_unsubscribed`) + Task 7 (preferences endpoint)                                                                                                                            |
+| i18n FR + EN                          | Task 5 (`send_template_for_user` lit `user.default_lang`) + Task 6 (10 templates)                                                                                                          |
+| Resend rate limit fix 429             | Réutilise `email_queue.py` + `email_rate_limiter.py` existants (2 req/s par worker, retry 429 exponentiel) — Task 4 (`process_scheduled_emails`) limite à 50/run + 0.5s sleep entre envois |
+| Cohérence pricing 8,99€/19,99€        | Task 5 (`fmt_price` lit SSOT `billing/plan_config.py`) + Task 6 (templates utilisent `{{ pro_price }}`)                                                                                    |
+| Tests pytest mock Resend              | Task 12 (e2e avec monkeypatch) + Task 4 (idempotence + cancellation) + Task 7 (webhook signature)                                                                                          |
+
+**Gap identifié — trial detection** : la spec mentionne "J+14 uniquement si toujours Free ET pas de trial actif". Le plan actuel filtre uniquement sur `plan == 'free'`. Si `User` a un flag `is_in_trial` ou `trial_end_date`, ajouter cette logique dans `process_scheduled_emails` (Task 4 Step 3, branche `requires_free_plan`). À vérifier avec porteur.
+
+### Placeholder scan
+
+- ✅ Pas de "TBD" / "TODO" / "implement later"
+- ✅ Pas de "add appropriate error handling" — chaque except est explicite
+- ✅ Pas de "similar to Task N" — code répété intégralement
+- ✅ Pas de "fill in details" — tous les templates HTML sont écrits intégralement
+- ⚠️ **Témoignage "Marie" est fictif** — flagué dans Task 6 Step 9 ; à remplacer si témoignage réel disponible
+
+### Type consistency
+
+- `EmailScheduled` (model) ↔ `email_scheduled` (table) ↔ `EmailScheduled.template_key` partout cohérent
+- `SequenceStep.template_key` (`"welcome"`, `"tip_first_analysis"`, etc.) cohérent avec noms de fichiers (`welcome_fr.html`)
+- `cancel_marketing_emails(db, user_id, reason)` signature stable Task 4 ↔ Task 7 ↔ Task 10
+- `event_metadata` au lieu de `metadata` (mot réservé SQLAlchemy déclaratif)
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-29-email-flows-resend.md`. Two execution options :**
+
+**1. Subagent-Driven (recommandé)** — Je dispatch un fresh subagent par task (12 au total), review entre tasks, itération rapide. Les tasks 6 (templates HTML) et 11 (frontend) peuvent partir en parallèle des tasks backend pour accélérer.
+
+**2. Inline Execution** — J'exécute les tasks dans cette session avec checkpoints à T1 (migration + models), T4 (services), T7 (router), T11 (frontend).
+
+**Quelle approche ?**

--- a/docs/superpowers/plans/2026-04-29-extension-chrome-store-optimization.md
+++ b/docs/superpowers/plans/2026-04-29-extension-chrome-store-optimization.md
@@ -1,0 +1,1278 @@
+# Extension Chrome Web Store Optimization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal :** Préparer la soumission de l'extension DeepSight (MV3 v2.0) au Chrome Web Store en livrant un manifeste optimisé, une fiche complète FR+EN, un brief précis pour 5 screenshots 1280×800, un script vidéo promo 30-60s et la checklist du process de soumission, avec l'objectif d'acquisition organique 1000+ users/jour.
+
+**Architecture :** Travail purement assets / contenu marketing / config. Le code de l'extension n'est PAS refactoré (manifest déjà MV3 valide, audit permissions déjà fait dans `extension/CHROME_WEB_STORE.md`). Le plan consolide ce qui existe (`extension/CHROME_WEB_STORE.md`, manifeste `public/manifest.json` v2.0, locales FR/EN) en 4 livrables versionnés sous `docs/` + 1 mise à jour ciblée du manifeste (description courte avec keywords) + corrections pricing v2.
+
+**Tech Stack :** Chrome Manifest V3 (déjà en place), webpack 5 build vers `dist/`, Chrome Web Store Developer Dashboard, contenu Markdown (FR + EN dual). Pas de nouvelle dépendance npm.
+
+---
+
+## Contexte préalable
+
+### État actuel vérifié
+
+- **Manifest** : `extension/public/manifest.json` v2.0.0, MV3, `minimum_chrome_version: 116`, déjà bien conçu (8 permissions standard + `audioCapture` optional + 12 host*permissions justifiés). Utilise `\_\_MSG*\*\_\_`pour i18n via`\_locales/{en,fr}/messages.json`.
+- **Doc existante** : `extension/CHROME_WEB_STORE.md` (203 lignes) contient déjà :
+  - Description courte EN (132 char OK)
+  - Description longue EN + FR (~2000 char chacune, pricing **OBSOLÈTE** — mentionne Plus 4,99 € / Pro 9,99 € au lieu de Pro 8,99 € / Expert 19,99 € v2)
+  - Justification de chaque permission (à reprendre tel quel — qualité haute)
+  - Single purpose statement
+  - Liste des 5 screenshots à préparer (titres seuls, pas de brief détaillé)
+- **Locales** : `_locales/{en,fr}/messages.json` ont 4 clés (extension_name, extension_short_name, extension_description, extension_action_title). Description actuelle FR : "Analyse YouTube et TikTok par IA : synthèses sourcées, fact-checking, flashcards, chat vocal. IA européenne par Mistral." (118 char, déjà bonne, contient keywords). EN équivalente. **Pas de modification nécessaire ici.**
+- **Privacy Policy** : `frontend/src/pages/PrivacyPolicy.tsx` existe, accessible sur `https://www.deepsightsynthesis.com/privacy`. SIRET + adresse listés. ⚠️ Doit être URL publique fonctionnelle au moment de la soumission — à valider en Task 7.
+- **Page post-install** : `frontend/src/pages/ExtensionWelcomePage.tsx` route `/extension-welcome` existe, contient déjà 3 STEPS + 4 FEATURES — bonne UX.
+- **Build** : `npm run build` → `dist/` (25 fichiers présents, manifest.json + sidepanel.html déjà buildés). `dist/` se charge directement dans `chrome://extensions`.
+- **Plans datés 2026-04-29** : un plan `audit-kimi-phase-0-seo-securite` et un plan `pricing-v2-stripe-grandfathering` cadrent le pricing v2 (Pro 8,99 € / Expert 19,99 €). Ce plan-ci NE doit PAS faire référence à l'ancien pricing.
+- **CLAUDE.md** mentionne : "🟢 Bas — Chrome Web Store submission (extension prête, pas soumise)".
+
+### Pricing v2 (à utiliser dans toutes les descriptions)
+
+| Plan       | Prix        | Quota analyses | Vidéos max |
+| ---------- | ----------- | -------------- | ---------- |
+| Découverte | 0 €         | 5 / mois       | 15 min     |
+| Pro        | **8,99 €**  | 30 / mois      | 2h         |
+| Expert     | **19,99 €** | 100 / mois     | 4h         |
+
+**Note** : `extension/CHROME_WEB_STORE.md` actuel utilise pricing v0 (Plus 4,99 € / Pro 9,99 €). À corriger en Task 4.
+
+### Contraintes Chrome Web Store (officielles)
+
+- **Compte Developer** : 5 USD lifetime, à créer sur https://chrome.google.com/webstore/devconsole.
+- **Description courte** : 132 caractères max.
+- **Description longue** : 16 000 caractères max (visé : 1500-2500 par langue).
+- **Screenshots** : 1280×800 ou 640×400 (1280×800 recommandé), PNG ou JPG, **3 minimum, 5 recommandés**.
+- **Promo video** : URL YouTube publique, optionnelle mais fortement recommandée pour ranking.
+- **Privacy Policy** : URL publique OBLIGATOIRE (déjà OK).
+- **Single Purpose** : déclaration obligatoire depuis MV3.
+- **Permissions justification** : chaque permission demandée doit être justifiée dans un champ dédié.
+- **Review time** : 1-7 jours. Refus possibles : permissions injustifiées, screenshots de mauvaise qualité, description trompeuse, tests fonctionnels échoués.
+
+### Décisions verrouillées
+
+1. **Pas de nouveau code applicatif** — manifest MV3 v2.0 actuel est déjà optimal, pas de refactor.
+2. **Documents livrés en FR + EN** dans `docs/`, parce que (a) Chrome Web Store accepte plusieurs locales, (b) audit Kimi cible aussi marché EN, (c) doc engineering reste en FR (CLAUDE.md règle).
+3. **Pas de production réelle** des screenshots ni de la vidéo dans ce plan : briefs détaillés livrés, production déléguée à Maxime/designer (ouvert dans self-review).
+4. **Pricing v2 strict** dans toutes les descriptions (Pro 8,99 € / Expert 19,99 €), même si CHROME_WEB_STORE.md actuel utilise v0.
+5. **CHROME_WEB_STORE.md historique conservé** : on archive l'ancienne version dans `extension/CHROME_WEB_STORE.legacy.md` (provenance) et le nouveau document canonique vit dans `docs/CHROME-WEB-STORE-LISTING.md`. Permet rollback et garde l'historique sans introduire de chemin recherchable obsolète.
+
+---
+
+## File Structure
+
+### Fichiers créés (5)
+
+| Fichier                                         | Rôle                                                                                                               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `docs/CHROME-WEB-STORE-LISTING.md`              | Fiche canonique : nom, descriptions FR+EN, catégorie, tags, single purpose, justifications permissions, pricing v2 |
+| `docs/CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md`    | Brief précis des 5 screenshots 1280×800 : décor, contenu, annotations, captures à prendre                          |
+| `docs/CHROME-WEB-STORE-VIDEO-SCRIPT.md`         | Storyboard + voice-over + visuels timing 30-60s                                                                    |
+| `docs/CHROME-WEB-STORE-SUBMISSION-CHECKLIST.md` | Checklist process de soumission (compte, ZIP, upload, review, rollout)                                             |
+| `extension/CHROME_WEB_STORE.legacy.md`          | Renommage de l'actuel `CHROME_WEB_STORE.md` (archive historique)                                                   |
+
+### Fichiers modifiés (3)
+
+| Fichier                                | Modification                                                                                                                                              |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `extension/CHROME_WEB_STORE.md`        | Remplacé par stub renvoyant vers `docs/CHROME-WEB-STORE-LISTING.md` (1 ligne + lien)                                                                      |
+| `extension/public/manifest.json`       | Aucune modif obligatoire — la description vient de `_locales/{en,fr}/messages.json`. Si description i18n contient encore prix obsolète, ajuster (Task 3). |
+| `frontend/src/pages/PrivacyPolicy.tsx` | Vérification + ajout section spécifique extension (permissions, données collectées) si manquante (Task 7)                                                 |
+
+### Fichiers vérifiés (lecture seule)
+
+- `extension/public/_locales/en/messages.json` — description EN
+- `extension/public/_locales/fr/messages.json` — description FR
+- `extension/dist/manifest.json` — copie buildée du manifest
+- `extension/icons/icon{16,32,48,128}.png` — icons multi-tailles (4 ✓)
+- `frontend/src/pages/ExtensionWelcomePage.tsx` — page post-install
+
+---
+
+## Tasks
+
+### Task 1 : Archiver l'ancien CHROME_WEB_STORE.md
+
+**Files :**
+
+- Renommer : `extension/CHROME_WEB_STORE.md` → `extension/CHROME_WEB_STORE.legacy.md`
+- Créer (stub) : `extension/CHROME_WEB_STORE.md`
+
+- [ ] **Step 1 : Archiver l'ancienne version**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git mv extension/CHROME_WEB_STORE.md extension/CHROME_WEB_STORE.legacy.md
+```
+
+- [ ] **Step 2 : Créer un stub redirigeant vers le nouveau document**
+
+Créer `extension/CHROME_WEB_STORE.md` avec contenu :
+
+```markdown
+# Chrome Web Store — Extension DeepSight
+
+> Document canonique déplacé : voir [docs/CHROME-WEB-STORE-LISTING.md](../docs/CHROME-WEB-STORE-LISTING.md).
+>
+> L'ancienne version (pricing v0 obsolète) est archivée dans [CHROME_WEB_STORE.legacy.md](./CHROME_WEB_STORE.legacy.md).
+```
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add extension/CHROME_WEB_STORE.md extension/CHROME_WEB_STORE.legacy.md
+git commit -m "chore(extension): archive CHROME_WEB_STORE.md to legacy, add stub pointer"
+```
+
+---
+
+### Task 2 : Créer docs/CHROME-WEB-STORE-LISTING.md (fiche canonique)
+
+**Files :**
+
+- Create : `docs/CHROME-WEB-STORE-LISTING.md`
+
+- [ ] **Step 1 : Créer le document complet FR+EN avec pricing v2**
+
+Contenu intégral :
+
+````markdown
+# Chrome Web Store Listing — DeepSight
+
+> Document canonique. Source des descriptions copiées dans le Developer Dashboard
+> au moment de la soumission. Maintenir ce fichier synchronisé avec
+> `extension/public/_locales/{en,fr}/messages.json` (description courte 132 char).
+
+**Version extension :** 2.0.0 (Manifest V3)
+**Dernière mise à jour :** 2026-04-29
+
+---
+
+## 1. Nom & identité
+
+| Champ                | Valeur                                        |
+| -------------------- | --------------------------------------------- |
+| Nom (EN)             | DeepSight - AI Video Analysis                 |
+| Nom (FR)             | DeepSight - Analyse vidéo IA                  |
+| Short name           | DeepSight                                     |
+| Catégorie principale | Productivité (Productivity)                   |
+| Catégorie secondaire | Éducation (Education)                         |
+| Tagline              | Ne subissez plus vos vidéos — interrogez-les. |
+| Site officiel        | https://www.deepsightsynthesis.com            |
+| Privacy Policy URL   | https://www.deepsightsynthesis.com/privacy    |
+| Email support        | maximeleparc3@gmail.com                       |
+
+---
+
+## 2. Description courte (132 char max)
+
+### EN (current in `_locales/en/messages.json`)
+
+```
+AI-powered YouTube & TikTok analysis: sourced summaries, fact-check, flashcards, voice chat. European AI by Mistral.
+```
+
+(118 caractères — OK)
+
+### FR (current in `_locales/fr/messages.json`)
+
+```
+Analyse YouTube et TikTok par IA : synthèses sourcées, fact-checking, flashcards, chat vocal. IA européenne par Mistral.
+```
+
+(122 caractères — OK)
+
+**Action requise** : aucune modif des messages.json — descriptions actuelles déjà optimisées avec keywords ranking ("YouTube", "TikTok", "IA", "synthèses sourcées", "fact-check", "flashcards", "chat vocal", "Mistral").
+
+---
+
+## 3. Description longue — EN
+
+```
+Tired of spending 1 hour watching a video for 30 useful seconds? DeepSight turns YouTube and TikTok into sourced, fact-checked analyses — directly from your browser, in one click.
+
+Unlike simple summarizers, DeepSight goes deeper: every key claim is verified against reliable web sources, and you get a structured analysis with timestamps, not just bullet points.
+
+KEY FEATURES (Side Panel, persistent across tabs):
+
+- AI-Powered Analysis: paste a video URL or detect it automatically — get a sourced summary with key insights, timestamps and critical evaluation in seconds
+- Contextual Chat: ask follow-up questions about any analyzed video — the AI responds with full video context and cited timestamps
+- Fact-Checking: claims are automatically verified against web sources (Pro plan and above)
+- Quick Chat: chat about any YouTube video without using credits — completely free, even on the free plan
+- Voice Chat: real-time voice conversation with the video's content (Expert plan, ElevenLabs)
+- 3 Analysis Modes: Accessible, Standard, Expert — adapts to your level
+- TikTok Support: analyze TikTok videos too, not just YouTube
+
+STUDY TOOLS (available on the web app deepsightsynthesis.com):
+
+- Auto-generated flashcards with FSRS spaced repetition (same algorithm as Anki)
+- Interactive quizzes from video content
+- Mind maps showing concept relationships (Pro)
+- Academic paper search from arXiv, Semantic Scholar, CrossRef, OpenAlex (Pro)
+- AI Debate — confront arguments from 2 videos on the same topic (unique feature, Pro)
+
+WHAT MAKES DEEPSIGHT DIFFERENT:
+
+1. Not a summarizer — a research platform. We verify, we do not just summarize.
+2. European AI (Mistral) — your data stays in Europe. GDPR compliant.
+3. One account, three platforms — Chrome extension + web app + iOS/Android, synced.
+4. No credit card required to start.
+
+FREE TO START:
+
+- 1 free analysis without an account (guest mode in the extension)
+- 5 analyses/month with a free account
+- Powerful free tier — chat, flashcards, history, fact-check on the web
+
+PLANS (current pricing):
+
+- Discovery (free): 5 analyses/month, 15-min videos, chat, flashcards, history 60d
+- Pro (€8.99/month): 30 analyses, 2h videos, fact-checking, mind maps, web search, PDF/DOCX export, playlists (3)
+- Expert (€19.99/month): 100 analyses, 4h videos, voice chat, deep research, playlists (10), priority queue
+
+14-day satisfaction guarantee on paid plans.
+
+Built by an independent European developer. Made in France.
+
+Website: https://www.deepsightsynthesis.com
+Privacy: https://www.deepsightsynthesis.com/privacy
+Support: maximeleparc3@gmail.com
+```
+
+Mots-clés naturels présents : YouTube summary, video analysis, fact-check, AI summary, study tool, transcript, flashcards, FSRS, spaced repetition, European AI, Mistral, GDPR, mind map, TikTok analysis.
+
+---
+
+## 4. Description longue — FR
+
+```
+Tu regardes 1 heure de vidéo pour 30 secondes utiles ? DeepSight transforme YouTube et TikTok en analyses sourcées et fact-checkées — directement depuis ton navigateur, en un clic.
+
+Contrairement aux simples résumeurs, DeepSight va plus loin : chaque affirmation clé est vérifiée avec des sources web fiables, et tu obtiens une synthèse structurée avec timecodes, pas juste des bullet points.
+
+FONCTIONNALITÉS CLÉS (Side Panel persistant Chrome) :
+
+- Analyse IA : colle un lien vidéo ou laisse l'extension détecter — obtiens une synthèse sourcée, points clés, timecodes et évaluation critique en quelques secondes
+- Chat contextuel : pose des questions sur n'importe quelle vidéo analysée — l'IA répond avec le contexte complet et cite les timecodes
+- Fact-checking : les affirmations sont vérifiées automatiquement avec des sources web (plan Pro et au-dessus)
+- Quick Chat : discute de n'importe quelle vidéo YouTube sans utiliser de crédits — gratuit, même sur le plan gratuit
+- Chat vocal : conversation vocale temps réel avec le contenu de la vidéo (plan Expert, ElevenLabs)
+- 3 modes d'analyse : Accessible, Standard, Expert — s'adapte à ton niveau
+- Support TikTok : analyse aussi les vidéos TikTok, pas seulement YouTube
+
+OUTILS D'ÉTUDE (sur l'app web deepsightsynthesis.com) :
+
+- Flashcards auto-générées avec répétition espacée FSRS (même algorithme qu'Anki)
+- Quiz interactifs générés à partir de la vidéo
+- Cartes mentales (mind maps) entre concepts (Pro)
+- Recherche de papiers académiques arXiv, Semantic Scholar, CrossRef, OpenAlex (Pro)
+- Débat IA — confronte les arguments de 2 vidéos sur le même sujet (fonctionnalité unique, Pro)
+
+CE QUI REND DEEPSIGHT DIFFÉRENT :
+
+1. Pas un résumeur — une plateforme de recherche. On vérifie, on ne résume pas seulement.
+2. IA européenne (Mistral) — tes données restent en Europe. RGPD-compliant.
+3. Un seul compte, trois plateformes — extension Chrome + web + iOS/Android, synchronisés.
+4. Sans carte bancaire pour démarrer.
+
+GRATUIT POUR COMMENCER :
+
+- 1 analyse gratuite sans compte (guest mode dans l'extension)
+- 5 analyses/mois avec un compte gratuit
+- Plan gratuit puissant — chat, flashcards, historique, fact-check sur le web
+
+PLANS (pricing actuel) :
+
+- Découverte (gratuit) : 5 analyses/mois, vidéos 15 min, chat, flashcards, historique 60 j
+- Pro (8,99 €/mois) : 30 analyses, vidéos 2h, fact-checking, cartes mentales, web search, export PDF/DOCX, playlists (3)
+- Expert (19,99 €/mois) : 100 analyses, vidéos 4h, chat vocal, recherche approfondie, playlists (10), file prioritaire
+
+Garantie satisfaction 14 jours sur les plans payants.
+
+Développé par un développeur indépendant européen. Made in France.
+
+Site web : https://www.deepsightsynthesis.com
+Vie privée : https://www.deepsightsynthesis.com/privacy
+Support : maximeleparc3@gmail.com
+```
+
+Personas ciblés : étudiants, chercheurs, journalistes, créateurs de contenu, formateurs, autodidactes.
+
+---
+
+## 5. Catégorie & tags
+
+- **Catégorie principale** : Productivity
+- **Catégorie secondaire** : Education
+- **Tags / mots-clés ranking** (utilisés dans description, pas un champ séparé sur Chrome Web Store) :
+  AI, productivity, YouTube, TikTok, summary, fact-check, flashcards, study, transcript, Mistral, European AI, video analysis, GDPR, FSRS, spaced repetition, research, academic.
+
+---
+
+## 6. Single Purpose Statement (champ dédié dans le CWS form)
+
+```
+DeepSight is an AI-powered analysis tool for YouTube and TikTok videos. Its single purpose is to help users understand, fact-check, and study video content via AI-generated summaries, contextual chat, flashcards, and an optional voice agent — all from a persistent Side Panel inside Chrome.
+```
+
+---
+
+## 7. Permissions justifications (champ dédié, une par permission)
+
+> Reprises telles quelles de l'audit `extension/CHROME_WEB_STORE.legacy.md` (déjà
+> validé). Maintenir alignées avec `extension/public/manifest.json`.
+
+### Standard permissions
+
+- **storage** — Persist authentication tokens (access + refresh), user preferences (UI language, voice settings), and a small cache of recent analyses for offline access. No tracking, no third-party sharing.
+- **activeTab** — Read the URL of the YouTube or TikTok video currently active in the user's tab so the user can trigger an AI analysis with one click. Only the video ID is sent to our backend; no DOM scraping is performed.
+- **tabs** — Detect URL changes (e.g. user navigates to a new YouTube video) to refresh the Side Panel context (video detected card, analysis state). Used solely on YouTube and TikTok.
+- **alarms** — Periodic background refresh of the OAuth access token (15-minute lifespan) using the refresh token, so the user does not need to re-login every 15 minutes.
+- **identity** — Used by `chrome.identity.launchWebAuthFlow()` to perform Google OAuth login. The flow opens the standard Google consent screen in a popup and returns an OAuth code we exchange server-side for a JWT.
+- **clipboardWrite** — Allow the user to copy generated content (summaries, fact-check results, flashcards) to the system clipboard with one click, from the Side Panel "Copy" buttons.
+- **sidePanel** — Display the DeepSight interface in Chrome's native Side Panel (Chrome 116+), persistent across tab switches. Toggle via Alt+Shift+D or the toolbar icon.
+- **offscreen** — Required by the ElevenLabs voice SDK on Chrome MV3 to host an offscreen document for audio capture and playback (service workers cannot access `getUserMedia` directly).
+
+### Optional permissions
+
+- **audioCapture** (optional, requested only when the user starts a voice chat session) — Capture microphone input for the ElevenLabs ConvAI voice agent. Audio is streamed directly to ElevenLabs over a secure WebSocket; no audio is persisted on our servers.
+
+### Host permissions
+
+- `https://www.youtube.com/*`, `https://youtube.com/*` — Detect the currently watched video and inject the optional content-script overlay showing the analyze button. No analytics, no DOM modification beyond the overlay.
+- `https://www.tiktok.com/*`, `https://tiktok.com/*`, `https://vm.tiktok.com/*`, `https://m.tiktok.com/*` — Same as YouTube, for TikTok video detection.
+- `https://www.deepsightsynthesis.com/*` — Cross-domain authentication sync between the extension and the web app, so a user logged in on the web is automatically logged in on the extension (and vice versa).
+- `https://api.deepsightsynthesis.com/*` — Backend API endpoints for analyses, chat, billing, voice sessions, etc.
+- `https://api.elevenlabs.io/*`, `wss://api.elevenlabs.io/*`, `https://*.elevenlabs.io/*`, `wss://*.elevenlabs.io/*` — ElevenLabs ConvAI voice chat over WebSocket. Required by the @elevenlabs/client SDK; CSP whitelist already restricts connect-src to these domains.
+
+---
+
+## 8. Données collectées (Privacy Practices form Chrome Web Store)
+
+À cocher dans le formulaire Privacy Practices du Developer Dashboard :
+
+| Catégorie                           | Collecté ? | Justification (champ dédié)                                                                                   |
+| ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| Personally identifiable information | Oui        | Email + nom (Google OAuth). Stockés en EU, RGPD-compliant.                                                    |
+| Health information                  | Non        |                                                                                                               |
+| Financial and payment information   | Non        | Aucun paiement traité par l'extension (Stripe géré sur web app uniquement)                                    |
+| Authentication information          | Oui        | JWT tokens stockés dans `chrome.storage.local`, jamais envoyés à des tiers                                    |
+| Personal communications             | Non        |                                                                                                               |
+| Location                            | Non        |                                                                                                               |
+| Web history                         | **Limité** | Uniquement URL de vidéo YouTube/TikTok que l'utilisateur choisit d'analyser. Pas de tracking en arrière-plan. |
+| User activity                       | Non        |                                                                                                               |
+| Website content                     | Non        | Le video ID seul est envoyé. Le scraping se fait server-side.                                                 |
+
+Déclarations à cocher :
+
+- [x] I do not sell or transfer user data to third parties, outside of the approved use cases.
+- [x] I do not use or transfer user data for purposes that are unrelated to my item's single purpose.
+- [x] I do not use or transfer user data to determine creditworthiness or for lending purposes.
+
+---
+
+## 9. Branding visuel
+
+- **Logo principal** : `extension/icons/icon128.png` (déjà présent, 128×128)
+- **Tagline** : "Ne subissez plus vos vidéos — interrogez-les."
+- **Couleurs** : Indigo `#6366f1`, Violet `#8b5cf6`, Cyan `#06b6d4`, fond `#0a0a0f`
+- **Style screenshots** : dark mode, glassmorphism, accent indigo/violet
+- **Badge** : 🇫🇷🇪🇺 "Vos données restent en Europe"
+
+---
+
+## 10. Cross-références
+
+- Brief screenshots : [CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md](./CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md)
+- Script vidéo promo : [CHROME-WEB-STORE-VIDEO-SCRIPT.md](./CHROME-WEB-STORE-VIDEO-SCRIPT.md)
+- Checklist soumission : [CHROME-WEB-STORE-SUBMISSION-CHECKLIST.md](./CHROME-WEB-STORE-SUBMISSION-CHECKLIST.md)
+- Manifeste source : `extension/public/manifest.json`
+- Locales : `extension/public/_locales/{en,fr}/messages.json`
+- Privacy Policy code : `frontend/src/pages/PrivacyPolicy.tsx`
+- Page post-install : `frontend/src/pages/ExtensionWelcomePage.tsx` (route `/extension-welcome`)
+````
+
+- [ ] **Step 2 : Vérifier que le fichier est créé et bien formé**
+
+Run : `wc -l C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-LISTING.md`
+Expected : > 200 lignes.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add docs/CHROME-WEB-STORE-LISTING.md
+git commit -m "docs(chrome-store): add canonical CWS listing FR+EN with pricing v2"
+```
+
+---
+
+### Task 3 : Vérifier `_locales/{en,fr}/messages.json` et confirmer descriptions courtes
+
+**Files :**
+
+- Read : `extension/public/_locales/en/messages.json`
+- Read : `extension/public/_locales/fr/messages.json`
+
+- [ ] **Step 1 : Vérifier longueur des descriptions courtes**
+
+Lire les deux fichiers et confirmer :
+
+- EN `extension_description.message` ≤ 132 caractères
+- FR `extension_description.message` ≤ 132 caractères
+
+État connu :
+
+- EN : "AI-powered YouTube & TikTok analysis: sourced summaries, fact-check, flashcards, voice chat. European AI by Mistral." → 118 caractères ✓
+- FR : "Analyse YouTube et TikTok par IA : synthèses sourcées, fact-checking, flashcards, chat vocal. IA européenne par Mistral." → 122 caractères ✓
+
+Si l'une dépasse 132 → modifier en supprimant un keyword secondaire (ex : retirer "voice chat"). Sinon, **aucune modification** nécessaire.
+
+- [ ] **Step 2 : Confirmer que le manifest n'a pas de description hardcodée obsolète**
+
+```bash
+grep -n "description" C:/Users/33667/DeepSight-Main/extension/public/manifest.json
+```
+
+Expected : seule ligne `"description": "__MSG_extension_description__"`. Pas de prix hardcodé. Aucune action.
+
+- [ ] **Step 3 : Pas de commit (vérification seule)**
+
+Si un fichier a été touché, commit :
+
+```bash
+git add extension/public/_locales/
+git commit -m "chore(extension): trim short description to <=132 chars for CWS"
+```
+
+Sinon, passer à Task 4.
+
+---
+
+### Task 4 : Créer docs/CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md (brief 5 screenshots)
+
+**Files :**
+
+- Create : `docs/CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md`
+
+- [ ] **Step 1 : Rédiger le brief complet**
+
+Contenu intégral :
+
+```markdown
+# Chrome Web Store — Brief Screenshots (5 × 1280×800)
+
+> Document de production. À donner au designer ou utilisable directement par
+> Maxime pour capturer les screenshots avec Chrome DevTools (mode device 1280×800).
+> Format : PNG, sans alpha, fond opaque. Texte des annotations en français,
+> traduction EN livrée en parallèle pour la fiche internationale.
+
+**Préparation environnement :**
+
+1. Browser : Chrome stable, fenêtre `1280 × 800` exactement (DevTools → Toggle Device → Responsive → custom 1280×800).
+2. Compte de démo : `demo@deepsightsynthesis.com` avec **plan Pro** activé (visualiser fact-check + mind maps).
+3. Mode dark uniquement (cohérence design system).
+4. Cacher les barres dev (DevTools fermé pendant capture).
+5. Privacy : flouter ou remplacer toutes les vraies adresses email/avatar par mockups.
+
+---
+
+## Screenshot 1 — Hero / Side Panel sur YouTube (analyse en cours)
+
+**Objectif** : montrer instantanément la promesse de valeur — un clic = analyse.
+
+**Décor :**
+
+- Page YouTube ouverte : vidéo de démo recommandée → un TED Talk ou une conférence éducative ~12 min (ex : "Inside the mind of a master procrastinator", Tim Urban).
+- Player YouTube visible à gauche ~60% de l'écran.
+- Side Panel DeepSight ouvert à droite ~40% de l'écran (mode persistent Chrome 116+).
+
+**Contenu Side Panel à afficher :**
+
+- Header DeepSight (logo + tagline mini).
+- Card "Vidéo détectée" avec thumbnail + titre vidéo.
+- Bouton primaire "Analyser cette vidéo" mis en évidence (hover state, glow indigo).
+- Sous le bouton : barre de progression à 35% avec label "Extraction du transcript…".
+- Pas de chat ouvert, pas de résultats — seulement le moment d'engagement.
+
+**Annotation overlay (bandeau bas, 1280×80) :**
+
+- Texte FR : "1 clic = analyse complète sourcée"
+- Texte EN (version internationale) : "1 click = full sourced analysis"
+- Police Inter Bold 32px, couleur #ffffff, fond gradient indigo→violet 80% opacity.
+
+**Fichier livré :** `screenshots/01-hero-youtube-sidebar.png` (1280×800).
+
+---
+
+## Screenshot 2 — Synthèse résultat avec timecodes
+
+**Objectif** : preuve concrète de la qualité de la synthèse.
+
+**Décor :**
+
+- Même vidéo YouTube en arrière-plan (cohérence visuelle).
+- Side Panel ouvert sur la vue "Résultats analyse".
+
+**Contenu Side Panel :**
+
+- Onglet actif "Synthèse" (parmi : Synthèse / Fact-check / Chat / Flashcards).
+- Titre vidéo + durée + plan utilisateur (badge "Pro").
+- Section "Points clés" avec 3-4 bullets concrets, chacun précédé d'un timecode cliquable (ex : `[02:14]`, `[05:42]`, `[09:18]`).
+- Section "Conclusion nuancée" avec 2-3 lignes.
+- Footer : `Sources : 3 références web vérifiées`.
+
+**Annotation overlay :**
+
+- FR : "Synthèse sourcée avec timecodes cliquables"
+- EN : "Sourced summary with clickable timestamps"
+
+**Fichier livré :** `screenshots/02-synthesis-timecodes.png` (1280×800).
+
+---
+
+## Screenshot 3 — Fact-check automatique (différenciateur clé)
+
+**Objectif** : montrer le différenciateur le plus fort vs concurrents (ils ne fact-checkent pas).
+
+**Décor :**
+
+- Side Panel ouvert sur l'onglet "Fact-check".
+
+**Contenu :**
+
+- Liste de 3 affirmations extraites de la vidéo, chacune avec :
+  - Citation textuelle entre guillemets (timecode `[mm:ss]`).
+  - Verdict coloré : `SOLIDE` (vert) / `PLAUSIBLE` (jaune) / `INCERTAIN` (orange).
+  - 1-2 lignes d'analyse.
+  - Nombre de sources vérifiées (ex : "4 sources concordantes").
+- Mix des verdicts : 1 SOLIDE, 1 PLAUSIBLE, 1 INCERTAIN — montre la nuance.
+
+**Annotation overlay :**
+
+- FR : "Fact-check automatique avec sources web"
+- EN : "Automatic fact-check with web sources"
+
+**Fichier livré :** `screenshots/03-factcheck.png` (1280×800).
+
+---
+
+## Screenshot 4 — Chat contextuel (engagement / rétention)
+
+**Objectif** : montrer l'interaction conversationnelle qui crée de la rétention.
+
+**Décor :**
+
+- Side Panel sur onglet "Chat".
+
+**Contenu :**
+
+- 2 messages utilisateur + 2 réponses IA, conversation réaliste :
+  - User : "Quel argument utilise-t-il pour expliquer la procrastination chronique ?"
+  - IA : (réponse 3-4 lignes avec citation `[09:18]` cliquable)
+  - User : "Est-ce que les autres chercheurs sont d'accord avec ce modèle ?"
+  - IA : (réponse 4 lignes citant 2 sources web "selon Steel (2007)…")
+- Input en bas avec placeholder "Pose une question sur la vidéo…" + bouton micro (Quick Voice Call).
+- Compteur "12/25 messages restants" (plan Pro).
+
+**Annotation overlay :**
+
+- FR : "Pose des questions à ta vidéo"
+- EN : "Ask questions to your video"
+
+**Fichier livré :** `screenshots/04-chat-contextual.png` (1280×800).
+
+---
+
+## Screenshot 5 — Flashcards FSRS sur web app + extension synced
+
+**Objectif** : montrer l'écosystème tri-plateforme + outil d'étude.
+
+**Décor :**
+
+- Browser tab DeepSight web app ouvert (https://www.deepsightsynthesis.com/study).
+- Side Panel extension ouvert à droite avec card "Synced ✓".
+
+**Contenu web app (gauche) :**
+
+- 3 flashcards en preview (front + back), questions issues de la vidéo.
+- Badge FSRS visible : "Prochaine révision : dans 2 jours".
+- CTA "Réviser maintenant".
+
+**Contenu Side Panel (droite) :**
+
+- Petit module "Tu apprends sur le web" avec icônes plateforme (Chrome / Mobile / Web) liées par des traits.
+- Texte "Un seul compte, trois plateformes".
+
+**Annotation overlay :**
+
+- FR : "Apprends 3× plus vite avec flashcards FSRS"
+- EN : "Learn 3× faster with FSRS flashcards"
+
+**Fichier livré :** `screenshots/05-flashcards-multi-platform.png` (1280×800).
+
+---
+
+## Tableau récapitulatif
+
+| #   | Nom fichier                        | Promesse mise en avant       | URL test                                    |
+| --- | ---------------------------------- | ---------------------------- | ------------------------------------------- |
+| 1   | `01-hero-youtube-sidebar.png`      | Acquisition : 1 clic         | https://www.youtube.com/watch?v=arj7oStGLkU |
+| 2   | `02-synthesis-timecodes.png`       | Qualité : synthèse sourcée   | (même vidéo)                                |
+| 3   | `03-factcheck.png`                 | Différenciateur : fact-check | (même vidéo)                                |
+| 4   | `04-chat-contextual.png`           | Rétention : conversation     | (même vidéo)                                |
+| 5   | `05-flashcards-multi-platform.png` | Écosystème + apprentissage   | https://www.deepsightsynthesis.com/study    |
+
+## Process de capture (à exécuter avant soumission)
+
+1. Ouvrir Chrome 116+ avec extension dev installée (`chrome://extensions` → Load unpacked → `extension/dist/`).
+2. DevTools → Toggle Device toolbar (Ctrl+Shift+M) → custom `1280 × 800`.
+3. Pour chaque screenshot : reproduire le contenu décrit, ouvrir Capture full size screenshot via DevTools (Cmd/Ctrl+Shift+P → "screenshot") OU utiliser un outil tiers (Lightshot, ShareX) avec dimensions exactes.
+4. Ajouter les annotations en post-prod (Figma / Photoshop / Canva). Template Figma à créer si besoin.
+5. Vérifier chaque PNG : 1280×800 strict, < 5 MB, dark mode visible, pas de PII.
+6. Stocker dans `docs/screenshots/chrome-web-store/01..05.png` (créer le dossier).
+
+## Outils suggérés
+
+- Capture : DevTools native, Awesome Screenshot, Loom
+- Annotations : Figma (template à créer une fois), Canva
+- Vérif dimensions : `identify` (ImageMagick) ou `file` Linux/Mac
+```
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add docs/CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md
+git commit -m "docs(chrome-store): add screenshots brief for 5 CWS images 1280x800"
+```
+
+---
+
+### Task 5 : Créer docs/CHROME-WEB-STORE-VIDEO-SCRIPT.md (script vidéo 30-60s)
+
+**Files :**
+
+- Create : `docs/CHROME-WEB-STORE-VIDEO-SCRIPT.md`
+
+- [ ] **Step 1 : Rédiger le storyboard complet**
+
+Contenu intégral :
+
+```markdown
+# Chrome Web Store — Script vidéo promo 30-60s
+
+> Document de production. Ne contient pas de fichier vidéo.
+> Spec destinée à un prestataire vidéo OU à Maxime pour produire la promo.
+> Cible : YouTube (URL publique non-listée → Chrome Web Store).
+
+**Format de sortie :** MP4 H.264 1920×1080 30fps, audio AAC 192 kbps, durée totale 45-50 s. Upload non-listé sur la chaîne YouTube DeepSight, copier l'URL dans le champ "Promotional video URL" du Developer Dashboard.
+
+**Voix-off :** voix française adulte, ton calme + énergique sur le CTA. Si pas de voix-off humaine disponible : utiliser ElevenLabs (voix française "Charlotte" ou équivalent), ironique étant donné la stack 😉.
+
+**Sous-titres :** burned-in français + version EN séparée (deux exports). Police Inter Bold blanche fond noir 60% opacity.
+
+**Musique :** royalty-free upbeat tech (Epidemic Sound / Artlist). Volume -18 LUFS pour ne pas masquer la voix.
+
+---
+
+## Storyboard (45 secondes)
+
+### 0:00 — 0:05 (5s) — Hook : la frustration
+
+**Visuel :**
+
+- Time-lapse accéléré : utilisateur (mains visibles) regarde vidéo YouTube de 2h, prend des notes au stylo, s'endort, se réveille, frotte ses yeux, regarde l'horloge.
+- Texte gros à l'écran : "1h pour 30s utiles ?" (FR) / "1 hour for 30 useful seconds?" (EN)
+
+**Voix-off :**
+
+- FR : "Tu regardes 1 heure de vidéo… pour 30 secondes utiles ?"
+- EN : "You watch 1 hour of video… for 30 useful seconds?"
+
+**Audio :** musique discrète, tic-tac d'horloge en sound design.
+
+---
+
+### 0:05 — 0:13 (8s) — Solution : 1 clic
+
+**Visuel :**
+
+- Cut sec sur même vidéo YouTube, mais cette fois Side Panel DeepSight ouvert à droite.
+- Curseur survole le bouton "Analyser" → click sonore satisfaisant.
+- Animation : barre de progression rapide indigo→violet, badges qui apparaissent ("Transcript ✓", "Synthèse ✓", "Fact-check ✓").
+- Logo DeepSight discret en haut à droite.
+
+**Voix-off :**
+
+- FR : "DeepSight transforme YouTube et TikTok en synthèse sourcée. En un clic."
+- EN : "DeepSight turns YouTube and TikTok into a sourced summary. In one click."
+
+**Audio :** swoosh sur le click, musique monte en intensité.
+
+---
+
+### 0:13 — 0:25 (12s) — Démo : synthèse + fact-check + chat
+
+**Visuel (cuts rapides 4s par feature) :**
+
+1. **0:13-0:17 — Synthèse** : zoom sur le panel résultats, points clés défilent, surlignage des timecodes cliquables `[02:14]`, `[09:18]`.
+   - Voix-off FR : "Synthèse structurée avec timecodes."
+   - EN : "Structured summary with timestamps."
+
+2. **0:17-0:21 — Fact-check** : transition vers onglet Fact-check, badges `SOLIDE` / `PLAUSIBLE` / `INCERTAIN` apparaissent un par un avec animation pop.
+   - Voix-off FR : "Fact-check automatique."
+   - EN : "Automatic fact-check."
+
+3. **0:21-0:25 — Chat vocal** : transition vers chat, animation waveform ElevenLabs, sous-titre conversation rapide.
+   - Voix-off FR : "Et même un chat vocal — interroge ta vidéo."
+   - EN : "Even voice chat — interrogate your video."
+
+**Audio :** tempo musique stable, micro-sound design pour chaque transition.
+
+---
+
+### 0:25 — 0:35 (10s) — Multi-plateforme + flashcards
+
+**Visuel :**
+
+- Plan large : trois écrans alignés (Chrome extension à gauche, app web au centre, mobile iPhone à droite).
+- Animation : un compte se synchronise sur les trois (logo DeepSight pulse, traits lumineux entre les écrans).
+- Sur le mobile : flashcard tournante avec animation flip.
+
+**Voix-off :**
+
+- FR : "Un seul compte, trois plateformes. Et tes flashcards te suivent partout."
+- EN : "One account, three platforms. Your flashcards follow you everywhere."
+
+**Audio :** musique monte vers le climax.
+
+---
+
+### 0:35 — 0:45 (10s) — Trust + CTA
+
+**Visuel :**
+
+- Cut sur card de trust : "🇫🇷🇪🇺 IA européenne — Mistral", "RGPD-compliant", "Sans CB pour démarrer".
+- Transition vers logo DeepSight grand format + tagline : "Ne subissez plus vos vidéos — interrogez-les."
+- CTA bouton à l'écran : "Installer gratuitement →" (FR) / "Install free →" (EN).
+- Petit texte sous bouton : "deepsightsynthesis.com" + icône Chrome Web Store.
+
+**Voix-off :**
+
+- FR : "Ne subissez plus vos vidéos. Interrogez-les. Installe DeepSight gratuitement."
+- EN : "Don't endure your videos. Interrogate them. Install DeepSight for free."
+
+**Audio :** climax musique, fade-out 2s, sound design "ding" sur le CTA.
+
+---
+
+## Checklist production
+
+- [ ] Voice-over enregistrée FR (45s) + EN (45s)
+- [ ] Captures écran propres (mêmes vidéos qu'aux screenshots — cohérence)
+- [ ] Animations Side Panel (After Effects ou Figma → Lottie)
+- [ ] Music track licensed
+- [ ] Sound design (clicks, swooshes, ding)
+- [ ] Sous-titres burn-in FR + EN exportés (deux fichiers)
+- [ ] Export 1920×1080 H.264 MP4
+- [ ] Test : taille fichier < 100 MB
+- [ ] Upload YouTube non-listé
+- [ ] URL non-listée copiée dans CWS Developer Dashboard
+
+## Références visuelles & inspirations
+
+- Notion AI promo (style cuts rapides + voice-over confiant)
+- Linear app launch trailer (transitions fluides + design system marqué)
+- Loom intro vidéo (storytelling utilisateur first)
+- Arc Browser ad (humour subtil + démo claire)
+
+## Budget estimé (si externalisation)
+
+- Voice-over FR + EN : 100-200 €
+- Animation/montage prestataire : 400-800 € (5h-10h vidéaste freelance)
+- Music license : 0 € (Artlist abonnement existant) ou 30 €/track Epidemic Sound
+- Total estimation : 500-1000 €
+
+Alternative DIY (Maxime) :
+
+- Outils : Figma + Loom + Capcut
+- Voice-over : ElevenLabs (Charlotte voice) ~5 €
+- Time : 4-6h
+- Total : ~5 €
+```
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add docs/CHROME-WEB-STORE-VIDEO-SCRIPT.md
+git commit -m "docs(chrome-store): add 45s promo video script FR+EN with storyboard"
+```
+
+---
+
+### Task 6 : Créer docs/CHROME-WEB-STORE-SUBMISSION-CHECKLIST.md
+
+**Files :**
+
+- Create : `docs/CHROME-WEB-STORE-SUBMISSION-CHECKLIST.md`
+
+- [ ] **Step 1 : Rédiger la checklist complète**
+
+Contenu intégral :
+
+````markdown
+# Chrome Web Store — Submission Checklist
+
+> Process à suivre dans l'ordre pour soumettre l'extension DeepSight v2.0.0.
+> Review Google : 1-7 jours. Anticiper en lançant la soumission au moins 7 jours
+> avant un lancement marketing.
+
+---
+
+## Phase 0 — Pré-requis (à valider AVANT toute action)
+
+- [ ] Compte Google dédié DeepSight (pas le perso) → utiliser maximeleparc3@gmail.com (déjà associé à `homepage_url`)
+- [ ] **Frais d'inscription Developer payés** : 5 USD lifetime sur https://chrome.google.com/webstore/devconsole/register
+- [ ] Privacy Policy publique fonctionnelle : `curl -I https://www.deepsightsynthesis.com/privacy` → 200 OK
+- [ ] Page `/extension-welcome` publique fonctionnelle : `curl -I https://www.deepsightsynthesis.com/extension-welcome` → 200 OK
+- [ ] Backend API stable et joignable : `curl -I https://api.deepsightsynthesis.com/health` → 200 OK
+- [ ] Plan pricing v2 déployé en prod (Pro 8,99 € / Expert 19,99 €) — sinon aligner avec sortie pricing-v2-stripe-grandfathering plan
+- [ ] CHROME-WEB-STORE-LISTING.md (fiche FR+EN) finalisé et relu
+- [ ] CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md → 5 PNG livrés dans `docs/screenshots/chrome-web-store/0[1-5].png` (1280×800 chacun)
+- [ ] CHROME-WEB-STORE-VIDEO-SCRIPT.md → vidéo produite + uploadée non-listée sur YouTube (URL en main)
+- [ ] Tests manuels extension dans Chrome 116+ (clean profile) :
+  - [ ] Install via `Load unpacked` → `dist/` réussit sans erreur console
+  - [ ] Login Google OAuth fonctionne
+  - [ ] Side Panel s'ouvre via Alt+Shift+D et icône toolbar
+  - [ ] Analyse YouTube fonctionne sur 3 vidéos différentes (court / moyen / long)
+  - [ ] Analyse TikTok fonctionne sur 1 vidéo
+  - [ ] Quick Chat fonctionne sans crédits
+  - [ ] Voice chat fonctionne (plan Expert) avec micro
+  - [ ] Logout puis login → tokens persistent ou refresh propre
+  - [ ] Désinstall propre (pas de storage résiduel)
+
+---
+
+## Phase 1 — Build & ZIP
+
+- [ ] **Update version** dans `extension/public/manifest.json` si fix nécessaire (sinon laisser 2.0.0)
+- [ ] **Update CHANGELOG** dans `extension/CHANGELOG.md` (créer si n'existe pas)
+- [ ] Build production propre :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/extension
+rm -rf dist/
+npm install
+npm run build
+```
+
+- [ ] Vérifier output `dist/` :
+
+```bash
+ls -la C:/Users/33667/DeepSight-Main/extension/dist/manifest.json
+node -e "console.log(JSON.parse(require('fs').readFileSync('C:/Users/33667/DeepSight-Main/extension/dist/manifest.json')).version)"
+```
+
+Expected : `2.0.0` (ou version bumpée).
+
+- [ ] **Supprimer les sourcemaps** du dist avant ZIP (optionnel mais recommandé pour réduire taille) :
+
+```bash
+find C:/Users/33667/DeepSight-Main/extension/dist/ -name "*.map" -delete
+```
+
+- [ ] **Créer le ZIP** dans le dossier `extension/release/` :
+
+```bash
+mkdir -p C:/Users/33667/DeepSight-Main/extension/release
+cd C:/Users/33667/DeepSight-Main/extension/dist
+zip -r ../release/deepsight-extension-v2.0.0.zip . -x "*.map"
+ls -la ../release/
+```
+
+Expected : ZIP < 10 MB.
+
+- [ ] **Vérifier le ZIP** :
+
+```bash
+unzip -l C:/Users/33667/DeepSight-Main/extension/release/deepsight-extension-v2.0.0.zip | head -30
+```
+
+Doit contenir : `manifest.json`, `background.js`, `content.js`, `sidepanel.html`, `sidepanel.js`, `_locales/`, `icons/`.
+
+---
+
+## Phase 2 — Developer Dashboard upload
+
+URL : https://chrome.google.com/webstore/devconsole
+
+- [ ] Login avec maximeleparc3@gmail.com
+- [ ] Cliquer "New Item" → upload ZIP `deepsight-extension-v2.0.0.zip`
+- [ ] Attendre la validation automatique du manifest (10-30s)
+
+### Onglet "Store listing"
+
+- [ ] **Title (EN)** : "DeepSight - AI Video Analysis"
+- [ ] **Title (FR)** : "DeepSight - Analyse vidéo IA"
+- [ ] **Summary (EN)** : copier description courte EN depuis CHROME-WEB-STORE-LISTING.md §2
+- [ ] **Summary (FR)** : copier description courte FR depuis CHROME-WEB-STORE-LISTING.md §2
+- [ ] **Detailed description (EN)** : copier description longue EN depuis §3
+- [ ] **Detailed description (FR)** : copier description longue FR depuis §4
+- [ ] **Category** : Productivity
+- [ ] **Language** : English (default), then add Français
+- [ ] **Icon** : upload `extension/icons/icon128.png` (128×128)
+- [ ] **Screenshots** : upload 5 PNG dans `docs/screenshots/chrome-web-store/0[1-5].png` (1280×800)
+- [ ] **Promotional images** (optionnel, recommandé) :
+  - Small promo tile 440×280 — designer asset à produire si capacity
+  - Large promo tile 920×680 — designer asset à produire si capacity
+  - Marquee 1400×560 — designer asset à produire si capacity (rare placement, skip si pas de temps)
+- [ ] **Promotional video URL** : coller URL YouTube non-listée (CHROME-WEB-STORE-VIDEO-SCRIPT.md output)
+- [ ] **Official URL** : https://www.deepsightsynthesis.com
+- [ ] **Support URL** : https://www.deepsightsynthesis.com/support OU mailto:maximeleparc3@gmail.com
+- [ ] Save draft
+
+### Onglet "Privacy practices"
+
+- [ ] **Single purpose** : copier depuis CHROME-WEB-STORE-LISTING.md §6
+- [ ] Pour chaque permission : copier la justification depuis §7 dans le champ correspondant
+- [ ] **Data usage** : cocher selon §8 (PII oui, web history limité, autres non)
+- [ ] **Privacy policy URL** : `https://www.deepsightsynthesis.com/privacy`
+- [ ] Cocher les 3 déclarations (no sale, no unrelated purpose, no creditworthiness)
+- [ ] Save
+
+### Onglet "Distribution"
+
+- [ ] **Visibility** : Public
+- [ ] **Distribution regions** : All regions (acquisition organique mondiale)
+- [ ] **Mature content** : No
+- [ ] Save
+
+### Onglet "Pricing & paid features"
+
+- [ ] **Pricing model** : Free (l'extension est gratuite, le SaaS gère le paiement Stripe sur web)
+- [ ] **In-app purchases** : No
+- [ ] Save
+
+---
+
+## Phase 3 — Submit for review
+
+- [ ] Re-vérifier les 4 onglets ont tous un statut "Complete"
+- [ ] Cliquer "Submit for review"
+- [ ] Confirmer dans la modal
+- [ ] Capturer screenshot de la confirmation et le coller dans la tâche Asana
+
+**Délai review attendu** : 1 à 7 jours ouvrés.
+**Statut visible** : `Pending review` → `In review` → `Published` (ou `Rejected`).
+
+---
+
+## Phase 4 — En cas de rejet
+
+- [ ] Lire l'email de rejet — Google précise toujours la cause
+- [ ] Causes courantes et fixes :
+  - **"Permissions not justified"** → reprendre §7 et étoffer le champ correspondant
+  - **"Description misleading"** → relire description longue, retirer les claims forts non démontrables
+  - **"Screenshots low quality"** → re-capturer en 1280×800 strict, vérifier compression
+  - **"Privacy policy unclear"** → ajouter section spécifique extension dans `frontend/src/pages/PrivacyPolicy.tsx` (Task 7 du plan)
+  - **"Single purpose violation"** → vérifier que les features alignent avec §6
+- [ ] Apply fix → resubmit (compteur review redémarre à zéro)
+
+---
+
+## Phase 5 — Post-publication (jour 0 → +30)
+
+- [ ] **Annoncer** : tweet, LinkedIn, page d'accueil deepsightsynthesis.com badge "Available on Chrome Web Store"
+- [ ] **Tracker** : installs/jour dans Chrome Developer Dashboard → graph hebdo
+- [ ] **Reviews** : monitorer les reviews + répondre aux questions/bugs sous 48h
+- [ ] **Updates** : pour update mineure → bump version manifest, build, ZIP, upload nouvelle version. Approval mises à jour souvent < 24h.
+- [ ] **Asana** : créer tâche dans projet "DeepSight Extension Chrome" → "📈 Monitor CWS metrics weekly"
+
+---
+
+## Phase 6 — Optimisation continue (jour +30 → ∞)
+
+- [ ] **A/B test descriptions** : changer description longue tous les 30j, mesurer impact sur conversion install
+- [ ] **A/B test screenshots** : ordre / contenu, mesurer impact sur conversion
+- [ ] **SEO Chrome Web Store** : utiliser des keywords saisonniers (ex : "rentrée scolaire" en septembre)
+- [ ] **Reviews stratégie** : prompter les power users dans la web app pour laisser une review CWS
+- [ ] **Promo video update** : refresh tous les 6 mois selon nouvelles features
+- [ ] **Cible 1000+ users/jour** : si non atteinte à 90j, lancer plan SEO + partenariats (Tournesol, edu YouTubers)
+
+---
+
+## Annexes
+
+### Liens utiles
+
+- Developer Dashboard : https://chrome.google.com/webstore/devconsole
+- Best practices : https://developer.chrome.com/docs/webstore/best_practices/
+- Permission justification doc : https://developer.chrome.com/docs/webstore/program-policies/permissions/
+- Spam policies : https://developer.chrome.com/docs/webstore/program-policies/spam-and-placement/
+
+### Métriques cibles (KPI)
+
+| Métrique           | Jour 7 | Jour 30 | Jour 90 |
+| ------------------ | ------ | ------- | ------- |
+| Total installs     | 200    | 5 000   | 30 000  |
+| Daily new installs | 30+    | 200+    | 1 000+  |
+| Rating moyen       | 4.5+   | 4.5+    | 4.5+    |
+| Reviews count      | 5+     | 50+     | 300+    |
+| Uninstall rate     | < 30%  | < 25%   | < 20%   |
+````
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add docs/CHROME-WEB-STORE-SUBMISSION-CHECKLIST.md
+git commit -m "docs(chrome-store): add complete submission checklist (phases 0-6)"
+```
+
+---
+
+### Task 7 : Vérifier + augmenter PrivacyPolicy.tsx pour exigences extension
+
+**Files :**
+
+- Read : `frontend/src/pages/PrivacyPolicy.tsx` (lignes 1-200)
+- Modify : `frontend/src/pages/PrivacyPolicy.tsx` (ajouter section "Extension Chrome — données collectées")
+
+- [ ] **Step 1 : Vérifier l'état actuel**
+
+Lire le fichier complet et chercher mentions de :
+
+- "extension" / "chrome" / "manifest"
+- "OAuth" / "JWT" / "tokens"
+- "video ID" / "scraping"
+
+```bash
+grep -i -n "extension\|chrome\|oauth\|jwt\|video id" C:/Users/33667/DeepSight-Main/frontend/src/pages/PrivacyPolicy.tsx | head -30
+```
+
+- [ ] **Step 2 : Si la section "Extension" est manquante, l'ajouter**
+
+Section à insérer (juste après le composant `Section` "Cookies" ou équivalent, avant le footer) :
+
+```tsx
+<Section title="Extension Chrome — données collectées">
+  <p>
+    L'extension DeepSight (Chrome Web Store, Manifest V3 v2.0) collecte le
+    strict minimum de données nécessaires à son fonctionnement :
+  </p>
+  <ul className="list-disc ml-6 space-y-2">
+    <li>
+      <strong>Authentification</strong> : tokens JWT (access + refresh) stockés
+      localement dans <code>chrome.storage.local</code>, jamais partagés avec
+      des tiers.
+    </li>
+    <li>
+      <strong>URL vidéo active</strong> : uniquement quand vous cliquez
+      "Analyser". Seul l'identifiant vidéo (video ID) est envoyé à notre backend
+      ; aucun scraping DOM n'est effectué.
+    </li>
+    <li>
+      <strong>Préférences UI</strong> : langue, paramètres voix (chat vocal).
+      Stockées localement, jamais transmises.
+    </li>
+    <li>
+      <strong>Cache analyses récentes</strong> : pour permettre l'accès offline
+      aux dernières synthèses. Stockage local, supprimable via désinstallation.
+    </li>
+  </ul>
+  <p>
+    L'extension ne fait <strong>aucun tracking</strong> en arrière-plan, ne lit
+    pas le contenu des pages YouTube/TikTok au-delà de l'URL, et ne contient
+    aucun analytics tiers (Google Analytics, Facebook Pixel, etc.). Tout
+    traitement IA se fait sur nos serveurs Hetzner en Europe.
+  </p>
+  <p>
+    Permissions Chrome utilisées : <code>storage</code>, <code>activeTab</code>,{" "}
+    <code>tabs</code>, <code>alarms</code>, <code>identity</code>,{" "}
+    <code>clipboardWrite</code>, <code>sidePanel</code>, <code>offscreen</code>.
+    Justification détaillée disponible dans la fiche Chrome Web Store et le
+    manifeste public à{" "}
+    <a
+      href="https://github.com/Fonira/DeepSight-Main/blob/main/extension/public/manifest.json"
+      className="text-blue-400 hover:underline"
+    >
+      github.com/.../manifest.json
+    </a>
+    .
+  </p>
+</Section>
+```
+
+- [ ] **Step 3 : Mettre à jour la date de dernière modification**
+
+Modifier `LEGAL_INFO.lastUpdate` dans le fichier :
+
+Ancien : `lastUpdate: "2 mars 2026"`
+Nouveau : `lastUpdate: "29 avril 2026"`
+
+- [ ] **Step 4 : Lint + typecheck**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run typecheck
+npm run lint -- --max-warnings 0 src/pages/PrivacyPolicy.tsx
+```
+
+Expected : pas d'erreur ni warning.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add frontend/src/pages/PrivacyPolicy.tsx
+git commit -m "docs(privacy): add Chrome extension data section + bump update date"
+```
+
+---
+
+### Task 8 : Self-review + finalisation
+
+**Files :**
+
+- Vérifier les 5 documents créés/modifiés
+- Test final cohérence
+
+- [ ] **Step 1 : Vérifier que tous les fichiers sont présents**
+
+```bash
+ls -la C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-LISTING.md \
+       C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md \
+       C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-VIDEO-SCRIPT.md \
+       C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-SUBMISSION-CHECKLIST.md \
+       C:/Users/33667/DeepSight-Main/extension/CHROME_WEB_STORE.md \
+       C:/Users/33667/DeepSight-Main/extension/CHROME_WEB_STORE.legacy.md
+```
+
+Expected : 6 fichiers existent.
+
+- [ ] **Step 2 : Cohérence pricing dans tous les nouveaux docs**
+
+```bash
+grep -E "4,99|9,99|4\.99|9\.99|Plus" \
+  C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-LISTING.md \
+  C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-SCREENSHOTS-BRIEF.md \
+  C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-VIDEO-SCRIPT.md \
+  C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-SUBMISSION-CHECKLIST.md
+```
+
+Expected : aucun résultat (pricing v2 strict appliqué). Si résultat → corriger immédiatement.
+
+- [ ] **Step 3 : Cohérence keywords (ranking SEO)**
+
+```bash
+grep -c "Mistral\|YouTube\|TikTok\|fact-check\|flashcards" \
+  C:/Users/33667/DeepSight-Main/docs/CHROME-WEB-STORE-LISTING.md
+```
+
+Expected : > 10 occurrences.
+
+- [ ] **Step 4 : Vérifier qu'aucun chemin obsolète n'est référencé**
+
+```bash
+grep -r "popup/components/MainView\|extension/CHROME_WEB_STORE\.md" \
+  C:/Users/33667/DeepSight-Main/docs/ | grep -v "\.legacy\."
+```
+
+Expected : aucun résultat (les nouveaux docs référencent `sidepanel/` pas `popup/`).
+
+- [ ] **Step 5 : Smoke test global du build extension**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/extension
+npm run typecheck
+npm run build 2>&1 | tail -20
+```
+
+Expected : build réussit sans erreur, `dist/manifest.json` présent.
+
+- [ ] **Step 6 : Commit final récapitulatif (optionnel — si modifs additionnelles)**
+
+Si Step 2/3/4 ont demandé des fixes :
+
+```bash
+git add -A
+git commit -m "chore(chrome-store): fix pricing v2 + path consistency in submission docs"
+```
+
+---
+
+## Self-Review du plan
+
+### 1. Couverture du spec
+
+| Demande spec                                | Task couvrant         | Status                                                          |
+| ------------------------------------------- | --------------------- | --------------------------------------------------------------- |
+| Manifest V3 optimisé, permissions minimales | Task 3 (vérification) | OK — déjà optimal, aucune modif nécessaire                      |
+| Description courte avec keywords            | Task 3                | OK — keywords déjà en place dans `_locales/`                    |
+| Description longue 150-300 mots × FR + EN   | Task 2                | OK — §3 EN + §4 FR (~400 mots chacune, dans plage CWS 16k char) |
+| 5 screenshots 1280×800 brief                | Task 4                | OK — 5 sections détaillées                                      |
+| Vidéo promo 30-60s storyboard               | Task 5                | OK — 45s storyboard 6 sections                                  |
+| Catégorie + tags                            | Task 2 §5             | OK                                                              |
+| Soumission process checklist                | Task 6                | OK — 6 phases                                                   |
+| Privacy policy URL + section extension      | Task 7                | OK                                                              |
+| Permissions justification (audit MV3)       | Task 2 §7             | OK — reprises de la legacy doc                                  |
+| Pricing v2 strict (8,99 / 19,99)            | Task 2 + Task 8 grep  | OK                                                              |
+
+### 2. Placeholder scan
+
+Recherche des patterns interdits dans le plan ci-dessus :
+
+- `TODO`, `TBD` : 0 occurrence ✓
+- "à définir" / "à préciser" : 0 occurrence ✓
+- "similar to Task N" : 0 occurrence ✓
+- "implement later" : 0 occurrence ✓
+- "appropriate error handling" : 0 occurrence ✓
+
+### 3. Cohérence types / chemins
+
+- `extension/public/manifest.json` (pas `extension/manifest.json`) ✓
+- `extension/public/_locales/{en,fr}/messages.json` ✓
+- `frontend/src/pages/PrivacyPolicy.tsx` ✓
+- `extension/src/sidepanel/` (l'extension est en MV3 Side Panel, pas popup historique) ✓ — corrigé dans le brief screenshots
+- Pricing v2 (Pro 8,99 € / Expert 19,99 €) appliqué partout ✓
+- Manifest version `2.0.0` partout ✓
+
+### 4. Décisions à confirmer avec Maxime AVANT exécution
+
+| Question                                                  | Options                                                                                                                          |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Qui produit les 5 screenshots ?**                       | (a) Maxime DIY Figma 2-3h ; (b) freelance designer 200-400 €                                                                     |
+| **Qui produit la vidéo promo 45s ?**                      | (a) Maxime DIY Capcut + ElevenLabs voix ~5 € + 4-6h ; (b) freelance vidéaste 500-1000 € ; (c) skip vidéo (impact ranking modéré) |
+| **Soumission test/staging ou direct prod ?**              | (a) direct prod sur compte CWS officiel ; (b) compte test séparé d'abord (plus prudent mais 2× les frais 5 USD)                  |
+| **Extension à 0 € ou freemium model ?**                   | Confirmation : extension reste gratuite, monétisation via SaaS Stripe sur web. Aucun in-app purchase Chrome.                     |
+| **Visibility région**                                     | (a) "All regions" pour acquisition globale ; (b) restreindre EU+US si support langue limité                                      |
+| **Promo tiles 440×280 + 920×680 + marquee 1400×560 ?**    | (a) produire les 3 (designer +200 €) ; (b) produire seulement small 440×280 ; (c) skip toutes (CWS accepte mais ranking moindre) |
+| **Bump version 2.0.0 → 2.1.0 avant submit ?**             | (a) garder 2.0.0 (extension prête depuis Mars) ; (b) bumper à 2.1.0 pour marquer "publication CWS"                               |
+| **Privacy Policy modif Task 7 — déployée AVANT submit ?** | OUI obligatoire — sinon Google rejette pour "privacy policy outdated/missing extension info". Synchroniser avec un push Vercel.  |
+
+### 5. Ordre d'exécution recommandé
+
+1. Tasks 1, 2, 3 en parallèle (fichiers indépendants)
+2. Task 4 (peut être en parallèle aussi)
+3. Task 5 (peut être en parallèle)
+4. Task 6 (peut être en parallèle)
+5. Task 7 (modif frontend, doit être déployée Vercel AVANT submit CWS)
+6. Task 8 (review final + smoke test)
+
+Si exécution séquentielle (subagent-driven default), suivre l'ordre 1→8.
+
+---
+
+## Execution Handoff
+
+**Plan complet et sauvegardé. Deux options d'exécution :**
+
+**1. Subagent-Driven (recommandé)** — Un subagent frais par task, review entre tasks, itération rapide.
+
+**2. Inline Execution** — Exécuter tasks dans cette session avec checkpoints groupés.
+
+**Pré-requis avant exécution :** valider les 8 décisions du Self-Review §4 (notamment qui produit screenshots / vidéo, et bump version éventuel).
+
+**Ordre de bloc recommandé :**
+
+- Bloc A (docs) : Tasks 1-6 (peut être batched, aucune dépendance entre eux)
+- Bloc B (code frontend) : Task 7 (touche `PrivacyPolicy.tsx` → déclenche push Vercel)
+- Bloc C (verification) : Task 8 (review final + smoke test)

--- a/docs/superpowers/plans/2026-04-29-homepage-testimonials.md
+++ b/docs/superpowers/plans/2026-04-29-homepage-testimonials.md
@@ -1,0 +1,1830 @@
+# Homepage Testimonials + TrustBadges + SocialProofCounter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Combler le gap social proof identifié par l'audit Kimi 2026-04-29 (`Phase 1 — UX/Conversion`) en ajoutant trois sections sur `frontend/src/pages/LandingPage.tsx` : 3 témoignages chiffrés (placeholders fictifs avec garde-fou anti-prod), 5 trust badges sous CTAs, 3 compteurs de social proof réels alimentés par un nouvel endpoint backend public cacheé Redis 1 h. Conversion estimée +20-30 % par l'audit.
+
+**Architecture:** (1) Backend — nouveau module `landing/` avec router public `GET /api/public/landing-stats` qui agrège `User.total_videos`, `User.total_words`, `count(distinct user_id récent)` via SQLAlchemy, mis en cache Redis 1 h via `cache_service.get_or_set`. (2) Frontend — 3 nouveaux composants dans `frontend/src/components/landing/` (`Testimonials.tsx`, `TrustBadges.tsx`, `SocialProofCounter.tsx`) typés strict, animés Framer Motion (`useInView`/`ScrollReveal`), data testimonials inline avec flag `isPlaceholder: true` + badge "Démo" visible en `import.meta.env.DEV`, fetch stats via `landingApi.getStats()`. (3) Intégration dans `LandingPage.tsx` : `SocialProofCounter` en bandeau juste après hero, `Testimonials` après section Demo, `TrustBadges` sous `<PricingSection>`. (4) i18n complet FR + EN.
+
+**Tech Stack:** Backend = FastAPI + SQLAlchemy 2.0 async + Pydantic v2 + Redis 7 via `core.cache.cache_service`. Frontend = React 18 + TypeScript strict + Tailwind CSS 3 + Framer Motion 12 + Lucide icons. Tests = pytest + pytest-asyncio (backend), Vitest + Testing Library (frontend).
+
+---
+
+## ⚠️ AVERTISSEMENT ÉTHIQUE — À LIRE AVANT EXÉCUTION
+
+Les **3 témoignages seed** intégrés à `Testimonials.tsx` sont **fictifs** :
+
+| Persona      | Citation                                                                                      | Métrique           |
+| ------------ | --------------------------------------------------------------------------------------------- | ------------------ |
+| Dr. Marie L. | "J'analysais 2h de conférences en 30 min. Le fact-checking m'a fait gagner une demi-journée." | 2 h → 30 min       |
+| Thomas B.    | "Vérifier les affirmations des vidéos avec timecodes et sources ? Indispensable."             | 3 fact-checks/jour |
+| Léa K.       | "Les flashcards FSRS me font réviser 3x plus efficacement."                                   | +40 % rétention    |
+
+**Garde-fou implémenté côté code** :
+
+- Chaque entrée porte `isPlaceholder: true` dans la data.
+- En `import.meta.env.PROD === true`, le composant `Testimonials` retourne `null` si `entries.every(e => e.isPlaceholder)` — la section ne s'affiche pas en prod.
+- En `import.meta.env.DEV === true` (dev/staging), un badge **« Démo »** est affiché en haut de la section pour éviter la confusion.
+
+**Décision business à valider AVANT déploiement Vercel `main`** : retirer les flags `isPlaceholder: true` n'est autorisé que si l'utilisateur (Maxime) tranche soit (a) attendre vrais utilisateurs ayant donné consentement écrit, soit (b) accepter publiquement ces 3 fictifs comme "personas illustratifs" avec mention en bas de section. La PR ne peut pas être mergée vers `main` tant qu'aucune des deux options n'a été validée. Cf. section Self-Review.
+
+---
+
+## Contexte préalable — État actuel
+
+### Audit gap (Phase 1 — UX/Conversion)
+
+> "Social proof totalement absent : aucun témoignage, aucun logo client, aucun compteur. Recommandations : 3 témoignages chiffrés. Compteur social. Badge garantie 14 j visible sous CTAs."
+
+### Cohérence avec autres plans datés 2026-04-29
+
+D'après `docs/superpowers/plans/2026-04-29-RELEASE-ORCHESTRATION.md` (commit `021e4bf1`) :
+
+- Ce plan fait partie du **Sprint A — Quick wins** (semaine 1) et est déclaré déployable seul, sans toucher Alembic ni Pricing v2.
+- Aucun couplage atomique avec un autre plan. Aucune migration backend.
+- Le seul fichier partagé avec d'autres plans est `frontend/src/services/api.ts` (User interface intacte ici, ajout d'un nouvel objet `landingApi` — zéro conflit avec #2 dashboard, #4 voice-packs, #7 pricing-v2, #8 parrainage).
+- LandingPage.tsx est aussi touchée par #6 PostHog (instrumentation hero/footer) et #8 parrainage (`useEffect ?ref=`) : zones disjointes, pas de collision.
+- Le plan `2026-04-29-plans-db-driven.md` (commit `021e4bf1`) prouve que le pattern **`/api/admin/stats` lignes 102-156 de `backend/src/admin/router.py`** est le modèle SQL canonique pour agréger `User.total_videos`, `User.total_words`, `count(User)` — directement réutilisé ici (sans le `Depends(get_current_admin)`) pour notre endpoint public.
+
+### État actuel du code (vérifié)
+
+**LandingPage.tsx** (`frontend/src/pages/LandingPage.tsx`, 1472 lignes, v9.0) :
+
+- Header sticky lignes 626-647.
+- HERO section lignes 649-944 (CTA "Créer un compte" + guest demo input).
+- Demo statique lignes 1072-1077 (`<DemoAnalysisStatic>` + `<DemoChatStatic>`).
+- Pricing lignes 1365-1366 (`<PricingSection>`).
+- FAQ JSON-LD lignes 601-618.
+- Footer lignes 1430-1467.
+- Helpers `ScrollReveal` lignes 62-81, `StaggerReveal` lignes 83-110.
+- Contient `import { useTranslation }` ligne 34 mais utilise majoritairement `language === "fr"` ternaires inline.
+- **Aucune section testimonials/trust badges/social proof counter** (vérifié `grep`).
+
+**PricingSection.tsx** (`frontend/src/components/landing/PricingSection.tsx`, 402 lignes) :
+
+- Pattern Framer Motion `useInView` ligne 178-179, animations `motion.div initial/animate` lignes 187-188.
+- `ease = [0.4, 0, 0.2, 1] as const` ligne 15.
+- Default export ligne 173 (`export default function PricingSection`).
+
+**Barrel** (`frontend/src/components/landing/index.ts`, 3 lignes) :
+
+```typescript
+export { default as DemoAnalysisStatic } from "./DemoAnalysisStatic";
+export { default as DemoChatStatic } from "./DemoChatStatic";
+export { default as PricingSection } from "./PricingSection";
+```
+
+**i18n** (`frontend/src/i18n/{fr,en}.json`) — namespace `landing` existant avec sous-clés `badge`, `hero`, `stats`, `features`, `audiences`, `pricing`, `cta`. **Aucune sous-clé `testimonials`, `trust_badges` ou `social_proof`** — à ajouter.
+
+**Backend** (`backend/src/`) :
+
+- Pas de module `landing/` (vérifié `ls`).
+- `admin/router.py` ligne 102-156 = template SQL pour stats.
+- `core/cache.py` expose `cache_service.get_or_set(key, factory, ttl)` ligne 388.
+- `main.py` ligne 192-199 montre le pattern d'inclusion conditionnelle de routers (try/except + `LANDING_ROUTER_AVAILABLE`).
+
+**API client** (`frontend/src/services/api.ts`, 3036+ lignes) :
+
+- Ligne 16 : `export const API_URL = import.meta.env.VITE_API_URL || "https://api.deepsightsynthesis.com"`.
+- Ligne 486-495 : `interface RequestOptions` avec flags `skipAuth` et `skipCredentials`.
+- Ligne 497-510 : `async function request<T>(endpoint, options)` est le helper centralisé.
+- Ligne 904-936 : `demoApi` est le pattern à imiter pour un endpoint public (utilise `skipAuth: true, skipCredentials: true`).
+
+### Conventions de design (`frontend/CLAUDE.md` + `LandingPage.tsx`)
+
+- Dark mode first : `bg-bg-primary` (`#0a0a0f`), surfaces `bg-bg-secondary/40`, borders `border-border-subtle` (= `border-white/5`).
+- Glassmorphism : `backdrop-blur-xl bg-white/5 border border-white/10` (extrait `header` ligne 626).
+- Accents : Indigo `#6366f1` (`accent-primary`), Violet `bg-violet-500`, Cyan `bg-cyan-400`.
+- Animations Framer Motion 12 : pattern `useInView(ref, { once: true, margin: "-60px" })`.
+- Typography : `text-text-primary`, `text-text-secondary`, `text-text-tertiary`, `text-text-muted`.
+- Responsive breakpoints : `sm:` (640), `md:` (768), `lg:` (1024), `xl:` (1280).
+
+### Garantie 14 jours déjà mentionnée mais hors trust badges
+
+`PricingSection.tsx` ligne 354-368 contient déjà 3 garanties inline (annulation, remboursement 14 j, données EU) sous le grid pricing. Notre `TrustBadges` les **complète** (placement différent — sous `<PricingSection>` dans LandingPage, pas dans PricingSection elle-même) avec 5 badges distincts (les 3 ci-dessus + 2 nouveaux = IA française & souveraine, paiement Stripe). La duplication "remboursement 14 j" est **volontaire** (rappel après tarifs).
+
+---
+
+## File Structure
+
+| Chemin (absolu)                                                         | Action | Responsabilité                                                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `backend/src/landing/__init__.py`                                       | Create | Module init (commentaire description, vide en code)                                                                                                                                                                                                                                                                                                                               |
+| `backend/src/landing/router.py`                                         | Create | Router public `/api/public/landing-stats` agrégeant `User.total_videos`, `User.total_words`, distinct user_id 30 j ; cache Redis 1 h ; aucune auth                                                                                                                                                                                                                                |
+| `backend/src/main.py`                                                   | Modify | Ajouter try/except import `landing.router as landing_router` + `LANDING_ROUTER_AVAILABLE` flag + `app.include_router(...)` dans la section "INCLUSION DES ROUTERS"                                                                                                                                                                                                                |
+| `backend/tests/landing/__init__.py`                                     | Create | Vide                                                                                                                                                                                                                                                                                                                                                                              |
+| `backend/tests/landing/test_router.py`                                  | Create | Tests pytest-asyncio : endpoint sans auth → 200, payload schema, cache hit (deuxième appel = même valeur sans nouvelle query DB)                                                                                                                                                                                                                                                  |
+| `frontend/src/components/landing/Testimonials.tsx`                      | Create | Section 3 cards témoignages avec quote, étoiles, métrique badge, avatar initiales, badge "Démo" en dev, retourne `null` si all-placeholder en prod                                                                                                                                                                                                                                |
+| `frontend/src/components/landing/TrustBadges.tsx`                       | Create | Bandeau 5 badges horizontaux glassmorphism (IA française, archives à vie, RGPD, garantie 14 j, Stripe sécurisé)                                                                                                                                                                                                                                                                   |
+| `frontend/src/components/landing/SocialProofCounter.tsx`                | Create | 3 compteurs avec animation count-up Framer Motion ; fetch via `landingApi.getStats()` ; skeleton loading ; fallback graceful si erreur réseau                                                                                                                                                                                                                                     |
+| `frontend/src/components/landing/index.ts`                              | Modify | Ajouter `export { default as Testimonials } from "./Testimonials";` etc.                                                                                                                                                                                                                                                                                                          |
+| `frontend/src/components/landing/__tests__/Testimonials.test.tsx`       | Create | Vitest + Testing Library : rendu 3 cards FR, rendu EN, badge Démo en DEV (mock `import.meta.env.DEV = true`), retourne null en PROD si all placeholder                                                                                                                                                                                                                            |
+| `frontend/src/components/landing/__tests__/TrustBadges.test.tsx`        | Create | Vitest : rendu 5 badges, i18n FR/EN, ARIA labels                                                                                                                                                                                                                                                                                                                                  |
+| `frontend/src/components/landing/__tests__/SocialProofCounter.test.tsx` | Create | Vitest : rendu skeleton initial, rendu 3 compteurs après resolve mock fetch, fallback erreur réseau (compteurs masqués)                                                                                                                                                                                                                                                           |
+| `frontend/src/i18n/fr.json`                                             | Modify | Ajouter sous-clés `landing.testimonials`, `landing.trust_badges`, `landing.social_proof`                                                                                                                                                                                                                                                                                          |
+| `frontend/src/i18n/en.json`                                             | Modify | Idem en anglais                                                                                                                                                                                                                                                                                                                                                                   |
+| `frontend/src/services/api.ts`                                          | Modify | Ajouter `interface LandingStatsResponse` + `export const landingApi = { getStats() }` (utilise `skipAuth: true, skipCredentials: true` comme `demoApi`)                                                                                                                                                                                                                           |
+| `frontend/src/pages/LandingPage.tsx`                                    | Modify | (a) Insérer `<SocialProofCounter language={language} />` après hero (juste avant le Demo statique vers ligne 944) ; (b) Insérer `<Testimonials language={language} />` après le `<section>` Demo lignes 1072-1077 ; (c) Insérer `<TrustBadges language={language} />` directement après `<PricingSection ... />` ligne 1366 ; (d) Mettre à jour les imports du barrel ligne 45-49 |
+| `scripts/check-no-placeholders-in-prod.cjs` (optionnel — Task 8)        | Create | Script Node lancé en pré-deploy CI qui scanne `Testimonials.tsx` ; échoue si `isPlaceholder: true` ET `process.env.NODE_ENV === "production"` ET `DEEPSIGHT_ALLOW_FAKE_TESTIMONIALS !== "yes"`                                                                                                                                                                                    |
+
+**Note importante sur l'organisation des tests frontend** : le projet n'utilise pas un dossier `__tests__/` au niveau de `components/landing/` aujourd'hui, mais le pattern existe ailleurs (`frontend/src/components/__tests__/`, `frontend/src/components/voice/__tests__/`). On crée donc `frontend/src/components/landing/__tests__/` à plat — c'est cohérent avec le pattern le plus répandu du projet.
+
+---
+
+## Tasks
+
+### Task 1 : Backend — endpoint public `/api/public/landing-stats` avec cache Redis 1 h
+
+**Files:**
+
+- Create : `backend/src/landing/__init__.py`
+- Create : `backend/src/landing/router.py`
+- Modify : `backend/src/main.py` (deux endroits — import section vers ligne 192, include_router section vers ligne 1078)
+- Create : `backend/tests/landing/__init__.py`
+- Create : `backend/tests/landing/test_router.py`
+
+- [ ] **Step 1 : Créer le test failing**
+
+Créer le fichier vide `backend/tests/landing/__init__.py`.
+
+Créer `backend/tests/landing/test_router.py` :
+
+```python
+"""Tests pour le router landing public (stats homepage)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def landing_app():
+    """Instancie une app FastAPI minimaliste avec le router landing seul."""
+    from fastapi import FastAPI
+    from landing.router import router as landing_router
+
+    app = FastAPI()
+    app.include_router(landing_router)
+    return app
+
+
+@pytest.fixture
+def client(landing_app):
+    return TestClient(landing_app)
+
+
+@pytest.mark.asyncio
+async def test_landing_stats_endpoint_no_auth_required(client, monkeypatch):
+    """L'endpoint doit répondre 200 sans header Authorization."""
+    # Mock cache_service.get_or_set pour retourner une valeur fixe
+    fake_stats = {
+        "total_videos_analyzed": 1234,
+        "total_words_synthesized": 56789012,
+        "active_users_30d": 87,
+    }
+
+    async def fake_get_or_set(key, factory, ttl=None):
+        return fake_stats
+
+    from core import cache as cache_module
+    monkeypatch.setattr(cache_module.cache_service, "get_or_set", fake_get_or_set)
+
+    response = client.get("/api/public/landing-stats")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["total_videos_analyzed"] == 1234
+    assert data["total_words_synthesized"] == 56789012
+    assert data["active_users_30d"] == 87
+
+
+@pytest.mark.asyncio
+async def test_landing_stats_response_schema(client, monkeypatch):
+    """Le payload doit contenir exactement les 3 champs typés int."""
+    fake_stats = {
+        "total_videos_analyzed": 0,
+        "total_words_synthesized": 0,
+        "active_users_30d": 0,
+    }
+
+    async def fake_get_or_set(key, factory, ttl=None):
+        return fake_stats
+
+    from core import cache as cache_module
+    monkeypatch.setattr(cache_module.cache_service, "get_or_set", fake_get_or_set)
+
+    response = client.get("/api/public/landing-stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data.keys()) == {"total_videos_analyzed", "total_words_synthesized", "active_users_30d"}
+    assert isinstance(data["total_videos_analyzed"], int)
+    assert isinstance(data["total_words_synthesized"], int)
+    assert isinstance(data["active_users_30d"], int)
+
+
+@pytest.mark.asyncio
+async def test_landing_stats_uses_cache_with_ttl_3600(client, monkeypatch):
+    """Vérifie que cache_service.get_or_set est appelé avec ttl=3600 et clé stable."""
+    captured = {}
+
+    async def fake_get_or_set(key, factory, ttl=None):
+        captured["key"] = key
+        captured["ttl"] = ttl
+        return {
+            "total_videos_analyzed": 1,
+            "total_words_synthesized": 2,
+            "active_users_30d": 3,
+        }
+
+    from core import cache as cache_module
+    monkeypatch.setattr(cache_module.cache_service, "get_or_set", fake_get_or_set)
+
+    response = client.get("/api/public/landing-stats")
+    assert response.status_code == 200
+    assert captured["key"] == "landing:public_stats"
+    assert captured["ttl"] == 3600
+```
+
+- [ ] **Step 2 : Lancer les tests, vérifier qu'ils échouent**
+
+Run :
+
+```bash
+cd backend && python -m pytest tests/landing/test_router.py -v
+```
+
+Expected : `ModuleNotFoundError: No module named 'landing'`.
+
+- [ ] **Step 3 : Créer le module `landing/__init__.py`**
+
+Créer `backend/src/landing/__init__.py` :
+
+```python
+"""Landing module — endpoints publics pour la homepage (stats agrégées sans auth)."""
+```
+
+- [ ] **Step 4 : Créer le router `backend/src/landing/router.py`**
+
+Créer le fichier complet :
+
+```python
+"""
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  🌐 LANDING PUBLIC ROUTER — Stats homepage (no auth)                         ║
+╠══════════════════════════════════════════════════════════════════════════════╣
+║  GET /api/public/landing-stats                                               ║
+║  Renvoie 3 compteurs agrégés (vidéos analysées, mots synthétisés,            ║
+║  utilisateurs actifs 30 j) avec cache Redis 1 h.                             ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import select, func, distinct
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import get_session, User, Summary
+from core.cache import cache_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/public", tags=["Landing Public"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📊 SCHEMAS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class LandingStatsResponse(BaseModel):
+    """Compteurs agrégés exposés publiquement sur la homepage."""
+
+    total_videos_analyzed: int
+    total_words_synthesized: int
+    active_users_30d: int
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎯 ENDPOINT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+CACHE_KEY = "landing:public_stats"
+CACHE_TTL_SECONDS = 3600  # 1 hour
+
+
+async def _compute_landing_stats(session: AsyncSession) -> dict:
+    """Calcule les 3 agrégats à partir de la DB. Modèle SQL inspiré
+    de admin/router.py:102-156 mais sans auth admin."""
+    total_videos_result = await session.execute(select(func.coalesce(func.sum(User.total_videos), 0)))
+    total_videos = int(total_videos_result.scalar() or 0)
+
+    total_words_result = await session.execute(select(func.coalesce(func.sum(User.total_words), 0)))
+    total_words = int(total_words_result.scalar() or 0)
+
+    cutoff = datetime.utcnow() - timedelta(days=30)
+    active_users_result = await session.execute(
+        select(func.count(distinct(Summary.user_id))).where(Summary.created_at >= cutoff)
+    )
+    active_users = int(active_users_result.scalar() or 0)
+
+    return {
+        "total_videos_analyzed": total_videos,
+        "total_words_synthesized": total_words,
+        "active_users_30d": active_users,
+    }
+
+
+@router.get("/landing-stats", response_model=LandingStatsResponse)
+async def get_landing_stats(session: AsyncSession = Depends(get_session)):
+    """
+    📊 Compteurs publics homepage.
+
+    - **total_videos_analyzed** : sum(User.total_videos) — toutes les analyses cumulées
+    - **total_words_synthesized** : sum(User.total_words) — tous les mots des synthèses
+    - **active_users_30d** : count distinct user_id avec une Summary créée < 30 j
+
+    Cache Redis 1 h (clé `landing:public_stats`). Pas d'auth requise.
+    """
+
+    async def _factory():
+        return await _compute_landing_stats(session)
+
+    stats = await cache_service.get_or_set(CACHE_KEY, _factory, ttl=CACHE_TTL_SECONDS)
+
+    if stats is None:
+        # cache_service KO : recompute live
+        logger.warning("cache_service.get_or_set returned None for %s, computing live", CACHE_KEY)
+        stats = await _compute_landing_stats(session)
+
+    return LandingStatsResponse(**stats)
+```
+
+**Note importante** : `cache_service.get_or_set` peut accepter une factory async (cf. `backend/src/core/cache.py` ligne 388 — `Callable[[], T]`). Le test Step 1 mocke directement le résultat retourné, donc l'inspection précise de la signature factory est non-bloquante pour le test ; néanmoins on **doit** confirmer que la factory async est bien acceptée. Si le décorateur attend du sync, fallback inline :
+
+```python
+        cached = await cache_service.get(CACHE_KEY)
+        if cached is not None:
+            return LandingStatsResponse(**cached)
+        stats = await _compute_landing_stats(session)
+        await cache_service.set(CACHE_KEY, stats, ttl=CACHE_TTL_SECONDS)
+        return LandingStatsResponse(**stats)
+```
+
+- [ ] **Step 5 : Lancer les tests, vérifier qu'ils passent**
+
+Run :
+
+```bash
+cd backend && python -m pytest tests/landing/test_router.py -v
+```
+
+Expected : `3 passed`.
+
+Si le test 3 échoue parce que `factory` est async-only, basculer sur le fallback `cache_service.get/set` inline (cf. note Step 4) et re-tester.
+
+- [ ] **Step 6 : Inclure le router dans `backend/src/main.py`**
+
+Repérer la section "Public API router" lignes 192-199 puis ajouter **juste après** (toujours dans la zone `try/except ImportError`) :
+
+```python
+# 🌐 NOUVEAU: Landing public router (stats homepage sans auth)
+try:
+    from landing.router import router as landing_router
+
+    LANDING_ROUTER_AVAILABLE = True
+except ImportError as e:
+    LANDING_ROUTER_AVAILABLE = False
+    logger.warning(f"⚠️ Landing router not available: {e}")
+```
+
+Puis dans la section "INCLUSION DES ROUTERS" — repérer le bloc `if API_PUBLIC_ROUTER_AVAILABLE:` lignes 1077-1080 et ajouter **juste après** :
+
+```python
+# 🌐 NOUVEAU: Landing public router
+if LANDING_ROUTER_AVAILABLE:
+    app.include_router(landing_router, tags=["Landing Public"])
+    logger.info("🌐 Landing router loaded (public stats homepage)")
+```
+
+Note : le router contient déjà `prefix="/api/public"` dans sa définition, donc on **ne** repasse pas de prefix ici (sinon double prefix).
+
+- [ ] **Step 7 : Smoke test local — démarrer le backend, curl l'endpoint**
+
+Run :
+
+```bash
+cd backend/src && uvicorn main:app --port 8000 --reload &
+sleep 4
+curl -s http://localhost:8000/api/public/landing-stats | python -m json.tool
+```
+
+Expected : JSON valide avec 3 clés `total_videos_analyzed`, `total_words_synthesized`, `active_users_30d` (toutes int >= 0).
+
+Stopper uvicorn (`kill %1`).
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add backend/src/landing/__init__.py backend/src/landing/router.py backend/src/main.py backend/tests/landing/__init__.py backend/tests/landing/test_router.py
+git commit -m "feat(landing): add public stats endpoint with redis cache 1h
+
+- New module backend/src/landing/ exposing GET /api/public/landing-stats
+- Aggregates User.total_videos, User.total_words, distinct active users (30d)
+- Cache key 'landing:public_stats' with ttl=3600s via cache_service
+- 3 pytest-asyncio tests covering no-auth, schema, cache invocation
+- Wired into main.py via try/except (LANDING_ROUTER_AVAILABLE flag)"
+```
+
+---
+
+### Task 2 : Frontend — `Testimonials.tsx` avec data placeholder + flag `isPlaceholder` + badge "Démo" en dev
+
+**Files:**
+
+- Create : `frontend/src/components/landing/Testimonials.tsx`
+- Create : `frontend/src/components/landing/__tests__/Testimonials.test.tsx`
+
+- [ ] **Step 1 : Écrire le test failing**
+
+Créer `frontend/src/components/landing/__tests__/Testimonials.test.tsx` :
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Testimonials from "../Testimonials";
+
+describe("Testimonials", () => {
+  const originalEnv = { ...import.meta.env };
+
+  afterEach(() => {
+    // restore vitest stub
+    vi.unstubAllEnvs();
+  });
+
+  it("renders 3 testimonial cards in French", () => {
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("PROD", false);
+    render(<Testimonials language="fr" />);
+    expect(screen.getByText(/Dr\. Marie L\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Thomas B\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Léa K\./i)).toBeInTheDocument();
+    // Métriques visibles
+    expect(screen.getByText(/2h\s*→\s*30 min/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 fact-checks\/jour/i)).toBeInTheDocument();
+    expect(screen.getByText(/\+40\s*%\s*rétention/i)).toBeInTheDocument();
+  });
+
+  it("renders 3 testimonial cards in English", () => {
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("PROD", false);
+    render(<Testimonials language="en" />);
+    expect(screen.getByText(/Dr\. Marie L\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Thomas B\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Léa K\./i)).toBeInTheDocument();
+  });
+
+  it("displays a 'Démo' badge when DEV", () => {
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("PROD", false);
+    render(<Testimonials language="fr" />);
+    expect(screen.getByTestId("testimonials-demo-badge")).toBeInTheDocument();
+    expect(screen.getByTestId("testimonials-demo-badge")).toHaveTextContent(
+      /démo/i,
+    );
+  });
+
+  it("returns null when PROD and all entries are placeholder", () => {
+    vi.stubEnv("DEV", false);
+    vi.stubEnv("PROD", true);
+    const { container } = render(<Testimonials language="fr" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders avatar initials from author name", () => {
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("PROD", false);
+    render(<Testimonials language="fr" />);
+    // "Dr. Marie L." -> "ML" (initials of first non-honorific words)
+    expect(
+      screen.getByLabelText(/avatar de Dr\. Marie L\./i),
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2 : Lancer le test, vérifier qu'il échoue**
+
+Run :
+
+```bash
+cd frontend && npm run test -- Testimonials.test
+```
+
+Expected : `Failed to resolve import "../Testimonials"`.
+
+- [ ] **Step 3 : Implémenter `Testimonials.tsx`**
+
+Créer `frontend/src/components/landing/Testimonials.tsx` :
+
+```tsx
+/**
+ * Testimonials — 3 cards témoignages chiffrés
+ *
+ * ⚠️ Les 3 témoignages seed sont fictifs (`isPlaceholder: true`).
+ * En prod, le composant retourne null si toutes les entrées sont placeholder.
+ * En dev/staging, un badge "Démo" rappelle leur statut fictif.
+ */
+
+import { motion, useInView } from "framer-motion";
+import { useRef } from "react";
+import { Quote, Star } from "lucide-react";
+
+const ease = [0.4, 0, 0.2, 1] as const;
+
+export interface TestimonialEntry {
+  id: string;
+  author: string;
+  roleFr: string;
+  roleEn: string;
+  quoteFr: string;
+  quoteEn: string;
+  metricFr: string;
+  metricEn: string;
+  isPlaceholder: boolean;
+}
+
+const TESTIMONIALS: TestimonialEntry[] = [
+  {
+    id: "marie-l",
+    author: "Dr. Marie L.",
+    roleFr: "Chercheuse CNRS",
+    roleEn: "CNRS Researcher",
+    quoteFr:
+      "J'analysais 2h de conférences en 30 min. Le fact-checking m'a fait gagner une demi-journée.",
+    quoteEn:
+      "I used to spend 2h on conference videos — now 30 min. Fact-checking saved me half a day.",
+    metricFr: "2h → 30 min",
+    metricEn: "2h → 30 min",
+    isPlaceholder: true,
+  },
+  {
+    id: "thomas-b",
+    author: "Thomas B.",
+    roleFr: "Journaliste, agence régionale",
+    roleEn: "Journalist, regional agency",
+    quoteFr:
+      "Vérifier les affirmations des vidéos avec timecodes et sources ? Indispensable.",
+    quoteEn:
+      "Verifying video claims with timecodes and sources? Indispensable.",
+    metricFr: "3 fact-checks/jour",
+    metricEn: "3 fact-checks/day",
+    isPlaceholder: true,
+  },
+  {
+    id: "lea-k",
+    author: "Léa K.",
+    roleFr: "Étudiante Master Droit",
+    roleEn: "Law Master's student",
+    quoteFr: "Les flashcards FSRS me font réviser 3x plus efficacement.",
+    quoteEn: "FSRS flashcards make me review 3x more efficiently.",
+    metricFr: "+40 % rétention",
+    metricEn: "+40 % retention",
+    isPlaceholder: true,
+  },
+];
+
+function getInitials(author: string): string {
+  // "Dr. Marie L." -> "ML" ; "Thomas B." -> "TB" ; "Léa K." -> "LK"
+  const honorifics = new Set([
+    "dr",
+    "dr.",
+    "mr",
+    "mr.",
+    "mme",
+    "mme.",
+    "m.",
+    "ms",
+    "ms.",
+  ]);
+  const tokens = author
+    .split(/\s+/)
+    .map((t) => t.replace(/[.,]/g, ""))
+    .filter((t) => t.length > 0 && !honorifics.has(t.toLowerCase()));
+  return tokens
+    .slice(0, 2)
+    .map((t) => t[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+export interface TestimonialsProps {
+  language: "fr" | "en" | string;
+}
+
+export default function Testimonials({ language }: TestimonialsProps) {
+  const lang = language === "fr" ? "fr" : "en";
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, margin: "-60px" });
+
+  // Anti-prod garde-fou : si toutes les entrées sont placeholder ET on est en prod, ne rien rendre
+  const allPlaceholder = TESTIMONIALS.every((t) => t.isPlaceholder);
+  if (import.meta.env.PROD && allPlaceholder) {
+    return null;
+  }
+
+  const showDemoBadge = import.meta.env.DEV && allPlaceholder;
+
+  return (
+    <section
+      id="testimonials"
+      className="py-16 sm:py-24 px-4 sm:px-6"
+      ref={ref}
+      aria-labelledby="testimonials-heading"
+    >
+      <div className="max-w-6xl mx-auto">
+        {showDemoBadge && (
+          <div className="flex justify-center mb-6">
+            <div
+              data-testid="testimonials-demo-badge"
+              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-300 text-xs font-semibold"
+            >
+              {lang === "fr"
+                ? "⚠ Démo — témoignages fictifs (dev/staging)"
+                : "⚠ Demo — fictional testimonials (dev/staging)"}
+            </div>
+          </div>
+        )}
+
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 24 }}
+          transition={{ duration: 0.5, ease }}
+          className="text-center mb-12 sm:mb-16"
+        >
+          <h2
+            id="testimonials-heading"
+            className="text-2xl sm:text-3xl font-semibold tracking-tight text-text-primary mb-3"
+          >
+            {lang === "fr"
+              ? "Ce que nos utilisateurs en disent"
+              : "What our users say"}
+          </h2>
+          <p className="text-text-secondary text-sm sm:text-base max-w-xl mx-auto">
+            {lang === "fr"
+              ? "Des chercheurs, journalistes et étudiants qui gagnent un temps précieux."
+              : "Researchers, journalists and students saving precious time."}
+          </p>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5 sm:gap-6">
+          {TESTIMONIALS.map((t, i) => (
+            <motion.div
+              key={t.id}
+              initial={{ opacity: 0, y: 24 }}
+              animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 24 }}
+              transition={{ duration: 0.4, ease, delay: 0.1 + i * 0.08 }}
+              className="relative p-6 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl flex flex-col"
+            >
+              <Quote
+                className="w-6 h-6 text-accent-primary/40 mb-3"
+                aria-hidden="true"
+              />
+
+              <div
+                className="flex items-center gap-1 mb-3"
+                aria-label={
+                  lang === "fr" ? "5 étoiles sur 5" : "5 stars out of 5"
+                }
+              >
+                {[0, 1, 2, 3, 4].map((s) => (
+                  <Star
+                    key={s}
+                    className="w-3.5 h-3.5 text-amber-400 fill-amber-400"
+                    aria-hidden="true"
+                  />
+                ))}
+              </div>
+
+              <p className="text-sm text-text-secondary leading-relaxed mb-5 flex-1">
+                « {lang === "fr" ? t.quoteFr : t.quoteEn} »
+              </p>
+
+              <div className="inline-flex self-start items-center gap-1.5 px-2.5 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/30 text-emerald-300 text-xs font-semibold mb-4">
+                {lang === "fr" ? t.metricFr : t.metricEn}
+              </div>
+
+              <div className="flex items-center gap-3 mt-auto pt-4 border-t border-white/5">
+                <div
+                  className="w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500/30 to-violet-500/30 border border-white/10 flex items-center justify-center text-sm font-semibold text-text-primary"
+                  aria-label={
+                    lang === "fr"
+                      ? `Avatar de ${t.author}`
+                      : `Avatar of ${t.author}`
+                  }
+                >
+                  {getInitials(t.author)}
+                </div>
+                <div>
+                  <div className="text-sm font-semibold text-text-primary">
+                    {t.author}
+                  </div>
+                  <div className="text-xs text-text-tertiary">
+                    {lang === "fr" ? t.roleFr : t.roleEn}
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4 : Lancer le test, vérifier qu'il passe**
+
+Run :
+
+```bash
+cd frontend && npm run test -- Testimonials.test
+```
+
+Expected : `5 passed`.
+
+Si le test 4 (`returns null when PROD`) échoue parce que `import.meta.env.PROD` n'est pas correctement stub, vérifier la version de Vitest. Utiliser `vi.stubEnv("PROD", true)` (Vitest >= 0.25) — confirmer en lançant `npx vitest --version`. Si trop ancien, fallback : passer un prop `__forceMode` au composant (uniquement en test) — mais d'abord essayer la stub.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add frontend/src/components/landing/Testimonials.tsx frontend/src/components/landing/__tests__/Testimonials.test.tsx
+git commit -m "feat(landing): add Testimonials component with placeholder safeguard
+
+- 3 fictional seed entries (Dr. Marie L., Thomas B., Léa K.) with isPlaceholder flag
+- Returns null in production if all entries are placeholders (anti-deploy guard)
+- Shows 'Démo' badge in DEV environments
+- 5-star rating, metric badge, avatar initials, glassmorphism dark mode
+- Framer Motion useInView reveal, FR + EN inline strings
+- 5 vitest cases covering FR/EN render, dev badge, prod null, initials"
+```
+
+---
+
+### Task 3 : Frontend — `TrustBadges.tsx` (5 badges horizontaux)
+
+**Files:**
+
+- Create : `frontend/src/components/landing/TrustBadges.tsx`
+- Create : `frontend/src/components/landing/__tests__/TrustBadges.test.tsx`
+
+- [ ] **Step 1 : Écrire le test failing**
+
+Créer `frontend/src/components/landing/__tests__/TrustBadges.test.tsx` :
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TrustBadges from "../TrustBadges";
+
+describe("TrustBadges", () => {
+  it("renders 5 badges in French", () => {
+    render(<TrustBadges language="fr" />);
+    expect(screen.getByText(/IA 100\s*%\s*Française/i)).toBeInTheDocument();
+    expect(screen.getByText(/archivées à vie/i)).toBeInTheDocument();
+    expect(screen.getByText(/RGPD/i)).toBeInTheDocument();
+    expect(screen.getByText(/14 jours/i)).toBeInTheDocument();
+    expect(screen.getByText(/Stripe/i)).toBeInTheDocument();
+  });
+
+  it("renders 5 badges in English", () => {
+    render(<TrustBadges language="en" />);
+    expect(screen.getByText(/100\s*%\s*French/i)).toBeInTheDocument();
+    expect(screen.getByText(/lifetime/i)).toBeInTheDocument();
+    expect(screen.getByText(/GDPR/i)).toBeInTheDocument();
+    expect(screen.getByText(/14[- ]day/i)).toBeInTheDocument();
+    expect(screen.getByText(/Stripe/i)).toBeInTheDocument();
+  });
+
+  it("each badge has a role-list item with aria-label", () => {
+    render(<TrustBadges language="fr" />);
+    const list = screen.getByRole("list", { name: /trust badges|garanties/i });
+    expect(list).toBeInTheDocument();
+    expect(list.querySelectorAll("li")).toHaveLength(5);
+  });
+});
+```
+
+- [ ] **Step 2 : Lancer le test, vérifier qu'il échoue**
+
+Run :
+
+```bash
+cd frontend && npm run test -- TrustBadges.test
+```
+
+Expected : `Failed to resolve import "../TrustBadges"`.
+
+- [ ] **Step 3 : Implémenter `TrustBadges.tsx`**
+
+Créer `frontend/src/components/landing/TrustBadges.tsx` :
+
+```tsx
+/**
+ * TrustBadges — 5 badges horizontaux de réassurance, placés sous PricingSection.
+ */
+
+import { motion, useInView } from "framer-motion";
+import { useRef } from "react";
+
+const ease = [0.4, 0, 0.2, 1] as const;
+
+interface BadgeDef {
+  id: string;
+  icon: string; // emoji
+  labelFr: string;
+  labelEn: string;
+}
+
+const BADGES: BadgeDef[] = [
+  {
+    id: "french-ai",
+    icon: "🇫🇷",
+    labelFr: "IA 100 % Française & Européenne (Mistral)",
+    labelEn: "100 % French & European AI (Mistral)",
+  },
+  {
+    id: "lifetime-archive",
+    icon: "🗄️",
+    labelFr: "Analyses archivées à vie",
+    labelEn: "Analyses archived for lifetime",
+  },
+  {
+    id: "gdpr",
+    icon: "🛡️",
+    labelFr: "Conforme RGPD",
+    labelEn: "GDPR-compliant",
+  },
+  {
+    id: "refund-14d",
+    icon: "✓",
+    labelFr: "Garantie 14 jours satisfait ou remboursé",
+    labelEn: "14-day money-back guarantee",
+  },
+  {
+    id: "stripe-secure",
+    icon: "🔒",
+    labelFr: "Paiement sécurisé Stripe",
+    labelEn: "Secure Stripe payment",
+  },
+];
+
+export interface TrustBadgesProps {
+  language: "fr" | "en" | string;
+}
+
+export default function TrustBadges({ language }: TrustBadgesProps) {
+  const lang = language === "fr" ? "fr" : "en";
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, margin: "-60px" });
+
+  return (
+    <section className="py-10 sm:py-14 px-4 sm:px-6" ref={ref}>
+      <div className="max-w-5xl mx-auto">
+        <motion.ul
+          initial={{ opacity: 0, y: 16 }}
+          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
+          transition={{ duration: 0.5, ease }}
+          aria-label={lang === "fr" ? "Garanties de confiance" : "Trust badges"}
+          className="grid grid-cols-2 md:grid-cols-5 gap-3 sm:gap-4"
+        >
+          {BADGES.map((b) => (
+            <li
+              key={b.id}
+              className="flex items-center gap-2 px-3 py-2.5 rounded-lg border border-white/10 bg-white/5 backdrop-blur-xl text-xs sm:text-[13px] text-text-secondary text-center justify-center"
+            >
+              <span className="text-base flex-shrink-0" aria-hidden="true">
+                {b.icon}
+              </span>
+              <span className="leading-tight">
+                {lang === "fr" ? b.labelFr : b.labelEn}
+              </span>
+            </li>
+          ))}
+        </motion.ul>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4 : Lancer le test, vérifier qu'il passe**
+
+Run :
+
+```bash
+cd frontend && npm run test -- TrustBadges.test
+```
+
+Expected : `3 passed`.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add frontend/src/components/landing/TrustBadges.tsx frontend/src/components/landing/__tests__/TrustBadges.test.tsx
+git commit -m "feat(landing): add TrustBadges component (5 horizontal badges)
+
+- French AI sovereignty, lifetime archives, GDPR, 14-day refund, Stripe
+- Glassmorphism dark mode, responsive grid 2/5 cols
+- aria-label on the list, 3 vitest cases (FR, EN, list semantics)"
+```
+
+---
+
+### Task 4 : Frontend — `landingApi.getStats()` côté API client
+
+**Files:**
+
+- Modify : `frontend/src/services/api.ts` (ajout d'un nouvel objet exporté)
+
+- [ ] **Step 1 : Identifier le bon emplacement**
+
+Ouvrir `frontend/src/services/api.ts` et localiser la fin de `demoApi` (ligne ~936). On insère **juste après** la fermeture du bloc `};` de `demoApi`. C'est intentionnel : on garde les API publiques sans auth groupées.
+
+- [ ] **Step 2 : Ajouter le type + l'objet API**
+
+Ajouter directement après `};` qui ferme `demoApi` (vers ligne 937) :
+
+```typescript
+// 🌐 Landing public — stats homepage (cache Redis 1h, no auth)
+export interface LandingStatsResponse {
+  total_videos_analyzed: number;
+  total_words_synthesized: number;
+  active_users_30d: number;
+}
+
+export const landingApi = {
+  /**
+   * 🌐 Get aggregated public stats for the homepage social proof counter.
+   * Cached on the backend for 1 hour (Redis).
+   */
+  async getStats(): Promise<LandingStatsResponse> {
+    return request<LandingStatsResponse>("/api/public/landing-stats", {
+      method: "GET",
+      skipAuth: true,
+      skipCredentials: true,
+      timeout: 10000,
+    });
+  },
+};
+```
+
+- [ ] **Step 3 : Vérifier la compilation TypeScript**
+
+Run :
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected : 0 nouvelle erreur introduite (les éventuelles erreurs préexistantes dans d'autres fichiers ne nous concernent pas — mais on doit s'assurer que `services/api.ts` n'a aucune nouvelle erreur sur les lignes ajoutées).
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add frontend/src/services/api.ts
+git commit -m "feat(api): add landingApi.getStats() for homepage social proof
+
+- New LandingStatsResponse interface (3 int fields)
+- landingApi.getStats() calls GET /api/public/landing-stats with skipAuth+skipCredentials
+- 10s timeout, follows demoApi pattern"
+```
+
+---
+
+### Task 5 : Frontend — `SocialProofCounter.tsx` avec fetch + skeleton + count-up
+
+**Files:**
+
+- Create : `frontend/src/components/landing/SocialProofCounter.tsx`
+- Create : `frontend/src/components/landing/__tests__/SocialProofCounter.test.tsx`
+
+- [ ] **Step 1 : Écrire le test failing**
+
+Créer `frontend/src/components/landing/__tests__/SocialProofCounter.test.tsx` :
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import SocialProofCounter from "../SocialProofCounter";
+import { landingApi } from "../../../services/api";
+
+vi.mock("../../../services/api", () => ({
+  landingApi: {
+    getStats: vi.fn(),
+  },
+}));
+
+const mockedGetStats = landingApi.getStats as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+describe("SocialProofCounter", () => {
+  beforeEach(() => {
+    mockedGetStats.mockReset();
+  });
+
+  it("shows skeleton placeholders before fetch resolves", () => {
+    mockedGetStats.mockImplementation(() => new Promise(() => {})); // never resolves
+    render(<SocialProofCounter language="fr" />);
+    const skeletons = screen.getAllByTestId("social-proof-skeleton");
+    expect(skeletons).toHaveLength(3);
+  });
+
+  it("renders 3 counters once stats are fetched (FR)", async () => {
+    mockedGetStats.mockResolvedValue({
+      total_videos_analyzed: 12345,
+      total_words_synthesized: 6789012,
+      active_users_30d: 432,
+    });
+    render(<SocialProofCounter language="fr" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("counter-videos")).toBeInTheDocument();
+      expect(screen.getByTestId("counter-words")).toBeInTheDocument();
+      expect(screen.getByTestId("counter-users")).toBeInTheDocument();
+    });
+    // Final value visible (count-up may animate, but final number must appear)
+    expect(screen.getByTestId("counter-videos")).toHaveTextContent(
+      /12[\s  ]?345/,
+    );
+  });
+
+  it("renders nothing visible (no error UI, no counters) on fetch failure", async () => {
+    mockedGetStats.mockRejectedValue(new Error("Network error"));
+    const { container } = render(<SocialProofCounter language="fr" />);
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("social-proof-skeleton"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("counter-videos")).not.toBeInTheDocument();
+    expect(container.querySelector("section")).toBeNull();
+  });
+
+  it("renders English labels when language='en'", async () => {
+    mockedGetStats.mockResolvedValue({
+      total_videos_analyzed: 1,
+      total_words_synthesized: 2,
+      active_users_30d: 3,
+    });
+    render(<SocialProofCounter language="en" />);
+    await waitFor(() => {
+      expect(screen.getByText(/videos analyzed/i)).toBeInTheDocument();
+      expect(screen.getByText(/words synthesized/i)).toBeInTheDocument();
+      expect(screen.getByText(/active users/i)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2 : Lancer le test, vérifier qu'il échoue**
+
+Run :
+
+```bash
+cd frontend && npm run test -- SocialProofCounter.test
+```
+
+Expected : `Failed to resolve import "../SocialProofCounter"`.
+
+- [ ] **Step 3 : Implémenter `SocialProofCounter.tsx`**
+
+Créer `frontend/src/components/landing/SocialProofCounter.tsx` :
+
+```tsx
+/**
+ * SocialProofCounter — 3 compteurs en bandeau (vidéos analysées, mots synthétisés, utilisateurs actifs 30j).
+ *
+ * Fetch via landingApi.getStats() ; skeleton pendant chargement ;
+ * en cas d'erreur réseau, le composant s'efface silencieusement (pas d'UI d'erreur sur la home).
+ */
+
+import {
+  motion,
+  useInView,
+  useMotionValue,
+  useSpring,
+  useTransform,
+} from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+import { Video, FileText, Users } from "lucide-react";
+import { landingApi, type LandingStatsResponse } from "../../services/api";
+
+const ease = [0.4, 0, 0.2, 1] as const;
+
+export interface SocialProofCounterProps {
+  language: "fr" | "en" | string;
+}
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "success"; stats: LandingStatsResponse }
+  | { status: "error" };
+
+function formatNumber(value: number, lang: "fr" | "en"): string {
+  return value.toLocaleString(lang === "fr" ? "fr-FR" : "en-US");
+}
+
+interface CountUpProps {
+  value: number;
+  lang: "fr" | "en";
+  testId: string;
+}
+
+function CountUp({ value, lang, testId }: CountUpProps) {
+  const motionValue = useMotionValue(0);
+  const spring = useSpring(motionValue, {
+    stiffness: 60,
+    damping: 18,
+    mass: 1,
+  });
+  const display = useTransform(spring, (latest) =>
+    formatNumber(Math.round(latest), lang),
+  );
+  const [text, setText] = useState(formatNumber(0, lang));
+
+  useEffect(() => {
+    const unsubscribe = display.on("change", setText);
+    motionValue.set(value);
+    return () => unsubscribe();
+  }, [value, motionValue, display]);
+
+  return (
+    <span data-testid={testId} className="tabular-nums">
+      {text}
+    </span>
+  );
+}
+
+export default function SocialProofCounter({
+  language,
+}: SocialProofCounterProps) {
+  const lang = language === "fr" ? "fr" : "en";
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, margin: "-40px" });
+  const [state, setState] = useState<FetchState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    landingApi
+      .getStats()
+      .then((stats) => {
+        if (!cancelled) setState({ status: "success", stats });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Erreur réseau : on s'efface silencieusement (pas d'UI d'erreur sur la home)
+  if (state.status === "error") {
+    return null;
+  }
+
+  const cards = [
+    {
+      id: "videos",
+      icon: Video,
+      labelFr: "vidéos analysées",
+      labelEn: "videos analyzed",
+      value: state.status === "success" ? state.stats.total_videos_analyzed : 0,
+    },
+    {
+      id: "words",
+      icon: FileText,
+      labelFr: "mots synthétisés",
+      labelEn: "words synthesized",
+      value:
+        state.status === "success" ? state.stats.total_words_synthesized : 0,
+    },
+    {
+      id: "users",
+      icon: Users,
+      labelFr: "utilisateurs actifs (30 j)",
+      labelEn: "active users (30 d)",
+      value: state.status === "success" ? state.stats.active_users_30d : 0,
+    },
+  ];
+
+  return (
+    <section
+      className="py-8 sm:py-12 px-4 sm:px-6"
+      ref={ref}
+      aria-labelledby="social-proof-heading"
+    >
+      <div className="max-w-5xl mx-auto">
+        <h2 id="social-proof-heading" className="sr-only">
+          {lang === "fr" ? "Statistiques DeepSight" : "DeepSight statistics"}
+        </h2>
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
+          transition={{ duration: 0.5, ease }}
+          className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6"
+        >
+          {cards.map((c) => {
+            const Icon = c.icon;
+            return (
+              <div
+                key={c.id}
+                className="flex items-center gap-4 p-5 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl"
+              >
+                <div className="w-10 h-10 rounded-lg bg-accent-primary/10 border border-accent-primary/20 flex items-center justify-center flex-shrink-0">
+                  <Icon
+                    className="w-5 h-5 text-accent-primary"
+                    aria-hidden="true"
+                  />
+                </div>
+                <div className="flex-1 min-w-0">
+                  {state.status === "loading" ? (
+                    <div
+                      data-testid="social-proof-skeleton"
+                      className="h-7 w-28 rounded bg-white/10 animate-pulse mb-1.5"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <div className="text-2xl font-bold text-text-primary">
+                      <CountUp
+                        value={c.value}
+                        lang={lang}
+                        testId={`counter-${c.id}`}
+                      />
+                    </div>
+                  )}
+                  <div className="text-xs text-text-tertiary">
+                    {lang === "fr" ? c.labelFr : c.labelEn}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4 : Lancer le test, vérifier qu'il passe**
+
+Run :
+
+```bash
+cd frontend && npm run test -- SocialProofCounter.test
+```
+
+Expected : `4 passed`.
+
+Si le test 2 (counter-videos value 12345) échoue parce que `useSpring` n'a pas le temps de finir l'animation dans le test, on a deux options :
+
+- (a) Augmenter le `stiffness` à 200+ et `damping` à 30+ pour converger en quelques frames.
+- (b) Utiliser `vi.useFakeTimers()` et `await vi.runAllTimersAsync()` dans le test avant l'assertion.
+
+Préférer (a) si possible, sinon (b). Documenter le choix dans le commit.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add frontend/src/components/landing/SocialProofCounter.tsx frontend/src/components/landing/__tests__/SocialProofCounter.test.tsx
+git commit -m "feat(landing): add SocialProofCounter with backend-driven stats
+
+- Fetches GET /api/public/landing-stats via landingApi.getStats()
+- 3 counters (videos analyzed, words synthesized, active users 30d)
+- Framer Motion useSpring count-up animation, fr-FR/en-US locale formatting
+- Skeleton placeholders during loading, silent unmount on network error
+- 4 vitest cases (skeleton, success, network failure, EN labels)"
+```
+
+---
+
+### Task 6 : i18n FR + EN — namespaces `landing.testimonials`, `landing.trust_badges`, `landing.social_proof`
+
+**Files:**
+
+- Modify : `frontend/src/i18n/fr.json`
+- Modify : `frontend/src/i18n/en.json`
+
+> **Note** : les composants Task 2/3/5 utilisent des chaînes inline (`lang === "fr" ? "..." : "..."`) pour rester cohérents avec le pattern majoritaire de `LandingPage.tsx`. Néanmoins, on **enrichit** les fichiers i18n avec les libellés (clés) — ils servent de référence pour toute traduction future et alignent avec la consigne "i18n FR + EN obligatoire" du prompt utilisateur.
+
+- [ ] **Step 1 : Ouvrir `frontend/src/i18n/fr.json` et localiser le bloc `landing`**
+
+Le bloc commence par `"landing": {` et contient les sous-clés `badge`, `hero`, `stats`, `features`, `audiences`, `pricing`, `cta`. Trouver la **dernière** sous-clé existante (`cta` ou la dernière) et **avant la fermeture `}`** du bloc landing, ajouter :
+
+```json
+    ,
+    "testimonials": {
+      "heading": "Ce que nos utilisateurs en disent",
+      "subheading": "Des chercheurs, journalistes et étudiants qui gagnent un temps précieux.",
+      "demoBadge": "⚠ Démo — témoignages fictifs (dev/staging)",
+      "stars": "5 étoiles sur 5"
+    },
+    "trust_badges": {
+      "heading": "Garanties de confiance",
+      "frenchAi": "IA 100 % Française & Européenne (Mistral)",
+      "lifetimeArchive": "Analyses archivées à vie",
+      "gdpr": "Conforme RGPD",
+      "refund14d": "Garantie 14 jours satisfait ou remboursé",
+      "stripeSecure": "Paiement sécurisé Stripe"
+    },
+    "social_proof": {
+      "heading": "Statistiques DeepSight",
+      "videos": "vidéos analysées",
+      "words": "mots synthétisés",
+      "users": "utilisateurs actifs (30 j)"
+    }
+```
+
+⚠ Conserver le `,` initial avant `"testimonials"` car il sépare de la sous-clé précédente `cta`. Conserver l'absence de virgule finale après `"users": "utilisateurs actifs (30 j)"`}` si c'est la dernière sous-clé du bloc landing — vérifier le JSON est valide.
+
+- [ ] **Step 2 : Idem dans `frontend/src/i18n/en.json`**
+
+Ajouter avant la fermeture du bloc `landing` :
+
+```json
+    ,
+    "testimonials": {
+      "heading": "What our users say",
+      "subheading": "Researchers, journalists and students saving precious time.",
+      "demoBadge": "⚠ Demo — fictional testimonials (dev/staging)",
+      "stars": "5 stars out of 5"
+    },
+    "trust_badges": {
+      "heading": "Trust badges",
+      "frenchAi": "100 % French & European AI (Mistral)",
+      "lifetimeArchive": "Analyses archived for lifetime",
+      "gdpr": "GDPR-compliant",
+      "refund14d": "14-day money-back guarantee",
+      "stripeSecure": "Secure Stripe payment"
+    },
+    "social_proof": {
+      "heading": "DeepSight statistics",
+      "videos": "videos analyzed",
+      "words": "words synthesized",
+      "users": "active users (30 d)"
+    }
+```
+
+- [ ] **Step 3 : Vérifier la validité JSON des deux fichiers**
+
+Run :
+
+```bash
+cd frontend && python -c "import json; json.load(open('src/i18n/fr.json', encoding='utf-8')); json.load(open('src/i18n/en.json', encoding='utf-8')); print('OK')"
+```
+
+Expected : `OK`. Sinon, fixer la virgule manquante / en trop.
+
+- [ ] **Step 4 : Vérifier que les tests existants passent encore**
+
+Run :
+
+```bash
+cd frontend && npm run test -- --run
+```
+
+Expected : tous les tests existants passent (la modif ne casse rien). Si un test snapshot landing échoue, regénérer ou ajuster (peu probable, on n'a touché que le JSON).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add frontend/src/i18n/fr.json frontend/src/i18n/en.json
+git commit -m "feat(landing): add i18n keys for testimonials, trust_badges, social_proof
+
+- FR + EN namespaces under 'landing'
+- Reference for future externalization (components currently inline strings)"
+```
+
+---
+
+### Task 7 : Intégration dans `LandingPage.tsx` (3 sections)
+
+**Files:**
+
+- Modify : `frontend/src/pages/LandingPage.tsx` (4 endroits — barrel import + 3 insertions)
+- Modify : `frontend/src/components/landing/index.ts` (4 nouveaux exports)
+
+- [ ] **Step 1 : Mettre à jour le barrel `frontend/src/components/landing/index.ts`**
+
+Le fichier actuel contient 3 lignes. Le remplacer par :
+
+```typescript
+export { default as DemoAnalysisStatic } from "./DemoAnalysisStatic";
+export { default as DemoChatStatic } from "./DemoChatStatic";
+export { default as PricingSection } from "./PricingSection";
+export { default as Testimonials } from "./Testimonials";
+export { default as TrustBadges } from "./TrustBadges";
+export { default as SocialProofCounter } from "./SocialProofCounter";
+```
+
+- [ ] **Step 2 : Mettre à jour l'import barrel dans `LandingPage.tsx` lignes 45-49**
+
+Bloc actuel :
+
+```tsx
+import {
+  DemoAnalysisStatic,
+  DemoChatStatic,
+  PricingSection,
+} from "../components/landing";
+```
+
+Remplacer par :
+
+```tsx
+import {
+  DemoAnalysisStatic,
+  DemoChatStatic,
+  PricingSection,
+  Testimonials,
+  TrustBadges,
+  SocialProofCounter,
+} from "../components/landing";
+```
+
+- [ ] **Step 3 : Insertion #1 — `<SocialProofCounter>` en bandeau juste après le HERO**
+
+Trouver la fin de la section HERO. Le HERO se ferme à la ligne ~944 (juste avant le bloc `{/* ─── DEMO INTERACTIVE ─── */}` qui commence à la ligne 1071-1072 selon le grep mais peut varier après les autres tasks). On localise le commentaire **`{/* ─── DEMO INTERACTIVE ─── */}`** ligne 1071 et on insère **juste avant** ce commentaire :
+
+```tsx
+{
+  /* ─── SOCIAL PROOF COUNTER (bandeau hero) ─── */
+}
+<SocialProofCounter language={language} />;
+```
+
+- [ ] **Step 4 : Insertion #2 — `<Testimonials>` après la section Demo statique**
+
+La section Demo se ferme ligne ~1077 (`</section>` après `<DemoChatStatic />`). Insérer **juste après** cette fermeture, AVANT le commentaire `{/* ─── FEATURES ─── */}` ligne 1078 :
+
+```tsx
+{
+  /* ─── TESTIMONIALS ─── */
+}
+<Testimonials language={language} />;
+```
+
+- [ ] **Step 5 : Insertion #3 — `<TrustBadges>` directement sous `<PricingSection>`**
+
+La ligne actuelle contenant `<PricingSection language={language} onNavigate={navigate} />` est ligne 1366. Juste après cette ligne, AVANT le commentaire `{/* ─── FAQ ─── */}` ligne 1367, ajouter :
+
+```tsx
+{
+  /* ─── TRUST BADGES (sous pricing) ─── */
+}
+<TrustBadges language={language} />;
+```
+
+- [ ] **Step 6 : Vérifier le typecheck**
+
+Run :
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected : aucune nouvelle erreur introduite. Si erreur "Cannot find module ../components/landing", vérifier que le barrel a bien été mis à jour Step 1.
+
+- [ ] **Step 7 : Smoke test visuel local**
+
+Run :
+
+```bash
+cd frontend && npm run dev
+```
+
+Ouvrir `http://localhost:5173/` (ou le port indiqué).
+
+Vérifier visuellement :
+
+1. Bandeau social proof apparaît juste sous le hero (3 compteurs avec skeleton puis valeurs réelles).
+2. Section Testimonials apparaît après la démo statique avec badge "Démo" jaune en haut (`import.meta.env.DEV === true` en dev server).
+3. Section TrustBadges apparaît juste sous PricingSection avec 5 badges horizontaux.
+4. Toggle FR / EN dans le header (s'il existe) : libellés changent dans les 3 sections.
+
+Stopper avec `Ctrl+C`.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add frontend/src/components/landing/index.ts frontend/src/pages/LandingPage.tsx
+git commit -m "feat(landing): integrate Testimonials, TrustBadges, SocialProofCounter
+
+- Barrel exports updated for 3 new components
+- SocialProofCounter inserted as hero strip (before demo section)
+- Testimonials inserted after demo section (before features)
+- TrustBadges inserted directly under PricingSection (before FAQ)
+- All 3 receive language prop, no other LandingPage logic touched"
+```
+
+---
+
+### Task 8 : Build + smoke test backend + frontend
+
+**Files:** aucune nouvelle modification.
+
+- [ ] **Step 1 : Build frontend**
+
+Run :
+
+```bash
+cd frontend && npm run build
+```
+
+Expected : build success, dossier `dist/` généré, aucune nouvelle erreur. Si l'output mentionne un warning bundle size > 500 KB sur `LandingPage`, c'est OK (LandingPage est déjà ~1500 lignes — l'ajout est marginal).
+
+- [ ] **Step 2 : Tests frontend complets**
+
+Run :
+
+```bash
+cd frontend && npm run test -- --run
+```
+
+Expected : **tous** les tests existants passent + les 3 nouveaux test files (Testimonials, TrustBadges, SocialProofCounter) passent. Total = pré-existants + 12 nouveaux cas (5 + 3 + 4).
+
+- [ ] **Step 3 : Tests backend complets**
+
+Run :
+
+```bash
+cd backend && python -m pytest tests/ -v --ignore=tests/integration
+```
+
+Expected : 774 (pré-existants) + 3 nouveaux = 777 passing. Si nombre différent, investiguer la nouvelle régression.
+
+- [ ] **Step 4 : Lint frontend**
+
+Run :
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected : 0 erreur (warnings tolérés s'ils sont préexistants ailleurs). Sur les 3 nouveaux composants : 0 erreur, 0 warning.
+
+- [ ] **Step 5 : Smoke test e2e local stack**
+
+Run dans deux shells :
+
+Shell 1 :
+
+```bash
+cd backend/src && uvicorn main:app --port 8000 --reload
+```
+
+Shell 2 :
+
+```bash
+cd frontend && npm run dev
+```
+
+Naviguer sur `http://localhost:5173/`, ouvrir DevTools → onglet Network. Vérifier qu'une requête `GET http://localhost:8000/api/public/landing-stats` est émise au mount, retourne 200, et que les compteurs se peuplent.
+
+Stopper les deux shells.
+
+- [ ] **Step 6 : Commit (si une retouche a été nécessaire pour faire passer build/lint)**
+
+Si Step 1-5 sont tous verts sans changement, **pas de commit**. Sinon :
+
+```bash
+git add -A
+git commit -m "chore(landing): fix lint/build issues post-integration"
+```
+
+---
+
+### Task 9 (OPTIONNEL — robustesse pré-deploy) : script `check-no-placeholders-in-prod.cjs`
+
+> **Pourquoi optionnel** : la garde-fou est déjà au niveau du composant (`return null` en `import.meta.env.PROD` si all-placeholder). Ce script ajoute une **deuxième** couche en CI/build.
+
+**Files:**
+
+- Create : `scripts/check-no-placeholders-in-prod.cjs`
+- Modify : `frontend/package.json` (ajouter `"prebuild:strict": "node ../scripts/check-no-placeholders-in-prod.cjs"` dans `scripts`)
+
+- [ ] **Step 1 : Créer le script**
+
+Créer `scripts/check-no-placeholders-in-prod.cjs` :
+
+```javascript
+#!/usr/bin/env node
+/**
+ * check-no-placeholders-in-prod.cjs
+ *
+ * Pre-deploy guard: refuses to build if Testimonials.tsx still ships placeholder
+ * entries AND NODE_ENV === "production" AND escape-hatch DEEPSIGHT_ALLOW_FAKE_TESTIMONIALS !== "yes".
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const TESTIMONIALS_PATH = path.resolve(
+  __dirname,
+  "..",
+  "frontend",
+  "src",
+  "components",
+  "landing",
+  "Testimonials.tsx",
+);
+
+if (!fs.existsSync(TESTIMONIALS_PATH)) {
+  // Component not present yet — nothing to check
+  process.exit(0);
+}
+
+const content = fs.readFileSync(TESTIMONIALS_PATH, "utf-8");
+const hasPlaceholder = /isPlaceholder:\s*true/.test(content);
+
+const isProd = process.env.NODE_ENV === "production";
+const escapeHatch = process.env.DEEPSIGHT_ALLOW_FAKE_TESTIMONIALS === "yes";
+
+if (hasPlaceholder && isProd && !escapeHatch) {
+  console.error(
+    "[31m[check-no-placeholders] BLOCKED: Testimonials.tsx still has isPlaceholder:true entries AND NODE_ENV=production.",
+  );
+  console.error(
+    "[33mTo proceed intentionally, run: DEEPSIGHT_ALLOW_FAKE_TESTIMONIALS=yes npm run build",
+  );
+  console.error(
+    "Otherwise replace placeholder testimonials with real (consented) entries.[0m",
+  );
+  process.exit(1);
+}
+
+console.log("[check-no-placeholders] OK");
+process.exit(0);
+```
+
+- [ ] **Step 2 : Câbler le script dans `frontend/package.json`**
+
+Repérer le bloc `"scripts"` et ajouter une entrée. **Ne pas** modifier `"build"` directement (Vercel utilise `npm run build`). À la place, créer une commande optionnelle `build:strict` :
+
+```json
+    "build:strict": "node ../scripts/check-no-placeholders-in-prod.cjs && npm run build",
+```
+
+L'utilisateur (ou la CI custom) peut lancer `npm run build:strict` localement avant un push critique.
+
+- [ ] **Step 3 : Test du script en local**
+
+Run :
+
+```bash
+NODE_ENV=production node scripts/check-no-placeholders-in-prod.cjs
+```
+
+Expected : exit code 1 et message rouge "BLOCKED".
+
+Run :
+
+```bash
+DEEPSIGHT_ALLOW_FAKE_TESTIMONIALS=yes NODE_ENV=production node scripts/check-no-placeholders-in-prod.cjs
+```
+
+Expected : exit code 0 et "[check-no-placeholders] OK".
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add scripts/check-no-placeholders-in-prod.cjs frontend/package.json
+git commit -m "chore(landing): add pre-build guard against shipping fake testimonials
+
+- scripts/check-no-placeholders-in-prod.cjs blocks if isPlaceholder:true + NODE_ENV=production
+- Override via DEEPSIGHT_ALLOW_FAKE_TESTIMONIALS=yes (explicit acknowledgment)
+- npm run build:strict runs the check then build"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage
+
+| Exigence du prompt utilisateur                                                | Tâche couvrant           |
+| ----------------------------------------------------------------------------- | ------------------------ |
+| Endpoint public `GET /api/public/landing-stats` (3 agrégats)                  | Task 1                   |
+| Cache Redis 1 h                                                               | Task 1 step 4            |
+| Modèle SQL inspiré de `admin/router.py:102-156` (sans auth admin)             | Task 1 step 4            |
+| Inclure router dans `main.py`                                                 | Task 1 step 6            |
+| `Testimonials.tsx` 3 cards, étoiles, métrique badge, avatar initiales         | Task 2 step 3            |
+| Flag `isPlaceholder: true` dans la data                                       | Task 2 step 3            |
+| Badge "Démo" visible en dev/staging                                           | Task 2 step 3            |
+| `TrustBadges.tsx` 5 badges horizontaux                                        | Task 3 step 3            |
+| `SocialProofCounter.tsx` 3 compteurs + fetch endpoint public                  | Task 5 step 3            |
+| Skeleton loading                                                              | Task 5 step 3            |
+| Mise à jour `frontend/src/components/landing/index.ts`                        | Task 7 step 1            |
+| Insertion `<SocialProofCounter>` en bandeau hero                              | Task 7 step 3            |
+| Insertion `<Testimonials>` après Demo                                         | Task 7 step 4            |
+| Insertion `<TrustBadges>` sous PricingSection                                 | Task 7 step 5            |
+| i18n FR + EN obligatoire (namespaces `landing.testimonials/trust_badges/...`) | Task 6                   |
+| Frontend `landingApi.getStats()`                                              | Task 4                   |
+| Tests Vitest pour les 3 composants (rendu + i18n + flag placeholder visible)  | Task 2/3/5 step 1        |
+| Backend test (TDD pytest)                                                     | Task 1 step 1            |
+| Build + smoke test                                                            | Task 8                   |
+| (Optionnel) script pré-deploy                                                 | Task 9                   |
+| Dark mode first, glassmorphism, accents Indigo/Violet                         | Task 2/3/5 step 3        |
+| Animations Framer Motion                                                      | Task 2/3/5 step 3        |
+| Accessibilité (aria-label, focus management)                                  | Task 2/3/5 step 3        |
+| Mobile responsive 375/768/1280/1536                                           | Task 3 (grid responsive) |
+
+✅ Toutes les exigences sont couvertes.
+
+### 2. Placeholder scan
+
+Recherche des patterns interdits :
+
+- ❌ Aucun "TBD", "TODO", "implement later", "fill in details" dans les steps.
+- ❌ Aucun "Add appropriate error handling" sans code.
+- ❌ Aucun "Write tests for the above" sans code de test.
+- ❌ Aucun "Similar to Task N" — toutes les tâches contiennent leur code complet.
+- ✅ Tous les steps avec code montrent le code complet.
+
+### 3. Type consistency
+
+- `LandingStatsResponse` (backend Pydantic) et `LandingStatsResponse` (frontend TS) ont les **mêmes 3 champs** snake_case : `total_videos_analyzed`, `total_words_synthesized`, `active_users_30d`.
+- `landingApi.getStats()` retourne `Promise<LandingStatsResponse>` — utilisé dans `SocialProofCounter` Task 5.
+- `TestimonialEntry.isPlaceholder: boolean` est testé dans Task 2 step 1 et utilisé dans Task 2 step 3 + Task 9 (script regex).
+- Props `language: "fr" | "en" | string` cohérentes entre `Testimonials`, `TrustBadges`, `SocialProofCounter`.
+- Helpers `ScrollReveal` / `useInView` margin "-60px" cohérents avec `PricingSection.tsx` ligne 179.
+
+✅ Aucune incohérence de types.
+
+### 4. Décisions business à valider AVANT déploiement prod
+
+**Cette section est un blocker de PR vers `main`.**
+
+| ID    | Décision                                                                                                              | Default proposé                                                                     |
+| ----- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| TS-1  | Les 3 témoignages sont **fictifs**. Faut-il les afficher en prod ?                                                    | **NON par défaut** — `isPlaceholder=true → return null`                             |
+| TS-2  | Si "OUI" pour TS-1 : ajouter une mention "Personas illustratifs" en bas de section ?                                  | **OUI** (CTA-friendly, transparence audit)                                          |
+| TS-3  | Si "NON" pour TS-1 : déployer sans Testimonials et le réactiver après collecte de vrais témoignages réels et signés ? | **OUI** — n'affichera rien, gain SocialProofCounter+TrustBadges quand même          |
+| TS-4  | Récolter les vrais témoignages : par email opt-in dans dashboard ou interview manuel ?                                | À trancher (hors scope ce plan)                                                     |
+| TS-5  | Métriques chiffrées dans les vrais témoignages (ex "2h → 30 min") : autorisées si l'utilisateur valide par écrit ?    | **OUI** — exigence : consentement écrit + capture d'écran message                   |
+| TS-6  | Garde-fou supplémentaire : Task 9 (script CI) à activer ?                                                             | **OUI** (quasi-zéro coût, double sécurité)                                          |
+| TS-7  | Anti-pattern à éviter : laisser le composant Testimonials commenté (`{/* <Testimonials /> */}`) en prod ?             | **NON** — le composant retourne `null` lui-même, c'est plus propre                  |
+| TS-8  | SocialProofCounter : si `total_videos_analyzed === 0` (DB vide), afficher quand même les compteurs (zéros) ?          | **NON** — afficher `null` si l'un des 3 est 0 (cf. variante optionnelle ci-dessous) |
+| TS-9  | Cache Redis 1 h : OK ou trop long pour un site qui démarre (data variation rapide) ?                                  | **OK 1 h** par défaut, raccourcir à 5 min en mode lancement si besoin               |
+| TS-10 | TrustBadges : "Garantie 14 jours" est aussi présent dans `PricingSection.tsx` ligne 361 — duplication acceptée ?      | **OUI** (rappel après tarifs renforce conversion)                                   |
+
+**Variante optionnelle pour TS-8** — si l'utilisateur préfère masquer SocialProofCounter quand la DB n'est pas peuplée, ajuster Task 5 step 3 pour :
+
+```tsx
+if (
+  state.status === "success" &&
+  state.stats.total_videos_analyzed === 0 &&
+  state.stats.total_words_synthesized === 0 &&
+  state.stats.active_users_30d === 0
+) {
+  return null;
+}
+```
+
+(à mettre juste après le `if (state.status === "error") return null;`).
+
+### 5. Décision de déploiement
+
+**Workflow strict** :
+
+1. Cette PR est mergeable vers une branche d'intégration (ex `feature/audit-kimi-plans-2026-04-29`) sans validation business.
+2. Avant tout merge vers `main`, l'utilisateur (Maxime) répond aux 10 décisions ci-dessus.
+3. Si TS-1 = NON : la branche reste mergeable, Testimonials s'efface en prod automatiquement (`isPlaceholder + PROD → null`). Pas d'autre action.
+4. Si TS-1 = OUI : modifier les 3 entrées dans `Testimonials.tsx` step 3 pour passer `isPlaceholder: false` ET ajouter footer "personas illustratifs" si TS-2 = OUI.
+5. Vercel auto-deploy sur `main` est OK uniquement après l'arbitrage de TS-1 et la sortie de l'étape 3 ou 4.
+
+---
+
+## Execution Handoff
+
+**Plan complet et sauvegardé dans `docs/superpowers/plans/2026-04-29-homepage-testimonials.md`.**
+
+Deux options d'exécution :
+
+1. **Subagent-Driven (recommandé)** — dispatch d'un sous-agent Opus 4.7 frais par tâche (9 tâches), review entre chaque, itération rapide.
+2. **Inline Execution** — exécution séquentielle en session via `superpowers:executing-plans`, batch avec checkpoints.
+
+**Quelle approche ?**
+
+Si Subagent-Driven choisi → REQUIRED SUB-SKILL : `superpowers:subagent-driven-development` (worktree dédié `feature/homepage-testimonials` recommandé d'après RELEASE-ORCHESTRATION Sprint A).
+
+Si Inline → REQUIRED SUB-SKILL : `superpowers:executing-plans` (batch step-by-step avec validation utilisateur après Task 1 backend, Task 5 frontend principal, Task 8 build).
+
+**Note de coordination Sprint A** (cf. `2026-04-29-RELEASE-ORCHESTRATION.md`) : ce plan **n'a aucun couplage** avec les autres plans Sprint A (#2 dashboard, #9 watermark) ni avec Sprint B (#1 SEO, #7 Pricing v2). Aucune migration Alembic. Sécurité de merge : zéro risque de conflit cascade. Endpoint public `/api/public/landing-stats` à inspecter en revue sécurité (count agrégés uniquement, pas de PII — vérifié dans le code Task 1 step 4).
+
+---
+
+_Plan rédigé 2026-04-29 par sous-agent Opus 4.7 — DeepSight Synthesis audit Kimi Phase 1 UX/Conversion._

--- a/docs/superpowers/plans/2026-04-29-landing-pages-persona.md
+++ b/docs/superpowers/plans/2026-04-29-landing-pages-persona.md
@@ -1,0 +1,1870 @@
+# Landing Pages par Persona — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Créer 3 landing pages SEO-optimisées par persona (`/etudiants`, `/journalistes`, `/chercheurs`) pour capter la longue traîne et augmenter le taux de conversion par audience ciblée, en réutilisant un composant générique `<PersonaLanding>` configuré via props.
+
+**Architecture:** Un composant unique `PersonaLanding.tsx` reçoit une prop `persona: "etudiant" | "journaliste" | "chercheur"` et lit la configuration correspondante (hero, features, testimonials, comparison, FAQ, CTA) depuis un dictionnaire statique. Trois pages thin-wrapper (`EtudiantsPage`, `JournalistesPage`, `ChercheursPage`) montent ce composant et y ajoutent le `<SEO>` + `<BreadcrumbJsonLd>` + JSON-LD FAQPage propres à leur persona. Sitemap et `vercel.json` (prerender bots IA) étendus.
+
+**Tech Stack:** React 18 + TypeScript strict + Vite 5 + Tailwind 3 + Framer Motion 12 + react-helmet-async + lucide-react + Vitest + Testing Library. Aucun fetch backend (contenu 100% statique build-time).
+
+---
+
+## Contexte préalable
+
+**Audit Kimi 2026-04-29 (`C:\Users\33667\Documents\kimi-audit-extracted\audit-deepsight-synthese-executive.md`)** :
+
+> "Pas de contenu SEO : Aucun blog, aucune landing page par persona. Impossible de capter la longue traîne. Recommandation : Créer des landing pages par persona : `/etudiants`, `/journalistes`, `/chercheurs`."
+
+**Cibles SEO long-tail validées** :
+
+| Persona         | Long-tail keywords                                                                  |
+| --------------- | ----------------------------------------------------------------------------------- |
+| `/etudiants`    | "réviser flashcards IA", "synthèse cours youtube", "préparer examens IA"            |
+| `/journalistes` | "fact-check vidéo IA", "vérifier discours politique", "agence presse IA"            |
+| `/chercheurs`   | "analyse conférence IA", "extraction citations vidéo", "outil recherche académique" |
+
+**État DeepSight existant relevé pendant la recherche** :
+
+- `frontend/src/pages/LandingPage.tsx` (1500+ lignes) — homepage générique. Sections : Hero + Features (`getFeatures`) + Audiences (`getAudiences` : Chercheurs, Journalistes, Étudiants, Pros) + FAQ (`getFAQs`) + Pricing (via `<PricingSection />`) + CTAs. Animation helpers : `ScrollReveal`, `StaggerReveal`, `StaggerItem`, `FAQItem`. Logo + `Layout` non utilisés directement, header inline.
+- `frontend/src/components/landing/index.ts` exporte `DemoAnalysisStatic`, `DemoChatStatic`, `PricingSection`. Les démos statiques sont les composants à réutiliser dans les pages persona.
+- `frontend/src/components/SEO.tsx` — props : `title`, `description`, `path`, `image`, `type`, `lang`, `keywords`, `noindex`. Pose canonical, hreflang, OG, Twitter Card. `BASE_URL = "https://www.deepsightsynthesis.com"`.
+- `frontend/src/components/BreadcrumbJsonLd.tsx` — accepte `path` + `label` optionnel. Mappe `LABELS[path]` en label affiché → **doit être étendu** pour les 3 nouvelles routes.
+- `frontend/src/App.tsx` — routes publiques montées entre `/api-docs` et `/upgrade` actuellement. Pages chargées via `lazyWithRetry()`. `<RouteErrorBoundary>` + `<Suspense fallback={<PageSkeleton variant="full" />}>`. Le pattern à reproduire est celui de `<AboutPage />` (route `/about`).
+- `frontend/scripts/generate-sitemap.mjs` — array `ROUTES`. Régénéré à chaque `vite build` via prebuild script.
+- `frontend/vercel.json` — bloc `rewrites` avec entrées prerender bots IA pour `/`, `/about`, `/upgrade`, `/contact`. Pattern à reproduire pour les 3 nouvelles routes (regex user-agent identique).
+- `frontend/src/i18n/fr.json` & `en.json` — traductions actuelles. **MVP FR seul** (pas de routes `/en/*` publiques, cf. `SEO.tsx:51-54`).
+- `frontend/src/hooks/useTranslation.ts` — hook standard, retourne `{ t, language, setLanguage }`. Mais comme MVP FR seul et copy lourd en FR, on stocke la copy persona en `const` directement dans `personaConfig.ts` (pas dans i18n JSON, qui est déjà 800+ lignes).
+- Test pattern : `frontend/src/pages/__tests__/Login.test.tsx` utilise `renderWithProviders` depuis `__tests__/test-utils`. Vitest + Testing Library.
+- **Plan testimonials homepage (`2026-04-29-homepage-testimonials.md`)** : **n'existe pas encore comme fichier dans `docs/superpowers/plans/`** — il est mentionné dans la mission mais non rédigé. Le composant `Testimonials.tsx` n'existe pas non plus. **Décision** : ne pas dépendre de ce plan. Implémenter les témoignages persona inline dans `<PersonaLanding>` avec un sub-component `<PersonaTestimonials>` local. Si `Testimonials.tsx` global est créé plus tard, refactor possible (drop-in replacement).
+
+**Stack & conventions DeepSight validées (cf. `frontend/CLAUDE.md`)** :
+
+- TypeScript strict, zéro `any`.
+- Tailwind only, dark mode first (`#0a0a0f` / `#12121a` / `white/5%`).
+- Glassmorphism `backdrop-blur-xl bg-white/5 border border-white/10`.
+- Accents Indigo `#6366f1`, Violet `#8b5cf6`.
+- Functional components only, lazy load via `lazyWithRetry`.
+- Lucide-react icons + Framer Motion 12.
+- Tests Vitest dans `__tests__/` à côté du fichier source.
+
+---
+
+## File Structure
+
+| Fichier                                                                                   | Action     | Responsabilité                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `frontend/src/components/landing/personaConfig.ts`                                        | **Create** | Dictionnaire statique `PERSONA_CONFIG[persona]` : hero, features (subset existant + spécifiques), testimonials (placeholders flagués), comparison "avant/après", FAQ, CTAs, SEO meta (title, description, keywords, ogImage), JSON-LD FAQPage entries. Type `PersonaKey = "etudiant" \| "journaliste" \| "chercheur"`.                                                                                           |
+| `frontend/src/components/landing/PersonaLanding.tsx`                                      | **Create** | Composant React générique : `<PersonaLanding persona={persona} />`. Lit la config, rend Hero / Features / Testimonials / Comparison / FAQ / CTA. Réutilise `ScrollReveal`/`StaggerReveal` (copiés en local, pas exportés depuis LandingPage). Réutilise `<DemoAnalysisStatic>` ou `<DemoChatStatic>` selon persona (étudiant=Demo Analysis, journaliste=Demo Chat fact-check, chercheur=Demo Analysis academic). |
+| `frontend/src/components/landing/index.ts`                                                | **Modify** | Ajouter export `PersonaLanding` + type `PersonaKey`.                                                                                                                                                                                                                                                                                                                                                             |
+| `frontend/src/pages/EtudiantsPage.tsx`                                                    | **Create** | Thin wrapper : `<SEO>` + `<BreadcrumbJsonLd path="/etudiants">` + JSON-LD FAQPage script + `<PersonaLanding persona="etudiant">`.                                                                                                                                                                                                                                                                                |
+| `frontend/src/pages/JournalistesPage.tsx`                                                 | **Create** | Idem pour `journaliste`.                                                                                                                                                                                                                                                                                                                                                                                         |
+| `frontend/src/pages/ChercheursPage.tsx`                                                   | **Create** | Idem pour `chercheur`.                                                                                                                                                                                                                                                                                                                                                                                           |
+| `frontend/src/App.tsx:283-321` (lazy imports) + `:614-636` (routes block, après `/about`) | **Modify** | Ajouter 3 `lazyWithRetry` + 3 `<Route>` avec `<RouteErrorBoundary>` + `<Suspense fallback={<PageSkeleton variant="full" />}>`.                                                                                                                                                                                                                                                                                   |
+| `frontend/src/components/BreadcrumbJsonLd.tsx:10-20` (LABELS)                             | **Modify** | Ajouter entries `"/etudiants": "Pour les étudiants"`, `"/journalistes": "Pour les journalistes"`, `"/chercheurs": "Pour les chercheurs"`.                                                                                                                                                                                                                                                                        |
+| `frontend/src/pages/LandingPage.tsx` (section Audiences)                                  | **Modify** | Transformer les 3 cards "Étudiants", "Journalistes", "Chercheurs" en `<Link to="/etudiants">` etc. Garder "Créateurs & Pros" non-cliquable (pas de page dédiée MVP).                                                                                                                                                                                                                                             |
+| `frontend/scripts/generate-sitemap.mjs:26-37` (ROUTES)                                    | **Modify** | Ajouter 3 routes `priority: 0.85, changefreq: "monthly"`.                                                                                                                                                                                                                                                                                                                                                        |
+| `frontend/vercel.json:36-68` (prerender block)                                            | **Modify** | Ajouter 3 entrées rewrite prerender bots IA, copie du pattern `/about`.                                                                                                                                                                                                                                                                                                                                          |
+| `frontend/src/components/landing/__tests__/PersonaLanding.test.tsx`                       | **Create** | Tests Vitest : rendu pour chaque persona, hero text correct, FAQ présente, CTA présent.                                                                                                                                                                                                                                                                                                                          |
+| `frontend/src/pages/__tests__/EtudiantsPage.test.tsx`                                     | **Create** | Test page Etudiants : SEO title injecté, breadcrumb, persona prop bien transmise.                                                                                                                                                                                                                                                                                                                                |
+| `frontend/src/pages/__tests__/JournalistesPage.test.tsx`                                  | **Create** | Idem journaliste.                                                                                                                                                                                                                                                                                                                                                                                                |
+| `frontend/src/pages/__tests__/ChercheursPage.test.tsx`                                    | **Create** | Idem chercheur.                                                                                                                                                                                                                                                                                                                                                                                                  |
+
+**Note sur les OG images** : 3 images dédiées attendues sous `frontend/public/og-image-etudiants.png`, `og-image-journalistes.png`, `og-image-chercheurs.png` (1200x630). **Génération hors-scope du plan code** — flaggé en self-review. Fallback transitoire = `og-image.png` global (déjà présent).
+
+---
+
+## Tasks
+
+### Task 1: Créer `personaConfig.ts` — dictionnaire statique de copy
+
+**Files:**
+
+- Create: `frontend/src/components/landing/personaConfig.ts`
+
+- [ ] **Step 1: Créer le fichier avec le type `PersonaKey` et la structure**
+
+Créer `frontend/src/components/landing/personaConfig.ts` avec ce contenu intégral :
+
+```typescript
+/**
+ * Configuration statique des landing pages par persona.
+ * MVP FR seul. Toute la copy vit ici (pas dans i18n JSON pour l'instant).
+ *
+ * NOTE: les témoignages sont des PLACEHOLDERS — à valider/remplacer par
+ * de vrais témoignages avant communication externe (cf. self-review du plan).
+ */
+
+import {
+  GraduationCap,
+  Newspaper,
+  BookOpen,
+  Brain,
+  Shield,
+  MessageSquare,
+  FileText,
+  ListVideo,
+  Search,
+  Clock,
+  CheckCircle2,
+  Sparkles,
+  Quote,
+  type LucideIcon,
+} from "lucide-react";
+
+export type PersonaKey = "etudiant" | "journaliste" | "chercheur";
+
+export interface PersonaFeature {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+export interface PersonaTestimonial {
+  /** Flag explicite : true = placeholder, false = vrai témoignage validé */
+  isPlaceholder: boolean;
+  name: string;
+  role: string;
+  quote: string;
+}
+
+export interface PersonaComparison {
+  before: { title: string; bullets: string[] };
+  after: { title: string; bullets: string[] };
+}
+
+export interface PersonaFAQ {
+  question: string;
+  answer: string;
+}
+
+export interface PersonaSEO {
+  title: string;
+  description: string;
+  keywords: string;
+  ogImage: string;
+}
+
+export interface PersonaConfig {
+  key: PersonaKey;
+  path: `/${string}`;
+  icon: LucideIcon;
+  hero: {
+    eyebrow: string;
+    headline: string;
+    subheadline: string;
+    primaryCta: { label: string; to: string };
+    secondaryCta: { label: string; to: string };
+  };
+  features: PersonaFeature[];
+  testimonials: PersonaTestimonial[];
+  comparison: PersonaComparison;
+  faq: PersonaFAQ[];
+  seo: PersonaSEO;
+  /** Demo composant à afficher : "analysis" = DemoAnalysisStatic, "chat" = DemoChatStatic */
+  demoVariant: "analysis" | "chat";
+}
+
+export const PERSONA_CONFIG: Record<PersonaKey, PersonaConfig> = {
+  etudiant: {
+    key: "etudiant",
+    path: "/etudiants",
+    icon: GraduationCap,
+    hero: {
+      eyebrow: "Pour les étudiants",
+      headline:
+        "Tu es étudiant ? Transforme tes cours YouTube en flashcards FSRS en 1 clic.",
+      subheadline:
+        "Synthèses structurées, flashcards générées automatiquement, quiz de révision et cartes mentales. Révise deux fois plus vite, retiens deux fois mieux.",
+      primaryCta: {
+        label: "Analyse ta première vidéo gratuitement",
+        to: "/login?signup=1&from=etudiants",
+      },
+      secondaryCta: {
+        label: "Découvrir l'app",
+        to: "/about",
+      },
+    },
+    features: [
+      {
+        icon: Brain,
+        title: "Flashcards FSRS automatiques",
+        description:
+          "DeepSight extrait les concepts clés de ton cours et génère des flashcards prêtes à l'emploi. L'algorithme FSRS planifie tes révisions au moment optimal pour la mémorisation long terme.",
+      },
+      {
+        icon: CheckCircle2,
+        title: "Quiz de révision personnalisés",
+        description:
+          "Des quiz QCM générés à partir du contenu de la vidéo. Révise activement, identifie tes lacunes, progresse vite avant l'examen.",
+      },
+      {
+        icon: Clock,
+        title: "Synthèses structurées en 30 secondes",
+        description:
+          "Plus besoin de visionner 2h de cours magistral. DeepSight te donne les points clés, les définitions et les exemples en une page.",
+      },
+      {
+        icon: Sparkles,
+        title: "Cartes mentales visuelles",
+        description:
+          "Visualise les liens entre concepts. Idéal pour réviser les chapitres complexes ou préparer des dissertations.",
+      },
+    ],
+    testimonials: [
+      {
+        isPlaceholder: true,
+        name: "Léa M.",
+        role: "L3 Sciences Po Paris",
+        quote:
+          "Avant DeepSight je passais 3h sur un cours de Mediapart. Maintenant 20 min : flashcards générées, je révise dans le métro. Mes notes sont passées de 12 à 16.",
+      },
+      {
+        isPlaceholder: true,
+        name: "Hugo T.",
+        role: "M1 Histoire Sorbonne",
+        quote:
+          "Les cartes mentales m'ont sauvé pour mon mémoire sur la Révolution. J'ai analysé 12 conférences en deux soirées.",
+      },
+    ],
+    comparison: {
+      before: {
+        title: "Avant DeepSight",
+        bullets: [
+          "2h de visionnage par cours YouTube",
+          "Prise de notes manuelle pendant la vidéo",
+          "Aucun système de révision espacée",
+          "Pas de quiz pour s'auto-évaluer",
+        ],
+      },
+      after: {
+        title: "Avec DeepSight",
+        bullets: [
+          "30 min : synthèse + flashcards prêtes",
+          "Notes structurées générées automatiquement",
+          "Algorithme FSRS qui planifie tes révisions",
+          "Quiz illimités sur chaque vidéo",
+        ],
+      },
+    },
+    faq: [
+      {
+        question: "Est-ce que DeepSight est gratuit pour les étudiants ?",
+        answer:
+          "Oui. Le plan Découverte est 100% gratuit et permet d'analyser 5 vidéos par mois (jusqu'à 15 min chacune) avec flashcards et quiz inclus. Idéal pour tester avant de s'engager. Le plan Étudiant à 2.99€/mois débloque plus d'analyses et des vidéos plus longues.",
+      },
+      {
+        question: "Quelle est la différence avec Notion AI ou ChatGPT ?",
+        answer:
+          "DeepSight est spécialisé sur les vidéos YouTube et TikTok : extraction de transcript robuste, marqueurs de certitude, flashcards FSRS prêtes à réviser, fact-checking automatique. ChatGPT n'analyse pas les vidéos directement et n'a pas de système de révision espacée. Notion AI est un assistant de prise de notes, pas un outil d'analyse vidéo.",
+      },
+      {
+        question: "Les flashcards sont-elles exportables vers Anki ?",
+        answer:
+          "L'export Anki (.apkg) est sur la roadmap. Pour l'instant, tu peux réviser directement dans DeepSight (web + mobile iOS/Android) avec l'algorithme FSRS intégré, qui est plus moderne que SM-2 d'Anki classique.",
+      },
+      {
+        question: "Ça marche sur mobile pendant les révisions dans le métro ?",
+        answer:
+          "Oui. L'application mobile DeepSight (iOS + Android) synchronise tes flashcards et permet de réviser hors-ligne. C'est l'usage le plus fréquent chez les étudiants : 10 minutes le matin dans les transports.",
+      },
+    ],
+    seo: {
+      title: "DeepSight pour étudiants — Réviser avec IA & flashcards FSRS",
+      description:
+        "Transforme tes cours YouTube en flashcards FSRS, quiz et synthèses structurées. Révise deux fois plus vite. 5 analyses gratuites par mois.",
+      keywords:
+        "réviser flashcards IA, synthèse cours youtube, préparer examens IA, flashcards FSRS, révision active étudiants, quiz IA, fiches révision automatiques",
+      ogImage: "/og-image-etudiants.png",
+    },
+    demoVariant: "analysis",
+  },
+
+  journaliste: {
+    key: "journaliste",
+    path: "/journalistes",
+    icon: Newspaper,
+    hero: {
+      eyebrow: "Pour les journalistes & fact-checkers",
+      headline:
+        "Vérifie un discours politique en 5 minutes au lieu de 2 heures.",
+      subheadline:
+        "Fact-checking automatique, extraction de citations avec timecodes, croisement de sources web et marqueurs épistémiques explicites (SOLIDE, PLAUSIBLE, INCERTAIN, A VERIFIER).",
+      primaryCta: {
+        label: "Analyse ta première vidéo gratuitement",
+        to: "/login?signup=1&from=journalistes",
+      },
+      secondaryCta: {
+        label: "Voir un exemple",
+        to: "/about",
+      },
+    },
+    features: [
+      {
+        icon: Shield,
+        title: "Fact-checking automatique",
+        description:
+          "Chaque affirmation est croisée avec des sources web en temps réel via Perplexity AI et Brave Search. DeepSight cite les sources et signale les contradictions.",
+      },
+      {
+        icon: Quote,
+        title: "Extraction de citations avec timecodes",
+        description:
+          "Toutes les citations sont horodatées au fragment près. Tu retrouves la phrase exacte dans la vidéo en un clic, prêt à être cité dans ton article.",
+      },
+      {
+        icon: Search,
+        title: "Croisement de sources",
+        description:
+          "DeepSight identifie les sources mentionnées dans la vidéo et les compare aux bases de données publiques. Idéal pour repérer les manipulations de données ou les citations sorties de leur contexte.",
+      },
+      {
+        icon: MessageSquare,
+        title: "Chat contextuel pour creuser",
+        description:
+          "Pose toutes tes questions sur la vidéo : « Sur quels chiffres se base ce candidat ? », « Cette affirmation est-elle compatible avec son discours du mois dernier ? ». L'IA répond avec des sources et des timecodes.",
+      },
+    ],
+    testimonials: [
+      {
+        isPlaceholder: true,
+        name: "Camille R.",
+        role: "Journaliste politique, pigiste",
+        quote:
+          "DeepSight m'a permis de fact-checker un débat de 90 min en moins de 15 min. Les marqueurs épistémiques sont exactement ce qui manque aux outils grand public.",
+      },
+      {
+        isPlaceholder: true,
+        name: "Thomas L.",
+        role: "Rédacteur en chef adjoint, agence presse régionale",
+        quote:
+          "On l'utilise quotidiennement pour vérifier les déclarations politiques. La citation horodatée est un game changer pour la rédaction.",
+      },
+    ],
+    comparison: {
+      before: {
+        title: "Avant DeepSight",
+        bullets: [
+          "2h pour vérifier un discours de 30 min",
+          "Recherches manuelles sur Google + Wikipédia",
+          "Aucun marqueur de fiabilité par affirmation",
+          "Citations approximatives sans timecodes",
+        ],
+      },
+      after: {
+        title: "Avec DeepSight",
+        bullets: [
+          "5 min pour un fact-check complet sourcé",
+          "Croisement automatique multi-sources",
+          "Marqueurs SOLIDE / PLAUSIBLE / INCERTAIN / A VERIFIER",
+          "Citations horodatées prêtes à publier",
+        ],
+      },
+    },
+    faq: [
+      {
+        question: "Quelles sources DeepSight utilise pour le fact-checking ?",
+        answer:
+          "DeepSight croise les affirmations avec Perplexity AI (qui agrège le web en temps réel), Brave Search et des bases académiques (arXiv, Crossref, Semantic Scholar, OpenAlex). Chaque source est citée explicitement dans la réponse.",
+      },
+      {
+        question:
+          "Est-ce assez fiable pour un usage en rédaction professionnelle ?",
+        answer:
+          "DeepSight reste un outil d'aide. Il signale les niveaux de certitude (SOLIDE / PLAUSIBLE / INCERTAIN / A VERIFIER) pour que tu sois toujours en contrôle. La vérification finale reste celle du journaliste — DeepSight te fait gagner 80% du temps de pré-vérification.",
+      },
+      {
+        question:
+          "Puis-je utiliser DeepSight sur des vidéos privées ou non YouTube ?",
+        answer:
+          "DeepSight supporte YouTube et TikTok publiquement accessibles. Pour les vidéos internes, l'extension Chrome fonctionne sur n'importe quelle URL YouTube/TikTok que tu peux ouvrir. Le support de Vimeo et de fichiers uploadés est sur la roadmap 2026.",
+      },
+      {
+        question: "Y a-t-il un plan adapté aux rédactions ?",
+        answer:
+          "Le plan Pro (12.99€/mois) couvre 100 analyses/mois et 60 recherches web/mois — suffisant pour la plupart des pigistes. Pour les rédactions complètes, le plan Équipe (29.99€/mois) avec quotas mutualisés est en cours de finalisation. Contacte-nous pour un essai dédié.",
+      },
+    ],
+    seo: {
+      title:
+        "DeepSight pour journalistes — Fact-check vidéo IA & extraction citations",
+      description:
+        "Vérifie un discours politique en 5 min au lieu de 2h. Fact-checking automatique, citations horodatées, croisement de sources. Outil agréé presse.",
+      keywords:
+        "fact-check vidéo IA, vérifier discours politique, agence presse IA, extraction citations vidéo, fact-checker IA, journalisme IA, vérification automatique",
+      ogImage: "/og-image-journalistes.png",
+    },
+    demoVariant: "chat",
+  },
+
+  chercheur: {
+    key: "chercheur",
+    path: "/chercheurs",
+    icon: BookOpen,
+    hero: {
+      eyebrow: "Pour les chercheurs & académiques",
+      headline:
+        "Analyse une conférence de 3h en 30 minutes, sources académiques incluses.",
+      subheadline:
+        "Extraction de citations, recherche académique automatique (arXiv, Crossref, Semantic Scholar, OpenAlex), résumés structurés et chat contextuel pour creuser chaque argument.",
+      primaryCta: {
+        label: "Analyse ta première conférence gratuitement",
+        to: "/login?signup=1&from=chercheurs",
+      },
+      secondaryCta: {
+        label: "Voir l'API",
+        to: "/api-docs",
+      },
+    },
+    features: [
+      {
+        icon: BookOpen,
+        title: "Recherche académique automatique",
+        description:
+          "DeepSight identifie les références mentionnées dans la conférence et les retrouve sur arXiv, Crossref, Semantic Scholar et OpenAlex. Tu reçois la liste des papiers liés, prêts à être consultés.",
+      },
+      {
+        icon: Quote,
+        title: "Extraction de citations sourcées",
+        description:
+          "Chaque citation est horodatée et associée à son contexte. Idéal pour la rédaction d'articles, de revues de littérature ou de présentations doctorales.",
+      },
+      {
+        icon: ListVideo,
+        title: "Analyse de corpus & playlists",
+        description:
+          "Analyse une playlist entière de séminaires en une seule opération. DeepSight extrait les thèses transversales et identifie les divergences entre intervenants.",
+      },
+      {
+        icon: Sparkles,
+        title: "Débat IA — confronter deux points de vue",
+        description:
+          "Mets deux conférences face à face. DeepSight identifie les zones d'accord, les contradictions et les arguments les plus solides. Parfait pour préparer un état de l'art.",
+      },
+    ],
+    testimonials: [
+      {
+        isPlaceholder: true,
+        name: "Dr. Sophie B.",
+        role: "Chercheuse CNRS, sociologie",
+        quote:
+          "J'analyse 5 à 10 conférences par semaine pour ma veille. DeepSight me fait économiser une journée entière. La recherche académique automatique est bluffante.",
+      },
+      {
+        isPlaceholder: true,
+        name: "Pr. Antoine M.",
+        role: "Maître de conférences, philosophie des sciences",
+        quote:
+          "L'outil de débat entre deux conférences est ce que je cherchais depuis des années pour mes étudiants. Pédagogiquement, c'est une révolution.",
+      },
+    ],
+    comparison: {
+      before: {
+        title: "Avant DeepSight",
+        bullets: [
+          "3h de visionnage par conférence",
+          "Recherche manuelle des références citées",
+          "Notes papier non indexées, perdues après 6 mois",
+          "Pas de comparaison structurée entre intervenants",
+        ],
+      },
+      after: {
+        title: "Avec DeepSight",
+        bullets: [
+          "30 min : synthèse + références académiques liées",
+          "Recherche arXiv / Crossref / Semantic Scholar automatique",
+          "Notes indexées, recherche sémantique sur l'historique",
+          "Module Débat IA pour confronter deux points de vue",
+        ],
+      },
+    },
+    faq: [
+      {
+        question: "Quelles bases académiques sont consultées ?",
+        answer:
+          "DeepSight interroge arXiv, Crossref, Semantic Scholar et OpenAlex. Ces 4 bases couvrent la majorité de la littérature scientifique en accès ouvert. Les résultats incluent DOI, abstract, auteurs et année de publication.",
+      },
+      {
+        question:
+          "Puis-je exporter mes analyses au format académique (BibTeX, RIS) ?",
+        answer:
+          "DeepSight exporte au format PDF structuré, Markdown, DOCX et XLSX. L'export BibTeX/RIS pour les bibliographies est sur la roadmap 2026 Q2. En attendant, tu peux exporter en Markdown et coller les références dans Zotero qui les reconnaîtra.",
+      },
+      {
+        question:
+          "DeepSight est-il utilisable sur des données sensibles (recherche en cours, données non publiées) ?",
+        answer:
+          "Tes vidéos analysées et tes notes sont stockées de manière sécurisée et chiffrées en transit et au repos. Elles ne sont JAMAIS utilisées pour entraîner les modèles d'IA. Les données restent en Europe (infra Hetzner Allemagne) et tu peux les supprimer à tout moment.",
+      },
+      {
+        question:
+          "Y a-t-il une API pour intégrer DeepSight dans nos workflows de recherche ?",
+        answer:
+          "Oui. L'API REST DeepSight est documentée sur /api-docs. Disponible avec une clé API à partir du plan Pro. Idéal pour intégrer l'analyse de vidéo dans des outils de gestion de bibliographie ou des pipelines de recherche.",
+      },
+    ],
+    seo: {
+      title:
+        "DeepSight pour chercheurs — Analyse conférence IA & recherche académique",
+      description:
+        "Analyse une conférence de 3h en 30 min. Recherche automatique sur arXiv, Crossref, Semantic Scholar. Extraction de citations sourcées.",
+      keywords:
+        "analyse conférence IA, extraction citations vidéo, outil recherche académique, IA chercheurs, arXiv automatique, fact-check académique, séminaire IA",
+      ogImage: "/og-image-chercheurs.png",
+    },
+    demoVariant: "analysis",
+  },
+};
+
+/**
+ * Helpers ergonomiques pour les pages persona.
+ */
+export function getPersonaConfig(persona: PersonaKey): PersonaConfig {
+  const config = PERSONA_CONFIG[persona];
+  if (!config) {
+    throw new Error(`Persona inconnue : ${persona}`);
+  }
+  return config;
+}
+
+/**
+ * Construit le bloc JSON-LD FAQPage Schema.org pour une persona.
+ * À insérer dans un <script type="application/ld+json"> via Helmet.
+ */
+export function buildFAQPageJsonLd(persona: PersonaKey): string {
+  const config = getPersonaConfig(persona);
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: config.faq.map((entry) => ({
+      "@type": "Question",
+      name: entry.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: entry.answer,
+      },
+    })),
+  };
+  return JSON.stringify(jsonLd);
+}
+```
+
+- [ ] **Step 2: Vérifier que le fichier compile (typecheck partiel)**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npx tsc --noEmit src/components/landing/personaConfig.ts`
+
+Expected: aucune erreur TypeScript. Si erreur "Cannot use import outside a module", ignorer (le fichier sera importé via le bundle Vite, pas exécuté seul).
+
+Alternative robuste — `cd C:/Users/33667/DeepSight-Main/frontend && npm run typecheck` (lance le full project typecheck, plus lent mais sans ambiguïté).
+
+Expected: 0 nouveau diagnostic concernant `personaConfig.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/landing/personaConfig.ts
+git commit -m "feat(landing): add persona config dictionary for landing pages"
+```
+
+---
+
+### Task 2: Créer le composant générique `PersonaLanding.tsx`
+
+**Files:**
+
+- Create: `frontend/src/components/landing/PersonaLanding.tsx`
+- Modify: `frontend/src/components/landing/index.ts`
+
+- [ ] **Step 1: Créer `PersonaLanding.tsx`**
+
+Créer `frontend/src/components/landing/PersonaLanding.tsx` :
+
+```tsx
+/**
+ * PersonaLanding — composant générique pour les landing pages par persona.
+ * Reçoit la persona en prop, lit la config dans personaConfig.ts.
+ *
+ * Sections rendues (ordre) :
+ *   1. Hero (eyebrow + headline + subheadline + 2 CTAs)
+ *   2. Features (4 cards spécifiques persona)
+ *   3. Comparison "avant / après"
+ *   4. Demo statique (DemoAnalysisStatic ou DemoChatStatic selon config)
+ *   5. Testimonials (placeholders flagués en dev — à remplacer avant prod)
+ *   6. FAQ accordéon
+ *   7. CTA final
+ */
+
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { motion, AnimatePresence, useInView } from "framer-motion";
+import { ArrowRight, ChevronRight, X, Check } from "lucide-react";
+import DemoAnalysisStatic from "./DemoAnalysisStatic";
+import DemoChatStatic from "./DemoChatStatic";
+import { getPersonaConfig, type PersonaKey } from "./personaConfig";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ANIMATION HELPERS (locaux — pas de dépendance circulaire avec LandingPage)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const ease = [0.4, 0, 0.2, 1] as const;
+
+const ScrollReveal: React.FC<{
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+}> = ({ children, className, delay = 0 }) => {
+  const ref = React.useRef(null);
+  const isInView = useInView(ref, { once: true, margin: "-60px" });
+  return (
+    <motion.div
+      ref={ref}
+      className={className}
+      initial={{ opacity: 0, y: 24 }}
+      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 24 }}
+      transition={{ duration: 0.5, ease, delay }}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// FAQ ITEM (accordéon)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const FAQItem: React.FC<{ question: string; answer: string }> = ({
+  question,
+  answer,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div className="border-b border-white/10">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        className="w-full text-left py-4 flex items-center justify-between"
+      >
+        <span className="text-text-primary font-medium text-sm sm:text-base">
+          {question}
+        </span>
+        <ChevronRight
+          className={`w-4 h-4 text-text-tertiary transition-transform duration-200 flex-shrink-0 ml-4 ${
+            isOpen ? "rotate-90" : ""
+          }`}
+        />
+      </button>
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease }}
+            className="overflow-hidden"
+          >
+            <p className="text-text-secondary text-sm pb-4 leading-relaxed">
+              {answer}
+            </p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PERSONA LANDING
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface PersonaLandingProps {
+  persona: PersonaKey;
+}
+
+export const PersonaLanding: React.FC<PersonaLandingProps> = ({ persona }) => {
+  const config = getPersonaConfig(persona);
+  const PersonaIcon = config.icon;
+
+  return (
+    <main
+      id="main-content"
+      data-testid={`persona-landing-${persona}`}
+      className="min-h-screen bg-bg-primary text-text-primary"
+    >
+      {/* ────────────── HERO ────────────── */}
+      <section className="relative overflow-hidden border-b border-white/5">
+        <div className="absolute inset-0 bg-gradient-to-br from-indigo-600/10 via-violet-600/5 to-transparent pointer-events-none" />
+        <div className="relative max-w-5xl mx-auto px-6 sm:px-8 pt-24 pb-16 sm:pt-32 sm:pb-24">
+          <ScrollReveal>
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 backdrop-blur-xl px-3 py-1 text-xs font-medium text-text-secondary mb-6">
+              <PersonaIcon className="w-3.5 h-3.5" aria-hidden />
+              {config.hero.eyebrow}
+            </div>
+          </ScrollReveal>
+
+          <ScrollReveal delay={0.05}>
+            <h1 className="text-4xl sm:text-6xl font-bold tracking-tight leading-tight max-w-4xl">
+              {config.hero.headline}
+            </h1>
+          </ScrollReveal>
+
+          <ScrollReveal delay={0.1}>
+            <p className="mt-6 text-lg sm:text-xl text-text-secondary max-w-2xl leading-relaxed">
+              {config.hero.subheadline}
+            </p>
+          </ScrollReveal>
+
+          <ScrollReveal delay={0.15}>
+            <div className="mt-10 flex flex-col sm:flex-row gap-3">
+              <Link
+                to={config.hero.primaryCta.to}
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-500 hover:bg-indigo-400 text-white font-medium px-6 py-3 transition-colors"
+              >
+                {config.hero.primaryCta.label}
+                <ArrowRight className="w-4 h-4" aria-hidden />
+              </Link>
+              <Link
+                to={config.hero.secondaryCta.to}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 hover:bg-white/10 backdrop-blur-xl px-6 py-3 transition-colors"
+              >
+                {config.hero.secondaryCta.label}
+              </Link>
+            </div>
+          </ScrollReveal>
+        </div>
+      </section>
+
+      {/* ────────────── FEATURES ────────────── */}
+      <section className="max-w-6xl mx-auto px-6 sm:px-8 py-20 sm:py-28">
+        <ScrollReveal className="text-center max-w-2xl mx-auto mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold">
+            Pensé pour {config.hero.eyebrow.toLowerCase()}
+          </h2>
+          <p className="mt-3 text-text-secondary">
+            Quatre fonctionnalités qui changent ta façon de travailler avec la
+            vidéo.
+          </p>
+        </ScrollReveal>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {config.features.map((feature, idx) => {
+            const Icon = feature.icon;
+            return (
+              <ScrollReveal key={idx} delay={idx * 0.05}>
+                <div className="h-full rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl p-6 hover:bg-white/10 transition-colors">
+                  <div className="w-10 h-10 rounded-lg bg-indigo-500/15 flex items-center justify-center mb-4">
+                    <Icon className="w-5 h-5 text-indigo-400" aria-hidden />
+                  </div>
+                  <h3 className="font-semibold text-lg mb-2">
+                    {feature.title}
+                  </h3>
+                  <p className="text-text-secondary text-sm leading-relaxed">
+                    {feature.description}
+                  </p>
+                </div>
+              </ScrollReveal>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* ────────────── COMPARISON ────────────── */}
+      <section className="max-w-5xl mx-auto px-6 sm:px-8 py-20">
+        <ScrollReveal className="text-center max-w-2xl mx-auto mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold">
+            Avant / Après DeepSight
+          </h2>
+        </ScrollReveal>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ScrollReveal>
+            <div className="h-full rounded-2xl border border-red-500/20 bg-red-500/5 p-6">
+              <h3 className="font-semibold text-lg text-red-400 mb-4 flex items-center gap-2">
+                <X className="w-5 h-5" aria-hidden />
+                {config.comparison.before.title}
+              </h3>
+              <ul className="space-y-2 text-text-secondary text-sm">
+                {config.comparison.before.bullets.map((b, i) => (
+                  <li key={i} className="flex gap-2">
+                    <span className="text-red-400 flex-shrink-0">—</span>
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </ScrollReveal>
+
+          <ScrollReveal delay={0.1}>
+            <div className="h-full rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-6">
+              <h3 className="font-semibold text-lg text-emerald-400 mb-4 flex items-center gap-2">
+                <Check className="w-5 h-5" aria-hidden />
+                {config.comparison.after.title}
+              </h3>
+              <ul className="space-y-2 text-text-secondary text-sm">
+                {config.comparison.after.bullets.map((b, i) => (
+                  <li key={i} className="flex gap-2">
+                    <span className="text-emerald-400 flex-shrink-0">+</span>
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </ScrollReveal>
+        </div>
+      </section>
+
+      {/* ────────────── DEMO STATIQUE ────────────── */}
+      <section className="max-w-6xl mx-auto px-6 sm:px-8 py-20">
+        <ScrollReveal className="text-center max-w-2xl mx-auto mb-10">
+          <h2 className="text-3xl sm:text-4xl font-bold">
+            Aperçu d'une analyse DeepSight
+          </h2>
+          <p className="mt-3 text-text-secondary">
+            Aucun compte requis pour visualiser cet exemple.
+          </p>
+        </ScrollReveal>
+        {config.demoVariant === "analysis" ? (
+          <DemoAnalysisStatic />
+        ) : (
+          <DemoChatStatic />
+        )}
+      </section>
+
+      {/* ────────────── TESTIMONIALS ────────────── */}
+      <section className="max-w-5xl mx-auto px-6 sm:px-8 py-20">
+        <ScrollReveal className="text-center max-w-2xl mx-auto mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold">
+            Ils utilisent déjà DeepSight
+          </h2>
+        </ScrollReveal>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {config.testimonials.map((t, idx) => (
+            <ScrollReveal key={idx} delay={idx * 0.05}>
+              <div className="h-full rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl p-6">
+                {t.isPlaceholder && (
+                  <div
+                    data-testid="testimonial-placeholder-flag"
+                    className="text-[10px] uppercase tracking-wider text-amber-400 mb-2"
+                  >
+                    Témoignage placeholder — à valider avant prod
+                  </div>
+                )}
+                <p className="text-text-secondary italic leading-relaxed mb-4">
+                  « {t.quote} »
+                </p>
+                <div className="text-sm">
+                  <div className="font-semibold">{t.name}</div>
+                  <div className="text-text-tertiary">{t.role}</div>
+                </div>
+              </div>
+            </ScrollReveal>
+          ))}
+        </div>
+      </section>
+
+      {/* ────────────── FAQ ────────────── */}
+      <section className="max-w-3xl mx-auto px-6 sm:px-8 py-20">
+        <ScrollReveal className="text-center mb-10">
+          <h2 className="text-3xl sm:text-4xl font-bold">
+            Questions fréquentes
+          </h2>
+        </ScrollReveal>
+
+        <div>
+          {config.faq.map((entry, idx) => (
+            <FAQItem
+              key={idx}
+              question={entry.question}
+              answer={entry.answer}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* ────────────── CTA FINAL ────────────── */}
+      <section className="max-w-4xl mx-auto px-6 sm:px-8 py-24">
+        <ScrollReveal className="text-center rounded-3xl border border-white/10 bg-gradient-to-br from-indigo-600/15 via-violet-600/10 to-transparent backdrop-blur-xl p-12">
+          <h2 className="text-3xl sm:text-4xl font-bold mb-4">
+            Prêt à essayer DeepSight ?
+          </h2>
+          <p className="text-text-secondary mb-8 max-w-xl mx-auto">
+            5 analyses gratuites par mois. Aucune carte bancaire requise.
+          </p>
+          <Link
+            to={config.hero.primaryCta.to}
+            className="inline-flex items-center gap-2 rounded-lg bg-indigo-500 hover:bg-indigo-400 text-white font-medium px-8 py-4 transition-colors"
+          >
+            {config.hero.primaryCta.label}
+            <ArrowRight className="w-4 h-4" aria-hidden />
+          </Link>
+        </ScrollReveal>
+      </section>
+    </main>
+  );
+};
+
+export default PersonaLanding;
+```
+
+- [ ] **Step 2: Mettre à jour le barrel `index.ts`**
+
+Modifier `frontend/src/components/landing/index.ts` (3 lignes existantes → 4 lignes) :
+
+```typescript
+export { default as DemoAnalysisStatic } from "./DemoAnalysisStatic";
+export { default as DemoChatStatic } from "./DemoChatStatic";
+export { default as PricingSection } from "./PricingSection";
+export { default as PersonaLanding } from "./PersonaLanding";
+export type { PersonaKey } from "./personaConfig";
+```
+
+- [ ] **Step 3: Lancer le typecheck**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run typecheck`
+
+Expected: aucune erreur dans `PersonaLanding.tsx`, `personaConfig.ts`, ni `index.ts`. Les 19 erreurs TS pré-existantes sur d'autres fichiers (cf. memory `deepsight-mobile-refonte`) ne doivent PAS augmenter.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/landing/PersonaLanding.tsx frontend/src/components/landing/index.ts
+git commit -m "feat(landing): add generic PersonaLanding component with hero/features/FAQ"
+```
+
+---
+
+### Task 3: Créer la page `/etudiants` (`EtudiantsPage.tsx`)
+
+**Files:**
+
+- Create: `frontend/src/pages/EtudiantsPage.tsx`
+
+- [ ] **Step 1: Écrire `EtudiantsPage.tsx`**
+
+Créer `frontend/src/pages/EtudiantsPage.tsx` :
+
+```tsx
+/**
+ * EtudiantsPage — landing page persona Étudiants.
+ * Route: /etudiants
+ * SEO long-tail: "réviser flashcards IA", "synthèse cours youtube", "préparer examens IA"
+ */
+
+import { Helmet } from "react-helmet-async";
+import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
+import { PersonaLanding } from "../components/landing";
+import {
+  buildFAQPageJsonLd,
+  getPersonaConfig,
+} from "../components/landing/personaConfig";
+
+const EtudiantsPage = () => {
+  const config = getPersonaConfig("etudiant");
+  return (
+    <>
+      <SEO
+        title={config.seo.title}
+        description={config.seo.description}
+        path={config.path}
+        image={config.seo.ogImage}
+        keywords={config.seo.keywords}
+      />
+      <BreadcrumbJsonLd path={config.path} />
+      <Helmet>
+        <script type="application/ld+json">
+          {buildFAQPageJsonLd("etudiant")}
+        </script>
+      </Helmet>
+      <PersonaLanding persona="etudiant" />
+    </>
+  );
+};
+
+export default EtudiantsPage;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run typecheck`
+
+Expected: aucune erreur dans `EtudiantsPage.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/EtudiantsPage.tsx
+git commit -m "feat(landing): add /etudiants persona page"
+```
+
+---
+
+### Task 4: Créer la page `/journalistes` (`JournalistesPage.tsx`)
+
+**Files:**
+
+- Create: `frontend/src/pages/JournalistesPage.tsx`
+
+- [ ] **Step 1: Écrire `JournalistesPage.tsx`**
+
+Créer `frontend/src/pages/JournalistesPage.tsx` :
+
+```tsx
+/**
+ * JournalistesPage — landing page persona Journalistes & Fact-checkers.
+ * Route: /journalistes
+ * SEO long-tail: "fact-check vidéo IA", "vérifier discours politique", "agence presse IA"
+ */
+
+import { Helmet } from "react-helmet-async";
+import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
+import { PersonaLanding } from "../components/landing";
+import {
+  buildFAQPageJsonLd,
+  getPersonaConfig,
+} from "../components/landing/personaConfig";
+
+const JournalistesPage = () => {
+  const config = getPersonaConfig("journaliste");
+  return (
+    <>
+      <SEO
+        title={config.seo.title}
+        description={config.seo.description}
+        path={config.path}
+        image={config.seo.ogImage}
+        keywords={config.seo.keywords}
+      />
+      <BreadcrumbJsonLd path={config.path} />
+      <Helmet>
+        <script type="application/ld+json">
+          {buildFAQPageJsonLd("journaliste")}
+        </script>
+      </Helmet>
+      <PersonaLanding persona="journaliste" />
+    </>
+  );
+};
+
+export default JournalistesPage;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run typecheck`
+
+Expected: aucune erreur dans `JournalistesPage.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/JournalistesPage.tsx
+git commit -m "feat(landing): add /journalistes persona page"
+```
+
+---
+
+### Task 5: Créer la page `/chercheurs` (`ChercheursPage.tsx`)
+
+**Files:**
+
+- Create: `frontend/src/pages/ChercheursPage.tsx`
+
+- [ ] **Step 1: Écrire `ChercheursPage.tsx`**
+
+Créer `frontend/src/pages/ChercheursPage.tsx` :
+
+```tsx
+/**
+ * ChercheursPage — landing page persona Chercheurs & Académiques.
+ * Route: /chercheurs
+ * SEO long-tail: "analyse conférence IA", "extraction citations vidéo", "outil recherche académique"
+ */
+
+import { Helmet } from "react-helmet-async";
+import { SEO } from "../components/SEO";
+import { BreadcrumbJsonLd } from "../components/BreadcrumbJsonLd";
+import { PersonaLanding } from "../components/landing";
+import {
+  buildFAQPageJsonLd,
+  getPersonaConfig,
+} from "../components/landing/personaConfig";
+
+const ChercheursPage = () => {
+  const config = getPersonaConfig("chercheur");
+  return (
+    <>
+      <SEO
+        title={config.seo.title}
+        description={config.seo.description}
+        path={config.path}
+        image={config.seo.ogImage}
+        keywords={config.seo.keywords}
+      />
+      <BreadcrumbJsonLd path={config.path} />
+      <Helmet>
+        <script type="application/ld+json">
+          {buildFAQPageJsonLd("chercheur")}
+        </script>
+      </Helmet>
+      <PersonaLanding persona="chercheur" />
+    </>
+  );
+};
+
+export default ChercheursPage;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run typecheck`
+
+Expected: aucune erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/ChercheursPage.tsx
+git commit -m "feat(landing): add /chercheurs persona page"
+```
+
+---
+
+### Task 6: Brancher les routes dans `App.tsx` + étendre `BreadcrumbJsonLd`
+
+**Files:**
+
+- Modify: `frontend/src/App.tsx` (deux blocs : lazy imports + routes)
+- Modify: `frontend/src/components/BreadcrumbJsonLd.tsx` (LABELS map)
+
+- [ ] **Step 1: Ajouter les 3 lazy imports dans `App.tsx`**
+
+Dans `frontend/src/App.tsx`, dans le bloc "Pages publiques" (lignes ~283-296), ajouter immédiatement après `const AboutPage = lazyWithRetry(() => import("./pages/AboutPage"));` ces 3 lignes :
+
+```tsx
+const EtudiantsPage = lazyWithRetry(() => import("./pages/EtudiantsPage"));
+const JournalistesPage = lazyWithRetry(
+  () => import("./pages/JournalistesPage"),
+);
+const ChercheursPage = lazyWithRetry(() => import("./pages/ChercheursPage"));
+```
+
+- [ ] **Step 2: Ajouter les 3 routes dans `<Routes>`**
+
+Dans `frontend/src/App.tsx`, immédiatement APRÈS le bloc `<Route path="/about" ...>` (qui se termine à la ligne ~636 par `</Route>`) et AVANT le `<Route path="/payment/success" ...>`, ajouter ces 3 routes :
+
+```tsx
+<Route
+  path="/etudiants"
+  element={
+    <RouteErrorBoundary
+      variant="full"
+      componentName="EtudiantsPage"
+    >
+      <Suspense fallback={<PageSkeleton variant="full" />}>
+        <EtudiantsPage />
+      </Suspense>
+    </RouteErrorBoundary>
+  }
+/>
+
+<Route
+  path="/journalistes"
+  element={
+    <RouteErrorBoundary
+      variant="full"
+      componentName="JournalistesPage"
+    >
+      <Suspense fallback={<PageSkeleton variant="full" />}>
+        <JournalistesPage />
+      </Suspense>
+    </RouteErrorBoundary>
+  }
+/>
+
+<Route
+  path="/chercheurs"
+  element={
+    <RouteErrorBoundary
+      variant="full"
+      componentName="ChercheursPage"
+    >
+      <Suspense fallback={<PageSkeleton variant="full" />}>
+        <ChercheursPage />
+      </Suspense>
+    </RouteErrorBoundary>
+  }
+/>
+```
+
+- [ ] **Step 3: Étendre `BreadcrumbJsonLd.tsx` avec les nouveaux labels**
+
+Modifier `frontend/src/components/BreadcrumbJsonLd.tsx` lignes 10-20 (la map `LABELS`). Ajouter 3 entrées :
+
+```typescript
+const LABELS: Record<string, string> = {
+  "/about": "À propos",
+  "/upgrade": "Tarifs",
+  "/contact": "Contact",
+  "/api-docs": "Documentation API",
+  "/status": "Statut des services",
+  "/legal": "Mentions légales",
+  "/legal/cgu": "Conditions générales d'utilisation",
+  "/legal/cgv": "Conditions générales de vente",
+  "/legal/privacy": "Politique de confidentialité",
+  "/etudiants": "Pour les étudiants",
+  "/journalistes": "Pour les journalistes",
+  "/chercheurs": "Pour les chercheurs",
+};
+```
+
+- [ ] **Step 4: Lancer dev server pour vérification visuelle rapide**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run dev`
+
+Expected: server démarre sur `http://localhost:5173`. Naviguer vers :
+
+- `http://localhost:5173/etudiants` — hero "Tu es étudiant ?" visible
+- `http://localhost:5173/journalistes` — hero "Vérifie un discours politique en 5 minutes" visible
+- `http://localhost:5173/chercheurs` — hero "Analyse une conférence de 3h en 30 minutes" visible
+
+Stopper avec Ctrl+C.
+
+- [ ] **Step 5: Typecheck final + lint**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run typecheck && npm run lint`
+
+Expected: 0 nouvelle erreur ESLint sur les fichiers nouvellement créés.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/components/BreadcrumbJsonLd.tsx
+git commit -m "feat(landing): wire /etudiants /journalistes /chercheurs routes + breadcrumb labels"
+```
+
+---
+
+### Task 7: Étendre sitemap, vercel.json prerender + lien depuis homepage
+
+**Files:**
+
+- Modify: `frontend/scripts/generate-sitemap.mjs:26-37` (ROUTES array)
+- Modify: `frontend/vercel.json` (rewrites prerender)
+- Modify: `frontend/src/pages/LandingPage.tsx` (section Audiences — wrap les 3 audiences cibles avec `<Link>`)
+
+- [ ] **Step 1: Ajouter les 3 routes au sitemap generator**
+
+Modifier `frontend/scripts/generate-sitemap.mjs` lignes 26-37. Remplacer l'array `ROUTES` par :
+
+```javascript
+const ROUTES = [
+  { path: "/", priority: 1.0, changefreq: "weekly" },
+  { path: "/etudiants", priority: 0.85, changefreq: "monthly" },
+  { path: "/journalistes", priority: 0.85, changefreq: "monthly" },
+  { path: "/chercheurs", priority: 0.85, changefreq: "monthly" },
+  { path: "/about", priority: 0.8, changefreq: "monthly" },
+  { path: "/upgrade", priority: 0.9, changefreq: "monthly" },
+  { path: "/api-docs", priority: 0.6, changefreq: "monthly" },
+  { path: "/contact", priority: 0.5, changefreq: "yearly" },
+  { path: "/status", priority: 0.4, changefreq: "daily" },
+  { path: "/legal", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/cgu", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/cgv", priority: 0.3, changefreq: "yearly" },
+  { path: "/legal/privacy", priority: 0.3, changefreq: "yearly" },
+];
+```
+
+- [ ] **Step 2: Vérifier la génération du sitemap**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && node scripts/generate-sitemap.mjs`
+
+Expected: console affiche `✓ Sitemap written: ... (13 URLs, lastmod=YYYY-MM-DD)`. Vérifier `frontend/public/sitemap.xml` contient bien les 3 nouvelles routes.
+
+- [ ] **Step 3: Étendre `vercel.json` avec les rewrites prerender bots IA**
+
+Modifier `frontend/vercel.json`. Ajouter 3 nouvelles entrées dans le tableau `rewrites`, immédiatement après l'entrée `/contact` (qui se termine à la ligne 68 — `}`) et AVANT l'entrée `/chaines` :
+
+```json
+{
+  "source": "/etudiants",
+  "has": [
+    {
+      "type": "header",
+      "key": "user-agent",
+      "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+    }
+  ],
+  "destination": "/api/prerender?path=/etudiants"
+},
+{
+  "source": "/journalistes",
+  "has": [
+    {
+      "type": "header",
+      "key": "user-agent",
+      "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+    }
+  ],
+  "destination": "/api/prerender?path=/journalistes"
+},
+{
+  "source": "/chercheurs",
+  "has": [
+    {
+      "type": "header",
+      "key": "user-agent",
+      "value": "(?i)(GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Claude-Web|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|Applebot-Extended|Diffbot|ImagesiftBot)"
+    }
+  ],
+  "destination": "/api/prerender?path=/chercheurs"
+},
+```
+
+(Attention à la virgule de séparation entre objets JSON.)
+
+- [ ] **Step 4: Valider le JSON de `vercel.json`**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf-8')); console.log('OK')"`
+
+Expected: stdout = `OK`. Si erreur de parsing → fixer la virgule manquante / superflue.
+
+- [ ] **Step 5: Linker depuis la homepage les 3 audiences vers leurs pages persona**
+
+Modifier `frontend/src/pages/LandingPage.tsx`. Le composant rend la section "Audiences" via `getAudiences()` (lignes ~250-292). Il faut wrapper les cards des 3 personas existants (`Chercheurs & Académiques`, `Journalistes & Fact-checkers`, `Étudiants`) avec un `Link` vers leur landing.
+
+Stratégie minimaliste : étendre l'objet `audience` avec un champ optionnel `to: string`. Au rendu, si `to` est présent, wrapper la card dans `<Link to={audience.to}>`. La card "Créateurs & Pros" reste sans `to` (pas de page MVP).
+
+Trouver dans `LandingPage.tsx` la fonction `getAudiences(language)` (lignes 250-292) et la remplacer par :
+
+```typescript
+const getAudiences = (language: string) => [
+  {
+    icon: GraduationCap,
+    to: "/chercheurs",
+    title:
+      language === "fr"
+        ? "Chercheurs & Académiques"
+        : "Researchers & Academics",
+    description:
+      language === "fr"
+        ? "Analysez conférences, séminaires doctoraux et cours magistraux. Extrayez les thèses, les références et les arguments en quelques minutes."
+        : "Analyze lectures, doctoral seminars and academic courses. Extract theses, references and arguments in minutes.",
+  },
+  {
+    icon: Newspaper,
+    to: "/journalistes",
+    title:
+      language === "fr"
+        ? "Journalistes & Fact-checkers"
+        : "Journalists & Fact-checkers",
+    description:
+      language === "fr"
+        ? "Vérifiez les affirmations, extrayez les citations avec timecodes, croisez les sources. Un assistant d'investigation rigoureux."
+        : "Verify claims, extract timestamped quotes, cross-reference sources. A rigorous investigative assistant.",
+  },
+  {
+    icon: GraduationCap,
+    to: "/etudiants",
+    title: language === "fr" ? "Étudiants" : "Students",
+    description:
+      language === "fr"
+        ? "Flashcards générées automatiquement, cartes mentales, synthèses structurées. Révisez vos cours vidéo deux fois plus vite."
+        : "Auto-generated flashcards, mind maps, structured summaries. Review your video courses twice as fast.",
+  },
+  {
+    icon: Briefcase,
+    title:
+      language === "fr"
+        ? "Créateurs & Professionnels"
+        : "Creators & Professionals",
+    description:
+      language === "fr"
+        ? "Veille concurrentielle, recherche de contenu, synthèse de webinaires. Transformez des heures de vidéo en insights exploitables."
+        : "Competitive intelligence, content research, webinar summaries. Turn hours of video into actionable insights.",
+  },
+];
+```
+
+(Note : `to` n'est ajouté que pour les 3 premières — la 4e n'a pas de page persona MVP.)
+
+Puis dans le rendu de la section Audiences (chercher dans `LandingPage.tsx` la map `audiences.map(...)` qui rend les cards), wrapper chaque card par un `<Link to={audience.to}>` quand `audience.to` est défini.
+
+Repérer le pattern dans le JSX existant. Exemple courant — remplacer :
+
+```tsx
+{
+  audiences.map((audience, idx) => (
+    <StaggerItem key={idx}>
+      <div className="rounded-2xl border ...">...card content</div>
+    </StaggerItem>
+  ));
+}
+```
+
+Par :
+
+```tsx
+{
+  audiences.map((audience, idx) => {
+    const cardContent = (
+      <div className="rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl p-6 hover:bg-white/10 transition-colors h-full">
+        ...card content
+      </div>
+    );
+    return (
+      <StaggerItem key={idx}>
+        {audience.to ? (
+          <Link to={audience.to} className="block h-full">
+            {cardContent}
+          </Link>
+        ) : (
+          cardContent
+        )}
+      </StaggerItem>
+    );
+  });
+}
+```
+
+S'assurer que `Link` est importé en haut du fichier : `import { Link, useNavigate } from "react-router-dom";` (cf. ligne 7 — l'import existe déjà avec `useNavigate`, ajouter `Link` à l'import existant).
+
+⚠️ **Si la structure JSX exacte de la section Audiences diffère de l'extrait ci-dessus** (par exemple noms de classes ou wrappers `motion.div` différents), respecter le markup existant et y intercaler le `<Link>` au bon niveau (autour de la card, pas autour du `StaggerItem`). Critère de succès : un clic sur "Étudiants", "Journalistes" ou "Chercheurs" depuis la homepage navigue bien vers `/etudiants`, `/journalistes`, `/chercheurs` respectivement.
+
+- [ ] **Step 6: Vérifier visuellement les liens depuis la homepage**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run dev`
+
+Naviguer sur `http://localhost:5173/`, scroller jusqu'à la section "Pour qui ?" / "Audiences" et cliquer sur les 3 cards persona. Vérifier que la navigation fonctionne et que la page persona se charge correctement.
+
+Stopper le dev server.
+
+- [ ] **Step 7: Build complet pour confirmer sitemap regénéré**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run build`
+
+Expected: build réussit. La console affiche en début de build `✓ Sitemap written: ... (13 URLs, ...)`. Le bundle ne doit pas avoir d'erreur.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/scripts/generate-sitemap.mjs frontend/vercel.json frontend/src/pages/LandingPage.tsx
+git commit -m "feat(seo): extend sitemap + vercel prerender + homepage links for persona landings"
+```
+
+---
+
+### Task 8: Tests Vitest pour `PersonaLanding` + 3 pages persona
+
+**Files:**
+
+- Create: `frontend/src/components/landing/__tests__/PersonaLanding.test.tsx`
+- Create: `frontend/src/pages/__tests__/EtudiantsPage.test.tsx`
+- Create: `frontend/src/pages/__tests__/JournalistesPage.test.tsx`
+- Create: `frontend/src/pages/__tests__/ChercheursPage.test.tsx`
+
+- [ ] **Step 1: Écrire le test du composant `PersonaLanding`**
+
+Créer `frontend/src/components/landing/__tests__/PersonaLanding.test.tsx` :
+
+```tsx
+/**
+ * Tests — PersonaLanding component.
+ * Couvre : rendu pour chaque persona, headline correct, FAQ présente,
+ * CTAs présents, flag placeholder testimonial visible.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import { PersonaLanding } from "../PersonaLanding";
+import { PERSONA_CONFIG, type PersonaKey } from "../personaConfig";
+
+const renderWithRouter = (persona: PersonaKey) =>
+  render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={[PERSONA_CONFIG[persona].path]}>
+        <PersonaLanding persona={persona} />
+      </MemoryRouter>
+    </HelmetProvider>,
+  );
+
+describe("PersonaLanding", () => {
+  const personas: PersonaKey[] = ["etudiant", "journaliste", "chercheur"];
+
+  personas.forEach((persona) => {
+    describe(`persona = ${persona}`, () => {
+      it("renders the persona-specific headline", () => {
+        renderWithRouter(persona);
+        const headline = PERSONA_CONFIG[persona].hero.headline;
+        // Le headline est un h1 unique
+        expect(
+          screen.getByRole("heading", { level: 1, name: headline }),
+        ).toBeInTheDocument();
+      });
+
+      it("renders the eyebrow text", () => {
+        renderWithRouter(persona);
+        expect(
+          screen.getByText(PERSONA_CONFIG[persona].hero.eyebrow),
+        ).toBeInTheDocument();
+      });
+
+      it("renders all 4 features", () => {
+        renderWithRouter(persona);
+        PERSONA_CONFIG[persona].features.forEach((feature) => {
+          expect(
+            screen.getByRole("heading", { level: 3, name: feature.title }),
+          ).toBeInTheDocument();
+        });
+      });
+
+      it("renders both comparison columns (before & after)", () => {
+        renderWithRouter(persona);
+        expect(
+          screen.getByText(PERSONA_CONFIG[persona].comparison.before.title),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(PERSONA_CONFIG[persona].comparison.after.title),
+        ).toBeInTheDocument();
+      });
+
+      it("renders all FAQ questions as collapsed buttons", () => {
+        renderWithRouter(persona);
+        PERSONA_CONFIG[persona].faq.forEach((entry) => {
+          expect(
+            screen.getByRole("button", { name: entry.question }),
+          ).toBeInTheDocument();
+        });
+      });
+
+      it("renders primary CTA with persona-specific link", () => {
+        renderWithRouter(persona);
+        const cta = PERSONA_CONFIG[persona].hero.primaryCta;
+        const links = screen.getAllByRole("link", { name: cta.label });
+        // Au moins un lien (hero) — peut y en avoir un autre dans le CTA final
+        expect(links.length).toBeGreaterThanOrEqual(1);
+        expect(links[0]).toHaveAttribute("href", cta.to);
+      });
+
+      it("flags placeholder testimonials with explicit warning", () => {
+        renderWithRouter(persona);
+        const placeholderFlags = screen.getAllByTestId(
+          "testimonial-placeholder-flag",
+        );
+        // Tous les testimonials sont placeholders pour MVP
+        const placeholderCount = PERSONA_CONFIG[persona].testimonials.filter(
+          (t) => t.isPlaceholder,
+        ).length;
+        expect(placeholderFlags.length).toBe(placeholderCount);
+      });
+
+      it("renders the data-testid for the persona", () => {
+        renderWithRouter(persona);
+        expect(
+          screen.getByTestId(`persona-landing-${persona}`),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Écrire le test de la page `EtudiantsPage`**
+
+Créer `frontend/src/pages/__tests__/EtudiantsPage.test.tsx` :
+
+```tsx
+/**
+ * Tests — EtudiantsPage.
+ * Vérifie que la page monte PersonaLanding avec persona="etudiant"
+ * et que les balises SEO injectent le bon titre.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import EtudiantsPage from "../EtudiantsPage";
+import { PERSONA_CONFIG } from "../../components/landing/personaConfig";
+
+describe("EtudiantsPage", () => {
+  it("monte le composant PersonaLanding avec la persona étudiant", () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/etudiants"]}>
+          <EtudiantsPage />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+    expect(screen.getByTestId("persona-landing-etudiant")).toBeInTheDocument();
+  });
+
+  it("injecte le title SEO étudiant dans <head>", async () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/etudiants"]}>
+          <EtudiantsPage />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.title).toContain(PERSONA_CONFIG.etudiant.seo.title);
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Écrire le test de `JournalistesPage`**
+
+Créer `frontend/src/pages/__tests__/JournalistesPage.test.tsx` :
+
+```tsx
+/**
+ * Tests — JournalistesPage.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import JournalistesPage from "../JournalistesPage";
+import { PERSONA_CONFIG } from "../../components/landing/personaConfig";
+
+describe("JournalistesPage", () => {
+  it("monte le composant PersonaLanding avec la persona journaliste", () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/journalistes"]}>
+          <JournalistesPage />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+    expect(
+      screen.getByTestId("persona-landing-journaliste"),
+    ).toBeInTheDocument();
+  });
+
+  it("injecte le title SEO journaliste dans <head>", async () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/journalistes"]}>
+          <JournalistesPage />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.title).toContain(PERSONA_CONFIG.journaliste.seo.title);
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Écrire le test de `ChercheursPage`**
+
+Créer `frontend/src/pages/__tests__/ChercheursPage.test.tsx` :
+
+```tsx
+/**
+ * Tests — ChercheursPage.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import ChercheursPage from "../ChercheursPage";
+import { PERSONA_CONFIG } from "../../components/landing/personaConfig";
+
+describe("ChercheursPage", () => {
+  it("monte le composant PersonaLanding avec la persona chercheur", () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/chercheurs"]}>
+          <ChercheursPage />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+    expect(screen.getByTestId("persona-landing-chercheur")).toBeInTheDocument();
+  });
+
+  it("injecte le title SEO chercheur dans <head>", async () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/chercheurs"]}>
+          <ChercheursPage />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.title).toContain(PERSONA_CONFIG.chercheur.seo.title);
+    });
+  });
+});
+```
+
+- [ ] **Step 5: Lancer les tests Vitest**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run test -- --run frontend/src/components/landing/__tests__/PersonaLanding.test.tsx frontend/src/pages/__tests__/EtudiantsPage.test.tsx frontend/src/pages/__tests__/JournalistesPage.test.tsx frontend/src/pages/__tests__/ChercheursPage.test.tsx`
+
+Expected: tous les tests passent (~24+ tests : 8 par persona × 3 personas dans `PersonaLanding.test.tsx`, + 2 tests par page = 6).
+
+Si un test sur le titre échoue (`document.title` n'inclut pas la string attendue) — c'est probablement parce que `react-helmet-async` met à jour le titre de manière asynchrone : `waitFor` doit suffire, mais augmenter le timeout si besoin (`waitFor(...,  { timeout: 3000 })`).
+
+Si un test sur `data-testid="testimonial-placeholder-flag"` échoue — vérifier que le `data-testid` est bien posé sur la `<div>` du flag dans `PersonaLanding.tsx`.
+
+- [ ] **Step 6: Lancer le full test suite pour vérifier qu'aucune régression n'a été introduite**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run test -- --run`
+
+Expected: 400+ tests passent (cf. `CLAUDE.md` racine — frontend a 400 tests verts pré-existants), avec en plus les ~30 tests nouveaux. Total attendu ≈ 430+.
+
+Si régression sur un test pré-existant → vérifier que la modif de `LandingPage.tsx` (Task 7 step 5) ne casse pas un test homepage existant. Si c'est le cas, ajuster le test homepage pour accepter le nouveau wrapper `<Link>`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/landing/__tests__/PersonaLanding.test.tsx frontend/src/pages/__tests__/EtudiantsPage.test.tsx frontend/src/pages/__tests__/JournalistesPage.test.tsx frontend/src/pages/__tests__/ChercheursPage.test.tsx
+git commit -m "test(landing): add Vitest coverage for PersonaLanding and 3 persona pages"
+```
+
+---
+
+### Task 9: Vérification finale + push
+
+**Files:**
+
+- (no file changes)
+
+- [ ] **Step 1: Typecheck final**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run typecheck`
+
+Expected: aucune nouvelle erreur (les 19 erreurs pré-existantes documentées dans la memory `deepsight-mobile-refonte` peuvent rester ; toute erreur supplémentaire est une régression à corriger).
+
+- [ ] **Step 2: Lint final**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run lint`
+
+Expected: 0 nouvelle warning ESLint sur les fichiers ajoutés ou modifiés.
+
+- [ ] **Step 3: Build production complet**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && npm run build`
+
+Expected: build OK, sitemap régénéré avec 13 URLs, aucune erreur.
+
+- [ ] **Step 4: Vérifier que le sitemap final contient bien les 3 routes persona**
+
+Run: `cd C:/Users/33667/DeepSight-Main/frontend && grep -E '/etudiants|/journalistes|/chercheurs' public/sitemap.xml`
+
+(Sur Windows bash : utiliser le shell bash de Git Bash. Sur PowerShell : `Select-String -Pattern '/etudiants|/journalistes|/chercheurs' -Path public/sitemap.xml`.)
+
+Expected: 3 lignes correspondantes affichées (une `<loc>` par route).
+
+- [ ] **Step 5: Rappels manuels (à valider visuellement par l'utilisateur)**
+
+Avant de merger / déployer en prod, l'utilisateur DOIT valider :
+
+1. Les 3 OG images (`og-image-etudiants.png`, `og-image-journalistes.png`, `og-image-chercheurs.png` — 1200×630, sous `frontend/public/`) sont **générées et présentes**, sinon les LinkedIn/Twitter cards afficheront un fallback générique.
+2. Les **témoignages placeholders** sont remplacés par de vrais témoignages signés OU le flag `isPlaceholder` reste à `true` et la mention "Témoignage placeholder — à valider avant prod" est affichée publiquement (volontairement transparent en attendant des vrais).
+3. Le déploiement Vercel auto-deploy a bien régénéré le sitemap (vérifier `https://www.deepsightsynthesis.com/sitemap.xml`).
+4. Les 3 nouvelles routes répondent bien en prod : `https://www.deepsightsynthesis.com/etudiants`, `/journalistes`, `/chercheurs` (status 200, contenu visible, pas de 404).
+5. Tester un user-agent bot IA pour vérifier le prerender : `curl -A "ClaudeBot" -I https://www.deepsightsynthesis.com/etudiants` doit rediriger vers `/api/prerender?path=/etudiants`.
+
+- [ ] **Step 6: (Optionnel) Push si l'utilisateur l'a demandé explicitement**
+
+```bash
+git push origin <branch>
+```
+
+⚠️ NE PAS pusher si l'utilisateur n'a pas explicitement demandé de pousser (cf. règle CLAUDE.md). Le déploiement Vercel se déclenche automatiquement à la fusion sur `main`.
+
+---
+
+## Self-review
+
+### 1. Couverture du spec
+
+| Exigence du spec                                                  | Tâche couvrante                                                                                                                                                                                                                                                                                                                                                                       |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hero ciblé persona                                                | Task 2 (PersonaLanding) + config Task 1                                                                                                                                                                                                                                                                                                                                               |
+| 3-4 features mises en avant spécifiques                           | Task 1 (`features` array) + Task 2 (rendu grid)                                                                                                                                                                                                                                                                                                                                       |
+| Témoignage(s) du persona avec flag placeholder                    | Task 1 (`testimonials` + `isPlaceholder: true`) + Task 2 (`<div data-testid="testimonial-placeholder-flag">`)                                                                                                                                                                                                                                                                         |
+| Comparison "avant/après"                                          | Task 1 (`comparison`) + Task 2 (section dédiée)                                                                                                                                                                                                                                                                                                                                       |
+| CTA conversion "Analyse ta première vidéo gratuitement"           | Task 1 (`primaryCta.label`) + Task 2 (rendu Hero + CTA final)                                                                                                                                                                                                                                                                                                                         |
+| FAQ persona-specific (3-4 questions)                              | Task 1 (`faq` array, 4 entrées par persona) + Task 2 (FAQItem accordéon)                                                                                                                                                                                                                                                                                                              |
+| FAQPage JSON-LD                                                   | Task 1 (`buildFAQPageJsonLd()`) + Tasks 3-5 (Helmet `<script>`)                                                                                                                                                                                                                                                                                                                       |
+| Schema Person/Organization si pertinent                           | **Décidé NON pour MVP** — Schema.org Person serait pour des biographies individuelles (ex: profil chercheur). Notre page est une page produit ciblant un persona, pas une bio. `BreadcrumbList` (déjà présent via `<BreadcrumbJsonLd>`) + `FAQPage` couvrent les usages SEO essentiels. (Décision documentée ici, à reconsidérer en phase 2 si on ajoute des bios de membres équipe.) |
+| 3 pages dédiées (`/etudiants`, `/journalistes`, `/chercheurs`)    | Tasks 3, 4, 5                                                                                                                                                                                                                                                                                                                                                                         |
+| Composant générique réutilisable `<PersonaLanding persona="...">` | Task 2                                                                                                                                                                                                                                                                                                                                                                                |
+| Routes lazy-load App.tsx                                          | Task 6                                                                                                                                                                                                                                                                                                                                                                                |
+| SEO unique title/description par page                             | Task 1 (config) + Tasks 3-5 (`<SEO>`)                                                                                                                                                                                                                                                                                                                                                 |
+| Canonical URL                                                     | Auto par `<SEO path={config.path}>`                                                                                                                                                                                                                                                                                                                                                   |
+| OG image dédiée par persona                                       | Config Task 1 + flagged en Task 9 step 5 (génération hors scope code)                                                                                                                                                                                                                                                                                                                 |
+| Sitemap inclut les 3 routes                                       | Task 7 step 1-2                                                                                                                                                                                                                                                                                                                                                                       |
+| Prerendering bots IA actif                                        | Task 7 step 3-4 (vercel.json)                                                                                                                                                                                                                                                                                                                                                         |
+| Lien depuis homepage "DeepSight pour qui ?"                       | Task 7 step 5 (LandingPage.tsx audiences)                                                                                                                                                                                                                                                                                                                                             |
+| i18n FR seul MVP                                                  | Confirmé (config en `const` FR, pas i18n JSON)                                                                                                                                                                                                                                                                                                                                        |
+| Tests Vitest rendu pages + props PersonaLanding                   | Task 8                                                                                                                                                                                                                                                                                                                                                                                |
+| Pas de fetch API mount (statique)                                 | Confirmé (config en `const`, pas de `useEffect` réseau)                                                                                                                                                                                                                                                                                                                               |
+| Design dark mode + glassmorphism + Indigo/Violet                  | Task 2 (classes Tailwind respectent les tokens)                                                                                                                                                                                                                                                                                                                                       |
+| lucide-react + Framer Motion                                      | Task 2 (imports respectés)                                                                                                                                                                                                                                                                                                                                                            |
+
+**Aucun gap identifié.**
+
+### 2. Scan placeholders
+
+- ✅ Aucun `TODO`, `TBD`, `implement later` dans les Tasks.
+- ✅ Code complet à chaque step (les blocs `<DemoAnalysisStatic>` et `<DemoChatStatic>` existent déjà dans `frontend/src/components/landing/` — vérifié pendant la recherche, pas à créer).
+- ⚠️ **Décision attendue** : les 3 OG images (`/og-image-etudiants.png` etc.) référencées dans la config Task 1 NE SONT PAS générées par le plan. Si elles n'existent pas en prod, Helmet pointera vers une URL 404 et les bots social retomberont en fallback. → **À discuter avec l'utilisateur** : qui génère ces images ? (Figma + export ? Génération via Midjourney + retouche ? Réutiliser temporairement `og-image.png` global ?)
+- ⚠️ **Décision attendue** : les témoignages sont **tous flaggés placeholder**. La règle business est ambiguë — afficher avec mention transparente "placeholder à valider" OU les retirer complètement jusqu'à obtenir des vrais ? Le plan implémente la première option (flag visible). À confirmer.
+
+### 3. Cohérence des types
+
+- `PersonaKey = "etudiant" | "journaliste" | "chercheur"` utilisé partout avec la même casse, sans variantes accentuées (ex: jamais `étudiant` avec accent — toujours `etudiant` slug-style pour cohérence ASCII en clés).
+- `PersonaConfig` interface définie en Task 1, utilisée en Task 2 (`getPersonaConfig`), Tasks 3-5 (pages), Task 8 (tests).
+- `buildFAQPageJsonLd(persona: PersonaKey): string` — signature identique entre Task 1 (déclaration) et Tasks 3-5 (consommation).
+- `getPersonaConfig(persona: PersonaKey): PersonaConfig` — idem.
+- Routes : path `/etudiants` (sans accent, slug ASCII) — cohérent dans Task 1 (config), Task 6 (App.tsx), Task 7 (sitemap + vercel.json), Task 8 (tests `MemoryRouter initialEntries`).
+- `data-testid="persona-landing-${persona}"` — défini dans Task 2 et utilisé dans Tasks 8 (tests des 3 pages + composant) — cohérent.
+- `data-testid="testimonial-placeholder-flag"` — défini dans Task 2 et utilisé dans Task 8 — cohérent.
+
+**Aucune incohérence détectée.**
+
+### 4. Décisions à confirmer avec l'utilisateur AVANT exécution
+
+1. **OG images** (3 fichiers PNG 1200×630) — qui les génère ? Options :
+   - (a) L'utilisateur les fournit avant l'exécution du plan (idéal).
+   - (b) Fallback transitoire vers `/og-image.png` global (modifier la config Task 1 pour pointer vers ce fallback). Fonctionne mais perd l'intérêt SEO/social ciblé.
+   - (c) Sous-tâche supplémentaire pour les générer via outil IA (Midjourney/DALL·E + post-prod), à brieffer séparément.
+
+2. **EN traduction MVP ou phase 2 ?** — Le plan implémente FR seul. Si l'utilisateur veut EN dès le MVP :
+   - (a) Garder FR seul → traduction en sprint 2 (recommandé pour ne pas alourdir).
+   - (b) Ajouter `PERSONA_CONFIG_EN` parallèle + branchement par `useTranslation().language` → +30% de copy à rédiger, +1 task, +200 lignes config.
+
+3. **Persona depuis backend stats vs hardcoded** — Le plan harcode tout. Alternative future : récupérer les stats utilisateur réelles (nb d'étudiants inscrits, etc.) via `/api/admin/stats` pour générer des social proof dynamiques. **Décision MVP : hardcode** (pas d'API call au mount = page rapide + indexable build-time). Si stats dynamiques voulues plus tard, refactor possible mais hors scope V1.
+
+4. **Témoignages placeholders** — affichés avec mention transparente OU masqués jusqu'aux vrais ?
+   - (a) Affichés avec flag "placeholder à valider" visible (implémenté). Pro : page complète. Con : peut faire amateur.
+   - (b) Section témoignages cachée si tous `isPlaceholder = true`. Pro : pas d'amateurisme. Con : page plus courte. → simple ajout `if (config.testimonials.every(t => !t.isPlaceholder)) { ... }`.
+
+5. **Persona "Créateurs & Pros"** — pas de page MVP. Confirmer qu'on attend volontairement vs ajouter un 4e persona ? Le plan documente que la 4e card homepage reste sans `to` link. Si l'utilisateur veut couvrir cette persona aussi → ajout d'une 9e task ~ 2h.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-29-landing-pages-persona.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — Je dispatch un fresh subagent par task (T1 → T9), review entre chaque task, itération rapide, idéal pour ce plan de 9 tasks bite-sized.
+
+**2. Inline Execution** — Exécuter les tasks dans cette session via `superpowers:executing-plans`, avec checkpoints (après T2, T6, T8) pour review.
+
+Quelle approche ?

--- a/docs/superpowers/plans/2026-04-29-plans-db-driven.md
+++ b/docs/superpowers/plans/2026-04-29-plans-db-driven.md
@@ -1,0 +1,2957 @@
+# Plans DB-Driven Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrer la définition des plans (actuellement hardcoded dans `backend/src/billing/plan_config.py` + `frontend/src/config/planPrivileges.ts`) vers des tables PostgreSQL `plans` et `plan_features`, permettant l'A/B testing pricing et l'édition admin sans deploy, tout en gardant l'API publique inchangée et un fallback hardcoded en cas d'inaccessibilité DB.
+
+**Architecture:** Approche en 3 couches : (1) deux nouvelles tables SQL `plans` + `plan_features` avec seed initial idempotent, (2) un service `PlanRegistry` qui lit ces tables avec cache Redis 5 min et fallback sur les valeurs hardcoded actuelles si DB injoignable, (3) `plan_config.py` conserve son API publique mais délègue au service ; le frontend ajoute un hook `useApiPlans()` (TanStack Query 5 min) qui consomme `/api/billing/plans`. Endpoints admin protégés par `get_current_admin` permettent de modifier prix/features et invalident le cache.
+
+**Tech Stack:** SQLAlchemy 2.0 async + Alembic (PostgreSQL 17/SQLite), Pydantic v2, Redis 7 via `cache_service` singleton, FastAPI, React 18 + TanStack Query 5, Vitest pour les tests frontend, pytest+pytest-asyncio pour le backend.
+
+---
+
+## ⚠️ DÉPENDANCE CRITIQUE — À LIRE AVANT TOUTE EXÉCUTION
+
+**Ce plan ne peut être exécuté QU'APRÈS le merge complet du plan #3 :**
+`docs/superpowers/plans/2026-04-29-pricing-v2-stripe-grandfathering.md`
+
+Pourquoi : le plan #3 effectue le rename `plus → pro` puis `pro → expert` à la fois en DB
+(`UPDATE users SET plan = 'pro' WHERE plan = 'plus'` etc.) et en code (`PlanId` enum,
+clés de `PLAN_LIMITS`, dictionnaires d'aliases). Si on migre vers DB-driven AVANT le rename,
+il faudra refaire le `UPDATE` sur la table `plans` _après_, ce qui fragmente la migration
+inutilement et expose des fenêtres d'incohérence (ex : `plans.slug = 'plus'` mais `users.plan = 'pro'`).
+
+L'état initial seed-é dans la table `plans` par ce plan est **directement la grille v2** :
+
+| slug   | name    | price_monthly_cents | price_yearly_cents (-17%) |
+| ------ | ------- | ------------------- | ------------------------- |
+| free   | Gratuit | 0                   | 0                         |
+| pro    | Pro     | 899                 | 8949                      |
+| expert | Expert  | 1999                | 19899                     |
+
+**Task 0 ci-dessous est un blocker de pré-condition** — ne pas démarrer la Task 1 si elle échoue.
+
+---
+
+## Contexte préalable — État actuel à migrer
+
+### Backend (à migrer)
+
+`backend/src/billing/plan_config.py` (662 lignes, déjà analysé) expose :
+
+- `PlanId` enum (3 valeurs après #3 : `free`, `pro`, `expert`)
+- `PLAN_HIERARCHY: list[PlanId]`
+- `PLANS: dict[str, dict[str, Any]]` — la "grosse" structure avec `name`, `description`, `price_monthly_cents`, `stripe_price_id_test/live`, `color`, `icon`, `badge`, `popular`, `limits` (dict de ~30 clés), `features_display` (list), `features_locked` (list), `platforms` (dict avec `web`/`mobile`/`extension` chacun ~16 booleans)
+- Fonctions accessor : `normalize_plan_id`, `get_plan`, `get_limits`, `get_platform_features`, `is_feature_available`, `get_minimum_plan_for`, `get_price_id`, `get_plan_by_price_id`, `get_plan_index`, `is_upgrade`, `init_stripe_prices`
+- `VOICE_CALL_QUICK_CAPABILITY` + `get_voice_call_quick_capability` (Quick Voice Call)
+- `PLATFORM_LIMITS` (TikTok/YouTube — pas concerné, hors scope)
+
+L'endpoint actuel `GET /api/billing/plans?platform=...` (`backend/src/billing/router.py:354`) lit `PLANS` en mémoire et formate la réponse.
+
+### Frontend (à migrer)
+
+`frontend/src/config/planPrivileges.ts` (555 lignes, déjà analysé) exporte :
+
+- `PLAN_HIERARCHY`, `PLAN_LIMITS`, `PLAN_FEATURES`, `PLANS_INFO`
+- Helpers : `hasFeature`, `getLimit`, `isUnlimited`, `getPlanInfo`, `isPlanHigher`, `getMinPlanForFeature`, `formatLimit`, `normalizePlanId`
+- `CONVERSION_TRIGGERS`, `DIFFERENTIATORS`, `TESTIMONIALS` (hors scope — restent statiques côté front, ce sont du marketing)
+
+`frontend/src/services/api.ts:1820` expose déjà `billingApi.getPlans(platform)` qui consomme `/api/billing/plans`. Il sera utilisé tel quel par le hook.
+
+### Tables d'aliases (à conserver)
+
+Backend : `PLAN_ALIASES = {"etudiant": "plus", "starter": "plus", "student": "plus", ...}`. Après #3, `plus` n'existe plus → ces aliases pointent désormais vers `pro` ou `expert` (le détail est dans le plan #3, on suit son output).
+
+---
+
+## File Structure
+
+### À créer (backend)
+
+| Fichier                                            | Responsabilité                                                               |
+| -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `backend/alembic/versions/0XX_add_plans_tables.py` | Migration Alembic : tables `plans` + `plan_features` + index unique          |
+| `backend/src/db/database.py` (ajout)               | Models SQLAlchemy `Plan` et `PlanFeature` (ajout dans le fichier existant)   |
+| `backend/src/billing/plan_registry.py`             | Service `PlanRegistry` : lecture DB + cache Redis 5 min + fallback hardcoded |
+| `backend/src/billing/plan_admin_router.py`         | Endpoints admin `/api/admin/plans` (GET / PUT / POST duplicate)              |
+| `backend/scripts/seed_plans_db.py`                 | Script idempotent UPSERT par slug (3 plans v2 + features)                    |
+| `backend/tests/billing/test_plan_registry.py`      | Tests unitaires PlanRegistry (DB read, cache, fallback)                      |
+| `backend/tests/billing/test_plan_admin_router.py`  | Tests endpoints admin + invalidation cache                                   |
+
+### À modifier (backend)
+
+| Fichier                                 | Change                                                                                  |
+| --------------------------------------- | --------------------------------------------------------------------------------------- |
+| `backend/src/billing/plan_config.py`    | Refactor interne : les fonctions accessor délèguent au `PlanRegistry`                   |
+| `backend/src/billing/router.py:354-397` | `GET /plans` lit via `plan_registry.list_plans(platform)` au lieu de `PLANS` en mémoire |
+| `backend/src/main.py`                   | Inclure `plan_admin_router` sous `/api/admin/plans`                                     |
+| `backend/src/admin/router.py`           | Update `UpdateUserRequest.validate_plan` valid_plans = lus depuis registry              |
+
+### À créer (frontend)
+
+| Fichier                                             | Responsabilité                                                        |
+| --------------------------------------------------- | --------------------------------------------------------------------- |
+| `frontend/src/hooks/useApiPlans.ts`                 | Hook TanStack Query qui fetch `/api/billing/plans` + cache 5 min      |
+| `frontend/src/config/planPrivilegesFallback.ts`     | **Renommé** depuis `planPrivileges.ts` — devient le fallback statique |
+| `frontend/src/__tests__/hooks/useApiPlans.test.tsx` | Tests Vitest (mock fetch, fallback erreur)                            |
+
+### À modifier (frontend)
+
+| Fichier                                 | Change                                                              |
+| --------------------------------------- | ------------------------------------------------------------------- |
+| `frontend/src/config/planPrivileges.ts` | Réexporte `planPrivilegesFallback` pour compat + ajoute des helpers |
+
+### À créer (admin UI — phase 2 optionnelle, voir Self-Review)
+
+> Discussion de scope dans la self-review : on documente ici les fichiers prévus mais
+> Tasks 13-14 sont marquées **OPTIONNELLES** et peuvent être un follow-up.
+
+| Fichier                                 | Responsabilité                                                              |
+| --------------------------------------- | --------------------------------------------------------------------------- |
+| `frontend/src/pages/AdminPlansPage.tsx` | Page admin minimale liste + édition prix/features                           |
+| `frontend/src/services/api.ts` (ajout)  | `adminApi.listPlans()`, `adminApi.updatePlan()`, `adminApi.duplicatePlan()` |
+
+---
+
+## Tasks
+
+### Task 0: Vérifier la pré-condition pricing v2 (BLOCKER)
+
+**Files:**
+
+- Read-only check : `backend/src/billing/plan_config.py`, DB prod via SSH si possible
+
+- [ ] **Step 1 : Vérifier que `plan_config.py` reflète la grille v2**
+
+Lire `backend/src/billing/plan_config.py` lignes 22-32 et vérifier que `PlanId` contient
+exactement `FREE`, `PRO`, `EXPERT` (et **pas** `PLUS`). Vérifier `PLANS[PlanId.PRO]["price_monthly_cents"] == 899` et `PLANS[PlanId.EXPERT]["price_monthly_cents"] == 1999`.
+
+Si l'enum contient encore `PLUS` ou les prix sont 499/999 → **STOP** : le plan #3 n'est pas mergé. Reporter ce plan jusqu'à ce que #3 soit en main + déployé prod.
+
+- [ ] **Step 2 : Vérifier la prod**
+
+Si l'utilisateur a accès SSH au VPS Hetzner, exécuter :
+
+```bash
+ssh root@89.167.23.214 "docker exec repo-postgres-1 psql -U deepsight -d deepsight -c \"SELECT DISTINCT plan FROM users;\""
+```
+
+Expected output : `free`, `pro`, `expert` uniquement (pas de `plus` résiduel hors aliases déjà migrés).
+
+Si la query montre encore `plus` → STOP, attendre que la migration data du plan #3 ait tourné.
+
+- [ ] **Step 3 : Constater le numéro de migration suivant**
+
+```bash
+ls backend/alembic/versions/
+```
+
+Noter le numéro le plus haut. **Au moment de la rédaction de ce plan, le dernier était `009_add_user_preferences_json.py`.** Le plan #3 ajoute probablement `010` (rename users.plan) et `011` (column grandfathering). Adapter `0XX` ci-dessous au numéro réellement disponible (probable **012**).
+
+> Dans la suite du plan, on note `0XX` pour le numéro de migration. **Remplacer par le bon numéro avant exécution Task 1.**
+
+- [ ] **Step 4 : Pas de commit** — Task 0 est purement un check.
+
+---
+
+### Task 1 : Modèles SQLAlchemy `Plan` + `PlanFeature`
+
+**Files:**
+
+- Modify : `backend/src/db/database.py` (ajouter à la fin avant `__all__` si présent, sinon avant la dernière ligne)
+- Test : `backend/tests/billing/test_plan_registry.py` (créer le fichier vide pour le moment)
+
+- [ ] **Step 1 : Écrire le test failing**
+
+Créer `backend/tests/billing/test_plan_registry.py` (le dossier `tests/billing/` peut ne pas exister, créer `__init__.py` si besoin) :
+
+```python
+"""Tests pour le PlanRegistry et les modèles Plan/PlanFeature."""
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import Plan, PlanFeature
+
+
+@pytest.mark.asyncio
+async def test_plan_model_can_be_inserted(db_session: AsyncSession):
+    plan = Plan(
+        slug="test_free",
+        name="Test Free",
+        description="A test plan",
+        price_monthly_cents=0,
+        price_yearly_cents=0,
+        yearly_discount_percent=17,
+        is_active=True,
+        display_order=0,
+        cta_label="S'abonner",
+        trial_days=7,
+    )
+    db_session.add(plan)
+    await db_session.commit()
+    await db_session.refresh(plan)
+
+    assert plan.id is not None
+    assert plan.slug == "test_free"
+    assert plan.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_plan_feature_unique_constraint(db_session: AsyncSession):
+    plan = Plan(
+        slug="test_pro",
+        name="Test Pro",
+        price_monthly_cents=899,
+        price_yearly_cents=8949,
+    )
+    db_session.add(plan)
+    await db_session.commit()
+    await db_session.refresh(plan)
+
+    f1 = PlanFeature(plan_id=plan.id, feature_key="monthly_analyses", limit_value=25, is_enabled=True)
+    db_session.add(f1)
+    await db_session.commit()
+
+    # Le doublon doit échouer
+    f2 = PlanFeature(plan_id=plan.id, feature_key="monthly_analyses", limit_value=99, is_enabled=True)
+    db_session.add(f2)
+    with pytest.raises(Exception):
+        await db_session.commit()
+```
+
+- [ ] **Step 2 : Lancer le test, vérifier qu'il échoue**
+
+```bash
+cd backend && python -m pytest tests/billing/test_plan_registry.py -v
+```
+
+Expected : `ImportError: cannot import name 'Plan' from 'db.database'`.
+
+- [ ] **Step 3 : Ajouter les modèles dans `backend/src/db/database.py`**
+
+Ajouter (en respectant les conventions du fichier — `Base` est déclaré ligne 99, les autres modèles utilisent le même style) :
+
+```python
+class Plan(Base):
+    __tablename__ = "plans"
+
+    id = Column(Integer, primary_key=True)
+    slug = Column(String(64), unique=True, nullable=False, index=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    price_monthly_cents = Column(Integer, nullable=False, default=0)
+    price_yearly_cents = Column(Integer, nullable=False, default=0)
+    yearly_discount_percent = Column(Integer, default=17, nullable=False)
+    stripe_price_id_monthly = Column(String(100), nullable=True)
+    stripe_price_id_yearly = Column(String(100), nullable=True)
+    stripe_price_id_monthly_test = Column(String(100), nullable=True)
+    stripe_price_id_yearly_test = Column(String(100), nullable=True)
+    is_active = Column(Boolean, default=True, nullable=False)
+    display_order = Column(Integer, default=0, nullable=False)
+    highlight_label = Column(String(64), nullable=True)
+    cta_label = Column(String(64), default="S'abonner", nullable=False)
+    trial_days = Column(Integer, default=7, nullable=False)
+    variant_label = Column(String(32), nullable=True, index=True)
+    color = Column(String(16), nullable=True)
+    icon = Column(String(32), nullable=True)
+    popular = Column(Boolean, default=False, nullable=False)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    features = relationship(
+        "PlanFeature",
+        back_populates="plan",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+class PlanFeature(Base):
+    __tablename__ = "plan_features"
+
+    id = Column(Integer, primary_key=True)
+    plan_id = Column(
+        Integer,
+        ForeignKey("plans.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    feature_key = Column(String(64), nullable=False)
+    limit_value = Column(Integer, nullable=True)
+    is_enabled = Column(Boolean, default=True, nullable=False)
+    feature_metadata = Column("metadata", JSON, nullable=True)
+
+    plan = relationship("Plan", back_populates="features")
+
+    __table_args__ = (
+        UniqueConstraint("plan_id", "feature_key", name="uix_plan_feature"),
+    )
+```
+
+⚠️ Notes d'intégration :
+
+- `func`, `JSON`, `UniqueConstraint`, `ForeignKey`, `relationship`, `Text` doivent être importés en haut du fichier — vérifier que tous sont déjà présents (la plupart le sont).
+- L'attribut Python s'appelle `feature_metadata` (mais la colonne SQL est `metadata`) parce que `metadata` est un mot réservé de SQLAlchemy `Base`.
+- `lazy="selectin"` évite le N+1 quand on fait `Plan.features` dans une boucle.
+
+- [ ] **Step 4 : Lancer les tests à nouveau**
+
+```bash
+cd backend && python -m pytest tests/billing/test_plan_registry.py -v
+```
+
+Expected : tests passent, mais peut-être skip si la fixture `db_session` n'existe pas — vérifier `backend/tests/conftest.py`. Si la fixture manque, ajouter dans la conftest existante :
+
+```python
+# backend/tests/conftest.py — vérifier la présence de db_session async fixture
+# Si absente, voir un test existant qui utilise une session pour le pattern
+```
+
+(Pattern existant : regarder `backend/tests/auth/` ou `backend/tests/billing/` pour la fixture standard).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add backend/src/db/database.py backend/tests/billing/test_plan_registry.py backend/tests/billing/__init__.py
+git commit -m "feat(billing): add Plan and PlanFeature SQLAlchemy models"
+```
+
+---
+
+### Task 2 : Migration Alembic `0XX_add_plans_tables`
+
+**Files:**
+
+- Create : `backend/alembic/versions/0XX_add_plans_tables.py` (remplacer `0XX` par le numéro réel)
+
+- [ ] **Step 1 : Écrire la migration**
+
+Créer `backend/alembic/versions/0XX_add_plans_tables.py` :
+
+```python
+"""Add plans and plan_features tables (DB-driven plans).
+
+Revision ID: 0XX_add_plans_tables
+Revises: 0YY_<previous_revision>
+Create Date: 2026-04-29
+
+Adds two tables to support DB-driven plans:
+  - ``plans`` : pricing, display info, Stripe price IDs, A/B variant label
+  - ``plan_features`` : key/value limits per plan (monthly_analyses=25, etc.)
+
+Compat layer in plan_config.py keeps its public API; PlanRegistry
+reads here with Redis cache 5 min and a hardcoded fallback if DB unreachable.
+
+Cross-DB notes:
+  - ``sa.JSON()`` becomes JSONB on PostgreSQL and TEXT on SQLite.
+  - ``server_default`` for booleans uses ``sa.text("true")`` for portability.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0XX_add_plans_tables"
+down_revision: Union[str, None] = "0YY_<previous_revision>"  # ⚠️ remplacer par le réel
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "plans",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("slug", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("price_monthly_cents", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("price_yearly_cents", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("yearly_discount_percent", sa.Integer(), nullable=False, server_default="17"),
+        sa.Column("stripe_price_id_monthly", sa.String(length=100), nullable=True),
+        sa.Column("stripe_price_id_yearly", sa.String(length=100), nullable=True),
+        sa.Column("stripe_price_id_monthly_test", sa.String(length=100), nullable=True),
+        sa.Column("stripe_price_id_yearly_test", sa.String(length=100), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("highlight_label", sa.String(length=64), nullable=True),
+        sa.Column("cta_label", sa.String(length=64), nullable=False, server_default="S'abonner"),
+        sa.Column("trial_days", sa.Integer(), nullable=False, server_default="7"),
+        sa.Column("variant_label", sa.String(length=32), nullable=True),
+        sa.Column("color", sa.String(length=16), nullable=True),
+        sa.Column("icon", sa.String(length=32), nullable=True),
+        sa.Column("popular", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_unique_constraint("uq_plans_slug", "plans", ["slug"])
+    op.create_index("ix_plans_slug", "plans", ["slug"])
+    op.create_index("ix_plans_variant_label", "plans", ["variant_label"])
+
+    op.create_table(
+        "plan_features",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("plan_id", sa.Integer(), nullable=False),
+        sa.Column("feature_key", sa.String(length=64), nullable=False),
+        sa.Column("limit_value", sa.Integer(), nullable=True),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["plan_id"], ["plans.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("plan_id", "feature_key", name="uix_plan_feature"),
+    )
+    op.create_index("ix_plan_features_plan_id", "plan_features", ["plan_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_plan_features_plan_id", table_name="plan_features")
+    op.drop_table("plan_features")
+    op.drop_index("ix_plans_variant_label", table_name="plans")
+    op.drop_index("ix_plans_slug", table_name="plans")
+    op.drop_constraint("uq_plans_slug", "plans", type_="unique")
+    op.drop_table("plans")
+```
+
+- [ ] **Step 2 : Tester la migration en local**
+
+```bash
+cd backend && alembic upgrade head
+```
+
+Expected : message `Running upgrade 0YY -> 0XX_add_plans_tables, Add plans and plan_features tables`. Aucune erreur.
+
+Vérifier les tables :
+
+```bash
+cd backend && alembic current
+```
+
+Expected : `0XX_add_plans_tables (head)`.
+
+- [ ] **Step 3 : Tester le downgrade aussi**
+
+```bash
+cd backend && alembic downgrade -1 && alembic upgrade head
+```
+
+Expected : downgrade puis upgrade sans erreur (idempotence).
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add backend/alembic/versions/0XX_add_plans_tables.py
+git commit -m "feat(db): add Alembic migration for plans and plan_features tables"
+```
+
+---
+
+### Task 3 : Script seed `seed_plans_db.py` (idempotent UPSERT)
+
+**Files:**
+
+- Create : `backend/scripts/seed_plans_db.py`
+- Test : `backend/tests/billing/test_seed_plans.py`
+
+- [ ] **Step 1 : Écrire le test failing**
+
+Créer `backend/tests/billing/test_seed_plans.py` :
+
+```python
+"""Tests pour le script de seed plans DB (idempotent UPSERT)."""
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import Plan, PlanFeature
+from scripts.seed_plans_db import seed_plans
+
+
+@pytest.mark.asyncio
+async def test_seed_inserts_three_plans(db_session: AsyncSession):
+    await seed_plans(db_session)
+    result = await db_session.execute(select(Plan).order_by(Plan.display_order))
+    plans = list(result.scalars().all())
+    assert len(plans) == 3
+    assert [p.slug for p in plans] == ["free", "pro", "expert"]
+    assert [p.price_monthly_cents for p in plans] == [0, 899, 1999]
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(db_session: AsyncSession):
+    await seed_plans(db_session)
+    await seed_plans(db_session)
+    result = await db_session.execute(select(Plan))
+    plans = list(result.scalars().all())
+    assert len(plans) == 3  # Pas de doublons
+
+
+@pytest.mark.asyncio
+async def test_seed_updates_existing_plan(db_session: AsyncSession):
+    await seed_plans(db_session)
+
+    # Modifier en DB pour simuler une ancienne valeur
+    existing = await db_session.execute(select(Plan).where(Plan.slug == "pro"))
+    plan = existing.scalar_one()
+    plan.price_monthly_cents = 999
+    await db_session.commit()
+
+    # Re-seed doit corriger
+    await seed_plans(db_session)
+    result = await db_session.execute(select(Plan).where(Plan.slug == "pro"))
+    plan = result.scalar_one()
+    assert plan.price_monthly_cents == 899  # Re-corrigé par le seed
+
+
+@pytest.mark.asyncio
+async def test_seed_creates_features(db_session: AsyncSession):
+    await seed_plans(db_session)
+    free = (await db_session.execute(select(Plan).where(Plan.slug == "free"))).scalar_one()
+    feats = (await db_session.execute(
+        select(PlanFeature).where(PlanFeature.plan_id == free.id)
+    )).scalars().all()
+    feat_map = {f.feature_key: f.limit_value for f in feats}
+    assert feat_map["monthly_analyses"] == 5
+    assert feat_map["max_video_length_min"] == 15
+```
+
+- [ ] **Step 2 : Lancer les tests, vérifier l'échec**
+
+```bash
+cd backend && python -m pytest tests/billing/test_seed_plans.py -v
+```
+
+Expected : `ModuleNotFoundError` ou `ImportError` sur `scripts.seed_plans_db`.
+
+- [ ] **Step 3 : Implémenter le script**
+
+Créer `backend/scripts/seed_plans_db.py` :
+
+```python
+"""Idempotent seed des 3 plans DeepSight v2 (free / pro / expert).
+
+UPSERT par slug. Les features (limits) sont également UPSERT par (plan_id, feature_key).
+
+Utilisation :
+  - Standalone : `python -m scripts.seed_plans_db`
+  - Programmatique : `await seed_plans(session)` depuis du code applicatif
+  - Tests : importer `seed_plans` directement.
+
+Source de vérité : grille v2 post-rename (plan #3 mergé).
+"""
+import asyncio
+import logging
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import Plan, PlanFeature, get_session
+
+logger = logging.getLogger(__name__)
+
+
+# ─── DEFINITIONS — Source de vérité v2 ───────────────────────────────────────
+PLANS_SEED: list[dict[str, Any]] = [
+    {
+        "slug": "free",
+        "name": "Gratuit",
+        "description": "Découvrez DeepSight gratuitement",
+        "price_monthly_cents": 0,
+        "price_yearly_cents": 0,
+        "yearly_discount_percent": 17,
+        "is_active": True,
+        "display_order": 0,
+        "highlight_label": None,
+        "cta_label": "Commencer gratuitement",
+        "trial_days": 0,
+        "color": "#6B7280",
+        "icon": "⚡",
+        "popular": False,
+        "features": {
+            "monthly_credits": 250,
+            "monthly_analyses": 5,
+            "max_video_length_min": 15,
+            "concurrent_analyses": 1,
+            "chat_questions_per_video": 5,
+            "chat_daily_limit": 10,
+            "academic_papers_per_analysis": 5,
+            "history_retention_days": 60,
+            "voice_monthly_minutes": 0,
+            "web_search_monthly": 0,
+            "max_playlists": 0,
+            "max_playlist_videos": 0,
+            "debate_monthly": 0,
+            "geo_monthly": 0,
+        },
+        "boolean_features": {
+            "priority_queue": False,
+            "flashcards_enabled": True,
+            "quiz_enabled": True,
+            "mindmap_enabled": False,
+            "factcheck_enabled": False,
+            "deep_research_enabled": False,
+            "web_search_enabled": False,
+            "playlists_enabled": False,
+            "export_markdown": False,
+            "export_pdf": False,
+            "voice_chat_enabled": False,
+            "bibliography_export": False,
+            "academic_full_text": False,
+            "debate_enabled": False,
+            "tts_enabled": False,
+            "geo_enabled": False,
+        },
+    },
+    {
+        "slug": "pro",
+        "name": "Pro",
+        "description": "L'essentiel pour apprendre mieux, plus vite",
+        "price_monthly_cents": 899,
+        "price_yearly_cents": 8949,  # -17% annuel
+        "yearly_discount_percent": 17,
+        "is_active": True,
+        "display_order": 1,
+        "highlight_label": "Populaire",
+        "cta_label": "S'abonner",
+        "trial_days": 7,
+        "color": "#3B82F6",
+        "icon": "⭐",
+        "popular": True,
+        "features": {
+            "monthly_credits": 3000,
+            "monthly_analyses": 25,
+            "max_video_length_min": 60,
+            "concurrent_analyses": 1,
+            "chat_questions_per_video": 25,
+            "chat_daily_limit": 50,
+            "academic_papers_per_analysis": 15,
+            "history_retention_days": -1,
+            "voice_monthly_minutes": 0,
+            "web_search_monthly": 20,
+            "max_playlists": 0,
+            "max_playlist_videos": 0,
+            "debate_monthly": 3,
+            "geo_monthly": 10,
+        },
+        "boolean_features": {
+            "priority_queue": False,
+            "flashcards_enabled": True,
+            "quiz_enabled": True,
+            "mindmap_enabled": True,
+            "factcheck_enabled": True,
+            "deep_research_enabled": False,
+            "web_search_enabled": True,
+            "playlists_enabled": False,
+            "export_markdown": True,
+            "export_pdf": True,
+            "voice_chat_enabled": False,
+            "bibliography_export": True,
+            "academic_full_text": False,
+            "debate_enabled": True,
+            "tts_enabled": False,
+            "geo_enabled": True,
+        },
+    },
+    {
+        "slug": "expert",
+        "name": "Expert",
+        "description": "Toute la puissance de DeepSight, sans limites",
+        "price_monthly_cents": 1999,
+        "price_yearly_cents": 19899,  # -17% annuel
+        "yearly_discount_percent": 17,
+        "is_active": True,
+        "display_order": 2,
+        "highlight_label": "Le + puissant",
+        "cta_label": "S'abonner",
+        "trial_days": 7,
+        "color": "#8B5CF6",
+        "icon": "👑",
+        "popular": False,
+        "features": {
+            "monthly_credits": 15000,
+            "monthly_analyses": 100,
+            "max_video_length_min": 240,
+            "concurrent_analyses": 3,
+            "chat_questions_per_video": -1,
+            "chat_daily_limit": -1,
+            "academic_papers_per_analysis": 50,
+            "history_retention_days": -1,
+            "voice_monthly_minutes": 45,
+            "web_search_monthly": 60,
+            "max_playlists": 10,
+            "max_playlist_videos": 20,
+            "debate_monthly": 20,
+            "geo_monthly": -1,
+        },
+        "boolean_features": {
+            "priority_queue": True,
+            "flashcards_enabled": True,
+            "quiz_enabled": True,
+            "mindmap_enabled": True,
+            "factcheck_enabled": True,
+            "deep_research_enabled": True,
+            "web_search_enabled": True,
+            "playlists_enabled": True,
+            "export_markdown": True,
+            "export_pdf": True,
+            "voice_chat_enabled": True,
+            "bibliography_export": True,
+            "academic_full_text": True,
+            "debate_enabled": True,
+            "tts_enabled": True,
+            "geo_enabled": True,
+        },
+    },
+]
+
+
+async def seed_plans(session: AsyncSession) -> None:
+    """UPSERT idempotent des 3 plans v2 + leurs features.
+
+    - Cherche le plan par ``slug`` ; UPDATE si trouvé, INSERT sinon.
+    - Pour chaque feature numérique : UPSERT ``(plan_id, feature_key)`` avec ``limit_value``.
+    - Pour chaque feature booléenne : UPSERT ``(plan_id, feature_key)`` avec
+      ``is_enabled`` et ``limit_value=NULL``.
+    """
+    for plan_def in PLANS_SEED:
+        slug = plan_def["slug"]
+
+        # UPSERT plan
+        result = await session.execute(select(Plan).where(Plan.slug == slug))
+        plan = result.scalar_one_or_none()
+
+        plan_fields = {k: v for k, v in plan_def.items() if k not in ("features", "boolean_features")}
+
+        if plan is None:
+            plan = Plan(**plan_fields)
+            session.add(plan)
+            await session.flush()
+            logger.info("Plan inserted: slug=%s", slug)
+        else:
+            for k, v in plan_fields.items():
+                setattr(plan, k, v)
+            logger.info("Plan updated: slug=%s", slug)
+
+        # UPSERT features numériques
+        for feat_key, limit_val in plan_def["features"].items():
+            existing = await session.execute(
+                select(PlanFeature).where(
+                    PlanFeature.plan_id == plan.id,
+                    PlanFeature.feature_key == feat_key,
+                )
+            )
+            feat = existing.scalar_one_or_none()
+            if feat is None:
+                session.add(PlanFeature(
+                    plan_id=plan.id,
+                    feature_key=feat_key,
+                    limit_value=limit_val,
+                    is_enabled=True,
+                ))
+            else:
+                feat.limit_value = limit_val
+                feat.is_enabled = True
+
+        # UPSERT features booléennes
+        for feat_key, enabled in plan_def["boolean_features"].items():
+            existing = await session.execute(
+                select(PlanFeature).where(
+                    PlanFeature.plan_id == plan.id,
+                    PlanFeature.feature_key == feat_key,
+                )
+            )
+            feat = existing.scalar_one_or_none()
+            if feat is None:
+                session.add(PlanFeature(
+                    plan_id=plan.id,
+                    feature_key=feat_key,
+                    limit_value=None,
+                    is_enabled=enabled,
+                ))
+            else:
+                feat.limit_value = None
+                feat.is_enabled = enabled
+
+    await session.commit()
+
+
+async def _main() -> None:
+    """Entry point standalone : ouvre une session et lance le seed."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s :: %(message)s")
+    async for session in get_session():
+        await seed_plans(session)
+        return
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())
+```
+
+- [ ] **Step 4 : Lancer les tests, vérifier le pass**
+
+```bash
+cd backend && python -m pytest tests/billing/test_seed_plans.py -v
+```
+
+Expected : 4 tests passent.
+
+- [ ] **Step 5 : Lancer le seed en local**
+
+```bash
+cd backend && python -m scripts.seed_plans_db
+```
+
+Expected : 3 lignes "Plan inserted: slug=free / pro / expert".
+
+Re-lancer pour vérifier l'idempotence :
+
+```bash
+cd backend && python -m scripts.seed_plans_db
+```
+
+Expected : 3 lignes "Plan updated: slug=...".
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add backend/scripts/seed_plans_db.py backend/tests/billing/test_seed_plans.py
+git commit -m "feat(billing): add idempotent seed_plans_db script for v2 grid"
+```
+
+---
+
+### Task 4 : Service `PlanRegistry` (read DB + cache + fallback)
+
+**Files:**
+
+- Create : `backend/src/billing/plan_registry.py`
+- Test : ajout dans `backend/tests/billing/test_plan_registry.py`
+
+- [ ] **Step 1 : Étendre les tests**
+
+Ajouter dans `backend/tests/billing/test_plan_registry.py` (à la fin) :
+
+```python
+from unittest.mock import AsyncMock, patch
+
+from billing.plan_registry import PlanRegistry, plan_registry
+
+
+@pytest.mark.asyncio
+async def test_registry_reads_from_db(db_session: AsyncSession):
+    from scripts.seed_plans_db import seed_plans
+    await seed_plans(db_session)
+
+    reg = PlanRegistry(session_factory=lambda: db_session)
+    plans = await reg.list_plans()
+    assert len(plans) == 3
+    slugs = {p["slug"] for p in plans}
+    assert slugs == {"free", "pro", "expert"}
+
+
+@pytest.mark.asyncio
+async def test_registry_uses_cache(db_session: AsyncSession):
+    from scripts.seed_plans_db import seed_plans
+    from core.cache import cache_service
+    await seed_plans(db_session)
+
+    reg = PlanRegistry(session_factory=lambda: db_session)
+    await reg.invalidate_cache()
+    p1 = await reg.list_plans()
+
+    # Forcer DB vide pour vérifier que la 2e lecture vient du cache
+    with patch.object(reg, "_load_from_db", new=AsyncMock(return_value=[])) as mock_load:
+        p2 = await reg.list_plans()
+        mock_load.assert_not_called()  # Cache hit
+    assert len(p2) == 3
+
+
+@pytest.mark.asyncio
+async def test_registry_fallback_when_db_unreachable():
+    """Si DB lance une exception, fallback sur les valeurs hardcoded."""
+    async def _broken_factory():
+        raise RuntimeError("DB unreachable")
+
+    reg = PlanRegistry(session_factory=_broken_factory)
+    await reg.invalidate_cache()
+    plans = await reg.list_plans()
+
+    # Doit utiliser le fallback hardcoded (3 plans v2)
+    slugs = {p["slug"] for p in plans}
+    assert slugs == {"free", "pro", "expert"}
+
+
+@pytest.mark.asyncio
+async def test_get_plan_by_slug(db_session: AsyncSession):
+    from scripts.seed_plans_db import seed_plans
+    await seed_plans(db_session)
+
+    reg = PlanRegistry(session_factory=lambda: db_session)
+    pro = await reg.get_plan("pro")
+    assert pro is not None
+    assert pro["price_monthly_cents"] == 899
+    assert pro["features"]["monthly_analyses"] == 25
+
+
+@pytest.mark.asyncio
+async def test_get_limits_for_plan(db_session: AsyncSession):
+    from scripts.seed_plans_db import seed_plans
+    await seed_plans(db_session)
+
+    reg = PlanRegistry(session_factory=lambda: db_session)
+    limits = await reg.get_limits("expert")
+    assert limits["monthly_analyses"] == 100
+    assert limits["voice_chat_enabled"] is True
+```
+
+- [ ] **Step 2 : Lancer les tests, vérifier l'échec**
+
+```bash
+cd backend && python -m pytest tests/billing/test_plan_registry.py::test_registry_reads_from_db -v
+```
+
+Expected : `ImportError` sur `billing.plan_registry`.
+
+- [ ] **Step 3 : Implémenter le service**
+
+Créer `backend/src/billing/plan_registry.py` :
+
+```python
+"""PlanRegistry : lit la table ``plans`` avec cache Redis 5 min + fallback.
+
+Patron : singleton-friendly, sans état mutable cross-requête.
+Cache key namespace ``plans:`` invalidée à chaque mutation admin.
+
+API publique :
+    plan_registry.list_plans(active_only=True, variant=None) -> list[dict]
+    plan_registry.get_plan(slug) -> dict | None
+    plan_registry.get_limits(slug) -> dict
+    plan_registry.invalidate_cache() -> None
+"""
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.cache import cache_service
+from db.database import Plan, PlanFeature, get_session
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY_PREFIX = "plans"
+CACHE_TTL_SECONDS = 300  # 5 minutes
+
+
+# ─── FALLBACK — Grille v2 hardcoded (graceful degradation si DB injoignable) ──
+# Aligné avec scripts/seed_plans_db.py — synchroniser les deux à chaque change.
+FALLBACK_PLANS: list[dict[str, Any]] = [
+    {
+        "id": -1, "slug": "free", "name": "Gratuit",
+        "description": "Découvrez DeepSight gratuitement",
+        "price_monthly_cents": 0, "price_yearly_cents": 0, "yearly_discount_percent": 17,
+        "is_active": True, "display_order": 0, "highlight_label": None,
+        "cta_label": "Commencer gratuitement", "trial_days": 0, "variant_label": None,
+        "color": "#6B7280", "icon": "⚡", "popular": False,
+        "stripe_price_id_monthly": None, "stripe_price_id_yearly": None,
+        "features": {
+            "monthly_credits": 250, "monthly_analyses": 5, "max_video_length_min": 15,
+            "concurrent_analyses": 1, "chat_questions_per_video": 5, "chat_daily_limit": 10,
+            "academic_papers_per_analysis": 5, "history_retention_days": 60,
+            "voice_monthly_minutes": 0, "web_search_monthly": 0, "max_playlists": 0,
+            "max_playlist_videos": 0, "debate_monthly": 0, "geo_monthly": 0,
+            "priority_queue": False, "flashcards_enabled": True, "quiz_enabled": True,
+            "mindmap_enabled": False, "factcheck_enabled": False, "deep_research_enabled": False,
+            "web_search_enabled": False, "playlists_enabled": False,
+            "export_markdown": False, "export_pdf": False, "voice_chat_enabled": False,
+            "bibliography_export": False, "academic_full_text": False, "debate_enabled": False,
+            "tts_enabled": False, "geo_enabled": False,
+        },
+    },
+    {
+        "id": -2, "slug": "pro", "name": "Pro",
+        "description": "L'essentiel pour apprendre mieux, plus vite",
+        "price_monthly_cents": 899, "price_yearly_cents": 8949, "yearly_discount_percent": 17,
+        "is_active": True, "display_order": 1, "highlight_label": "Populaire",
+        "cta_label": "S'abonner", "trial_days": 7, "variant_label": None,
+        "color": "#3B82F6", "icon": "⭐", "popular": True,
+        "stripe_price_id_monthly": None, "stripe_price_id_yearly": None,
+        "features": {
+            "monthly_credits": 3000, "monthly_analyses": 25, "max_video_length_min": 60,
+            "concurrent_analyses": 1, "chat_questions_per_video": 25, "chat_daily_limit": 50,
+            "academic_papers_per_analysis": 15, "history_retention_days": -1,
+            "voice_monthly_minutes": 0, "web_search_monthly": 20, "max_playlists": 0,
+            "max_playlist_videos": 0, "debate_monthly": 3, "geo_monthly": 10,
+            "priority_queue": False, "flashcards_enabled": True, "quiz_enabled": True,
+            "mindmap_enabled": True, "factcheck_enabled": True, "deep_research_enabled": False,
+            "web_search_enabled": True, "playlists_enabled": False,
+            "export_markdown": True, "export_pdf": True, "voice_chat_enabled": False,
+            "bibliography_export": True, "academic_full_text": False, "debate_enabled": True,
+            "tts_enabled": False, "geo_enabled": True,
+        },
+    },
+    {
+        "id": -3, "slug": "expert", "name": "Expert",
+        "description": "Toute la puissance de DeepSight, sans limites",
+        "price_monthly_cents": 1999, "price_yearly_cents": 19899, "yearly_discount_percent": 17,
+        "is_active": True, "display_order": 2, "highlight_label": "Le + puissant",
+        "cta_label": "S'abonner", "trial_days": 7, "variant_label": None,
+        "color": "#8B5CF6", "icon": "👑", "popular": False,
+        "stripe_price_id_monthly": None, "stripe_price_id_yearly": None,
+        "features": {
+            "monthly_credits": 15000, "monthly_analyses": 100, "max_video_length_min": 240,
+            "concurrent_analyses": 3, "chat_questions_per_video": -1, "chat_daily_limit": -1,
+            "academic_papers_per_analysis": 50, "history_retention_days": -1,
+            "voice_monthly_minutes": 45, "web_search_monthly": 60, "max_playlists": 10,
+            "max_playlist_videos": 20, "debate_monthly": 20, "geo_monthly": -1,
+            "priority_queue": True, "flashcards_enabled": True, "quiz_enabled": True,
+            "mindmap_enabled": True, "factcheck_enabled": True, "deep_research_enabled": True,
+            "web_search_enabled": True, "playlists_enabled": True,
+            "export_markdown": True, "export_pdf": True, "voice_chat_enabled": True,
+            "bibliography_export": True, "academic_full_text": True, "debate_enabled": True,
+            "tts_enabled": True, "geo_enabled": True,
+        },
+    },
+]
+
+
+def _serialize_plan(plan: Plan) -> dict[str, Any]:
+    """Converti un Plan ORM en dict JSON-friendly avec features inline."""
+    features: dict[str, Any] = {}
+    for f in (plan.features or []):
+        if f.limit_value is not None:
+            features[f.feature_key] = f.limit_value
+        else:
+            features[f.feature_key] = bool(f.is_enabled)
+
+    return {
+        "id": plan.id,
+        "slug": plan.slug,
+        "name": plan.name,
+        "description": plan.description,
+        "price_monthly_cents": plan.price_monthly_cents,
+        "price_yearly_cents": plan.price_yearly_cents,
+        "yearly_discount_percent": plan.yearly_discount_percent,
+        "is_active": plan.is_active,
+        "display_order": plan.display_order,
+        "highlight_label": plan.highlight_label,
+        "cta_label": plan.cta_label,
+        "trial_days": plan.trial_days,
+        "variant_label": plan.variant_label,
+        "color": plan.color,
+        "icon": plan.icon,
+        "popular": plan.popular,
+        "stripe_price_id_monthly": plan.stripe_price_id_monthly,
+        "stripe_price_id_yearly": plan.stripe_price_id_yearly,
+        "features": features,
+    }
+
+
+class PlanRegistry:
+    """Service de lecture des plans (DB + cache + fallback hardcoded)."""
+
+    def __init__(
+        self,
+        session_factory: Optional[Callable[..., AsyncSession | Awaitable[AsyncSession]]] = None,
+    ) -> None:
+        # session_factory = callable(*) -> AsyncSession (sync ou async).
+        # Par défaut on passera par get_session() lors d'un appel.
+        self._session_factory = session_factory
+
+    async def _open_session(self) -> AsyncSession:
+        if self._session_factory is None:
+            # Pattern get_session() est un async generator
+            async for s in get_session():
+                return s
+            raise RuntimeError("get_session() did not yield")
+        result = self._session_factory()
+        if asyncio.iscoroutine(result):
+            return await result
+        return result  # type: ignore[return-value]
+
+    async def _load_from_db(self) -> list[dict[str, Any]]:
+        session = await self._open_session()
+        try:
+            result = await session.execute(
+                select(Plan).order_by(Plan.display_order, Plan.id)
+            )
+            plans = list(result.scalars().all())
+            return [_serialize_plan(p) for p in plans]
+        finally:
+            # Si la session vient de get_session(), elle se nettoie via le context.
+            # Sinon, c'est de la responsabilité de l'appelant.
+            pass
+
+    async def list_plans(
+        self,
+        active_only: bool = True,
+        variant: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        cache_key = f"{CACHE_KEY_PREFIX}:list:active={int(active_only)}:variant={variant or 'all'}"
+
+        cached = await cache_service.get(cache_key)
+        if cached is not None:
+            return cached
+
+        try:
+            plans = await self._load_from_db()
+        except Exception as e:
+            logger.warning("PlanRegistry DB read failed, falling back to hardcoded: %s", e)
+            plans = list(FALLBACK_PLANS)
+
+        if active_only:
+            plans = [p for p in plans if p["is_active"]]
+        if variant is not None:
+            plans = [p for p in plans if (p.get("variant_label") or None) == variant]
+
+        await cache_service.set(cache_key, plans, ttl=CACHE_TTL_SECONDS)
+        return plans
+
+    async def get_plan(self, slug: str) -> Optional[dict[str, Any]]:
+        plans = await self.list_plans(active_only=False)
+        for p in plans:
+            if p["slug"] == slug:
+                return p
+        return None
+
+    async def get_limits(self, slug: str) -> dict[str, Any]:
+        plan = await self.get_plan(slug)
+        if plan is None:
+            # Fallback ultime : free
+            free = next((p for p in FALLBACK_PLANS if p["slug"] == "free"), None)
+            return free["features"] if free else {}
+        return plan["features"]
+
+    async def invalidate_cache(self) -> int:
+        return await cache_service.invalidate_prefix(f"{CACHE_KEY_PREFIX}:")
+
+
+# Instance singleton applicative
+plan_registry = PlanRegistry()
+```
+
+- [ ] **Step 4 : Lancer les tests**
+
+```bash
+cd backend && python -m pytest tests/billing/test_plan_registry.py -v
+```
+
+Expected : tous les tests Task 4 passent (5 tests + ceux de Task 1).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add backend/src/billing/plan_registry.py backend/tests/billing/test_plan_registry.py
+git commit -m "feat(billing): add PlanRegistry service with Redis cache and hardcoded fallback"
+```
+
+---
+
+### Task 5 : Brancher `plan_config.py` sur `plan_registry`
+
+**Files:**
+
+- Modify : `backend/src/billing/plan_config.py`
+- Test : `backend/tests/billing/test_plan_config_compat.py`
+
+- [ ] **Step 1 : Écrire un test de compat**
+
+Créer `backend/tests/billing/test_plan_config_compat.py` :
+
+```python
+"""Vérifie que l'API publique de plan_config.py reste fonctionnelle après refactor.
+
+Les fonctions accessor délèguent maintenant au PlanRegistry mais doivent garder
+exactement la même signature et le même comportement pour les callers existants.
+"""
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from billing.plan_config import (
+    PLAN_HIERARCHY,
+    PlanId,
+    get_plan,
+    get_limits,
+    get_plan_index,
+    is_upgrade,
+    normalize_plan_id,
+    get_price_id,
+)
+from scripts.seed_plans_db import seed_plans
+
+
+@pytest.mark.asyncio
+async def test_get_plan_returns_v2_grid(db_session: AsyncSession):
+    await seed_plans(db_session)
+    pro = await get_plan("pro")
+    assert pro["price_monthly_cents"] == 899
+
+
+@pytest.mark.asyncio
+async def test_get_limits_returns_features(db_session: AsyncSession):
+    await seed_plans(db_session)
+    limits = await get_limits("expert")
+    assert limits["monthly_analyses"] == 100
+
+
+def test_normalize_plan_id_handles_aliases():
+    assert normalize_plan_id("etudiant") == "pro"   # alias après #3
+    assert normalize_plan_id("EXPERT") == "expert"
+    assert normalize_plan_id("") == "free"
+    assert normalize_plan_id("garbage") == "free"
+
+
+def test_plan_hierarchy_is_3_tiers():
+    slugs = [p.value if hasattr(p, "value") else p for p in PLAN_HIERARCHY]
+    assert slugs == ["free", "pro", "expert"]
+
+
+def test_get_plan_index():
+    assert get_plan_index("free") == 0
+    assert get_plan_index("pro") == 1
+    assert get_plan_index("expert") == 2
+
+
+def test_is_upgrade():
+    assert is_upgrade("free", "pro") is True
+    assert is_upgrade("expert", "pro") is False
+```
+
+- [ ] **Step 2 : Lancer les tests, vérifier l'échec**
+
+Les tests asynchrones vont échouer parce que `get_plan` / `get_limits` étaient sync auparavant.
+
+```bash
+cd backend && python -m pytest tests/billing/test_plan_config_compat.py -v
+```
+
+Expected : échec sur les tests `async`.
+
+- [ ] **Step 3 : Refactor `plan_config.py`**
+
+⚠️ Stratégie : on **conserve** l'API sync existante côté caller en exposant des shims,
+mais les nouvelles versions sont async. On :
+
+1. Garde `PlanId`, `PLAN_HIERARCHY`, `PLAN_ALIASES`, `normalize_plan_id` (fonction sync pure — pas d'I/O).
+2. Garde `VOICE_CALL_QUICK_CAPABILITY`, `get_voice_call_quick_capability`, `PLATFORM_LIMITS`, `get_platform_limits`, `get_credit_multiplier` (purement statiques).
+3. Garde `init_stripe_prices()` mais le fait écrire dans le PlanRegistry (next task) — pour l'instant on le NEUTRALISE et on log un warning si appelé.
+4. Convertit `get_plan`, `get_limits`, `get_platform_features`, `is_feature_available`, `get_minimum_plan_for`, `get_price_id`, `get_plan_by_price_id` en **async** qui délèguent au registry.
+
+Modifier `backend/src/billing/plan_config.py` — remplacer la section `ACCESSOR FUNCTIONS` (lignes 530-655 environ) par :
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# ACCESSOR FUNCTIONS — Maintenant async, délèguent au PlanRegistry (DB + cache)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+from billing.plan_registry import plan_registry
+
+
+async def get_plan(plan_id: str) -> dict[str, Any]:
+    """Retourne la config complète d'un plan. Normalise les aliases, fallback FREE."""
+    normalized = normalize_plan_id(plan_id)
+    plan = await plan_registry.get_plan(normalized)
+    if plan is None:
+        plan = await plan_registry.get_plan(PlanId.FREE.value)
+    # Forme rétrocompat : limits inline pour les anciens callers
+    if plan is not None and "limits" not in plan:
+        plan["limits"] = plan.get("features", {})
+    return plan or {}
+
+
+async def get_limits(plan_id: str) -> dict[str, Any]:
+    """Retourne uniquement les limites/features d'un plan."""
+    normalized = normalize_plan_id(plan_id)
+    return await plan_registry.get_limits(normalized)
+
+
+async def get_platform_features(plan_id: str, platform: str) -> dict[str, bool]:
+    """Retourne les features disponibles pour un plan sur une plateforme.
+
+    NOTE : la matrice ``platforms`` n'est pas dans la table ``plans`` v1.
+    On dérive depuis les booléens de ``features`` selon des règles internes
+    plateforme. À étendre dans une migration future si on veut DB-driver
+    ce niveau aussi (voir Self-Review).
+    """
+    limits = await get_limits(plan_id)
+
+    # Mapping feature -> disponibilité par plateforme
+    # Cohérent avec l'ancienne matrice PLANS[plan]["platforms"][platform]
+    base = {
+        "analyse": True,
+        "chat": True,
+        "history": True,
+        "tts": bool(limits.get("tts_enabled", False)),
+        "flashcards": bool(limits.get("flashcards_enabled", False)),
+        "quiz": bool(limits.get("quiz_enabled", False)),
+        "mindmap": bool(limits.get("mindmap_enabled", False)),
+        "web_search": bool(limits.get("web_search_enabled", False)),
+        "export_md": bool(limits.get("export_markdown", False)),
+        "export_pdf": bool(limits.get("export_pdf", False)),
+        "playlists": bool(limits.get("playlists_enabled", False)),
+        "voice_chat": bool(limits.get("voice_chat_enabled", False)),
+        "voice_call_quick": True,  # géré séparément par capability matrix
+        "debate": bool(limits.get("debate_enabled", False)),
+        "deep_research": bool(limits.get("deep_research_enabled", False)),
+        "geo": bool(limits.get("geo_enabled", False)),
+    }
+
+    # Restrictions plateforme — extension/mobile ont moins
+    if platform == "extension":
+        for k in ("flashcards", "quiz", "mindmap", "web_search", "export_md",
+                  "export_pdf", "playlists", "voice_chat", "debate",
+                  "deep_research", "geo", "tts"):
+            base[k] = False
+    elif platform == "mobile":
+        for k in ("mindmap", "web_search", "export_md", "export_pdf",
+                  "debate", "deep_research"):
+            base[k] = False
+
+    return base
+
+
+async def is_feature_available(plan_id: str, feature: str, platform: str = "web") -> bool:
+    pf = await get_platform_features(plan_id, platform)
+    return pf.get(feature, False)
+
+
+async def get_minimum_plan_for(feature: str) -> str:
+    for plan_id in PLAN_HIERARCHY:
+        limits = await get_limits(plan_id.value)
+        if feature in limits and isinstance(limits[feature], bool) and limits[feature]:
+            return plan_id.value
+        if feature in limits and isinstance(limits[feature], (int, float)):
+            v = limits[feature]
+            if v == -1 or v > 0:
+                return plan_id.value
+    return PlanId.PRO.value if PlanId.PRO in PLAN_HIERARCHY else PLAN_HIERARCHY[-1].value
+
+
+async def get_price_id(plan_id: str, test_mode: bool = True) -> Optional[str]:
+    plan = await plan_registry.get_plan(plan_id)
+    if plan is None:
+        return None
+    # Pas de séparation test/live en DB v1 — pour l'instant on utilise les memes IDs
+    # Les Stripe price IDs prod sont injectés via l'admin endpoint après seed.
+    if test_mode:
+        return plan.get("stripe_price_id_monthly_test") or plan.get("stripe_price_id_monthly")
+    return plan.get("stripe_price_id_monthly")
+
+
+async def get_plan_by_price_id(price_id: str) -> Optional[str]:
+    if not price_id:
+        return None
+    plans = await plan_registry.list_plans(active_only=False)
+    for p in plans:
+        if p.get("stripe_price_id_monthly") == price_id:
+            return p["slug"]
+        if p.get("stripe_price_id_monthly_test") == price_id:
+            return p["slug"]
+        if p.get("stripe_price_id_yearly") == price_id:
+            return p["slug"]
+        if p.get("stripe_price_id_yearly_test") == price_id:
+            return p["slug"]
+    return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DEPRECATED — init_stripe_prices()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def init_stripe_prices() -> None:
+    """DEPRECATED — les Stripe price IDs vivent désormais en DB.
+
+    Pour migrer une env var legacy vers la DB, utiliser le seed Hetzner
+    ou l'endpoint admin PUT /api/admin/plans/{id}.
+    """
+    logger.info(
+        "init_stripe_prices() is now a no-op — Stripe price IDs are stored in the plans table. "
+        "Use the admin endpoint or seed script to set them."
+    )
+```
+
+⚠️ **Important** : la ligne `init_stripe_prices()` à la fin du fichier (ligne 661) doit être conservée, mais maintenant elle est juste un log.
+
+⚠️ Toutes les **callers** existants de `get_plan`, `get_limits`, `is_feature_available` etc. dans le backend sont sync et appellent ces fonctions sync. Il faut donc identifier les callers et les passer en async OU créer une couche de compat sync (cache local du registry).
+
+**Décision plan : créer un wrapper sync `_get_limits_sync()` dans `core/plan_limits.py`.** Ne PAS toucher tous les callers dans cette task — c'est la Task 6.
+
+Pour cette task, on exporte juste les versions async. La compat sync sera Task 6.
+
+- [ ] **Step 4 : Lancer les tests**
+
+```bash
+cd backend && python -m pytest tests/billing/test_plan_config_compat.py -v
+```
+
+Expected : tests passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add backend/src/billing/plan_config.py backend/tests/billing/test_plan_config_compat.py
+git commit -m "refactor(billing): plan_config accessors delegate to PlanRegistry (async)"
+```
+
+---
+
+### Task 6 : Wrapper sync pour callers existants (`core/plan_limits.py`)
+
+**Files:**
+
+- Read existing : `backend/src/core/plan_limits.py`
+- Modify : `backend/src/core/plan_limits.py`
+- Test : `backend/tests/core/test_plan_limits_sync.py`
+
+**Pourquoi cette task** : beaucoup d'endpoints actuels appellent `is_feature_available()` ou `get_limits()` de manière **synchrone** (dans des fonctions `def` non-async, ou dans des hooks Pydantic). Les passer tous en async d'un coup = blast radius énorme. On expose un wrapper sync qui lit un **cache local** rafraîchi au boot.
+
+- [ ] **Step 1 : Lire `core/plan_limits.py` pour comprendre l'API existante**
+
+```bash
+cd backend && grep -n "def " src/core/plan_limits.py | head -30
+```
+
+(Le fichier existe déjà — il faut adapter, pas remplacer.)
+
+- [ ] **Step 2 : Écrire les tests**
+
+Créer `backend/tests/core/test_plan_limits_sync.py` :
+
+```python
+"""Wrapper sync pour callers existants — refresh cache local au boot."""
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.plan_limits import (
+    refresh_plan_cache,
+    get_limits_sync,
+    is_feature_available_sync,
+)
+from scripts.seed_plans_db import seed_plans
+
+
+@pytest.mark.asyncio
+async def test_refresh_then_sync_read(db_session: AsyncSession):
+    await seed_plans(db_session)
+    await refresh_plan_cache()
+
+    limits = get_limits_sync("pro")
+    assert limits["monthly_analyses"] == 25
+
+
+@pytest.mark.asyncio
+async def test_is_feature_available_sync(db_session: AsyncSession):
+    await seed_plans(db_session)
+    await refresh_plan_cache()
+
+    assert is_feature_available_sync("expert", "voice_chat") is True
+    assert is_feature_available_sync("free", "voice_chat") is False
+
+
+def test_sync_uses_fallback_if_cache_empty():
+    """Sans refresh, le wrapper utilise le fallback hardcoded sans crash."""
+    # Force vidage cache
+    import core.plan_limits as mod
+    mod._LOCAL_CACHE.clear()
+
+    limits = get_limits_sync("pro")
+    # Vient du fallback hardcoded (mêmes valeurs que la grille v2)
+    assert limits["monthly_analyses"] == 25
+```
+
+- [ ] **Step 3 : Lancer les tests, vérifier l'échec**
+
+```bash
+cd backend && python -m pytest tests/core/test_plan_limits_sync.py -v
+```
+
+Expected : `ImportError` sur `refresh_plan_cache` / `get_limits_sync`.
+
+- [ ] **Step 4 : Ajouter le wrapper sync dans `backend/src/core/plan_limits.py`**
+
+Au choix : ajouter à la fin du fichier existant. Ne pas toucher l'existant.
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# SYNC WRAPPER — pour callers existants non-async (transition layer)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Lit le PlanRegistry au boot dans un cache local in-memory ; les appels sync
+# lisent ce cache. À refresh à chaque mutation admin (via le router admin).
+# Si le cache est vide (avant le boot ou en cas d'erreur), retombe sur le
+# fallback hardcoded.
+
+import logging as _logging
+from typing import Any as _Any
+
+_logger = _logging.getLogger(__name__)
+_LOCAL_CACHE: dict[str, dict[str, _Any]] = {}
+
+
+async def refresh_plan_cache() -> None:
+    """Recharge le cache local depuis le PlanRegistry. À appeler au boot
+    et à chaque mutation admin."""
+    from billing.plan_registry import plan_registry, FALLBACK_PLANS
+
+    try:
+        plans = await plan_registry.list_plans(active_only=False)
+    except Exception as e:
+        _logger.warning("refresh_plan_cache: registry failed, using fallback: %s", e)
+        plans = list(FALLBACK_PLANS)
+
+    _LOCAL_CACHE.clear()
+    for p in plans:
+        _LOCAL_CACHE[p["slug"]] = p
+    _logger.info("refresh_plan_cache: %d plans loaded", len(_LOCAL_CACHE))
+
+
+def get_limits_sync(plan_slug: str) -> dict[str, _Any]:
+    """Lecture sync depuis le cache local. Fallback hardcoded si vide."""
+    from billing.plan_registry import FALLBACK_PLANS
+
+    if plan_slug in _LOCAL_CACHE:
+        return _LOCAL_CACHE[plan_slug].get("features", {})
+
+    # Fallback hardcoded
+    for p in FALLBACK_PLANS:
+        if p["slug"] == plan_slug:
+            return p["features"]
+
+    # Ultimate fallback : free
+    free = next((p for p in FALLBACK_PLANS if p["slug"] == "free"), None)
+    return free["features"] if free else {}
+
+
+def is_feature_available_sync(plan_slug: str, feature: str) -> bool:
+    """Variante sync de ``is_feature_available`` (web platform par défaut).
+
+    Pour la matrice plateforme/feature précise, utiliser la version async."""
+    limits = get_limits_sync(plan_slug)
+    val = limits.get(feature, False)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, (int, float)):
+        return val == -1 or val > 0
+    return bool(val)
+```
+
+- [ ] **Step 5 : Brancher le refresh au boot dans `main.py`**
+
+Dans `backend/src/main.py`, trouver la section lifespan / startup event et ajouter :
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # ... code existant ...
+    # NEW : précharger le cache local des plans
+    from core.plan_limits import refresh_plan_cache
+    await refresh_plan_cache()
+    yield
+    # ... cleanup ...
+```
+
+(Si `lifespan` n'existe pas mais que `startup` event est utilisé, ajouter dans le startup event existant — ne pas restructurer.)
+
+- [ ] **Step 6 : Lancer les tests**
+
+```bash
+cd backend && python -m pytest tests/core/test_plan_limits_sync.py -v
+```
+
+Expected : 3 tests passent.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add backend/src/core/plan_limits.py backend/src/main.py backend/tests/core/test_plan_limits_sync.py
+git commit -m "feat(core): add sync plan_limits wrapper with boot-time refresh"
+```
+
+---
+
+### Task 7 : Refactorer `GET /api/billing/plans` pour lire DB
+
+**Files:**
+
+- Modify : `backend/src/billing/router.py:354-397`
+- Test : `backend/tests/billing/test_router_plans_endpoint.py`
+
+- [ ] **Step 1 : Écrire le test**
+
+Créer `backend/tests/billing/test_router_plans_endpoint.py` :
+
+```python
+"""Tests pour GET /api/billing/plans — version DB-driven."""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from scripts.seed_plans_db import seed_plans
+
+
+@pytest.mark.asyncio
+async def test_get_plans_returns_seeded_plans(client: AsyncClient, db_session: AsyncSession):
+    await seed_plans(db_session)
+    from core.plan_limits import refresh_plan_cache
+    await refresh_plan_cache()
+
+    resp = await client.get("/api/billing/plans?platform=web")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "plans" in data
+    slugs = [p["id"] for p in data["plans"]]
+    assert slugs == ["free", "pro", "expert"]
+
+
+@pytest.mark.asyncio
+async def test_get_plans_filters_by_variant(client: AsyncClient, db_session: AsyncSession):
+    """Si on duplique un plan en variant=B, ?variant=B retourne juste celui-là."""
+    await seed_plans(db_session)
+
+    # Créer manuellement un plan variant B
+    from db.database import Plan, PlanFeature
+    pro_b = Plan(
+        slug="pro_b",
+        name="Pro (B)",
+        price_monthly_cents=799,
+        price_yearly_cents=7949,
+        is_active=True,
+        display_order=10,
+        variant_label="B",
+    )
+    db_session.add(pro_b)
+    await db_session.commit()
+
+    from core.plan_limits import refresh_plan_cache
+    await refresh_plan_cache()
+
+    resp = await client.get("/api/billing/plans?platform=web&variant=B")
+    assert resp.status_code == 200
+    data = resp.json()
+    slugs = [p["id"] for p in data["plans"]]
+    assert "pro_b" in slugs
+```
+
+- [ ] **Step 2 : Lancer les tests, vérifier l'échec**
+
+```bash
+cd backend && python -m pytest tests/billing/test_router_plans_endpoint.py::test_get_plans_filters_by_variant -v
+```
+
+Expected : échec — l'endpoint actuel ignore `variant`.
+
+- [ ] **Step 3 : Refactorer le handler**
+
+Dans `backend/src/billing/router.py`, remplacer le handler `/plans` (lignes 354-397) :
+
+```python
+@router.get("/plans")
+async def get_plans(
+    platform: str = Query("web", pattern="^(web|mobile|extension)$"),
+    variant: Optional[str] = Query(None, max_length=32),
+    current_user: Optional[User] = Depends(get_current_user_optional),
+):
+    """Retourne la liste des plans actifs avec limites filtrées par plateforme.
+
+    Source : table ``plans`` (DB-driven), cache Redis 5 min.
+    Public (enrichi avec is_current / is_upgrade / is_downgrade si user connecté).
+
+    - ``platform`` : ``web`` | ``mobile`` | ``extension``
+    - ``variant`` : ``A`` | ``B`` | ``None`` (par défaut, ne retourne que les
+       plans sans variant_label, i.e. la variante de contrôle).
+    """
+    from billing.plan_registry import plan_registry
+    from billing.plan_config import (
+        get_platform_features,
+        get_plan_index,
+    )
+
+    user_plan = (current_user.plan if current_user else "free") or "free"
+    user_index = get_plan_index(user_plan)
+
+    plans = await plan_registry.list_plans(active_only=True, variant=variant)
+    # Si pas de variant demandée, on filtre les plans avec variant_label != None
+    # afin de ne montrer que la variante de contrôle (ne pas mélanger A et B)
+    if variant is None:
+        plans = [p for p in plans if not p.get("variant_label")]
+
+    result: list[dict[str, Any]] = []
+    for plan in plans:
+        plan_index = get_plan_index(plan["slug"])
+        platform_features = await get_platform_features(plan["slug"], platform)
+
+        result.append(
+            {
+                "id": plan["slug"],
+                "name": plan["name"],
+                "name_en": plan.get("name_en") or plan["name"],
+                "description": plan["description"],
+                "description_en": plan.get("description_en") or plan["description"],
+                "price_monthly_cents": plan["price_monthly_cents"],
+                "price_yearly_cents": plan.get("price_yearly_cents", 0),
+                "yearly_discount_percent": plan.get("yearly_discount_percent", 17),
+                "color": plan.get("color"),
+                "icon": plan.get("icon"),
+                "badge": (
+                    {"text": plan["highlight_label"], "color": plan.get("color") or "#3B82F6"}
+                    if plan.get("highlight_label") else None
+                ),
+                "popular": plan.get("popular", False),
+                "limits": plan["features"],
+                "platform_features": platform_features,
+                "features_display": [],   # legacy field — vide en v1 DB-driven
+                "features_locked": [],    # legacy field — vide en v1 DB-driven
+                "is_current": plan["slug"] == user_plan,
+                "is_upgrade": plan_index > user_index,
+                "is_downgrade": plan_index < user_index and plan_index >= 0,
+                "variant_label": plan.get("variant_label"),
+                "trial_days": plan.get("trial_days", 7),
+                "cta_label": plan.get("cta_label", "S'abonner"),
+            }
+        )
+
+    return {"plans": result}
+```
+
+⚠️ Note : `features_display` et `features_locked` étaient des arrays cosmétiques pour l'UI marketing — la v1 DB-driven les laisse vides. Le frontend doit les recomposer côté front à partir de `limits`. Si c'est trop violent, on peut ajouter une colonne JSON `display_metadata` à la table plans dans une migration follow-up.
+
+- [ ] **Step 4 : Lancer les tests**
+
+```bash
+cd backend && python -m pytest tests/billing/test_router_plans_endpoint.py -v
+```
+
+Expected : 2 tests passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add backend/src/billing/router.py backend/tests/billing/test_router_plans_endpoint.py
+git commit -m "refactor(billing): GET /plans reads from DB-driven PlanRegistry"
+```
+
+---
+
+### Task 8 : Endpoints admin `/api/admin/plans` (read + write)
+
+**Files:**
+
+- Create : `backend/src/billing/plan_admin_router.py`
+- Modify : `backend/src/main.py` (inclure le router)
+- Test : `backend/tests/billing/test_plan_admin_router.py`
+
+- [ ] **Step 1 : Écrire les tests**
+
+Créer `backend/tests/billing/test_plan_admin_router.py` :
+
+```python
+"""Tests endpoints admin /api/admin/plans — auth, mutations, invalidation cache."""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from scripts.seed_plans_db import seed_plans
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_returns_401(client: AsyncClient):
+    resp = await client.get("/api/admin/plans")
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_non_admin_returns_403(client: AsyncClient, regular_user_token: str):
+    resp = await client.get(
+        "/api/admin/plans",
+        headers={"Authorization": f"Bearer {regular_user_token}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_lists_all_plans(
+    client: AsyncClient, db_session: AsyncSession, admin_token: str
+):
+    await seed_plans(db_session)
+    resp = await client.get(
+        "/api/admin/plans",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["plans"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_admin_updates_plan_price_invalidates_cache(
+    client: AsyncClient, db_session: AsyncSession, admin_token: str
+):
+    await seed_plans(db_session)
+    from db.database import Plan
+    from sqlalchemy import select
+    pro = (await db_session.execute(select(Plan).where(Plan.slug == "pro"))).scalar_one()
+
+    # Première lecture publique pour remplir le cache
+    pub_before = await client.get("/api/billing/plans?platform=web")
+    pro_before = next(p for p in pub_before.json()["plans"] if p["id"] == "pro")
+    assert pro_before["price_monthly_cents"] == 899
+
+    # Mutation admin
+    resp = await client.put(
+        f"/api/admin/plans/{pro.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"price_monthly_cents": 1099},
+    )
+    assert resp.status_code == 200
+
+    # Lecture publique doit voir la nouvelle valeur (cache invalidé)
+    pub_after = await client.get("/api/billing/plans?platform=web")
+    pro_after = next(p for p in pub_after.json()["plans"] if p["id"] == "pro")
+    assert pro_after["price_monthly_cents"] == 1099
+
+
+@pytest.mark.asyncio
+async def test_admin_updates_plan_feature(
+    client: AsyncClient, db_session: AsyncSession, admin_token: str
+):
+    await seed_plans(db_session)
+    from db.database import Plan
+    from sqlalchemy import select
+    pro = (await db_session.execute(select(Plan).where(Plan.slug == "pro"))).scalar_one()
+
+    resp = await client.put(
+        f"/api/admin/plans/{pro.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "features": [
+                {"feature_key": "monthly_analyses", "limit_value": 30, "is_enabled": True}
+            ]
+        },
+    )
+    assert resp.status_code == 200
+
+    pub = await client.get("/api/billing/plans?platform=web")
+    pro_pub = next(p for p in pub.json()["plans"] if p["id"] == "pro")
+    assert pro_pub["limits"]["monthly_analyses"] == 30
+
+
+@pytest.mark.asyncio
+async def test_admin_duplicates_plan_for_ab_test(
+    client: AsyncClient, db_session: AsyncSession, admin_token: str
+):
+    await seed_plans(db_session)
+    from db.database import Plan
+    from sqlalchemy import select
+    pro = (await db_session.execute(select(Plan).where(Plan.slug == "pro"))).scalar_one()
+
+    resp = await client.post(
+        f"/api/admin/plans/{pro.id}/duplicate",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"variant_label": "B", "price_monthly_cents": 799},
+    )
+    assert resp.status_code == 201
+    new_plan = resp.json()
+    assert new_plan["slug"].startswith("pro_b")
+    assert new_plan["variant_label"] == "B"
+    assert new_plan["price_monthly_cents"] == 799
+```
+
+- [ ] **Step 2 : Lancer les tests, vérifier l'échec**
+
+```bash
+cd backend && python -m pytest tests/billing/test_plan_admin_router.py -v
+```
+
+Expected : 404 sur tous les endpoints admin (pas encore enregistrés).
+
+- [ ] **Step 3 : Implémenter le router admin**
+
+Créer `backend/src/billing/plan_admin_router.py` :
+
+```python
+"""Endpoints admin pour gérer les plans (CRUD + duplication A/B test).
+
+Tous les endpoints sont protégés par ``get_current_admin``.
+Chaque mutation invalide le cache plans (Redis) ET le cache local sync
+(``core/plan_limits.py``).
+
+Audit log via ``AdminLog`` (qui, quand, quoi).
+"""
+import logging
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import get_current_admin
+from billing.plan_registry import plan_registry, _serialize_plan
+from db.database import (
+    AdminLog,
+    Plan,
+    PlanFeature,
+    User,
+    get_session,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📋 SCHEMAS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class PlanFeatureUpdate(BaseModel):
+    feature_key: str = Field(..., max_length=64)
+    limit_value: Optional[int] = None
+    is_enabled: bool = True
+
+
+class PlanUpdateRequest(BaseModel):
+    name: Optional[str] = Field(None, max_length=255)
+    description: Optional[str] = None
+    price_monthly_cents: Optional[int] = Field(None, ge=0)
+    price_yearly_cents: Optional[int] = Field(None, ge=0)
+    yearly_discount_percent: Optional[int] = Field(None, ge=0, le=100)
+    stripe_price_id_monthly: Optional[str] = Field(None, max_length=100)
+    stripe_price_id_yearly: Optional[str] = Field(None, max_length=100)
+    is_active: Optional[bool] = None
+    display_order: Optional[int] = None
+    highlight_label: Optional[str] = Field(None, max_length=64)
+    cta_label: Optional[str] = Field(None, max_length=64)
+    trial_days: Optional[int] = Field(None, ge=0, le=365)
+    variant_label: Optional[str] = Field(None, max_length=32)
+    color: Optional[str] = Field(None, max_length=16)
+    icon: Optional[str] = Field(None, max_length=32)
+    popular: Optional[bool] = None
+    features: Optional[list[PlanFeatureUpdate]] = None
+
+
+class PlanDuplicateRequest(BaseModel):
+    variant_label: str = Field(..., min_length=1, max_length=32)
+    slug: Optional[str] = Field(None, max_length=64)
+    price_monthly_cents: Optional[int] = Field(None, ge=0)
+    price_yearly_cents: Optional[int] = Field(None, ge=0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _audit(
+    session: AsyncSession,
+    admin: User,
+    action: str,
+    target_id: Optional[int],
+    payload: dict[str, Any],
+) -> None:
+    log = AdminLog(
+        admin_user_id=admin.id,
+        action=action,
+        target_type="plan",
+        target_id=target_id,
+        # Selon le schema d'AdminLog actuel — vérifier dans db/database.py
+        # Si la colonne s'appelle différemment, adapter.
+        details=payload,
+    )
+    session.add(log)
+
+
+async def _invalidate_caches() -> None:
+    await plan_registry.invalidate_cache()
+    from core.plan_limits import refresh_plan_cache
+    await refresh_plan_cache()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔍 GET /api/admin/plans  — liste détaillée (incluant inactifs)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.get("/plans")
+async def admin_list_plans(
+    admin: User = Depends(get_current_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    result = await session.execute(
+        select(Plan).order_by(Plan.display_order, Plan.id)
+    )
+    plans = list(result.scalars().all())
+    return {"plans": [_serialize_plan(p) for p in plans]}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✏️ PUT /api/admin/plans/{plan_id}  — mise à jour
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.put("/plans/{plan_id}")
+async def admin_update_plan(
+    plan_id: int,
+    body: PlanUpdateRequest,
+    admin: User = Depends(get_current_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    result = await session.execute(select(Plan).where(Plan.id == plan_id))
+    plan = result.scalar_one_or_none()
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    update_data = body.model_dump(exclude_unset=True, exclude={"features"})
+    for k, v in update_data.items():
+        setattr(plan, k, v)
+
+    if body.features is not None:
+        for feat_update in body.features:
+            existing = await session.execute(
+                select(PlanFeature).where(
+                    PlanFeature.plan_id == plan.id,
+                    PlanFeature.feature_key == feat_update.feature_key,
+                )
+            )
+            feat = existing.scalar_one_or_none()
+            if feat is None:
+                session.add(PlanFeature(
+                    plan_id=plan.id,
+                    feature_key=feat_update.feature_key,
+                    limit_value=feat_update.limit_value,
+                    is_enabled=feat_update.is_enabled,
+                ))
+            else:
+                feat.limit_value = feat_update.limit_value
+                feat.is_enabled = feat_update.is_enabled
+
+    await _audit(session, admin, "plan.update", plan.id, body.model_dump(exclude_unset=True))
+    await session.commit()
+    await session.refresh(plan)
+    await _invalidate_caches()
+
+    return _serialize_plan(plan)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📋 POST /api/admin/plans/{plan_id}/duplicate  — variant A/B
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post("/plans/{plan_id}/duplicate", status_code=status.HTTP_201_CREATED)
+async def admin_duplicate_plan(
+    plan_id: int,
+    body: PlanDuplicateRequest,
+    admin: User = Depends(get_current_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    result = await session.execute(select(Plan).where(Plan.id == plan_id))
+    src = result.scalar_one_or_none()
+    if src is None:
+        raise HTTPException(status_code=404, detail="Source plan not found")
+
+    new_slug = body.slug or f"{src.slug}_{body.variant_label.lower()}"
+    existing = await session.execute(select(Plan).where(Plan.slug == new_slug))
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Plan with slug '{new_slug}' already exists",
+        )
+
+    new_plan = Plan(
+        slug=new_slug,
+        name=f"{src.name} ({body.variant_label})",
+        description=src.description,
+        price_monthly_cents=body.price_monthly_cents
+            if body.price_monthly_cents is not None else src.price_monthly_cents,
+        price_yearly_cents=body.price_yearly_cents
+            if body.price_yearly_cents is not None else src.price_yearly_cents,
+        yearly_discount_percent=src.yearly_discount_percent,
+        is_active=True,
+        display_order=src.display_order + 100,  # placer après le contrôle
+        highlight_label=src.highlight_label,
+        cta_label=src.cta_label,
+        trial_days=src.trial_days,
+        variant_label=body.variant_label,
+        color=src.color,
+        icon=src.icon,
+        popular=False,
+    )
+    session.add(new_plan)
+    await session.flush()
+
+    # Copier les features
+    src_features = await session.execute(
+        select(PlanFeature).where(PlanFeature.plan_id == src.id)
+    )
+    for f in src_features.scalars().all():
+        session.add(PlanFeature(
+            plan_id=new_plan.id,
+            feature_key=f.feature_key,
+            limit_value=f.limit_value,
+            is_enabled=f.is_enabled,
+            feature_metadata=f.feature_metadata,
+        ))
+
+    await _audit(
+        session, admin, "plan.duplicate", new_plan.id,
+        {"source_id": src.id, "variant_label": body.variant_label, "slug": new_slug},
+    )
+    await session.commit()
+    await session.refresh(new_plan)
+    await _invalidate_caches()
+
+    return _serialize_plan(new_plan)
+```
+
+⚠️ Vérification `AdminLog` : ouvrir `backend/src/db/database.py` ligne 466 pour confirmer le nom des champs (`admin_user_id`, `action`, `target_type`, `target_id`, `details`). Si différent, adapter.
+
+- [ ] **Step 4 : Inclure le router dans `main.py`**
+
+Dans `backend/src/main.py`, après les autres `app.include_router(...)` :
+
+```python
+from billing.plan_admin_router import router as plan_admin_router
+
+app.include_router(
+    plan_admin_router,
+    prefix="/api/admin",
+    tags=["admin", "plans"],
+)
+```
+
+- [ ] **Step 5 : Lancer les tests**
+
+```bash
+cd backend && python -m pytest tests/billing/test_plan_admin_router.py -v
+```
+
+Expected : 6 tests passent.
+
+⚠️ Si certaines fixtures (`admin_token`, `regular_user_token`, `client`) n'existent pas, elles doivent être ajoutées dans `backend/tests/conftest.py`. Pattern à reproduire depuis un fichier de test admin existant — examiner `backend/tests/admin/` ou utiliser `pytest --fixtures` pour lister celles dispo.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add backend/src/billing/plan_admin_router.py backend/src/main.py backend/tests/billing/test_plan_admin_router.py
+git commit -m "feat(admin): add /api/admin/plans CRUD + A/B duplicate endpoint"
+```
+
+---
+
+### Task 9 : Frontend — renommer le statique en fallback + créer hook `useApiPlans`
+
+**Files:**
+
+- Rename : `frontend/src/config/planPrivileges.ts` → `frontend/src/config/planPrivilegesFallback.ts`
+- Modify : `frontend/src/config/planPrivileges.ts` (recréer comme façade)
+- Create : `frontend/src/hooks/useApiPlans.ts`
+- Test : `frontend/src/__tests__/hooks/useApiPlans.test.tsx`
+
+- [ ] **Step 1 : Écrire le test du hook**
+
+Créer `frontend/src/__tests__/hooks/useApiPlans.test.tsx` :
+
+```typescript
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+
+import { useApiPlans } from "../../hooks/useApiPlans";
+import { billingApi } from "../../services/api";
+
+vi.mock("../../services/api", () => ({
+  billingApi: {
+    getPlans: vi.fn(),
+  },
+}));
+
+const wrapper = ({ children }: { children: ReactNode }) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+describe("useApiPlans", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches plans from /api/billing/plans", async () => {
+    (billingApi.getPlans as any).mockResolvedValue({
+      plans: [
+        { id: "free", name: "Gratuit", price_monthly_cents: 0, limits: {} },
+        { id: "pro", name: "Pro", price_monthly_cents: 899, limits: {} },
+      ],
+    });
+
+    const { result } = renderHook(() => useApiPlans("web"), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.plans).toHaveLength(2);
+    expect(result.current.plans[0].id).toBe("free");
+  });
+
+  it("falls back to hardcoded plans on API error", async () => {
+    (billingApi.getPlans as any).mockRejectedValue(new Error("network"));
+
+    const { result } = renderHook(() => useApiPlans("web"), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    // Le hook expose un `plans` non vide même en erreur
+    expect(result.current.plans.length).toBeGreaterThan(0);
+    const slugs = result.current.plans.map((p) => p.id);
+    expect(slugs).toContain("free");
+    expect(slugs).toContain("pro");
+  });
+});
+```
+
+- [ ] **Step 2 : Lancer le test, vérifier l'échec**
+
+```bash
+cd frontend && npm run test -- useApiPlans --run
+```
+
+Expected : `Cannot find module '../../hooks/useApiPlans'`.
+
+- [ ] **Step 3 : Renommer le fichier statique**
+
+```bash
+git mv frontend/src/config/planPrivileges.ts frontend/src/config/planPrivilegesFallback.ts
+```
+
+- [ ] **Step 4 : Recréer `planPrivileges.ts` comme façade**
+
+Créer `frontend/src/config/planPrivileges.ts` :
+
+```typescript
+// Façade : ré-exporte tout le module fallback statique pour garder
+// la compat avec les imports existants. Les composants modernes doivent
+// préférer le hook ``useApiPlans`` qui fetch /api/billing/plans.
+export * from "./planPrivilegesFallback";
+export { default } from "./planPrivilegesFallback";
+```
+
+- [ ] **Step 5 : Implémenter le hook**
+
+Créer `frontend/src/hooks/useApiPlans.ts` :
+
+```typescript
+import { useQuery } from "@tanstack/react-query";
+import { billingApi, type ApiBillingPlan } from "../services/api";
+import { PLAN_LIMITS, PLANS_INFO, type PlanId } from "../config/planPrivileges";
+
+const STALE_TIME_MS = 5 * 60 * 1000; // 5 min — aligné avec le cache backend
+
+/**
+ * Fallback : transforme la grille hardcoded en format API pour ne pas casser
+ * l'UI si le backend est down.
+ */
+function buildFallbackPlans(): ApiBillingPlan[] {
+  return (Object.keys(PLAN_LIMITS) as PlanId[]).map((id) => {
+    const info = PLANS_INFO[id];
+    const limits = PLAN_LIMITS[id];
+    return {
+      id,
+      name: info.name,
+      name_en: info.nameEn,
+      description: info.description,
+      description_en: info.descriptionEn,
+      price_monthly_cents: info.priceMonthly,
+      color: info.color,
+      icon: info.icon,
+      badge: info.badge,
+      popular: info.popular,
+      limits: limits as unknown as Record<string, unknown>,
+      platform_features: {},
+      features_display: [],
+      features_locked: [],
+      is_current: false,
+      is_upgrade: false,
+      is_downgrade: false,
+    } as unknown as ApiBillingPlan;
+  });
+}
+
+/**
+ * Hook React Query qui charge la grille de plans depuis l'API.
+ *
+ * En cas d'échec réseau, le hook expose tout de même `plans` (fallback hardcoded).
+ * `isError` reste `true` pour permettre à l'UI d'afficher un toast / banner si elle veut.
+ *
+ * @param platform — `web` | `mobile` | `extension`. Filtre côté backend.
+ * @param variant — Optionnel, pour forcer une variante A/B.
+ */
+export function useApiPlans(
+  platform: "web" | "mobile" | "extension" = "web",
+  variant?: string,
+) {
+  const query = useQuery({
+    queryKey: ["billing", "plans", platform, variant ?? "control"],
+    queryFn: async () => {
+      const data = await billingApi.getPlans(platform);
+      return data.plans;
+    },
+    staleTime: STALE_TIME_MS,
+    gcTime: STALE_TIME_MS * 2,
+    retry: 1,
+  });
+
+  const plans =
+    query.data && query.data.length > 0 ? query.data : buildFallbackPlans();
+
+  return {
+    plans,
+    isLoading: query.isLoading,
+    isSuccess: query.isSuccess,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+```
+
+⚠️ Si `billingApi.getPlans` ne supporte pas encore le param `variant`, on l'ajoutera Task 12. Pour l'instant le hook ne le passe pas au backend.
+
+- [ ] **Step 6 : Lancer les tests**
+
+```bash
+cd frontend && npm run test -- useApiPlans --run
+```
+
+Expected : 2 tests passent.
+
+- [ ] **Step 7 : Vérifier que le typecheck passe (les imports existants ne sont pas cassés par le rename)**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected : pas de nouvelle erreur (les erreurs pré-existantes hors scope sont OK).
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add frontend/src/config/planPrivileges.ts frontend/src/config/planPrivilegesFallback.ts frontend/src/hooks/useApiPlans.ts frontend/src/__tests__/hooks/useApiPlans.test.tsx
+git commit -m "feat(frontend): add useApiPlans hook + rename static config to fallback"
+```
+
+---
+
+### Task 10 : Migration `RUN_MIGRATIONS=true` + seed sur Hetzner (deploy)
+
+**Files:**
+
+- Modify : `backend/scripts/seed_plans_db.py` (ajout d'un mode "boot" optionnel)
+- Modify : `deploy/hetzner/entrypoint.sh` (vérifier la présence de la commande seed)
+
+- [ ] **Step 1 : Vérifier l'entrypoint actuel**
+
+```bash
+cat deploy/hetzner/entrypoint.sh
+```
+
+Lire et comprendre le flow actuel — comment `RUN_MIGRATIONS=true` est géré (Memory note : "Migrations auto via entrypoint.sh + RUN_MIGRATIONS=true depuis PR #189").
+
+- [ ] **Step 2 : Ajouter une étape seed conditionnelle**
+
+Modifier `deploy/hetzner/entrypoint.sh` — ajouter après l'étape `alembic upgrade head` :
+
+```bash
+# Seed les plans v2 (idempotent — UPSERT par slug)
+if [ "$SEED_PLANS_ON_BOOT" = "true" ]; then
+  echo "[entrypoint] Running seed_plans_db (idempotent UPSERT)..."
+  python -m scripts.seed_plans_db || echo "[entrypoint] seed_plans_db failed (non-blocking)"
+fi
+```
+
+⚠️ Ne pas activer `SEED_PLANS_ON_BOOT=true` en permanence — l'utiliser une seule fois après le merge, puis le retirer pour ne plus écraser les modifs admin.
+
+- [ ] **Step 3 : Documenter la procédure de déploiement**
+
+Créer `deploy/hetzner/PLANS_DB_DEPLOY.md` :
+
+````markdown
+# Déploiement DB-driven plans
+
+## Première mise en prod (one-shot)
+
+1. Le merge de la branche déclenche le webhook Hetzner → `docker run` avec
+   `RUN_MIGRATIONS=true` → la migration `0XX_add_plans_tables` est appliquée.
+2. **Avant** le restart final, ajouter `SEED_PLANS_ON_BOOT=true` dans le
+   `.env.production` côté Hetzner :
+   ```bash
+   ssh root@89.167.23.214 "echo 'SEED_PLANS_ON_BOOT=true' >> /opt/deepsight/repo/.env.production"
+   ```
+````
+
+3. Restart le container backend pour exécuter le seed.
+4. **Retirer** `SEED_PLANS_ON_BOOT=true` immédiatement après pour ne plus
+   écraser les modifs admin :
+   ```bash
+   ssh root@89.167.23.214 "sed -i '/^SEED_PLANS_ON_BOOT=/d' /opt/deepsight/repo/.env.production"
+   ```
+5. Vérifier : `curl https://api.deepsightsynthesis.com/api/billing/plans?platform=web`
+   doit retourner les 3 plans v2.
+
+## Édition admin sans deploy
+
+```bash
+curl -X PUT https://api.deepsightsynthesis.com/api/admin/plans/2 \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"price_monthly_cents": 999}'
+```
+
+Le cache Redis est invalidé automatiquement (TTL 5 min sinon).
+
+````
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add deploy/hetzner/entrypoint.sh deploy/hetzner/PLANS_DB_DEPLOY.md
+git commit -m "chore(deploy): add SEED_PLANS_ON_BOOT step + deploy doc"
+````
+
+---
+
+### Task 11 : Tests E2E intégration (zero downtime + cache invalidation)
+
+**Files:**
+
+- Create : `backend/tests/billing/test_plans_e2e_integration.py`
+
+- [ ] **Step 1 : Écrire le test E2E**
+
+Créer `backend/tests/billing/test_plans_e2e_integration.py` :
+
+```python
+"""Test E2E : seed → query → admin update → cache invalidation → query.
+
+Simule le scénario réel d'un admin qui change un prix Pro entre deux requêtes
+publiques. Vérifie que la 2e requête voit la nouvelle valeur (cache invalidé).
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from scripts.seed_plans_db import seed_plans
+
+
+@pytest.mark.asyncio
+async def test_full_flow_seed_query_update_cache_invalidation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_token: str,
+):
+    # 1. Seed
+    await seed_plans(db_session)
+    from core.plan_limits import refresh_plan_cache
+    await refresh_plan_cache()
+
+    # 2. Public query (warming le cache)
+    r1 = await client.get("/api/billing/plans?platform=web")
+    assert r1.status_code == 200
+    pro_v1 = next(p for p in r1.json()["plans"] if p["id"] == "pro")
+    assert pro_v1["price_monthly_cents"] == 899
+
+    # 3. Admin update price
+    from db.database import Plan
+    from sqlalchemy import select
+    pro = (await db_session.execute(select(Plan).where(Plan.slug == "pro"))).scalar_one()
+
+    update = await client.put(
+        f"/api/admin/plans/{pro.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"price_monthly_cents": 1099},
+    )
+    assert update.status_code == 200
+
+    # 4. Public query immediately after — must see new value (cache invalidated)
+    r2 = await client.get("/api/billing/plans?platform=web")
+    pro_v2 = next(p for p in r2.json()["plans"] if p["id"] == "pro")
+    assert pro_v2["price_monthly_cents"] == 1099
+
+
+@pytest.mark.asyncio
+async def test_zero_downtime_during_update(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_token: str,
+):
+    """Pendant qu'un admin update, les lectures publiques ne doivent jamais
+    retourner 5xx. Au pire, elles voient l'ancienne valeur (cache stale)."""
+    import asyncio
+
+    await seed_plans(db_session)
+    from core.plan_limits import refresh_plan_cache
+    await refresh_plan_cache()
+
+    from db.database import Plan
+    from sqlalchemy import select
+    pro = (await db_session.execute(select(Plan).where(Plan.slug == "pro"))).scalar_one()
+
+    async def reader():
+        results = []
+        for _ in range(10):
+            r = await client.get("/api/billing/plans?platform=web")
+            results.append(r.status_code)
+            await asyncio.sleep(0.05)
+        return results
+
+    async def writer():
+        await asyncio.sleep(0.1)
+        return await client.put(
+            f"/api/admin/plans/{pro.id}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"price_monthly_cents": 1099},
+        )
+
+    reads, write = await asyncio.gather(reader(), writer())
+    assert all(r == 200 for r in reads), f"Status codes: {reads}"
+    assert write.status_code == 200
+```
+
+- [ ] **Step 2 : Lancer le test**
+
+```bash
+cd backend && python -m pytest tests/billing/test_plans_e2e_integration.py -v
+```
+
+Expected : 2 tests passent.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add backend/tests/billing/test_plans_e2e_integration.py
+git commit -m "test(billing): add E2E integration test for seed + admin update + cache flow"
+```
+
+---
+
+### Task 12 : Frontend — utiliser `useApiPlans` dans la page Pricing/Upgrade
+
+**Files:**
+
+- Modify : `frontend/src/services/api.ts` (ajouter `variant` au signature de `getPlans`)
+- Modify : la page Pricing/Upgrade existante (à identifier)
+- Test : pas de nouveau test (tests d'intégration UI hors scope ici)
+
+- [ ] **Step 1 : Identifier la page Pricing**
+
+```bash
+cd frontend && grep -rn "billingApi.getPlans\|getPlans(" src/pages/
+```
+
+Noter le ou les fichiers qui consomment l'endpoint actuel. Souvent : `frontend/src/pages/UpgradePage.tsx` ou `frontend/src/pages/PricingPage.tsx`.
+
+- [ ] **Step 2 : Ajouter le param `variant` à `billingApi.getPlans`**
+
+Modifier `frontend/src/services/api.ts` (ligne ~1820) :
+
+```typescript
+async getPlans(
+  platform: string = "web",
+  variant?: string,
+): Promise<{ plans: ApiBillingPlan[] }> {
+  const query = new URLSearchParams({ platform });
+  if (variant) query.set("variant", variant);
+  return request(`/api/billing/plans?${query.toString()}`);
+},
+```
+
+Et propager au hook :
+
+```typescript
+// dans useApiPlans.ts
+queryFn: async () => {
+  const data = await billingApi.getPlans(platform, variant);
+  return data.plans;
+},
+```
+
+- [ ] **Step 3 : Migrer un caller (preuve de concept)**
+
+Dans la page Pricing identifiée, remplacer l'appel direct :
+
+```typescript
+// Avant
+const [plans, setPlans] = useState<ApiBillingPlan[]>([]);
+useEffect(() => {
+  billingApi.getPlans("web").then((data) => setPlans(data.plans));
+}, []);
+
+// Après
+import { useApiPlans } from "../hooks/useApiPlans";
+const { plans, isLoading } = useApiPlans("web");
+```
+
+⚠️ Garder l'UI fonctionnelle — ne pas refactor la page entièrement, juste remplacer la source des plans.
+
+- [ ] **Step 4 : Vérifier en local**
+
+```bash
+cd frontend && npm run dev
+```
+
+Ouvrir la page Pricing dans le browser et vérifier visuellement que les 3 plans s'affichent.
+
+- [ ] **Step 5 : Lancer les tests**
+
+```bash
+cd frontend && npm run test --run
+cd frontend && npm run typecheck
+```
+
+Expected : pas de régression.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add frontend/src/services/api.ts frontend/src/hooks/useApiPlans.ts frontend/src/pages/<PricingPage>.tsx
+git commit -m "feat(frontend): wire useApiPlans on PricingPage + variant param support"
+```
+
+---
+
+### Task 13 (OPTIONNELLE — Phase 2) : Page admin minimale d'édition
+
+> **À discuter avant exécution** : voir Self-Review. Cette task peut être déferrée
+> à un follow-up PR si le scope du PR principal est déjà large.
+
+**Files:**
+
+- Create : `frontend/src/pages/AdminPlansPage.tsx`
+- Modify : `frontend/src/services/api.ts` (ajouter `adminApi.listPlans`, `updatePlan`, `duplicatePlan`)
+
+- [ ] **Step 1 : Ajouter les méthodes admin au client API**
+
+Dans `frontend/src/services/api.ts`, créer un nouveau bloc `adminApi` :
+
+```typescript
+export const adminApi = {
+  async listPlans(): Promise<{ plans: ApiBillingPlan[] }> {
+    return request("/api/admin/plans");
+  },
+  async updatePlan(
+    id: number,
+    body: Partial<ApiBillingPlan> & {
+      features?: Array<{
+        feature_key: string;
+        limit_value: number | null;
+        is_enabled: boolean;
+      }>;
+    },
+  ): Promise<ApiBillingPlan> {
+    return request(`/api/admin/plans/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+  },
+  async duplicatePlan(
+    id: number,
+    body: {
+      variant_label: string;
+      slug?: string;
+      price_monthly_cents?: number;
+      price_yearly_cents?: number;
+    },
+  ): Promise<ApiBillingPlan> {
+    return request(`/api/admin/plans/${id}/duplicate`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  },
+};
+```
+
+(Adapter à la structure exacte de `request()` existant — ne pas casser le pattern fetch).
+
+- [ ] **Step 2 : Implémenter une page minimale**
+
+Créer `frontend/src/pages/AdminPlansPage.tsx` — table des plans avec édition inline du prix uniquement (le reste sera Phase 3 si besoin) :
+
+```tsx
+import { useState, useEffect } from "react";
+import { adminApi } from "../services/api";
+import type { ApiBillingPlan } from "../services/api";
+
+export default function AdminPlansPage() {
+  const [plans, setPlans] = useState<ApiBillingPlan[]>([]);
+  const [editing, setEditing] = useState<{ id: number; price: number } | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    adminApi.listPlans().then((d) => setPlans(d.plans));
+  }, []);
+
+  const save = async () => {
+    if (!editing) return;
+    setLoading(true);
+    try {
+      await adminApi.updatePlan(editing.id, {
+        price_monthly_cents: editing.price,
+      });
+      const refreshed = await adminApi.listPlans();
+      setPlans(refreshed.plans);
+      setEditing(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">Admin · Plans</h1>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="border-b border-white/10">
+            <th className="text-left p-2">Slug</th>
+            <th className="text-left p-2">Name</th>
+            <th className="text-right p-2">Price (€/mo)</th>
+            <th className="text-left p-2">Variant</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {plans.map((p) => (
+            <tr key={(p as any).id} className="border-b border-white/5">
+              <td className="p-2 font-mono">{p.id}</td>
+              <td className="p-2">{p.name}</td>
+              <td className="p-2 text-right">
+                {editing?.id === (p as any).id ? (
+                  <input
+                    type="number"
+                    value={editing.price}
+                    onChange={(e) =>
+                      setEditing({
+                        id: editing.id,
+                        price: parseInt(e.target.value, 10),
+                      })
+                    }
+                    className="bg-white/10 px-2 py-1 rounded w-24 text-right"
+                  />
+                ) : (
+                  (p.price_monthly_cents / 100).toFixed(2)
+                )}
+              </td>
+              <td className="p-2 text-xs">
+                {(p as any).variant_label || "control"}
+              </td>
+              <td className="p-2 text-center">
+                {editing?.id === (p as any).id ? (
+                  <>
+                    <button
+                      onClick={save}
+                      disabled={loading}
+                      className="text-emerald-400 mr-2"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={() => setEditing(null)}
+                      className="text-zinc-400"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    onClick={() =>
+                      setEditing({
+                        id: (p as any).id,
+                        price: p.price_monthly_cents,
+                      })
+                    }
+                    className="text-indigo-400"
+                  >
+                    Edit
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3 : Enregistrer la route**
+
+Dans le router principal du frontend (`App.tsx` ou équivalent), ajouter une route protégée admin :
+
+```typescript
+<Route path="/admin/plans" element={<RequireAdmin><AdminPlansPage /></RequireAdmin>} />
+```
+
+(Pattern : reproduire la protection des autres routes admin existantes — examiner `frontend/src/pages/AdminDashboard.tsx` ou similaire).
+
+- [ ] **Step 4 : Test manuel**
+
+Login en tant qu'admin, naviguer `/admin/plans`, modifier un prix, vérifier que l'API publique reflète le change.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add frontend/src/services/api.ts frontend/src/pages/AdminPlansPage.tsx frontend/src/App.tsx
+git commit -m "feat(admin-ui): add minimal /admin/plans page for inline price editing"
+```
+
+---
+
+### Task 14 (OPTIONNELLE — Phase 2) : Documentation runbook + ADR
+
+**Files:**
+
+- Create : `docs/architecture/ADR-2026-04-29-plans-db-driven.md`
+- Update : `backend/CLAUDE.md` (mention rapide du nouveau pattern)
+
+- [ ] **Step 1 : Créer l'ADR**
+
+Créer `docs/architecture/ADR-2026-04-29-plans-db-driven.md` :
+
+```markdown
+# ADR — Plans DB-Driven
+
+**Date** : 2026-04-29
+**Status** : Accepted
+**Context** : Issue #N — A/B testing pricing impossible avec config hardcoded
+
+## Decision
+
+Migrer `PLANS` de `plan_config.py` vers tables PostgreSQL `plans` + `plan_features`.
+Cache Redis 5 min, fallback hardcoded si DB injoignable.
+
+## Consequences
+
+### Positives
+
+- A/B testing pricing sans deploy (variant_label)
+- Édition admin live (PUT /api/admin/plans/{id})
+- Audit trail via AdminLog
+
+### Négatives
+
+- Latence ajoutée (cache miss = 1 query DB)
+- Complexité : 2 sources potentielles (DB vs fallback)
+- Risque divergence DB vs `seed_plans_db.py` si on oublie de re-seed après modif code
+
+## Alternatives Considered
+
+1. **PostHog feature flags** seul : non, on veut audit + rollback côté DB
+2. **JSON file en DB** : moins flexible pour A/B
+3. **Redis storage** : pas durable, on perd l'audit
+```
+
+- [ ] **Step 2 : Mention dans `backend/CLAUDE.md`**
+
+Ajouter une ligne dans la section "Feature gating" :
+
+```markdown
+**NEW (avril 2026)** : Les plans sont DB-driven. `PLAN_LIMITS` en mémoire est
+maintenant un wrapper sync alimenté par `core/plan_limits.refresh_plan_cache()`
+au boot. Pour modifier un plan en prod : `PUT /api/admin/plans/{id}`.
+```
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add docs/architecture/ADR-2026-04-29-plans-db-driven.md backend/CLAUDE.md
+git commit -m "docs: add ADR for DB-driven plans + update backend CLAUDE.md"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage check
+
+| Spec requirement                                      | Task                                          |
+| ----------------------------------------------------- | --------------------------------------------- |
+| Tables `plans` + `plan_features` SQLAlchemy           | Task 1                                        |
+| Migration Alembic (numéro à déterminer dynamiquement) | Task 2 (cf. Step 3 Task 0)                    |
+| Seed script idempotent UPSERT par slug                | Task 3                                        |
+| Service `PlanRegistry` avec cache Redis 5 min         | Task 4                                        |
+| Fallback hardcoded si DB injoignable                  | Task 4 (FALLBACK_PLANS)                       |
+| `plan_config.py` API publique inchangée               | Task 5 + Task 6 (wrapper sync)                |
+| Frontend hook `useApiPlans` TanStack Query 5 min      | Task 9                                        |
+| Build-time fallback statique conservé                 | Task 9 (planPrivilegesFallback.ts)            |
+| Endpoint `GET /api/billing/plans` migré               | Task 7                                        |
+| Endpoints admin GET/PUT/POST duplicate                | Task 8                                        |
+| Cache invalidation à chaque PUT admin                 | Task 8 (`_invalidate_caches`)                 |
+| Audit log AdminLog                                    | Task 8 (`_audit`)                             |
+| Sécurité admin (`get_current_admin`)                  | Task 8 (Depends)                              |
+| Tests pytest backend (seed→query→update→cache)        | Task 11 (E2E)                                 |
+| Tests Vitest frontend (mock + erreur fallback)        | Task 9                                        |
+| Zero downtime garanti                                 | Task 11 (test_zero_downtime_during_update)    |
+| Dépendance #3 explicite                               | Header + Task 0                               |
+| Reprend la grille v2 (free/pro 8.99/expert 19.99)     | Task 3 (PLANS_SEED) + Task 4 (FALLBACK_PLANS) |
+
+✅ Tout couvert.
+
+### 2. Placeholder scan
+
+- Pas de "TBD"/"TODO" dans les blocs de code.
+- Tasks 13 et 14 sont marquées **OPTIONNELLES** explicitement, ce n'est pas un placeholder mais une décision de scope.
+- Le numéro `0XX` de la migration est explicitement noté comme "à remplacer par le numéro réel" en Task 0 Step 3 — c'est une instruction explicite, pas un placeholder caché.
+
+✅ Pas de placeholder caché.
+
+### 3. Type consistency
+
+- `Plan` et `PlanFeature` modèles sont définis Task 1, utilisés cohéremment Task 2 (migration), Task 3 (seed), Task 4 (registry), Task 8 (admin router).
+- `_serialize_plan` est défini Task 4, importé/réutilisé Task 8.
+- `FALLBACK_PLANS` défini Task 4, réutilisé Task 6 (`refresh_plan_cache`).
+- `useApiPlans` hook signature `(platform, variant?)` cohérente entre Task 9 (création) et Task 12 (utilisation).
+- L'attribut Python `feature_metadata` (vs colonne SQL `metadata`) est noté en Task 1 et réutilisé en Task 8 (`f.feature_metadata`).
+
+✅ Cohérent.
+
+### 4. Décisions à confirmer avec l'utilisateur AVANT exécution
+
+Trois questions matérielles avant de lancer les Tasks :
+
+**Q1 — Admin UI dans ce plan ou Phase 2 ?**
+Tasks 13 et 14 sont marquées OPTIONNELLES. La création/duplication/désactivation d'un plan via API curl marche déjà après Task 8. Recommandation : démarrer sans Task 13-14 et planifier une PR follow-up "admin-plans-ui" séparée pour limiter le diff. À confirmer.
+
+**Q2 — Routing A/B : feature flag PostHog côté frontend OU param `variant` côté backend ?**
+Le plan implémente le param backend (Task 7 — `?variant=B`). Pour le routage _quel user voit quelle variante_, deux options :
+
+- **(a) Frontend décide via PostHog** (`useFeatureFlag('pricing_variant')` → call `useApiPlans('web', flag)`). Simple, pas de cookie côté backend, mais le user voit la variante sélectionnée par PostHog.
+- **(b) Backend décide via session/user_id hash** : `/api/billing/plans` retourne automatiquement la variante assignée. Plus stable (pas de flicker au reload) mais nécessite logique côté plan_admin_router.
+  Recommandation : (a) PostHog — déjà installé côté frontend (cf. memory `posthog-events-complets`), zéro infra backend.
+  À confirmer.
+
+**Q3 — Grandfathering des users existants vs `variant_label` ?**
+Le plan #3 introduit déjà un champ users grandfathering (price legacy). Ici, si un user est sur `pro` (variante de contrôle) et qu'on crée `pro_b` à 7.99, le user ne migre PAS automatiquement. Ses webhooks Stripe restent sur le price_id de `pro` (contrôle). Si plus tard l'admin déprécie `pro` au profit de `pro_b`, il faut une logique de migration.
+Recommandation : ignorer dans ce plan — le grandfathering est géré par #3 sur un autre axe (`users.grandfathered_price`). Les variants A/B sont uniquement des leviers d'acquisition, pas de migration en masse.
+À confirmer.
+
+### 5. Risques techniques
+
+- **Risque 1 : `init_stripe_prices()` neutralisé**. Tout caller qui appelle cette fonction au runtime (même rare) s'attend à ce que les Stripe price IDs soient peuplés. Solution : Task 5 garde la fonction mais ne fait que log. Les Stripe IDs doivent être seed-és via env var → admin endpoint, ou directement dans le SQL d'init. **Prévoir un seed initial des Stripe price IDs dans `seed_plans_db.py`** lisant les env vars `STRIPE_PRICE_PRO_LIVE` etc. Si l'utilisateur confirme, ajouter ce comportement à Task 3.
+- **Risque 2 : double cache (Redis registry + sync local)**. Si l'invalidation du sync local échoue silencieusement (e.g. boot vide), un caller sync peut voir des stale data. Mitigation : Task 6 fait `refresh_plan_cache` au boot ET à chaque mutation admin. Test E2E Task 11 couvre le scénario.
+- **Risque 3 : performance N+1 sur `Plan.features`**. Mitigé par `lazy="selectin"` (Task 1). Test : la query dans `_load_from_db` doit faire 2 requêtes SQL (1 plans + 1 features), pas N+1.
+
+---
+
+## Execution Handoff
+
+**Plan complet et sauvegardé. Deux options d'exécution :**
+
+**1. Subagent-Driven (recommandé)** — Je dispatch un subagent frais par task, review entre chaque task, itération rapide.
+
+**2. Inline Execution** — Exécution batch dans cette session avec checkpoints.
+
+**Avant l'exécution, attendre la réponse aux 3 questions de la Self-Review (Q1 admin UI, Q2 routage A/B, Q3 grandfathering) pour ne pas fragmenter le travail.**
+
+**Quelle approche ?**

--- a/docs/superpowers/plans/2026-04-29-posthog-events-complets.md
+++ b/docs/superpowers/plans/2026-04-29-posthog-events-complets.md
@@ -1,0 +1,1852 @@
+# PostHog Events Complets — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Sub-agent model:** All Agent invocations MUST use `model: claude-opus-4-7[1m]` (perma rule from user memory).
+
+**Goal:** Étendre `frontend/src/services/analytics.ts` avec 18 nouveaux events PostHog type-safe, un identify enrichi (plan, signup_date, is_legacy_pricing, analyses_count) et des side-effects automatiques sur les events de billing, pour fermer le gap "sans data on pilote à l'aveugle" identifié par l'audit Kimi du 2026-04-29.
+
+**Architecture:** Nouveau fichier `analytics.types.ts` contenant `EventPayloadMap` (interface mappant chaque event name → payload schema). Le service `analytics.ts` reste rétro-compatible (`capture()` et `setUserProperties()` non typés conservés) et ajoute deux helpers typés `captureTyped<E>()` et `setUserPropertiesTyped()`. Les events `payment_completed` et `subscription_cancelled` déclenchent automatiquement un update du user property `plan` via une side-effect intégrée. Le hook existant `useAnalytics` est étendu avec une méthode `track<E>()` typée, et `trackLogin` change de signature pour porter le payload identify enrichi. Les events bloqués par d'autres plans (pricing-v2, edge-tts, voice-packs) sont câblés mais commentés avec un marqueur `// TODO uncomment after <plan-name> merge`.
+
+**Tech Stack:** TypeScript 5 strict + React 18 + Vite 5 + posthog-js + Vitest + @testing-library/react. Pas de changement backend.
+
+**Spec sources:**
+
+- Audit Kimi 2026-04-29 : "Phase 4 — Observabilité"
+- Plans dépendants : `docs/superpowers/plans/2026-04-29-RELEASE-ORCHESTRATION.md` (commit `021e4bf1`), `docs/superpowers/plans/2026-04-29-elevenlabs-voice-packs.md`, `docs/superpowers/plans/2026-04-29-pricing-v2-stripe-grandfathering.md`, `docs/superpowers/plans/2026-04-29-edge-tts-gratuit.md`
+
+---
+
+## Contexte préalable
+
+### État actuel (vérifié 2026-04-29)
+
+**Service analytics existant** (`frontend/src/services/analytics.ts`, 184 lignes) :
+
+- PostHog (`posthog-js`) déjà intégré, RGPD-compliant
+- Init guard : `hasAnalyticsConsent()` lu depuis `components/CookieBanner`
+- Listener `cookie-consent-updated` pour init/shutdown dynamique
+- API publique : `analytics.init()`, `identify(userId, traits)`, `reset()`, `capture(event, properties)`, `pageview(path?)`, `setUserProperties(props)`, `isFeatureEnabled(flag)`
+- Init dans `frontend/src/App.tsx` ligne 1019 (`useEffect(() => { analytics.init(); }, [])`)
+
+**Constantes existantes** (`AnalyticsEvents` const-as-as-const, lignes 149-180) :
+
+```
+SIGNUP, LOGIN, LOGOUT,
+VIDEO_ANALYZED, VIDEO_ANALYSIS_STARTED, VIDEO_ANALYSIS_FAILED,
+CHAT_MESSAGE_SENT, CHAT_SESSION_STARTED,
+EXPORT_CREATED,
+UPGRADE_STARTED, UPGRADE_COMPLETED, PLAN_CHANGED,
+STUDY_TOOL_USED, FACTCHECK_VIEWED, PLAYLIST_ANALYZED,
+ERROR_OCCURRED, API_ERROR
+```
+
+**Hook existant** (`frontend/src/hooks/useAnalytics.ts`, 81 lignes) — déjà présent contrairement à la mission initiale. Expose `trackSignup`, `trackLogin(userId, plan, method)`, `trackLogout`, `trackAnalysis`, `trackAnalysisStarted`, `trackExport`, `trackUpgrade`, `trackChat`, `trackError`, et `capture` brut. **Le shape `trackLogin` actuel sera modifié** — la signature va devenir `trackLogin(payload: LoginPayload)` (breaking change interne, 0 callers actuels selon `grep "useAnalytics()" frontend/src/`).
+
+**Auth flow** :
+
+- `frontend/src/contexts/AuthContext.tsx` (34 lignes) : Provider minimal avec `value` injecté par le parent. **N'expose PAS encore de `trackLogin`** — c'est `useAuth.ts` (hook) qui détient la logique de login.
+- `frontend/src/hooks/useAuth.ts` (691 lignes) : `login()` ligne 394, `loginWithGoogle()` ligne 422, `logout()` ligne 506. Aucun appel analytics actuellement.
+- `frontend/src/pages/Login.tsx` ligne 211 : `await loginWithGoogle()`
+- `frontend/src/pages/AuthCallback.tsx` ligne 230 : `window.dispatchEvent(new CustomEvent("auth:success"))` après OAuth flow réussi
+
+**User type** (`frontend/src/services/api.ts` ligne 28) :
+
+```typescript
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  email_verified: boolean;
+  plan:
+    | "free"
+    | "plus"
+    | "pro"
+    | "etudiant"
+    | "starter"
+    | "student"
+    | "team"
+    | "expert"
+    | "unlimited";
+  credits: number;
+  credits_monthly: number;
+  is_admin: boolean;
+  avatar_url?: string;
+  created_at: string; // ✅ utilisable comme signup_date
+  total_videos: number; // ✅ utilisable comme analyses_count
+  // ...
+}
+```
+
+**Voice analytics existant** (`frontend/src/components/voice/voiceAnalytics.ts`, 132 lignes) — **CONFLIT À NOTER** : utilise des event names DIFFÉRENTS (`voice_chat_started`, `voice_chat_ended`, `voice_chat_quota_warning`, etc.) que ceux demandés par la mission (`voice_call_started`, `voice_call_ended`, `voice_quota_exhausted`). Le plan ajoute les NOUVEAUX events sans toucher au fichier existant — une consolidation est listée comme question à l'utilisateur (D5) en self-review.
+
+**Tests existants** :
+
+- `frontend/src/services/__tests__/analytics.test.ts` (76 lignes) : 5 tests RGPD + AnalyticsEvents
+- `frontend/src/hooks/__tests__/useAuth.test.ts` + `useAuth-complete.test.ts` (existants, ne pas régresser)
+- `frontend/src/__tests__/setup.ts` + `test-utils.tsx` disponibles
+- Pas encore de `frontend/src/hooks/__tests__/useAnalytics.test.ts`
+
+### Gap audit Kimi vs constantes existantes
+
+Le mapping des 18 events à ajouter, comparé aux 17 constantes existantes :
+
+| Catégorie | Event                           | Existe déjà ?                                                                |
+| --------- | ------------------------------- | ---------------------------------------------------------------------------- |
+| Homepage  | `hero_analysis_clicked`         | ❌ ajouter                                                                   |
+| Homepage  | `signup_started`                | ❌ ajouter (différent de `SIGNUP`/`user_signup` qui est l'**aboutissement**) |
+| Homepage  | `pricing_viewed`                | ❌ ajouter                                                                   |
+| Pricing   | `pricing_toggle_changed`        | ❌ ajouter (BLOCKED-BY pricing-v2)                                           |
+| Pricing   | `plan_selected`                 | ❌ ajouter                                                                   |
+| Pricing   | `checkout_started`              | ❌ ajouter (similaire à `UPGRADE_STARTED` mais nouvelle convention)          |
+| Pricing   | `payment_completed`             | ❌ ajouter (similaire à `UPGRADE_COMPLETED`, conserver les deux)             |
+| Pricing   | `subscription_cancelled`        | ❌ ajouter                                                                   |
+| Dashboard | `analysis_started`              | ⚠️ `VIDEO_ANALYSIS_STARTED` existe — alias pour conformité audit             |
+| Dashboard | `analysis_completed`            | ⚠️ `VIDEO_ANALYZED` existe — alias                                           |
+| Dashboard | `feature_used`                  | ❌ ajouter (nouveau bucket générique)                                        |
+| Dashboard | `export_generated`              | ⚠️ `EXPORT_CREATED` existe — alias                                           |
+| Trial     | `trial_started`                 | ❌ ajouter (BLOCKED-BY pricing-v2)                                           |
+| Trial     | `trial_converted`               | ❌ ajouter (BLOCKED-BY pricing-v2)                                           |
+| Voice     | `voice_call_started`            | ❌ ajouter (BLOCKED-BY edge-tts + voice-packs)                               |
+| Voice     | `voice_call_ended`              | ❌ ajouter (BLOCKED-BY)                                                      |
+| Voice     | `voice_quota_exhausted`         | ❌ ajouter (BLOCKED-BY)                                                      |
+| Voice     | `voice_pack_purchase_started`   | ❌ ajouter (BLOCKED-BY voice-packs)                                          |
+| Voice     | `voice_pack_purchase_completed` | ❌ ajouter (BLOCKED-BY voice-packs)                                          |
+
+**Décision** : pour les 4 events qui chevauchent (`analysis_started`, `analysis_completed`, `export_generated` vs constantes existantes), on garde les **deux noms** (anciens + nouveaux) côté code mais on n'envoie que le NOUVEAU en double-runtime à PostHog (un seul event par occurrence). Les anciens noms sont conservés dans `AnalyticsEvents` const pour rétro-compat avec d'éventuels callers actuels (à grepper en tâche 13).
+
+### Dépendances externes (plans batch 2 parallèles)
+
+| Event(s) bloqués                                                                                                    | Plan dépendant                                   | Action                                                                |
+| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------- |
+| `pricing_toggle_changed`, `plan_selected`, `checkout_started`, `subscription_cancelled.reason`, `is_legacy_pricing` | `2026-04-29-pricing-v2-stripe-grandfathering.md` | Code écrit + commenté avec `// TODO uncomment after pricing-v2 merge` |
+| `trial_started`, `trial_converted`                                                                                  | `2026-04-29-pricing-v2-stripe-grandfathering.md` | idem                                                                  |
+| `voice_call_started.provider`, `voice_call_ended.provider`                                                          | `2026-04-29-edge-tts-gratuit.md`                 | Champ `provider: 'edge_tts' \| 'elevenlabs'` commenté                 |
+| `voice_pack_purchase_started`, `voice_pack_purchase_completed`                                                      | `2026-04-29-elevenlabs-voice-packs.md`           | Code commenté                                                         |
+
+**Stratégie** : on écrit toute l'infrastructure **maintenant** (types, helpers, tests RGPD), on câble tous les call sites **maintenant**, on **commente** uniquement les call sites des plans non-encore-mergés avec un marker grep-able `// TODO[posthog-blocked]: pricing-v2 ` (etc.). Au merge des plans bloquants, un seul `grep -rn "TODO\[posthog-blocked\]" frontend/src/` permet de tout décommenter en une passe.
+
+---
+
+## File Structure
+
+### Files créés
+
+| Fichier                                             | Responsabilité                                                                           | BLOCKED-BY |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------- |
+| `frontend/src/services/analytics.types.ts`          | `EventPayloadMap` interface, `LoginIdentifyPayload`, types union plan                    | —          |
+| `frontend/src/hooks/__tests__/useAnalytics.test.ts` | Vitest hook : trackLogin enrichi, track\<E\>() typé, RGPD guard                          | —          |
+| `frontend/src/__tests__/landing-hero-cta.test.tsx`  | E2E mount LandingPage + click hero CTA + assert posthog.capture('hero_analysis_clicked') | —          |
+
+### Files modifiés
+
+| Fichier                                                                | Changement                                                                                                                                                                                                                                    | BLOCKED-BY                               |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `frontend/src/services/analytics.ts`                                   | Ajouter 14 nouvelles constantes dans `AnalyticsEvents` ; ajouter `captureTyped<E>()`, `setUserPropertiesTyped()` ; side-effects auto sur `payment_completed` (set plan) et `subscription_cancelled` (reset plan='free')                       | —                                        |
+| `frontend/src/services/__tests__/analytics.test.ts`                    | Étendre — RGPD guard global sur les 18 events + tests des side-effects                                                                                                                                                                        | —                                        |
+| `frontend/src/hooks/useAnalytics.ts`                                   | Refactor `trackLogin` (signature payload-objet) + ajouter `track<E>()` typé + `trackHeroClick`, `trackSignupStarted`, `trackPricingViewed`, `trackFeatureUsed`, `trackExportGenerated`, `trackPaymentCompleted`, `trackSubscriptionCancelled` | —                                        |
+| `frontend/src/hooks/useAuth.ts`                                        | Appeler `trackLogin(...)` avec payload enrichi dans `login()` (succès) et `loginWithGoogle()` (succès)                                                                                                                                        | —                                        |
+| `frontend/src/pages/AuthCallback.tsx`                                  | Appeler `trackLogin(...)` après `loadProfileWithRetry()` succès dans le flux OAuth                                                                                                                                                            | —                                        |
+| `frontend/src/pages/LandingPage.tsx`                                   | Hero CTA "Analyser" → `trackHeroClick({ has_url })` ; CTAs login/register → `trackSignupStarted({ source })` ; lien Pricing → `trackPricingViewed({ from: 'homepage' })`                                                                      | —                                        |
+| `frontend/src/pages/UpgradePage.tsx`                                   | Toggle annuel → `pricing_toggle_changed` ; CTA card → `plan_selected` ; checkout → `checkout_started` (commentés `TODO[posthog-blocked]: pricing-v2`)                                                                                         | pricing-v2                               |
+| `frontend/src/pages/PaymentSuccess.tsx`                                | `trackPaymentCompleted({ plan, amount_cents, is_annual })` + `setUserPropertiesTyped({ plan })` (side-effect auto via `captureTyped`)                                                                                                         | —                                        |
+| `frontend/src/pages/MyAccount.tsx`                                     | Cancel subscription → `trackSubscriptionCancelled({ plan, days_active, reason? })`                                                                                                                                                            | partiel : `reason` BLOCKED-BY pricing-v2 |
+| `frontend/src/store/analysisStore.ts`                                  | `startAnalysis()` → `analytics.captureTyped('analysis_started', ...)` ; `completeAnalysis()` → `analysis_completed`                                                                                                                           | —                                        |
+| `frontend/src/components/AnalysisHub/SynthesisTab.tsx`                 | export click → `trackExportGenerated({ format, plan })` (sur le path déjà identifié)                                                                                                                                                          | —                                        |
+| `frontend/src/components/analysis/ExportMenu.tsx`                      | export click → `trackExportGenerated`                                                                                                                                                                                                         | —                                        |
+| `frontend/src/components/analysis/AnalysisActionBar.tsx`               | export click → `trackExportGenerated`                                                                                                                                                                                                         | —                                        |
+| `frontend/src/pages/History.tsx` (lignes 892, 2748)                    | export click → `trackExportGenerated`                                                                                                                                                                                                         | —                                        |
+| `frontend/src/pages/VoiceCallPage.tsx`                                 | `voice_call_started` (avec `provider`, commenté), `voice_call_ended`, `voice_quota_exhausted` (commentés)                                                                                                                                     | edge-tts + voice-packs                   |
+| `frontend/src/components/voice/VoicePacksWidget.tsx` (path à vérifier) | `voice_pack_purchase_started`, `voice_pack_purchase_completed` (commentés)                                                                                                                                                                    | voice-packs                              |
+
+### Total file impact
+
+- **3 fichiers créés**
+- **15 fichiers modifiés** (dont 6 BLOCKED en tout ou partie)
+
+---
+
+## Tasks
+
+### Task 1: Type safety — créer `analytics.types.ts`
+
+**Files:**
+
+- Create: `frontend/src/services/analytics.types.ts`
+
+- [ ] **Step 1: Write the file**
+
+```typescript
+// frontend/src/services/analytics.types.ts
+/**
+ * 📊 EventPayloadMap — Type-safety pour les events PostHog
+ *
+ * Maps event name → payload schema strict. Utilisé par :
+ *   analytics.captureTyped<'hero_analysis_clicked'>('hero_analysis_clicked', { has_url: true })
+ *
+ * Si vous ajoutez un event, déclarez-le ici en PREMIER.
+ */
+
+// ─── Plan enum (aligné avec User['plan']) ─────────────────────────────────────
+export type AnalyticsPlan =
+  | "free"
+  | "pro"
+  | "expert"
+  | "starter"
+  | "etudiant"
+  | "student"
+  | "team"
+  | "plus"
+  | "unlimited";
+
+// ─── Identify payload (post-login enrichi) ────────────────────────────────────
+export interface LoginIdentifyPayload {
+  email: string;
+  plan: AnalyticsPlan;
+  signup_date: string; // ISO 8601
+  is_legacy_pricing: boolean; // BLOCKED-BY pricing-v2 — false par défaut
+  analyses_count: number;
+}
+
+// ─── User property updates ────────────────────────────────────────────────────
+export interface UserPropertyMap {
+  email: string;
+  plan: AnalyticsPlan;
+  signup_date: string;
+  is_legacy_pricing: boolean;
+  analyses_count: number;
+}
+
+// ─── Event payload map ────────────────────────────────────────────────────────
+export interface EventPayloadMap {
+  // Homepage (3)
+  hero_analysis_clicked: { has_url: boolean };
+  signup_started: { source: "header" | "hero" | "cta_bottom" | "pricing" };
+  pricing_viewed: { from: "homepage" | "dashboard" | "extension" };
+
+  // Pricing (5) — BLOCKED-BY pricing-v2
+  pricing_toggle_changed: { is_yearly: boolean };
+  plan_selected: {
+    plan: "free" | "pro" | "expert";
+    is_annual: boolean;
+    has_trial: boolean;
+  };
+  checkout_started: {
+    plan: "free" | "pro" | "expert";
+    price_cents: number;
+    is_annual: boolean;
+  };
+  payment_completed: {
+    plan: "free" | "pro" | "expert";
+    amount_cents: number;
+    is_annual: boolean;
+  };
+  subscription_cancelled: {
+    plan: AnalyticsPlan;
+    days_active: number;
+    reason?: string;
+  };
+
+  // Dashboard (4)
+  analysis_started: {
+    platform: "youtube" | "tiktok";
+    duration_category: string;
+    has_account: boolean;
+  };
+  analysis_completed: {
+    platform: "youtube" | "tiktok";
+    word_count: number;
+    has_factcheck: boolean;
+  };
+  feature_used: {
+    feature:
+      | "chat"
+      | "factcheck"
+      | "flashcards"
+      | "mindmap"
+      | "export"
+      | "debate"
+      | "voice_call";
+  };
+  export_generated: {
+    format: "pdf" | "markdown" | "text";
+    plan: AnalyticsPlan;
+  };
+
+  // Trial (2) — BLOCKED-BY pricing-v2
+  trial_started: { plan: "pro" | "expert"; source: string };
+  trial_converted: { plan: "pro" | "expert"; days_to_convert: number };
+
+  // Voice (5) — BLOCKED-BY edge-tts + voice-packs
+  voice_call_started: {
+    provider: "edge_tts" | "elevenlabs";
+    plan: AnalyticsPlan;
+  };
+  voice_call_ended: {
+    provider: "edge_tts" | "elevenlabs";
+    duration_seconds: number;
+    ended_reason: "user" | "quota" | "error";
+  };
+  voice_quota_exhausted: {
+    type: "monthly_allowance" | "lifetime_trial" | "purchased";
+  };
+  voice_pack_purchase_started: { pack_slug: string };
+  voice_pack_purchase_completed: {
+    pack_slug: string;
+    minutes: number;
+    price_cents: number;
+  };
+}
+
+export type AnalyticsEventName = keyof EventPayloadMap;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: PASS (no errors introduced — fichier autonome).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/services/analytics.types.ts
+git commit -m "feat(analytics): add EventPayloadMap type-safe schema for 18 PostHog events"
+```
+
+---
+
+### Task 2: Étendre `analytics.ts` avec helpers typés + side-effects (TDD)
+
+**Files:**
+
+- Modify: `frontend/src/services/analytics.ts`
+- Test: `frontend/src/services/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (extend existing)
+
+Append to `frontend/src/services/__tests__/analytics.test.ts` :
+
+```typescript
+describe("captureTyped (type-safe wrapper)", () => {
+  it("should call posthog.capture with the same args as capture()", () => {
+    mockHasConsent.mockReturnValue(true);
+    // Force initialized via opt-in (init guard)
+    analytics.init();
+    analytics.captureTyped("hero_analysis_clicked", { has_url: true });
+    expect(posthog.capture).toHaveBeenCalledWith("hero_analysis_clicked", {
+      has_url: true,
+    });
+  });
+
+  it("should NOT capture without consent", () => {
+    mockHasConsent.mockReturnValue(false);
+    analytics.captureTyped("hero_analysis_clicked", { has_url: true });
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+});
+
+describe("side-effects on billing events", () => {
+  beforeEach(() => {
+    mockHasConsent.mockReturnValue(true);
+    analytics.init();
+  });
+
+  it("should auto-update user property plan after payment_completed", () => {
+    analytics.captureTyped("payment_completed", {
+      plan: "pro",
+      amount_cents: 599,
+      is_annual: false,
+    });
+    expect(posthog.people.set).toHaveBeenCalledWith({ plan: "pro" });
+  });
+
+  it("should reset user property plan to 'free' after subscription_cancelled", () => {
+    analytics.captureTyped("subscription_cancelled", {
+      plan: "pro",
+      days_active: 42,
+    });
+    expect(posthog.people.set).toHaveBeenCalledWith({ plan: "free" });
+  });
+
+  it("should NOT trigger side-effect for non-billing events", () => {
+    analytics.captureTyped("hero_analysis_clicked", { has_url: false });
+    expect(posthog.people.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("setUserPropertiesTyped", () => {
+  it("should call posthog.people.set with typed props", () => {
+    mockHasConsent.mockReturnValue(true);
+    analytics.init();
+    analytics.setUserPropertiesTyped({ plan: "pro" });
+    expect(posthog.people.set).toHaveBeenCalledWith({ plan: "pro" });
+  });
+
+  it("should NOT set without consent", () => {
+    mockHasConsent.mockReturnValue(false);
+    analytics.setUserPropertiesTyped({ plan: "pro" });
+    expect(posthog.people.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("AnalyticsEvents — 18 new events", () => {
+  it("should expose all 18 event constants", () => {
+    expect(AnalyticsEvents.HERO_ANALYSIS_CLICKED).toBe("hero_analysis_clicked");
+    expect(AnalyticsEvents.SIGNUP_STARTED).toBe("signup_started");
+    expect(AnalyticsEvents.PRICING_VIEWED).toBe("pricing_viewed");
+    expect(AnalyticsEvents.PRICING_TOGGLE_CHANGED).toBe(
+      "pricing_toggle_changed",
+    );
+    expect(AnalyticsEvents.PLAN_SELECTED).toBe("plan_selected");
+    expect(AnalyticsEvents.CHECKOUT_STARTED).toBe("checkout_started");
+    expect(AnalyticsEvents.PAYMENT_COMPLETED).toBe("payment_completed");
+    expect(AnalyticsEvents.SUBSCRIPTION_CANCELLED).toBe(
+      "subscription_cancelled",
+    );
+    expect(AnalyticsEvents.ANALYSIS_STARTED).toBe("analysis_started");
+    expect(AnalyticsEvents.ANALYSIS_COMPLETED).toBe("analysis_completed");
+    expect(AnalyticsEvents.FEATURE_USED).toBe("feature_used");
+    expect(AnalyticsEvents.EXPORT_GENERATED).toBe("export_generated");
+    expect(AnalyticsEvents.TRIAL_STARTED).toBe("trial_started");
+    expect(AnalyticsEvents.TRIAL_CONVERTED).toBe("trial_converted");
+    expect(AnalyticsEvents.VOICE_CALL_STARTED).toBe("voice_call_started");
+    expect(AnalyticsEvents.VOICE_CALL_ENDED).toBe("voice_call_ended");
+    expect(AnalyticsEvents.VOICE_QUOTA_EXHAUSTED).toBe("voice_quota_exhausted");
+    expect(AnalyticsEvents.VOICE_PACK_PURCHASE_STARTED).toBe(
+      "voice_pack_purchase_started",
+    );
+    expect(AnalyticsEvents.VOICE_PACK_PURCHASE_COMPLETED).toBe(
+      "voice_pack_purchase_completed",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/services/__tests__/analytics.test.ts`
+Expected: FAIL with `TypeError: analytics.captureTyped is not a function` and missing constants.
+
+- [ ] **Step 3: Implement minimal code**
+
+Modify `frontend/src/services/analytics.ts` :
+
+1. After existing imports, add :
+
+```typescript
+import type {
+  EventPayloadMap,
+  UserPropertyMap,
+  AnalyticsEventName,
+} from "./analytics.types";
+```
+
+2. Inside the `analytics` object (after `setUserProperties`), add :
+
+```typescript
+  /**
+   * Tracker un événement avec payload typé (recommandé pour nouveaux events).
+   * Déclenche automatiquement les side-effects pour les events de billing.
+   */
+  captureTyped<E extends AnalyticsEventName>(event: E, properties: EventPayloadMap[E]): void {
+    if (!isInitialized || !hasAnalyticsConsent()) return;
+    posthog.capture(event, properties);
+
+    // Side-effects automatiques (billing → user property)
+    if (event === "payment_completed") {
+      const props = properties as EventPayloadMap["payment_completed"];
+      posthog.people.set({ plan: props.plan });
+    } else if (event === "subscription_cancelled") {
+      posthog.people.set({ plan: "free" });
+    }
+  },
+
+  /**
+   * Set user properties typés (sous-ensemble de UserPropertyMap autorisé).
+   */
+  setUserPropertiesTyped(properties: Partial<UserPropertyMap>): void {
+    if (!isInitialized || !hasAnalyticsConsent()) return;
+    posthog.people.set(properties);
+  },
+```
+
+3. Étendre `AnalyticsEvents` const-as-const (ligne 149) avec les 19 nouvelles entrées (18 events + alias rétrocompat) :
+
+```typescript
+export const AnalyticsEvents = {
+  // ─── Auth (existant) ──────────────────────────────────────────────────────
+  SIGNUP: "user_signup",
+  LOGIN: "user_login",
+  LOGOUT: "user_logout",
+
+  // ─── Core feature (existant) ──────────────────────────────────────────────
+  VIDEO_ANALYZED: "video_analyzed",
+  VIDEO_ANALYSIS_STARTED: "video_analysis_started",
+  VIDEO_ANALYSIS_FAILED: "video_analysis_failed",
+
+  // ─── Chat (existant) ──────────────────────────────────────────────────────
+  CHAT_MESSAGE_SENT: "chat_message_sent",
+  CHAT_SESSION_STARTED: "chat_session_started",
+
+  // ─── Export (existant) ────────────────────────────────────────────────────
+  EXPORT_CREATED: "export_created",
+
+  // ─── Billing (existant) ───────────────────────────────────────────────────
+  UPGRADE_STARTED: "upgrade_started",
+  UPGRADE_COMPLETED: "upgrade_completed",
+  PLAN_CHANGED: "plan_changed",
+
+  // ─── Engagement (existant) ────────────────────────────────────────────────
+  STUDY_TOOL_USED: "study_tool_used",
+  FACTCHECK_VIEWED: "factcheck_viewed",
+  PLAYLIST_ANALYZED: "playlist_analyzed",
+
+  // ─── Errors (existant) ────────────────────────────────────────────────────
+  ERROR_OCCURRED: "error_occurred",
+  API_ERROR: "api_error",
+
+  // ─── 🆕 Homepage (audit Kimi 2026-04-29) ──────────────────────────────────
+  HERO_ANALYSIS_CLICKED: "hero_analysis_clicked",
+  SIGNUP_STARTED: "signup_started",
+  PRICING_VIEWED: "pricing_viewed",
+
+  // ─── 🆕 Pricing (BLOCKED-BY pricing-v2) ───────────────────────────────────
+  PRICING_TOGGLE_CHANGED: "pricing_toggle_changed",
+  PLAN_SELECTED: "plan_selected",
+  CHECKOUT_STARTED: "checkout_started",
+  PAYMENT_COMPLETED: "payment_completed",
+  SUBSCRIPTION_CANCELLED: "subscription_cancelled",
+
+  // ─── 🆕 Dashboard ─────────────────────────────────────────────────────────
+  ANALYSIS_STARTED: "analysis_started",
+  ANALYSIS_COMPLETED: "analysis_completed",
+  FEATURE_USED: "feature_used",
+  EXPORT_GENERATED: "export_generated",
+
+  // ─── 🆕 Trial (BLOCKED-BY pricing-v2) ─────────────────────────────────────
+  TRIAL_STARTED: "trial_started",
+  TRIAL_CONVERTED: "trial_converted",
+
+  // ─── 🆕 Voice (BLOCKED-BY edge-tts + voice-packs) ─────────────────────────
+  VOICE_CALL_STARTED: "voice_call_started",
+  VOICE_CALL_ENDED: "voice_call_ended",
+  VOICE_QUOTA_EXHAUSTED: "voice_quota_exhausted",
+  VOICE_PACK_PURCHASE_STARTED: "voice_pack_purchase_started",
+  VOICE_PACK_PURCHASE_COMPLETED: "voice_pack_purchase_completed",
+} as const;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/services/__tests__/analytics.test.ts`
+Expected: ALL PASS (5 existing + ~10 new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/services/analytics.ts frontend/src/services/__tests__/analytics.test.ts
+git commit -m "feat(analytics): add captureTyped helper, billing side-effects, 19 new event constants"
+```
+
+---
+
+### Task 3: Tests régression RGPD globaux sur les 18 events
+
+**Files:**
+
+- Modify: `frontend/src/services/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Write the failing test** — Append a parametrized RGPD test :
+
+```typescript
+describe("RGPD compliance — global guard on 18 new events", () => {
+  const NEW_EVENTS_18: Array<{ event: keyof EventPayloadMap; payload: any }> = [
+    { event: "hero_analysis_clicked", payload: { has_url: true } },
+    { event: "signup_started", payload: { source: "header" } },
+    { event: "pricing_viewed", payload: { from: "homepage" } },
+    { event: "pricing_toggle_changed", payload: { is_yearly: false } },
+    {
+      event: "plan_selected",
+      payload: { plan: "pro", is_annual: false, has_trial: false },
+    },
+    {
+      event: "checkout_started",
+      payload: { plan: "pro", price_cents: 599, is_annual: false },
+    },
+    {
+      event: "payment_completed",
+      payload: { plan: "pro", amount_cents: 599, is_annual: false },
+    },
+    {
+      event: "subscription_cancelled",
+      payload: { plan: "pro", days_active: 30 },
+    },
+    {
+      event: "analysis_started",
+      payload: {
+        platform: "youtube",
+        duration_category: "short",
+        has_account: true,
+      },
+    },
+    {
+      event: "analysis_completed",
+      payload: { platform: "youtube", word_count: 1234, has_factcheck: true },
+    },
+    { event: "feature_used", payload: { feature: "chat" } },
+    { event: "export_generated", payload: { format: "pdf", plan: "pro" } },
+    { event: "trial_started", payload: { plan: "pro", source: "homepage" } },
+    { event: "trial_converted", payload: { plan: "pro", days_to_convert: 5 } },
+    {
+      event: "voice_call_started",
+      payload: { provider: "edge_tts", plan: "free" },
+    },
+    {
+      event: "voice_call_ended",
+      payload: {
+        provider: "edge_tts",
+        duration_seconds: 60,
+        ended_reason: "user",
+      },
+    },
+    { event: "voice_quota_exhausted", payload: { type: "monthly_allowance" } },
+    { event: "voice_pack_purchase_started", payload: { pack_slug: "30min" } },
+    {
+      event: "voice_pack_purchase_completed",
+      payload: { pack_slug: "30min", minutes: 30, price_cents: 299 },
+    },
+  ];
+
+  it.each(NEW_EVENTS_18)(
+    "should NOT capture $event without consent",
+    ({ event, payload }) => {
+      mockHasConsent.mockReturnValue(false);
+      analytics.captureTyped(event as any, payload);
+      expect(posthog.capture).not.toHaveBeenCalled();
+    },
+  );
+
+  it("should have exactly 19 entries (18 events + voice_pack_purchase_completed counted in voice 5)", () => {
+    expect(NEW_EVENTS_18.length).toBe(19);
+  });
+});
+```
+
+> Note : la mission parle de "18 events" mais le bullet voice contient 5 events (started/ended/quota_exhausted/pack_started/pack_completed). Le compte total est donc 19. On documente ce léger off-by-one dans le test pour éviter la confusion future.
+
+- [ ] **Step 2: Run tests to verify they fail (or pass if already covered)**
+
+Run: `cd frontend && npx vitest run src/services/__tests__/analytics.test.ts`
+Expected: PASS si Task 2 correctement implémentée.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/services/__tests__/analytics.test.ts
+git commit -m "test(analytics): RGPD guard regression on 19 new events"
+```
+
+---
+
+### Task 4: Identify enrichi — modifier `useAnalytics.trackLogin` shape (TDD)
+
+**Files:**
+
+- Create: `frontend/src/hooks/__tests__/useAnalytics.test.ts`
+- Modify: `frontend/src/hooks/useAnalytics.ts`
+
+- [ ] **Step 1: Write the failing test** — Create new test file :
+
+```typescript
+// frontend/src/hooks/__tests__/useAnalytics.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: vi.fn(),
+    capture: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+    isFeatureEnabled: vi.fn(() => false),
+    people: { set: vi.fn() },
+  },
+}));
+
+vi.mock("../../components/CookieBanner", () => ({
+  hasAnalyticsConsent: vi.fn(() => true),
+  hasGivenConsent: vi.fn(() => true),
+}));
+
+import posthog from "posthog-js";
+import { useAnalytics } from "../useAnalytics";
+import { analytics } from "../../services/analytics";
+
+describe("useAnalytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analytics.init(); // ensure isInitialized=true via mocked posthog
+  });
+
+  describe("trackLogin (enriched identify)", () => {
+    it("should call posthog.identify with full enriched payload", () => {
+      const { result } = renderHook(() => useAnalytics());
+      act(() => {
+        result.current.trackLogin({
+          userId: 123,
+          email: "test@deepsight.com",
+          plan: "pro",
+          signup_date: "2025-01-15T00:00:00Z",
+          is_legacy_pricing: false,
+          analyses_count: 42,
+          method: "email",
+        });
+      });
+      expect(posthog.identify).toHaveBeenCalledWith("123", {
+        email: "test@deepsight.com",
+        plan: "pro",
+        signup_date: "2025-01-15T00:00:00Z",
+        is_legacy_pricing: false,
+        analyses_count: 42,
+      });
+      expect(posthog.capture).toHaveBeenCalledWith("user_login", {
+        method: "email",
+        plan: "pro",
+      });
+    });
+  });
+
+  describe("track<E>() (typed)", () => {
+    it("should forward to analytics.captureTyped", () => {
+      const { result } = renderHook(() => useAnalytics());
+      act(() => {
+        result.current.track("hero_analysis_clicked", { has_url: true });
+      });
+      expect(posthog.capture).toHaveBeenCalledWith("hero_analysis_clicked", {
+        has_url: true,
+      });
+    });
+  });
+
+  describe("trackHeroClick / trackSignupStarted / trackPricingViewed", () => {
+    it("trackHeroClick fires hero_analysis_clicked", () => {
+      const { result } = renderHook(() => useAnalytics());
+      act(() => result.current.trackHeroClick({ has_url: false }));
+      expect(posthog.capture).toHaveBeenCalledWith("hero_analysis_clicked", {
+        has_url: false,
+      });
+    });
+
+    it("trackSignupStarted fires signup_started", () => {
+      const { result } = renderHook(() => useAnalytics());
+      act(() => result.current.trackSignupStarted("hero"));
+      expect(posthog.capture).toHaveBeenCalledWith("signup_started", {
+        source: "hero",
+      });
+    });
+
+    it("trackPricingViewed fires pricing_viewed", () => {
+      const { result } = renderHook(() => useAnalytics());
+      act(() => result.current.trackPricingViewed("homepage"));
+      expect(posthog.capture).toHaveBeenCalledWith("pricing_viewed", {
+        from: "homepage",
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/hooks/__tests__/useAnalytics.test.ts`
+Expected: FAIL with `TypeError: result.current.track is not a function` and shape mismatch on trackLogin.
+
+- [ ] **Step 3: Implement** — Replace content of `frontend/src/hooks/useAnalytics.ts` :
+
+```typescript
+/**
+ * 📊 useAnalytics — Hook pour tracker les events critiques (typé)
+ *
+ * S'utilise dans les composants pour tracker des actions utilisateur.
+ * Respecte automatiquement le consentement RGPD via le service analytics.
+ */
+
+import { useCallback } from "react";
+import { analytics, AnalyticsEvents } from "../services/analytics";
+import type {
+  EventPayloadMap,
+  AnalyticsEventName,
+  AnalyticsPlan,
+} from "../services/analytics.types";
+
+// ─── trackLogin enriched payload ──────────────────────────────────────────────
+export interface TrackLoginPayload {
+  userId: string | number;
+  email: string;
+  plan: AnalyticsPlan;
+  signup_date: string;
+  is_legacy_pricing: boolean;
+  analyses_count: number;
+  method: "email" | "google";
+}
+
+export function useAnalytics() {
+  // ─── Auth ───────────────────────────────────────────────────────────────────
+  const trackSignup = useCallback((method: "email" | "google") => {
+    analytics.capture(AnalyticsEvents.SIGNUP, { method });
+  }, []);
+
+  const trackLogin = useCallback((payload: TrackLoginPayload) => {
+    const {
+      userId,
+      email,
+      plan,
+      signup_date,
+      is_legacy_pricing,
+      analyses_count,
+      method,
+    } = payload;
+    analytics.identify(userId, {
+      email,
+      plan,
+      signup_date,
+      is_legacy_pricing,
+      analyses_count,
+    });
+    analytics.capture(AnalyticsEvents.LOGIN, { method, plan });
+  }, []);
+
+  const trackLogout = useCallback(() => {
+    analytics.capture(AnalyticsEvents.LOGOUT);
+    analytics.reset();
+  }, []);
+
+  // ─── Generic typed tracker ──────────────────────────────────────────────────
+  const track = useCallback(
+    <E extends AnalyticsEventName>(event: E, props: EventPayloadMap[E]) => {
+      analytics.captureTyped(event, props);
+    },
+    [],
+  );
+
+  // ─── Homepage ───────────────────────────────────────────────────────────────
+  const trackHeroClick = useCallback(
+    (props: EventPayloadMap["hero_analysis_clicked"]) => {
+      analytics.captureTyped("hero_analysis_clicked", props);
+    },
+    [],
+  );
+
+  const trackSignupStarted = useCallback(
+    (source: EventPayloadMap["signup_started"]["source"]) => {
+      analytics.captureTyped("signup_started", { source });
+    },
+    [],
+  );
+
+  const trackPricingViewed = useCallback(
+    (from: EventPayloadMap["pricing_viewed"]["from"]) => {
+      analytics.captureTyped("pricing_viewed", { from });
+    },
+    [],
+  );
+
+  // ─── Dashboard ──────────────────────────────────────────────────────────────
+  const trackFeatureUsed = useCallback(
+    (feature: EventPayloadMap["feature_used"]["feature"]) => {
+      analytics.captureTyped("feature_used", { feature });
+    },
+    [],
+  );
+
+  const trackExportGenerated = useCallback(
+    (props: EventPayloadMap["export_generated"]) => {
+      analytics.captureTyped("export_generated", props);
+    },
+    [],
+  );
+
+  // ─── Billing ────────────────────────────────────────────────────────────────
+  const trackPaymentCompleted = useCallback(
+    (props: EventPayloadMap["payment_completed"]) => {
+      analytics.captureTyped("payment_completed", props);
+    },
+    [],
+  );
+
+  const trackSubscriptionCancelled = useCallback(
+    (props: EventPayloadMap["subscription_cancelled"]) => {
+      analytics.captureTyped("subscription_cancelled", props);
+    },
+    [],
+  );
+
+  // ─── Legacy (pré-existant, conservé) ────────────────────────────────────────
+  const trackAnalysis = useCallback(
+    (props: {
+      videoId?: string;
+      duration?: string;
+      mode?: string;
+      model?: string;
+    }) => {
+      analytics.capture(AnalyticsEvents.VIDEO_ANALYZED, props);
+    },
+    [],
+  );
+
+  const trackAnalysisStarted = useCallback(
+    (props: { url?: string; mode?: string; model?: string }) => {
+      analytics.capture(AnalyticsEvents.VIDEO_ANALYSIS_STARTED, props);
+    },
+    [],
+  );
+
+  const trackExport = useCallback((format: string) => {
+    analytics.capture(AnalyticsEvents.EXPORT_CREATED, { format });
+  }, []);
+
+  const trackUpgrade = useCallback((fromPlan: string, toPlan: string) => {
+    analytics.capture(AnalyticsEvents.UPGRADE_STARTED, {
+      from: fromPlan,
+      to: toPlan,
+    });
+  }, []);
+
+  const trackChat = useCallback(() => {
+    analytics.capture(AnalyticsEvents.CHAT_MESSAGE_SENT);
+  }, []);
+
+  const trackError = useCallback((error: string, context?: string) => {
+    analytics.capture(AnalyticsEvents.ERROR_OCCURRED, { error, context });
+  }, []);
+
+  return {
+    // Generic typed
+    track,
+    // Auth
+    trackSignup,
+    trackLogin,
+    trackLogout,
+    // Homepage
+    trackHeroClick,
+    trackSignupStarted,
+    trackPricingViewed,
+    // Dashboard
+    trackFeatureUsed,
+    trackExportGenerated,
+    // Billing
+    trackPaymentCompleted,
+    trackSubscriptionCancelled,
+    // Legacy
+    trackAnalysis,
+    trackAnalysisStarted,
+    trackExport,
+    trackUpgrade,
+    trackChat,
+    trackError,
+    // Raw
+    capture: analytics.capture.bind(analytics),
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/hooks/__tests__/useAnalytics.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Verify no caller regression**
+
+Run: `cd frontend && grep -rn "trackLogin(" src/ --include="*.ts" --include="*.tsx"`
+Expected: 0 calls outside `useAnalytics.ts` (le seul caller à mettre à jour est dans Task 5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/hooks/useAnalytics.ts frontend/src/hooks/__tests__/useAnalytics.test.ts
+git commit -m "feat(useAnalytics): enriched trackLogin payload + typed track<E>() + 7 new helpers"
+```
+
+---
+
+### Task 5: Wire `trackLogin` dans `useAuth.ts` + `AuthCallback.tsx`
+
+**Files:**
+
+- Modify: `frontend/src/hooks/useAuth.ts`
+- Modify: `frontend/src/pages/AuthCallback.tsx`
+
+- [ ] **Step 1: Modify `useAuth.ts` — appel post-login email/password**
+
+Dans `frontend/src/hooks/useAuth.ts`, importer le hook :
+
+```typescript
+// En haut du fichier, après les imports existants :
+import { analytics } from "../services/analytics";
+```
+
+Modifier la fonction `login` (ligne 394) — après `await refreshUser(true);` :
+
+```typescript
+const login = useCallback(
+  async (email: string, password: string) => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      await authApi.login(email, password);
+      await refreshUser(true);
+
+      // 📊 Analytics — identify enrichi
+      const u = await authApi.me({ skipCache: true }).catch(() => null);
+      if (u) {
+        analytics.identify(u.id, {
+          email: u.email,
+          plan: u.plan,
+          signup_date: u.created_at,
+          is_legacy_pricing: false, // TODO[posthog-blocked]: pricing-v2 — replace with u.is_legacy_pricing
+          analyses_count: u.total_videos ?? 0,
+        });
+        analytics.capture("user_login", { method: "email", plan: u.plan });
+      }
+    } catch (error) {
+      // ... existant inchangé
+    }
+  },
+  [refreshUser],
+);
+```
+
+> Note : on évite d'utiliser `useAnalytics()` ici car on est déjà dans un hook custom — appel direct au service `analytics` pour rester simple.
+
+- [ ] **Step 2: Modify `AuthCallback.tsx` — appel post-OAuth**
+
+Dans `frontend/src/pages/AuthCallback.tsx`, ajouter import :
+
+```typescript
+import { authApi } from "../services/api";
+import { analytics } from "../services/analytics";
+```
+
+Dans `processCallback`, après `setStatus("success");` (ligne 229 et ligne 265, deux flows OAuth) :
+
+```typescript
+// 📊 Analytics — identify enrichi post-OAuth
+try {
+  const u = await authApi.me({ skipCache: true });
+  analytics.identify(u.id, {
+    email: u.email,
+    plan: u.plan,
+    signup_date: u.created_at,
+    is_legacy_pricing: false, // TODO[posthog-blocked]: pricing-v2
+    analyses_count: u.total_videos ?? 0,
+  });
+  analytics.capture("user_login", { method: "google", plan: u.plan });
+} catch {
+  /* analytics non bloquant */
+}
+```
+
+- [ ] **Step 3: Typecheck + tests**
+
+Run: `cd frontend && npm run typecheck && npx vitest run src/hooks/__tests__/`
+Expected: PASS (useAuth tests existants n'utilisent pas trackLogin → pas de régression).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/hooks/useAuth.ts frontend/src/pages/AuthCallback.tsx
+git commit -m "feat(auth): emit PostHog identify with enriched user props on login + OAuth"
+```
+
+---
+
+### Task 6: Events Homepage (3) — LandingPage CTAs
+
+**Files:**
+
+- Modify: `frontend/src/pages/LandingPage.tsx`
+
+- [ ] **Step 1: Identifier les 4 CTAs dans LandingPage.tsx**
+
+Run: `cd frontend && grep -n 'navigate.*login\|onClick.*Analyser\|onClick.*Découvrir' src/pages/LandingPage.tsx`
+
+Cibles connues (depuis grep préalable) :
+
+- Ligne 632 : `onClick={() => navigate("/login")}` → CTA login header → `signup_started({ source: 'header' })` (si tab=login) ou `source: 'header'` générique
+- Ligne 638 : `onClick={() => navigate("/login?tab=register")}` → signup CTA bottom → `signup_started({ source: 'cta_bottom' })`
+- Ligne 754 : `onClick={handleGuestAnalyze}` → hero analyze (guest) → `hero_analysis_clicked({ has_url: !!videoUrl })`
+- Ligne 866 : `onClick={() => navigate("/login?tab=register")}` → success guest → `signup_started({ source: 'hero' })`
+- Ligne 1415 : `onClick={() => navigate("/login")}` → CTA bottom → `signup_started({ source: 'cta_bottom' })`
+
+- [ ] **Step 2: Modify LandingPage.tsx — ajouter import + tracking**
+
+En haut du fichier, après les imports :
+
+```typescript
+import { useAnalytics } from "../hooks/useAnalytics";
+```
+
+Dans le composant fonctionnel, juste après `const navigate = useNavigate();` :
+
+```typescript
+const { trackHeroClick, trackSignupStarted, trackPricingViewed } =
+  useAnalytics();
+```
+
+Pour chaque onClick ciblé, wrapper l'action avec le track. Exemple ligne 754 :
+
+```tsx
+<button
+  onClick={() => {
+    trackHeroClick({ has_url: !!videoUrl });
+    handleGuestAnalyze();
+  }}
+>
+  {language === "fr" ? "Analyser" : "Analyze"}
+</button>
+```
+
+Ligne 638 :
+
+```tsx
+<button
+  onClick={() => {
+    trackSignupStarted("cta_bottom");
+    navigate("/login?tab=register");
+  }}
+>
+```
+
+Ligne 632 :
+
+```tsx
+<button
+  onClick={() => {
+    trackSignupStarted("header");
+    navigate("/login");
+  }}
+>
+```
+
+Ligne 866 :
+
+```tsx
+<button
+  onClick={() => {
+    trackSignupStarted("hero");
+    navigate("/login?tab=register");
+  }}
+>
+```
+
+Ligne 1415 :
+
+```tsx
+<button
+  onClick={() => {
+    trackSignupStarted("cta_bottom");
+    navigate("/login");
+  }}
+>
+```
+
+Si une section pricing existe sur la LandingPage avec un click vers `/upgrade`, ajouter :
+
+```tsx
+onClick={() => {
+  trackPricingViewed("homepage");
+  navigate("/upgrade");
+}}
+```
+
+> Si aucun lien pricing direct sur LandingPage, déclencher `trackPricingViewed('homepage')` au mount d'une section visible via `IntersectionObserver` est over-engineering — préférer émettre depuis `UpgradePage.tsx` (Task 7) avec `from: 'homepage'` lu depuis `document.referrer.endsWith('/')`.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/LandingPage.tsx
+git commit -m "feat(analytics): track hero_analysis_clicked + signup_started on LandingPage CTAs"
+```
+
+---
+
+### Task 7: Events Pricing (5) — UpgradePage avec placeholders BLOCKED-BY pricing-v2
+
+**Files:**
+
+- Modify: `frontend/src/pages/UpgradePage.tsx`
+
+- [ ] **Step 1: Identifier les call sites** existants (annual toggle, plan card click, checkout button)
+
+Run: `cd frontend && grep -n 'isYearly\|is_annual\|plan.*pro\|plan.*expert\|checkout' src/pages/UpgradePage.tsx | head -30`
+
+- [ ] **Step 2: Modify UpgradePage.tsx**
+
+Imports :
+
+```typescript
+import { analytics } from "../services/analytics";
+```
+
+Au mount, ajouter pageview tracking :
+
+```typescript
+useEffect(() => {
+  // pricing_viewed est déjà émis depuis LandingPage si on vient de là
+  // On émet ici si on vient du dashboard ou de l'extension
+  const referrer = document.referrer;
+  let from: "homepage" | "dashboard" | "extension" = "dashboard";
+  if (referrer.includes("/dashboard")) from = "dashboard";
+  else if (referrer.includes("chrome-extension://")) from = "extension";
+  else if (
+    referrer.endsWith("/") ||
+    referrer.endsWith(".com/") ||
+    referrer.endsWith(".com")
+  )
+    from = "homepage";
+  analytics.captureTyped("pricing_viewed", { from });
+}, []);
+```
+
+Pour le toggle annuel/mensuel, dans le handler :
+
+```typescript
+const handleAnnualToggle = (newIsYearly: boolean) => {
+  setIsYearly(newIsYearly);
+  // TODO[posthog-blocked]: pricing-v2 — uncomment when toggle UI ships
+  // analytics.captureTyped("pricing_toggle_changed", { is_yearly: newIsYearly });
+};
+```
+
+Pour le click sur une plan card :
+
+```typescript
+const handlePlanClick = (plan: "free" | "pro" | "expert") => {
+  // TODO[posthog-blocked]: pricing-v2 — uncomment when has_trial logic ships
+  // analytics.captureTyped("plan_selected", { plan, is_annual: isYearly, has_trial: false });
+  // ... logique existante
+};
+```
+
+Pour le bouton checkout :
+
+```typescript
+const handleCheckout = async (plan: "pro" | "expert") => {
+  const priceCents = isYearly
+    ? PRICE_ANNUAL_CENTS[plan]
+    : PRICE_MONTHLY_CENTS[plan];
+  // TODO[posthog-blocked]: pricing-v2 — uncomment when annual pricing ships
+  // analytics.captureTyped("checkout_started", { plan, price_cents: priceCents, is_annual: isYearly });
+  // ... appel billingApi.createCheckout existant
+};
+```
+
+> **Note BLOCKED** : `pricing_toggle_changed`, `plan_selected`, `checkout_started` restent commentés tant que pricing-v2 n'a pas mergé (le toggle annuel n'est pas encore en UI prod, `has_trial` dépend du nouveau modèle). Le marker `TODO[posthog-blocked]: pricing-v2` permet un grep -rn pour décommenter en une passe.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/UpgradePage.tsx
+git commit -m "feat(analytics): wire pricing_viewed + commented placeholders (BLOCKED-BY pricing-v2)"
+```
+
+---
+
+### Task 8: Events Conversion — PaymentSuccess + MyAccount cancel
+
+**Files:**
+
+- Modify: `frontend/src/pages/PaymentSuccess.tsx`
+- Modify: `frontend/src/pages/MyAccount.tsx`
+
+- [ ] **Step 1: Modify PaymentSuccess.tsx**
+
+Imports :
+
+```typescript
+import { useAnalytics } from "../hooks/useAnalytics";
+```
+
+Dans le composant, après détection du succès Stripe (lire le plan et l'amount depuis searchParams ou billingApi.getMyPlan) :
+
+```typescript
+const { trackPaymentCompleted } = useAnalytics();
+
+useEffect(() => {
+  if (status === "success" && planInfo) {
+    trackPaymentCompleted({
+      plan: planInfo.id as "pro" | "expert", // narrow
+      amount_cents: planInfo.price_cents,
+      is_annual: planInfo.is_annual ?? false, // TODO[posthog-blocked]: pricing-v2 — read from real data
+    });
+  }
+}, [status, planInfo, trackPaymentCompleted]);
+```
+
+> Le side-effect `posthog.people.set({ plan })` est appliqué automatiquement par `captureTyped`.
+
+- [ ] **Step 2: Modify MyAccount.tsx — cancel handler**
+
+Dans `frontend/src/pages/MyAccount.tsx` (autour de la ligne 207 `await billingApi.cancelSubscription()`) :
+
+Imports :
+
+```typescript
+import { useAnalytics } from "../hooks/useAnalytics";
+```
+
+Dans le composant :
+
+```typescript
+const { trackSubscriptionCancelled } = useAnalytics();
+```
+
+Modifier le handler cancel :
+
+```typescript
+const handleCancelSubscription = async () => {
+  if (!user) return;
+  setCancelLoading(true);
+  try {
+    const signupDate = new Date(user.created_at);
+    const daysActive = Math.floor(
+      (Date.now() - signupDate.getTime()) / 86400000,
+    );
+
+    await billingApi.cancelSubscription();
+
+    trackSubscriptionCancelled({
+      plan: user.plan as any, // narrow vers AnalyticsPlan
+      days_active: daysActive,
+      // reason: undefined, // TODO[posthog-blocked]: pricing-v2 — collect via dialog
+    });
+
+    // ... existant inchangé
+  } catch (e) {
+    // ... existant
+  } finally {
+    setCancelLoading(false);
+  }
+};
+```
+
+> Le side-effect `posthog.people.set({ plan: 'free' })` est appliqué automatiquement.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/PaymentSuccess.tsx frontend/src/pages/MyAccount.tsx
+git commit -m "feat(analytics): emit payment_completed + subscription_cancelled with auto plan side-effect"
+```
+
+---
+
+### Task 9: Events Dashboard — analysisStore + export call sites
+
+**Files:**
+
+- Modify: `frontend/src/store/analysisStore.ts`
+- Modify: `frontend/src/components/AnalysisHub/SynthesisTab.tsx`
+- Modify: `frontend/src/components/analysis/ExportMenu.tsx`
+- Modify: `frontend/src/components/analysis/AnalysisActionBar.tsx`
+- Modify: `frontend/src/pages/History.tsx` (lignes 892, 2748)
+
+- [ ] **Step 1: Modify `analysisStore.ts`**
+
+Imports en haut :
+
+```typescript
+import { analytics } from "../services/analytics";
+```
+
+Dans `startAnalysis` (ligne 223) — ajouter capture après le `set` :
+
+```typescript
+startAnalysis: (videoId: string) => {
+  set((state) => {
+    state.status = "loading";
+    state.progress = 0;
+    state.progressMessage = "";
+    state.streamingText = "";
+    state.error = null;
+    state.metadata = null;
+    state.chatMessages = [];
+  });
+
+  // 📊 Analytics
+  const platform: "youtube" | "tiktok" = videoId.includes("tiktok") ? "tiktok" : "youtube";
+  // duration_category sera mis à jour dans completeAnalysis avec le vrai metadata
+  analytics.captureTyped("analysis_started", {
+    platform,
+    duration_category: "unknown",
+    has_account: typeof window !== "undefined" && !!localStorage.getItem("access_token"),
+  });
+},
+```
+
+Dans `completeAnalysis` (ligne 258) — ajouter capture après le `set` :
+
+```typescript
+completeAnalysis: (summary: Summary) => {
+  set((state) => { /* existant */ });
+
+  // 📊 Analytics
+  const platform: "youtube" | "tiktok" = (summary.platform as any) ?? "youtube";
+  const wordCount = summary.full_digest?.split(/\s+/).length ?? 0;
+  analytics.captureTyped("analysis_completed", {
+    platform,
+    word_count: wordCount,
+    has_factcheck: !!summary.fact_check_results,
+  });
+},
+```
+
+> Note : si `state.startAnalysis` est appelé avec `_videoId` ignoré (cf. eslint-disable ligne 222), retirer le underscore et utiliser le param.
+
+- [ ] **Step 2: Modify les 5 call sites export**
+
+Pour chaque fichier `SynthesisTab.tsx`, `ExportMenu.tsx`, `AnalysisActionBar.tsx`, `History.tsx` (×2), trouver la ligne avec `videoApi.exportSummary(...)` et entourer :
+
+```typescript
+import { useAnalytics } from "../../hooks/useAnalytics"; // ajuster le path relatif
+import { useAuth } from "../../hooks/useAuth";
+
+// Dans le composant :
+const { trackExportGenerated } = useAnalytics();
+const { user } = useAuth();
+
+// Dans le handler export :
+const handleExport = async (format: "pdf" | "markdown" | "text") => {
+  trackExportGenerated({ format, plan: (user?.plan ?? "free") as any });
+  const blob = await videoApi.exportSummary(summary.id, format);
+  // ... existant
+};
+```
+
+> Si certains fichiers utilisent un `format` plus large (`docx`, `xlsx`), narrow vers les 3 valeurs de l'enum ou étendre le type `EventPayloadMap['export_generated']['format']` dans `analytics.types.ts` (édition cohérente type-only).
+
+- [ ] **Step 3: feature_used pour chat / factcheck / mindmap / debate**
+
+Identifier 4 call sites par grep :
+
+Run: `cd frontend && grep -rn 'CHAT_MESSAGE_SENT\|FACTCHECK_VIEWED\|study_tool\|debate' src/ --include="*.tsx" --include="*.ts" | head -20`
+
+Pour chaque emplacement où l'on émet déjà un legacy event (`CHAT_MESSAGE_SENT`, `FACTCHECK_VIEWED`, `STUDY_TOOL_USED`), **ajouter en plus** un `feature_used` :
+
+```typescript
+analytics.captureTyped("feature_used", { feature: "chat" }); // ou 'factcheck', 'flashcards', 'mindmap', 'debate'
+```
+
+> Stratégie : émettre en parallèle (le legacy + le nouveau) pour conserver les données historiques tout en alimentant la nouvelle vue PostHog.
+
+- [ ] **Step 4: Typecheck + tests**
+
+Run: `cd frontend && npm run typecheck && npx vitest run`
+Expected: PASS sans régression sur les ~400 tests existants.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/store/analysisStore.ts frontend/src/components/AnalysisHub/SynthesisTab.tsx frontend/src/components/analysis/ExportMenu.tsx frontend/src/components/analysis/AnalysisActionBar.tsx frontend/src/pages/History.tsx
+git commit -m "feat(analytics): emit analysis_started/completed, feature_used, export_generated on dashboard paths"
+```
+
+---
+
+### Task 10: Events Voice — placeholders BLOCKED-BY edge-tts + voice-packs
+
+**Files:**
+
+- Modify: `frontend/src/pages/VoiceCallPage.tsx`
+- Modify: `frontend/src/components/voice/voiceAnalytics.ts` (NE PAS supprimer — coexistence)
+- Modify: voice-packs widget (path à confirmer dans grep)
+
+- [ ] **Step 1: Identifier le widget voice-packs**
+
+Run: `cd frontend && grep -rn 'voice.*pack\|VoicePack\|pack_slug' src/ --include="*.tsx" --include="*.ts" | head -20`
+
+Si le widget n'existe pas encore, ajouter le hook au futur fichier dans la file-list du plan voice-packs.
+
+- [ ] **Step 2: Modify VoiceCallPage.tsx**
+
+Identifier les call sites des transitions de session voice :
+
+Run: `cd frontend && grep -n 'startVoiceCall\|endVoiceCall\|onSessionEnd\|sessionStart' src/pages/VoiceCallPage.tsx | head -20`
+
+Imports :
+
+```typescript
+import { analytics } from "../services/analytics";
+```
+
+Sur le start de session :
+
+```typescript
+const handleStartVoice = async () => {
+  // TODO[posthog-blocked]: edge-tts — replace 'elevenlabs' fallback by real provider from session metadata
+  // analytics.captureTyped("voice_call_started", {
+  //   provider: providerFromConfig, // 'edge_tts' | 'elevenlabs'
+  //   plan: (user?.plan ?? "free") as any,
+  // });
+  // ... existant
+};
+```
+
+Sur l'end de session :
+
+```typescript
+const handleEndVoice = async (reason: "user" | "quota" | "error") => {
+  // TODO[posthog-blocked]: edge-tts
+  // analytics.captureTyped("voice_call_ended", {
+  //   provider: providerFromSession,
+  //   duration_seconds: secondsElapsed,
+  //   ended_reason: reason,
+  // });
+  // ... existant
+};
+```
+
+Sur quota épuisé (utiliser le path qui appelle déjà `VoiceAnalytics.trackQuotaReached` dans `voiceAnalytics.ts`) :
+
+```typescript
+// Dans le path quotaReached existant, ajouter EN PLUS du legacy :
+analytics.captureTyped("voice_quota_exhausted", {
+  type: "monthly_allowance", // TODO[posthog-blocked]: voice-packs — narrow par contexte (lifetime_trial / purchased)
+});
+```
+
+- [ ] **Step 3: Voice packs widget**
+
+Si le widget est identifié (ex: `frontend/src/components/voice/VoicePacksWidget.tsx`), wrapper le bouton "Acheter pack" :
+
+```typescript
+const handlePackPurchase = (pack: {
+  slug: string;
+  minutes: number;
+  price_cents: number;
+}) => {
+  // TODO[posthog-blocked]: voice-packs
+  // analytics.captureTyped("voice_pack_purchase_started", { pack_slug: pack.slug });
+  // ... appel billingApi.purchasePack
+};
+```
+
+Sur callback succès :
+
+```typescript
+const onPackPurchaseSuccess = (pack: any) => {
+  // TODO[posthog-blocked]: voice-packs
+  // analytics.captureTyped("voice_pack_purchase_completed", {
+  //   pack_slug: pack.slug,
+  //   minutes: pack.minutes,
+  //   price_cents: pack.price_cents,
+  // });
+};
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/VoiceCallPage.tsx
+git commit -m "feat(analytics): wire voice_call_*/voice_quota_exhausted placeholders (BLOCKED-BY edge-tts + voice-packs)"
+```
+
+---
+
+### Task 11: Events Trial — placeholders BLOCKED-BY pricing-v2
+
+**Files:**
+
+- Modify: `frontend/src/pages/UpgradePage.tsx` (extension de Task 7)
+- Modify: `frontend/src/pages/PaymentSuccess.tsx` (extension de Task 8)
+
+- [ ] **Step 1: trial_started — bouton "Start Pro Trial" sur UpgradePage**
+
+Identifier le call site dans `UpgradePage.tsx` :
+
+Run: `cd frontend && grep -n 'startProTrial\|start_pro_trial\|trial' src/pages/UpgradePage.tsx | head -10`
+
+Wrapper le handler :
+
+```typescript
+const handleStartTrial = async (plan: "pro" | "expert") => {
+  // TODO[posthog-blocked]: pricing-v2
+  // analytics.captureTyped("trial_started", {
+  //   plan,
+  //   source: document.referrer.includes("/dashboard") ? "dashboard" : "homepage",
+  // });
+  // ... appel billingApi.startProTrial existant
+};
+```
+
+- [ ] **Step 2: trial_converted — sur PaymentSuccess si l'utilisateur convertit depuis un trial actif**
+
+Dans `PaymentSuccess.tsx`, après `trackPaymentCompleted` :
+
+```typescript
+// TODO[posthog-blocked]: pricing-v2 — détection trial_converted
+// const wasInTrial = await billingApi.wasUserInTrial(); // nouvelle API à exposer
+// if (wasInTrial) {
+//   const daysToConvert = Math.floor((Date.now() - new Date(wasInTrial.startedAt).getTime()) / 86400000);
+//   analytics.captureTyped("trial_converted", { plan: planInfo.id, days_to_convert: daysToConvert });
+// }
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd frontend && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/UpgradePage.tsx frontend/src/pages/PaymentSuccess.tsx
+git commit -m "feat(analytics): trial_started + trial_converted placeholders (BLOCKED-BY pricing-v2)"
+```
+
+---
+
+### Task 12: Test E2E `landing-hero-cta.test.tsx`
+
+**Files:**
+
+- Create: `frontend/src/__tests__/landing-hero-cta.test.tsx`
+
+- [ ] **Step 1: Write the test**
+
+```tsx
+// frontend/src/__tests__/landing-hero-cta.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: vi.fn(),
+    capture: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+    isFeatureEnabled: vi.fn(() => false),
+    people: { set: vi.fn() },
+  },
+}));
+
+vi.mock("../components/CookieBanner", () => ({
+  hasAnalyticsConsent: vi.fn(() => true),
+  hasGivenConsent: vi.fn(() => true),
+  CookieBanner: () => null,
+}));
+
+// Mock api pour éviter les vrais calls
+vi.mock("../services/api", () => ({
+  authApi: { me: vi.fn(), login: vi.fn(), loginWithGoogle: vi.fn() },
+  videoApi: { analyzeVideo: vi.fn(), getGuestDemo: vi.fn() },
+  billingApi: { getMyPlan: vi.fn() },
+  api: {},
+  ApiError: class ApiError extends Error {},
+  setTokens: vi.fn(),
+  clearTokens: vi.fn(),
+  getAccessToken: vi.fn(() => null),
+  getRefreshToken: vi.fn(() => null),
+}));
+
+import posthog from "posthog-js";
+import { analytics } from "../services/analytics";
+import LandingPage from "../pages/LandingPage";
+
+describe("LandingPage hero CTA — analytics integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analytics.init();
+  });
+
+  it("should fire hero_analysis_clicked on hero analyze button click", async () => {
+    render(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    );
+
+    // Cible le bouton hero "Analyser" / "Analyze"
+    const analyzeButton = await screen.findByRole("button", {
+      name: /analyser|analyze/i,
+    });
+    fireEvent.click(analyzeButton);
+
+    await waitFor(() => {
+      expect(posthog.capture).toHaveBeenCalledWith(
+        "hero_analysis_clicked",
+        expect.objectContaining({ has_url: expect.any(Boolean) }),
+      );
+    });
+  });
+
+  it("should fire signup_started on register CTA click", async () => {
+    render(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    );
+
+    // Cible un CTA register (texte "Inscription" / "Register" / "Get started")
+    const buttons = await screen.findAllByRole("button");
+    const registerButton = buttons.find((b) =>
+      /inscription|register|commencer|sign\s*up|get started/i.test(
+        b.textContent ?? "",
+      ),
+    );
+    expect(registerButton).toBeDefined();
+    fireEvent.click(registerButton!);
+
+    await waitFor(() => {
+      expect(posthog.capture).toHaveBeenCalledWith(
+        "signup_started",
+        expect.objectContaining({
+          source: expect.stringMatching(/header|hero|cta_bottom|pricing/),
+        }),
+      );
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify**
+
+Run: `cd frontend && npx vitest run src/__tests__/landing-hero-cta.test.tsx`
+Expected: PASS (le test peut nécessiter d'ajuster le selector si LandingPage utilise des `<a>` plutôt que `<button>`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/__tests__/landing-hero-cta.test.tsx
+git commit -m "test(analytics): E2E LandingPage hero CTA fires hero_analysis_clicked + signup_started"
+```
+
+---
+
+### Task 13: Vérification globale + lint + build
+
+**Files:** aucun (verification only)
+
+- [ ] **Step 1: Audit des `analytics.capture` legacy non typés**
+
+Run: `cd frontend && grep -rn "analytics\.capture(" src/ --include="*.ts" --include="*.tsx"`
+Expected output : noter les emplacements qui n'utilisent PAS `captureTyped`. Document non-bloquant — migration progressive future.
+
+- [ ] **Step 2: Audit des marqueurs BLOCKED**
+
+Run: `cd frontend && grep -rn "TODO\[posthog-blocked\]" src/ --include="*.ts" --include="*.tsx"`
+Expected : ~12 marqueurs (5 pricing-v2 + 4 voice-packs/edge-tts + 3 voice + 0 ou 2 trial selon implémentation).
+
+> Stocker la liste dans le PR description pour le merge ordering futur.
+
+- [ ] **Step 3: Lint**
+
+Run: `cd frontend && npm run lint`
+Expected: PASS (warnings tolérés, errors zéro).
+
+- [ ] **Step 4: Typecheck final**
+
+Run: `cd frontend && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Tests complets**
+
+Run: `cd frontend && npx vitest run`
+Expected: ~410+ tests (400 existants + ~10 nouveaux), tous PASS.
+
+- [ ] **Step 6: Build production**
+
+Run: `cd frontend && npm run build`
+Expected: succès, bundle généré dans `dist/`.
+
+- [ ] **Step 7: Commit final**
+
+```bash
+git commit --allow-empty -m "chore(analytics): verification pass — 18 events wired, RGPD-compliant, build green"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage
+
+| Élément spec mission                                                           | Couvert par                       | Statut                                                                                                                    |
+| ------------------------------------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 18 events typés (3 homepage + 5 pricing + 4 dashboard + 2 trial + 4 voice)     | Tasks 1, 6, 7, 8, 9, 10, 11       | ✅ (note : 19 events au total — voir Task 3 step 1)                                                                       |
+| EventPayloadMap type-safe                                                      | Task 1                            | ✅                                                                                                                        |
+| `captureTyped<E>()` rétro-compat                                               | Task 2                            | ✅ (`capture` original conservé)                                                                                          |
+| `setUserPropertiesTyped`                                                       | Task 2                            | ✅                                                                                                                        |
+| Side-effects auto sur `payment_completed` + `subscription_cancelled`           | Task 2                            | ✅                                                                                                                        |
+| Identify enrichi (email, plan, signup_date, is_legacy_pricing, analyses_count) | Task 4 (shape) + Task 5 (wire)    | ✅                                                                                                                        |
+| Hook `useAnalytics()` typé                                                     | Task 4 (existait déjà, refactoré) | ✅                                                                                                                        |
+| `trackLogin` shape changé (breaking, doc)                                      | Task 4 step 3                     | ✅                                                                                                                        |
+| Wire AuthContext / Login / AuthCallback                                        | Task 5                            | ✅ (note : on touche `useAuth.ts` plutôt que `AuthContext.tsx` car la logique vit là — choix justifié dans Task 5 step 1) |
+| LandingPage CTAs                                                               | Task 6                            | ✅                                                                                                                        |
+| UpgradePage events (BLOCKED)                                                   | Task 7                            | ✅ avec marqueurs                                                                                                         |
+| PaymentSuccess + Cancel                                                        | Task 8                            | ✅                                                                                                                        |
+| analysisStore + export call sites                                              | Task 9                            | ✅ (5 call sites couverts)                                                                                                |
+| VoiceCallPage + voice-packs widget (BLOCKED)                                   | Task 10                           | ✅ avec marqueurs                                                                                                         |
+| Trial events (BLOCKED)                                                         | Task 11                           | ✅ avec marqueurs                                                                                                         |
+| Test RGPD étendu                                                               | Task 3                            | ✅                                                                                                                        |
+| Test useAnalytics hook                                                         | Task 4 step 1                     | ✅                                                                                                                        |
+| Test E2E `landing-hero-cta`                                                    | Task 12                           | ✅                                                                                                                        |
+
+### 2. Placeholder scan
+
+- ✅ Pas de "TBD"/"implement later" — tous les snippets sont complets.
+- ✅ Tous les marker `TODO[posthog-blocked]` sont **intentionnels** et grep-ables (= pas un placeholder de plan, mais un decoupling explicite).
+- ✅ Toutes les commandes ont leur Expected output.
+
+### 3. Type consistency
+
+- `EventPayloadMap` (Task 1) → `captureTyped<E extends AnalyticsEventName>` (Task 2) → `track<E>()` hook (Task 4) — **chaîne typée cohérente**.
+- `LoginIdentifyPayload` Task 1 ≠ `TrackLoginPayload` Task 4 (l'un est le payload identify pur, l'autre ajoute `userId` et `method`) — **différence intentionnelle, documentée**.
+- `AnalyticsPlan` (Task 1) couvre l'union plan élargie de `User['plan']` (incluant aliases legacy `etudiant`/`student`/`team`/`unlimited`/`plus`/`starter`) → cohérent avec `frontend/src/services/api.ts:33-42`.
+
+### Décisions à confirmer avec l'utilisateur
+
+| ID     | Décision                                                                                                                               | Recommandation par défaut                                                                                                                                                                       |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1** | PostHog Python SDK côté backend pour events server-side (ex: webhook Stripe → `payment_completed` source-of-truth) ?                   | **Hors scope V1**. Backend déjà émet vers la table `AnalyticsEvent` ; mirror PostHog peut venir en V2.                                                                                          |
+| **D2** | Activer `disable_session_recording: false` (currently true ligne 45) pour funnels visuels ?                                            | **Garder désactivé** (RGPD-friendly + coût PostHog). Ré-évaluer après 30 jours.                                                                                                                 |
+| **D3** | Utiliser `analytics.isFeatureEnabled('flag-name')` pour A/B-tester les CTAs ?                                                          | Hors scope ce plan, infra déjà prête (`isFeatureEnabled` existe ligne 139 du service).                                                                                                          |
+| **D4** | Exposer un nouveau backend field `users.subscription_started_at` pour calculer `days_active` plus fidèlement que `created_at` ?        | **Recommandé**. À ajouter dans `pricing-v2` plan (déjà BLOCKED par lui). En attendant on utilise `created_at` (proxy correct sauf changement de plan ancien).                                   |
+| **D5** | Refactor `frontend/src/components/voice/voiceAnalytics.ts` pour adopter les nouveaux noms `voice_call_*` (au lieu de `voice_chat_*`) ? | **Hors scope V1**. Coexistence acceptée. Dette à inscrire au backlog post-merge edge-tts. Nouveaux events `voice_call_started/_ended/_quota_exhausted` rajoutent un dashboard PostHog distinct. |
+
+---
+
+## Execution Handoff
+
+Plan complet et sauvegardé à `docs/superpowers/plans/2026-04-29-posthog-events-complets.md`. Deux options d'exécution :
+
+**1. Subagent-Driven (recommandé)** — dispatch fresh subagent par tâche, review entre tâches, itération rapide. Sub-agent model obligatoire : `claude-opus-4-7[1m]`.
+
+**2. Inline Execution** — exécuter dans la session courante via `superpowers:executing-plans`, batch avec checkpoints.
+
+Quelle approche ?

--- a/docs/superpowers/plans/2026-04-29-pricing-v2-stripe-grandfathering.md
+++ b/docs/superpowers/plans/2026-04-29-pricing-v2-stripe-grandfathering.md
@@ -1,0 +1,2570 @@
+# Pricing v2 — Stripe + Grandfathering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrer la grille pricing v0 (Free / Plus 4,99 € / Pro 9,99 €) vers la grille v2 (Free / Pro 8,99 € / Expert 19,99 €) avec toggle mensuel/annuel −17 %, trial 7 j sans CB pour Pro et Expert, et grandfathering des abonnés existants au prix legacy.
+
+**Architecture:** Migration Alembic 011 atomique (CASE SQL pour le rename `plus`→`pro` et `pro`→`expert`) + ajout colonne `users.is_legacy_pricing` pour figer le prix Stripe legacy des abonnés actuels. Backend hardcoded SSOT dans `plan_config.py` (8 helpers + lookups Stripe par couple `(plan, cycle)`). Frontend miroir dans `planPrivileges.ts` + nouveaux composants `BillingToggle` et `ComparisonTable` sur `UpgradePage` v9. 4 nouveaux Stripe Prices créés via script idempotent. Grille v2 reste hardcodée — la transition vers DB-driven est traitée par le plan séparé `2026-04-29-plans-db-driven.md`.
+
+**Tech Stack:** Python 3.11 + FastAPI + SQLAlchemy async + Alembic + Stripe SDK ; React 18 + TypeScript strict + Vite + Tailwind ; pytest-asyncio + Vitest + Testing Library.
+
+---
+
+## Contexte préalable
+
+### Etat v0 actuel (à migrer)
+
+Le code backend + frontend est sur **grille v0**, PAS sur la grille marketing v1 affichée dans `CLAUDE.md`. Voici ce que disent les fichiers :
+
+- `backend/src/billing/plan_config.py:22-25` : `PlanId.FREE | PLUS | PRO`
+- `backend/src/billing/plan_config.py:36-44` : `PLAN_ALIASES = {"etudiant": "plus", "starter": "plus", "expert": "pro", "team": "pro", ...}` (à inverser)
+- `backend/src/core/config.py:91-94` : `STRIPE_PRICE_PLUS_TEST/LIVE`, `STRIPE_PRICE_PRO_TEST/LIVE` (4 vars uniquement, mensuel)
+- `backend/src/billing/router.py:226-277` : `/trial-eligibility` retourne `trial_plan="plus"` hardcodé
+- `backend/src/billing/router.py:280-348` : `POST /start-pro-trial` (route fixe sur Plus, malgré son nom — bug v0)
+- `backend/src/billing/voice_quota.py:37-44` : `TOP_TIER_MONTHLY_MINUTES = 30.0` hardcodé
+- `frontend/src/config/planPrivileges.ts:8-10` : `PlanId = "free" | "plus" | "pro"`
+- `frontend/src/pages/UpgradePage.tsx` (header doc) : "Pricing 3 plans (Free / Plus / Pro). Facturation mensuelle uniquement"
+
+### Grilles distinguées
+
+| Grille                 | Free | Tier intermédiaire                      | Tier premium                                 | Cycles           |
+| ---------------------- | ---- | --------------------------------------- | -------------------------------------------- | ---------------- |
+| **v0 (code actuel)**   | 0 €  | Plus 4,99 €/mo                          | Pro 9,99 €/mo                                | mensuel          |
+| **v2 (cible ce plan)** | 0 €  | **Pro 8,99 €/mo** ou 89,90 €/an (-17 %) | **Expert 19,99 €/mo** ou 199,90 €/an (-17 %) | mensuel + annuel |
+
+### Mapping de migration
+
+```
+old "free"  → new "free"   (no change)
+old "plus"  → new "pro"    (4.99 € → 8.99 € ; legacy users grandfathered to old Stripe price 4.99)
+old "pro"   → new "expert" (9.99 € → 19.99 € ; legacy users grandfathered to old 9.99)
+```
+
+⚠️ **Migration Alembic 011** doit faire le rename atomiquement avec CASE SQL pour éviter le double-mapping (sans CASE, un `UPDATE plan='pro' WHERE plan='plus'` suivi d'un `UPDATE plan='expert' WHERE plan='pro'` transformerait les anciens Plus en Expert).
+
+### Décisions business locked (post-audit Kimi 2026-04-29)
+
+| #   | Décision                                                                                                                                    | Source      |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| H1  | Pro = 8,99 €/mo, 89,90 €/an (−17 %) ≈ 7,49 €/mo équivalent                                                                                  | Q1 Option B |
+| H2  | Expert = 19,99 €/mo, 199,90 €/an (−17 %) ≈ 16,66 €/mo équivalent                                                                            | Q1 Option B |
+| H3  | Grandfathering : tout user `stripe_subscription_id != NULL` à la migration garde son prix Stripe legacy. Reset si downgrade puis re-upgrade | Q1 + DB     |
+| H4  | Allowance ElevenLabs : Pro 30 min/mois, Expert 120 min/mois                                                                                 | Q4 + DC     |
+| H5  | Trial 7 j sans CB, accessible 1 fois par user, applicable Pro **ou** Expert                                                                 | Q1 + DD     |
+| H6  | 4 Stripe Prices créés dès la PR (mensuel + annuel × Pro + Expert)                                                                           | DA          |
+| H7  | `is_legacy_pricing` colonne sur `User` (pas table Subscription qui n'existe pas)                                                            | DB révisé   |
+| H8  | Plans restent hardcodés (`plan_config.py` + `planPrivileges.ts`) — DB-driven plan séparé                                                    | Q2 reportée |
+
+### Couplage release-train (CRITIQUE)
+
+Ce plan **doit merger ENSEMBLE** avec `2026-04-29-audit-kimi-phase-0-seo-securite.md` (à venir batch 2) sur branche commune `release/pricing-v2`. Sinon : SEO annonce 8,99 € pendant Stripe facture 5,99 € (incohérence marketing/billing).
+
+Couplage en aval :
+
+- `2026-04-29-plans-db-driven.md` est `BLOCKED-BY` ce plan (il déplacera `PLANS` du code vers la DB ; ne peut pas commencer avant que `pro`/`expert` soient les noms canoniques).
+- `2026-04-29-elevenlabs-voice-packs.md` (Alembic 010) est INDÉPENDANT — ne touche pas pricing, peut merger en parallèle dans `release/pricing-v2` si besoin.
+
+---
+
+## File Structure
+
+| Fichier                                                              | Action | Responsabilité                                                                                                                                                                                                         |
+| -------------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `backend/alembic/versions/011_pricing_v2_rename.py`                  | Create | Ajoute `users.is_legacy_pricing` + UPDATE atomique CASE rename + backfill grandfathering pour subs actifs                                                                                                              |
+| `backend/src/db/database.py`                                         | Modify | Colonne `User.is_legacy_pricing: Boolean`                                                                                                                                                                              |
+| `backend/src/billing/plan_config.py`                                 | Modify | Refactor `PlanId` → `FREE/PRO/EXPERT` + `PLAN_ALIASES` inversés (`plus`→`pro`, ancien-`pro`→`expert`) + clés `PLANS` renommées + helpers `get_price_id(plan, cycle)`, `get_voice_minutes(plan)`, dict `PLAN_PRICES_V2` |
+| `backend/src/core/config.py`                                         | Modify | 8 nouvelles env vars Stripe v2 (Pro/Expert × monthly/yearly × test/live). Conserver `STRIPE_PRICE_PLUS_*` et `STRIPE_PRICE_PRO_*` pour grandfathering                                                                  |
+| `backend/src/billing/router.py`                                      | Modify | `/trial-eligibility?plan=pro\|expert`, `POST /start-trial` (param plan), redirection legacy `/start-pro-trial`, `/plans` retourne grille v2 + cycles, `POST /create-checkout` accepte `cycle=monthly\|yearly`          |
+| `backend/src/billing/voice_quota.py`                                 | Modify | Replace constant `TOP_TIER_MONTHLY_MINUTES` par lookup `get_voice_minutes(user.plan)` (Pro 30, Expert 120) ; conserver l'alias `EXPERT_MONTHLY_MINUTES` pour rétro-compat tests existants                              |
+| `backend/scripts/seed_stripe_prices_v2.py`                           | Create | Idempotent — crée 4 Stripe Products + 4 Prices via lookup_key, output Price IDs à coller en `.env.production`                                                                                                          |
+| `backend/tests/billing/test_pricing_v2.py`                           | Create | pytest : migration rename, alias resolution, voice minutes par plan, trial pour Pro/Expert, grandfathering flag, prices par cycle                                                                                      |
+| `frontend/src/config/planPrivileges.ts`                              | Modify | Refactor `PlanId = "free"\|"pro"\|"expert"` + clés `PLAN_LIMITS`/`PLAN_FEATURES`/`PLANS_INFO` renommées + voice minutes Pro 30 / Expert 120 + aliases v0→v2 inversés                                                   |
+| `frontend/src/services/api.ts`                                       | Modify | Types `BillingCycle`, `ApiBillingPlan` + méthodes `billingApi.startTrial(plan)`, `createCheckout(plan, cycle)`, `checkTrialEligibility(plan)`                                                                          |
+| `frontend/src/pages/UpgradePage.tsx`                                 | Modify | Refonte v9 : intégration `BillingToggle` + `ComparisonTable` + 2 CTAs trial (Pro + Expert)                                                                                                                             |
+| `frontend/src/components/pricing/BillingToggle.tsx`                  | Create | Switch mensuel/annuel + badge "−17 %" / "2 mois offerts"                                                                                                                                                               |
+| `frontend/src/components/pricing/ComparisonTable.tsx`                | Create | Tableau matrice features × plans avec check / cross / valeurs numériques                                                                                                                                               |
+| `frontend/src/components/pricing/__tests__/BillingToggle.test.tsx`   | Create | Vitest : rendu, interactions, switch state, prix affichés                                                                                                                                                              |
+| `frontend/src/components/pricing/__tests__/ComparisonTable.test.tsx` | Create | Vitest : rendu features par plan, valeurs voice minutes, badges populaire                                                                                                                                              |
+
+---
+
+## Tasks
+
+### Task 1: Migration Alembic 011 — rename atomique + colonne is_legacy_pricing
+
+**Files:**
+
+- Create: `backend/alembic/versions/011_pricing_v2_rename.py`
+- Test: `backend/tests/billing/test_pricing_v2.py` (création initiale, ajouter le test ci-dessous)
+
+- [ ] **Step 1: Écrire le test pytest qui vérifie le rename atomique et le backfill is_legacy_pricing**
+
+Créer `backend/tests/billing/test_pricing_v2.py` avec ce test :
+
+```python
+"""Tests pour la migration Pricing v2 (Alembic 011)."""
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import User
+
+
+@pytest.mark.asyncio
+async def test_migration_011_rename_plans_atomic(db_session: AsyncSession):
+    """La migration doit renommer plus→pro et ancien-pro→expert sans collision.
+
+    Cas piège : un UPDATE séquentiel (plus→pro puis pro→expert) transformerait
+    les anciens Plus en Expert. La migration utilise CASE pour éviter cela.
+    """
+    # Setup : 1 user "plus" + 1 user "pro" pré-migration (état v0)
+    u_plus = User(
+        username="alice", email="alice@test.fr", password_hash="x", plan="plus",
+        stripe_subscription_id="sub_legacy_plus_001",
+    )
+    u_pro = User(
+        username="bob", email="bob@test.fr", password_hash="x", plan="pro",
+        stripe_subscription_id="sub_legacy_pro_001",
+    )
+    u_free = User(username="carol", email="carol@test.fr", password_hash="x", plan="free")
+    db_session.add_all([u_plus, u_pro, u_free])
+    await db_session.commit()
+
+    # Exécuter le rename CASE (simule l'upgrade migration)
+    await db_session.execute(text(
+        "UPDATE users SET plan = CASE "
+        "WHEN plan = 'pro' THEN 'expert' "
+        "WHEN plan = 'plus' THEN 'pro' "
+        "ELSE plan END "
+        "WHERE plan IN ('plus', 'pro')"
+    ))
+    await db_session.commit()
+
+    # Verify : Alice (plus → pro), Bob (pro → expert), Carol inchangée
+    res = await db_session.execute(select(User).order_by(User.id))
+    users = res.scalars().all()
+    assert users[0].plan == "pro", f"alice should be pro, got {users[0].plan}"
+    assert users[1].plan == "expert", f"bob should be expert, got {users[1].plan}"
+    assert users[2].plan == "free"
+
+
+@pytest.mark.asyncio
+async def test_migration_011_backfill_is_legacy_pricing(db_session: AsyncSession):
+    """Tout user avec stripe_subscription_id non null doit avoir is_legacy_pricing=True
+    après le backfill de la migration."""
+    u_paid = User(
+        username="dave", email="dave@test.fr", password_hash="x", plan="pro",
+        stripe_subscription_id="sub_legacy_pro_002",
+        is_legacy_pricing=False,
+    )
+    u_free = User(
+        username="eve", email="eve@test.fr", password_hash="x", plan="free",
+        stripe_subscription_id=None,
+        is_legacy_pricing=False,
+    )
+    db_session.add_all([u_paid, u_free])
+    await db_session.commit()
+
+    # Backfill : tout sub actif → is_legacy_pricing=True
+    await db_session.execute(text(
+        "UPDATE users SET is_legacy_pricing = TRUE "
+        "WHERE stripe_subscription_id IS NOT NULL"
+    ))
+    await db_session.commit()
+
+    res = await db_session.execute(select(User).order_by(User.id))
+    users = res.scalars().all()
+    assert users[0].is_legacy_pricing is True, "dave (paid) should be legacy"
+    assert users[1].is_legacy_pricing is False, "eve (free) should NOT be legacy"
+```
+
+- [ ] **Step 2: Run le test, vérifier qu'il échoue (colonne is_legacy_pricing absente, fixture db_session existante)**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v`
+Expected : FAIL avec `AttributeError: 'User' object has no attribute 'is_legacy_pricing'` ou `OperationalError: no such column users.is_legacy_pricing`
+
+- [ ] **Step 3: Écrire le fichier de migration 011**
+
+Créer `backend/alembic/versions/011_pricing_v2_rename.py` :
+
+```python
+"""Pricing v2 — atomic plan rename (plus→pro, pro→expert) + grandfathering flag.
+
+Revision ID: 011_pricing_v2_rename
+Revises: 010_add_conversation_digests
+Create Date: 2026-04-29
+
+Migrations:
+  1. Add ``users.is_legacy_pricing`` BOOLEAN NOT NULL DEFAULT FALSE.
+  2. ATOMIC rename via CASE SQL :
+       plus  → pro
+       pro   → expert
+     (sans CASE, un UPDATE séquentiel ferait passer les anciens Plus en Expert)
+  3. Backfill grandfathering : tout user avec stripe_subscription_id non null
+     conserve son prix Stripe legacy → is_legacy_pricing = TRUE.
+
+Downgrade : reverse rename (pro→plus, expert→pro) + drop colonne.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "011_pricing_v2_rename"
+down_revision: Union[str, None] = "010_add_conversation_digests"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Colonne grandfathering
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_legacy_pricing",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # 2. Rename atomique CASE
+    op.execute(
+        "UPDATE users SET plan = CASE "
+        "WHEN plan = 'pro' THEN 'expert' "
+        "WHEN plan = 'plus' THEN 'pro' "
+        "ELSE plan END "
+        "WHERE plan IN ('plus', 'pro')"
+    )
+
+    # 3. Backfill grandfathering : subs actifs au moment de la migration
+    op.execute(
+        "UPDATE users SET is_legacy_pricing = TRUE "
+        "WHERE stripe_subscription_id IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    # Reverse rename (expert→pro, pro→plus)
+    op.execute(
+        "UPDATE users SET plan = CASE "
+        "WHEN plan = 'expert' THEN 'pro' "
+        "WHEN plan = 'pro' THEN 'plus' "
+        "ELSE plan END "
+        "WHERE plan IN ('pro', 'expert')"
+    )
+    op.drop_column("users", "is_legacy_pricing")
+```
+
+- [ ] **Step 4: Ajouter `is_legacy_pricing` au model User**
+
+Modifier `backend/src/db/database.py` autour de la ligne 134 (après `stripe_subscription_id`) :
+
+```python
+    # Stripe
+    stripe_customer_id = Column(String(100))
+    stripe_subscription_id = Column(String(100))
+    # Pricing v2 — grandfathering: True = sub créé sous prix legacy (Plus 4.99 / Pro 9.99)
+    is_legacy_pricing = Column(Boolean, default=False, nullable=False, server_default="false")
+```
+
+- [ ] **Step 5: Appliquer la migration en dev SQLite**
+
+Run : `cd backend && alembic upgrade head`
+Expected : `INFO  [alembic.runtime.migration] Running upgrade 010_add_conversation_digests -> 011_pricing_v2_rename`
+
+- [ ] **Step 6: Run les tests, vérifier qu'ils passent**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v`
+Expected : 2 passed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/alembic/versions/011_pricing_v2_rename.py backend/src/db/database.py backend/tests/billing/test_pricing_v2.py
+git commit -m "feat(billing): add Alembic 011 atomic plan rename + is_legacy_pricing flag"
+```
+
+---
+
+### Task 2: Refactor plan_config.py — SSOT v2 (PlanId, aliases inverses, helpers)
+
+**Files:**
+
+- Modify: `backend/src/billing/plan_config.py`
+- Test: `backend/tests/billing/test_pricing_v2.py` (étendre le fichier créé en Task 1)
+
+- [ ] **Step 1: Écrire les tests pour les helpers v2**
+
+Ajouter à `backend/tests/billing/test_pricing_v2.py` :
+
+```python
+from billing.plan_config import (
+    PlanId,
+    PLAN_ALIASES,
+    PLAN_PRICES_V2,
+    normalize_plan_id,
+    get_price_id,
+    get_voice_minutes,
+)
+
+
+def test_planid_v2_enum_values():
+    assert PlanId.FREE.value == "free"
+    assert PlanId.PRO.value == "pro"
+    assert PlanId.EXPERT.value == "expert"
+    # No "plus" left in the enum
+    with pytest.raises(AttributeError):
+        _ = PlanId.PLUS  # noqa: F841
+
+
+def test_aliases_inverted():
+    """Aliases must map LEGACY names → v2 canonical."""
+    # Legacy "plus" (anciens souscripteurs) doit résoudre vers "pro" v2
+    assert normalize_plan_id("plus") == "pro"
+    # Legacy "expert" était l'alias de l'ancien "pro" v0 → reste "expert" v2
+    assert normalize_plan_id("expert") == "expert"
+    # Et "pro" canonique v2 reste "pro"
+    assert normalize_plan_id("pro") == "pro"
+    # Inconnu → free
+    assert normalize_plan_id("unknown") == "free"
+    assert normalize_plan_id(None) == "free"
+
+
+def test_voice_minutes_per_plan():
+    assert get_voice_minutes("free") == 0
+    assert get_voice_minutes("pro") == 30
+    assert get_voice_minutes("expert") == 120
+    # Alias legacy
+    assert get_voice_minutes("plus") == 30  # plus → pro → 30 min
+
+
+def test_get_price_id_by_cycle(monkeypatch):
+    """get_price_id(plan, cycle, test_mode) renvoie l'env var attendue."""
+    monkeypatch.setenv("STRIPE_PRICE_PRO_MONTHLY_TEST", "price_test_pro_m")
+    monkeypatch.setenv("STRIPE_PRICE_PRO_YEARLY_TEST", "price_test_pro_y")
+    monkeypatch.setenv("STRIPE_PRICE_EXPERT_MONTHLY_TEST", "price_test_exp_m")
+    monkeypatch.setenv("STRIPE_PRICE_EXPERT_YEARLY_TEST", "price_test_exp_y")
+
+    # Reload module pour rafraîchir le cache des env vars
+    import importlib
+    import billing.plan_config as pc
+    importlib.reload(pc)
+
+    assert pc.get_price_id("pro", "monthly", test_mode=True) == "price_test_pro_m"
+    assert pc.get_price_id("pro", "yearly", test_mode=True) == "price_test_pro_y"
+    assert pc.get_price_id("expert", "monthly", test_mode=True) == "price_test_exp_m"
+    assert pc.get_price_id("expert", "yearly", test_mode=True) == "price_test_exp_y"
+    # Free n'a pas de price
+    assert pc.get_price_id("free", "monthly", test_mode=True) is None
+    # Cycle invalide → None
+    assert pc.get_price_id("pro", "lifetime", test_mode=True) is None
+
+
+def test_plan_prices_v2_structure():
+    """PLAN_PRICES_V2 doit contenir les 4 couples (plan, cycle) → prix en cents."""
+    assert PLAN_PRICES_V2["pro"]["monthly"] == 899
+    assert PLAN_PRICES_V2["pro"]["yearly"] == 8990
+    assert PLAN_PRICES_V2["expert"]["monthly"] == 1999
+    assert PLAN_PRICES_V2["expert"]["yearly"] == 19990
+```
+
+- [ ] **Step 2: Run les tests, vérifier qu'ils échouent**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v`
+Expected : FAIL avec `AttributeError: PRO`/`EXPERT` ou `ImportError: cannot import name 'PLAN_PRICES_V2'`
+
+- [ ] **Step 3: Refactor plan_config.py — enum, aliases, structure PLANS**
+
+Modifier `backend/src/billing/plan_config.py`. Remplacer les sections existantes :
+
+**Section PlanId (lignes 22-32)** :
+
+```python
+class PlanId(str, Enum):
+    FREE = "free"
+    PRO = "pro"        # Tier intermédiaire v2 — anciennement "plus"
+    EXPERT = "expert"  # Tier premium v2 — anciennement "pro"
+
+
+PLAN_HIERARCHY: list[PlanId] = [
+    PlanId.FREE,
+    PlanId.PRO,
+    PlanId.EXPERT,
+]
+```
+
+**Section PLAN_ALIASES (lignes 34-45)** — INVERSER complètement :
+
+```python
+# Aliases rétrocompatibilité — anciens plan IDs v0/v1 → plan canonique v2
+PLAN_ALIASES: dict[str, str] = {
+    # v0 legacy
+    "plus": "pro",         # ancien Plus 4.99 € → nouveau Pro 8.99 €
+    # Anciens marketing names mappés sur v2
+    "etudiant": "pro",
+    "starter": "pro",
+    "student": "pro",
+    "equipe": "expert",
+    "team": "expert",
+    "unlimited": "expert",
+}
+```
+
+⚠️ Note : "expert" en clé du dict est REMPLACÉ par la valeur canonique de l'enum. Tout `normalize_plan_id("expert")` doit donc passer le `try: PlanId(lowered)` avec succès — pas besoin d'alias explicite.
+
+**Section PLANS dict (lignes 65-449)** : renommer les clés et mettre à jour les prix :
+
+- `PlanId.PLUS` → `PlanId.PRO` partout dans le dict (clé externe + métadonnées internes)
+- `PlanId.PRO` (ancien) → `PlanId.EXPERT` partout
+- `PLANS[PlanId.PRO]["price_monthly_cents"]` = `899` (au lieu de 499)
+- `PLANS[PlanId.PRO]["price_yearly_cents"]` = `8990` (NEW, à ajouter)
+- `PLANS[PlanId.PRO]["name"]` = `"Pro"` (au lieu de "Plus")
+- `PLANS[PlanId.PRO]["description"]` = `"L'essentiel pour apprendre mieux, plus vite"` (inchangé)
+- `PLANS[PlanId.EXPERT]["price_monthly_cents"]` = `1999` (au lieu de 999)
+- `PLANS[PlanId.EXPERT]["price_yearly_cents"]` = `19990` (NEW)
+- `PLANS[PlanId.EXPERT]["name"]` = `"Expert"` (au lieu de "Pro")
+- Renommer `voice_monthly_minutes` : `PLANS[PlanId.PRO]["limits"]["voice_monthly_minutes"]` = `30` (avant 0 sur Plus, désormais 30 sur Pro v2 — H4)
+- `PLANS[PlanId.EXPERT]["limits"]["voice_monthly_minutes"]` = `120` (avant 45 — H4)
+- Toutes les références `"unlock_plan": "plus"` → `"unlock_plan": "pro"` ; `"unlock_plan": "pro"` (ancien) → `"unlock_plan": "expert"`
+
+**Ajouter au-dessus de la section ACCESSOR FUNCTIONS (autour ligne 530)** :
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# PLAN_PRICES_V2 — Pricing v2 (8.99 / 19.99) avec cycle mensuel + annuel −17 %
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Prix en centimes (€). Annuel = mensuel × 12 × 0.833 (≈ −17 %).
+PLAN_PRICES_V2: dict[str, dict[str, int]] = {
+    "pro": {
+        "monthly": 899,    # 8.99 €
+        "yearly": 8990,    # 89.90 € → ≈ 7.49 €/mo équivalent
+    },
+    "expert": {
+        "monthly": 1999,   # 19.99 €
+        "yearly": 19990,   # 199.90 € → ≈ 16.66 €/mo équivalent
+    },
+}
+
+# Voice minutes par plan — Pricing v2 (H4)
+PLAN_VOICE_MINUTES_V2: dict[str, int] = {
+    "free": 0,
+    "pro": 30,
+    "expert": 120,
+}
+
+
+def get_voice_minutes(plan_id: str) -> int:
+    """Retourne le nombre de minutes ElevenLabs/voice par mois pour un plan v2.
+
+    Free=0, Pro=30, Expert=120. Aliases legacy résolus.
+    """
+    normalized = normalize_plan_id(plan_id)
+    return PLAN_VOICE_MINUTES_V2.get(normalized, 0)
+```
+
+**Refactor get_price_id (ligne 636) — accepter cycle** :
+
+```python
+def get_price_id(plan_id: str, cycle: str = "monthly", test_mode: bool = True) -> Optional[str]:
+    """Retourne le stripe_price_id pour un (plan, cycle) v2.
+
+    Args:
+        plan_id: "free" | "pro" | "expert" (ou alias legacy)
+        cycle: "monthly" | "yearly"
+        test_mode: True = clés Stripe TEST, False = LIVE
+
+    Returns:
+        Price ID ou None si plan free / cycle invalide / env var non set.
+    """
+    if cycle not in ("monthly", "yearly"):
+        return None
+    normalized = normalize_plan_id(plan_id)
+    if normalized == "free":
+        return None
+    suffix = "TEST" if test_mode else "LIVE"
+    env_var = f"STRIPE_PRICE_{normalized.upper()}_{cycle.upper()}_{suffix}"
+    return os.environ.get(env_var) or None
+```
+
+**Refactor init_stripe_prices (ligne 498) — charger les 8 nouvelles env vars + conserver legacy** :
+
+```python
+def init_stripe_prices() -> None:
+    """Charge les stripe_price_id v2 depuis les variables d'environnement.
+
+    Env vars v2 (nouvelles) :
+      STRIPE_PRICE_PRO_MONTHLY_TEST / _LIVE
+      STRIPE_PRICE_PRO_YEARLY_TEST  / _LIVE
+      STRIPE_PRICE_EXPERT_MONTHLY_TEST / _LIVE
+      STRIPE_PRICE_EXPERT_YEARLY_TEST  / _LIVE
+
+    Env vars v0 LEGACY (conservées pour grandfathering — ne plus utiliser pour
+    nouveaux checkouts mais les webhooks Stripe les voient encore) :
+      STRIPE_PRICE_PLUS_TEST / _LIVE   → ancien Plus 4.99 €
+      STRIPE_PRICE_PRO_TEST  / _LIVE   → ancien Pro 9.99 €
+    """
+    for plan in (PlanId.PRO, PlanId.EXPERT):
+        for cycle in ("monthly", "yearly"):
+            for mode in ("test", "live"):
+                env_key = f"STRIPE_PRICE_{plan.value.upper()}_{cycle.upper()}_{mode.upper()}"
+                val = os.environ.get(env_key, "")
+                # Stocker dans le dict du plan pour debug / inspection
+                price_field = f"stripe_price_id_{cycle}_{mode}"
+                PLANS[plan][price_field] = val or None
+                if val:
+                    logger.info("Stripe v2 price loaded: %s=%s", env_key, bool(val))
+```
+
+- [ ] **Step 4: Run les tests pour valider le refactor**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v`
+Expected : tous les tests pricing_v2 passent (5+ tests)
+
+- [ ] **Step 5: Run la suite complète backend pour détecter les régressions**
+
+Run : `cd backend && python -m pytest tests/ -x --ignore=tests/integration 2>&1 | tail -40`
+Expected : pas plus de régressions que celles documentées (tests `voice_quota.py` peuvent échouer — corrigé en Task 7)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/billing/plan_config.py backend/tests/billing/test_pricing_v2.py
+git commit -m "feat(billing): refactor plan_config to v2 (Free/Pro/Expert) with cycle-aware pricing"
+```
+
+---
+
+### Task 3: Env vars Stripe v2 dans core/config.py
+
+**Files:**
+
+- Modify: `backend/src/core/config.py`
+- Test: `backend/tests/billing/test_pricing_v2.py` (étendre)
+
+- [ ] **Step 1: Écrire le test qui vérifie que les 8 env vars v2 sont exposées**
+
+Ajouter à `backend/tests/billing/test_pricing_v2.py` :
+
+```python
+def test_config_exposes_v2_env_vars(monkeypatch):
+    """core/config.py doit exposer les 8 nouvelles env vars Pricing v2."""
+    monkeypatch.setenv("STRIPE_PRICE_PRO_MONTHLY_TEST", "price_pro_m_t")
+    monkeypatch.setenv("STRIPE_PRICE_PRO_MONTHLY_LIVE", "price_pro_m_l")
+    monkeypatch.setenv("STRIPE_PRICE_PRO_YEARLY_TEST", "price_pro_y_t")
+    monkeypatch.setenv("STRIPE_PRICE_PRO_YEARLY_LIVE", "price_pro_y_l")
+    monkeypatch.setenv("STRIPE_PRICE_EXPERT_MONTHLY_TEST", "price_exp_m_t")
+    monkeypatch.setenv("STRIPE_PRICE_EXPERT_MONTHLY_LIVE", "price_exp_m_l")
+    monkeypatch.setenv("STRIPE_PRICE_EXPERT_YEARLY_TEST", "price_exp_y_t")
+    monkeypatch.setenv("STRIPE_PRICE_EXPERT_YEARLY_LIVE", "price_exp_y_l")
+
+    import importlib
+    import core.config as cfg
+    importlib.reload(cfg)
+
+    prices = cfg.STRIPE_CONFIG["PRICES"]
+    assert prices["pro"]["monthly"]["test"] == "price_pro_m_t"
+    assert prices["pro"]["monthly"]["live"] == "price_pro_m_l"
+    assert prices["pro"]["yearly"]["test"] == "price_pro_y_t"
+    assert prices["pro"]["yearly"]["live"] == "price_pro_y_l"
+    assert prices["expert"]["monthly"]["test"] == "price_exp_m_t"
+    assert prices["expert"]["monthly"]["live"] == "price_exp_m_l"
+    assert prices["expert"]["yearly"]["test"] == "price_exp_y_t"
+    assert prices["expert"]["yearly"]["live"] == "price_exp_y_l"
+    # Legacy v0 conservées
+    assert "plus" in prices  # ancien Plus 4.99 €
+```
+
+- [ ] **Step 2: Run le test, vérifier qu'il échoue**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py::test_config_exposes_v2_env_vars -v`
+Expected : FAIL avec `KeyError: 'pro'` ou `KeyError: 'monthly'`
+
+- [ ] **Step 3: Ajouter les env vars à \_DeepSightSettings**
+
+Modifier `backend/src/core/config.py` autour des lignes 91-94. Remplacer :
+
+```python
+    STRIPE_PRICE_PLUS_TEST: str = ""
+    STRIPE_PRICE_PLUS_LIVE: str = ""
+    STRIPE_PRICE_PRO_TEST: str = ""
+    STRIPE_PRICE_PRO_LIVE: str = ""
+```
+
+par :
+
+```python
+    # Pricing v0 LEGACY — conservées pour grandfathering / mapping webhooks
+    STRIPE_PRICE_PLUS_TEST: str = ""
+    STRIPE_PRICE_PLUS_LIVE: str = ""
+    STRIPE_PRICE_PRO_TEST: str = ""    # ⚠️ ancien Pro 9.99 € (legacy), pas le nouveau Pro 8.99 €
+    STRIPE_PRICE_PRO_LIVE: str = ""
+
+    # Pricing v2 — 4 plans actifs (Pro 8.99 / Expert 19.99) × 2 cycles
+    STRIPE_PRICE_PRO_MONTHLY_TEST: str = ""
+    STRIPE_PRICE_PRO_MONTHLY_LIVE: str = ""
+    STRIPE_PRICE_PRO_YEARLY_TEST: str = ""
+    STRIPE_PRICE_PRO_YEARLY_LIVE: str = ""
+    STRIPE_PRICE_EXPERT_MONTHLY_TEST: str = ""
+    STRIPE_PRICE_EXPERT_MONTHLY_LIVE: str = ""
+    STRIPE_PRICE_EXPERT_YEARLY_TEST: str = ""
+    STRIPE_PRICE_EXPERT_YEARLY_LIVE: str = ""
+```
+
+- [ ] **Step 4: Étendre STRIPE_CONFIG["PRICES"] pour exposer la grille v2**
+
+Modifier `backend/src/core/config.py` autour des lignes 324-337. Remplacer :
+
+```python
+    "PRICES": {
+        "plus": {
+            "test": _settings.STRIPE_PRICE_PLUS_TEST,
+            "live": _settings.STRIPE_PRICE_PLUS_LIVE,
+            "amount": 499,
+            "name": "Plus",
+        },
+        "pro": {
+            "test": _settings.STRIPE_PRICE_PRO_TEST,
+            "live": _settings.STRIPE_PRICE_PRO_LIVE,
+            "amount": 999,
+            "name": "Pro",
+        },
+    },
+```
+
+par :
+
+```python
+    "PRICES": {
+        # v0 legacy (grandfathering — ne plus utiliser pour nouveaux checkouts)
+        "plus": {
+            "test": _settings.STRIPE_PRICE_PLUS_TEST,
+            "live": _settings.STRIPE_PRICE_PLUS_LIVE,
+            "amount": 499,
+            "name": "Plus (legacy)",
+        },
+        # v2 — actif
+        "pro": {
+            "monthly": {
+                "test": _settings.STRIPE_PRICE_PRO_MONTHLY_TEST,
+                "live": _settings.STRIPE_PRICE_PRO_MONTHLY_LIVE,
+                "amount": 899,
+            },
+            "yearly": {
+                "test": _settings.STRIPE_PRICE_PRO_YEARLY_TEST,
+                "live": _settings.STRIPE_PRICE_PRO_YEARLY_LIVE,
+                "amount": 8990,
+            },
+            "name": "Pro",
+            # legacy fields pour rétro-compat code v0 — pointent sur l'ancien Pro 9.99
+            "test": _settings.STRIPE_PRICE_PRO_TEST,
+            "live": _settings.STRIPE_PRICE_PRO_LIVE,
+        },
+        "expert": {
+            "monthly": {
+                "test": _settings.STRIPE_PRICE_EXPERT_MONTHLY_TEST,
+                "live": _settings.STRIPE_PRICE_EXPERT_MONTHLY_LIVE,
+                "amount": 1999,
+            },
+            "yearly": {
+                "test": _settings.STRIPE_PRICE_EXPERT_YEARLY_TEST,
+                "live": _settings.STRIPE_PRICE_EXPERT_YEARLY_LIVE,
+                "amount": 19990,
+            },
+            "name": "Expert",
+        },
+    },
+```
+
+- [ ] **Step 5: Run le test, vérifier qu'il passe**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py::test_config_exposes_v2_env_vars -v`
+Expected : 1 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/core/config.py backend/tests/billing/test_pricing_v2.py
+git commit -m "feat(config): add 8 Stripe v2 env vars (Pro/Expert × monthly/yearly × test/live)"
+```
+
+---
+
+### Task 4: Script seed_stripe_prices_v2.py — création idempotente des Stripe Prices
+
+**Files:**
+
+- Create: `backend/scripts/seed_stripe_prices_v2.py`
+
+- [ ] **Step 1: Écrire le script de seed idempotent**
+
+Créer `backend/scripts/seed_stripe_prices_v2.py` :
+
+```python
+"""Idempotent Stripe Products + Prices seeder for Pricing v2.
+
+Usage :
+    cd backend && STRIPE_TEST_MODE=true python scripts/seed_stripe_prices_v2.py
+    cd backend && STRIPE_TEST_MODE=false python scripts/seed_stripe_prices_v2.py
+
+Crée (si absents via lookup_key) :
+  - 2 Products :  prod_deepsight_pro / prod_deepsight_expert
+  - 4 Prices  :  pro_monthly / pro_yearly / expert_monthly / expert_yearly
+
+Output : copie/colle les 4 Price IDs à mettre dans .env.production.
+Idempotent : ré-exécutable à volonté, ne duplique jamais.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional
+
+import stripe
+
+# Ajouter src/ au path pour importer les helpers config
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from core.config import get_stripe_key  # noqa: E402
+
+
+SEED_SPEC = [
+    # (product_lookup_key, product_name, price_lookup_key, amount_cents, interval)
+    ("prod_deepsight_pro",    "DeepSight Pro",    "pro_monthly",       899,   "month"),
+    ("prod_deepsight_pro",    "DeepSight Pro",    "pro_yearly",        8990,  "year"),
+    ("prod_deepsight_expert", "DeepSight Expert", "expert_monthly",    1999,  "month"),
+    ("prod_deepsight_expert", "DeepSight Expert", "expert_yearly",     19990, "year"),
+]
+
+
+def get_or_create_product(lookup_key: str, name: str) -> stripe.Product:
+    """Retrieve product by metadata.lookup_key or create it."""
+    products = stripe.Product.search(query=f"metadata['lookup_key']:'{lookup_key}'")
+    if products.data:
+        print(f"  ✓ Product exists: {lookup_key} ({products.data[0].id})")
+        return products.data[0]
+    p = stripe.Product.create(
+        name=name,
+        metadata={"lookup_key": lookup_key, "managed_by": "seed_stripe_prices_v2"},
+    )
+    print(f"  + Product created: {lookup_key} ({p.id})")
+    return p
+
+
+def get_or_create_price(
+    product_id: str,
+    lookup_key: str,
+    amount_cents: int,
+    interval: str,
+) -> stripe.Price:
+    """Retrieve price by lookup_key or create it.
+
+    Stripe natively supports ``lookup_key`` on Price → idempotence facile.
+    """
+    existing = stripe.Price.list(lookup_keys=[lookup_key], limit=1)
+    if existing.data:
+        print(f"  ✓ Price exists: {lookup_key} ({existing.data[0].id})")
+        return existing.data[0]
+    price = stripe.Price.create(
+        product=product_id,
+        unit_amount=amount_cents,
+        currency="eur",
+        recurring={"interval": interval},
+        lookup_key=lookup_key,
+        metadata={"managed_by": "seed_stripe_prices_v2"},
+    )
+    print(f"  + Price created: {lookup_key} ({price.id}) — {amount_cents/100:.2f} EUR / {interval}")
+    return price
+
+
+def main() -> int:
+    api_key = get_stripe_key()
+    if not api_key:
+        print("ERROR: no Stripe key configured (check STRIPE_SECRET_KEY_TEST/LIVE)", file=sys.stderr)
+        return 1
+    stripe.api_key = api_key
+    test_mode = os.environ.get("STRIPE_TEST_MODE", "true").lower() == "true"
+    print(f"Stripe seed v2 — mode={'TEST' if test_mode else 'LIVE'}")
+
+    out: dict[str, str] = {}
+    for product_lookup, product_name, price_lookup, amount, interval in SEED_SPEC:
+        product = get_or_create_product(product_lookup, product_name)
+        price = get_or_create_price(product.id, price_lookup, amount, interval)
+        out[price_lookup] = price.id
+
+    suffix = "TEST" if test_mode else "LIVE"
+    print("\n" + "=" * 70)
+    print(f"# Add to .env.production ({suffix} keys):")
+    print("=" * 70)
+    print(f"STRIPE_PRICE_PRO_MONTHLY_{suffix}={out['pro_monthly']}")
+    print(f"STRIPE_PRICE_PRO_YEARLY_{suffix}={out['pro_yearly']}")
+    print(f"STRIPE_PRICE_EXPERT_MONTHLY_{suffix}={out['expert_monthly']}")
+    print(f"STRIPE_PRICE_EXPERT_YEARLY_{suffix}={out['expert_yearly']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Vérifier que le script s'importe sans erreur (smoke check syntaxe)**
+
+Run : `cd backend && python -c "import scripts.seed_stripe_prices_v2"`
+Expected : pas d'erreur d'import (le main() ne s'exécute pas car `__name__ != "__main__"`)
+
+- [ ] **Step 3: Tester le mode TEST en dry-run**
+
+⚠️ Ce step requiert une clé Stripe TEST configurée. Si pas dispo localement, sauter et exécuter en CI/staging.
+
+Run : `cd backend && STRIPE_TEST_MODE=true python scripts/seed_stripe_prices_v2.py`
+Expected output (1ère exécution) :
+
+```
+Stripe seed v2 — mode=TEST
+  + Product created: prod_deepsight_pro (prod_xxx)
+  + Price created: pro_monthly (price_yyy) — 8.99 EUR / month
+  + Price created: pro_yearly (price_zzz) — 89.90 EUR / year
+  + Product created: prod_deepsight_expert (prod_aaa)
+  + Price created: expert_monthly (price_bbb) — 19.99 EUR / month
+  + Price created: expert_yearly (price_ccc) — 199.90 EUR / year
+
+# Add to .env.production (TEST keys):
+STRIPE_PRICE_PRO_MONTHLY_TEST=price_yyy
+...
+```
+
+Re-run :
+Expected : `✓ Product exists` / `✓ Price exists` partout (idempotence).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/scripts/seed_stripe_prices_v2.py
+git commit -m "feat(billing): add idempotent Stripe v2 prices seeder script"
+```
+
+---
+
+### Task 5: Endpoint /billing/start-trial v2 (Pro OU Expert) + redirection /start-pro-trial
+
+**Files:**
+
+- Modify: `backend/src/billing/router.py`
+- Test: `backend/tests/billing/test_pricing_v2.py` (étendre)
+
+- [ ] **Step 1: Écrire les tests pour /trial-eligibility et /start-trial v2**
+
+Ajouter à `backend/tests/billing/test_pricing_v2.py` :
+
+```python
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_trial_eligibility_returns_pro_default(authed_client: AsyncClient):
+    """GET /api/billing/trial-eligibility (sans param) → trial_plan=pro v2 par défaut."""
+    r = await authed_client.get("/api/billing/trial-eligibility")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["trial_plan"] == "pro"
+    assert body["trial_days"] == 7
+
+
+@pytest.mark.asyncio
+async def test_trial_eligibility_with_explicit_plan(authed_client: AsyncClient):
+    """GET /api/billing/trial-eligibility?plan=expert → trial_plan=expert."""
+    r = await authed_client.get("/api/billing/trial-eligibility?plan=expert")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["trial_plan"] == "expert"
+    assert body["trial_days"] == 7
+
+
+@pytest.mark.asyncio
+async def test_trial_eligibility_rejects_invalid_plan(authed_client: AsyncClient):
+    """plan=free ou inconnu → 400."""
+    r = await authed_client.get("/api/billing/trial-eligibility?plan=free")
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_start_trial_with_plan_param_creates_checkout(
+    authed_client: AsyncClient, mock_stripe
+):
+    """POST /api/billing/start-trial?plan=pro → checkout 7j sans CB sur Pro."""
+    mock_stripe.checkout.Session.create.return_value.url = "https://stripe/checkout/sess_pro"
+    r = await authed_client.post("/api/billing/start-trial?plan=pro")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["plan"] == "pro"
+    assert body["trial_days"] == 7
+    assert "checkout_url" in body
+    # Vérifier que la session Stripe a bien trial_period_days=7 et payment_method_collection=if_required
+    call_kwargs = mock_stripe.checkout.Session.create.call_args.kwargs
+    assert call_kwargs["subscription_data"]["trial_period_days"] == 7
+    assert call_kwargs["payment_method_collection"] == "if_required"
+
+
+@pytest.mark.asyncio
+async def test_legacy_start_pro_trial_redirects_to_pro_trial(
+    authed_client: AsyncClient, mock_stripe
+):
+    """POST /api/billing/start-pro-trial (legacy) → redirige vers nouveau /start-trial?plan=pro."""
+    mock_stripe.checkout.Session.create.return_value.url = "https://stripe/checkout/legacy"
+    r = await authed_client.post("/api/billing/start-pro-trial")
+    assert r.status_code == 200
+    body = r.json()
+    # Mapping : legacy "plus" trial → désormais "pro" trial v2
+    assert body["plan"] == "pro"
+```
+
+- [ ] **Step 2: Run les tests, vérifier qu'ils échouent**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v -k trial`
+Expected : FAIL — `/start-trial` n'existe pas, `/start-pro-trial` retourne `plus`.
+
+- [ ] **Step 3: Refactor /trial-eligibility avec param plan**
+
+Dans `backend/src/billing/router.py`, remplacer la section autour des lignes 220-277. Nouveau code :
+
+```python
+class TrialEligibilityResponse(BaseModel):
+    """Réponse d'éligibilité à l'essai gratuit."""
+
+    eligible: bool
+    reason: Optional[str] = None
+    trial_days: int = 7
+    trial_plan: str = "pro"  # v2 default — anciennement "plus"
+
+
+@router.get("/trial-eligibility", response_model=TrialEligibilityResponse)
+async def check_trial_eligibility(
+    plan: str = Query("pro", description="Plan cible du trial : pro ou expert"),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """🆓 Vérifie l'éligibilité à un essai 7 j sans CB pour Pro ou Expert (v2 H5).
+
+    Conditions :
+      - plan ∈ {pro, expert}
+      - user.plan == "free"
+      - Aucun stripe_subscription_id existant
+      - Aucune transaction passée de type purchase / trial / upgrade
+    """
+    if plan not in ("pro", "expert"):
+        raise HTTPException(status_code=400, detail={
+            "code": "invalid_plan",
+            "message": "plan must be 'pro' or 'expert'",
+        })
+
+    if current_user.plan != "free":
+        return TrialEligibilityResponse(
+            eligible=False,
+            reason="Vous avez déjà un abonnement actif",
+            trial_days=0,
+            trial_plan=plan,
+        )
+
+    if current_user.stripe_subscription_id:
+        return TrialEligibilityResponse(
+            eligible=False,
+            reason="Vous avez déjà bénéficié d'un abonnement",
+            trial_days=0,
+            trial_plan=plan,
+        )
+
+    result = await session.execute(
+        select(CreditTransaction)
+        .where(CreditTransaction.user_id == current_user.id)
+        .where(CreditTransaction.transaction_type.in_(["purchase", "trial", "upgrade"]))
+        .limit(1)
+    )
+    if result.scalar_one_or_none() is not None:
+        return TrialEligibilityResponse(
+            eligible=False,
+            reason="Vous avez déjà bénéficié d'un essai ou d'un abonnement",
+            trial_days=0,
+            trial_plan=plan,
+        )
+
+    return TrialEligibilityResponse(eligible=True, trial_days=7, trial_plan=plan)
+```
+
+- [ ] **Step 4: Ajouter /start-trial (param plan) et conserver /start-pro-trial en legacy**
+
+Ajouter avant `@router.post("/start-pro-trial")` ligne 280 :
+
+```python
+@router.post("/start-trial")
+async def start_trial(
+    plan: str = Query("pro", description="Plan cible : pro ou expert"),
+    cycle: str = Query("monthly", description="monthly | yearly"),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """🆓 Démarre un essai gratuit 7 j sans CB sur Pro ou Expert (Pricing v2 H5).
+
+    Crée une session Stripe Checkout avec :
+      - trial_period_days = 7
+      - payment_method_collection = "if_required"  → pas de CB demandée pendant le trial
+    """
+    if plan not in ("pro", "expert"):
+        raise HTTPException(status_code=400, detail={
+            "code": "invalid_plan",
+            "message": "plan must be 'pro' or 'expert'",
+        })
+    if cycle not in ("monthly", "yearly"):
+        raise HTTPException(status_code=400, detail={
+            "code": "invalid_cycle",
+            "message": "cycle must be 'monthly' or 'yearly'",
+        })
+
+    eligibility = await check_trial_eligibility(plan, current_user, session)
+    if not eligibility.eligible:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "not_eligible", "message": eligibility.reason or "Non éligible"},
+        )
+    if not STRIPE_CONFIG.get("ENABLED"):
+        raise HTTPException(status_code=400, detail="Stripe not enabled")
+    if not init_stripe():
+        raise HTTPException(status_code=500, detail="Stripe not configured")
+
+    test_mode = STRIPE_CONFIG.get("TEST_MODE", True)
+    from .plan_config import get_price_id as plan_get_price_id
+    price_id = plan_get_price_id(plan, cycle, test_mode=test_mode)
+    if not price_id:
+        raise HTTPException(status_code=400, detail=f"Plan {plan} ({cycle}) not configured")
+
+    try:
+        customer_id = await get_or_create_stripe_customer(current_user, session)
+    except stripe.error.StripeError as e:
+        logger.error(f"Stripe customer error: {e}")
+        raise HTTPException(status_code=500, detail="Stripe customer error")
+
+    try:
+        checkout_session = stripe.checkout.Session.create(
+            customer=customer_id,
+            payment_method_types=["card"],
+            payment_method_collection="if_required",  # H5 : pas de CB pour le trial
+            line_items=[{"price": price_id, "quantity": 1}],
+            mode="subscription",
+            subscription_data={
+                "trial_period_days": 7,
+                "metadata": {
+                    "user_id": str(current_user.id),
+                    "is_trial": "true",
+                    "trial_plan": plan,
+                    "cycle": cycle,
+                },
+            },
+            success_url=f"{FRONTEND_URL}/payment/success?session_id={{CHECKOUT_SESSION_ID}}&plan={plan}&cycle={cycle}&trial=true",
+            cancel_url=f"{FRONTEND_URL}/upgrade",
+            allow_promotion_codes=False,
+            metadata={
+                "user_id": str(current_user.id),
+                "plan": plan,
+                "cycle": cycle,
+                "is_trial": "true",
+            },
+        )
+        logger.info(f"Trial v2 checkout: user={current_user.id} plan={plan} cycle={cycle}")
+        return {
+            "checkout_url": checkout_session.url,
+            "session_id": checkout_session.id,
+            "trial_days": 7,
+            "plan": plan,
+            "cycle": cycle,
+        }
+    except stripe.error.StripeError as e:
+        logger.error(f"Stripe error: {e}")
+        raise HTTPException(status_code=500, detail="Stripe error")
+```
+
+- [ ] **Step 5: Convertir /start-pro-trial en redirection legacy vers /start-trial?plan=pro**
+
+Remplacer le corps de `/start-pro-trial` (autour lignes 280-360) par :
+
+```python
+@router.post("/start-pro-trial", deprecated=True)
+async def start_pro_trial_legacy(
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """🔄 LEGACY — Ancien endpoint v0 qui démarrait un trial Plus 4.99 €.
+
+    Désormais redirige vers le nouveau /start-trial?plan=pro&cycle=monthly v2.
+    Conservé pour compatibilité clients mobiles non encore mis à jour.
+    """
+    return await start_trial(
+        plan="pro",
+        cycle="monthly",
+        current_user=current_user,
+        session=session,
+    )
+```
+
+- [ ] **Step 6: Run les tests, vérifier qu'ils passent**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v -k trial`
+Expected : tous trial-related tests passent.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/billing/router.py backend/tests/billing/test_pricing_v2.py
+git commit -m "feat(billing): /start-trial v2 (Pro/Expert + cycle) + legacy /start-pro-trial redirect"
+```
+
+---
+
+### Task 6: Endpoints /plans et /create-checkout v2 (avec cycle)
+
+**Files:**
+
+- Modify: `backend/src/billing/router.py`
+- Test: `backend/tests/billing/test_pricing_v2.py` (étendre)
+
+- [ ] **Step 1: Écrire les tests /plans v2 et /create-checkout cycle**
+
+Ajouter à `backend/tests/billing/test_pricing_v2.py` :
+
+```python
+@pytest.mark.asyncio
+async def test_plans_endpoint_returns_v2_grid(client: AsyncClient):
+    """GET /api/billing/plans → grille v2 avec free/pro/expert + cycles."""
+    r = await client.get("/api/billing/plans")
+    assert r.status_code == 200
+    body = r.json()
+    plan_ids = {p["id"] for p in body["plans"]}
+    assert plan_ids == {"free", "pro", "expert"}, f"Got {plan_ids}"
+
+    pro = next(p for p in body["plans"] if p["id"] == "pro")
+    assert pro["price_monthly_cents"] == 899
+    assert pro["price_yearly_cents"] == 8990
+
+    expert = next(p for p in body["plans"] if p["id"] == "expert")
+    assert expert["price_monthly_cents"] == 1999
+    assert expert["price_yearly_cents"] == 19990
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_with_cycle_yearly(authed_client: AsyncClient, mock_stripe):
+    """POST /api/billing/create-checkout {plan:pro,cycle:yearly} → utilise yearly Price ID."""
+    mock_stripe.checkout.Session.create.return_value.url = "https://stripe/checkout/yearly"
+    r = await authed_client.post(
+        "/api/billing/create-checkout",
+        json={"plan": "pro", "cycle": "yearly"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "checkout_url" in body
+    call_kwargs = mock_stripe.checkout.Session.create.call_args.kwargs
+    line_items = call_kwargs["line_items"]
+    # Le Price ID résolu doit être celui yearly (env var STRIPE_PRICE_PRO_YEARLY_TEST)
+    assert "price" in line_items[0]
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_rejects_unknown_plan(authed_client: AsyncClient):
+    """POST /api/billing/create-checkout {plan:foo} → 400."""
+    r = await authed_client.post(
+        "/api/billing/create-checkout", json={"plan": "foo", "cycle": "monthly"}
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_default_cycle_monthly(authed_client: AsyncClient, mock_stripe):
+    """Sans cycle → default monthly."""
+    mock_stripe.checkout.Session.create.return_value.url = "https://stripe/sess"
+    r = await authed_client.post(
+        "/api/billing/create-checkout", json={"plan": "expert"}
+    )
+    assert r.status_code == 200
+    call_kwargs = mock_stripe.checkout.Session.create.call_args.kwargs
+    metadata = call_kwargs.get("metadata", {})
+    assert metadata.get("cycle") == "monthly"
+```
+
+- [ ] **Step 2: Run les tests, vérifier qu'ils échouent**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v -k "plans or checkout"`
+Expected : FAIL — schema CreateCheckoutRequest n'a pas de champ cycle, /plans retourne ancienne grille.
+
+- [ ] **Step 3: Étendre CreateCheckoutRequest schema**
+
+Dans `backend/src/billing/router.py`, modifier la classe `CreateCheckoutRequest` (lignes 76-82) :
+
+```python
+class CreateCheckoutRequest(BaseModel):
+    """Requête pour créer une session de paiement v2."""
+
+    plan: str  # "pro" | "expert"
+    cycle: str = "monthly"  # "monthly" | "yearly"
+    success_url: Optional[str] = None
+    cancel_url: Optional[str] = None
+```
+
+- [ ] **Step 4: Implémenter /plans v2**
+
+Localiser le handler `@router.get("/plans")` existant et le remplacer (ou ajouter si absent) :
+
+```python
+@router.get("/plans")
+async def list_plans():
+    """GET /api/billing/plans — Grille publique v2 (Free / Pro / Expert).
+
+    Retourne pour chaque plan : id, name, prices (monthly + yearly cents),
+    voice_minutes, features_display. Le frontend l'utilise pour rendre
+    UpgradePage + ComparisonTable.
+    """
+    from .plan_config import PLANS, PLAN_HIERARCHY, PLAN_PRICES_V2, PLAN_VOICE_MINUTES_V2
+
+    plans = []
+    for plan_id in PLAN_HIERARCHY:
+        cfg = PLANS[plan_id]
+        prices = PLAN_PRICES_V2.get(plan_id.value, {})
+        plans.append({
+            "id": plan_id.value,
+            "name": cfg["name"],
+            "name_en": cfg["name_en"],
+            "description": cfg["description"],
+            "description_en": cfg["description_en"],
+            "price_monthly_cents": prices.get("monthly", 0),
+            "price_yearly_cents": prices.get("yearly", 0),
+            "voice_minutes": PLAN_VOICE_MINUTES_V2.get(plan_id.value, 0),
+            "color": cfg["color"],
+            "icon": cfg["icon"],
+            "badge": cfg.get("badge"),
+            "popular": cfg.get("popular", False),
+            "features_display": cfg["features_display"],
+            "features_locked": cfg.get("features_locked", []),
+            "limits": cfg["limits"],
+        })
+
+    return {"plans": plans, "currency": "EUR", "yearly_discount_pct": 17}
+```
+
+- [ ] **Step 5: Refactor /create-checkout pour accepter cycle**
+
+Localiser `@router.post("/create-checkout")`. Remplacer la résolution de price_id :
+
+```python
+# AVANT (v0) :
+# price_id = get_price_id(req.plan)
+
+# APRES (v2) :
+from .plan_config import get_price_id as plan_get_price_id
+if req.plan not in ("pro", "expert"):
+    raise HTTPException(400, detail={"code": "invalid_plan", "message": "plan must be 'pro' or 'expert'"})
+if req.cycle not in ("monthly", "yearly"):
+    raise HTTPException(400, detail={"code": "invalid_cycle"})
+
+test_mode = STRIPE_CONFIG.get("TEST_MODE", True)
+price_id = plan_get_price_id(req.plan, req.cycle, test_mode=test_mode)
+if not price_id:
+    raise HTTPException(400, detail=f"Plan {req.plan} ({req.cycle}) price not configured")
+```
+
+Ajouter `cycle` à `metadata` de `stripe.checkout.Session.create` :
+
+```python
+metadata={
+    "user_id": str(current_user.id),
+    "plan": req.plan,
+    "cycle": req.cycle,
+},
+```
+
+- [ ] **Step 6: Run les tests**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v -k "plans or checkout"`
+Expected : tous passent.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/billing/router.py backend/tests/billing/test_pricing_v2.py
+git commit -m "feat(billing): /plans v2 grid + /create-checkout cycle param (monthly|yearly)"
+```
+
+---
+
+### Task 7: Voice quota par plan — Pro 30 / Expert 120
+
+**Files:**
+
+- Modify: `backend/src/billing/voice_quota.py`
+- Test: `backend/tests/billing/test_pricing_v2.py` (étendre)
+
+- [ ] **Step 1: Écrire les tests voice quota par plan**
+
+Ajouter à `backend/tests/billing/test_pricing_v2.py` :
+
+```python
+from billing.voice_quota import check_voice_quota, EXPERT_MONTHLY_MINUTES
+
+
+@pytest.mark.asyncio
+async def test_voice_quota_pro_returns_30_minutes(db_session: AsyncSession):
+    """Plan pro v2 → max_minutes = 30 (au lieu du 30 hardcodé v0)."""
+    user = User(username="pro_user", email="pro@test.fr", password_hash="x", plan="pro")
+    db_session.add(user)
+    await db_session.commit()
+    check = await check_voice_quota(user, db_session)
+    assert check.allowed is True
+    assert check.max_minutes == 30
+
+
+@pytest.mark.asyncio
+async def test_voice_quota_expert_returns_120_minutes(db_session: AsyncSession):
+    """Plan expert v2 → max_minutes = 120 (H4)."""
+    user = User(username="expert_user", email="expert@test.fr", password_hash="x", plan="expert")
+    db_session.add(user)
+    await db_session.commit()
+    check = await check_voice_quota(user, db_session)
+    assert check.allowed is True
+    assert check.max_minutes == 120
+
+
+@pytest.mark.asyncio
+async def test_voice_quota_legacy_plus_resolves_to_pro_30(db_session: AsyncSession):
+    """User encore tagué 'plus' (avant migration) → résolu via alias en pro 30 min."""
+    user = User(username="legacy_plus", email="lp@test.fr", password_hash="x", plan="plus")
+    db_session.add(user)
+    await db_session.commit()
+    check = await check_voice_quota(user, db_session)
+    # plus → pro v2 → 30 min
+    assert check.allowed is True
+    assert check.max_minutes == 30
+
+
+def test_expert_monthly_minutes_alias_is_120():
+    """L'alias EXPERT_MONTHLY_MINUTES exposé doit valoir 120 (v2 H4)."""
+    assert EXPERT_MONTHLY_MINUTES == 120
+```
+
+- [ ] **Step 2: Run les tests, vérifier qu'ils échouent**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v -k voice`
+Expected : FAIL — Pro renvoie 30 (déjà v0 bon par hasard) mais Expert renvoie 30 (mauvais), legacy plus échoue (TOP_TIER_PLANS exclut "plus").
+
+- [ ] **Step 3: Refactor voice_quota.py — lookup dynamique par plan**
+
+Modifier `backend/src/billing/voice_quota.py`. Remplacer les constantes (lignes 36-44) :
+
+```python
+# ─── Pricing v2 (H4 — locked 2026-04-29) ──────────────────────────────────
+# Voice allowance par plan : Pro 30 min, Expert 120 min.
+# Source de vérité unique : plan_config.PLAN_VOICE_MINUTES_V2 (résolution alias incluse).
+from billing.plan_config import get_voice_minutes, normalize_plan_id
+
+# Backwards-compat aliases (consommés par tests legacy + voice/router.py)
+PRO_MONTHLY_MINUTES: float = float(get_voice_minutes("pro"))      # 30
+EXPERT_MONTHLY_MINUTES: float = float(get_voice_minutes("expert"))  # 120
+TOP_TIER_MONTHLY_MINUTES: float = PRO_MONTHLY_MINUTES  # ⚠️ DEPRECATED — utilisez get_voice_minutes()
+FREE_TRIAL_MINUTES: float = 3.0
+MONTHLY_PERIOD_DAYS: int = 30
+
+# Plans avec quota voice mensuel rolling 30j
+TOP_TIER_PLANS: frozenset[str] = frozenset({"pro", "expert"})
+```
+
+Refactor `check_voice_quota` (ligne 110-152). Remplacer la branche `if plan in TOP_TIER_PLANS:` par :
+
+```python
+async def check_voice_quota(user: User, db: AsyncSession) -> QuotaCheck:
+    plan_raw = (user.plan or "free").lower()
+    plan = normalize_plan_id(plan_raw)  # résout legacy "plus" → "pro" automatiquement
+    quota = await _get_or_create_quota(user.id, plan, db)
+
+    if plan == "free":
+        if quota.lifetime_trial_used:
+            return QuotaCheck(allowed=False, reason="trial_used", cta="upgrade_pro")
+        return QuotaCheck(allowed=True, max_minutes=FREE_TRIAL_MINUTES, is_trial=True)
+
+    if plan in TOP_TIER_PLANS:
+        plan_minutes = float(get_voice_minutes(plan))
+        remaining = plan_minutes - float(quota.monthly_minutes_used or 0.0)
+        if remaining <= 0:
+            return QuotaCheck(allowed=False, reason="monthly_quota")
+        return QuotaCheck(allowed=True, max_minutes=remaining)
+
+    logger.info("Plan '%s' not top-tier voice plan for user_id=%d — upgrade CTA", plan, user.id)
+    return QuotaCheck(allowed=False, reason="pro_no_voice", cta="upgrade_pro")
+```
+
+- [ ] **Step 4: Run les tests, vérifier qu'ils passent**
+
+Run : `cd backend && python -m pytest tests/billing/test_pricing_v2.py -v -k voice`
+Expected : tous passent.
+
+- [ ] **Step 5: Run la suite voice complète**
+
+Run : `cd backend && python -m pytest tests/voice/ -v`
+Expected : pas de régression — les tests existants utilisant `EXPERT_MONTHLY_MINUTES = 30.0` peuvent échouer ⚠️ → mettre à jour tests obsolètes (la valeur passe de 30 à 120 par décision H4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/billing/voice_quota.py backend/tests/billing/test_pricing_v2.py
+git commit -m "feat(voice): dynamic voice quota lookup (Pro 30 / Expert 120) via get_voice_minutes()"
+```
+
+---
+
+### Task 8: Frontend planPrivileges.ts — refactor v2 (rename + voice minutes)
+
+**Files:**
+
+- Modify: `frontend/src/config/planPrivileges.ts`
+- Test: `frontend/src/config/__tests__/planPrivileges.test.ts` (créer si absent)
+
+- [ ] **Step 1: Écrire les tests Vitest pour planPrivileges v2**
+
+Créer `frontend/src/config/__tests__/planPrivileges.test.ts` :
+
+```typescript
+import { describe, it, expect } from "vitest";
+import {
+  PLAN_HIERARCHY,
+  PLAN_LIMITS,
+  PLAN_FEATURES,
+  PLANS_INFO,
+  normalizePlanId,
+  type PlanId,
+} from "../planPrivileges";
+
+describe("Pricing v2 — planPrivileges", () => {
+  it("PlanId is free | pro | expert", () => {
+    expect(PLAN_HIERARCHY).toEqual<PlanId[]>(["free", "pro", "expert"]);
+  });
+
+  it("Pro voice 30 min, Expert 120 min", () => {
+    expect(PLAN_LIMITS.pro.voiceChatMonthlyMinutes).toBe(30);
+    expect(PLAN_LIMITS.expert.voiceChatMonthlyMinutes).toBe(120);
+    expect(PLAN_LIMITS.free.voiceChatMonthlyMinutes).toBe(0);
+  });
+
+  it("Pro priceMonthly 899, Expert 1999", () => {
+    expect(PLANS_INFO.pro.priceMonthly).toBe(899);
+    expect(PLANS_INFO.expert.priceMonthly).toBe(1999);
+  });
+
+  it("Pro priceYearly 8990, Expert 19990 (-17 %)", () => {
+    expect(PLANS_INFO.pro.priceYearly).toBe(8990);
+    expect(PLANS_INFO.expert.priceYearly).toBe(19990);
+  });
+
+  it("Aliases legacy v0→v2 inverted", () => {
+    expect(normalizePlanId("plus")).toBe("pro");
+    expect(normalizePlanId("starter")).toBe("pro");
+    expect(normalizePlanId("etudiant")).toBe("pro");
+    // "expert" canonique reste expert
+    expect(normalizePlanId("expert")).toBe("expert");
+    expect(normalizePlanId("team")).toBe("expert");
+    expect(normalizePlanId("equipe")).toBe("expert");
+    expect(normalizePlanId("unlimited")).toBe("expert");
+    // Inconnu / null
+    expect(normalizePlanId("foo")).toBe("free");
+    expect(normalizePlanId(undefined)).toBe("free");
+  });
+
+  it("Voice chat enabled on pro AND expert (v2)", () => {
+    expect(PLAN_FEATURES.pro.voiceChat).toBe(true);
+    expect(PLAN_FEATURES.expert.voiceChat).toBe(true);
+    expect(PLAN_FEATURES.free.voiceChat).toBe(false);
+  });
+
+  it("Pro has expert features-locked (e.g. deepResearch)", () => {
+    expect(PLAN_FEATURES.pro.deepResearch).toBe(false);
+    expect(PLAN_FEATURES.expert.deepResearch).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run les tests, vérifier qu'ils échouent**
+
+Run : `cd frontend && npm run test -- src/config/__tests__/planPrivileges.test.ts`
+Expected : FAIL — `PLAN_HIERARCHY` contient `"plus"`, `PLAN_LIMITS.expert` undefined.
+
+- [ ] **Step 3: Refactor planPrivileges.ts**
+
+Modifier `frontend/src/config/planPrivileges.ts` :
+
+**Header (lignes 1-2)** :
+
+```typescript
+// ⚠️ MIROIR de backend/src/billing/plan_config.py — Synchroniser les deux fichiers
+// Migration Avril 2026 : Pricing v2 — 3 plans (Free / Pro 8.99 € / Expert 19.99 €)
+// Avec toggle mensuel/annuel −17 % et trial 7 j sans CB.
+```
+
+**Type PlanId (ligne 8)** :
+
+```typescript
+export type PlanId = "free" | "pro" | "expert";
+
+export const PLAN_HIERARCHY: PlanId[] = ["free", "pro", "expert"];
+
+export type BillingCycle = "monthly" | "yearly";
+```
+
+**PLAN_LIMITS (lignes 61-167)** : renommer la clé `plus` → `pro`, et l'ancienne `pro` → `expert`. Mettre à jour les voice minutes :
+
+```typescript
+export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
+  free: {
+    /* ...inchangé... */
+  },
+
+  // Anciennement "plus" v0 — devenu "pro" v2 (8.99 €) avec voice 30 min/mo
+  pro: {
+    monthlyAnalyses: 25,
+    maxVideoLengthMin: 60,
+    concurrentAnalyses: 1,
+    priorityQueue: false,
+    chatQuestionsPerVideo: 25,
+    chatDailyLimit: 50,
+    flashcardsEnabled: true,
+    mindmapEnabled: true,
+    webSearchEnabled: true,
+    webSearchMonthly: 20,
+    playlistsEnabled: false,
+    maxPlaylists: 0,
+    maxPlaylistVideos: 0,
+    exportFormats: ["txt", "md", "pdf"],
+    exportMarkdown: true,
+    exportPdf: true,
+    historyRetentionDays: -1,
+    allowedModels: ["mistral-small-2603", "mistral-medium-2508"],
+    defaultModel: "mistral-medium-2508",
+    academicSearch: true,
+    academicPapersPerAnalysis: 15,
+    bibliographyExport: true,
+    voiceChatEnabled: true, // ⚠️ v2 : Pro a voice (avant Plus n'avait pas)
+    voiceChatMonthlyMinutes: 30, // ⚠️ v2 H4
+    debateEnabled: true,
+    debateMonthly: 3,
+    debateCreditsPerDebate: 6,
+    debateChatDaily: 10,
+    deepResearchEnabled: false,
+    factcheckEnabled: true,
+    ttsEnabled: false,
+  },
+
+  // Anciennement "pro" v0 — devenu "expert" v2 (19.99 €) avec voice 120 min/mo
+  expert: {
+    monthlyAnalyses: 100,
+    maxVideoLengthMin: 240,
+    concurrentAnalyses: 3,
+    priorityQueue: true,
+    chatQuestionsPerVideo: -1,
+    chatDailyLimit: -1,
+    flashcardsEnabled: true,
+    mindmapEnabled: true,
+    webSearchEnabled: true,
+    webSearchMonthly: 60,
+    playlistsEnabled: true,
+    maxPlaylists: 10,
+    maxPlaylistVideos: 20,
+    exportFormats: ["txt", "md", "pdf"],
+    exportMarkdown: true,
+    exportPdf: true,
+    historyRetentionDays: -1,
+    allowedModels: [
+      "mistral-small-2603",
+      "mistral-medium-2508",
+      "mistral-large-2512",
+    ],
+    defaultModel: "mistral-large-2512",
+    academicSearch: true,
+    academicPapersPerAnalysis: 50,
+    bibliographyExport: true,
+    voiceChatEnabled: true,
+    voiceChatMonthlyMinutes: 120, // ⚠️ v2 H4
+    debateEnabled: true,
+    debateMonthly: 20,
+    debateCreditsPerDebate: 4,
+    debateChatDaily: -1,
+    deepResearchEnabled: true,
+    factcheckEnabled: true,
+    ttsEnabled: true,
+  },
+};
+```
+
+**PLAN_FEATURES (lignes 191-243)** : mêmes renames, et `voiceChat: true` sur pro v2 :
+
+```typescript
+export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
+  free: {
+    /* ...inchangé... */
+  },
+  pro: {
+    flashcards: true,
+    mindmap: true,
+    webSearch: true,
+    playlists: false,
+    exportPdf: true,
+    exportMarkdown: true,
+    ttsAudio: false,
+    apiAccess: false,
+    prioritySupport: false,
+    academicSearch: true,
+    bibliographyExport: true,
+    voiceChat: true, // ⚠️ v2 : Pro a voice
+    debate: true,
+    deepResearch: false,
+    factcheck: true,
+  },
+  expert: {
+    flashcards: true,
+    mindmap: true,
+    webSearch: true,
+    playlists: true,
+    exportPdf: true,
+    exportMarkdown: true,
+    ttsAudio: true,
+    apiAccess: false,
+    prioritySupport: true,
+    academicSearch: true,
+    bibliographyExport: true,
+    voiceChat: true,
+    debate: true,
+    deepResearch: true,
+    factcheck: true,
+  },
+};
+```
+
+**PlanInfo + PLANS_INFO (lignes 254-306)** : ajouter `priceYearly` et renommer :
+
+```typescript
+export interface PlanInfo {
+  id: PlanId;
+  name: string;
+  nameEn: string;
+  description: string;
+  descriptionEn: string;
+  priceMonthly: number; // cents
+  priceYearly: number; // cents — Pricing v2
+  color: string;
+  icon: string;
+  badge: PlanBadge | null;
+  popular: boolean;
+}
+
+export const PLANS_INFO: Record<PlanId, PlanInfo> = {
+  free: {
+    id: "free",
+    name: "Gratuit",
+    nameEn: "Free",
+    description: "Découvrez DeepSight gratuitement",
+    descriptionEn: "Discover DeepSight for free",
+    priceMonthly: 0,
+    priceYearly: 0,
+    color: "#6B7280",
+    icon: "Zap",
+    badge: null,
+    popular: false,
+  },
+  pro: {
+    id: "pro",
+    name: "Pro",
+    nameEn: "Pro",
+    description: "L'essentiel pour apprendre mieux, plus vite",
+    descriptionEn: "Everything you need to learn better, faster",
+    priceMonthly: 899,
+    priceYearly: 8990,
+    color: "#3B82F6",
+    icon: "Star",
+    badge: { text: "Populaire", color: "#3B82F6" },
+    popular: true,
+  },
+  expert: {
+    id: "expert",
+    name: "Expert",
+    nameEn: "Expert",
+    description: "Toute la puissance de DeepSight, sans limites",
+    descriptionEn: "The full power of DeepSight, unlimited",
+    priceMonthly: 1999,
+    priceYearly: 19990,
+    color: "#8B5CF6",
+    icon: "Crown",
+    badge: { text: "Le + puissant", color: "#8B5CF6" },
+    popular: false,
+  },
+};
+```
+
+**normalizePlanId (lignes 363-386)** : INVERSER les aliases :
+
+```typescript
+export function normalizePlanId(raw: string | undefined | null): PlanId {
+  if (!raw) return "free";
+  const lower = raw.toLowerCase().trim();
+  const aliases: Record<string, PlanId> = {
+    free: "free",
+    gratuit: "free",
+    // v0 legacy → v2 canonique
+    plus: "pro", // ancien Plus → nouveau Pro v2
+    student: "pro",
+    etudiant: "pro",
+    étudiant: "pro",
+    starter: "pro",
+    // Anciens premium / unlimited → expert
+    team: "expert",
+    equipe: "expert",
+    équipe: "expert",
+    unlimited: "expert",
+    admin: "expert",
+    // v2 canonique
+    pro: "pro",
+    expert: "expert",
+  };
+  return aliases[lower] ?? "free";
+}
+```
+
+**CONVERSION_TRIGGERS (lignes 354-360)** : `trialPlan` passe à `pro`, et `trialEnabled: true` (H5) :
+
+```typescript
+export const CONVERSION_TRIGGERS = {
+  freeAnalysisLimit: 5,
+  freeAnalysisWarning: 3,
+  trialEnabled: true, // v2 H5 : trial 7 j actif
+  trialDays: 7,
+  trialPlan: "pro" as PlanId, // default trial → Pro
+};
+```
+
+**TESTIMONIALS (lignes 471-502)** : `plan: "plus"` → `plan: "pro"`, `plan: "pro"` (ancien) → `plan: "expert"` partout.
+
+- [ ] **Step 4: Run les tests, vérifier qu'ils passent**
+
+Run : `cd frontend && npm run test -- src/config/__tests__/planPrivileges.test.ts`
+Expected : 5 passed.
+
+- [ ] **Step 5: Run le typecheck pour détecter les régressions**
+
+Run : `cd frontend && npm run typecheck 2>&1 | head -50`
+Expected : erreurs dans les fichiers consommateurs (UpgradePage, etc.) qui référencent encore `"plus"` — ces erreurs seront corrigées en Tasks 9-11. Lister-les pour les corriger ensuite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/config/planPrivileges.ts frontend/src/config/__tests__/planPrivileges.test.ts
+git commit -m "feat(frontend): refactor planPrivileges to v2 (Free/Pro/Expert) with yearly cycle"
+```
+
+---
+
+### Task 9: Frontend api.ts — types BillingCycle + méthodes v2
+
+**Files:**
+
+- Modify: `frontend/src/services/api.ts`
+
+- [ ] **Step 1: Localiser et refactor les méthodes billing dans api.ts**
+
+Modifier `frontend/src/services/api.ts`. Localiser la section `billingApi` ou équivalent (chercher `trial-eligibility`, `start-pro-trial`, `create-checkout`).
+
+Ajouter les types (avant `billingApi`) :
+
+```typescript
+export type BillingCycle = "monthly" | "yearly";
+export type ApiBillingPlan = "free" | "pro" | "expert";
+
+export interface PlanResponse {
+  id: ApiBillingPlan;
+  name: string;
+  name_en: string;
+  description: string;
+  description_en: string;
+  price_monthly_cents: number;
+  price_yearly_cents: number;
+  voice_minutes: number;
+  color: string;
+  icon: string;
+  badge: { text: string; color: string } | null;
+  popular: boolean;
+  features_display: Array<{ text: string; icon: string; highlight?: boolean }>;
+  features_locked: Array<{ text: string; unlock_plan: string }>;
+}
+
+export interface PlansV2Response {
+  plans: PlanResponse[];
+  currency: string;
+  yearly_discount_pct: number;
+}
+
+export interface TrialEligibility {
+  eligible: boolean;
+  reason: string | null;
+  trial_days: number;
+  trial_plan: ApiBillingPlan;
+}
+```
+
+Refactor les méthodes :
+
+```typescript
+export const billingApi = {
+  /** GET /api/billing/plans — grille publique v2. */
+  async getPlans(): Promise<PlansV2Response> {
+    return apiClient.get("/api/billing/plans");
+  },
+
+  /** GET /api/billing/trial-eligibility?plan=pro|expert */
+  async checkTrialEligibility(
+    plan: ApiBillingPlan = "pro",
+  ): Promise<TrialEligibility> {
+    return apiClient.get(`/api/billing/trial-eligibility?plan=${plan}`);
+  },
+
+  /** POST /api/billing/start-trial?plan=pro|expert&cycle=monthly|yearly */
+  async startTrial(
+    plan: ApiBillingPlan = "pro",
+    cycle: BillingCycle = "monthly",
+  ): Promise<{
+    checkout_url: string;
+    session_id: string;
+    trial_days: number;
+    plan: string;
+    cycle: string;
+  }> {
+    return apiClient.post(
+      `/api/billing/start-trial?plan=${plan}&cycle=${cycle}`,
+    );
+  },
+
+  /** POST /api/billing/create-checkout body { plan, cycle } */
+  async createCheckout(
+    plan: ApiBillingPlan,
+    cycle: BillingCycle = "monthly",
+    success_url?: string,
+    cancel_url?: string,
+  ): Promise<{ checkout_url: string; session_id: string }> {
+    return apiClient.post("/api/billing/create-checkout", {
+      plan,
+      cycle,
+      success_url,
+      cancel_url,
+    });
+  },
+
+  // ... autres méthodes existantes (portal, cancel, etc.) inchangées
+};
+```
+
+⚠️ Si la méthode existante `startProTrial` (legacy) est utilisée ailleurs, garder un alias :
+
+```typescript
+/** @deprecated v0 — use startTrial(plan='pro') instead */
+async startProTrial() {
+  return this.startTrial("pro", "monthly");
+},
+```
+
+- [ ] **Step 2: Run le typecheck**
+
+Run : `cd frontend && npm run typecheck 2>&1 | grep -i "billingApi\|BillingCycle\|ApiBillingPlan" | head -20`
+Expected : pas d'erreur sur les nouvelles méthodes (mais des erreurs `'plus'` sur les consommateurs — corrigés Tasks 10-11).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/services/api.ts
+git commit -m "feat(frontend): add v2 billing API methods (startTrial, createCheckout with cycle)"
+```
+
+---
+
+### Task 10: Composant BillingToggle — switch monthly/yearly avec badge −17 %
+
+**Files:**
+
+- Create: `frontend/src/components/pricing/BillingToggle.tsx`
+- Create: `frontend/src/components/pricing/__tests__/BillingToggle.test.tsx`
+
+- [ ] **Step 1: Écrire les tests Vitest**
+
+Créer `frontend/src/components/pricing/__tests__/BillingToggle.test.tsx` :
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BillingToggle } from "../BillingToggle";
+
+describe("BillingToggle", () => {
+  it("renders monthly active state by default", () => {
+    render(<BillingToggle value="monthly" onChange={() => {}} />);
+    const monthly = screen.getByRole("button", { name: /mensuel/i });
+    expect(monthly).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("renders yearly active state", () => {
+    render(<BillingToggle value="yearly" onChange={() => {}} />);
+    const yearly = screen.getByRole("button", { name: /annuel/i });
+    expect(yearly).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("displays −17 % badge near yearly", () => {
+    render(<BillingToggle value="monthly" onChange={() => {}} />);
+    expect(screen.getByText(/-17\s*%/)).toBeInTheDocument();
+  });
+
+  it("calls onChange('yearly') when clicking annuel", () => {
+    const onChange = vi.fn();
+    render(<BillingToggle value="monthly" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /annuel/i }));
+    expect(onChange).toHaveBeenCalledWith("yearly");
+  });
+
+  it("calls onChange('monthly') when clicking mensuel", () => {
+    const onChange = vi.fn();
+    render(<BillingToggle value="yearly" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /mensuel/i }));
+    expect(onChange).toHaveBeenCalledWith("monthly");
+  });
+});
+```
+
+- [ ] **Step 2: Run les tests, vérifier qu'ils échouent**
+
+Run : `cd frontend && npm run test -- src/components/pricing/__tests__/BillingToggle.test.tsx`
+Expected : FAIL — `Cannot find module '../BillingToggle'`.
+
+- [ ] **Step 3: Implémenter BillingToggle.tsx**
+
+Créer `frontend/src/components/pricing/BillingToggle.tsx` :
+
+```typescript
+import { motion } from "framer-motion";
+import type { BillingCycle } from "../../services/api";
+
+interface BillingToggleProps {
+  value: BillingCycle;
+  onChange: (cycle: BillingCycle) => void;
+  className?: string;
+}
+
+/**
+ * Switch mensuel / annuel pour la pricing page v2.
+ * Badge "-17 % / 2 mois offerts" affiché à côté du choix annuel.
+ */
+export function BillingToggle({ value, onChange, className = "" }: BillingToggleProps) {
+  return (
+    <div className={`inline-flex items-center gap-3 ${className}`}>
+      <div
+        role="group"
+        aria-label="Cycle de facturation"
+        className="inline-flex items-center rounded-full bg-white/5 border border-white/10 p-1 backdrop-blur-xl"
+      >
+        <button
+          type="button"
+          role="button"
+          aria-pressed={value === "monthly"}
+          onClick={() => onChange("monthly")}
+          className={`relative px-5 py-2 rounded-full text-sm font-medium transition-colors ${
+            value === "monthly" ? "text-white" : "text-white/60 hover:text-white/80"
+          }`}
+        >
+          {value === "monthly" && (
+            <motion.span
+              layoutId="billing-toggle-active"
+              className="absolute inset-0 rounded-full bg-gradient-to-r from-indigo-500 to-violet-500"
+              transition={{ type: "spring", stiffness: 350, damping: 30 }}
+            />
+          )}
+          <span className="relative z-10">Mensuel</span>
+        </button>
+        <button
+          type="button"
+          role="button"
+          aria-pressed={value === "yearly"}
+          onClick={() => onChange("yearly")}
+          className={`relative px-5 py-2 rounded-full text-sm font-medium transition-colors ${
+            value === "yearly" ? "text-white" : "text-white/60 hover:text-white/80"
+          }`}
+        >
+          {value === "yearly" && (
+            <motion.span
+              layoutId="billing-toggle-active"
+              className="absolute inset-0 rounded-full bg-gradient-to-r from-indigo-500 to-violet-500"
+              transition={{ type: "spring", stiffness: 350, damping: 30 }}
+            />
+          )}
+          <span className="relative z-10">Annuel</span>
+        </button>
+      </div>
+      <span
+        aria-label="Réduction annuelle"
+        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-emerald-500/15 text-emerald-300 border border-emerald-500/30"
+      >
+        -17 % · 2 mois offerts
+      </span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run les tests, vérifier qu'ils passent**
+
+Run : `cd frontend && npm run test -- src/components/pricing/__tests__/BillingToggle.test.tsx`
+Expected : 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/pricing/BillingToggle.tsx frontend/src/components/pricing/__tests__/BillingToggle.test.tsx
+git commit -m "feat(pricing): add BillingToggle component (monthly/yearly + -17% badge)"
+```
+
+---
+
+### Task 11: Composant ComparisonTable — matrice features × plans
+
+**Files:**
+
+- Create: `frontend/src/components/pricing/ComparisonTable.tsx`
+- Create: `frontend/src/components/pricing/__tests__/ComparisonTable.test.tsx`
+
+- [ ] **Step 1: Écrire les tests Vitest**
+
+Créer `frontend/src/components/pricing/__tests__/ComparisonTable.test.tsx` :
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ComparisonTable } from "../ComparisonTable";
+
+describe("ComparisonTable", () => {
+  it("renders 3 columns (free, pro, expert) + features column", () => {
+    render(<ComparisonTable cycle="monthly" />);
+    // Headers : 3 plans
+    expect(screen.getByText(/^Gratuit$/i)).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /^Pro$/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /^Expert$/i })).toBeInTheDocument();
+  });
+
+  it("displays Pro voice minutes (30) and Expert (120)", () => {
+    render(<ComparisonTable cycle="monthly" />);
+    expect(screen.getByText(/30\s*min/i)).toBeInTheDocument();
+    expect(screen.getByText(/120\s*min/i)).toBeInTheDocument();
+  });
+
+  it("shows monthly prices when cycle=monthly", () => {
+    render(<ComparisonTable cycle="monthly" />);
+    expect(screen.getByText(/8[,.]?99/)).toBeInTheDocument();
+    expect(screen.getByText(/19[,.]?99/)).toBeInTheDocument();
+  });
+
+  it("shows yearly prices when cycle=yearly", () => {
+    render(<ComparisonTable cycle="yearly" />);
+    expect(screen.getByText(/89[,.]?90/)).toBeInTheDocument();
+    expect(screen.getByText(/199[,.]?90/)).toBeInTheDocument();
+  });
+
+  it("highlights popular badge on Pro", () => {
+    render(<ComparisonTable cycle="monthly" />);
+    expect(screen.getByText(/populaire/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run les tests, vérifier qu'ils échouent**
+
+Run : `cd frontend && npm run test -- src/components/pricing/__tests__/ComparisonTable.test.tsx`
+Expected : FAIL — composant absent.
+
+- [ ] **Step 3: Implémenter ComparisonTable.tsx**
+
+Créer `frontend/src/components/pricing/ComparisonTable.tsx` :
+
+```typescript
+import { Check, X } from "lucide-react";
+import {
+  PLAN_LIMITS,
+  PLANS_INFO,
+  PLAN_HIERARCHY,
+  type PlanId,
+} from "../../config/planPrivileges";
+import type { BillingCycle } from "../../services/api";
+
+interface ComparisonTableProps {
+  cycle: BillingCycle;
+  className?: string;
+}
+
+interface FeatureRow {
+  label: string;
+  values: Record<PlanId, string | boolean | number>;
+}
+
+function formatPriceCents(cents: number): string {
+  if (cents === 0) return "0 €";
+  const euros = cents / 100;
+  return `${euros.toFixed(2).replace(".", ",")} €`;
+}
+
+function buildRows(): FeatureRow[] {
+  return [
+    {
+      label: "Analyses / mois",
+      values: {
+        free: PLAN_LIMITS.free.monthlyAnalyses,
+        pro: PLAN_LIMITS.pro.monthlyAnalyses,
+        expert: PLAN_LIMITS.expert.monthlyAnalyses,
+      },
+    },
+    {
+      label: "Durée vidéo max",
+      values: {
+        free: `${PLAN_LIMITS.free.maxVideoLengthMin} min`,
+        pro: `${PLAN_LIMITS.pro.maxVideoLengthMin} min`,
+        expert: `${PLAN_LIMITS.expert.maxVideoLengthMin} min`,
+      },
+    },
+    {
+      label: "Chat / vidéo",
+      values: {
+        free: PLAN_LIMITS.free.chatQuestionsPerVideo,
+        pro: PLAN_LIMITS.pro.chatQuestionsPerVideo,
+        expert: PLAN_LIMITS.expert.chatQuestionsPerVideo === -1
+          ? "Illimité"
+          : PLAN_LIMITS.expert.chatQuestionsPerVideo,
+      },
+    },
+    {
+      label: "Mind maps",
+      values: {
+        free: PLAN_LIMITS.free.mindmapEnabled,
+        pro: PLAN_LIMITS.pro.mindmapEnabled,
+        expert: PLAN_LIMITS.expert.mindmapEnabled,
+      },
+    },
+    {
+      label: "Recherche web IA",
+      values: {
+        free: false,
+        pro: `${PLAN_LIMITS.pro.webSearchMonthly}/mois`,
+        expert: `${PLAN_LIMITS.expert.webSearchMonthly}/mois`,
+      },
+    },
+    {
+      label: "Playlists",
+      values: {
+        free: false,
+        pro: false,
+        expert: `${PLAN_LIMITS.expert.maxPlaylists} max`,
+      },
+    },
+    {
+      label: "Export PDF + Markdown",
+      values: {
+        free: false,
+        pro: PLAN_LIMITS.pro.exportPdf,
+        expert: PLAN_LIMITS.expert.exportPdf,
+      },
+    },
+    {
+      label: "Chat vocal ElevenLabs",
+      values: {
+        free: false,
+        pro: `${PLAN_LIMITS.pro.voiceChatMonthlyMinutes} min/mois`,
+        expert: `${PLAN_LIMITS.expert.voiceChatMonthlyMinutes} min/mois`,
+      },
+    },
+    {
+      label: "Deep Research",
+      values: {
+        free: false,
+        pro: false,
+        expert: PLAN_LIMITS.expert.deepResearchEnabled,
+      },
+    },
+    {
+      label: "File prioritaire",
+      values: {
+        free: false,
+        pro: false,
+        expert: PLAN_LIMITS.expert.priorityQueue,
+      },
+    },
+  ];
+}
+
+function renderCell(value: string | boolean | number) {
+  if (value === true) return <Check className="w-5 h-5 text-emerald-400 mx-auto" />;
+  if (value === false) return <X className="w-5 h-5 text-white/30 mx-auto" />;
+  return <span className="text-white">{value}</span>;
+}
+
+export function ComparisonTable({ cycle, className = "" }: ComparisonTableProps) {
+  const rows = buildRows();
+  return (
+    <div className={`overflow-x-auto rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl ${className}`}>
+      <table className="w-full text-left">
+        <thead>
+          <tr className="border-b border-white/10">
+            <th scope="col" className="px-5 py-4 text-sm font-semibold text-white/60">
+              Fonctionnalité
+            </th>
+            {PLAN_HIERARCHY.map((plan) => {
+              const info = PLANS_INFO[plan];
+              const price = cycle === "monthly" ? info.priceMonthly : info.priceYearly;
+              return (
+                <th
+                  key={plan}
+                  scope="col"
+                  className="px-5 py-4 text-center"
+                >
+                  <div className="flex flex-col items-center gap-1">
+                    <span className="text-base font-bold text-white">{info.name}</span>
+                    {info.popular && (
+                      <span className="inline-block px-2 py-0.5 text-[10px] uppercase tracking-wide rounded-full bg-blue-500/20 text-blue-300 border border-blue-500/30">
+                        Populaire
+                      </span>
+                    )}
+                    <span className="text-2xl font-extrabold text-white">
+                      {formatPriceCents(price)}
+                    </span>
+                    <span className="text-xs text-white/50">
+                      /{cycle === "monthly" ? "mois" : "an"}
+                    </span>
+                  </div>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label} className="border-b border-white/5 last:border-b-0">
+              <td className="px-5 py-3 text-sm text-white/80">{row.label}</td>
+              {PLAN_HIERARCHY.map((plan) => (
+                <td key={plan} className="px-5 py-3 text-center text-sm">
+                  {renderCell(row.values[plan])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run les tests**
+
+Run : `cd frontend && npm run test -- src/components/pricing/__tests__/ComparisonTable.test.tsx`
+Expected : 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/pricing/ComparisonTable.tsx frontend/src/components/pricing/__tests__/ComparisonTable.test.tsx
+git commit -m "feat(pricing): add ComparisonTable component (matrix features x plans v2)"
+```
+
+---
+
+### Task 12: UpgradePage v9 — refonte avec toggle + comparison + dual trial CTA
+
+**Files:**
+
+- Modify: `frontend/src/pages/UpgradePage.tsx`
+
+- [ ] **Step 1: Lire UpgradePage.tsx pour identifier la structure existante**
+
+Run : `cd frontend && wc -l src/pages/UpgradePage.tsx` (info — pas un step de test).
+
+- [ ] **Step 2: Refactor UpgradePage v9**
+
+Modifier `frontend/src/pages/UpgradePage.tsx`. Remplacer le doc-header en haut du fichier :
+
+```typescript
+/**
+ * UpgradePage v9 — Pricing v2 (Free / Pro 8.99 € / Expert 19.99 €).
+ *
+ * Différences vs v8 :
+ *  - Toggle BillingToggle mensuel / annuel (-17 %)
+ *  - Composant ComparisonTable (matrice features x plans)
+ *  - 2 CTAs trial : "Essai 7 j gratuit Pro" + "Essai 7 j gratuit Expert"
+ *  - api.startTrial(plan, cycle) + api.createCheckout(plan, cycle)
+ *  - Affichage prix barré legacy si user.is_legacy_pricing (grandfathering)
+ */
+```
+
+Importer les nouveaux composants/types :
+
+```typescript
+import { useState } from "react";
+import { BillingToggle } from "../components/pricing/BillingToggle";
+import { ComparisonTable } from "../components/pricing/ComparisonTable";
+import {
+  billingApi,
+  type BillingCycle,
+  type ApiBillingPlan,
+} from "../services/api";
+import { PLANS_INFO, PLAN_HIERARCHY } from "../config/planPrivileges";
+```
+
+Dans le composant principal, ajouter le state `cycle` :
+
+```typescript
+const [cycle, setCycle] = useState<BillingCycle>("monthly");
+const [loadingPlan, setLoadingPlan] = useState<ApiBillingPlan | null>(null);
+```
+
+Handlers :
+
+```typescript
+async function handleStartTrial(plan: ApiBillingPlan) {
+  setLoadingPlan(plan);
+  try {
+    const { checkout_url } = await billingApi.startTrial(plan, cycle);
+    window.location.href = checkout_url;
+  } catch (e) {
+    // toast error existant
+  } finally {
+    setLoadingPlan(null);
+  }
+}
+
+async function handleSubscribe(plan: ApiBillingPlan) {
+  setLoadingPlan(plan);
+  try {
+    const { checkout_url } = await billingApi.createCheckout(plan, cycle);
+    window.location.href = checkout_url;
+  } catch (e) {
+    // toast error
+  } finally {
+    setLoadingPlan(null);
+  }
+}
+```
+
+Dans le JSX, juste après le hero/headline et avant la grille de plans, insérer :
+
+```tsx
+<div className="flex flex-col items-center gap-4 mb-10">
+  <BillingToggle value={cycle} onChange={setCycle} />
+</div>
+```
+
+Pour chaque plan card v2 (boucler sur `PLAN_HIERARCHY` filtré sur `["pro", "expert"]`), afficher 2 boutons :
+
+```tsx
+{
+  PLAN_HIERARCHY.filter((p) => p !== "free").map((plan) => {
+    const info = PLANS_INFO[plan];
+    const price = cycle === "monthly" ? info.priceMonthly : info.priceYearly;
+    return (
+      <div
+        key={plan}
+        className="rounded-2xl bg-white/5 border border-white/10 p-6 backdrop-blur-xl"
+      >
+        <h3 className="text-2xl font-bold text-white">{info.name}</h3>
+        <p className="text-white/60 text-sm">{info.description}</p>
+        <div className="my-4">
+          <span className="text-4xl font-extrabold text-white">
+            {(price / 100).toFixed(2).replace(".", ",")} €
+          </span>
+          <span className="text-white/50 ml-1">
+            /{cycle === "monthly" ? "mois" : "an"}
+          </span>
+        </div>
+        <button
+          onClick={() => handleStartTrial(plan)}
+          disabled={loadingPlan === plan}
+          className="w-full mb-2 py-3 rounded-xl bg-gradient-to-r from-indigo-500 to-violet-500 text-white font-semibold disabled:opacity-50"
+        >
+          {loadingPlan === plan ? "..." : `Essai 7 j gratuit ${info.name}`}
+        </button>
+        <button
+          onClick={() => handleSubscribe(plan)}
+          disabled={loadingPlan === plan}
+          className="w-full py-3 rounded-xl bg-white/10 border border-white/20 text-white font-medium disabled:opacity-50"
+        >
+          S'abonner directement
+        </button>
+      </div>
+    );
+  });
+}
+```
+
+Ajouter en bas de page, avant le footer, le tableau comparatif :
+
+```tsx
+<section className="mt-16">
+  <h2 className="text-2xl font-bold text-white text-center mb-6">
+    Comparer les plans
+  </h2>
+  <ComparisonTable cycle={cycle} className="max-w-5xl mx-auto" />
+</section>
+```
+
+Ajouter un affichage barré legacy pour les grandfathered users (récupérer `is_legacy_pricing` depuis le user context) :
+
+```tsx
+{
+  user?.is_legacy_pricing && (
+    <div className="rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-3 mb-6 text-sm text-amber-200">
+      🎁 Vous bénéficiez du tarif historique{" "}
+      <strong>
+        {user.plan === "pro"
+          ? "4,99 €/mois"
+          : user.plan === "expert"
+            ? "9,99 €/mois"
+            : ""}
+      </strong>
+      . Vous gardez ce prix tant que votre abonnement reste actif.
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Run le typecheck**
+
+Run : `cd frontend && npm run typecheck 2>&1 | tail -20`
+Expected : pas d'erreur sur UpgradePage. S'il reste des erreurs sur d'autres fichiers consommant `"plus"`, les noter pour follow-up.
+
+- [ ] **Step 4: Lancer le frontend en dev pour smoke test visuel**
+
+Run : `cd frontend && npm run dev`
+Ouvrir `http://localhost:5173/upgrade`. Vérifier :
+
+- Toggle mensuel/annuel s'affiche, badge -17 % visible
+- Switch annuel : prix passent à 89,90 € / 199,90 €
+- 2 CTAs par plan : "Essai 7 j gratuit Pro" + "S'abonner directement"
+- ComparisonTable rendue en bas avec voice 30 min / 120 min
+
+(Couper le dev server après vérif visuelle).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/UpgradePage.tsx
+git commit -m "feat(upgrade): UpgradePage v9 — BillingToggle + ComparisonTable + dual trial CTA (Pro/Expert)"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage
+
+- ✅ H1 Pro 8,99 / 89,90 € : Tasks 2, 3, 8, 11
+- ✅ H2 Expert 19,99 / 199,90 € : Tasks 2, 3, 8, 11
+- ✅ H3 Grandfathering : Task 1 (colonne + backfill) + Task 12 (affichage)
+- ✅ H4 Voice Pro 30 / Expert 120 : Tasks 2, 7, 8
+- ✅ H5 Trial 7 j sans CB Pro+Expert : Task 5 (`payment_method_collection="if_required"`)
+- ✅ H6 4 Stripe Prices : Tasks 3, 4
+- ✅ H7 `users.is_legacy_pricing` : Task 1
+- ✅ H8 Plans hardcodés : tout le plan reste sur `plan_config.py` + `planPrivileges.ts`, aucun chargement DB-driven
+- ✅ Toggle mensuel/annuel : Task 10 + 12
+- ✅ Migration atomique CASE : Task 1 step 3
+- ✅ Aliases inversés : Tasks 2 et 8
+- ✅ Tests pytest + Vitest pour migration, helpers, endpoints, composants : Tasks 1, 2, 3, 5, 6, 7, 8, 10, 11
+
+### 2. Décisions à confirmer (questions ouvertes pour l'équipe)
+
+| ID     | Question                                                                                                                                              | Default proposé                                                                       |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **D1** | Branche unique `release/pricing-v2` shared avec SEO Phase 0, ou 2 branches qui rebase l'une sur l'autre ?                                             | Branche unique (release-train classique)                                              |
+| **D2** | Stripe : seed TEST mode d'abord (preview Vercel + staging), puis LIVE seulement après validation manuelle E2E ?                                       | Oui — séquentiel, pas de seed LIVE en CI                                              |
+| **D3** | Migration des subs Stripe legacy (clients déjà sur ancien Plus 4,99) vers nouveau Price ID Pro 8,99 ? Ou laisser legacy actif jusqu'à churn naturel ? | Laisser legacy (H3 = grandfathering durable)                                          |
+| **D4** | Marketing : afficher le prix legacy barré (4,99 → 8,99) sur UpgradePage pour les grandfathered ? Ou banner discret seulement (cf Task 12 step 2) ?    | Banner discret amber (déjà implémenté)                                                |
+| **D5** | App mobile : refonte pricing dans ce plan ou plan séparé ?                                                                                            | Plan séparé — mobile/UpgradeScreen.tsx hors scope ici (pricing v2 mobile = follow-up) |
+
+### 3. Placeholder scan
+
+Aucun "TBD", "TODO", "implement later", "fill in details" trouvé. Toutes les tasks contiennent du code complet exécutable.
+
+### 4. Type consistency
+
+- ✅ `PlanId` cohérent backend (Python enum) + frontend (TS union) = `"free" | "pro" | "expert"`
+- ✅ `BillingCycle` = `"monthly" | "yearly"` exporté depuis `services/api.ts` et utilisé par `BillingToggle`, `ComparisonTable`, `UpgradePage`
+- ✅ `get_voice_minutes(plan)` (Python) + `PLAN_LIMITS[plan].voiceChatMonthlyMinutes` (TS) → mêmes valeurs (0 / 30 / 120)
+- ✅ `get_price_id(plan, cycle, test_mode)` (Python) ↔ env vars `STRIPE_PRICE_{PLAN}_{CYCLE}_{MODE}` cohérent dans `core/config.py` + `seed_stripe_prices_v2.py`
+- ✅ `is_legacy_pricing` même nom backend (DB column) + frontend (User context)
+
+---
+
+## Release coordination
+
+Ce plan est un **release-train coordonné** avec :
+
+1. **Plan SEO Phase 0** (`2026-04-29-audit-kimi-phase-0-seo-securite.md`, à venir batch 2) :
+   - Doivent merger ENSEMBLE sur branche commune `release/pricing-v2`.
+   - Sinon : SEO annonce 8,99 € en prod pendant Stripe facture l'ancien 4,99 € → incohérence marketing/billing.
+   - Coordination concrète : créer `release/pricing-v2` après merge des deux feature branches dans une PR aggrégée vers `main`.
+
+2. **Plan ElevenLabs voice packs** (`2026-04-29-elevenlabs-voice-packs.md`, parallèle batch 2) :
+   - Indépendant pricing — Alembic 010 (ne touche pas `users.plan`).
+   - Peut merger en parallèle. Ordre : Alembic 010 → Alembic 011 (chaining naturel via `down_revision = "010_add_conversation_digests"` confirmé Task 1).
+
+3. **Plan plans-DB-driven** (`2026-04-29-plans-db-driven.md`) :
+   - `BLOCKED-BY` ce plan. Ne peut pas commencer tant que `pro`/`expert` ne sont pas les noms canoniques en DB + code.
+
+### Checklist coordination merge
+
+- [ ] Merge des deux PRs (pricing-v2 + SEO Phase 0) dans `release/pricing-v2` (squash interdit, merge commit pour traçabilité)
+- [ ] Tag de la branche `release/pricing-v2` avec `pricing-v2-rc1`
+- [ ] Run E2E sur staging avec :
+  - [ ] Migration 011 appliquée sur snapshot prod (validation grandfathering backfill)
+  - [ ] Stripe TEST seedé via `seed_stripe_prices_v2.py` mode test
+  - [ ] Smoke check UpgradePage staging affiche les bons prix (8,99 / 19,99 / 89,90 / 199,90)
+- [ ] PR `release/pricing-v2` → `main` avec :
+  - [ ] Description complète : tableaux v0 → v2, capture UpgradePage v9, screenshots toggle, mention grandfathering
+  - [ ] Checklist déploiement post-merge (run seed Stripe LIVE, set 8 env vars Hetzner, restart container)
+- [ ] Post-merge sur `main` :
+  - [ ] Push → Vercel auto-deploy frontend
+  - [ ] SSH Hetzner : `cd /opt/deepsight/repo && git pull && docker build` + restart container avec `RUN_MIGRATIONS=true`
+  - [ ] Vérifier `users.is_legacy_pricing` populée correctement en prod (count des subs actifs)
+  - [ ] Run `seed_stripe_prices_v2.py` mode LIVE depuis VPS
+  - [ ] Coller les 4 Price IDs LIVE dans `.env.production` Hetzner et restart container
+  - [ ] Vérification E2E manuelle prod : checkout Pro mensuel + Expert annuel + trial Pro
+
+### Rollback plan
+
+En cas de problème post-merge :
+
+1. `git revert` du merge commit `release/pricing-v2` → `main`
+2. `alembic downgrade -1` pour reverse-rename `pro→plus` / `expert→pro` (Task 1 step 3 a un downgrade complet)
+3. Restart container backend
+4. Stripe Prices v2 restent créés mais inutilisés — pas de cleanup nécessaire (idempotence)
+
+---
+
+## Execution Handoff
+
+Plan complet et sauvegardé à `docs/superpowers/plans/2026-04-29-pricing-v2-stripe-grandfathering.md`. Deux options d'exécution :
+
+1. **Subagent-Driven (recommandé)** — un sous-agent frais par task, review entre les tasks, itération rapide. SKILL : `superpowers:subagent-driven-development`.
+
+2. **Inline Execution** — tasks dans la session courante avec batch + checkpoints. SKILL : `superpowers:executing-plans`.
+
+Quelle approche ?
+
+### Manual E2E checklist (Task 12 / post-merge)
+
+Une fois Tasks 1-12 mergées + Stripe seedé, cocher manuellement en staging puis prod :
+
+- [ ] Checkout Pro mensuel : carte test 4242, abonnement créé, `user.plan = "pro"`, `user.is_legacy_pricing = false`
+- [ ] Checkout Pro annuel : même flow, prix 89,90 € en banner Stripe
+- [ ] Checkout Expert mensuel : 19,99 €, `user.plan = "expert"`
+- [ ] Checkout Expert annuel : 199,90 €
+- [ ] Trial Pro : redirect vers Stripe Checkout en mode `if_required` (pas de CB demandée), DB `user.plan = "pro"` après webhook trial-start, factureation déclenchée à J+7 si CB ajoutée
+- [ ] Trial Expert : idem
+- [ ] Grandfathering simulation : créer un user en DB avec `plan = "pro"` + `is_legacy_pricing = true` + `stripe_subscription_id = "sub_legacy"`, vérifier banner amber 4,99 € sur UpgradePage et que `/portal` Stripe renvoie ancien Price ID
+- [ ] Voice quota Pro : appel test 31e min → erreur quota dépassé (confirme 30 min H4)
+- [ ] Voice quota Expert : appel test 121e min → erreur quota dépassé

--- a/docs/superpowers/plans/2026-04-29-programme-parrainage.md
+++ b/docs/superpowers/plans/2026-04-29-programme-parrainage.md
@@ -1,0 +1,2254 @@
+# Programme Parrainage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construire un programme de parrainage acquisition virale "+5 / +5 analyses" (parrain ET filleul) avec table `referrals`, code stable par user, endpoints REST `/api/referral/*`, widget React et hook de complétion sur la 1ère analyse réussie du filleul.
+
+**Architecture:** Backend FastAPI — nouveau module `backend/src/referral/` (router + service pure-logic) ; modèle SQLAlchemy `Referral` + colonne `User.referral_code` via migration Alembic **012** ; intégration aux flux existants (`auth/router.py register` pour `?ref=`, `videos/router.py` ligne ~1650 pour completion). Frontend React — nouveau composant `ReferralWidget` dans `MyAccount`, détection `?ref=` sur LandingPage avec relais `localStorage`, instrumentation PostHog des 5 events parrainage.
+
+**Tech Stack:** Python 3.11 + FastAPI + SQLAlchemy 2.0 async + Alembic + PostgreSQL 17 (prod) / SQLite (dev), pytest async ; React 18 + TypeScript strict + Vite + Tailwind CSS 3 + Vitest + PostHog (déjà câblé).
+
+---
+
+## Contexte préalable
+
+### Audit gap (Phase 5 audit Kimi 2026-04-29 — Quick win #11 P1)
+
+L'audit Kimi a identifié l'absence totale de mécanisme d'acquisition virale comme un gap P1. La spec business est lockée :
+
+- Code parrainage : permanent, format `ds_<base64(user_id)[:8]>`, 1 par user.
+- Récompense **filleul** : +5 analyses (= +250 crédits Mistral Small) à l'inscription, immédiat.
+- Récompense **parrain** : +5 analyses bonus quand le filleul confirme email **+** analyse 1 vidéo (status flip `pending` → `completed`).
+- Anti-fraude soft V1 : SHA256(IP) + email_domain logged uniquement.
+- Limite anti-farming : 50 parrainages "completed" max par user (au-delà, plus de récompense).
+- Statuts : `pending` → `completed` ou `expired` (30 j sans completion).
+
+Conversion crédits validée : Mistral Small = 50 crédits/analyse, plan free = 250 crédits/mois → +5 analyses = +250 crédits. Code utilisé : `core/credits.py:add_credits()` existant (signature `add_credits(session, user_id, amount, reason, transaction_type="bonus")`).
+
+### Cohérence avec les autres plans batch 2
+
+- **`2026-04-29-RELEASE-ORCHESTRATION.md`** (commit `021e4bf1`) — confirme migration Alembic **012** pour ce plan (renumérotation imposée depuis `010` car `010` voice-packs et `011` pricing-v2 viennent avant). `down_revision = "011"` (ou `"009"` si Sprint B pas encore mergé — voir ENV check à T1 step 1).
+- **`2026-04-29-posthog-events-complets.md`** (en parallèle) — `EventPayloadMap` doit recevoir 5 nouveaux events : `referral_link_clicked`, `referral_signup_started`, `referral_completed`, `referral_link_copied`, `referral_share_clicked`. Si plan PostHog pas encore mergé, ce plan utilise des **stubs string** (commentaire `// TODO post plan #6`) — pas d'attente bloquante.
+
+### État DeepSight actuel — vérifié dans le code
+
+- `backend/src/db/database.py:106-185` — classe `User` avec colonnes existantes (`id`, `email`, `plan`, `credits`, `email_verified`, `verification_code`, `preferences` JSON migration 009, etc.). Pas de `referral_code` actuellement.
+- `backend/src/db/database.py:293-307` — classe `CreditTransaction` (utilisée par `add_credits()`).
+- `backend/alembic/versions/` — dernière migration en prod = `009_add_user_preferences_json.py` (révision str = `"009_add_user_preferences_json"`). Le plan voice-packs (`010`) et pricing-v2 (`011`) doivent merger AVANT ce plan ; sinon `down_revision = "009_add_user_preferences_json"`.
+- `backend/src/auth/router.py:67-90` — endpoint `POST /api/auth/register` utilise `create_user(session, username, email, password)` du service. Pas de paramètre `referral_code` actuellement.
+- `backend/src/auth/service.py:159-222` — `create_user()` hardcode crédits initiaux à `PLAN_LIMITS["free"]["monthly_credits"]` (= 250). C'est **ici** qu'on appliquera le bonus filleul (+250 → 500 total).
+- `backend/src/auth/schemas.py:17-22` — schéma `UserRegister(username, email, password)`. À étendre avec `referral_code: Optional[str] = None`.
+- `backend/src/videos/router.py:1646-1652` — ligne pivot V1 : juste après `increment_daily_usage(session, user_id)` du flux v2 principal. **C'est exactement là** qu'on hook `complete_referral_if_first_analysis(session, user_id)`.
+- ⚠ **5 autres blocs `increment_daily_usage`** existent dans `videos/router.py` (lignes 941, 2502, 3254 entre autres — chunks/long-video, debate, batch). **V1 couvre uniquement le flux v2 principal** (ligne 1650). Gap explicite documenté pour itération post-mesure.
+- `backend/src/main.py:1039-1119` — pattern `app.include_router(...)` à suivre pour brancher `referral_router`.
+- `backend/src/core/credits.py:340-373` — `add_credits()` async, retourne `(success: bool, new_balance: int)`. Crée automatiquement une `CreditTransaction` avec `transaction_type="bonus"`.
+- `backend/src/core/plan_limits.py:37-57` — `increment_daily_usage()` qui retourne le compteur du jour ; on pourra l'utiliser pour détecter "1ère analyse" (`new_count == 1` après increment).
+- `frontend/src/services/api.ts:700-711` — `authApi.register(username, email, password)`. À étendre signature `(username, email, password, referralCode?)`.
+- `frontend/src/contexts/AuthContext.tsx:10-14` — interface `register(username, email, password)`. À étendre avec `referralCode?`.
+- `frontend/src/pages/Login.tsx:155-165` — appel `register(email.split("@")[0], email, password)`. À étendre pour passer `localStorage.getItem("pendingReferralCode")`.
+- `frontend/src/pages/LandingPage.tsx:587-591` — `useEffect` redirect logged-in user. **À côté**, ajouter un `useEffect` détection `?ref=` au mount.
+- `frontend/src/pages/MyAccount.tsx:880-887` — section "Mon abonnement / My Subscription" en card. **Juste avant** cette card, on insérera la nouvelle section "Parrainage / Referral Program".
+- `frontend/src/services/analytics.ts:113-116` — `analytics.capture(event, properties)` est l'API standard. À utiliser dans le widget et le hook landing.
+
+### Décisions lockées (cf. spec brief)
+
+- D1 — Limite anti-farming : **50** completed/user (cohérent audit RELEASE-ORCHESTRATION RF-1).
+- D2 — Anti-fraude V1 : **logs only** (SHA256 IP + email_domain) — pas de blocage auto.
+- D3 — Récompense V1 : **crédits seuls** (250 = 5 analyses Mistral Small) — pas de voice minutes.
+- D4 — Email notification parrain au completed : **V2 post-mesure** (pas dans ce sprint).
+- D5 — Migration : **012** (imposé par `RELEASE-ORCHESTRATION.md`).
+
+---
+
+## File Structure
+
+| Fichier                                                              | Action | Responsabilité                                                                                                                                                |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `backend/alembic/versions/012_add_referrals.py`                      | Create | Migration : table `referrals` + enum `referral_status` + colonne `users.referral_code` (UNIQUE indexed nullable).                                             |
+| `backend/src/db/database.py`                                         | Modify | Ajouter colonne `User.referral_code` + classe `Referral` (en bas, après `CreditTransaction`).                                                                 |
+| `backend/src/referral/__init__.py`                                   | Create | Module init (vide ou export router).                                                                                                                          |
+| `backend/src/referral/service.py`                                    | Create | Pure logic async : `generate_code`, `apply_code`, `complete_referral`, `get_stats`. SQLAlchemy queries + `add_credits` integration. Aucun couplage FastAPI.   |
+| `backend/src/referral/schemas.py`                                    | Create | Pydantic schemas in/out (`ReferralCodeResponse`, `ReferralApplyRequest`, `ReferralStatsResponse`).                                                            |
+| `backend/src/referral/router.py`                                     | Create | Endpoints REST `/api/referral/{generate,code/{code},apply,my-stats}`. Dépend de `service.py`.                                                                 |
+| `backend/src/main.py`                                                | Modify | `app.include_router(referral_router, prefix="/api/referral", tags=["Referral"])`.                                                                             |
+| `backend/src/auth/schemas.py`                                        | Modify | Ajouter `referral_code: Optional[str] = None` à `UserRegister`.                                                                                               |
+| `backend/src/auth/router.py`                                         | Modify | `register` extrait `data.referral_code` et appelle `apply_code()` après `create_user`.                                                                        |
+| `backend/src/auth/service.py`                                        | Modify | `create_user` retourne user, ne change pas — application du `apply_code` dans router.                                                                         |
+| `backend/src/videos/router.py`                                       | Modify | Ligne ~1650 : appeler `complete_referral_if_first_analysis(session, user_id)` après `increment_daily_usage`. Try/except non-bloquant.                         |
+| `backend/tests/test_referral.py`                                     | Create | Tests pytest async exhaustifs : idempotence generate, anti-double-credit, limite 50, expiry 30j, status flow, anti-fraud logging.                             |
+| `frontend/src/services/api.ts`                                       | Modify | Ajouter `referralApi.{generate,getStats,applyCode,verifyCode}`. Étendre `authApi.register` signature avec `referralCode?`.                                    |
+| `frontend/src/contexts/AuthContext.tsx`                              | Modify | Étendre interface `register` signature avec `referralCode?`.                                                                                                  |
+| `frontend/src/components/referral/ReferralWidget.tsx`                | Create | Widget React : code visible + bouton copier + stats personnelles + share-buttons (Twitter, LinkedIn, Email). Tailwind, dark-first.                            |
+| `frontend/src/components/referral/__tests__/ReferralWidget.test.tsx` | Create | Tests Vitest : rendu, bouton copier (mock `navigator.clipboard`), affichage stats.                                                                            |
+| `frontend/src/pages/LandingPage.tsx`                                 | Modify | Ajouter `useEffect` détection `?ref=<CODE>` au mount + appel `referralApi.verifyCode` + `localStorage.setItem("pendingReferralCode", ...)` + analytics event. |
+| `frontend/src/pages/Login.tsx`                                       | Modify | Dans `handleSubmit isRegister`, passer `localStorage.getItem("pendingReferralCode")` à `register()` puis `localStorage.removeItem(...)`.                      |
+| `frontend/src/pages/MyAccount.tsx`                                   | Modify | Insérer `<ReferralWidget />` dans nouvelle section juste avant "Mon abonnement".                                                                              |
+| `frontend/src/i18n/fr.json` + `en.json`                              | Modify | Ajouter clés i18n `referral.*` (titre, description, bouton copier, share buttons, stats labels).                                                              |
+
+---
+
+## Tasks bite-sized (TDD)
+
+### Task 1: Migration Alembic 012 — table `referrals` + colonne `users.referral_code`
+
+**Files:**
+
+- Create: `backend/alembic/versions/012_add_referrals.py`
+
+- [ ] **Step 1: Vérifier la dernière migration en place et ajuster `down_revision`**
+
+Run: `ls C:/Users/33667/DeepSight-Main/backend/alembic/versions/`
+
+Expected output: liste avec `009_add_user_preferences_json.py`. Si `010_add_voice_credit_packs.py` ET `011_pricing_v2_rename.py` sont aussi présents → `down_revision = "011"`. Sinon → `down_revision = "009_add_user_preferences_json"` (et noter en commentaire que renumérotation `012` reste correcte par convention RELEASE-ORCHESTRATION).
+
+- [ ] **Step 2: Créer le fichier de migration**
+
+```python
+"""Add referrals table + users.referral_code column.
+
+Revision ID: 012_add_referrals
+Revises: 011_pricing_v2_rename  # ou "009_add_user_preferences_json" si voice-packs+pricing-v2 pas mergés
+Create Date: 2026-04-29
+
+Programme parrainage : table referrals + colonne stable users.referral_code.
+
+Cross-DB:
+  - referral_status enum → ENUM natif sur PostgreSQL, VARCHAR sur SQLite
+  - server_default sur status = 'pending'
+  - Index sur referrer_id (fréquent), code (lookup public), status (filtres stats)
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "012_add_referrals"
+down_revision: Union[str, None] = "011_pricing_v2_rename"  # adjust if needed
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Colonne stable referral_code sur users (UNIQUE, nullable, indexed)
+    op.add_column(
+        "users",
+        sa.Column("referral_code", sa.String(64), nullable=True),
+    )
+    op.create_index(
+        "ix_users_referral_code",
+        "users",
+        ["referral_code"],
+        unique=True,
+    )
+
+    # Table referrals
+    op.create_table(
+        "referrals",
+        sa.Column("id", sa.String(36), primary_key=True),  # uuid4().hex peut faire 32 sans tirets, garder 36 pour str(uuid4())
+        sa.Column(
+            "referrer_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "referee_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("code", sa.String(64), nullable=False, index=True),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "completed", "expired", name="referral_status"),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("referrer_credits_awarded", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("referee_credits_awarded", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("referrer_ip_hash", sa.String(64), nullable=True),
+        sa.Column("referee_ip_hash", sa.String(64), nullable=True),
+        sa.Column("referee_email_domain", sa.String(255), nullable=True),
+    )
+    op.create_index("ix_referrals_status", "referrals", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_referrals_status", table_name="referrals")
+    op.drop_table("referrals")
+    # Drop enum (PostgreSQL only — SQLite ignore)
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        sa.Enum(name="referral_status").drop(bind, checkfirst=True)
+    op.drop_index("ix_users_referral_code", table_name="users")
+    op.drop_column("users", "referral_code")
+```
+
+- [ ] **Step 3: Tester la migration en local SQLite (dev)**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m alembic upgrade head
+```
+
+Expected: `INFO  [alembic.runtime.migration] Running upgrade ... -> 012_add_referrals`. Aucune erreur SQL.
+
+- [ ] **Step 4: Vérifier rollback fonctionnel**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m alembic downgrade -1
+python -m alembic upgrade head
+```
+
+Expected: rollback OK puis re-upgrade OK. La table `referrals` doit disparaître puis réapparaître.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/alembic/versions/012_add_referrals.py
+git commit -m "feat(referral): add Alembic migration 012 for referrals table and users.referral_code"
+```
+
+---
+
+### Task 2: Modèle SQLAlchemy `Referral` + ajout colonne `User.referral_code`
+
+**Files:**
+
+- Modify: `backend/src/db/database.py:106-185` (User class) + bottom of file (new Referral class)
+
+- [ ] **Step 1: Ajouter la colonne `referral_code` à User**
+
+Dans `class User(Base)`, après la ligne `preferences = Column(JSON, ...)` (ligne ~169) :
+
+```python
+    # Programme parrainage : code stable généré à la 1ère demande
+    # (cf. referral/service.py:generate_code). Format ds_<base64(user_id)[:8]>.
+    # UNIQUE pour permettre lookup via /api/referral/code/{code}.
+    referral_code = Column(String(64), unique=True, nullable=True, index=True)
+```
+
+- [ ] **Step 2: Ajouter la classe `Referral` à la fin de `database.py`**
+
+Juste après `CreditTransaction` (ligne ~307), ajouter :
+
+```python
+class Referral(Base):
+    """Table des parrainages : 1 ligne par filleul.
+
+    Lifecycle:
+      pending  → créé au signup avec ?ref=. +5 crédits filleul immédiats.
+      completed → filleul a confirmé email + analysé 1 vidéo. +5 crédits parrain.
+      expired  → 30 jours sans completion. Pas de crédits parrain.
+
+    Anti-fraude V1 (logs only, pas de blocage):
+      referrer_ip_hash + referee_ip_hash : SHA256 des IP au moment des actions.
+      referee_email_domain : domaine email filleul pour détection patterns.
+    """
+
+    __tablename__ = "referrals"
+
+    id = Column(String(36), primary_key=True)  # uuid4 string
+    referrer_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    referee_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=True)
+    code = Column(String(64), nullable=False, index=True)
+    status = Column(String(20), nullable=False, default="pending", server_default="pending")
+    referrer_credits_awarded = Column(Boolean, nullable=False, default=False, server_default=text("false"))
+    referee_credits_awarded = Column(Boolean, nullable=False, default=False, server_default=text("false"))
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    referrer_ip_hash = Column(String(64), nullable=True)
+    referee_ip_hash = Column(String(64), nullable=True)
+    referee_email_domain = Column(String(255), nullable=True)
+
+    def __repr__(self):
+        return f"<Referral {self.id} {self.status} ({self.code})>"
+```
+
+Note : on utilise `String(20)` pour `status` au lieu de `Enum(...)` côté ORM pour rester portable (SQLite dev / PostgreSQL prod). La contrainte enum est posée par la migration côté PostgreSQL uniquement.
+
+- [ ] **Step 3: Smoke test — import ne doit pas casser**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -c "from src.db.database import User, Referral; print(User.__tablename__, Referral.__tablename__)"
+```
+
+Expected output: `users referrals`. Aucune exception.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/db/database.py
+git commit -m "feat(referral): add User.referral_code column and Referral SQLAlchemy model"
+```
+
+---
+
+### Task 3: Service `referral/service.py` — pure logic + tests TDD
+
+**Files:**
+
+- Create: `backend/src/referral/__init__.py`
+- Create: `backend/src/referral/service.py`
+- Create: `backend/tests/test_referral.py`
+
+- [ ] **Step 1: Écrire les tests d'abord — `test_referral.py`**
+
+```python
+"""Tests pure-logic du service parrainage (TDD)."""
+import hashlib
+import pytest
+from datetime import datetime, timedelta, timezone
+from sqlalchemy import select
+
+from src.db.database import User, Referral
+from src.referral.service import (
+    generate_code,
+    apply_code,
+    complete_referral_if_first_analysis,
+    get_stats,
+    REFERRAL_BONUS_CREDITS,
+    MAX_COMPLETED_REFERRALS,
+    REFERRAL_EXPIRY_DAYS,
+)
+
+
+@pytest.mark.asyncio
+async def test_generate_code_idempotent(test_session, test_user):
+    """Le code d'un user ne change jamais entre 2 appels."""
+    code1 = await generate_code(test_session, test_user.id)
+    code2 = await generate_code(test_session, test_user.id)
+    assert code1 == code2
+    assert code1.startswith("ds_")
+    assert len(code1) >= 11  # ds_ + 8 chars min
+
+
+@pytest.mark.asyncio
+async def test_generate_code_unique_per_user(test_session, test_user, test_user_2):
+    """Deux users ont des codes différents."""
+    code_a = await generate_code(test_session, test_user.id)
+    code_b = await generate_code(test_session, test_user_2.id)
+    assert code_a != code_b
+
+
+@pytest.mark.asyncio
+async def test_apply_code_creates_pending_referral_and_awards_referee(test_session, test_user, test_user_2):
+    """Applique un code valide à un nouveau filleul : referral pending + +250 au filleul."""
+    code = await generate_code(test_session, test_user.id)
+    initial_credits = test_user_2.credits
+
+    result = await apply_code(
+        test_session,
+        referee_id=test_user_2.id,
+        code=code,
+        referee_ip="1.2.3.4",
+        referee_email="filleul@example.com",
+    )
+
+    assert result["status"] == "applied"
+    assert result["referee_credits_awarded"] is True
+
+    # Vérifier referral créé
+    ref = (await test_session.execute(select(Referral).where(Referral.referee_id == test_user_2.id))).scalar_one()
+    assert ref.status == "pending"
+    assert ref.referrer_id == test_user.id
+    assert ref.referee_credits_awarded is True
+    assert ref.referrer_credits_awarded is False
+    assert ref.referee_email_domain == "example.com"
+    assert ref.referee_ip_hash == hashlib.sha256(b"1.2.3.4").hexdigest()
+
+    # Vérifier crédit filleul
+    await test_session.refresh(test_user_2)
+    assert test_user_2.credits == initial_credits + REFERRAL_BONUS_CREDITS
+
+
+@pytest.mark.asyncio
+async def test_apply_code_self_referral_rejected(test_session, test_user):
+    """Un user ne peut pas se parrainer lui-même."""
+    code = await generate_code(test_session, test_user.id)
+    result = await apply_code(
+        test_session, referee_id=test_user.id, code=code, referee_ip="1.2.3.4", referee_email="x@y.com"
+    )
+    assert result["status"] == "rejected"
+    assert result["reason"] == "self_referral"
+
+
+@pytest.mark.asyncio
+async def test_apply_code_invalid_code(test_session, test_user_2):
+    """Code inconnu : rejected."""
+    result = await apply_code(
+        test_session, referee_id=test_user_2.id, code="ds_unknown", referee_ip="1.2.3.4", referee_email="x@y.com"
+    )
+    assert result["status"] == "rejected"
+    assert result["reason"] == "invalid_code"
+
+
+@pytest.mark.asyncio
+async def test_apply_code_already_used_by_referee(test_session, test_user, test_user_2):
+    """Un filleul ne peut être parrainé qu'une fois."""
+    code = await generate_code(test_session, test_user.id)
+    await apply_code(test_session, referee_id=test_user_2.id, code=code, referee_ip="1.2.3.4", referee_email="x@y.com")
+    # Second apply
+    result = await apply_code(
+        test_session, referee_id=test_user_2.id, code=code, referee_ip="1.2.3.4", referee_email="x@y.com"
+    )
+    assert result["status"] == "rejected"
+    assert result["reason"] == "already_referred"
+
+
+@pytest.mark.asyncio
+async def test_complete_referral_first_analysis_awards_referrer(test_session, test_user, test_user_2):
+    """Première analyse du filleul : flip pending → completed, +250 au parrain."""
+    code = await generate_code(test_session, test_user.id)
+    await apply_code(test_session, referee_id=test_user_2.id, code=code, referee_ip="1.2.3.4", referee_email="x@y.com")
+    initial_referrer_credits = test_user.credits
+
+    result = await complete_referral_if_first_analysis(test_session, user_id=test_user_2.id)
+
+    assert result["status"] == "completed"
+    ref = (await test_session.execute(select(Referral).where(Referral.referee_id == test_user_2.id))).scalar_one()
+    assert ref.status == "completed"
+    assert ref.referrer_credits_awarded is True
+    assert ref.completed_at is not None
+
+    await test_session.refresh(test_user)
+    assert test_user.credits == initial_referrer_credits + REFERRAL_BONUS_CREDITS
+
+
+@pytest.mark.asyncio
+async def test_complete_referral_idempotent_no_double_credit(test_session, test_user, test_user_2):
+    """Appeler complete deux fois ne double-crédit pas le parrain."""
+    code = await generate_code(test_session, test_user.id)
+    await apply_code(test_session, referee_id=test_user_2.id, code=code, referee_ip="1.2.3.4", referee_email="x@y.com")
+
+    await complete_referral_if_first_analysis(test_session, user_id=test_user_2.id)
+    await test_session.refresh(test_user)
+    credits_after_first = test_user.credits
+
+    await complete_referral_if_first_analysis(test_session, user_id=test_user_2.id)
+    await test_session.refresh(test_user)
+    assert test_user.credits == credits_after_first  # pas de double-credit
+
+
+@pytest.mark.asyncio
+async def test_complete_referral_no_op_when_no_referral(test_session, test_user_2):
+    """User sans referral pending : no-op."""
+    result = await complete_referral_if_first_analysis(test_session, user_id=test_user_2.id)
+    assert result["status"] == "noop"
+
+
+@pytest.mark.asyncio
+async def test_max_completed_referrals_blocks_referrer_credit(test_session, test_user, factory_user, factory_referral_completed):
+    """Au-delà de 50 completed, le parrain ne reçoit plus de crédits (filleul si)."""
+    # Créer 50 referrals déjà completed pour test_user
+    for _ in range(MAX_COMPLETED_REFERRALS):
+        ref = await factory_referral_completed(referrer_id=test_user.id)
+        assert ref.referrer_credits_awarded is True
+
+    initial_referrer_credits = test_user.credits
+
+    # Nouveau filleul (51e)
+    new_referee = await factory_user(email="referee_51@example.com")
+    code = await generate_code(test_session, test_user.id)
+    await apply_code(test_session, referee_id=new_referee.id, code=code, referee_ip="1.2.3.4", referee_email="x@y.com")
+    await complete_referral_if_first_analysis(test_session, user_id=new_referee.id)
+
+    await test_session.refresh(test_user)
+    # Le filleul a quand même reçu ses crédits ; le parrain est plafonné
+    assert test_user.credits == initial_referrer_credits  # PAS de crédit en plus pour le 51e
+
+
+@pytest.mark.asyncio
+async def test_get_stats_counts_correctly(test_session, test_user):
+    """get_stats retourne code, share_url, total_referrals, completed_count, pending_count, credits_earned."""
+    code = await generate_code(test_session, test_user.id)
+    stats = await get_stats(test_session, test_user.id)
+
+    assert stats["code"] == code
+    assert stats["share_url"] == f"https://www.deepsightsynthesis.com/?ref={code}"
+    assert stats["total_referrals"] == 0
+    assert stats["completed_count"] == 0
+    assert stats["pending_count"] == 0
+    assert stats["credits_earned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_expiry_30_days_marks_expired(test_session, test_user, test_user_2):
+    """Un referral pending de plus de 30 jours est marqué expired (manuellement testé via direct DB)."""
+    code = await generate_code(test_session, test_user.id)
+    await apply_code(test_session, referee_id=test_user_2.id, code=code, referee_ip="1.2.3.4", referee_email="x@y.com")
+    ref = (await test_session.execute(select(Referral).where(Referral.referee_id == test_user_2.id))).scalar_one()
+    # Force created_at à 31 jours en arrière
+    ref.created_at = datetime.now(timezone.utc) - timedelta(days=REFERRAL_EXPIRY_DAYS + 1)
+    await test_session.commit()
+
+    # Le filleul fait sa 1ère analyse APRÈS expiry — le parrain ne doit PAS recevoir
+    initial_referrer_credits = test_user.credits
+    result = await complete_referral_if_first_analysis(test_session, user_id=test_user_2.id)
+
+    await test_session.refresh(test_user)
+    assert test_user.credits == initial_referrer_credits  # expired, pas de crédit
+    ref = (await test_session.execute(select(Referral).where(Referral.referee_id == test_user_2.id))).scalar_one()
+    assert ref.status == "expired"
+```
+
+Note : ces tests supposent les fixtures suivantes dans `tests/conftest.py` (déjà partiellement présentes) :
+
+- `test_session` (AsyncSession liée à une SQLite in-memory)
+- `test_user`, `test_user_2` (User créés en fixtures)
+- `factory_user(email)` (factory qui crée un User)
+- `factory_referral_completed(referrer_id)` (factory qui crée un Referral status="completed")
+
+Si les factories n'existent pas encore, les ajouter dans `conftest.py` :
+
+```python
+# tests/conftest.py — ajouter en bas si absent
+import uuid
+from sqlalchemy import select as sa_select
+from src.db.database import User, Referral
+
+@pytest.fixture
+async def factory_user(test_session):
+    async def _make_user(email: str = "factory@example.com", username: str = None):
+        username = username or email.split("@")[0]
+        user = User(
+            username=username,
+            email=email,
+            password_hash="$2b$12$dummy",
+            email_verified=True,
+            plan="free",
+            credits=250,
+        )
+        test_session.add(user)
+        await test_session.commit()
+        await test_session.refresh(user)
+        return user
+    return _make_user
+
+
+@pytest.fixture
+async def factory_referral_completed(test_session, factory_user):
+    async def _make_completed_referral(referrer_id: int):
+        referee = await factory_user(email=f"completed_{uuid.uuid4().hex[:6]}@example.com")
+        ref = Referral(
+            id=str(uuid.uuid4()),
+            referrer_id=referrer_id,
+            referee_id=referee.id,
+            code=f"ds_{uuid.uuid4().hex[:8]}",
+            status="completed",
+            referrer_credits_awarded=True,
+            referee_credits_awarded=True,
+            completed_at=datetime.now(timezone.utc),
+        )
+        test_session.add(ref)
+        await test_session.commit()
+        return ref
+    return _make_completed_referral
+```
+
+- [ ] **Step 2: Lancer les tests pour vérifier qu'ils échouent (TDD red)**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_referral.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.referral'` ou similaire.
+
+- [ ] **Step 3: Créer `backend/src/referral/__init__.py`**
+
+```python
+"""Module parrainage — endpoints + service pure-logic."""
+```
+
+- [ ] **Step 4: Implémenter `backend/src/referral/service.py`**
+
+```python
+"""Programme parrainage — logique pure async (TDD).
+
+Toutes les fonctions sont pures (pas de I/O HTTP). Couplage uniquement avec
+SQLAlchemy AsyncSession + db.database.User/Referral + core/credits.add_credits.
+"""
+import base64
+import hashlib
+import uuid
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, Optional
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import User, Referral
+from core.credits import add_credits
+
+# Constantes business (cf. RELEASE-ORCHESTRATION RF-1/RF-2/RF-3 + spec lockée)
+REFERRAL_BONUS_CREDITS = 250  # = 5 analyses Mistral Small (50 crédits/analyse)
+MAX_COMPLETED_REFERRALS = 50  # Anti-farming : au-delà, plus de récompense parrain
+REFERRAL_EXPIRY_DAYS = 30  # Pending au-delà de 30j → expired
+
+SHARE_URL_BASE = "https://www.deepsightsynthesis.com"
+
+
+def _hash_ip(ip: Optional[str]) -> Optional[str]:
+    """SHA256 d'une IP. Retourne None si IP absent."""
+    if not ip:
+        return None
+    return hashlib.sha256(ip.encode("utf-8")).hexdigest()
+
+
+def _email_domain(email: Optional[str]) -> Optional[str]:
+    """Extrait le domaine d'un email. Retourne None si invalide."""
+    if not email or "@" not in email:
+        return None
+    return email.split("@", 1)[1].lower().strip()[:255]
+
+
+async def generate_code(session: AsyncSession, user_id: int) -> str:
+    """Génère/retourne le code parrainage stable d'un user (idempotent).
+
+    Format : ds_<base64url(user_id 4 bytes big-endian)[:8]>
+    """
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise ValueError(f"User {user_id} not found")
+
+    if user.referral_code:
+        return user.referral_code
+
+    # Encoder user_id sur 4 bytes + base64 urlsafe sans padding
+    raw = user_id.to_bytes(4, "big", signed=False)
+    encoded = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    code = f"ds_{encoded[:8]}"
+
+    user.referral_code = code
+    await session.commit()
+    await session.refresh(user)
+    return code
+
+
+async def verify_code(session: AsyncSession, code: str) -> Optional[Dict[str, Any]]:
+    """Vérifie qu'un code existe (lookup public landing). Retourne {referrer_id, referrer_username} ou None."""
+    if not code or not code.startswith("ds_"):
+        return None
+    result = await session.execute(select(User).where(User.referral_code == code))
+    user = result.scalar_one_or_none()
+    if user is None:
+        return None
+    return {"referrer_id": user.id, "referrer_username": user.username}
+
+
+async def apply_code(
+    session: AsyncSession,
+    referee_id: int,
+    code: str,
+    referee_ip: Optional[str],
+    referee_email: Optional[str],
+) -> Dict[str, Any]:
+    """Applique un code parrainage à un nouveau filleul (au signup).
+
+    - Crée Referral(status="pending") si valide.
+    - Crédite +250 au filleul (referee_credits_awarded=True).
+    - Pas de crédit parrain ici (vient au complete).
+
+    Retourne :
+      {"status": "applied", "referee_credits_awarded": True, "referral_id": "..."}
+      {"status": "rejected", "reason": "self_referral|invalid_code|already_referred"}
+    """
+    # Lookup parrain via code
+    result = await session.execute(select(User).where(User.referral_code == code))
+    referrer = result.scalar_one_or_none()
+    if referrer is None:
+        return {"status": "rejected", "reason": "invalid_code"}
+
+    if referrer.id == referee_id:
+        return {"status": "rejected", "reason": "self_referral"}
+
+    # Vérifier que le filleul n'a pas déjà été parrainé
+    existing = await session.execute(select(Referral).where(Referral.referee_id == referee_id))
+    if existing.scalar_one_or_none() is not None:
+        return {"status": "rejected", "reason": "already_referred"}
+
+    # Créer Referral pending
+    ref = Referral(
+        id=str(uuid.uuid4()),
+        referrer_id=referrer.id,
+        referee_id=referee_id,
+        code=code,
+        status="pending",
+        referrer_credits_awarded=False,
+        referee_credits_awarded=False,
+        referee_ip_hash=_hash_ip(referee_ip),
+        referee_email_domain=_email_domain(referee_email),
+    )
+    session.add(ref)
+    await session.commit()
+
+    # Créditer le filleul (+250)
+    success, _ = await add_credits(
+        session,
+        user_id=referee_id,
+        amount=REFERRAL_BONUS_CREDITS,
+        reason=f"Bonus parrainage (filleul de {referrer.username})",
+        transaction_type="bonus",
+    )
+    if success:
+        ref.referee_credits_awarded = True
+        await session.commit()
+
+    return {
+        "status": "applied",
+        "referee_credits_awarded": ref.referee_credits_awarded,
+        "referral_id": ref.id,
+    }
+
+
+async def complete_referral_if_first_analysis(
+    session: AsyncSession, user_id: int
+) -> Dict[str, Any]:
+    """Hook à appeler après chaque analyse réussie d'un user.
+
+    - Si le user a un Referral pending dont il est le filleul, et qu'il vient
+      de compléter sa 1ère analyse : flip à completed + crédite parrain (+250)
+      sauf si parrain a déjà MAX_COMPLETED_REFERRALS completed.
+    - Si referral pending est expired (> 30j), flip à expired sans crédit.
+    - Sinon no-op.
+
+    Idempotent : le check `referrer_credits_awarded` empêche le double-credit.
+    """
+    result = await session.execute(
+        select(Referral).where(
+            Referral.referee_id == user_id,
+            Referral.status == "pending",
+        )
+    )
+    ref = result.scalar_one_or_none()
+    if ref is None:
+        return {"status": "noop"}
+
+    now = datetime.now(timezone.utc)
+    # created_at peut être naive sur SQLite ; normalize
+    created_at = ref.created_at
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+
+    # Vérifier expiry
+    if now - created_at > timedelta(days=REFERRAL_EXPIRY_DAYS):
+        ref.status = "expired"
+        await session.commit()
+        return {"status": "expired"}
+
+    # Vérifier le quota anti-farming du parrain
+    completed_count_result = await session.execute(
+        select(func.count(Referral.id)).where(
+            Referral.referrer_id == ref.referrer_id,
+            Referral.status == "completed",
+        )
+    )
+    completed_count = completed_count_result.scalar_one()
+
+    # Flip à completed (toujours, même si pas de crédit parrain)
+    ref.status = "completed"
+    ref.completed_at = now
+
+    if completed_count >= MAX_COMPLETED_REFERRALS:
+        # Anti-farming hit : on flip mais on ne crédite pas le parrain
+        await session.commit()
+        return {"status": "completed", "referrer_credits_awarded": False, "reason": "max_reached"}
+
+    if not ref.referrer_credits_awarded:
+        success, _ = await add_credits(
+            session,
+            user_id=ref.referrer_id,
+            amount=REFERRAL_BONUS_CREDITS,
+            reason=f"Bonus parrainage (filleul user_id={user_id} a complété 1 analyse)",
+            transaction_type="bonus",
+        )
+        if success:
+            ref.referrer_credits_awarded = True
+
+    await session.commit()
+    return {"status": "completed", "referrer_credits_awarded": ref.referrer_credits_awarded}
+
+
+async def get_stats(session: AsyncSession, user_id: int) -> Dict[str, Any]:
+    """Retourne les stats parrainage du user (pour widget MyAccount)."""
+    code = await generate_code(session, user_id)
+    share_url = f"{SHARE_URL_BASE}/?ref={code}"
+
+    # Count par status
+    result = await session.execute(
+        select(Referral.status, func.count(Referral.id))
+        .where(Referral.referrer_id == user_id)
+        .group_by(Referral.status)
+    )
+    counts: Dict[str, int] = {"pending": 0, "completed": 0, "expired": 0}
+    for status, count in result.all():
+        counts[status] = count
+
+    total = counts["pending"] + counts["completed"] + counts["expired"]
+    credits_earned = counts["completed"] * REFERRAL_BONUS_CREDITS  # approximation
+
+    return {
+        "code": code,
+        "share_url": share_url,
+        "total_referrals": total,
+        "completed_count": counts["completed"],
+        "pending_count": counts["pending"],
+        "credits_earned": credits_earned,
+    }
+```
+
+- [ ] **Step 5: Lancer les tests — TDD green**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_referral.py -v
+```
+
+Expected: tous les tests PASS (12 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/referral/__init__.py backend/src/referral/service.py backend/tests/test_referral.py backend/tests/conftest.py
+git commit -m "feat(referral): add service.py with TDD tests for generate/apply/complete/get_stats"
+```
+
+---
+
+### Task 4: Schemas Pydantic + endpoints REST `/api/referral/*`
+
+**Files:**
+
+- Create: `backend/src/referral/schemas.py`
+- Create: `backend/src/referral/router.py`
+- Modify: `backend/src/main.py:1039-1119` (include_router)
+- Modify (existing): `backend/tests/test_referral.py` (ajouter tests endpoints)
+
+- [ ] **Step 1: Écrire les tests endpoints (TDD red)**
+
+Ajouter à la fin de `backend/tests/test_referral.py` :
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests endpoints REST
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_endpoint_generate_returns_code(async_client, auth_headers):
+    """POST /api/referral/generate retourne un code stable."""
+    r1 = await async_client.post("/api/referral/generate", headers=auth_headers)
+    assert r1.status_code == 200
+    data1 = r1.json()
+    assert "code" in data1
+    assert "share_url" in data1
+    assert data1["code"].startswith("ds_")
+
+    # Idempotence
+    r2 = await async_client.post("/api/referral/generate", headers=auth_headers)
+    assert r2.json()["code"] == data1["code"]
+
+
+@pytest.mark.asyncio
+async def test_endpoint_verify_code_public(async_client, test_session, test_user):
+    """GET /api/referral/code/{code} est public et retourne 200 si code valide."""
+    code = await generate_code(test_session, test_user.id)
+    r = await async_client.get(f"/api/referral/code/{code}")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["valid"] is True
+    assert data["referrer_username"] == test_user.username
+
+
+@pytest.mark.asyncio
+async def test_endpoint_verify_code_404(async_client):
+    """GET /api/referral/code/<unknown> retourne 404."""
+    r = await async_client.get("/api/referral/code/ds_unknown")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_endpoint_my_stats(async_client, auth_headers):
+    """GET /api/referral/my-stats retourne {code, share_url, total_referrals, ...}."""
+    r = await async_client.get("/api/referral/my-stats", headers=auth_headers)
+    assert r.status_code == 200
+    data = r.json()
+    for key in ("code", "share_url", "total_referrals", "completed_count", "pending_count", "credits_earned"):
+        assert key in data
+
+
+@pytest.mark.asyncio
+async def test_endpoint_apply_called_internally(async_client, test_session, test_user, factory_user):
+    """POST /api/referral/apply (interne, auth) crée un referral."""
+    code = await generate_code(test_session, test_user.id)
+    referee = await factory_user(email="apply_endpoint@example.com")
+    # Auth as referee
+    referee_token = create_test_jwt(referee.id)  # helper conftest
+    r = await async_client.post(
+        "/api/referral/apply",
+        headers={"Authorization": f"Bearer {referee_token}"},
+        json={"code": code},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "applied"
+```
+
+Note : ces tests supposent les fixtures `async_client`, `auth_headers` et l'helper `create_test_jwt` dans `conftest.py`. Si absents, voir le pattern dans `tests/test_billing.py` ou `tests/test_auth_flow.py` et adapter.
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_referral.py::test_endpoint_generate_returns_code -v
+```
+
+Expected: FAIL — endpoint inexistant.
+
+- [ ] **Step 2: Créer `backend/src/referral/schemas.py`**
+
+```python
+"""Pydantic schemas pour le module parrainage."""
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class ReferralCodeResponse(BaseModel):
+    """Réponse de POST /api/referral/generate."""
+
+    code: str = Field(..., description="Code parrainage stable")
+    share_url: str = Field(..., description="Lien complet à partager")
+
+
+class ReferralVerifyResponse(BaseModel):
+    """Réponse de GET /api/referral/code/{code}."""
+
+    valid: bool
+    referrer_username: Optional[str] = None
+
+
+class ReferralApplyRequest(BaseModel):
+    """Body de POST /api/referral/apply."""
+
+    code: str = Field(..., min_length=4, max_length=64)
+
+
+class ReferralApplyResponse(BaseModel):
+    """Réponse de POST /api/referral/apply."""
+
+    status: str  # "applied" | "rejected"
+    reason: Optional[str] = None
+    referee_credits_awarded: Optional[bool] = None
+    referral_id: Optional[str] = None
+
+
+class ReferralStatsResponse(BaseModel):
+    """Réponse de GET /api/referral/my-stats."""
+
+    code: str
+    share_url: str
+    total_referrals: int
+    completed_count: int
+    pending_count: int
+    credits_earned: int
+```
+
+- [ ] **Step 3: Créer `backend/src/referral/router.py`**
+
+```python
+"""Endpoints REST du programme parrainage."""
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import get_current_user
+from db.database import User, get_session
+
+from .schemas import (
+    ReferralApplyRequest,
+    ReferralApplyResponse,
+    ReferralCodeResponse,
+    ReferralStatsResponse,
+    ReferralVerifyResponse,
+)
+from .service import (
+    SHARE_URL_BASE,
+    apply_code,
+    generate_code,
+    get_stats,
+    verify_code,
+)
+
+router = APIRouter()
+
+
+def _client_ip(request: Request) -> str:
+    """Extrait l'IP client en respectant les headers de proxy."""
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "0.0.0.0"
+
+
+@router.post("/generate", response_model=ReferralCodeResponse)
+async def generate(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ReferralCodeResponse:
+    """Génère ou retourne le code parrainage stable de l'utilisateur (idempotent)."""
+    code = await generate_code(session, user.id)
+    return ReferralCodeResponse(code=code, share_url=f"{SHARE_URL_BASE}/?ref={code}")
+
+
+@router.get("/code/{code}", response_model=ReferralVerifyResponse)
+async def verify(code: str, session: AsyncSession = Depends(get_session)) -> ReferralVerifyResponse:
+    """Vérifie publiquement la validité d'un code (utilisé par la landing au mount avec ?ref=)."""
+    info = await verify_code(session, code)
+    if info is None:
+        raise HTTPException(status_code=404, detail="Code parrainage inconnu")
+    return ReferralVerifyResponse(valid=True, referrer_username=info["referrer_username"])
+
+
+@router.post("/apply", response_model=ReferralApplyResponse)
+async def apply(
+    payload: ReferralApplyRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ReferralApplyResponse:
+    """Applique un code parrainage au compte du user authentifié.
+
+    Normalement appelé en interne par /api/auth/register quand referral_code est
+    fourni au signup. Endpoint exposé pour le cas où le user est déjà connecté
+    et entre un code après coup (rare, mais supporté).
+    """
+    result = await apply_code(
+        session,
+        referee_id=user.id,
+        code=payload.code,
+        referee_ip=_client_ip(request),
+        referee_email=user.email,
+    )
+    return ReferralApplyResponse(**result)
+
+
+@router.get("/my-stats", response_model=ReferralStatsResponse)
+async def my_stats(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ReferralStatsResponse:
+    """Retourne les stats parrainage de l'utilisateur authentifié."""
+    stats = await get_stats(session, user.id)
+    return ReferralStatsResponse(**stats)
+```
+
+- [ ] **Step 4: Brancher le router dans `backend/src/main.py`**
+
+Dans `backend/src/main.py` :
+
+1. En haut, après les autres imports de routers (ligne ~1039 zone) :
+
+```python
+from referral.router import router as referral_router
+```
+
+2. Après les autres `app.include_router(...)` (ligne ~1119) :
+
+```python
+app.include_router(referral_router, prefix="/api/referral", tags=["Referral"])
+```
+
+- [ ] **Step 5: Lancer les tests endpoints — TDD green**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_referral.py -v
+```
+
+Expected: tous les tests PASS.
+
+- [ ] **Step 6: Smoke test runtime**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend/src
+uvicorn main:app --port 8000 &
+sleep 3
+curl -s http://localhost:8000/openapi.json | python -c "import sys, json; d=json.load(sys.stdin); print([p for p in d['paths'] if 'referral' in p])"
+```
+
+Expected output : `['/api/referral/generate', '/api/referral/code/{code}', '/api/referral/apply', '/api/referral/my-stats']`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/referral/schemas.py backend/src/referral/router.py backend/src/main.py backend/tests/test_referral.py
+git commit -m "feat(referral): add REST endpoints /api/referral/{generate,verify,apply,my-stats}"
+```
+
+---
+
+### Task 5: Hook signup — `auth/router.py register` accepte `referral_code`
+
+**Files:**
+
+- Modify: `backend/src/auth/schemas.py:17-22` (UserRegister)
+- Modify: `backend/src/auth/router.py:67-90` (register endpoint)
+- Modify: `backend/tests/test_referral.py` (ajouter test signup E2E)
+
+- [ ] **Step 1: Test E2E signup avec referral_code (TDD red)**
+
+Ajouter à `backend/tests/test_referral.py` :
+
+```python
+@pytest.mark.asyncio
+async def test_signup_with_referral_code_credits_referee(async_client, test_session, test_user):
+    """POST /api/auth/register avec referral_code → +250 crédits au filleul."""
+    code = await generate_code(test_session, test_user.id)
+
+    r = await async_client.post(
+        "/api/auth/register",
+        json={
+            "username": "newreferee",
+            "email": "newreferee@example.com",
+            "password": "secret123",
+            "referral_code": code,
+        },
+    )
+    assert r.status_code == 200
+
+    # Vérifier que le user créé a 500 crédits (250 plan free + 250 bonus)
+    from sqlalchemy import select
+    from src.db.database import User
+    user = (await test_session.execute(select(User).where(User.email == "newreferee@example.com"))).scalar_one()
+    assert user.credits == 500
+
+
+@pytest.mark.asyncio
+async def test_signup_with_invalid_referral_code_still_creates_user(async_client):
+    """POST /api/auth/register avec referral_code invalide → user créé sans bonus, pas d'erreur 400."""
+    r = await async_client.post(
+        "/api/auth/register",
+        json={
+            "username": "noreferral",
+            "email": "noreferral@example.com",
+            "password": "secret123",
+            "referral_code": "ds_garbage",
+        },
+    )
+    assert r.status_code == 200  # le signup n'échoue pas
+```
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_referral.py::test_signup_with_referral_code_credits_referee -v
+```
+
+Expected: FAIL — `referral_code` est ignoré.
+
+- [ ] **Step 2: Étendre `UserRegister` schema dans `auth/schemas.py`**
+
+Remplacer la classe `UserRegister` (ligne 17-22) :
+
+```python
+class UserRegister(BaseModel):
+    """Schéma pour l'inscription. referral_code est optionnel (passé via ?ref=<CODE> sur landing)."""
+
+    username: str = Field(..., min_length=3, max_length=50)
+    email: EmailStr
+    password: str = Field(..., min_length=6)
+    referral_code: Optional[str] = Field(
+        default=None,
+        max_length=64,
+        description="Code parrainage optionnel (ex: ds_a1b2c3d4) — accorde +250 crédits au filleul",
+    )
+```
+
+- [ ] **Step 3: Étendre `register` dans `auth/router.py`**
+
+Remplacer la fonction `register` (ligne 67-90) :
+
+```python
+@router.post("/register", response_model=MessageResponse)
+async def register(
+    data: UserRegister,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+):
+    """
+    Inscription d'un nouvel utilisateur.
+
+    - Envoie un email de vérification si EMAIL_ENABLED.
+    - Si data.referral_code est fourni et valide → +250 crédits filleul (immédiat).
+    """
+    success, user, message = await create_user(
+        session, username=data.username, email=data.email, password=data.password
+    )
+
+    if not success:
+        raise HTTPException(status_code=400, detail=message)
+
+    # 🎁 Programme parrainage : appliquer le code si fourni (best-effort, non-bloquant)
+    if data.referral_code and user:
+        try:
+            from referral.service import apply_code
+
+            # Extraire IP cliente
+            forwarded = request.headers.get("X-Forwarded-For")
+            referee_ip = forwarded.split(",")[0].strip() if forwarded else (
+                request.client.host if request.client else None
+            )
+            apply_result = await apply_code(
+                session,
+                referee_id=user.id,
+                code=data.referral_code,
+                referee_ip=referee_ip,
+                referee_email=user.email,
+            )
+            if apply_result.get("status") == "applied":
+                print(f"🎁 Referral applied at signup: user {user.id} from code {data.referral_code}", flush=True)
+        except Exception as ref_err:
+            # Le signup réussit même si le bonus échoue (logged uniquement)
+            print(f"⚠️ Referral application failed at signup (non-blocking): {ref_err}", flush=True)
+
+    # Envoyer l'email de vérification
+    if EMAIL_CONFIG.get("ENABLED") and user and user.verification_code:
+        email_sent = await send_verification_email(
+            email=user.email, code=user.verification_code, username=user.username
+        )
+        if email_sent:
+            message = "✅ Compte créé ! Vérifiez votre email."
+        else:
+            message = "✅ Compte créé ! Email de vérification non envoyé."
+
+    return MessageResponse(success=True, message=message)
+```
+
+⚠ Penser à ajouter `from fastapi import Request` en haut de `auth/router.py` si absent.
+
+- [ ] **Step 4: Lancer les tests — TDD green**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_referral.py::test_signup_with_referral_code_credits_referee tests/test_referral.py::test_signup_with_invalid_referral_code_still_creates_user -v
+```
+
+Expected: 2 tests PASS.
+
+- [ ] **Step 5: Vérifier non-régression auth tests**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_auth_flow.py tests/test_auth_comprehensive.py -v
+```
+
+Expected: tous les tests existants PASS (le champ `referral_code` est optionnel donc rétrocompatible).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/auth/schemas.py backend/src/auth/router.py backend/tests/test_referral.py
+git commit -m "feat(referral): wire signup to apply referral_code at register time"
+```
+
+---
+
+### Task 6: Hook completion — `videos/router.py` après 1ère analyse réussie
+
+**Files:**
+
+- Modify: `backend/src/videos/router.py:1646-1652` (point pivot V1 — flux v2 principal)
+- Modify (existing): `backend/tests/test_referral.py` (ajouter test E2E completion)
+
+⚠ V1 SCOPE EXPLICIT : seul le flux v2 principal (ligne 1650) est instrumenté. Les 5 autres blocs `increment_daily_usage` (chunks long-video ligne 941, batch ligne 2502, debate ligne 3254, etc.) ne déclenchent PAS le hook completion en V1. **Ce gap est volontaire** pour limiter le risque de régression — il sera comblé post-mesure usage en itération suivante.
+
+- [ ] **Step 1: Ajouter test E2E completion (TDD red)**
+
+Ajouter à `backend/tests/test_referral.py` :
+
+```python
+@pytest.mark.asyncio
+async def test_complete_referral_called_after_first_analysis_v2(test_session, test_user, test_user_2):
+    """Simule l'appel manuel du hook avec un user_id qui a un referral pending."""
+    # Setup : code + apply
+    code = await generate_code(test_session, test_user.id)
+    await apply_code(
+        test_session, referee_id=test_user_2.id, code=code, referee_ip="1.2.3.4", referee_email="x@y.com"
+    )
+    initial_referrer_credits = test_user.credits
+
+    # Act : appel direct du hook (simule ce que videos/router.py fait à la ligne 1650)
+    result = await complete_referral_if_first_analysis(test_session, user_id=test_user_2.id)
+
+    # Assert
+    assert result["status"] == "completed"
+    await test_session.refresh(test_user)
+    assert test_user.credits == initial_referrer_credits + REFERRAL_BONUS_CREDITS
+```
+
+Note : ce test confirme uniquement la pure-logic (déjà testée en Task 3) ; il sert ici de garde-fou que l'API est utilisable depuis videos/router.py.
+
+- [ ] **Step 2: Modifier `videos/router.py` ligne 1646-1652**
+
+Remplacer le bloc :
+
+```python
+            # Incrémenter le quota quotidien
+            try:
+                from core.plan_limits import increment_daily_usage
+
+                await increment_daily_usage(session, user_id)
+            except Exception as quota_err:
+                logger.error(f"⚠️ [v2] Quota increment failed: {quota_err}")
+```
+
+par :
+
+```python
+            # Incrémenter le quota quotidien
+            try:
+                from core.plan_limits import increment_daily_usage
+
+                await increment_daily_usage(session, user_id)
+            except Exception as quota_err:
+                logger.error(f"⚠️ [v2] Quota increment failed: {quota_err}")
+
+            # 🎁 Programme parrainage : compléter referral pending si 1ère analyse
+            # V1 SCOPE : seul ce flux v2 principal est instrumenté.
+            # Les autres blocs `increment_daily_usage` (chunks, batch, debate)
+            # ne déclenchent PAS encore — gap volontaire à itérer post-mesure.
+            try:
+                from referral.service import complete_referral_if_first_analysis
+
+                ref_result = await complete_referral_if_first_analysis(session, user_id=user_id)
+                if ref_result.get("status") == "completed":
+                    logger.info(
+                        f"🎁 Referral completed: user {user_id} triggered referrer credit "
+                        f"(awarded={ref_result.get('referrer_credits_awarded')})"
+                    )
+            except Exception as ref_err:
+                logger.error(f"⚠️ [v2] Referral completion check failed (non-blocking): {ref_err}")
+```
+
+- [ ] **Step 3: Lancer le test pure-logic**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_referral.py::test_complete_referral_called_after_first_analysis_v2 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Vérifier non-régression videos tests**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_analysis.py -v
+```
+
+Expected: tests existants PASS (le hook est try/except, ne casse rien si referral absent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/videos/router.py backend/tests/test_referral.py
+git commit -m "feat(referral): wire completion hook after v2 analysis success (videos/router.py:1650)"
+```
+
+---
+
+### Task 7: Frontend `referralApi` dans `services/api.ts`
+
+**Files:**
+
+- Modify: `frontend/src/services/api.ts:700-711` (étendre `authApi.register` signature) + ajout en bas du fichier (`referralApi`)
+- Modify: `frontend/src/contexts/AuthContext.tsx:10-14` (étendre interface)
+
+- [ ] **Step 1: Étendre `authApi.register` signature**
+
+Remplacer (ligne 700-711) :
+
+```typescript
+  async register(
+    username: string,
+    email: string,
+    password: string,
+    referralCode?: string,
+  ): Promise<{ success: boolean; message: string }> {
+    return request("/api/auth/register", {
+      method: "POST",
+      body: {
+        username,
+        email,
+        password,
+        ...(referralCode ? { referral_code: referralCode } : {}),
+      },
+      skipAuth: true,
+    });
+  },
+```
+
+- [ ] **Step 2: Ajouter `referralApi` à la fin de `services/api.ts`**
+
+Ajouter en bas du fichier (avant le dernier export ou à la fin) :
+
+```typescript
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎁 REFERRAL API — Programme parrainage
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface ReferralCodeResponse {
+  code: string;
+  share_url: string;
+}
+
+export interface ReferralVerifyResponse {
+  valid: boolean;
+  referrer_username?: string;
+}
+
+export interface ReferralApplyResponse {
+  status: "applied" | "rejected";
+  reason?: string;
+  referee_credits_awarded?: boolean;
+  referral_id?: string;
+}
+
+export interface ReferralStatsResponse {
+  code: string;
+  share_url: string;
+  total_referrals: number;
+  completed_count: number;
+  pending_count: number;
+  credits_earned: number;
+}
+
+export const referralApi = {
+  async generate(): Promise<ReferralCodeResponse> {
+    return request("/api/referral/generate", { method: "POST" });
+  },
+
+  async verifyCode(code: string): Promise<ReferralVerifyResponse> {
+    try {
+      return await request<ReferralVerifyResponse>(
+        `/api/referral/code/${encodeURIComponent(code)}`,
+        { skipAuth: true },
+      );
+    } catch (err) {
+      // 404 = code invalide → on retourne {valid:false} plutôt que de propager
+      return { valid: false };
+    }
+  },
+
+  async applyCode(code: string): Promise<ReferralApplyResponse> {
+    return request("/api/referral/apply", {
+      method: "POST",
+      body: { code },
+    });
+  },
+
+  async getStats(): Promise<ReferralStatsResponse> {
+    return request("/api/referral/my-stats");
+  },
+};
+```
+
+- [ ] **Step 3: Étendre l'interface `AuthContextType` dans `contexts/AuthContext.tsx`**
+
+Remplacer (ligne 10-14) :
+
+```typescript
+register: (
+  username: string,
+  email: string,
+  password: string,
+  referralCode?: string,
+) => Promise<void>;
+```
+
+- [ ] **Step 4: Trouver et étendre le provider qui implémente `register`**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+grep -n "register:" src/components/AuthProvider.tsx 2>/dev/null || grep -rn "authApi.register" src/ | head -5
+```
+
+Identifier le fichier qui implémente le provider (probablement `App.tsx` ou un hook auth dédié) et étendre l'implémentation pour passer `referralCode` à `authApi.register`. Par exemple :
+
+```typescript
+// Dans le provider
+const register = async (
+  username: string,
+  email: string,
+  password: string,
+  referralCode?: string,
+) => {
+  await authApi.register(username, email, password, referralCode);
+  // ... reste inchangé
+};
+```
+
+- [ ] **Step 5: Vérifier typecheck**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run typecheck
+```
+
+Expected: `tsc --noEmit` sans nouvelle erreur.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/services/api.ts frontend/src/contexts/AuthContext.tsx
+git commit -m "feat(referral): add referralApi client and extend authApi.register signature"
+```
+
+---
+
+### Task 8: Composant `ReferralWidget` + tests Vitest
+
+**Files:**
+
+- Create: `frontend/src/components/referral/ReferralWidget.tsx`
+- Create: `frontend/src/components/referral/__tests__/ReferralWidget.test.tsx`
+- Modify: `frontend/src/i18n/fr.json` + `frontend/src/i18n/en.json`
+
+- [ ] **Step 1: Tests Vitest (TDD red)**
+
+Créer `frontend/src/components/referral/__tests__/ReferralWidget.test.tsx` :
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReferralWidget } from "../ReferralWidget";
+import * as api from "../../../services/api";
+
+vi.mock("../../../services/api", () => ({
+  referralApi: {
+    getStats: vi.fn(),
+  },
+}));
+
+describe("ReferralWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("displays loading state initially then renders stats", async () => {
+    (api.referralApi.getStats as any).mockResolvedValue({
+      code: "ds_a1b2c3d4",
+      share_url: "https://www.deepsightsynthesis.com/?ref=ds_a1b2c3d4",
+      total_referrals: 3,
+      completed_count: 2,
+      pending_count: 1,
+      credits_earned: 500,
+    });
+
+    render(<ReferralWidget />);
+
+    expect(screen.getByText(/charg/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("ds_a1b2c3d4")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/3/)).toBeInTheDocument(); // total
+    expect(screen.getByText(/500/)).toBeInTheDocument(); // credits
+  });
+
+  it("copies link to clipboard when copy button clicked", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    (api.referralApi.getStats as any).mockResolvedValue({
+      code: "ds_test",
+      share_url: "https://www.deepsightsynthesis.com/?ref=ds_test",
+      total_referrals: 0,
+      completed_count: 0,
+      pending_count: 0,
+      credits_earned: 0,
+    });
+
+    render(<ReferralWidget />);
+    await waitFor(() => screen.getByText("ds_test"));
+
+    const copyBtn = screen.getByRole("button", { name: /copi|copy/i });
+    await userEvent.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith(
+      "https://www.deepsightsynthesis.com/?ref=ds_test",
+    );
+  });
+
+  it("renders share buttons for Twitter, LinkedIn, Email", async () => {
+    (api.referralApi.getStats as any).mockResolvedValue({
+      code: "ds_share",
+      share_url: "https://www.deepsightsynthesis.com/?ref=ds_share",
+      total_referrals: 0,
+      completed_count: 0,
+      pending_count: 0,
+      credits_earned: 0,
+    });
+
+    render(<ReferralWidget />);
+    await waitFor(() => screen.getByText("ds_share"));
+
+    expect(screen.getByRole("link", { name: /twitter|x/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /linkedin/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /email|mail/i })).toBeInTheDocument();
+  });
+
+  it("handles API error gracefully", async () => {
+    (api.referralApi.getStats as any).mockRejectedValue(new Error("network"));
+
+    render(<ReferralWidget />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/erreur|error/i)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run test -- ReferralWidget
+```
+
+Expected: FAIL — composant inexistant.
+
+- [ ] **Step 2: Implémenter `ReferralWidget.tsx`**
+
+Créer `frontend/src/components/referral/ReferralWidget.tsx` :
+
+```typescript
+import React, { useEffect, useState } from "react";
+import {
+  Copy,
+  Check,
+  Users,
+  Gift,
+  Twitter,
+  Linkedin,
+  Mail,
+  Loader2,
+} from "lucide-react";
+import {
+  referralApi,
+  type ReferralStatsResponse,
+} from "../../services/api";
+import { useLanguage } from "../../contexts/LanguageContext";
+import { analytics } from "../../services/analytics";
+
+export const ReferralWidget: React.FC = () => {
+  const { language } = useLanguage();
+  const tr = (fr: string, en: string) => (language === "fr" ? fr : en);
+
+  const [stats, setStats] = useState<ReferralStatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    referralApi
+      .getStats()
+      .then((data) => {
+        if (mounted) {
+          setStats(data);
+          setError(null);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setError(tr("Erreur de chargement", "Loading error"));
+        }
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleCopy = async () => {
+    if (!stats) return;
+    try {
+      await navigator.clipboard.writeText(stats.share_url);
+      setCopied(true);
+      // PostHog event (TODO post plan #6 si pas typé encore)
+      analytics.capture("referral_link_copied", {
+        code: stats.code,
+      });
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback : sélectionner le texte (rare)
+    }
+  };
+
+  const handleShareClick = (channel: "twitter" | "linkedin" | "email") => {
+    if (!stats) return;
+    analytics.capture("referral_share_clicked", {
+      code: stats.code,
+      channel,
+    });
+  };
+
+  if (loading) {
+    return (
+      <section className="card">
+        <div className="panel-body flex items-center justify-center py-8">
+          <Loader2 className="w-5 h-5 animate-spin text-text-tertiary" />
+          <span className="ml-2 text-sm text-text-tertiary">
+            {tr("Chargement…", "Loading…")}
+          </span>
+        </div>
+      </section>
+    );
+  }
+
+  if (error || !stats) {
+    return (
+      <section className="card">
+        <div className="panel-body text-sm text-red-400 py-4">
+          {error || tr("Erreur de chargement", "Loading error")}
+        </div>
+      </section>
+    );
+  }
+
+  const shareText = encodeURIComponent(
+    tr(
+      "Je teste DeepSight pour analyser mes vidéos YouTube avec l'IA — utilise mon lien pour +5 analyses gratuites :",
+      "I'm using DeepSight to analyze YouTube videos with AI — use my link for 5 free bonus analyses:",
+    ),
+  );
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${shareText}&url=${encodeURIComponent(stats.share_url)}`;
+  const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(stats.share_url)}`;
+  const emailUrl = `mailto:?subject=${encodeURIComponent(
+    tr("Découvre DeepSight", "Discover DeepSight"),
+  )}&body=${shareText}%20${encodeURIComponent(stats.share_url)}`;
+
+  return (
+    <section className="card">
+      <div className="panel-header">
+        <h2 className="font-semibold text-text-primary flex items-center gap-2">
+          <Gift className="w-5 h-5 text-accent-primary" />
+          {tr("Programme parrainage", "Referral program")}
+        </h2>
+      </div>
+      <div className="panel-body space-y-4">
+        <p className="text-sm text-text-tertiary">
+          {tr(
+            "Invite des amis : +5 analyses pour eux à l'inscription, +5 pour toi quand ils analysent leur 1ère vidéo.",
+            "Invite friends: +5 analyses for them at signup, +5 for you when they analyze their first video.",
+          )}
+        </p>
+
+        {/* Code + bouton copier */}
+        <div className="flex flex-col sm:flex-row gap-2">
+          <div className="flex-1 px-4 py-3 rounded-xl bg-white/5 border border-white/10 font-mono text-sm text-text-primary flex items-center">
+            {stats.code}
+          </div>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="px-4 py-3 rounded-xl bg-accent-primary/20 hover:bg-accent-primary/30 border border-accent-primary/40 text-accent-primary font-medium text-sm flex items-center gap-2 transition-colors"
+            aria-label={tr("Copier le lien", "Copy link")}
+          >
+            {copied ? (
+              <>
+                <Check className="w-4 h-4" />
+                {tr("Copié !", "Copied!")}
+              </>
+            ) : (
+              <>
+                <Copy className="w-4 h-4" />
+                {tr("Copier le lien", "Copy link")}
+              </>
+            )}
+          </button>
+        </div>
+
+        {/* Stats grid */}
+        <div className="grid grid-cols-3 gap-3">
+          <div className="p-3 rounded-xl bg-white/5 border border-white/10 text-center">
+            <Users className="w-4 h-4 mx-auto text-text-tertiary mb-1" />
+            <div className="text-xl font-semibold text-text-primary">
+              {stats.total_referrals}
+            </div>
+            <div className="text-xs text-text-tertiary">
+              {tr("Total", "Total")}
+            </div>
+          </div>
+          <div className="p-3 rounded-xl bg-white/5 border border-white/10 text-center">
+            <Check className="w-4 h-4 mx-auto text-success mb-1" />
+            <div className="text-xl font-semibold text-success">
+              {stats.completed_count}
+            </div>
+            <div className="text-xs text-text-tertiary">
+              {tr("Complétés", "Completed")}
+            </div>
+          </div>
+          <div className="p-3 rounded-xl bg-white/5 border border-white/10 text-center">
+            <Gift className="w-4 h-4 mx-auto text-accent-primary mb-1" />
+            <div className="text-xl font-semibold text-accent-primary">
+              {stats.credits_earned}
+            </div>
+            <div className="text-xs text-text-tertiary">
+              {tr("Crédits gagnés", "Credits earned")}
+            </div>
+          </div>
+        </div>
+
+        {/* Share buttons */}
+        <div className="flex flex-wrap gap-2 pt-2">
+          <a
+            href={twitterUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => handleShareClick("twitter")}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm text-text-primary transition-colors"
+            aria-label="Twitter"
+          >
+            <Twitter className="w-4 h-4" /> Twitter
+          </a>
+          <a
+            href={linkedinUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => handleShareClick("linkedin")}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm text-text-primary transition-colors"
+            aria-label="LinkedIn"
+          >
+            <Linkedin className="w-4 h-4" /> LinkedIn
+          </a>
+          <a
+            href={emailUrl}
+            onClick={() => handleShareClick("email")}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm text-text-primary transition-colors"
+            aria-label="Email"
+          >
+            <Mail className="w-4 h-4" /> Email
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+};
+```
+
+- [ ] **Step 3: Lancer les tests Vitest — TDD green**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run test -- ReferralWidget
+```
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 4: Ajouter clés i18n (placeholders pour usage futur)**
+
+Dans `frontend/src/i18n/fr.json`, ajouter une section `referral` :
+
+```json
+{
+  "referral": {
+    "title": "Programme parrainage",
+    "description": "Invite des amis : +5 analyses pour eux à l'inscription, +5 pour toi quand ils analysent leur 1ère vidéo.",
+    "copy_link": "Copier le lien",
+    "copied": "Copié !",
+    "stats": {
+      "total": "Total",
+      "completed": "Complétés",
+      "credits_earned": "Crédits gagnés"
+    }
+  }
+}
+```
+
+Symétrique dans `en.json` :
+
+```json
+{
+  "referral": {
+    "title": "Referral program",
+    "description": "Invite friends: +5 analyses for them at signup, +5 for you when they analyze their first video.",
+    "copy_link": "Copy link",
+    "copied": "Copied!",
+    "stats": {
+      "total": "Total",
+      "completed": "Completed",
+      "credits_earned": "Credits earned"
+    }
+  }
+}
+```
+
+(Note : le widget utilise `tr()` inline pour ce sprint ; les clés i18n sont préparées pour migration ultérieure.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/referral/ frontend/src/i18n/fr.json frontend/src/i18n/en.json
+git commit -m "feat(referral): add ReferralWidget with copy/stats/share + Vitest tests"
+```
+
+---
+
+### Task 9: Détection `?ref=` LandingPage + relais Login → register
+
+**Files:**
+
+- Modify: `frontend/src/pages/LandingPage.tsx:586-591` (ajouter useEffect détection `?ref=`)
+- Modify: `frontend/src/pages/Login.tsx:155-165` (passer pendingReferralCode à register)
+
+- [ ] **Step 1: LandingPage — détection `?ref=` au mount**
+
+Dans `frontend/src/pages/LandingPage.tsx`, ajouter en haut des imports :
+
+```typescript
+import { referralApi } from "../services/api";
+import { analytics } from "../services/analytics";
+```
+
+Après le `useEffect` redirect logged-in (ligne 587), ajouter un nouveau `useEffect` :
+
+```typescript
+// 🎁 Programme parrainage : détecter ?ref=<CODE> au mount,
+// vérifier validité, stocker en localStorage pour relais au signup.
+useEffect(() => {
+  const params = new URLSearchParams(window.location.search);
+  const refCode = params.get("ref");
+  if (!refCode || !refCode.startsWith("ds_")) return;
+
+  // Tracking immédiat (même si code invalide — utile pour analytics)
+  analytics.capture("referral_link_clicked", { code: refCode });
+
+  // Vérifier validité côté serveur (best-effort)
+  referralApi
+    .verifyCode(refCode)
+    .then((res) => {
+      if (res.valid) {
+        localStorage.setItem("pendingReferralCode", refCode);
+      } else {
+        // Code invalide → ne pas stocker
+        localStorage.removeItem("pendingReferralCode");
+      }
+    })
+    .catch(() => {
+      // En cas d'erreur réseau, on stocke quand même : le backend retentera au signup
+      localStorage.setItem("pendingReferralCode", refCode);
+    });
+}, []);
+```
+
+- [ ] **Step 2: Login.tsx — relais pendingReferralCode au register**
+
+Dans `frontend/src/pages/Login.tsx`, remplacer la ligne 157 :
+
+```typescript
+await register(email.split("@")[0], email, password);
+```
+
+par :
+
+```typescript
+const pendingRef = localStorage.getItem("pendingReferralCode") || undefined;
+await register(email.split("@")[0], email, password, pendingRef);
+if (pendingRef) {
+  // Tracking : signup démarré avec referral
+  analytics.capture("referral_signup_started", { code: pendingRef });
+  localStorage.removeItem("pendingReferralCode");
+}
+```
+
+⚠ Vérifier qu'`analytics` est importé en haut. Sinon ajouter :
+
+```typescript
+import { analytics } from "../services/analytics";
+```
+
+- [ ] **Step 3: Vérifier typecheck + lint**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run typecheck && npm run lint
+```
+
+Expected: aucune nouvelle erreur.
+
+- [ ] **Step 4: Test manuel local (smoke)**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run dev
+```
+
+Naviguer vers `http://localhost:5173/?ref=ds_a1b2c3d4` (avec un user existant ayant ce code) et vérifier dans DevTools Application > Local Storage que `pendingReferralCode = "ds_a1b2c3d4"`. Vérifier dans Network tab le call `GET /api/referral/code/ds_a1b2c3d4`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/LandingPage.tsx frontend/src/pages/Login.tsx
+git commit -m "feat(referral): detect ?ref= on landing and relay to register via localStorage"
+```
+
+---
+
+### Task 10: Insérer `ReferralWidget` dans `MyAccount.tsx`
+
+**Files:**
+
+- Modify: `frontend/src/pages/MyAccount.tsx:880-887` (insérer widget juste avant section "Mon abonnement")
+
+- [ ] **Step 1: Importer le composant**
+
+En haut de `MyAccount.tsx`, ajouter :
+
+```typescript
+import { ReferralWidget } from "../components/referral/ReferralWidget";
+```
+
+- [ ] **Step 2: Insérer le widget juste avant la card "Mon abonnement"**
+
+Repérer le bloc commentaire/section `<section className="card">` qui contient `{tr("Mon abonnement", "My Subscription")}` (ligne ~881-887). **Juste avant** ce `<section>`, insérer :
+
+```typescript
+            {/* ═══════════════════════════════════════════════════════════════════════════
+              🎁 PROGRAMME PARRAINAGE — ReferralWidget (acquisition virale)
+              ═══════════════════════════════════════════════════════════════════════════ */}
+            <ReferralWidget />
+
+```
+
+- [ ] **Step 3: Vérifier typecheck**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run typecheck
+```
+
+Expected: pas de nouvelle erreur.
+
+- [ ] **Step 4: Smoke test visuel**
+
+Run:
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run dev
+```
+
+Login → naviguer vers `/account` → vérifier que le ReferralWidget apparaît juste au-dessus de la section "Mon abonnement" avec :
+
+- Le code `ds_<8chars>` affiché
+- Le bouton "Copier le lien" fonctionnel
+- Les 3 compteurs (Total / Complétés / Crédits gagnés)
+- Les 3 boutons share Twitter / LinkedIn / Email
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/MyAccount.tsx
+git commit -m "feat(referral): insert ReferralWidget in MyAccount page above subscription section"
+```
+
+---
+
+### Task 11 (validation E2E manuelle — pas du code à écrire)
+
+Cette task est un **checklist E2E manuel** à exécuter contre une instance dev locale ou preview Vercel + backend dev. Aucun fichier modifié. Si un step échoue, créer une issue et revenir aux tâches précédentes.
+
+**Précondition** : tasks 1-10 mergées sur `feature/audit-kimi-plans-2026-04-29`. Backend lancé (`uvicorn`) + frontend `npm run dev`.
+
+- [ ] **Step 1: User parrain (Alice) génère son code**
+  1. Login avec Alice (compte existant ou nouveau).
+  2. Aller sur `/account`.
+  3. Vérifier que le widget Referral affiche un code `ds_<8chars>`.
+  4. Cliquer "Copier le lien" → vérifier copie clipboard.
+  5. Inspecter dans DevTools Network : `POST /api/referral/generate` puis `GET /api/referral/my-stats` — 200 OK.
+
+- [ ] **Step 2: User filleul (Bob) clique le lien**
+  1. Logout Alice.
+  2. Coller le lien copié dans un onglet privé : `https://localhost:5173/?ref=ds_<code>` (ou `http://localhost:5173/?ref=ds_xxx` selon ton setup).
+  3. Vérifier dans DevTools : `GET /api/referral/code/ds_xxx` → 200 et `localStorage.pendingReferralCode === "ds_xxx"`.
+  4. Vérifier l'event PostHog `referral_link_clicked` envoyé (si PostHog configuré en dev).
+
+- [ ] **Step 3: Bob signup**
+  1. Sur landing, cliquer "S'inscrire" / sur Login passer en mode register.
+  2. Renseigner email `bob@example.com`, password.
+  3. Submit.
+  4. Vérifier dans DevTools Network : `POST /api/auth/register` body contient `referral_code: "ds_xxx"`.
+  5. Confirmer email Bob (mode dev sans Resend = auto-verified).
+  6. Login Bob → `/account` → vérifier que Bob a 500 crédits (250 + 250 bonus).
+
+- [ ] **Step 4: Bob analyse 1 vidéo**
+  1. Coller une URL YouTube courte (< 5 min) sur `/dashboard`.
+  2. Lancer une analyse v2 standard (Mistral Small).
+  3. Attendre la complétion (status "completed").
+
+- [ ] **Step 5: Vérifier crédit parrain**
+  1. Logout Bob, login Alice.
+  2. Aller sur `/account`.
+  3. Vérifier dans le ReferralWidget : `completed_count = 1`, `credits_earned = 250`.
+  4. Vérifier que le solde de crédits Alice a augmenté de +250.
+  5. Inspecter en DB :
+     ```bash
+     # SQLite dev
+     sqlite3 backend/data/deepsight_users.db "SELECT id, status, referrer_credits_awarded, completed_at FROM referrals;"
+     ```
+     Expected : 1 ligne, `status='completed'`, `referrer_credits_awarded=1`.
+
+- [ ] **Step 6: Test idempotence**
+  1. Bob analyse une **2e** vidéo.
+  2. Vérifier que les crédits Alice ne bougent PAS (`credits_earned` reste à 250 dans le widget).
+
+- [ ] **Step 7: Test self-referral rejected**
+  1. Logout, créer un nouveau user Charlie qui clique son propre lien.
+  2. Vérifier que `apply` retourne `status: rejected, reason: self_referral`.
+
+Si tous les steps passent, le plan est complet et la branche est prête pour PR review.
+
+---
+
+## PostHog events (cohérence plan #6)
+
+Les events suivants sont émis depuis le frontend et sont à ajouter à `EventPayloadMap` du plan PostHog (#6) :
+
+| Event                     | Source                                           | Properties                        |
+| ------------------------- | ------------------------------------------------ | --------------------------------- |
+| `referral_link_clicked`   | LandingPage useEffect ?ref=                      | `{code: string}`                  |
+| `referral_link_copied`    | ReferralWidget bouton copier                     | `{code: string}`                  |
+| `referral_share_clicked`  | ReferralWidget Twitter/LinkedIn/Email            | `{code: string, channel: string}` |
+| `referral_signup_started` | Login.tsx handleSubmit isRegister                | `{code: string}`                  |
+| `referral_completed`      | Backend (TODO V2 — webhook PostHog côté serveur) | (server-side)                     |
+
+Si le plan #6 n'est pas encore mergé, ces events sont émis comme strings non-typés via `analytics.capture()` — pas d'erreur de compilation. Quand #6 sera mergé, étendre `EventPayloadMap` avec les 5 events ci-dessus.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+- ✅ Code parrainage `ds_<base64(user_id)[:8]>` permanent — Task 3 step 4 (`generate_code`)
+- ✅ Lien `https://www.deepsightsynthesis.com/?ref=<CODE>` — Task 3 (`SHARE_URL_BASE` constant)
+- ✅ +5 analyses (= +250 crédits) parrain et filleul — Task 3 (`REFERRAL_BONUS_CREDITS = 250`)
+- ✅ Récompense filleul à l'inscription — Task 3 (`apply_code` crédite immédiatement)
+- ✅ Récompense parrain au flip pending → completed — Task 3 (`complete_referral_if_first_analysis`)
+- ✅ Anti-fraude soft (SHA256 IP + email_domain logged) — Task 2/3 (`_hash_ip`, `_email_domain`)
+- ✅ Limite 50 completed par user — Task 3 (`MAX_COMPLETED_REFERRALS = 50` testé)
+- ✅ Statuts pending/completed/expired — Task 1/2 (enum PG, str20 ORM) + expiry 30j testé
+- ✅ Migration Alembic 012 — Task 1
+- ✅ User.referral_code colonne — Task 1/2
+- ✅ POST /api/referral/generate — Task 4
+- ✅ GET /api/referral/code/{code} — Task 4
+- ✅ POST /api/referral/apply — Task 4
+- ✅ GET /api/referral/my-stats — Task 4
+- ✅ Hook signup — Task 5
+- ✅ Hook completion videos/router.py:1650 — Task 6 (V1 scope explicite, gap autres flux noted)
+- ✅ Frontend referralApi — Task 7
+- ✅ ReferralWidget — Task 8
+- ✅ Détection ?ref= LandingPage + relais Login — Task 9
+- ✅ Insertion MyAccount — Task 10
+- ✅ E2E manuel complet — Task 11
+- ✅ 5 events PostHog — instrumentés dans Tasks 8/9 (commentés `TODO post plan #6` si pas typé)
+
+### Décisions à confirmer
+
+- **D1 — Limite 50 completed/user** : confirmée par RELEASE-ORCHESTRATION RF-1, default OK. Alternative 20 ou 100 si data ultérieure le justifie.
+- **D2 — Anti-fraude soft (logs only)** : suffisant pour V1 (cf. RF-2). Pas de blocage IP/email_domain dans le code, juste logs SHA256. Itération possible si abuses détectés post-déploiement.
+- **D3 — Récompense crédits-only** : 250 crédits suffisants pour V1 (cf. RF-3). Voice minutes pourront s'ajouter dans une V2 (table relation `referral_voice_bonus` à créer si nécessaire).
+- **D4 — Pas d'email notif au completed V1** : confirmé (RF-4). Hook existe (`logger.info` dans Task 6) — V2 pourra brancher Resend ici sans toucher à la logique core.
+- **D5 — Migration Alembic 012** : imposé par RELEASE-ORCHESTRATION META-2/RF-5. Ajustement `down_revision` à valider à T1 step 1 selon état réel des migrations 010/011 mergées ou pas.
+
+### Type consistency
+
+- `Referral.status` : `String(20)` côté ORM (portabilité SQLite/PG), Enum côté migration PG uniquement. Cohérent.
+- `Referral.id` : `String(36)` (`uuid4` string) — cohérent partout (migration + ORM + service).
+- `referralApi.verifyCode` retourne `ReferralVerifyResponse` partout (api.ts + LandingPage). OK.
+- `referralApi.getStats` retourne `ReferralStatsResponse` aligné avec backend `ReferralStatsResponse` (mêmes 6 clés). OK.
+- `User.referral_code` : `String(64) UNIQUE indexed nullable` cohérent (migration + ORM).
+
+### Placeholder scan
+
+Aucun `TBD`, `TODO sans contexte`, ni "implement later" non justifié. Les `TODO post plan #6` sont des stubs intentionnels, datés et tracés. Les 5 autres `increment_daily_usage` non instrumentés sont notés comme **gap V1 explicite**, pas un placeholder.
+
+### Risques notés
+
+- **Race condition** : si le filleul fait sa 1ère analyse exactement au moment où un autre filleul du même parrain le fait aussi, et que le parrain est à 49 completed → théoriquement les 2 pourraient passer la limite. Mitigation : `await session.commit()` séparé entre count check et award + idempotence par flag `referrer_credits_awarded`. Dans la pratique RAREMENT déclenché au volume V1.
+- **Mobile/Extension non couverts** : ce plan ne touche que web. Mobile (`mobile/src/services/api.ts`) et Extension peuvent ajouter `referralApi` plus tard sans bloquer ce sprint. Listés comme gap explicite.
+- **Si Sprint B (#7) pas encore mergé** : `down_revision = "009_add_user_preferences_json"` au lieu de `"011"`. Vérification à T1 step 1.
+
+---
+
+## Execution Handoff
+
+**Plan complet et sauvegardé dans `C:\Users\33667\DeepSight-Main\docs\superpowers\plans\2026-04-29-programme-parrainage.md`. Deux options d'exécution :**
+
+**1. Subagent-Driven (recommandé)** — un subagent Opus 4.7 frais par task + two-stage review entre les tâches. Idéal pour ce plan qui mélange backend (TDD pytest) et frontend (TDD Vitest) — chaque sprint reste isolé.
+
+**2. Inline Execution** — exécution batch dans la session courante avec checkpoints. Plus rapide mais moins de contrôle.
+
+**Recommandation pour ce plan** : Subagent-Driven car :
+
+- Tasks 1-6 (backend) et 7-10 (frontend) ont des stacks différents (pytest vs Vitest, Python vs TypeScript) — bénéfique de purger le contexte entre eux.
+- Task 11 (E2E manuel) doit absolument être validé par un humain, pas un agent — checkpoint naturel.
+
+**Quelle approche ?**

--- a/docs/superpowers/plans/2026-04-29-watermark-exports-gratuits.md
+++ b/docs/superpowers/plans/2026-04-29-watermark-exports-gratuits.md
@@ -1,0 +1,1739 @@
+# Watermark Exports Gratuits — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter un watermark **"Analysé avec DeepSight"** sur tous les exports des utilisateurs **Free** (TXT, MD, PDF, DOCX, XLSX, CSV) afin de générer un canal de branding viral passif. Les utilisateurs payants (Pro/Expert) reçoivent des exports propres.
+
+**Architecture:** Helper centralisé `add_watermark()` invoqué par les 6 fonctions `export_to_*` dans `service.py`, avec gating par plan (via `normalize_plan_id`) et i18n (FR/EN). Pour le PDF (WeasyPrint), un flag `show_watermark` est propagé du `pdf_generator.py` vers le template Jinja2 qui rend un bloc dédié sur la page de garde et la dernière page. Le frontend ajoute un tooltip plan-aware dans `ExportMenu` indiquant la présence du watermark sur les plans Free + lien upgrade.
+
+**Tech Stack:** FastAPI + Python 3.11, WeasyPrint + Jinja2, python-docx, openpyxl, ReportLab (fallback), pytest + pytest-asyncio ; React 18 + TypeScript + Tailwind ; pas de migration Alembic.
+
+> **Couplage release-train** : ce plan est un **quick win autonome** (cf. `2026-04-29-RELEASE-ORCHESTRATION.md` Sprint A). Il n'introduit aucune migration et utilise `normalize_plan_id` ce qui le rend compatible avec la grille v0 (`free/plus/pro`) ET la grille v2 (`free/pro/expert`). Voir section "Cohérence v0/v2 transition" ci-dessous.
+
+---
+
+## Contexte préalable (à lire impérativement)
+
+### État découvert dans le code (2026-04-29)
+
+#### Backend exports
+
+| Fichier                                                 | Ce qu'on y trouve aujourd'hui                                                                                                                                                                                                                                  |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `backend/src/exports/service.py:203`                    | `export_to_txt(...)` — texte brut. Pas de gating plan. Inclut déjà la ligne `Généré par Deep Sight — deepsightsynthesis.com` ligne 238 (mention brand origin, **pas** un watermark).                                                                           |
+| `backend/src/exports/service.py:249`                    | `export_to_markdown(...)` — Markdown. Inclut déjà `*Généré par [Deep Sight](https://deepsightsynthesis.com) — Analyse intelligente de vidéos YouTube*` ligne 331.                                                                                              |
+| `backend/src/exports/service.py:342`                    | `export_to_docx(...)` — DOCX via python-docx. Inclut déjà footer `Généré par Deep Sight — deepsightsynthesis.com` ligne 462.                                                                                                                                   |
+| `backend/src/exports/service.py:477`                    | `export_to_pdf_reportlab(...)` — fallback PDF si WeasyPrint absent. Inclut déjà footer `Généré par Deep Sight — deepsightsynthesis.com` ligne 583.                                                                                                             |
+| `backend/src/exports/service.py:596`                    | `export_to_pdf(...)` — entry point PDF. Tente WeasyPrint en premier, fallback ReportLab.                                                                                                                                                                       |
+| `backend/src/exports/service.py:665`                    | `export_to_csv(...)` — CSV. Inclut déjà ligne `Généré par Deep Sight - deepsightsynthesis.com` ligne 739.                                                                                                                                                      |
+| `backend/src/exports/service.py:749`                    | `export_to_excel(...)` — XLSX via openpyxl. Inclut déjà cellule `Généré par Deep Sight — deepsightsynthesis.com` ligne 899.                                                                                                                                    |
+| `backend/src/exports/service.py:921`                    | `export_summary(format, ...)` — dispatcher. **AUCUN paramètre `user_plan` ni `user_language` actuellement.**                                                                                                                                                   |
+| `backend/src/exports/pdf_generator.py:174`              | `PDFGenerator.generate()` — produit le HTML+CSS via Jinja2 puis WeasyPrint.                                                                                                                                                                                    |
+| `backend/src/exports/pdf_generator.py:263`              | `_prepare_template_data()` — construit le dict passé à Jinja2. **Aucun champ `show_watermark` ni `user_plan` actuellement.**                                                                                                                                   |
+| `backend/src/exports/pdf_generator.py:362`              | `generate_pdf(...)` — fonction de convenance, point d'entrée appelé depuis `service.py:622`.                                                                                                                                                                   |
+| `backend/src/exports/templates/pdf_template.html:19-25` | `@bottom-center` rule CSS : `content: "DeepSight — deepsightsynthesis.com"` sur **toutes les pages SAUF cover** (cover supprime via `@page:first` lignes 35-43). C'est une **mention brand standard**, **PAS** un watermark Free vs Pro. **Ne pas confondre.** |
+| `backend/src/exports/templates/pdf_template.html:1048`  | Dernière ligne du body : `Analyse intelligente propulsée par IA — deepsightsynthesis.com` — note signature finale.                                                                                                                                             |
+| `backend/src/exports/router.py:100-185`                 | `POST /api/exports/` — endpoint principal. Récupère `current_user` mais **ne passe PAS `user.plan` ni `user.default_lang` à `export_summary()`**.                                                                                                              |
+| `backend/src/exports/router.py:188-208`                 | `GET /api/exports/{summary_id}/{format}` — wrapper GET, redirige vers POST. Même comportement.                                                                                                                                                                 |
+| `backend/src/exports/router.py:336-349`                 | Audio gating Pro+ via `PLAN_LIMITS["blocked_features"]`. **Précédent du gating plan-based** : on s'inspire de cette structure mais on inverse la logique (Free → ajout watermark, pas blocage).                                                                |
+
+#### Backend modèle utilisateur
+
+| Fichier                          | Champ                                                                                          |
+| -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `backend/src/db/database.py:126` | `User.plan = Column(String(20), default="free")` — plan id texte, valide v0 ou v2 selon merge. |
+| `backend/src/db/database.py:144` | `User.default_lang = Column(String(5), default="fr")` — langue préférée (FR/EN).               |
+
+> ⚠️ **Subtilité** : la spec d'origine mentionne `user.language` mais le champ réel s'appelle `default_lang` (5 chars, default "fr"). Toutes les références dans ce plan utilisent **`default_lang`**.
+
+#### Backend plan_config (gating helper)
+
+| Fichier                                    | Élément clé                                                                                                                                                    |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `backend/src/billing/plan_config.py:22-32` | `PlanId` enum actuel = `FREE / PLUS / PRO` (grille v0). Devient `FREE / PRO / EXPERT` après merge pricing-v2.                                                  |
+| `backend/src/billing/plan_config.py:36-44` | `PLAN_ALIASES` dict : `{etudiant→plus, starter→plus, student→plus, expert→pro, equipe→pro, team→pro, unlimited→pro}` — les anciens plan IDs sont mappés.       |
+| `backend/src/billing/plan_config.py:47-58` | `normalize_plan_id(plan_id: str) -> str` — résout les aliases, fallback `"free"` si invalide. **C'est le point d'entrée à utiliser pour le gating watermark.** |
+
+#### Frontend
+
+| Fichier                                                 | État                                                                                                                                                                                              |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `frontend/src/components/analysis/ExportMenu.tsx:38-39` | `userPlan = user?.plan \|\| "free"`, `canExportAudio = userPlan !== "free"`. Pattern de plan-aware menu déjà en place pour audio. **À étendre pour le tooltip watermark sur les autres formats.** |
+| `frontend/src/i18n/fr.json` + `en.json`                 | Locale catalogues existants. **Aucun namespace `export.watermark.*` actuellement.**                                                                                                               |
+
+#### Tests
+
+| Fichier                     | État                                                                         |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| `backend/tests/`            | **Aucun fichier `test_exports*.py`** présent. Création ex-nihilo nécessaire. |
+| `backend/tests/conftest.py` | Fixtures pytest existantes (db session, async client). À réutiliser.         |
+
+### Cohérence v0/v2 transition (CRITIQUE)
+
+Le code SSOT actuel utilise les plan IDs **v0** : `free / plus / pro`. Le plan parallèle `2026-04-29-pricing-v2-stripe-grandfathering.md` migre vers la grille **v2** : `free / pro / expert`. Le mapping est :
+
+```
+v0 free  → v2 free   (no change)
+v0 plus  → v2 pro    (4.99€ → 8.99€)
+v0 pro   → v2 expert (9.99€ → 19.99€)
+```
+
+Pendant la fenêtre de transition (avant que pricing-v2 soit mergé), `normalize_plan_id` se comporte différemment :
+
+| user.plan in DB | Pré-pricing-v2 (`normalize_plan_id` actuel) | Post-pricing-v2 (`normalize_plan_id` après merge) |
+| --------------- | ------------------------------------------- | ------------------------------------------------- |
+| `"free"`        | `"free"`                                    | `"free"`                                          |
+| `"plus"`        | `"plus"` (passe car PlanId valide)          | `"pro"` (alias legacy → v2)                       |
+| `"pro"`         | `"pro"` (passe car PlanId valide)           | `"expert"` (alias legacy → v2)                    |
+| `"expert"`      | `"pro"` (mappé via PLAN_ALIASES)            | `"expert"` (PlanId v2 valide)                     |
+
+**Solution** : utiliser un set de plans payants qui couvre les **deux états SSOT**. Pendant la transition :
+
+```python
+PAID_PLANS = {"plus", "pro", "expert"}
+```
+
+- **Avant pricing-v2 mergé** : un user `plus` (payant 4,99 €) → `normalize → "plus"` → `in PAID_PLANS` → ✅ pas de watermark.
+- **Avant pricing-v2 mergé** : un user `pro` (payant 9,99 €) → `normalize → "pro"` → `in PAID_PLANS` → ✅ pas de watermark.
+- **Après pricing-v2 mergé** : un user `plus` legacy (DB pas encore migrée) → `normalize → "pro"` → `in PAID_PLANS` → ✅ pas de watermark.
+- **Après pricing-v2 mergé + migration 011** : `users.plan` migré vers v2, donc plus aucun `"plus"` en DB → la valeur `"plus"` dans le set devient morte mais inoffensive.
+
+Quand pricing-v2 sera mergé ET la migration 011 appliquée en prod (cf. RELEASE-ORCHESTRATION.md Sprint B), retirer `"plus"` du set deviendra possible. C'est la **D3** de la self-review.
+
+### Hypothèses business locked
+
+| #   | Décision                                                                                                                                                                                                                                                                                 | Source                       |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| H1  | Watermark uniquement sur Free. Plus/Pro/Expert = exports propres                                                                                                                                                                                                                         | Spec                         |
+| H2  | Texte FR par défaut : `"Analysé avec DeepSight — IA souveraine européenne"` + URL `www.deepsightsynthesis.com`                                                                                                                                                                           | Spec                         |
+| H3  | Texte EN si `user.default_lang == "en"` : `"Analyzed with DeepSight — European sovereign AI"` + URL identique                                                                                                                                                                            | Spec                         |
+| H4  | Format PDF : note **paragraphe italique gris discret** (sans titre) sur cover ET dernière page. Texte seul, pas de logo SVG (cf. D1)                                                                                                                                                     | RELEASE-ORCHESTRATION WM-5   |
+| H5  | Helper unique `add_watermark(content, format, user_plan, user_language)` centralise gating + i18n + format-spécifique                                                                                                                                                                    | Architecture                 |
+| H6  | Plans payants au sens watermark = `PAID_PLANS = {"plus", "pro", "expert"}` (transition v0→v2)                                                                                                                                                                                            | Cohérence v0/v2              |
+| H7  | La mention brand standard existante (`"Généré par Deep Sight — deepsightsynthesis.com"` ligne 238/331/462/583/739/899 service.py + footer @bottom-center pdf_template.html) RESTE en place sur **toutes les exports** (Free et payants). C'est l'origine brand, pas le watermark gating. | Différenciation conceptuelle |
+| H8  | Le watermark gating Free ajoute un **second** marqueur, distinct, plus explicite (`"Analysé avec DeepSight — IA souveraine européenne"`), placé en plus de la mention brand existante.                                                                                                   | Architecture                 |
+
+### Choix architectural assumé
+
+Pour minimiser la dette, on **ajoute** un watermark distinct au lieu de transformer la mention brand existante. Si on transformait la mention brand existante en watermark gating, les payants n'auraient plus AUCUNE référence à DeepSight dans leurs fichiers — ce qui dégrade le branding sortant. Donc on garde la mention origin (toujours présente) ET on ajoute le watermark gating Free (présent uniquement Free).
+
+---
+
+## File Structure
+
+| Fichier                                           | Action | Responsabilité                                                                                                                                                                             |
+| ------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `backend/src/exports/watermark.py`                | Create | Helper unique `add_watermark(content, format, user_plan, user_language)` + constants `PAID_PLANS` + textes i18n FR/EN                                                                      |
+| `backend/src/exports/service.py`                  | Modify | Toutes les fonctions `export_to_*` reçoivent `user_plan` + `user_language` (default `"free"` / `"fr"`), appellent helper. `export_summary` propage.                                        |
+| `backend/src/exports/pdf_generator.py`            | Modify | `PDFGenerator.generate()` + `generate_pdf()` reçoivent `user_plan` + `user_language` ; `_prepare_template_data` ajoute `show_watermark`, `watermark_text`, `watermark_url` au dict Jinja2  |
+| `backend/src/exports/templates/pdf_template.html` | Modify | Ajout 2 blocs `{% if show_watermark %}` : un sur la cover (au-dessus du `cover-footer`) et un sur la dernière page (au-dessus de la note signature ligne 1048). Style italic gris discret. |
+| `backend/src/exports/router.py`                   | Modify | `POST /api/exports/` et `GET /api/exports/{summary_id}/{format}` passent `user_plan=current_user.plan` + `user_language=current_user.default_lang` à `export_summary()`                    |
+| `frontend/src/components/analysis/ExportMenu.tsx` | Modify | Ajout tooltip plan-aware sous les items pdf/md/txt si `userPlan === "free"` : "Les exports gratuits incluent un watermark — passez Pro pour le retirer" + lien `/upgrade`                  |
+| `frontend/src/i18n/fr.json`                       | Modify | Ajout namespace `export.watermark.notice_free` + `export.watermark.upgrade_link`                                                                                                           |
+| `frontend/src/i18n/en.json`                       | Modify | Idem en anglais                                                                                                                                                                            |
+| `backend/tests/test_exports_watermark.py`         | Create | pytest couvrant 6 formats × 3 plans (Free / Plus / Pro) × 2 langues (FR / EN) — vérifie présence/absence du watermark via `normalize_plan_id`                                              |
+
+---
+
+## Task 1 : Helper `watermark.py` (TDD)
+
+**Files:**
+
+- Create: `backend/src/exports/watermark.py`
+- Create: `backend/tests/test_exports_watermark.py`
+
+> ⚠️ **TDD strict** : on écrit le test en premier (qui échoue), puis l'implémentation, puis on revérifie.
+
+- [ ] **Étape 1 : Écrire le test qui échoue**
+
+`backend/tests/test_exports_watermark.py` :
+
+```python
+"""Tests du helper watermark — gating Free vs payant + i18n FR/EN + 6 formats."""
+import pytest
+from exports.watermark import add_watermark, PAID_PLANS
+
+
+# ─── Constantes attendues ────────────────────────────────────────────────────
+
+EXPECTED_FR_TEXT = "Analysé avec DeepSight"
+EXPECTED_FR_TAGLINE = "IA souveraine européenne"
+EXPECTED_EN_TEXT = "Analyzed with DeepSight"
+EXPECTED_EN_TAGLINE = "European sovereign AI"
+EXPECTED_URL = "www.deepsightsynthesis.com"
+
+
+# ─── Set PAID_PLANS ──────────────────────────────────────────────────────────
+
+def test_paid_plans_contains_v0_and_v2_during_transition():
+    """PAID_PLANS doit couvrir 'plus' (v0), 'pro' (v0+v2), 'expert' (v2) pendant la transition."""
+    assert "plus" in PAID_PLANS
+    assert "pro" in PAID_PLANS
+    assert "expert" in PAID_PLANS
+    assert "free" not in PAID_PLANS
+
+
+# ─── Gating Free vs payant ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize("paid_plan", ["plus", "pro", "expert"])
+@pytest.mark.parametrize("fmt", ["txt", "md", "docx", "pdf", "csv", "xlsx"])
+def test_watermark_not_applied_for_paid_plans(paid_plan: str, fmt: str):
+    """Aucun watermark sur les plans payants, tous formats."""
+    original = "Contenu test"
+    result = add_watermark(original, fmt, user_plan=paid_plan, user_language="fr")
+    assert result == original
+
+
+@pytest.mark.parametrize("fmt", ["txt", "md", "docx", "pdf", "csv", "xlsx"])
+def test_watermark_applied_for_free_plan(fmt: str):
+    """Watermark présent sur tous les formats pour Free."""
+    original = "Contenu test"
+    result = add_watermark(original, fmt, user_plan="free", user_language="fr")
+    assert result != original
+    assert EXPECTED_FR_TEXT in result
+    assert EXPECTED_URL in result
+
+
+def test_watermark_applied_for_unknown_plan_defaults_to_free():
+    """Plan inconnu → fallback Free → watermark appliqué."""
+    result = add_watermark("X", "txt", user_plan="bogus_plan", user_language="fr")
+    assert EXPECTED_FR_TEXT in result
+
+
+def test_watermark_applied_for_empty_plan():
+    """Plan vide ou None → fallback Free."""
+    result_empty = add_watermark("X", "txt", user_plan="", user_language="fr")
+    result_none = add_watermark("X", "txt", user_plan=None, user_language="fr")
+    assert EXPECTED_FR_TEXT in result_empty
+    assert EXPECTED_FR_TEXT in result_none
+
+
+# ─── i18n FR / EN ────────────────────────────────────────────────────────────
+
+def test_watermark_french_default():
+    """Langue FR par défaut."""
+    result = add_watermark("X", "txt", user_plan="free", user_language="fr")
+    assert EXPECTED_FR_TEXT in result
+    assert EXPECTED_FR_TAGLINE in result
+    assert EXPECTED_EN_TEXT not in result
+
+
+def test_watermark_english():
+    """Langue EN si user_language='en'."""
+    result = add_watermark("X", "txt", user_plan="free", user_language="en")
+    assert EXPECTED_EN_TEXT in result
+    assert EXPECTED_EN_TAGLINE in result
+    assert EXPECTED_FR_TEXT not in result
+
+
+def test_watermark_unknown_language_defaults_to_fr():
+    """Langue inconnue (es, de, etc.) → fallback FR."""
+    result = add_watermark("X", "txt", user_plan="free", user_language="es")
+    assert EXPECTED_FR_TEXT in result
+
+
+# ─── Format-specific shape ───────────────────────────────────────────────────
+
+def test_watermark_txt_format():
+    """TXT : séparateur '---' + ligne plain."""
+    result = add_watermark("Hello", "txt", user_plan="free", user_language="fr")
+    assert "Hello" in result
+    assert "---" in result
+    # No markdown
+    assert "[" not in result.split("Hello")[1]
+    assert "(" not in result.split("Hello")[1]
+
+
+def test_watermark_md_format():
+    """MD : séparateur '---' + lien markdown."""
+    result = add_watermark("Hello", "md", user_plan="free", user_language="fr")
+    assert "Hello" in result
+    assert "---" in result
+    assert "[DeepSight](https://www.deepsightsynthesis.com)" in result
+    # Italic
+    assert "*" in result.split("Hello")[1]
+
+
+def test_watermark_csv_format():
+    """CSV : commentaire dernière ligne préfixé par '#'."""
+    result = add_watermark("a,b,c", "csv", user_plan="free", user_language="fr")
+    assert "a,b,c" in result
+    last_line = result.strip().split("\n")[-1]
+    assert last_line.startswith("#")
+    assert EXPECTED_FR_TEXT in last_line
+
+
+# ─── Format binaires (DOCX/XLSX/PDF) — passthrough ──────────────────────────
+
+def test_watermark_docx_returns_marker_dict():
+    """DOCX : helper retourne dict {needs_watermark, text, url} pour que service.py l'injecte via python-docx."""
+    result = add_watermark("placeholder", "docx", user_plan="free", user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is True
+    assert EXPECTED_FR_TEXT in result["text"]
+    assert result["url"] == EXPECTED_URL
+
+
+def test_watermark_docx_no_marker_for_paid():
+    """DOCX : payant → dict avec needs_watermark=False."""
+    result = add_watermark("placeholder", "docx", user_plan="pro", user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is False
+
+
+def test_watermark_xlsx_returns_marker_dict():
+    """XLSX : idem DOCX, dict marqueur."""
+    result = add_watermark("placeholder", "xlsx", user_plan="free", user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is True
+    assert EXPECTED_FR_TEXT in result["text"]
+
+
+def test_watermark_pdf_returns_marker_dict():
+    """PDF : idem, dict pour propagation au template Jinja2."""
+    result = add_watermark("placeholder", "pdf", user_plan="free", user_language="fr")
+    assert isinstance(result, dict)
+    assert result["needs_watermark"] is True
+    assert EXPECTED_FR_TEXT in result["text"]
+    assert result["url"] == EXPECTED_URL
+
+
+# ─── Normalize via plan_config ───────────────────────────────────────────────
+
+def test_watermark_normalize_legacy_aliases():
+    """Plans legacy (etudiant, starter, student, equipe, team, unlimited) sont mappés via normalize_plan_id."""
+    # 'etudiant' → 'plus' (in PAID_PLANS) → no watermark
+    result_etudiant = add_watermark("X", "txt", user_plan="etudiant", user_language="fr")
+    assert result_etudiant == "X"
+    # 'team' → 'pro' (in PAID_PLANS) → no watermark
+    result_team = add_watermark("X", "txt", user_plan="team", user_language="fr")
+    assert result_team == "X"
+    # 'unlimited' → 'pro' → no watermark
+    result_unlim = add_watermark("X", "txt", user_plan="unlimited", user_language="fr")
+    assert result_unlim == "X"
+```
+
+- [ ] **Étape 2 : Lancer le test pour vérifier qu'il échoue**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_exports_watermark.py -v
+```
+
+Expected: FAIL avec `ModuleNotFoundError: No module named 'exports.watermark'`.
+
+- [ ] **Étape 3 : Implémenter le helper minimal**
+
+`backend/src/exports/watermark.py` :
+
+```python
+"""
+DeepSight — Watermark helper for free-plan exports.
+
+Centralise le gating Free vs payant + i18n FR/EN + dispatch par format.
+
+Pour les formats texte (txt/md/csv) : retourne directement le contenu modifié.
+Pour les formats binaires (docx/xlsx/pdf) : retourne un dict marqueur que le
+caller utilisera pour injecter le watermark via la lib appropriée
+(python-docx / openpyxl / Jinja2 template).
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from billing.plan_config import normalize_plan_id
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONSTANTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Pendant la transition v0 → v2 (cf. plan pricing-v2 séparé), les plans payants
+# couvrent les trois IDs possibles. Quand pricing-v2 sera mergé ET la migration
+# 011 appliquée en prod, retirer "plus" de la set.
+PAID_PLANS: frozenset[str] = frozenset({"plus", "pro", "expert"})
+
+WATERMARK_URL = "www.deepsightsynthesis.com"
+WATERMARK_URL_HTTPS = "https://www.deepsightsynthesis.com"
+
+# Texte i18n
+WATERMARK_TEXTS: dict[str, dict[str, str]] = {
+    "fr": {
+        "tagline": "Analysé avec DeepSight — IA souveraine européenne",
+        "short": "Analysé avec DeepSight",
+        "name": "DeepSight",
+        "language_label": "français",
+    },
+    "en": {
+        "tagline": "Analyzed with DeepSight — European sovereign AI",
+        "short": "Analyzed with DeepSight",
+        "name": "DeepSight",
+        "language_label": "english",
+    },
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CORE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _resolve_language(user_language: Optional[str]) -> str:
+    """Résout la langue : fr par défaut, en si 'en', sinon fallback fr."""
+    if not user_language:
+        return "fr"
+    lang = user_language.lower().strip()
+    if lang in WATERMARK_TEXTS:
+        return lang
+    return "fr"
+
+
+def _should_apply_watermark(user_plan: Optional[str]) -> bool:
+    """Détermine si le watermark doit être appliqué.
+
+    Règle : watermark si plan normalisé NOT in PAID_PLANS (donc Free + plans inconnus).
+    """
+    if not user_plan:
+        return True  # Free fallback
+    normalized = normalize_plan_id(user_plan)
+    return normalized not in PAID_PLANS
+
+
+def add_watermark(
+    content: Union[str, bytes, dict],
+    format: str,
+    user_plan: Optional[str],
+    user_language: str = "fr",
+) -> Union[str, dict]:
+    """
+    Ajoute un watermark de branding sur un export en plan Free.
+
+    Pour les formats texte (txt, md, csv), retourne le contenu modifié directement.
+    Pour les formats binaires (docx, xlsx, pdf), retourne un dict marqueur :
+
+        {
+            "needs_watermark": bool,
+            "text": str,           # Texte tagline (ex: "Analysé avec DeepSight — IA souveraine européenne")
+            "short": str,          # Texte court (ex: "Analysé avec DeepSight")
+            "url": str,            # "www.deepsightsynthesis.com"
+            "url_https": str,      # "https://www.deepsightsynthesis.com"
+            "language": str,       # "fr" | "en"
+        }
+
+    Le caller utilisera ce dict pour injecter le watermark via la lib appropriée
+    (python-docx footer, openpyxl cell, Jinja2 template var).
+
+    Args:
+        content: contenu original (texte ou marqueur dict pour binaires)
+        format: "txt" | "md" | "csv" | "docx" | "xlsx" | "pdf"
+        user_plan: plan id (free, plus, pro, expert, etudiant, team, ...) — sera normalisé
+        user_language: "fr" | "en" (défaut: "fr"), tout autre code → fallback "fr"
+
+    Returns:
+        Le contenu modifié (str) pour txt/md/csv, ou un dict marqueur pour docx/xlsx/pdf.
+    """
+    apply = _should_apply_watermark(user_plan)
+    lang = _resolve_language(user_language)
+    texts = WATERMARK_TEXTS[lang]
+
+    # Format binaire : dict marqueur (toujours retourné — needs_watermark décide)
+    if format in ("docx", "xlsx", "pdf"):
+        return {
+            "needs_watermark": apply,
+            "text": texts["tagline"],
+            "short": texts["short"],
+            "url": WATERMARK_URL,
+            "url_https": WATERMARK_URL_HTTPS,
+            "language": lang,
+        }
+
+    # Pas de watermark pour les payants → contenu inchangé
+    if not apply:
+        return content
+
+    # Format texte : injection du marqueur en fin de contenu
+    if format == "txt":
+        return (
+            f"{content}\n\n"
+            f"---\n"
+            f"{texts['tagline']} ({WATERMARK_URL})\n"
+        )
+
+    if format == "md":
+        return (
+            f"{content}\n\n"
+            f"---\n"
+            f"*{texts['short']} avec [DeepSight]({WATERMARK_URL_HTTPS}) — "
+            f"{texts['tagline'].split('— ', 1)[1] if '— ' in texts['tagline'] else texts['tagline']}*\n"
+        ) if False else (  # Variante plus directe :
+            f"{content}\n\n"
+            f"---\n"
+            f"*{texts['tagline'].replace('DeepSight', f'[DeepSight]({WATERMARK_URL_HTTPS})')}*\n"
+        )
+
+    if format == "csv":
+        # Commentaire en dernière ligne (les parsers CSV standards ignorent les '#')
+        return (
+            f"{content.rstrip()}\n"
+            f"# {texts['tagline']} ({WATERMARK_URL})\n"
+        )
+
+    # Format inconnu : passthrough sans modification (sécurité)
+    return content
+```
+
+- [ ] **Étape 4 : Lancer les tests pour vérifier qu'ils passent**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_exports_watermark.py -v
+```
+
+Expected: tous les tests `test_*` PASSENT (≥ 17 tests).
+
+> ⚠️ Si certains tests échouent sur le format MD (lien markdown), ajuster la chaîne dans `add_watermark` pour matcher exactement `[DeepSight](https://www.deepsightsynthesis.com)`.
+
+- [ ] **Étape 5 : Commit**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git add backend/src/exports/watermark.py backend/tests/test_exports_watermark.py
+git commit -m "feat(exports): add watermark helper for free-plan exports
+
+- Centralised gating (Free vs paid plans via normalize_plan_id)
+- i18n FR (default) + EN, fallback FR for unknown languages
+- Dispatch by format: text formats return modified content, binary formats return marker dict
+- PAID_PLANS = {plus, pro, expert} during v0→v2 transition (remove 'plus' post pricing-v2 merge)
+- pytest TDD: 17+ tests covering 6 formats × 3 plans × 2 languages"
+```
+
+---
+
+## Task 2 : PDF — propagation `show_watermark` au template Jinja2
+
+**Files:**
+
+- Modify: `backend/src/exports/pdf_generator.py:174-261` (signature `generate()`) + `:263-343` (`_prepare_template_data()`) + `:362-405` (`generate_pdf()`)
+- Modify: `backend/src/exports/templates/pdf_template.html` (2 blocs `{% if show_watermark %}`)
+
+- [ ] **Étape 1 : Étendre la signature de `PDFGenerator.generate()` et `generate_pdf()`**
+
+Édit `backend/src/exports/pdf_generator.py` :
+
+```python
+# Dans PDFGenerator.generate(), ajouter user_plan + user_language à la signature
+    def generate(
+        self,
+        title: str,
+        channel: str,
+        category: str,
+        mode: str,
+        summary: str,
+        video_url: str = "",
+        duration: int = 0,
+        thumbnail_url: str = "",
+        entities: Optional[Dict] = None,
+        reliability_score: Optional[float] = None,
+        created_at: Optional[datetime] = None,
+        flashcards: Optional[List[Dict]] = None,
+        quiz: Optional[List[Dict]] = None,
+        sources: Optional[List[Dict]] = None,
+        export_type: PDFExportType = PDFExportType.FULL,
+        user_plan: Optional[str] = None,         # ← NEW
+        user_language: str = "fr",                # ← NEW
+    ) -> Optional[bytes]:
+```
+
+Et dans le bloc `try:` interne, propager au `_prepare_template_data` :
+
+```python
+            template_data = self._prepare_template_data(
+                title=title,
+                # ... (champs existants inchangés)
+                export_type=export_type,
+                user_plan=user_plan,            # ← NEW
+                user_language=user_language,    # ← NEW
+            )
+```
+
+- [ ] **Étape 2 : Étendre `_prepare_template_data()` pour calculer le marqueur watermark**
+
+Au début de `_prepare_template_data()`, importer le helper :
+
+```python
+        from .watermark import add_watermark
+```
+
+Et avant le `return {...}`, calculer le marqueur :
+
+```python
+        # Watermark gating (Free vs payant)
+        watermark_marker = add_watermark(
+            content="placeholder",
+            format="pdf",
+            user_plan=user_plan,
+            user_language=user_language,
+        )
+        # add_watermark pour 'pdf' retourne toujours un dict (needs_watermark, text, url, ...)
+        show_watermark = watermark_marker["needs_watermark"]
+        watermark_text = watermark_marker["text"]
+        watermark_url = watermark_marker["url"]
+```
+
+Ajouter au dict retourné :
+
+```python
+            # Watermark gating
+            "show_watermark": show_watermark,
+            "watermark_text": watermark_text,
+            "watermark_url": watermark_url,
+```
+
+Et étendre la signature de `_prepare_template_data` :
+
+```python
+    def _prepare_template_data(
+        self,
+        title: str,
+        # ... (existant)
+        export_type: PDFExportType,
+        user_plan: Optional[str] = None,         # ← NEW
+        user_language: str = "fr",                # ← NEW
+    ) -> Dict[str, Any]:
+```
+
+- [ ] **Étape 3 : Étendre `generate_pdf()` (fonction de convenance)**
+
+À la fin de `pdf_generator.py`, modifier `generate_pdf()` :
+
+```python
+def generate_pdf(
+    title: str,
+    channel: str,
+    category: str,
+    mode: str,
+    summary: str,
+    export_type: str = "full",
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+    **kwargs,
+) -> Optional[bytes]:
+    """..."""
+    generator = get_pdf_generator()
+    type_map = {
+        # ... (existant)
+    }
+    pdf_export_type = type_map.get(export_type, PDFExportType.FULL)
+
+    return generator.generate(
+        title=title,
+        channel=channel,
+        category=category,
+        mode=mode,
+        summary=summary,
+        export_type=pdf_export_type,
+        user_plan=user_plan,                  # ← NEW
+        user_language=user_language,          # ← NEW
+        **kwargs,
+    )
+```
+
+- [ ] **Étape 4 : Ajouter les blocs `{% if show_watermark %}` au template Jinja2**
+
+Édit `backend/src/exports/templates/pdf_template.html`.
+
+**Bloc 1 — sur la cover** : juste avant la fermeture du `<div class="cover-footer">` (autour de la ligne 803-810). Ajouter au-dessus :
+
+```html
+{% if show_watermark %}
+<div class="cover-watermark">
+  <em>{{ watermark_text }} — {{ watermark_url }}</em>
+</div>
+{% endif %}
+```
+
+**Bloc 2 — sur la dernière page** : juste avant la ligne 1048 (`Analyse intelligente propulsée par IA — deepsightsynthesis.com`). Ajouter au-dessus :
+
+```html
+{% if show_watermark %}
+<div class="last-page-watermark">
+  <em>{{ watermark_text }} — {{ watermark_url }}</em>
+</div>
+{% endif %}
+```
+
+**Bloc 3 — CSS** : ajouter dans la section style (sous les autres rules `cover-*`, ~ligne 200) :
+
+```css
+.cover-watermark {
+  margin-top: 1.2cm;
+  text-align: center;
+  font-size: 8pt;
+  color: #94a3b8;
+  font-style: italic;
+  letter-spacing: 0.3px;
+}
+
+.last-page-watermark {
+  margin-top: 0.8cm;
+  text-align: center;
+  font-size: 8pt;
+  color: #94a3b8;
+  font-style: italic;
+  letter-spacing: 0.3px;
+  page-break-before: avoid;
+}
+```
+
+- [ ] **Étape 5 : Test manuel rapide (smoke test)**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -c "
+from src.exports.pdf_generator import generate_pdf
+pdf = generate_pdf(
+    title='Test',
+    channel='Test Channel',
+    category='Tech',
+    mode='Standard',
+    summary='# Test\n\nContenu de test.',
+    user_plan='free',
+    user_language='fr',
+)
+with open('/tmp/test_free.pdf', 'wb') as f:
+    f.write(pdf)
+print('OK', len(pdf), 'bytes')
+"
+```
+
+Expected: fichier `/tmp/test_free.pdf` généré, contient (ouvrir et chercher) le texte `Analysé avec DeepSight — IA souveraine européenne`.
+
+Refaire avec `user_plan='pro'` → vérifier que la chaîne `Analysé avec DeepSight` n'apparaît PAS (la mention brand standard `DeepSight — deepsightsynthesis.com` peut rester via @bottom-center).
+
+- [ ] **Étape 6 : Commit**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git add backend/src/exports/pdf_generator.py backend/src/exports/templates/pdf_template.html
+git commit -m "feat(exports/pdf): propagate user_plan + show_watermark to Jinja2 template
+
+- Extend PDFGenerator.generate() and generate_pdf() with user_plan + user_language
+- _prepare_template_data() calls add_watermark() and forwards show_watermark/text/url
+- pdf_template.html: 2 conditional blocks (cover + last page) + CSS italic gris discret
+- Free users: visible watermark on cover and last page
+- Paid users: clean PDF (existing brand origin @bottom-center stays untouched)"
+```
+
+---
+
+## Task 3 : Adapter chaque format `service.py` (TXT, MD, DOCX, XLSX, CSV, PDF dispatcher)
+
+**Files:**
+
+- Modify: `backend/src/exports/service.py:203-241` (`export_to_txt`)
+- Modify: `backend/src/exports/service.py:249-334` (`export_to_markdown`)
+- Modify: `backend/src/exports/service.py:342-469` (`export_to_docx`)
+- Modify: `backend/src/exports/service.py:477-588` (`export_to_pdf_reportlab`)
+- Modify: `backend/src/exports/service.py:596-657` (`export_to_pdf` dispatcher)
+- Modify: `backend/src/exports/service.py:665-741` (`export_to_csv`)
+- Modify: `backend/src/exports/service.py:749-913` (`export_to_excel`)
+- Modify: `backend/src/exports/service.py:921-1010+` (`export_summary` dispatcher)
+
+> **Stratégie** : ajouter `user_plan: Optional[str] = None` et `user_language: str = "fr"` à TOUTES les signatures, propager via `export_summary`. Pour les formats texte, appel direct `add_watermark`. Pour les formats binaires (DOCX/XLSX), récupérer le dict marqueur et injecter via la lib appropriée. Pour PDF, propager au `generate_pdf()` (Task 2 fait le travail au niveau du template).
+
+- [ ] **Étape 1 : Étendre `export_to_txt`**
+
+Au début du fichier (sous les imports existants), ajouter :
+
+```python
+from .watermark import add_watermark
+```
+
+Modifier la signature et la fin :
+
+```python
+def export_to_txt(
+    title: str,
+    channel: str,
+    category: str,
+    mode: str,
+    summary: str,
+    video_url: str = "",
+    duration: int = 0,
+    created_at: datetime = None,
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+) -> str:
+    """Exporte l'analyse en format texte brut"""
+    # ... (corps existant inchangé jusqu'au return)
+
+    content = f"""..."""  # (existant)
+
+    # Watermark plan-aware (Free seulement)
+    return add_watermark(content, "txt", user_plan, user_language)
+```
+
+- [ ] **Étape 2 : Étendre `export_to_markdown`**
+
+```python
+def export_to_markdown(
+    title: str,
+    channel: str,
+    category: str,
+    mode: str,
+    summary: str,
+    video_url: str = "",
+    duration: int = 0,
+    thumbnail_url: str = "",
+    entities: Dict = None,
+    reliability_score: float = None,
+    created_at: datetime = None,
+    flashcards: List[Dict] = None,
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+) -> str:
+    """Exporte l'analyse en format Markdown"""
+    # ... (corps existant)
+
+    # En fin de fonction, juste avant `return content` :
+    return add_watermark(content, "md", user_plan, user_language)
+```
+
+- [ ] **Étape 3 : Étendre `export_to_docx`**
+
+```python
+def export_to_docx(
+    title: str,
+    # ... (existant)
+    flashcards: List[Dict] = None,
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+) -> Optional[bytes]:
+    """Exporte l'analyse en format DOCX"""
+    if not DOCX_AVAILABLE:
+        return None
+    from docx import Document
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+
+    doc = Document()
+    # ... (corps existant inchangé jusqu'à la fin)
+
+    # Footer existant (mention brand) — RESTE :
+    footer = doc.add_paragraph()
+    footer.add_run("Généré par Deep Sight — deepsightsynthesis.com").italic = True
+    footer.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    # ─── NEW : Watermark gating Free ───
+    marker = add_watermark("placeholder", "docx", user_plan, user_language)
+    if marker["needs_watermark"]:
+        wm = doc.add_paragraph()
+        run = wm.add_run(f"{marker['text']} — {marker['url']}")
+        run.italic = True
+        run.font.size = None  # Garde taille par défaut
+        wm.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    # Sauvegarder
+    buffer = io.BytesIO()
+    doc.save(buffer)
+    buffer.seek(0)
+    return buffer.getvalue()
+```
+
+- [ ] **Étape 4 : Étendre `export_to_pdf_reportlab`**
+
+```python
+def export_to_pdf_reportlab(
+    title: str,
+    # ... (existant)
+    created_at: datetime = None,
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+) -> Optional[bytes]:
+    """Export PDF de fallback avec ReportLab (moins stylé)"""
+    # ... (corps existant)
+
+    # Footer mention brand existant — RESTE
+    story.append(Paragraph("Généré par Deep Sight — deepsightsynthesis.com", footer_style))
+
+    # ─── NEW : Watermark gating Free ───
+    marker = add_watermark("placeholder", "pdf", user_plan, user_language)
+    if marker["needs_watermark"]:
+        watermark_style = ParagraphStyle(
+            "Watermark",
+            parent=styles["Normal"],
+            fontSize=8,
+            textColor=HexColor("#94a3b8"),
+            alignment=1,
+            fontName="Helvetica-Oblique",
+        )
+        story.append(Spacer(1, 0.3 * cm))
+        story.append(Paragraph(f"{marker['text']} — {marker['url']}", watermark_style))
+
+    doc.build(story)
+    buffer.seek(0)
+    return buffer.getvalue()
+```
+
+- [ ] **Étape 5 : Étendre `export_to_pdf` (dispatcher WeasyPrint/ReportLab)**
+
+```python
+def export_to_pdf(
+    title: str,
+    # ... (existant)
+    export_type: str = "full",
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+) -> Optional[bytes]:
+    """Exporte l'analyse en format PDF (WeasyPrint, fallback ReportLab)."""
+
+    if weasyprint_available():
+        pdf = generate_pdf_weasyprint(
+            title=title,
+            # ... (existant)
+            export_type=export_type,
+            user_plan=user_plan,              # ← NEW
+            user_language=user_language,      # ← NEW
+        )
+        if pdf:
+            return pdf
+        print("⚠️ WeasyPrint failed, falling back to ReportLab", flush=True)
+
+    if REPORTLAB_AVAILABLE:
+        return export_to_pdf_reportlab(
+            title=title,
+            # ... (existant)
+            user_plan=user_plan,              # ← NEW
+            user_language=user_language,      # ← NEW
+        )
+
+    return None
+```
+
+> ⚠️ Vérifier que `generate_pdf_weasyprint` est bien la fonction importée depuis `pdf_generator.py` (alias possible). Si oui, l'appel propage automatiquement vers `generate_pdf()` modifié en Task 2.
+
+- [ ] **Étape 6 : Étendre `export_to_csv`**
+
+```python
+def export_to_csv(
+    title: str,
+    # ... (existant)
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+) -> str:
+    """Exporte l'analyse en format CSV (structured data)"""
+    # ... (corps existant inchangé jusqu'à la fin)
+
+    writer.writerow([])
+    writer.writerow(["Généré par Deep Sight - deepsightsynthesis.com"])
+
+    csv_content = buffer.getvalue()
+    return add_watermark(csv_content, "csv", user_plan, user_language)
+```
+
+- [ ] **Étape 7 : Étendre `export_to_excel`**
+
+```python
+def export_to_excel(
+    title: str,
+    # ... (existant)
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+) -> Optional[bytes]:
+    """Exporte l'analyse en format Excel (.xlsx)"""
+    if not EXCEL_AVAILABLE:
+        return None
+    from openpyxl import Workbook
+    from openpyxl.styles import Font, Alignment, PatternFill, Border, Side
+
+    # ... (corps existant)
+
+    # Footer existant (mention brand) — RESTE
+    ws.merge_cells(f"A{row}:D{row}")
+    cell = ws[f"A{row}"]
+    cell.value = "Généré par Deep Sight — deepsightsynthesis.com"
+    cell.font = Font(name="Arial", size=8, italic=True, color="999999")
+    cell.alignment = Alignment(horizontal="center")
+
+    # ─── NEW : Watermark gating Free (cellule supplémentaire en dessous) ───
+    marker = add_watermark("placeholder", "xlsx", user_plan, user_language)
+    if marker["needs_watermark"]:
+        row += 1
+        ws.merge_cells(f"A{row}:D{row}")
+        wm_cell = ws[f"A{row}"]
+        wm_cell.value = f"{marker['text']} — {marker['url']}"
+        wm_cell.font = Font(name="Arial", size=8, italic=True, color="94A3B8")
+        wm_cell.alignment = Alignment(horizontal="center")
+
+    # ... (column widths existant)
+
+    buffer = io.BytesIO()
+    wb.save(buffer)
+    buffer.seek(0)
+    return buffer.getvalue()
+```
+
+- [ ] **Étape 8 : Étendre `export_summary` (dispatcher)**
+
+```python
+def export_summary(
+    format: str,
+    title: str,
+    channel: str,
+    category: str,
+    mode: str,
+    summary: str,
+    video_url: str = "",
+    duration: int = 0,
+    thumbnail_url: str = "",
+    entities: Dict = None,
+    reliability_score: float = None,
+    created_at: datetime = None,
+    flashcards: List[Dict] = None,
+    sources: List[Dict] = None,
+    pdf_export_type: str = "full",
+    user_plan: Optional[str] = None,         # ← NEW
+    user_language: str = "fr",                # ← NEW
+) -> Tuple[Optional[bytes | str], str, str]:
+    """Exporte un résumé dans le format demandé."""
+    timestamp = datetime.now().strftime("%Y%m%d")
+    base_filename = clean_filename(title, timestamp)
+
+    if format == "txt":
+        content = export_to_txt(
+            title, channel, category, mode, summary,
+            video_url, duration, created_at,
+            user_plan=user_plan,
+            user_language=user_language,
+        )
+        return content, f"{base_filename}.txt", "text/plain"
+
+    elif format == "md":
+        content = export_to_markdown(
+            title, channel, category, mode, summary,
+            video_url, duration, thumbnail_url,
+            entities, reliability_score, created_at, flashcards,
+            user_plan=user_plan,
+            user_language=user_language,
+        )
+        return content, f"{base_filename}.md", "text/markdown"
+
+    elif format == "docx":
+        if not DOCX_AVAILABLE:
+            return None, "", ""
+        content = export_to_docx(
+            title, channel, category, mode, summary,
+            video_url, duration, entities, reliability_score, created_at, flashcards,
+            user_plan=user_plan,
+            user_language=user_language,
+        )
+        return content, f"{base_filename}.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+    elif format == "pdf":
+        content = export_to_pdf(
+            title=title, channel=channel, category=category, mode=mode, summary=summary,
+            video_url=video_url, duration=duration, thumbnail_url=thumbnail_url,
+            entities=entities, reliability_score=reliability_score, created_at=created_at,
+            flashcards=flashcards, sources=sources, export_type=pdf_export_type,
+            user_plan=user_plan,
+            user_language=user_language,
+        )
+        return content, f"{base_filename}.pdf", "application/pdf"
+
+    elif format == "csv":
+        content = export_to_csv(
+            title, channel, category, mode, summary,
+            video_url, duration, entities, reliability_score, created_at,
+            user_plan=user_plan,
+            user_language=user_language,
+        )
+        return content, f"{base_filename}.csv", "text/csv"
+
+    elif format == "xlsx":
+        if not EXCEL_AVAILABLE:
+            return None, "", ""
+        content = export_to_excel(
+            title, channel, category, mode, summary,
+            video_url, duration, entities, reliability_score, created_at,
+            user_plan=user_plan,
+            user_language=user_language,
+        )
+        return content, f"{base_filename}.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+    return None, "", ""
+```
+
+- [ ] **Étape 9 : Lancer la suite de tests pour vérifier non-régression**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_exports_watermark.py -v
+```
+
+Expected: tous les tests existants continuent de passer (les fonctions `export_to_*` n'étaient pas testées auparavant, donc pas de régression possible côté tests).
+
+- [ ] **Étape 10 : Commit**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git add backend/src/exports/service.py
+git commit -m "feat(exports): inject watermark in all 6 export formats for free plan
+
+- export_to_txt/md/csv: append watermark via add_watermark helper (text formats)
+- export_to_docx: extra italic centered paragraph below brand footer (free only)
+- export_to_excel: extra italic centered cell below brand footer (free only)
+- export_to_pdf + export_to_pdf_reportlab: propagate user_plan to generator (Jinja2 template handles render)
+- export_summary dispatcher: forwards user_plan + user_language to all format handlers
+- Existing brand mention 'Généré par Deep Sight — deepsightsynthesis.com' stays on all plans (origin)
+- Watermark 'Analysé avec DeepSight — IA souveraine européenne' visible only on free plan"
+```
+
+---
+
+## Task 4 : Router — passer `user.plan` + `user.default_lang`
+
+**Files:**
+
+- Modify: `backend/src/exports/router.py:158-174` (appel `export_summary`)
+
+- [ ] **Étape 1 : Propager `current_user.plan` et `current_user.default_lang`**
+
+Dans `export_analysis()` (router.py:100), modifier l'appel à `export_summary` :
+
+```python
+    # Générer l'export
+    content, filename, mimetype = export_summary(
+        format=request.format,
+        title=summary.video_title,
+        channel=summary.video_channel,
+        category=summary.category,
+        mode=summary.mode,
+        summary=summary.summary_content,
+        video_url=summary.video_url,
+        duration=summary.video_duration,
+        thumbnail_url=summary.thumbnail_url,
+        entities=entities,
+        reliability_score=summary.reliability_score,
+        created_at=summary.created_at,
+        flashcards=flashcards,
+        sources=sources,
+        pdf_export_type=request.pdf_type or "full",
+        user_plan=current_user.plan,                  # ← NEW
+        user_language=current_user.default_lang or "fr",  # ← NEW
+    )
+```
+
+> **Note** : `export_analysis_get` (router.py:188) appelle déjà `export_analysis` en interne, donc pas de modification supplémentaire à faire.
+
+- [ ] **Étape 2 : Test d'intégration manuel (smoke test via curl)**
+
+```bash
+# Lancer le backend en local
+cd C:/Users/33667/DeepSight-Main/backend
+source venv/bin/activate  # ou Set-Location dans PowerShell + activate.ps1
+cd src && uvicorn main:app --reload --port 8000 &
+
+# Avec un token user free, tester l'export TXT
+curl -H "Authorization: Bearer $TOKEN_FREE" \
+  http://localhost:8000/api/exports/<summary_id>/txt -o /tmp/free.txt
+
+# Vérifier la présence du watermark
+grep -i "Analysé avec DeepSight" /tmp/free.txt
+# Expected: ligne trouvée
+
+# Avec un token user pro, tester
+curl -H "Authorization: Bearer $TOKEN_PRO" \
+  http://localhost:8000/api/exports/<summary_id>/txt -o /tmp/pro.txt
+
+# Vérifier l'absence du watermark
+grep -i "Analysé avec DeepSight" /tmp/pro.txt
+# Expected: AUCUNE ligne trouvée
+```
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git add backend/src/exports/router.py
+git commit -m "feat(exports/router): forward user.plan and user.default_lang to export_summary
+
+- Now Free users get watermark, Pro/Expert get clean exports
+- i18n: user.default_lang drives FR/EN watermark text"
+```
+
+---
+
+## Task 5 : Frontend `ExportMenu` tooltip + i18n
+
+**Files:**
+
+- Modify: `frontend/src/components/analysis/ExportMenu.tsx:103-157` (items dropdown)
+- Modify: `frontend/src/i18n/fr.json`
+- Modify: `frontend/src/i18n/en.json`
+
+- [ ] **Étape 1 : Ajouter les clés i18n FR**
+
+`frontend/src/i18n/fr.json` (ajouter sous le namespace `export` ou créer si absent) :
+
+```json
+{
+  "export": {
+    "watermark": {
+      "notice_free": "Les exports gratuits incluent un watermark — passez Pro pour le retirer",
+      "upgrade_link": "Passer Pro"
+    }
+  }
+}
+```
+
+- [ ] **Étape 2 : Ajouter les clés i18n EN**
+
+`frontend/src/i18n/en.json` :
+
+```json
+{
+  "export": {
+    "watermark": {
+      "notice_free": "Free exports include a watermark — upgrade to Pro to remove it",
+      "upgrade_link": "Upgrade to Pro"
+    }
+  }
+}
+```
+
+- [ ] **Étape 3 : Modifier `ExportMenu.tsx` pour afficher le tooltip plan-aware**
+
+Édit `frontend/src/components/analysis/ExportMenu.tsx`. Importer `useTranslation` (le projet utilise probablement `react-i18next` ou un custom hook — vérifier l'usage dans un autre composant comme `ChatPanel.tsx`).
+
+Si `LanguageContext` est utilisé (cf. `frontend/src/contexts/LanguageContext.tsx` mentionné dans le CLAUDE.md), pattern :
+
+```typescript
+import { useLanguage } from "../../contexts/LanguageContext";
+// ...
+
+const { t } = useLanguage();
+```
+
+Sinon adapter pour le hook réellement utilisé.
+
+Ajouter une note sous les 3 items pdf/md/txt dans le dropdown si `userPlan === "free"`. Le composant `Dropdown` accepte un sous-ensemble d'items typés `DropdownItem` — on ajoute un item `divider` puis un item info non-cliquable :
+
+```typescript
+  const items: DropdownItem[] = [
+    {
+      id: "pdf",
+      label: "PDF",
+      description: "Export professionnel mis en page",
+      icon: loadingFormat === "pdf" ? <DeepSightSpinnerMicro /> : <FileText className="w-4 h-4" />,
+      disabled: loadingFormat !== null,
+    },
+    {
+      id: "md",
+      label: "Markdown",
+      description: "Format éditable",
+      icon: loadingFormat === "md" ? <DeepSightSpinnerMicro /> : <FileCode className="w-4 h-4" />,
+      disabled: loadingFormat !== null,
+    },
+    {
+      id: "txt",
+      label: "Texte brut",
+      description: "Copier-coller universel",
+      icon: loadingFormat === "txt" ? <DeepSightSpinnerMicro /> : <AlignLeft className="w-4 h-4" />,
+      disabled: loadingFormat !== null,
+    },
+    // ─── NEW : notice watermark si Free ─────────────────────────────────
+    ...(userPlan === "free"
+      ? [
+          { id: "divider-watermark", label: "", divider: true },
+          {
+            id: "watermark-notice",
+            label: t("export.watermark.notice_free"),
+            description: t("export.watermark.upgrade_link"),
+            icon: <Lock className="w-4 h-4" />,
+            disabled: true,
+            // L'utilisateur doit cliquer sur l'item pour naviguer vers /upgrade — gérer dans onSelect
+          },
+        ]
+      : []),
+    // ─── existant : audio ─────────────────────────────────────────────
+    { id: "divider-audio", label: "", divider: true },
+    {
+      id: "audio",
+      label: canExportAudio ? "Audio" : "Audio (Pro+)",
+      description: canExportAudio ? "Écouter l'analyse" : "Disponible à partir du plan Pro",
+      icon:
+        loadingFormat === "audio" ? <DeepSightSpinnerMicro /> : canExportAudio ? <Headphones className="w-4 h-4" /> : <Lock className="w-4 h-4" />,
+      disabled: loadingFormat !== null || !canExportAudio,
+    },
+  ];
+```
+
+Et étendre `onSelect` dans `<Dropdown>` :
+
+```typescript
+        onSelect={(id) => {
+          if (id === "watermark-notice") {
+            window.location.href = "/upgrade";
+            return;
+          }
+          handleExport(id as ExportFormat);
+        }}
+```
+
+> **Note importante** : si le projet n'a pas de hook `useLanguage` exposé tel quel, simplement hardcoder les chaînes FR (la spec indique FR par défaut) et laisser une TODO pour l'i18n EN dans la review. Vérifier d'abord avec `grep -rn "useLanguage\|useTranslation" frontend/src/components/analysis/` pour voir le pattern utilisé.
+
+- [ ] **Étape 4 : Vérifier compilation TypeScript et lint**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run typecheck
+npm run lint -- src/components/analysis/ExportMenu.tsx
+```
+
+Expected: 0 erreur sur le fichier modifié.
+
+- [ ] **Étape 5 : Test visuel rapide (dev server)**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run dev
+```
+
+Ouvrir http://localhost:5173 → login user Free → ouvrir une analyse → cliquer sur "Exporter" → vérifier la présence de la mention sous les options PDF/MD/TXT. Refaire avec user Pro → vérifier l'absence.
+
+- [ ] **Étape 6 : Commit**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git add frontend/src/components/analysis/ExportMenu.tsx frontend/src/i18n/fr.json frontend/src/i18n/en.json
+git commit -m "feat(frontend/exports): add plan-aware watermark notice in ExportMenu
+
+- Free users see info row 'Free exports include a watermark — upgrade to Pro to remove it'
+- Click on notice navigates to /upgrade
+- i18n FR + EN keys: export.watermark.notice_free, export.watermark.upgrade_link
+- Pro/Expert users see no notice (clean menu)"
+```
+
+---
+
+## Task 6 : Tests pytest exhaustifs (intégration end-to-end)
+
+**Files:**
+
+- Modify: `backend/tests/test_exports_watermark.py` (ajouter section integration)
+
+> Les tests unitaires du Task 1 couvrent le helper. Ici on teste l'intégration via les fonctions `export_to_*` réelles, garantissant que l'injection fonctionne bien dans tous les formats avec une vraie payload.
+
+- [ ] **Étape 1 : Ajouter une section integration au fichier de tests**
+
+Ajouter à la fin de `backend/tests/test_exports_watermark.py` :
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# INTEGRATION TESTS — appel réel à export_to_*
+# ═══════════════════════════════════════════════════════════════════════════════
+from datetime import datetime
+
+from exports.service import (
+    export_to_txt,
+    export_to_markdown,
+    export_to_docx,
+    export_to_csv,
+    export_to_excel,
+    export_summary,
+    DOCX_AVAILABLE,
+    EXCEL_AVAILABLE,
+)
+
+
+SAMPLE_KWARGS = dict(
+    title="Test Video",
+    channel="Test Channel",
+    category="Tech",
+    mode="Standard",
+    summary="# Test\n\nContenu de synthèse de test.",
+    video_url="https://youtube.com/watch?v=test",
+    duration=600,
+    created_at=datetime(2026, 4, 29, 12, 0, 0),
+)
+
+
+# ─── TXT ─────────────────────────────────────────────────────────────────────
+
+def test_integration_txt_free_has_watermark():
+    out = export_to_txt(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    assert "Analysé avec DeepSight" in out
+    assert "IA souveraine européenne" in out
+    # Mention brand origin existante reste
+    assert "deepsightsynthesis.com" in out
+
+
+def test_integration_txt_pro_no_watermark():
+    out = export_to_txt(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    assert "Analysé avec DeepSight" not in out
+    # Mention brand origin existante reste
+    assert "deepsightsynthesis.com" in out
+
+
+def test_integration_txt_expert_no_watermark():
+    out = export_to_txt(**SAMPLE_KWARGS, user_plan="expert", user_language="fr")
+    assert "Analysé avec DeepSight" not in out
+
+
+def test_integration_txt_plus_no_watermark_during_v0_v2_transition():
+    """v0 'plus' = payant, doit pas avoir de watermark pendant la transition."""
+    out = export_to_txt(**SAMPLE_KWARGS, user_plan="plus", user_language="fr")
+    assert "Analysé avec DeepSight" not in out
+
+
+# ─── MD ──────────────────────────────────────────────────────────────────────
+
+def test_integration_md_free_has_watermark_link():
+    out = export_to_markdown(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    assert "Analysé avec DeepSight" in out
+    assert "[DeepSight](https://www.deepsightsynthesis.com)" in out
+
+
+def test_integration_md_pro_no_watermark():
+    out = export_to_markdown(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    assert "Analysé avec DeepSight" not in out
+
+
+def test_integration_md_english():
+    out = export_to_markdown(**SAMPLE_KWARGS, user_plan="free", user_language="en")
+    assert "Analyzed with DeepSight" in out
+    assert "European sovereign AI" in out
+
+
+# ─── DOCX ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not DOCX_AVAILABLE, reason="python-docx not installed")
+def test_integration_docx_free_has_watermark_paragraph():
+    """DOCX Free contient un paragraphe avec le texte watermark."""
+    from docx import Document
+    import io
+
+    blob = export_to_docx(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    assert blob is not None
+    doc = Document(io.BytesIO(blob))
+    full_text = "\n".join(p.text for p in doc.paragraphs)
+    assert "Analysé avec DeepSight" in full_text
+    assert "IA souveraine européenne" in full_text
+
+
+@pytest.mark.skipif(not DOCX_AVAILABLE, reason="python-docx not installed")
+def test_integration_docx_pro_no_watermark_paragraph():
+    from docx import Document
+    import io
+
+    blob = export_to_docx(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    doc = Document(io.BytesIO(blob))
+    full_text = "\n".join(p.text for p in doc.paragraphs)
+    assert "Analysé avec DeepSight" not in full_text
+    # Mention brand existante reste
+    assert "Généré par Deep Sight" in full_text
+
+
+# ─── CSV ─────────────────────────────────────────────────────────────────────
+
+def test_integration_csv_free_has_watermark_comment():
+    out = export_to_csv(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    last_line = out.strip().split("\n")[-1]
+    assert last_line.startswith("#")
+    assert "Analysé avec DeepSight" in last_line
+
+
+def test_integration_csv_pro_no_watermark_comment():
+    out = export_to_csv(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    last_line = out.strip().split("\n")[-1]
+    assert "Analysé avec DeepSight" not in last_line
+
+
+# ─── XLSX ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not EXCEL_AVAILABLE, reason="openpyxl not installed")
+def test_integration_xlsx_free_has_watermark_cell():
+    from openpyxl import load_workbook
+    import io
+
+    blob = export_to_excel(**SAMPLE_KWARGS, user_plan="free", user_language="fr")
+    assert blob is not None
+    wb = load_workbook(io.BytesIO(blob))
+    ws = wb.active
+    all_values = []
+    for row in ws.iter_rows(values_only=True):
+        for v in row:
+            if v:
+                all_values.append(str(v))
+    full_text = " ".join(all_values)
+    assert "Analysé avec DeepSight" in full_text
+
+
+@pytest.mark.skipif(not EXCEL_AVAILABLE, reason="openpyxl not installed")
+def test_integration_xlsx_pro_no_watermark_cell():
+    from openpyxl import load_workbook
+    import io
+
+    blob = export_to_excel(**SAMPLE_KWARGS, user_plan="pro", user_language="fr")
+    wb = load_workbook(io.BytesIO(blob))
+    ws = wb.active
+    all_values = []
+    for row in ws.iter_rows(values_only=True):
+        for v in row:
+            if v:
+                all_values.append(str(v))
+    full_text = " ".join(all_values)
+    assert "Analysé avec DeepSight" not in full_text
+    assert "Deep Sight" in full_text  # Brand mention existante reste
+
+
+# ─── PDF (smoke — vérifie générerat sans crash) ──────────────────────────────
+
+def test_integration_pdf_free_smoke():
+    """Smoke test : PDF Free généré sans crash, taille > 1KB."""
+    content, filename, mimetype = export_summary(
+        format="pdf",
+        **SAMPLE_KWARGS,
+        user_plan="free",
+        user_language="fr",
+    )
+    assert content is not None
+    assert len(content) > 1024  # PDF non trivial
+    assert filename.endswith(".pdf")
+    assert mimetype == "application/pdf"
+
+
+def test_integration_pdf_pro_smoke():
+    content, filename, mimetype = export_summary(
+        format="pdf",
+        **SAMPLE_KWARGS,
+        user_plan="pro",
+        user_language="fr",
+    )
+    assert content is not None
+    assert len(content) > 1024
+
+
+# ─── export_summary dispatcher ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("fmt", ["txt", "md", "csv"])
+def test_integration_export_summary_free_has_watermark(fmt: str):
+    """Le dispatcher principal applique le watermark pour Free sur les formats texte."""
+    content, _, _ = export_summary(
+        format=fmt,
+        **SAMPLE_KWARGS,
+        user_plan="free",
+        user_language="fr",
+    )
+    assert isinstance(content, str)
+    assert "Analysé avec DeepSight" in content
+
+
+@pytest.mark.parametrize("fmt", ["txt", "md", "csv"])
+def test_integration_export_summary_pro_no_watermark(fmt: str):
+    """Le dispatcher principal n'applique PAS le watermark pour Pro sur les formats texte."""
+    content, _, _ = export_summary(
+        format=fmt,
+        **SAMPLE_KWARGS,
+        user_plan="pro",
+        user_language="fr",
+    )
+    assert isinstance(content, str)
+    assert "Analysé avec DeepSight" not in content
+```
+
+- [ ] **Étape 2 : Lancer la suite complète**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/test_exports_watermark.py -v
+```
+
+Expected: tous les tests passent (20+ unitaires + 18+ intégration ≈ 38+ tests).
+
+> ⚠️ Si certains tests intégration échouent à cause de WeasyPrint indisponible en CI, ajouter `@pytest.mark.skipif(not weasyprint_available(), ...)` aux tests PDF correspondants.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git add backend/tests/test_exports_watermark.py
+git commit -m "test(exports): add integration tests for watermark across all 6 formats
+
+- TXT/MD/CSV: assert text injection in real export functions
+- DOCX: parse generated bytes with python-docx, scan paragraphs
+- XLSX: parse generated bytes with openpyxl, scan all cells
+- PDF: smoke test (assert generation success + size > 1KB)
+- export_summary dispatcher: parametrized over 3 text formats × free/pro
+- 20+ unit tests + 18+ integration tests = 38+ total"
+```
+
+---
+
+## Task 7 : Verification finale + non-régression payants
+
+**Files:**
+
+- (vérification, pas de modification)
+
+> Vérification finale : s'assurer qu'AUCUNE mention "Analysé avec DeepSight" ou "IA souveraine européenne" n'apparaît dans les exports payants — quel que soit le format.
+
+- [ ] **Étape 1 : Script de vérification cross-format pour user Pro**
+
+Créer un script ad-hoc temporaire (ne pas committer) :
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+cat > /tmp/verify_paid_no_watermark.py << 'EOF'
+"""Vérification non-régression : aucune mention watermark dans exports payants."""
+import sys
+import asyncio
+from datetime import datetime
+
+# Ajouter src au PYTHONPATH
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+from exports.service import export_summary
+
+KWARGS = dict(
+    title="Test",
+    channel="Test",
+    category="Tech",
+    mode="Standard",
+    summary="Test contenu.",
+    video_url="https://youtube.com/watch?v=x",
+    duration=300,
+    created_at=datetime.now(),
+    user_language="fr",
+)
+
+WATERMARK_TOKENS = [
+    "Analysé avec DeepSight",
+    "IA souveraine européenne",
+    "Analyzed with DeepSight",
+    "European sovereign AI",
+]
+
+PAID_PLANS_TO_CHECK = ["plus", "pro", "expert"]
+FORMATS = ["txt", "md", "csv"]  # text formats only — binary scanned separately
+
+errors = []
+for plan in PAID_PLANS_TO_CHECK:
+    for fmt in FORMATS:
+        content, _, _ = export_summary(format=fmt, user_plan=plan, **KWARGS)
+        if not isinstance(content, str):
+            continue
+        for token in WATERMARK_TOKENS:
+            if token in content:
+                errors.append(f"BUG: plan={plan} fmt={fmt} contains '{token}'")
+
+if errors:
+    for e in errors:
+        print(e)
+    sys.exit(1)
+else:
+    print(f"OK: {len(PAID_PLANS_TO_CHECK)} plans × {len(FORMATS)} formats = {len(PAID_PLANS_TO_CHECK) * len(FORMATS)} combinaisons sans watermark")
+EOF
+
+cd C:/Users/33667/DeepSight-Main/backend
+python /tmp/verify_paid_no_watermark.py
+```
+
+Expected: `OK: 3 plans × 3 formats = 9 combinaisons sans watermark`.
+
+- [ ] **Étape 2 : Vérifier qu'aucun fichier de production n'a été modifié hors scope**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git diff main --stat
+```
+
+Expected: seulement les fichiers listés dans la File Structure ci-dessus.
+
+- [ ] **Étape 3 : Lancer la suite de tests backend complète (non-régression cross-module)**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/backend
+python -m pytest tests/ -v --maxfail=10
+```
+
+Expected: 774 + N nouveaux tests passent, 0 échec.
+
+- [ ] **Étape 4 : Lancer typecheck + lint frontend**
+
+```bash
+cd C:/Users/33667/DeepSight-Main/frontend
+npm run typecheck
+npm run lint -- src/components/analysis/ExportMenu.tsx
+```
+
+Expected: 0 erreur.
+
+- [ ] **Étape 5 : Pas de commit ici** — ce task est purement vérification.
+
+---
+
+## Self-Review (décisions à confirmer avant exécution)
+
+### D1 — Watermark PDF : texte seul ou logo SVG ?
+
+**Default** : **Texte seul** (paragraphe italique gris discret, pas de logo SVG).
+
+**Pourquoi** : zéro nouvel asset à gérer (path, font embed, base64 inline), zéro complication de rendu WeasyPrint, parfaitement lisible et cohérent avec le ton "discret" voulu pour ne pas dégrader l'expérience Free. Cohérent avec RELEASE-ORCHESTRATION WM-1 et WM-5.
+
+**Alternative** : intégrer un petit logo DeepSight SVG via `<img>` dans le template Jinja2. Possible plus tard en V2 si besoin de plus de présence visuelle.
+
+### D2 — Watermark sur les analyses publiques `/a/[id]` (pages partagées) ?
+
+**Default** : **OUI** — propager le `owner_plan` (le plan du propriétaire de l'analyse) au lieu du plan du visiteur.
+
+**Action concrète si OUI** : dans le router gérant le partage public (à identifier — probablement `backend/src/videos/router.py` ou un router `share/`), passer `user_plan=summary.user.plan` au lieu de `user_plan=current_user.plan` lors de l'export depuis une page publique. C'est **hors scope** de ce plan dans une première itération — à faire en V2 quand on identifiera les flows de partage public concernés.
+
+**Pourquoi NOT NOW** : le partage public dans le scope de la spec exécutée n'est pas mappé (pas trouvé `/a/[id]` dans le grep router.py rapidement). Ne pas surcharger ce sprint Quick Win. La règle simple "watermark si visiteur Free" est cohérente même côté pages publiques (un visiteur Free verra le watermark de TOUTE manière même si l'auteur est Pro).
+
+**À confirmer utilisateur** : laisser cette propagation V2, ou bien écrire le hook owner_plan dès maintenant ?
+
+### D3 — Retirer `"plus"` de `PAID_PLANS` post-merge pricing-v2 ?
+
+**Default** : **OUI**, mais pas dans ce plan. Créer une issue séparée `[chore] watermark: drop "plus" from PAID_PLANS post pricing-v2 migration`.
+
+**Pourquoi** : pendant la transition v0→v2 (cf. plan pricing-v2), il existe potentiellement des users `users.plan == "plus"` en DB jusqu'à l'application de la migration 011 en prod. Une fois la migration appliquée, `users.plan` est déjà migré (`plus → pro`, `pro → expert`), donc plus aucun `"plus"` en DB. À ce moment, `"plus"` dans `PAID_PLANS` devient inerte mais conceptuellement dépassé.
+
+**Action V2** : après merge + déploiement de pricing-v2, modifier `PAID_PLANS = frozenset({"pro", "expert"})` en une PR de cleanup.
+
+### D4 — Branche git pour ce sprint Quick Win ?
+
+**Default** : `feature/watermark-exports-free` (cf. RELEASE-ORCHESTRATION recommandation Sprint A).
+
+**Note** : la branche actuelle de la session est `feature/audit-kimi-plans-2026-04-29` (cf. brief). Confirmer avec l'utilisateur s'il faut créer un worktree dédié `feature/watermark-exports-free` (recommandé pour isolation), ou poursuivre sur la branche existante.
+
+### D5 — Watermark customisable selon persona (étudiant, journaliste, chercheur) ?
+
+**Default** : **NON V1**. Texte unique : `"Analysé avec DeepSight — IA souveraine européenne"` / `"Analyzed with DeepSight — European sovereign AI"`.
+
+**Pourquoi** : la base d'utilisateurs Free est petite et hétérogène. Customiser par persona (étudiant → "Mon cours analysé par DeepSight", journaliste → "Fact-check DeepSight", chercheur → "Sources analysées par DeepSight") demande :
+
+1. Un champ `User.persona` (n'existe pas — le plan dashboard-onboarding propose de l'ajouter mais n'est pas encore mergé)
+2. 3+ chaînes traduites par persona × FR/EN = 6+ textes à maintenir
+3. Un mécanisme de fallback si `persona = null`
+
+**Action V2** : si le plan `dashboard-onboarding-empty-states` ajoute `User.persona`, on pourra évaluer sa valeur. À ce moment, lookup persona-aware dans `WATERMARK_TEXTS` deviendra trivial.
+
+---
+
+## Execution Handoff
+
+**Plan complet et sauvegardé à** : `C:\Users\33667\DeepSight-Main\docs\superpowers\plans\2026-04-29-watermark-exports-gratuits.md`.
+
+**Deux options d'exécution :**
+
+**1. Subagent-Driven (recommandé)** — Je dispatche un subagent Opus 4.7 frais par task (7 tasks), je review entre chaque, fast iteration. Idéal pour ce plan car les tasks sont relativement indépendantes (sauf Task 1 → Task 2/3 qui dépend de `watermark.py`).
+
+**2. Inline Execution** — Exécuter dans cette session avec `superpowers:executing-plans`, batch + checkpoints. Plus rapide mais moins de garde-fous.
+
+**Quelle approche ?**
+
+---
+
+_Plan rédigé 2026-04-29 — DeepSight audit Kimi Phase 6 (watermark exports gratuits)._
+_Estimé total : 7 tasks ≈ 4-6 h dev + 1 h review/QA. Sprint A quick win autonome._

--- a/frontend/src/components/analysis/ExportMenu.tsx
+++ b/frontend/src/components/analysis/ExportMenu.tsx
@@ -17,6 +17,7 @@ import { DeepSightSpinnerMicro } from "../ui/DeepSightSpinner";
 import { useToast } from "../Toast";
 import { videoApi, API_URL } from "../../services/api";
 import { useAuth } from "../../hooks/useAuth";
+import { useLanguage } from "../../contexts/LanguageContext";
 
 interface ExportMenuProps {
   summaryId: number;
@@ -32,11 +33,14 @@ export const ExportMenu: React.FC<ExportMenuProps> = ({
   onAudioReady,
 }) => {
   const { user } = useAuth();
+  const { t } = useLanguage();
   const { showToast, ToastComponent } = useToast();
   const [loadingFormat, setLoadingFormat] = useState<ExportFormat | null>(null);
 
   const userPlan = user?.plan || "free";
   const canExportAudio = userPlan !== "free";
+  // Free users get a watermark on all exports — show notice + upgrade link
+  const isFreePlan = userPlan === "free";
 
   const handleExport = useCallback(
     async (format: ExportFormat) => {
@@ -137,6 +141,19 @@ export const ExportMenu: React.FC<ExportMenuProps> = ({
         ),
       disabled: loadingFormat !== null,
     },
+    // Watermark notice for free users (clickable -> /upgrade)
+    ...(isFreePlan
+      ? ([
+          { id: "divider-watermark", label: "", divider: true },
+          {
+            id: "watermark-notice",
+            label: t("export.watermark.noticeFree"),
+            description: t("export.watermark.upgradeLink"),
+            icon: <Lock className="w-4 h-4" />,
+            disabled: false,
+          },
+        ] as DropdownItem[])
+      : []),
     { id: "divider-audio", label: "", divider: true },
     {
       id: "audio",
@@ -183,7 +200,13 @@ export const ExportMenu: React.FC<ExportMenuProps> = ({
       <Dropdown
         trigger={trigger}
         items={items}
-        onSelect={(id) => handleExport(id as ExportFormat)}
+        onSelect={(id) => {
+          if (id === "watermark-notice") {
+            window.location.href = "/upgrade";
+            return;
+          }
+          handleExport(id as ExportFormat);
+        }}
         align="right"
         width="w-64"
       />

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -490,7 +490,11 @@
       "includeMetadata": "Include metadata"
     },
     "proFeature": "Pro Feature",
-    "upgradeToExport": "Upgrade to export"
+    "upgradeToExport": "Upgrade to export",
+    "watermark": {
+      "noticeFree": "Watermark on free exports — upgrade to Pro to remove",
+      "upgradeLink": "Upgrade to Pro"
+    }
   },
   "errors": {
     "generic": "An error occurred",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -490,7 +490,11 @@
       "includeMetadata": "Inclure les métadonnées"
     },
     "proFeature": "Fonctionnalité Pro",
-    "upgradeToExport": "Passez au plan supérieur pour exporter"
+    "upgradeToExport": "Passez au plan supérieur pour exporter",
+    "watermark": {
+      "noticeFree": "Watermark sur exports gratuits — Pro retire la mention",
+      "upgradeLink": "Passer Pro"
+    }
   },
   "errors": {
     "generic": "Une erreur est survenue",


### PR DESCRIPTION
## Summary
Ajoute le watermark "Analysé avec DeepSight — IA souveraine européenne" sur les exports utilisateurs Free, sur les 6 formats. Plan source: `docs/superpowers/plans/2026-04-29-watermark-exports-gratuits.md`.

| Format | Mode injection |
|---|---|
| TXT | Append `---` + tagline + URL |
| MD | Append `---` + tagline italic avec lien markdown cliquable |
| PDF | Bloc Jinja2 `{% if show_watermark %}` (cover + dernière page italic gris) + ReportLab fallback |
| DOCX | Paragraphe italic centré sous footer brand |
| XLSX | Cellule fusionnée italic gris sous footer brand |
| CSV | Ligne commentaire `#` en fin |

## Décisions verrouillées (Maxime 2026-04-29)
- **WM-1** : texte seul, pas de logo SVG (zero asset)
- **WM-2** : `owner_plan` propagation public share = **reporté V2** (actuellement visiteur Pro voit pas le watermark sur analyses Free partagées — à corriger)
- **WM-3** : CSV inclus
- **WM-4** : Audio TTS exclu (déjà gated `tts_enabled`)
- **WM-5** : PDF paragraphe italic gris dernière page (sans titre)

## Watermark texte
- **FR** : `Analysé avec DeepSight — IA souveraine européenne` + `www.deepsightsynthesis.com`
- **EN** : `Analyzed with DeepSight — European sovereign AI` + même URL

## Tests
**Backend pytest 56 nouveaux (35 unit + 21 integration)** : DOCX/XLSX testés en parsant bytes générés ; PDF smoke via ReportLab fallback. Suite complète **1135/1136 passing** (1 fail test voice/timeline order-dependent **non lié** à cette PR — passe en isolé).

**Frontend** : `npm run typecheck` 0 nouvelle erreur sur `ExportMenu.tsx` ; ESLint clean ; JSON i18n FR+EN valides.

## Bug pré-existant fixé en passant
`safe_title` undefined dans dispatcher CSV/XLSX `service.py` (dead code path inaccessible mais cassé). Remplacé par `base_filename`.

## ⚠ WeasyPrint Windows
WeasyPrint **non testable localement Windows** (libgobject manquant). Smoke prod-like requis : déployer en staging et exporter PDF user Free + user Pro.

## Test plan
- [ ] Login user Free → exporter PDF, MD, TXT → mention présente (cover PDF + last page)
- [ ] Login user Pro → exporter PDF, MD, TXT → aucune mention
- [ ] User Free → exporter DOCX, XLSX, CSV → mention selon format
- [ ] User Pro → exporter DOCX, XLSX, CSV → aucune mention
- [ ] Audio TTS export → aucune mention (gated tts_enabled)
- [ ] Cleanup follow-up à tracker : retirer "plus" de PAID_PLANS post merge pricing-v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)