### PR TITLE
chore(v2): align mobile PlanContext + project CLAUDE.md docs with pricing v2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,10 +88,12 @@ docker ps --format '{{.Names}} {{.Status}}'
 | AI          | Mistral (analyses) + Brave Search (fact-check)         | —                  |
 | Transcripts | Supadata → youtube-transcript-api → yt-dlp → Audio STT | —                  |
 
-### Plans d'abonnement (5 tiers)
+### Plans d'abonnement (3 tiers — Pricing v2, avril 2026)
 
-Découverte (gratuit) → Étudiant (2.99€) → Starter (5.99€) → Pro (12.99€) → Équipe (29.99€)
-SSOT : `is_feature_available(plan, feature, platform)` dans le backend.
+Free (0 €) → **Pro 8,99 €/mois** (89,90 €/an −17 %) → **Expert 19,99 €/mois** (199,90 €/an −17 %)
+Trial 7 jours sans CB sur Pro et Expert (un par user, à vie).
+Grandfathering legacy via colonne `users.is_legacy_pricing` (Alembic 012, mergée prod 2026-04-30).
+SSOT : `is_feature_available(plan, feature, platform)` dans le backend (`backend/src/billing/plan_config.py`) + `frontend/src/config/planPrivileges.ts` côté frontend (mirror) + `mobile/src/config/planPrivileges.ts` côté mobile (mirror).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,13 +416,17 @@ POST   /api/search/semantic         # Semantic search
 
 ---
 
-## Pricing Plans (3 tiers — Mars 2026)
+## Pricing Plans (3 tiers — Pricing v2, avril 2026)
 
-| Plan    | ID interne | Prix   | Analyses/mois | Max durée | Chat/vidéo | Features clés                                                          |
-| ------- | ---------- | ------ | ------------- | --------- | ---------- | ---------------------------------------------------------------------- |
-| Gratuit | free       | 0€     | 5             | 15min     | 5          | Flashcards, historique 60j                                             |
-| Pro     | pro        | 5.99€  | 30            | 2h        | 25         | Mind maps, web search (20/mois), playlists (3), export PDF             |
-| Expert  | expert     | 14.99€ | 100           | 4h        | illimité   | Web search (60/mois), playlists (10), priority queue, voice chat 20min |
+| Plan    | ID interne | Prix mensuel | Prix annuel (-17%) | Analyses/mois | Max durée | Chat/vidéo | Features clés                                                                                        |
+| ------- | ---------- | ------------ | ------------------ | ------------- | --------- | ---------- | ---------------------------------------------------------------------------------------------------- |
+| Gratuit | free       | 0 €          | 0 €                | 5             | 15 min    | 5          | Flashcards, historique 60 j                                                                          |
+| Pro     | pro        | **8,99 €**   | **89,90 €**        | 30            | 2 h       | 25         | Mind maps, web search (20/mois), playlists (3), export PDF, voice 30 min/mois, **trial 7 j sans CB** |
+| Expert  | expert     | **19,99 €**  | **199,90 €**       | 100           | 4 h       | illimité   | Web search (60/mois), playlists (10), priority queue, voice 120 min/mois, **trial 7 j sans CB**      |
+
+### Grandfathering legacy
+
+Migration v0/v1 → v2 (Alembic 012, mergée prod 2026-04-30) : `plus → pro`, `pro → expert`. Colonne `users.is_legacy_pricing BOOLEAN` flaggue les abonnements créés avant la migration → conservent leur ancien tarif via Stripe (`STRIPE_PRICE_PLUS_*` legacy conservés). Les nouveaux users souscrivent aux 4 nouveaux Stripe Prices : `STRIPE_PRICE_{PRO,EXPERT}_{MONTHLY,YEARLY}`.
 
 ### Modèles Mistral par plan
 
@@ -462,11 +466,11 @@ POST   /api/search/semantic         # Semantic search
 
 ## Chat v4.0 (Perplexity Enrichissement)
 
-| Plan     | Daily | Per-video | Web Search | Model |
-| -------- | ----- | --------- | ---------- | ----- |
-| Free     | 10    | 5         | ✗          | small |
-| Étudiant | 40    | 15        | ✗          | small |
-| Pro      | 100   | illimité  | ✓          | large |
+| Plan   | Daily    | Per-video | Web Search | Model  |
+| ------ | -------- | --------- | ---------- | ------ |
+| Free   | 10       | 5         | ✗          | small  |
+| Pro    | 50       | 25        | ✓ (20/mo)  | medium |
+| Expert | illimité | illimité  | ✓ (60/mo)  | large  |
 
 - Auto-enrichissement selon plan (none/light/full/deep)
 - Détection intelligente quand web search est pertinent

