### PR TITLE
feat(mobile): click-link password reset flow + fix API signature

### DIFF
--- a/mobile/app/(auth)/forgot-password.tsx
+++ b/mobile/app/(auth)/forgot-password.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useEffect } from "react";
+import React, { useCallback, useState } from "react";
 import {
   View,
   Text,
@@ -6,92 +6,30 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
-  Alert,
-  TextInput,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  FadeIn,
-  FadeOut,
-  SlideInRight,
-  SlideOutLeft,
-} from "react-native-reanimated";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { useTheme } from "@/contexts/ThemeContext";
-import { authApi, ApiError } from "@/services/api";
-import { sp, borderRadius } from "@/theme/spacing";
-import { fontFamily, fontSize, textStyles } from "@/theme/typography";
+import { authApi } from "@/services/api";
+import { sp } from "@/theme/spacing";
+import { fontSize, textStyles } from "@/theme/typography";
 import { palette } from "@/theme/colors";
-import { timings } from "@/theme/animations";
 import { DoodleBackground } from "@/components/ui/DoodleBackground";
-
-const CODE_LENGTH = 6;
-const RESEND_COOLDOWN = 60;
-
-type Step = 1 | 2 | 3;
 
 export default function ForgotPasswordScreen() {
   const router = useRouter();
   const { colors } = useTheme();
 
-  const [step, setStep] = useState<Step>(1);
-
-  // Step 1
   const [email, setEmail] = useState("");
   const [emailError, setEmailError] = useState("");
-  const [emailLoading, setEmailLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
 
-  // Step 2
-  const [code, setCode] = useState<string[]>(Array(CODE_LENGTH).fill(""));
-  const [codeError, setCodeError] = useState("");
-  const [codeLoading, setCodeLoading] = useState(false);
-  const [resendTimer, setResendTimer] = useState(0);
-  const inputRefs = useRef<Array<TextInput | null>>(
-    Array(CODE_LENGTH).fill(null),
-  );
-
-  // Step 3
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [passwordErrors, setPasswordErrors] = useState<{
-    newPassword?: string;
-    confirmPassword?: string;
-  }>({});
-  const [resetLoading, setResetLoading] = useState(false);
-  const confirmRef = useRef<TextInput>(null);
-
-  // The reset token (the code itself, used for resetPassword API)
-  const [resetToken, setResetToken] = useState("");
-
-  // Progress bar
-  const progress = useSharedValue(0.33);
-
-  useEffect(() => {
-    progress.value = withTiming(step / 3, timings.standard);
-  }, [step, progress]);
-
-  const progressStyle = useAnimatedStyle(() => ({
-    width: `${progress.value * 100}%`,
-  }));
-
-  // Resend countdown
-  useEffect(() => {
-    if (resendTimer <= 0) return;
-    const interval = setInterval(() => {
-      setResendTimer((prev) => prev - 1);
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [resendTimer]);
-
-  // Step 1: Send code
-  const handleSendCode = useCallback(async () => {
+  const handleSubmit = useCallback(async () => {
     if (!email.trim()) {
       setEmailError("L'email est requis");
       return;
@@ -102,160 +40,19 @@ export default function ForgotPasswordScreen() {
     }
 
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setEmailLoading(true);
+    setLoading(true);
     setEmailError("");
 
     try {
       await authApi.forgotPassword(email.trim());
-      setResendTimer(RESEND_COOLDOWN);
-      setStep(2);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        if (err.status === 404) {
-          setEmailError("Aucun compte associé à cet email");
-        } else {
-          Alert.alert("Erreur", err.message || "Impossible d'envoyer le code");
-        }
-      } else {
-        Alert.alert("Erreur", "Vérifiez votre connexion internet.");
-      }
+    } catch {
+      // Anti-énumération : on affiche le message succès même en cas d'erreur
+      // (sauf erreur réseau on pourrait alerter, mais on garde silencieux ici).
     } finally {
-      setEmailLoading(false);
+      setLoading(false);
+      setSubmitted(true);
     }
   }, [email]);
-
-  // Step 2: Verify code
-  const handleCodeChange = useCallback(
-    (text: string, index: number) => {
-      if (text.length > 1) {
-        const chars = text
-          .replace(/[^0-9]/g, "")
-          .slice(0, CODE_LENGTH)
-          .split("");
-        const newCode = [...code];
-        chars.forEach((char, i) => {
-          if (index + i < CODE_LENGTH) {
-            newCode[index + i] = char;
-          }
-        });
-        setCode(newCode);
-        setCodeError("");
-        const nextIndex = Math.min(index + chars.length, CODE_LENGTH - 1);
-        inputRefs.current[nextIndex]?.focus();
-        return;
-      }
-
-      const digit = text.replace(/[^0-9]/g, "");
-      const newCode = [...code];
-      newCode[index] = digit;
-      setCode(newCode);
-      setCodeError("");
-
-      if (digit && index < CODE_LENGTH - 1) {
-        inputRefs.current[index + 1]?.focus();
-      }
-    },
-    [code],
-  );
-
-  const handleKeyPress = useCallback(
-    (key: string, index: number) => {
-      if (key === "Backspace" && !code[index] && index > 0) {
-        const newCode = [...code];
-        newCode[index - 1] = "";
-        setCode(newCode);
-        inputRefs.current[index - 1]?.focus();
-      }
-    },
-    [code],
-  );
-
-  const handleVerifyCode = useCallback(async () => {
-    const fullCode = code.join("");
-    if (fullCode.length !== CODE_LENGTH) {
-      setCodeError("Entrez le code complet");
-      return;
-    }
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setResetToken(fullCode);
-    setStep(3);
-  }, [code]);
-
-  const handleResend = useCallback(async () => {
-    if (resendTimer > 0) return;
-    try {
-      await authApi.forgotPassword(email.trim());
-      setResendTimer(RESEND_COOLDOWN);
-      Alert.alert("Code envoyé", "Un nouveau code a été envoyé.");
-    } catch {
-      Alert.alert("Erreur", "Impossible de renvoyer le code.");
-    }
-  }, [resendTimer, email]);
-
-  // Step 3: Reset password
-  const handleResetPassword = useCallback(async () => {
-    const errs: { newPassword?: string; confirmPassword?: string } = {};
-    if (!newPassword) {
-      errs.newPassword = "Le mot de passe est requis";
-    } else if (newPassword.length < 8) {
-      errs.newPassword = "Minimum 8 caractères";
-    }
-    if (!confirmPassword) {
-      errs.confirmPassword = "Confirmez le mot de passe";
-    } else if (newPassword !== confirmPassword) {
-      errs.confirmPassword = "Les mots de passe ne correspondent pas";
-    }
-    if (Object.keys(errs).length > 0) {
-      setPasswordErrors(errs);
-      return;
-    }
-
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setResetLoading(true);
-    setPasswordErrors({});
-
-    try {
-      await authApi.resetPassword(resetToken, newPassword);
-      Alert.alert(
-        "Mot de passe réinitialisé",
-        "Vous pouvez maintenant vous connecter avec votre nouveau mot de passe.",
-        [{ text: "OK", onPress: () => router.replace("/(auth)/login") }],
-      );
-    } catch (err) {
-      if (err instanceof ApiError) {
-        if (err.status === 400) {
-          setCodeError("Code invalide ou expiré");
-          setStep(2);
-        } else {
-          Alert.alert("Erreur", err.message || "Réinitialisation échouée");
-        }
-      } else {
-        Alert.alert("Erreur", "Vérifiez votre connexion internet.");
-      }
-    } finally {
-      setResetLoading(false);
-    }
-  }, [newPassword, confirmPassword, resetToken, router]);
-
-  const handleBack = useCallback(() => {
-    if (step === 1) {
-      router.back();
-    } else {
-      setStep((prev) => (prev - 1) as Step);
-    }
-  }, [step, router]);
-
-  const stepTitles: Record<Step, string> = {
-    1: "Mot de passe oublié",
-    2: "Vérifier le code",
-    3: "Nouveau mot de passe",
-  };
-
-  const stepSubtitles: Record<Step, string> = {
-    1: "Entrez votre email pour recevoir un code de réinitialisation",
-    2: `Un code a été envoyé à ${email}`,
-    3: "Choisissez un nouveau mot de passe sécurisé",
-  };
 
   return (
     <SafeAreaView
@@ -267,41 +64,23 @@ export default function ForgotPasswordScreen() {
         style={styles.flex}
       >
         <View style={styles.content}>
-          {/* Back */}
           <Pressable
-            onPress={handleBack}
+            onPress={() => router.back()}
             style={styles.backButton}
             hitSlop={12}
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
 
-          {/* Progress bar */}
-          <View
-            style={[
-              styles.progressTrack,
-              { backgroundColor: colors.bgElevated },
-            ]}
-          >
-            <Animated.View
-              style={[
-                styles.progressFill,
-                { backgroundColor: palette.indigo },
-                progressStyle,
-              ]}
-            />
-          </View>
-
-          {/* Header */}
           <Text style={[styles.title, { color: colors.textPrimary }]}>
-            {stepTitles[step]}
+            Mot de passe oublié
           </Text>
           <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-            {stepSubtitles[step]}
+            Entrez votre email pour recevoir un lien de réinitialisation. Le
+            lien expire dans 1 heure.
           </Text>
 
-          {/* Step 1: Email */}
-          {step === 1 && (
+          {!submitted ? (
             <View style={styles.stepContent}>
               <Input
                 label="Email"
@@ -317,134 +96,50 @@ export default function ForgotPasswordScreen() {
                 autoCapitalize="none"
                 autoComplete="email"
                 returnKeyType="done"
-                onSubmitEditing={handleSendCode}
+                onSubmitEditing={handleSubmit}
               />
               <Button
-                title="Envoyer le code"
+                title="Envoyer le lien"
                 variant="primary"
                 size="lg"
                 fullWidth
-                loading={emailLoading}
-                disabled={emailLoading}
-                onPress={handleSendCode}
+                loading={loading}
+                disabled={loading}
+                onPress={handleSubmit}
               />
             </View>
-          )}
-
-          {/* Step 2: Code OTP */}
-          {step === 2 && (
-            <View style={styles.stepContent}>
-              <View style={styles.otpContainer}>
-                {code.map((digit, index) => (
-                  <TextInput
-                    key={index}
-                    ref={(ref) => {
-                      inputRefs.current[index] = ref;
-                    }}
-                    style={[
-                      styles.otpInput,
-                      {
-                        backgroundColor: colors.bgElevated,
-                        borderColor: digit
-                          ? palette.indigo
-                          : codeError
-                            ? colors.accentError
-                            : colors.border,
-                        color: colors.textPrimary,
-                      },
-                    ]}
-                    value={digit}
-                    onChangeText={(text) => handleCodeChange(text, index)}
-                    onKeyPress={({ nativeEvent }) =>
-                      handleKeyPress(nativeEvent.key, index)
-                    }
-                    keyboardType="number-pad"
-                    maxLength={index === 0 ? CODE_LENGTH : 1}
-                    selectTextOnFocus
-                  />
-                ))}
-              </View>
-
-              {codeError ? (
-                <Text style={[styles.error, { color: colors.accentError }]}>
-                  {codeError}
-                </Text>
-              ) : null}
-
-              <Button
-                title="Vérifier"
-                variant="primary"
-                size="lg"
-                fullWidth
-                loading={codeLoading}
-                disabled={codeLoading || code.join("").length !== CODE_LENGTH}
-                onPress={handleVerifyCode}
-              />
-
-              <Pressable
-                onPress={handleResend}
-                disabled={resendTimer > 0}
-                style={styles.resendContainer}
-                hitSlop={8}
+          ) : (
+            <View style={styles.successContainer}>
+              <View
+                style={[
+                  styles.successIconWrap,
+                  { backgroundColor: palette.indigo + "20" },
+                ]}
               >
-                <Text
-                  style={[
-                    styles.resendText,
-                    {
-                      color:
-                        resendTimer > 0 ? colors.textMuted : palette.indigo,
-                    },
-                  ]}
-                >
-                  {resendTimer > 0
-                    ? `Renvoyer le code (${resendTimer}s)`
-                    : "Renvoyer le code"}
-                </Text>
-              </Pressable>
-            </View>
-          )}
-
-          {/* Step 3: New password */}
-          {step === 3 && (
-            <View style={styles.stepContent}>
-              <Input
-                label="Nouveau mot de passe"
-                placeholder="Minimum 8 caractères"
-                value={newPassword}
-                onChangeText={(t) => {
-                  setNewPassword(t);
-                  setPasswordErrors({});
-                }}
-                error={passwordErrors.newPassword}
-                leftIcon="lock-closed-outline"
-                secureTextEntry
-                autoComplete="new-password"
-                returnKeyType="next"
-                onSubmitEditing={() => confirmRef.current?.focus()}
-              />
-              <Input
-                ref={confirmRef}
-                label="Confirmer le mot de passe"
-                placeholder="Retapez le mot de passe"
-                value={confirmPassword}
-                onChangeText={(t) => {
-                  setConfirmPassword(t);
-                  setPasswordErrors({});
-                }}
-                error={passwordErrors.confirmPassword}
-                leftIcon="lock-closed-outline"
-                secureTextEntry
-                returnKeyType="done"
-                onSubmitEditing={handleResetPassword}
-              />
+                <Ionicons
+                  name="mail-open-outline"
+                  size={40}
+                  color={palette.indigo}
+                />
+              </View>
+              <Text
+                style={[styles.successTitle, { color: colors.textPrimary }]}
+              >
+                Vérifiez votre boîte mail
+              </Text>
+              <Text
+                style={[styles.successText, { color: colors.textSecondary }]}
+              >
+                Si un compte existe pour cet email, un lien de réinitialisation
+                vient d'y être envoyé. Cliquez sur le lien pour choisir un
+                nouveau mot de passe.
+              </Text>
               <Button
-                title="Réinitialiser"
+                title="Retour à la connexion"
                 variant="primary"
                 size="lg"
                 fullWidth
-                loading={resetLoading}
-                disabled={resetLoading}
-                onPress={handleResetPassword}
+                onPress={() => router.replace("/(auth)/login")}
               />
             </View>
           )}
@@ -469,16 +164,6 @@ const styles = StyleSheet.create({
   backButton: {
     marginBottom: sp.xl,
   },
-  progressTrack: {
-    height: 4,
-    borderRadius: borderRadius.full,
-    marginBottom: sp["3xl"],
-    overflow: "hidden",
-  },
-  progressFill: {
-    height: "100%",
-    borderRadius: borderRadius.full,
-  },
   title: {
     ...textStyles.headingLg,
     marginBottom: sp.sm,
@@ -491,33 +176,28 @@ const styles = StyleSheet.create({
   stepContent: {
     gap: 0,
   },
-  otpContainer: {
-    flexDirection: "row",
-    justifyContent: "center",
-    gap: sp.sm,
-    marginBottom: sp.lg,
-  },
-  otpInput: {
-    width: 48,
-    height: 56,
-    borderRadius: borderRadius.md,
-    borderWidth: 1.5,
-    textAlign: "center",
-    fontSize: fontSize.xl,
-    fontFamily: fontFamily.bodySemiBold,
-  },
-  error: {
-    fontFamily: fontFamily.body,
-    fontSize: fontSize.sm,
-    textAlign: "center",
-    marginBottom: sp.lg,
-  },
-  resendContainer: {
+  successContainer: {
     alignItems: "center",
-    marginTop: sp.xl,
+    paddingTop: sp.xl,
+    gap: sp.lg,
   },
-  resendText: {
-    fontFamily: fontFamily.bodyMedium,
-    fontSize: fontSize.sm,
+  successIconWrap: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: sp.md,
+  },
+  successTitle: {
+    ...textStyles.headingMd,
+    textAlign: "center",
+  },
+  successText: {
+    ...textStyles.bodyMd,
+    textAlign: "center",
+    lineHeight: fontSize.base * 1.6,
+    marginBottom: sp.xl,
+    paddingHorizontal: sp.md,
   },
 });

--- a/mobile/app/(auth)/reset-password.tsx
+++ b/mobile/app/(auth)/reset-password.tsx
@@ -1,0 +1,251 @@
+import React, { useCallback, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  Alert,
+  TextInput,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { useTheme } from "@/contexts/ThemeContext";
+import { authApi, ApiError } from "@/services/api";
+import { sp } from "@/theme/spacing";
+import { fontSize, textStyles } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import { DoodleBackground } from "@/components/ui/DoodleBackground";
+
+export default function ResetPasswordScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const params = useLocalSearchParams<{ code?: string; email?: string }>();
+
+  const code = (params.code ?? "").trim();
+  const email = (params.email ?? "").trim();
+  const hasParams = code.length > 0 && email.length > 0;
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [errors, setErrors] = useState<{
+    newPassword?: string;
+    confirmPassword?: string;
+  }>({});
+  const [loading, setLoading] = useState(false);
+  const confirmRef = useRef<TextInput>(null);
+
+  const handleSubmit = useCallback(async () => {
+    const errs: { newPassword?: string; confirmPassword?: string } = {};
+    if (!newPassword) {
+      errs.newPassword = "Le mot de passe est requis";
+    } else if (newPassword.length < 6) {
+      errs.newPassword = "Minimum 6 caractères";
+    }
+    if (!confirmPassword) {
+      errs.confirmPassword = "Confirmez le mot de passe";
+    } else if (newPassword !== confirmPassword) {
+      errs.confirmPassword = "Les mots de passe ne correspondent pas";
+    }
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      return;
+    }
+
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setLoading(true);
+    setErrors({});
+
+    try {
+      await authApi.resetPassword(email, code, newPassword);
+      Alert.alert(
+        "Mot de passe réinitialisé",
+        "Vous pouvez maintenant vous connecter avec votre nouveau mot de passe.",
+        [{ text: "OK", onPress: () => router.replace("/(auth)/login") }],
+      );
+    } catch (err) {
+      if (err instanceof ApiError) {
+        Alert.alert(
+          "Lien invalide ou expiré",
+          err.message ||
+            "Le lien de réinitialisation a expiré. Demandez-en un nouveau.",
+          [
+            {
+              text: "Demander un nouveau lien",
+              onPress: () => router.replace("/(auth)/forgot-password"),
+            },
+            { text: "Annuler", style: "cancel" },
+          ],
+        );
+      } else {
+        Alert.alert("Erreur", "Vérifiez votre connexion internet.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [newPassword, confirmPassword, email, code, router]);
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.bgPrimary }]}
+    >
+      <DoodleBackground variant="default" density="low" />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={styles.flex}
+      >
+        <View style={styles.content}>
+          <Pressable
+            onPress={() => router.back()}
+            style={styles.backButton}
+            hitSlop={12}
+          >
+            <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+          </Pressable>
+
+          <Text style={[styles.title, { color: colors.textPrimary }]}>
+            Nouveau mot de passe
+          </Text>
+
+          {!hasParams ? (
+            <View style={styles.errorContainer}>
+              <View
+                style={[
+                  styles.errorIconWrap,
+                  { backgroundColor: colors.accentError + "20" },
+                ]}
+              >
+                <Ionicons
+                  name="alert-circle-outline"
+                  size={40}
+                  color={colors.accentError}
+                />
+              </View>
+              <Text style={[styles.errorTitle, { color: colors.textPrimary }]}>
+                Lien invalide
+              </Text>
+              <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+                Ce lien de réinitialisation est incomplet ou expiré. Demandez un
+                nouveau lien depuis la page de connexion.
+              </Text>
+              <Button
+                title="Demander un nouveau lien"
+                variant="primary"
+                size="lg"
+                fullWidth
+                onPress={() => router.replace("/(auth)/forgot-password")}
+              />
+            </View>
+          ) : (
+            <>
+              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+                Pour <Text style={{ color: colors.textPrimary }}>{email}</Text>
+                {"\n"}Choisissez un nouveau mot de passe sécurisé.
+              </Text>
+
+              <View style={styles.stepContent}>
+                <Input
+                  label="Nouveau mot de passe"
+                  placeholder="Minimum 6 caractères"
+                  value={newPassword}
+                  onChangeText={(t) => {
+                    setNewPassword(t);
+                    setErrors({});
+                  }}
+                  error={errors.newPassword}
+                  leftIcon="lock-closed-outline"
+                  secureTextEntry
+                  autoComplete="new-password"
+                  returnKeyType="next"
+                  onSubmitEditing={() => confirmRef.current?.focus()}
+                />
+                <Input
+                  ref={confirmRef}
+                  label="Confirmer le mot de passe"
+                  placeholder="Retapez le mot de passe"
+                  value={confirmPassword}
+                  onChangeText={(t) => {
+                    setConfirmPassword(t);
+                    setErrors({});
+                  }}
+                  error={errors.confirmPassword}
+                  leftIcon="lock-closed-outline"
+                  secureTextEntry
+                  returnKeyType="done"
+                  onSubmitEditing={handleSubmit}
+                />
+                <Button
+                  title="Réinitialiser"
+                  variant="primary"
+                  size="lg"
+                  fullWidth
+                  loading={loading}
+                  disabled={loading}
+                  onPress={handleSubmit}
+                />
+              </View>
+            </>
+          )}
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  flex: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: sp.lg,
+    paddingVertical: sp.xl,
+  },
+  backButton: {
+    marginBottom: sp.xl,
+  },
+  title: {
+    ...textStyles.headingLg,
+    marginBottom: sp.sm,
+  },
+  subtitle: {
+    ...textStyles.bodyMd,
+    marginBottom: sp["3xl"],
+    lineHeight: fontSize.base * 1.6,
+  },
+  stepContent: {
+    gap: 0,
+  },
+  errorContainer: {
+    alignItems: "center",
+    paddingTop: sp.xl,
+    gap: sp.lg,
+  },
+  errorIconWrap: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: sp.md,
+  },
+  errorTitle: {
+    ...textStyles.headingMd,
+    textAlign: "center",
+  },
+  errorText: {
+    ...textStyles.bodyMd,
+    textAlign: "center",
+    lineHeight: fontSize.base * 1.6,
+    marginBottom: sp.xl,
+    paddingHorizontal: sp.md,
+  },
+});

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -369,12 +369,13 @@ export const authApi = {
   },
 
   async resetPassword(
-    token: string,
-    password: string,
+    email: string,
+    code: string,
+    newPassword: string,
   ): Promise<{ message: string }> {
     return request("/api/auth/reset-password", {
       method: "POST",
-      body: { token, password },
+      body: { email, code, new_password: newPassword },
       requiresAuth: false,
     });
   },


### PR DESCRIPTION
## Summary

Refactor mobile forgot-password flow OTP 3-steps → click-link flow cohérent avec web (PR #209). Plus de saisie manuelle de code 6 chiffres.

### Changes
- **`mobile/app/(auth)/forgot-password.tsx`** — refactor : 3-steps OTP → 1-step email-only avec message anti-énumération inconditionnel.
- **`mobile/app/(auth)/reset-password.tsx`** — NEW : lit `?code=&email=` via `useLocalSearchParams`, form new password + confirm, call `authApi.resetPassword(email, code, newPassword)`, redirect login.
- **`mobile/src/services/api.ts`** — **fix bug pré-existant** : signature `authApi.resetPassword` était `(token, password)` avec body `{ token, password }` — incohérent avec backend Pydantic `ResetPasswordRequest` qui attend `{ email, code, new_password }`. Maintenant aligné avec frontend web.

### Change-password mobile
Déjà couvert par `AccountSection` (bottom sheet dans `(tabs)/profile.tsx`) qui utilise `userApi.changePassword` correctement. Pas dupliqué.

### Deep link
`app.json` a déjà `"scheme": "deepsight"` + `applinks` configurés (`deepsightsynthesis.com`, `deepsight.app`). Expo Router auto-matche `deepsight://reset-password?code=&email=` → `(auth)/reset-password.tsx`. Universal link iOS/Android = follow-up séparé (requires `apple-app-site-association` + `assetlinks.json` servis par `api.deepsightsynthesis.com`).

## Déploiement
EAS OTA — pas de rebuild nécessaire. Après merge :
```
cd mobile && eas update --branch production
```

## Test plan
- [ ] Login → "Mot de passe oublié ?" → email input → submit → message "Vérifiez votre boîte mail"
- [ ] Email Resend reçu → cliquer le lien → ouvre web (V1) ou app via universal link (V2)
- [ ] reset-password screen avec `?code=X&email=Y` params → form new password → submit → success → redirect login
- [ ] reset-password screen sans params → erreur claire + bouton "Demander un nouveau lien"
- [ ] `npx tsc --noEmit` PASS

Tied to PR #209 (web + extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)