### PR TITLE
fix(deploy): add --network-alias backend to docker run

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -105,6 +105,7 @@ jobs:
             docker run -d \
               --name repo-backend-1 \
               --network repo_deepsight \
+              --network-alias backend \
               --env-file /opt/deepsight/repo/.env.production \
               --restart unless-stopped \
               -p 127.0.0.1:8080:8080 \
@@ -158,6 +159,7 @@ jobs:
             docker run -d \
               --name repo-backend-1 \
               --network repo_deepsight \
+              --network-alias backend \
               --env-file /opt/deepsight/repo/.env.production \
               --restart unless-stopped \
               -p 127.0.0.1:8080:8080 \


### PR DESCRIPTION
## Summary

**HOTFIX critique** — empêche le SaaS de tomber en 502 après chaque redeploy backend.

## Symptôme rencontré

Workflow `deploy-backend.yml` du PR #211 ce matin (10:22 UTC) → smoke test fail → Caddy log : `dial tcp: lookup backend on 127.0.0.11:53: server misbehaving`. SaaS down ~2h (login web + mobile + extension cassés, emails Resend bloqués).

## Cause root

Le `Caddyfile` route `api.deepsightsynthesis.com → backend:8080` (alias logique). Le container actuel s'appelle `repo-backend-1`. Au build initial il avait probablement `--network-alias backend` ; les rebuilds successifs (workflow sans cet argument) ont fini par wiper l'alias.

Pas visible dans les logs container (interne 200 OK), seulement Caddy DNS lookup fail.

## Fix manuel appliqué (volatile)

```
docker network disconnect repo_deepsight repo-backend-1
docker network connect --alias backend repo_deepsight repo-backend-1
```

Backend prod up à nouveau. Mais **prochain push to main → re-cassé**.

## Fix durable (cette PR)

Ajoute `--network-alias backend` aux 2 `docker run` du workflow :
- Main run lignes 105-112 (déploiement)
- Rollback run lignes 159-166 (recovery)

Aucun changement comportemental pour les déploiements sains. Pure hardening infra.

## Test plan
- [ ] Merge → workflow déclenché par GitHub paths filter (touche `.github/workflows/deploy-backend.yml`)
- [ ] Smoke test post-deploy → 200 OK (au lieu de 502 cause alias absent)
- [ ] `docker network inspect repo_deepsight` → repo-backend-1 a aliases=[backend]
- [ ] `curl https://api.deepsightsynthesis.com/health` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)