--- a/mobile/src/contexts/PlanContext.tsx
+++ b/mobile/src/contexts/PlanContext.tsx
@@ -81,17 +81,21 @@ function buildPlanFeatures(planId: PlanId): PlanFeatures {
   };
 }
 
-// Plan configurations — synced from planPrivileges.ts (2 plans)
+// Plan configurations — synced from planPrivileges.ts (3 plans v2 : Free / Pro / Expert)
 const PLAN_FEATURES_MAP: Record<string, PlanFeatures> = {
   free: buildPlanFeatures("free"),
   pro: buildPlanFeatures("pro"),
-  // Legacy aliases → redirigés par normalizePlanId
+  expert: buildPlanFeatures("expert"),
+  // Legacy aliases v0/v1 → redirigés vers leur équivalent v2 (cohérent avec
+  // backend `normalize_plan_id` : plus → pro, starter/student/etudiant → pro,
+  // team/equipe/unlimited → expert).
+  plus: buildPlanFeatures("pro"),
   student: buildPlanFeatures("pro"),
+  etudiant: buildPlanFeatures("pro"),
   starter: buildPlanFeatures("pro"),
-  expert: buildPlanFeatures("pro"),
-  team: buildPlanFeatures("pro"),
-  equipe: buildPlanFeatures("pro"),
-  unlimited: buildPlanFeatures("pro"),
+  team: buildPlanFeatures("expert"),
+  equipe: buildPlanFeatures("expert"),
+  unlimited: buildPlanFeatures("expert"),
 };
 
 // Usage stats interface


### PR DESCRIPTION
## Summary
Cleanup follow-up post-merge PR #211 (pricing v2 atomique). 3 fichiers, 1 commit `bf8920ad`.

## Mobile `PlanContext.PLAN_FEATURES_MAP`
Avant : `expert: buildPlanFeatures("pro")` (legacy alias) — sémantiquement faux maintenant qu'Expert est un plan v2 distinct (19,99 €).

Après :
```ts
{
  free: buildPlanFeatures("free"),
  pro: buildPlanFeatures("pro"),
  expert: buildPlanFeatures("expert"),  // ← v2 distinct
  // Legacy aliases v0/v1 → leur équivalent v2
  plus: buildPlanFeatures("pro"),
  student/etudiant/starter: buildPlanFeatures("pro"),
  team/equipe/unlimited: buildPlanFeatures("expert"),
}
```

Cohérent avec backend `normalize_plan_id`. Impact : les users `expert` (v2) reçoivent maintenant les bonnes features Expert (voice 120 min, web search 60/mois, playlists 10, deep research, mistral-large-2512) au lieu des features Pro.

## Documentation projets — Pricing v2

`CLAUDE.md` (DeepSight-Main, root) :
- Section "Pricing Plans" : refonte de v0 (Pro 5.99 / Expert 14.99) → v2 (Pro 8,99 / Expert 19,99) avec colonne annuel -17 % et mention trial 7j
- Ajout section "Grandfathering legacy" expliquant Alembic 012 + `is_legacy_pricing`
- Section "Chat v4.0" : refonte tableau (Free/Pro/Expert au lieu de Free/Étudiant/Pro)

`.claude/CLAUDE.md` (orchestrateur Cowork) :
- Section "Plans d'abonnement" : refonte 5 tiers v0 (Découverte → Étudiant 2.99 → Starter 5.99 → Pro 12.99 → Équipe 29.99) → 3 tiers v2 (Free / Pro 8,99 / Expert 19,99)
- Ajout note grandfathering + références SSOT triple (backend + frontend + mobile)

## Tech-debt identifiée (à fixer en PR séparée)
- `deploy/hetzner/Dockerfile` n'a pas d'`ENTRYPOINT` — uvicorn lancé directement via `CMD`. Pas d'`alembic upgrade head` au boot → migrations ne s'appliquent pas auto au rebuild docker. Corrigé manuellement post-merge PR #211 par stamp 011 + upgrade 012 (mémoire incident à documenter dans `deploy/hetzner/RUNBOOK.md`).
- `RUN_MIGRATIONS=true` env var absente de `.env.production` Hetzner — à ajouter manuellement quand entrypoint.sh créé.

## Test plan
- [x] `cd mobile && npm run typecheck` (mobile vérifie nouvelle entrée `expert`)
- [ ] Login user `expert` mobile → vérifier que features Expert s'affichent (voice 120 min/mois, deep research, etc.) et NON celles de Pro
- [ ] CLAUDE.md prix v2 présents avant nouvelles sessions Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)