### PR TITLE
feat: unified Hub /hub merging chat + voice into single conversational interface

### DIFF
--- a/frontend/e2e/hub-unified.spec.ts
+++ b/frontend/e2e/hub-unified.spec.ts
@@ -1,0 +1,52 @@
+// frontend/e2e/hub-unified.spec.ts
+import { test, expect } from "@playwright/test";
+
+const TEST_USER = {
+  email: process.env.E2E_USER ?? "e2e@deepsight.test",
+  password: process.env.E2E_PASS ?? "test1234",
+};
+
+test.describe("Hub unifié /hub", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+    await page.fill('input[type="email"]', TEST_USER.email);
+    await page.fill('input[type="password"]', TEST_USER.password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/dashboard/);
+  });
+
+  test("legacy /chat redirects to /hub", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page).toHaveURL(/\/hub/);
+  });
+
+  test("legacy /voice-call redirects to /hub", async ({ page }) => {
+    await page.goto("/voice-call");
+    await expect(page).toHaveURL(/\/hub/);
+  });
+
+  test("hamburger opens conversations drawer", async ({ page }) => {
+    await page.goto("/hub");
+    await page.click('button[aria-label="Conversations"]');
+    await expect(page.getByText("Conversations").first()).toBeVisible();
+    // Close by clicking the backdrop
+    await page.click('button[aria-label="fermer"]');
+  });
+
+  test("typing and pressing Enter sends a text message when a conversation is active", async ({
+    page,
+  }) => {
+    await page.goto("/hub");
+    // Open drawer + select first conv (assumes user has at least one analysis)
+    await page.click('button[aria-label="Conversations"]');
+    const firstConv = page.locator("aside button").nth(0);
+    if (await firstConv.isVisible()) {
+      await firstConv.click();
+      await page.fill('input[placeholder*="question"]', "Test E2E hub message");
+      await page.keyboard.press("Enter");
+      await expect(page.getByText("Test E2E hub message")).toBeVisible();
+    } else {
+      test.skip(true, "no conversation available for test user");
+    }
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -315,8 +315,7 @@ const UsageDashboard = lazyWithRetry(() => import("./pages/UsageDashboard"));
 const AnalyticsPage = lazyWithRetry(() => import("./pages/AnalyticsPage"));
 const StudyPage = lazyWithRetry(() => import("./pages/StudyPage"));
 const StudyHubPage = lazyWithRetry(() => import("./pages/StudyHubPage"));
-const ChatPage = lazyWithRetry(() => import("./pages/ChatPage"));
-const VoiceCallPage = lazyWithRetry(() => import("./pages/VoiceCallPage"));
+const HubPage = lazyWithRetry(() => import("./pages/HubPage"));
 const DebatePage = lazyWithRetry(() => import("./pages/DebatePage"));
 const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundPage"));
 const ExtensionWelcomePage = lazyWithRetry(
@@ -337,6 +336,7 @@ const PREFETCH_MAP: Record<string, string[]> = {
     "/settings",
     "/debate",
     "/analytics",
+    "/hub",
     "/chat",
     "/voice-call",
     "/study",
@@ -361,6 +361,7 @@ const PAGE_LOADERS: Record<string, () => Promise<any>> = {
   "/analytics": () => import("./pages/AnalyticsPage"),
   "/chat": () => import("./pages/ChatPage"),
   "/voice-call": () => import("./pages/VoiceCallPage"),
+  "/hub": () => import("./pages/HubPage"),
   "/study": () => import("./pages/StudyHubPage"),
   "/about": () => import("./pages/AboutPage"),
 };
@@ -928,35 +929,29 @@ const AppRoutes = () => {
                         />
 
                         <Route
-                          path="/chat"
+                          path="/hub"
                           element={
                             <RouteErrorBoundary
                               variant="full"
-                              componentName="ChatPage"
+                              componentName="HubPage"
                             >
                               <Suspense
                                 fallback={<PageSkeleton variant="full" />}
                               >
-                                <ChatPage />
+                                <HubPage />
                               </Suspense>
                             </RouteErrorBoundary>
                           }
                         />
 
                         <Route
+                          path="/chat"
+                          element={<Navigate to="/hub" replace />}
+                        />
+
+                        <Route
                           path="/voice-call"
-                          element={
-                            <RouteErrorBoundary
-                              variant="full"
-                              componentName="VoiceCallPage"
-                            >
-                              <Suspense
-                                fallback={<PageSkeleton variant="dashboard" />}
-                              >
-                                <VoiceCallPage />
-                              </Suspense>
-                            </RouteErrorBoundary>
-                          }
+                          element={<Navigate to="/hub" replace />}
                         />
 
                         <Route

--- a/frontend/src/components/hub/CallModeFullBleed.tsx
+++ b/frontend/src/components/hub/CallModeFullBleed.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  VoiceOverlay,
+  type VoiceOverlayController,
+  type VoiceOverlayMessage,
+} from "../voice/VoiceOverlay";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  summaryId: number | null;
+  title: string | null;
+  subtitle: string | null;
+  onVoiceMessage: (msg: VoiceOverlayMessage) => void;
+  controllerRef?: React.MutableRefObject<VoiceOverlayController | null>;
+  language?: "fr" | "en";
+}
+
+export const CallModeFullBleed: React.FC<Props> = ({
+  open,
+  onClose,
+  summaryId,
+  title,
+  subtitle,
+  onVoiceMessage,
+  controllerRef,
+  language = "fr",
+}) => {
+  if (!open) return null;
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ y: "100%" }}
+        animate={{ y: 0 }}
+        exit={{ y: "100%" }}
+        transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
+        className="absolute inset-0 z-[60] overflow-hidden"
+      >
+        <VoiceOverlay
+          isOpen={true}
+          onClose={onClose}
+          title={title}
+          subtitle={subtitle}
+          summaryId={summaryId}
+          agentType={summaryId ? "explorer" : "companion"}
+          language={language}
+          onVoiceMessage={onVoiceMessage}
+          controllerRef={controllerRef}
+          presentationMode="fullbleed"
+        />
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/frontend/src/components/hub/ConversationsDrawer.tsx
+++ b/frontend/src/components/hub/ConversationsDrawer.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Search, Plus } from "lucide-react";
+import type { HubConversation } from "./types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  conversations: HubConversation[];
+  activeConvId: number | null;
+  onSelect: (id: number) => void;
+  onNewConv: () => void;
+}
+
+const groupBy = (convs: HubConversation[]) => {
+  const today: HubConversation[] = [];
+  const yesterday: HubConversation[] = [];
+  const week: HubConversation[] = [];
+  const older: HubConversation[] = [];
+  const now = Date.now();
+  for (const c of convs) {
+    const t = new Date(c.updated_at).getTime();
+    const d = (now - t) / 86_400_000;
+    if (d < 1) today.push(c);
+    else if (d < 2) yesterday.push(c);
+    else if (d < 7) week.push(c);
+    else older.push(c);
+  }
+  return { today, yesterday, week, older };
+};
+
+export const ConversationsDrawer: React.FC<Props> = ({
+  open,
+  onClose,
+  conversations,
+  activeConvId,
+  onSelect,
+  onNewConv,
+}) => {
+  const [query, setQuery] = useState("");
+
+  if (!open) return null;
+
+  const filtered = conversations.filter((c) =>
+    (c.title + " " + (c.last_snippet ?? ""))
+      .toLowerCase()
+      .includes(query.toLowerCase()),
+  );
+  const grouped = groupBy(filtered);
+
+  const renderGroup = (label: string, items: HubConversation[]) => {
+    if (items.length === 0) return null;
+    return (
+      <div key={label} className="mb-3">
+        <p className="font-mono text-[10px] tracking-[.12em] text-white/35 uppercase px-3 mb-1.5">
+          {label}
+        </p>
+        {items.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => {
+              onSelect(c.id);
+              onClose();
+            }}
+            className={
+              "w-full px-3 py-2 rounded-lg mb-0.5 flex gap-2.5 items-start text-left transition-colors " +
+              (c.id === activeConvId
+                ? "bg-indigo-500/10 border border-indigo-500/20"
+                : "border border-transparent hover:bg-white/[0.04]")
+            }
+          >
+            <div className="w-10 h-6 rounded overflow-hidden bg-white/[0.04] flex-shrink-0">
+              {c.video_thumbnail_url ? (
+                <img
+                  src={c.video_thumbnail_url}
+                  alt=""
+                  className="w-full h-full object-cover"
+                />
+              ) : null}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-[13px] text-white/85 truncate">{c.title}</p>
+              <p className="text-[11px] text-white/45 truncate mt-0.5">
+                {c.last_snippet ?? ""}
+              </p>
+            </div>
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40"
+        onClick={onClose}
+      />
+      <motion.aside
+        initial={{ x: "-100%" }}
+        animate={{ x: 0 }}
+        exit={{ x: "-100%" }}
+        transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+        className="fixed inset-y-0 left-0 z-50 w-[320px] max-w-[85vw] bg-[#0c0c14] border-r border-white/10 flex flex-col"
+      >
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-white/10">
+          <button
+            type="button"
+            aria-label="fermer"
+            onClick={onClose}
+            className="w-8 h-8 grid place-items-center rounded-lg hover:bg-white/[0.06] text-white/65"
+          >
+            <X className="w-4 h-4" />
+          </button>
+          <span className="flex-1 text-sm font-medium text-white">Conversations</span>
+          <button
+            type="button"
+            onClick={onNewConv}
+            aria-label="nouvelle conversation"
+            className="px-2.5 py-1 rounded-lg bg-indigo-500/15 border border-indigo-500/30 text-indigo-400 text-xs flex items-center gap-1"
+          >
+            <Plus className="w-3 h-3" />
+            <span>Nouvelle</span>
+          </button>
+        </div>
+        <div className="px-3 py-2 relative">
+          <Search className="absolute left-5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Rechercher…"
+            className="w-full pl-7 pr-3 py-2 rounded-lg bg-white/[0.04] border border-white/10 text-[13px] text-white outline-none focus:border-white/20"
+          />
+        </div>
+        <div className="flex-1 overflow-y-auto px-2 pb-4">
+          {renderGroup("Aujourd'hui", grouped.today)}
+          {renderGroup("Hier", grouped.yesterday)}
+          {renderGroup("Cette semaine", grouped.week)}
+          {renderGroup("Plus ancien", grouped.older)}
+          {filtered.length === 0 && (
+            <p className="px-3 py-6 text-[12px] text-white/35 text-center">
+              Aucune conversation
+            </p>
+          )}
+        </div>
+      </motion.aside>
+    </AnimatePresence>
+  );
+};

--- a/frontend/src/components/hub/HubHeader.tsx
+++ b/frontend/src/components/hub/HubHeader.tsx
@@ -1,0 +1,46 @@
+// frontend/src/components/hub/HubHeader.tsx
+import React from "react";
+import { Menu } from "lucide-react";
+
+interface Props {
+  onMenuClick: () => void;
+  title: string;
+  subtitle?: string;
+  pipSlot?: React.ReactNode;
+}
+
+export const HubHeader: React.FC<Props> = ({
+  onMenuClick,
+  title,
+  subtitle,
+  pipSlot,
+}) => {
+  return (
+    <header className="flex items-center gap-3 px-4 py-3 border-b border-white/10 bg-white/[0.02] backdrop-blur-xl sticky top-0 z-10">
+      <button
+        type="button"
+        aria-label="Conversations"
+        onClick={onMenuClick}
+        className="w-8 h-8 grid place-items-center rounded-lg text-white/65 hover:bg-white/[0.06] hover:text-white"
+      >
+        <Menu className="w-4 h-4" />
+      </button>
+      <div className="flex items-center gap-2">
+        <img
+          src="/deepsight-logo-cosmic.png"
+          alt=""
+          className="w-7 h-7 rounded-full opacity-80"
+        />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-white truncate">{title}</p>
+        {subtitle && (
+          <p className="font-mono text-[11px] text-white/45 truncate mt-0.5">
+            {subtitle}
+          </p>
+        )}
+      </div>
+      {pipSlot}
+    </header>
+  );
+};

--- a/frontend/src/components/hub/InputBar.tsx
+++ b/frontend/src/components/hub/InputBar.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Mic, Phone, Send, Plus } from "lucide-react";
+
+interface Props {
+  onSend: (text: string) => void;
+  onCallToggle: () => void;
+  /** Called when the user releases the mic button after holding > 0.4s. */
+  onPttHoldComplete: (durationSecs: number) => void;
+  disabled?: boolean;
+}
+
+export const InputBar: React.FC<Props> = ({
+  onSend,
+  onCallToggle,
+  onPttHoldComplete,
+  disabled,
+}) => {
+  const [val, setVal] = useState("");
+  const [holding, setHolding] = useState(false);
+  const [duration, setDuration] = useState(0);
+  const startRef = useRef(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!holding) {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      return;
+    }
+    startRef.current = performance.now();
+    const tick = (t: number) => {
+      setDuration((t - startRef.current) / 1000);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [holding]);
+
+  const startHold = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    setHolding(true);
+    setDuration(0);
+  };
+
+  const endHold = () => {
+    if (holding && duration > 0.4) {
+      onPttHoldComplete(duration);
+    }
+    setHolding(false);
+    setDuration(0);
+  };
+
+  const send = () => {
+    const trimmed = val.trim();
+    if (!trimmed) return;
+    onSend(trimmed);
+    setVal("");
+  };
+
+  return (
+    <div className="relative flex items-center gap-2 px-4 py-3 border-t border-white/10 bg-white/[0.02]">
+      <button
+        type="button"
+        aria-label="attachments"
+        className="w-8 h-8 grid place-items-center text-white/45 hover:text-white/80 rounded-full"
+      >
+        <Plus className="w-4 h-4" />
+      </button>
+      <input
+        type="text"
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            send();
+          }
+        }}
+        placeholder="Posez votre question — ou maintenez le micro…"
+        disabled={disabled}
+        className="flex-1 bg-white/[0.04] border border-white/10 rounded-full px-4 py-2 text-sm text-white outline-none focus:border-indigo-500/40"
+      />
+      {val.trim() ? (
+        <button
+          type="button"
+          aria-label="Envoyer"
+          onClick={send}
+          disabled={disabled}
+          className="w-9 h-9 rounded-full bg-indigo-500 text-white grid place-items-center hover:bg-indigo-400 transition-colors disabled:opacity-40"
+        >
+          <Send className="w-4 h-4 -ml-px" />
+        </button>
+      ) : (
+        <>
+          <button
+            type="button"
+            aria-label="Full Call mode"
+            onClick={onCallToggle}
+            className="w-9 h-9 rounded-full text-white/55 hover:text-violet-400 transition-colors grid place-items-center"
+          >
+            <Phone className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="Maintenir pour enregistrer"
+            onMouseDown={startHold}
+            onMouseUp={endHold}
+            onMouseLeave={() => holding && endHold()}
+            onTouchStart={startHold}
+            onTouchEnd={endHold}
+            className={
+              "w-9 h-9 grid place-items-center rounded-full transition-all " +
+              (holding
+                ? "bg-red-500 text-white scale-110 shadow-[0_8px_24px_rgba(239,68,68,.4)]"
+                : "bg-indigo-500/15 text-indigo-400")
+            }
+          >
+            <Mic className="w-4 h-4" />
+          </button>
+        </>
+      )}
+
+      <AnimatePresence>
+        {holding && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            className="absolute right-4 -top-9 px-3 py-1.5 bg-red-500 rounded-xl text-white font-mono text-[11px] shadow-[0_8px_24px_rgba(239,68,68,.4)]"
+          >
+            ● {duration.toFixed(1)}s
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/frontend/src/components/hub/MessageBubble.tsx
+++ b/frontend/src/components/hub/MessageBubble.tsx
@@ -1,0 +1,75 @@
+// frontend/src/components/hub/MessageBubble.tsx
+import React from "react";
+import { Mic } from "lucide-react";
+import type { HubMessage } from "./types";
+import { VoiceBubble } from "./VoiceBubble";
+
+interface Props {
+  msg: HubMessage;
+  /** Optional sampled bars override; otherwise use a deterministic default. */
+  bars?: number[];
+}
+
+const DEFAULT_BARS = [
+  6, 14, 9, 20, 11, 16, 8, 18, 12, 22, 9, 15, 7, 19, 11, 14, 8, 17, 10, 13, 6,
+  21, 9, 12, 15, 8, 17, 10,
+];
+
+export const MessageBubble: React.FC<Props> = ({ msg, bars }) => {
+  const isUser = msg.role === "user";
+  const isVoiceBubble =
+    (msg.source === "voice_user" || msg.source === "voice_agent") &&
+    typeof msg.audio_duration_secs === "number" &&
+    msg.audio_duration_secs > 0;
+
+  if (isVoiceBubble) {
+    return (
+      <div
+        className={"flex w-full " + (isUser ? "justify-end" : "justify-start")}
+      >
+        <VoiceBubble
+          durationSecs={msg.audio_duration_secs as number}
+          bars={bars ?? DEFAULT_BARS}
+          transcript={msg.content}
+          side={isUser ? "user" : "ai"}
+        />
+      </div>
+    );
+  }
+
+  // Plain text bubble
+  const isVoiceText =
+    msg.source === "voice_user" || msg.source === "voice_agent";
+
+  return (
+    <div
+      className={"flex w-full " + (isUser ? "justify-end" : "justify-start")}
+    >
+      <div
+        className={
+          "max-w-[85%] sm:max-w-[75%] px-4 py-3 rounded-2xl border text-sm leading-relaxed " +
+          (isUser
+            ? "bg-indigo-500/10 border-indigo-500/20 text-white rounded-br-md"
+            : "bg-white/5 border-white/10 text-white/85 rounded-bl-md")
+        }
+        data-testid={`hub-msg-${msg.source}`}
+      >
+        {isVoiceText && (
+          <div className="inline-flex items-center gap-1 mb-1.5 text-[10px] font-medium text-violet-300/80 uppercase tracking-wider">
+            <Mic className="w-2.5 h-2.5" />
+            <span>Vocal</span>
+            {typeof msg.time_in_call_secs === "number" && (
+              <span className="text-violet-300/50 normal-case">
+                · {Math.floor(msg.time_in_call_secs / 60)}:
+                {Math.floor(msg.time_in_call_secs % 60)
+                  .toString()
+                  .padStart(2, "0")}
+              </span>
+            )}
+          </div>
+        )}
+        <p className="whitespace-pre-wrap">{msg.content}</p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/hub/SummaryCollapsible.tsx
+++ b/frontend/src/components/hub/SummaryCollapsible.tsx
@@ -1,0 +1,78 @@
+// frontend/src/components/hub/SummaryCollapsible.tsx
+import React, { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronDown } from "lucide-react";
+import type { HubSummaryContext } from "./types";
+
+interface Props {
+  context: HubSummaryContext;
+  onCitationClick?: (timestampSecs: number) => void;
+}
+
+const formatTs = (s: number) => {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+};
+
+export const SummaryCollapsible: React.FC<Props> = ({ context, onCitationClick }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mx-4 my-3 px-4 py-3 bg-white/[0.04] border border-white/10 rounded-[14px]">
+      <button
+        type="button"
+        aria-label="Résumé"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center gap-3 text-left"
+      >
+        <span className="font-mono text-[10px] tracking-[.12em] px-2 py-[3px] rounded bg-indigo-500/15 text-indigo-400">
+          RÉSUMÉ
+        </span>
+        <span className="flex-1 text-sm font-medium text-white/85 truncate">
+          {context.short_summary}
+        </span>
+        <motion.span
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={{ duration: 0.2 }}
+          className="text-white/45"
+        >
+          <ChevronDown className="w-3.5 h-3.5" />
+        </motion.span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
+            className="overflow-hidden"
+          >
+            <div className="pt-3 text-sm text-white/65 leading-[1.55]">
+              <p className="mb-2">{context.short_summary}</p>
+              {context.citations.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {context.citations.map((c, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => onCitationClick?.(c.ts)}
+                      className="font-mono text-[10px] px-1.5 py-[1px] rounded-[3px] bg-cyan-500/10 text-cyan-300 hover:bg-cyan-500/20 transition-colors"
+                    >
+                      {formatTs(c.ts)}
+                      <span className="ml-1 text-white/55 normal-case">
+                        {c.label}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/frontend/src/components/hub/Timeline.tsx
+++ b/frontend/src/components/hub/Timeline.tsx
@@ -1,0 +1,67 @@
+// frontend/src/components/hub/Timeline.tsx
+import React, { useEffect, useRef } from "react";
+import { Sparkles } from "lucide-react";
+import type { HubMessage } from "./types";
+import { MessageBubble } from "./MessageBubble";
+
+interface Props {
+  messages: HubMessage[];
+  /** When true, displays a "thinking" dots placeholder at the end. */
+  isThinking?: boolean;
+}
+
+export const Timeline: React.FC<Props> = ({ messages, isThinking }) => {
+  const sorted = [...messages].sort((a, b) => a.timestamp - b.timestamp);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // jsdom (used by vitest) does not implement scrollIntoView — guard it.
+    if (typeof endRef.current?.scrollIntoView === "function") {
+      endRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [sorted.length, isThinking]);
+
+  if (sorted.length === 0 && !isThinking) {
+    return (
+      <div className="flex-1 flex items-center justify-center px-6">
+        <div className="max-w-sm text-center">
+          <Sparkles className="w-10 h-10 text-white/25 mx-auto mb-3" />
+          <p className="text-base text-white/85 font-medium mb-1.5">
+            Posez votre première question
+          </p>
+          <p className="text-sm text-white/50 leading-relaxed">
+            Tapez votre question, maintenez le micro pour une note vocale, ou
+            cliquez sur 📞 pour passer en appel.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-5">
+      <div className="max-w-3xl mx-auto flex flex-col gap-4">
+        {sorted.map((msg) => (
+          <MessageBubble key={msg.id} msg={msg} />
+        ))}
+        {isThinking && (
+          <div className="flex justify-start" aria-live="polite">
+            <div className="px-4 py-3 rounded-2xl border border-white/10 bg-white/5 inline-flex items-center gap-2">
+              <span className="w-1.5 h-1.5 rounded-full bg-cyan-400/60 animate-bounce" />
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-cyan-400/60 animate-bounce"
+                style={{ animationDelay: "150ms" }}
+              />
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-cyan-400/60 animate-bounce"
+                style={{ animationDelay: "300ms" }}
+              />
+              <span className="text-xs text-white/45 ml-1">Réflexion…</span>
+            </div>
+          </div>
+        )}
+        <div ref={endRef} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/hub/VideoPiPPlayer.tsx
+++ b/frontend/src/components/hub/VideoPiPPlayer.tsx
@@ -1,0 +1,142 @@
+// frontend/src/components/hub/VideoPiPPlayer.tsx
+import React, { useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { Maximize2, Minimize2, Play } from "lucide-react";
+
+interface Props {
+  thumbnailUrl: string | null;
+  title: string;
+  durationSecs: number;
+  expanded: boolean;
+  onExpand: () => void;
+  onShrink: () => void;
+  /** Optional jump-to-timestamp callback (used by SummaryCollapsible). */
+  onSeek?: (secs: number) => void;
+  /** Imperative seek API exposed via ref pattern is overkill — parent passes seekTo prop via key/state instead. */
+  seekTo?: number | null;
+}
+
+const fmt = (s: number) => {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+};
+
+export const VideoPiPPlayer: React.FC<Props> = ({
+  thumbnailUrl,
+  title,
+  durationSecs,
+  expanded,
+  onExpand,
+  onShrink,
+}) => {
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+  const startRef = useRef({ x: 0, y: 0, mx: 0, my: 0 });
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    if (expanded) return;
+    setDragging(true);
+    startRef.current = { x: pos.x, y: pos.y, mx: e.clientX, my: e.clientY };
+    e.preventDefault();
+  };
+
+  useEffect(() => {
+    if (!dragging) return;
+    const onMove = (e: MouseEvent) => {
+      setPos({
+        x: startRef.current.x + (e.clientX - startRef.current.mx),
+        y: startRef.current.y + (e.clientY - startRef.current.my),
+      });
+    };
+    const onUp = () => setDragging(false);
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [dragging]);
+
+  if (expanded) {
+    return (
+      <motion.div
+        layoutId="hub-pip"
+        data-testid="hub-pip"
+        className="absolute inset-4 z-30 rounded-2xl overflow-hidden bg-gradient-to-br from-[#1a1a2e] to-[#2a1a3e] border border-white/15 shadow-2xl"
+      >
+        {thumbnailUrl ? (
+          <img
+            src={thumbnailUrl}
+            alt={title}
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+        ) : null}
+        <div className="absolute inset-0 grid place-items-center">
+          <div className="w-20 h-20 rounded-full bg-black/40 backdrop-blur-md grid place-items-center">
+            <Play className="w-10 h-10 text-white ml-1" />
+          </div>
+        </div>
+        <button
+          type="button"
+          aria-label="Réduire"
+          onClick={onShrink}
+          className="absolute top-3 right-3 w-9 h-9 rounded-[10px] bg-black/55 border border-white/15 backdrop-blur-md text-white grid place-items-center"
+        >
+          <Minimize2 className="w-4 h-4" />
+        </button>
+        <div className="absolute bottom-6 left-6 right-6 px-4 py-3 bg-black/50 backdrop-blur-xl rounded-xl border border-white/10">
+          <p className="text-sm text-white">{title}</p>
+          <p className="font-mono text-[11px] text-white/65 mt-1">
+            00:00 / {fmt(durationSecs)}
+          </p>
+        </div>
+      </motion.div>
+    );
+  }
+
+  return (
+    <motion.div
+      layoutId="hub-pip"
+      data-testid="hub-pip"
+      onMouseDown={onMouseDown}
+      style={{
+        transform: `translate(${pos.x}px, ${pos.y}px)`,
+        transition: dragging
+          ? "none"
+          : "transform .25s cubic-bezier(.4,0,.2,1)",
+      }}
+      className={
+        "relative w-[112px] h-[64px] rounded-lg overflow-hidden bg-gradient-to-br from-[#1a1a2e] to-[#2a1a3e] border border-white/15 flex-shrink-0 " +
+        (dragging ? "cursor-grabbing shadow-2xl" : "cursor-grab shadow-md")
+      }
+    >
+      {thumbnailUrl ? (
+        <img
+          src={thumbnailUrl}
+          alt={title}
+          className="absolute inset-0 w-full h-full object-cover opacity-90"
+        />
+      ) : null}
+      <div className="absolute inset-0 grid place-items-center">
+        <div className="w-6 h-6 rounded-full bg-black/40 grid place-items-center">
+          <Play className="w-3 h-3 text-white ml-px" />
+        </div>
+      </div>
+      <button
+        type="button"
+        aria-label="Agrandir"
+        onClick={(e) => {
+          e.stopPropagation();
+          onExpand();
+        }}
+        className="absolute top-1 right-1 w-[18px] h-[18px] rounded bg-black/55 text-white grid place-items-center"
+      >
+        <Maximize2 className="w-2.5 h-2.5" />
+      </button>
+      <span className="absolute bottom-0.5 right-1 font-mono text-[8px] text-white/70 bg-black/55 px-1 rounded">
+        {fmt(durationSecs)}
+      </span>
+    </motion.div>
+  );
+};

--- a/frontend/src/components/hub/VoiceBubble.tsx
+++ b/frontend/src/components/hub/VoiceBubble.tsx
@@ -1,0 +1,153 @@
+// frontend/src/components/hub/VoiceBubble.tsx
+import React, { useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Play, Pause } from "lucide-react";
+import { VoiceWaveformBars } from "./VoiceWaveformBars";
+
+interface Props {
+  durationSecs: number;
+  /** Sampled bar heights in px, used by VoiceWaveformBars. */
+  bars: number[];
+  transcript?: string;
+  /** Right side bubble (user PTT) vs left (AI voice). */
+  side?: "user" | "ai";
+}
+
+const formatTime = (s: number) => {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${String(sec).padStart(2, "0")}`;
+};
+
+export const VoiceBubble: React.FC<Props> = ({
+  durationSecs,
+  bars,
+  transcript,
+  side = "user",
+}) => {
+  const [playing, setPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [showTranscript, setShowTranscript] = useState(false);
+  const rafRef = useRef<number | null>(null);
+  const startRef = useRef(0);
+
+  useEffect(() => {
+    if (!playing) {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      return;
+    }
+    startRef.current = performance.now() - progress * durationSecs * 1000;
+    const tick = (t: number) => {
+      const elapsed = (t - startRef.current) / 1000;
+      const p = Math.min(elapsed / durationSecs, 1);
+      setProgress(p);
+      if (p >= 1) {
+        setPlaying(false);
+        setProgress(0);
+        return;
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [playing, durationSecs, progress]);
+
+  const cur = playing ? progress * durationSecs : durationSecs;
+  const isUser = side === "user";
+
+  const words = transcript ? transcript.split(/\s+/) : [];
+
+  return (
+    <div
+      className={
+        "flex flex-col max-w-[320px] " +
+        (isUser ? "self-end items-end" : "self-start items-start")
+      }
+    >
+      <div
+        className={
+          "flex items-center gap-2.5 px-3 py-2.5 min-w-[220px] border " +
+          (isUser
+            ? "bg-indigo-500/10 border-indigo-500/20 rounded-[14px_14px_4px_14px]"
+            : "bg-white/5 border-white/10 rounded-[14px_14px_14px_4px]")
+        }
+      >
+        <button
+          type="button"
+          aria-label={playing ? "pause" : "play"}
+          onClick={() => setPlaying((p) => !p)}
+          className="w-8 h-8 grid place-items-center rounded-full bg-indigo-500 text-white"
+        >
+          {playing ? (
+            <Pause className="w-3 h-3" />
+          ) : (
+            <Play className="w-3 h-3 ml-px" />
+          )}
+        </button>
+        <VoiceWaveformBars bars={bars} progress={progress} playing={playing} />
+        <span className="font-mono text-[10px] text-white/55">
+          {formatTime(cur)}
+        </span>
+      </div>
+
+      {transcript && (
+        <button
+          type="button"
+          onClick={() => setShowTranscript((s) => !s)}
+          className="mt-1 px-2 text-[11px] text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          {showTranscript
+            ? "↑ masquer le transcript"
+            : "↓ afficher le transcript"}
+        </button>
+      )}
+
+      <AnimatePresence>
+        {showTranscript && transcript && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+            className="overflow-hidden max-w-full"
+          >
+            <div
+              data-testid="voice-transcript"
+              className={
+                "mt-1.5 px-3 py-2 rounded-[10px] bg-white/[0.03] border border-white/10 text-[13px] leading-snug " +
+                (isUser
+                  ? "text-right text-white/65"
+                  : "text-left text-white/75")
+              }
+            >
+              {words.map((w, i) => {
+                const wp = i / words.length;
+                const active =
+                  playing &&
+                  wp <= progress &&
+                  (i + 1) / words.length > progress;
+                const past = wp < progress;
+                return (
+                  <span
+                    key={i}
+                    className={
+                      active
+                        ? "text-white font-semibold transition-colors"
+                        : past
+                          ? "text-indigo-400 transition-colors"
+                          : "text-white/55"
+                    }
+                  >
+                    {w}{" "}
+                  </span>
+                );
+              })}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/frontend/src/components/hub/VoiceWaveformBars.tsx
+++ b/frontend/src/components/hub/VoiceWaveformBars.tsx
@@ -1,0 +1,46 @@
+// frontend/src/components/hub/VoiceWaveformBars.tsx
+import React from "react";
+
+interface Props {
+  /** Heights in px, sampled. */
+  bars: number[];
+  /** 0..1 — playback progress. */
+  progress: number;
+  playing: boolean;
+  className?: string;
+}
+
+export const VoiceWaveformBars: React.FC<Props> = ({
+  bars,
+  progress,
+  playing,
+  className,
+}) => {
+  return (
+    <div
+      className={
+        "flex-1 flex items-center gap-[2px] " +
+        (className ?? "") +
+        " h-7"
+      }
+    >
+      {bars.map((h, i) => {
+        const played = i / bars.length <= progress;
+        const isHead =
+          playing && Math.abs(i / bars.length - progress) < 0.04;
+        return (
+          <i
+            key={i}
+            data-played={played ? "true" : "false"}
+            className={
+              "block w-[2px] rounded-[1px] transition-[transform,background] duration-150 " +
+              (played ? "bg-indigo-500" : "bg-white/30") +
+              (isHead ? " scale-y-125" : "")
+            }
+            style={{ height: h }}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/components/hub/__tests__/CallModeFullBleed.test.tsx
+++ b/frontend/src/components/hub/__tests__/CallModeFullBleed.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { CallModeFullBleed } from "../CallModeFullBleed";
+
+vi.mock("../../voice/VoiceOverlay", () => ({
+  VoiceOverlay: ({ isOpen, presentationMode }: any) => (
+    <div data-testid="voice-overlay-mock" data-open={isOpen} data-mode={presentationMode} />
+  ),
+}));
+
+describe("CallModeFullBleed", () => {
+  it("does not render VoiceOverlay when closed", () => {
+    const { queryByTestId } = render(
+      <CallModeFullBleed
+        open={false}
+        onClose={() => {}}
+        summaryId={null}
+        title={null}
+        subtitle={null}
+        onVoiceMessage={() => {}}
+      />,
+    );
+    expect(queryByTestId("voice-overlay-mock")).toBeNull();
+  });
+
+  it("passes presentationMode='fullbleed' to VoiceOverlay when open", () => {
+    const { getByTestId } = render(
+      <CallModeFullBleed
+        open={true}
+        onClose={() => {}}
+        summaryId={42}
+        title="t"
+        subtitle="s"
+        onVoiceMessage={() => {}}
+      />,
+    );
+    const ov = getByTestId("voice-overlay-mock");
+    expect(ov.dataset.mode).toBe("fullbleed");
+    expect(ov.dataset.open).toBe("true");
+  });
+});

--- a/frontend/src/components/hub/__tests__/ConversationsDrawer.test.tsx
+++ b/frontend/src/components/hub/__tests__/ConversationsDrawer.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConversationsDrawer } from "../ConversationsDrawer";
+import type { HubConversation } from "../types";
+
+const convs: HubConversation[] = [
+  {
+    id: 1,
+    summary_id: 10,
+    title: "Lex Fridman · conscience",
+    video_source: "youtube",
+    video_thumbnail_url: null,
+    last_snippet: "3 niveaux de conscience",
+    updated_at: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    summary_id: 11,
+    title: "Naval · le levier",
+    video_source: "youtube",
+    video_thumbnail_url: null,
+    last_snippet: "Permissionless leverage",
+    updated_at: new Date(Date.now() - 86_400_000).toISOString(),
+  },
+];
+
+describe("ConversationsDrawer", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ConversationsDrawer
+        open={false}
+        onClose={() => {}}
+        conversations={convs}
+        activeConvId={null}
+        onSelect={() => {}}
+        onNewConv={() => {}}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders conversations when open", () => {
+    render(
+      <ConversationsDrawer
+        open={true}
+        onClose={() => {}}
+        conversations={convs}
+        activeConvId={null}
+        onSelect={() => {}}
+        onNewConv={() => {}}
+      />,
+    );
+    expect(screen.getByText("Lex Fridman · conscience")).toBeInTheDocument();
+    expect(screen.getByText("Naval · le levier")).toBeInTheDocument();
+  });
+
+  it("calls onSelect with conv id when clicked", () => {
+    const onSelect = vi.fn();
+    render(
+      <ConversationsDrawer
+        open={true}
+        onClose={() => {}}
+        conversations={convs}
+        activeConvId={null}
+        onSelect={onSelect}
+        onNewConv={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("Naval · le levier"));
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it("filters by search query", () => {
+    render(
+      <ConversationsDrawer
+        open={true}
+        onClose={() => {}}
+        conversations={convs}
+        activeConvId={null}
+        onSelect={() => {}}
+        onNewConv={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/rechercher/i), {
+      target: { value: "Naval" },
+    });
+    expect(screen.queryByText("Lex Fridman · conscience")).toBeNull();
+    expect(screen.getByText("Naval · le levier")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/hub/__tests__/HubHeader.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubHeader.test.tsx
@@ -1,0 +1,42 @@
+// frontend/src/components/hub/__tests__/HubHeader.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HubHeader } from "../HubHeader";
+
+describe("HubHeader", () => {
+  it("calls onMenuClick when hamburger pressed", () => {
+    const onMenuClick = vi.fn();
+    render(
+      <HubHeader
+        onMenuClick={onMenuClick}
+        title="Conv title"
+        subtitle="YouTube · 18:32"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /conversations/i }));
+    expect(onMenuClick).toHaveBeenCalled();
+  });
+
+  it("renders title + subtitle", () => {
+    render(
+      <HubHeader
+        onMenuClick={() => {}}
+        title="Conv title"
+        subtitle="YouTube · 18:32"
+      />,
+    );
+    expect(screen.getByText("Conv title")).toBeInTheDocument();
+    expect(screen.getByText(/YouTube/i)).toBeInTheDocument();
+  });
+
+  it("renders pipSlot child if provided", () => {
+    render(
+      <HubHeader
+        onMenuClick={() => {}}
+        title="t"
+        pipSlot={<div data-testid="pip-mock">PIP</div>}
+      />,
+    );
+    expect(screen.getByTestId("pip-mock")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/hub/__tests__/InputBar.test.tsx
+++ b/frontend/src/components/hub/__tests__/InputBar.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InputBar } from "../InputBar";
+
+describe("InputBar", () => {
+  it("calls onSend with the trimmed text", () => {
+    const onSend = vi.fn();
+    render(
+      <InputBar onSend={onSend} onCallToggle={() => {}} onPttHoldComplete={() => {}} />,
+    );
+    const input = screen.getByPlaceholderText(/posez votre question/i);
+    fireEvent.change(input, { target: { value: "Hello world" } });
+    const sendBtn = screen.getByRole("button", { name: /envoyer/i });
+    fireEvent.click(sendBtn);
+    expect(onSend).toHaveBeenCalledWith("Hello world");
+  });
+
+  it("shows mic and call buttons when input is empty", () => {
+    render(
+      <InputBar
+        onSend={() => {}}
+        onCallToggle={() => {}}
+        onPttHoldComplete={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /full call/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /maintenir/i })).toBeInTheDocument();
+  });
+
+  it("calls onCallToggle when phone button pressed", () => {
+    const onCallToggle = vi.fn();
+    render(
+      <InputBar onSend={() => {}} onCallToggle={onCallToggle} onPttHoldComplete={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /full call/i }));
+    expect(onCallToggle).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/hub/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/hub/__tests__/MessageBubble.test.tsx
@@ -1,0 +1,55 @@
+// frontend/src/components/hub/__tests__/MessageBubble.test.tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MessageBubble } from "../MessageBubble";
+import type { HubMessage } from "../types";
+
+const baseMsg: HubMessage = {
+  id: "m1",
+  role: "user",
+  content: "Hello",
+  source: "text",
+  timestamp: 1,
+};
+
+describe("MessageBubble", () => {
+  it("renders user text bubble on the right", () => {
+    const { container } = render(<MessageBubble msg={baseMsg} />);
+    const bubble = container.firstChild as HTMLElement;
+    expect(bubble.className).toMatch(/justify-end|self-end/);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("renders AI text bubble on the left", () => {
+    const { container } = render(
+      <MessageBubble msg={{ ...baseMsg, role: "assistant", content: "Hi" }} />,
+    );
+    const bubble = container.firstChild as HTMLElement;
+    expect(bubble.className).not.toMatch(/justify-end/);
+    expect(screen.getByText("Hi")).toBeInTheDocument();
+  });
+
+  it("renders voice bubble when source is voice_user with audio_duration_secs", () => {
+    const { container } = render(
+      <MessageBubble
+        msg={{
+          ...baseMsg,
+          source: "voice_user",
+          audio_duration_secs: 8,
+          content: "transcript text",
+        }}
+      />,
+    );
+    expect(container.querySelectorAll("i").length).toBeGreaterThan(0);
+  });
+
+  it("falls back to text rendering for voice_user without audio_duration_secs", () => {
+    const { container } = render(
+      <MessageBubble
+        msg={{ ...baseMsg, source: "voice_user", content: "fallback text" }}
+      />,
+    );
+    expect(screen.getByText("fallback text")).toBeInTheDocument();
+    expect(container.querySelectorAll("i").length).toBe(0);
+  });
+});

--- a/frontend/src/components/hub/__tests__/SummaryCollapsible.test.tsx
+++ b/frontend/src/components/hub/__tests__/SummaryCollapsible.test.tsx
@@ -1,0 +1,41 @@
+// frontend/src/components/hub/__tests__/SummaryCollapsible.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SummaryCollapsible } from "../SummaryCollapsible";
+
+const ctx = {
+  summary_id: 1,
+  video_title: "Lex Fridman",
+  video_channel: "Lex",
+  video_duration_secs: 1112,
+  video_source: "youtube" as const,
+  video_thumbnail_url: null,
+  short_summary: "3 niveaux de conscience",
+  citations: [
+    { ts: 134, label: "phénoménale" },
+    { ts: 468, label: "fonctionnelle" },
+  ],
+};
+
+describe("SummaryCollapsible", () => {
+  it("renders short summary when collapsed", () => {
+    render(<SummaryCollapsible context={ctx} />);
+    expect(screen.getByText(/3 niveaux de conscience/i)).toBeInTheDocument();
+  });
+
+  it("expands citations on toggle click", () => {
+    render(<SummaryCollapsible context={ctx} />);
+    const toggle = screen.getByRole("button", { name: /résumé/i });
+    fireEvent.click(toggle);
+    expect(screen.getByText("02:14")).toBeInTheDocument();
+    expect(screen.getByText("07:48")).toBeInTheDocument();
+  });
+
+  it("calls onCitationClick with the citation timestamp", () => {
+    const onCitationClick = vi.fn();
+    render(<SummaryCollapsible context={ctx} onCitationClick={onCitationClick} />);
+    fireEvent.click(screen.getByRole("button", { name: /résumé/i }));
+    fireEvent.click(screen.getByText("02:14"));
+    expect(onCitationClick).toHaveBeenCalledWith(134);
+  });
+});

--- a/frontend/src/components/hub/__tests__/Timeline.test.tsx
+++ b/frontend/src/components/hub/__tests__/Timeline.test.tsx
@@ -1,0 +1,43 @@
+// frontend/src/components/hub/__tests__/Timeline.test.tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Timeline } from "../Timeline";
+import type { HubMessage } from "../types";
+
+const msgs: HubMessage[] = [
+  { id: "m1", role: "user", content: "Q1", source: "text", timestamp: 1 },
+  { id: "m2", role: "assistant", content: "A1", source: "text", timestamp: 2 },
+  // No audio_duration_secs → MessageBubble falls back to text bubble (renders <p>),
+  // so the chronological-order test below can assert on querySelectorAll("p").
+  {
+    id: "m3",
+    role: "user",
+    content: "transcript",
+    source: "voice_user",
+    timestamp: 3,
+  },
+];
+
+describe("Timeline", () => {
+  it("renders one bubble per message", () => {
+    render(<Timeline messages={msgs} />);
+    expect(screen.getByText("Q1")).toBeInTheDocument();
+    expect(screen.getByText("A1")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no messages", () => {
+    render(<Timeline messages={[]} />);
+    expect(
+      screen.getByText(/posez votre première question/i),
+    ).toBeInTheDocument();
+  });
+
+  it("orders messages chronologically by timestamp", () => {
+    const reordered: HubMessage[] = [...msgs].reverse();
+    const { container } = render(<Timeline messages={reordered} />);
+    const texts = Array.from(container.querySelectorAll("p"))
+      .map((p) => p.textContent)
+      .filter((t) => ["Q1", "A1", "transcript"].includes(t || ""));
+    expect(texts).toEqual(["Q1", "A1", "transcript"]);
+  });
+});

--- a/frontend/src/components/hub/__tests__/VideoPiPPlayer.test.tsx
+++ b/frontend/src/components/hub/__tests__/VideoPiPPlayer.test.tsx
@@ -1,0 +1,52 @@
+// frontend/src/components/hub/__tests__/VideoPiPPlayer.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { VideoPiPPlayer } from "../VideoPiPPlayer";
+
+describe("VideoPiPPlayer", () => {
+  it("renders thumbnail or fallback gradient when no url", () => {
+    const { container } = render(
+      <VideoPiPPlayer
+        thumbnailUrl={null}
+        title="test"
+        durationSecs={1112}
+        expanded={false}
+        onExpand={() => {}}
+        onShrink={() => {}}
+      />,
+    );
+    expect(container.querySelector("[data-testid='hub-pip']")).toBeInTheDocument();
+  });
+
+  it("calls onExpand when expand button clicked", () => {
+    const onExpand = vi.fn();
+    render(
+      <VideoPiPPlayer
+        thumbnailUrl={null}
+        title="test"
+        durationSecs={1112}
+        expanded={false}
+        onExpand={onExpand}
+        onShrink={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /agrandir/i }));
+    expect(onExpand).toHaveBeenCalled();
+  });
+
+  it("renders shrink button when expanded", () => {
+    render(
+      <VideoPiPPlayer
+        thumbnailUrl={null}
+        title="test"
+        durationSecs={1112}
+        expanded={true}
+        onExpand={() => {}}
+        onShrink={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /réduire/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/hub/__tests__/VoiceBubble.test.tsx
+++ b/frontend/src/components/hub/__tests__/VoiceBubble.test.tsx
@@ -1,0 +1,40 @@
+// frontend/src/components/hub/__tests__/VoiceBubble.test.tsx
+import { describe, it, expect } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { VoiceBubble } from "../VoiceBubble";
+
+describe("VoiceBubble", () => {
+  it("renders play button and waveform", () => {
+    const { container } = render(
+      <VoiceBubble
+        durationSecs={8}
+        bars={[6, 14, 9, 20]}
+        transcript="hello world"
+      />,
+    );
+    expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument();
+    expect(container.querySelectorAll("i").length).toBeGreaterThan(0);
+  });
+
+  it("toggles transcript visibility on toggle click", () => {
+    render(
+      <VoiceBubble
+        durationSecs={8}
+        bars={[6, 14, 9, 20]}
+        transcript="hello world"
+      />,
+    );
+    expect(screen.queryByTestId("voice-transcript")).toBeNull();
+    const toggle = screen.getByText(/afficher le transcript/i);
+    fireEvent.click(toggle);
+    const transcript = screen.getByTestId("voice-transcript");
+    expect(transcript.textContent?.replace(/\s+/g, " ").trim()).toMatch(
+      /hello world/i,
+    );
+  });
+
+  it("does not render transcript toggle if no transcript", () => {
+    render(<VoiceBubble durationSecs={8} bars={[6, 14, 9, 20]} />);
+    expect(screen.queryByText(/transcript/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/hub/__tests__/VoiceWaveformBars.test.tsx
+++ b/frontend/src/components/hub/__tests__/VoiceWaveformBars.test.tsx
@@ -1,0 +1,23 @@
+// frontend/src/components/hub/__tests__/VoiceWaveformBars.test.tsx
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { VoiceWaveformBars } from "../VoiceWaveformBars";
+
+describe("VoiceWaveformBars", () => {
+  it("renders one i element per bar height", () => {
+    const { container } = render(
+      <VoiceWaveformBars bars={[6, 14, 9]} progress={0} playing={false} />,
+    );
+    expect(container.querySelectorAll("i")).toHaveLength(3);
+  });
+
+  it("marks bars at index <= progress*bars.length as played", () => {
+    const { container } = render(
+      <VoiceWaveformBars bars={[6, 14, 9, 20]} progress={0.5} playing />,
+    );
+    const bars = container.querySelectorAll("i");
+    expect(bars[0].getAttribute("data-played")).toBe("true");
+    expect(bars[1].getAttribute("data-played")).toBe("true");
+    expect(bars[3].getAttribute("data-played")).toBe("false");
+  });
+});

--- a/frontend/src/components/hub/types.ts
+++ b/frontend/src/components/hub/types.ts
@@ -1,10 +1,24 @@
 // frontend/src/components/hub/types.ts
+//
+// SSOT du hub conversationnel unifié (chat + voice). Volontairement
+// parallèle à ChatPage.ChatMessage et analysisStore.ChatMessage : les
+// pages legacy `/chat` et `/voice-call` seront supprimées J+30 (cf. plan
+// docs/superpowers/plans/2026-04-30-unified-hub-chat-voice.md). Pendant
+// cette fenêtre de cohabitation, NE PAS importer ces types depuis les
+// pages legacy — ils restent confinés à `components/hub/*` et `pages/HubPage`.
 
 /**
- * Schema unifié frontend pour le hub conversationnel.
- * Reflète backend ChatMessage (PR #203) — source distingue text/voice/voice_user/voice_agent.
+ * Mapping aplati frontend du couple backend (`source`, `voice_speaker`).
+ * Backend Pydantic (PR #203) modélise voice avec deux champs séparés :
+ *   { source: "text" | "voice", voice_speaker: "user" | "agent" | null }
+ * Frontend aplatit en un seul champ pour faciliter switch/JSX :
+ *   "voice_user"  ↔ backend { source: "voice", voice_speaker: "user" }
+ *   "voice_agent" ↔ backend { source: "voice", voice_speaker: "agent" }
+ *   "text"        ↔ backend { source: "text",  voice_speaker: null }
+ * Le mapping est appliqué au fetch dans HubPage (cf. Task 13).
  */
 export interface HubMessage {
+  /** crypto.randomUUID() côté client pour éviter les collisions de clés React. */
   id: string;
   role: "user" | "assistant";
   content: string;

--- a/frontend/src/components/hub/types.ts
+++ b/frontend/src/components/hub/types.ts
@@ -1,0 +1,55 @@
+// frontend/src/components/hub/types.ts
+
+/**
+ * Schema unifié frontend pour le hub conversationnel.
+ * Reflète backend ChatMessage (PR #203) — source distingue text/voice/voice_user/voice_agent.
+ */
+export interface HubMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  source: "text" | "voice_user" | "voice_agent";
+  sources?: { title: string; url: string }[];
+  web_search_used?: boolean;
+  voice_session_id?: string | null;
+  time_in_call_secs?: number;
+  /** Pour les bulles voice — durée de l'audio en secondes (pour waveform). */
+  audio_duration_secs?: number;
+  /** Date.now() au moment de l'append. */
+  timestamp: number;
+}
+
+export interface HubConversation {
+  id: number;
+  /** null si free-form (pas de vidéo attachée). */
+  summary_id: number | null;
+  /** Titre court (= titre vidéo ou première question). */
+  title: string;
+  /** Source vidéo si rattachée. */
+  video_source?: "youtube" | "tiktok";
+  video_thumbnail_url?: string | null;
+  /** Snippet de la dernière question/réponse pour la liste drawer. */
+  last_snippet?: string;
+  /** ISO date du dernier message. */
+  updated_at: string;
+}
+
+export interface HubSummaryContext {
+  summary_id: number;
+  video_title: string;
+  video_channel: string;
+  video_duration_secs: number;
+  video_source: "youtube" | "tiktok";
+  video_thumbnail_url: string | null;
+  /** Texte court (≤200 char) affiché dans la card collapsible. */
+  short_summary: string;
+  /** Citations [timestamp_secs, label] cliquables qui jump au PiP. */
+  citations: { ts: number; label: string }[];
+}
+
+export type HubVoiceState =
+  | "idle"
+  | "ptt_recording"
+  | "call_connecting"
+  | "call_active"
+  | "call_ending";

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -22,9 +22,8 @@ import {
   Scale,
   BarChart3,
   User,
-  MessageSquare,
+  MessageCircle,
   GraduationCap,
-  Phone,
   Menu,
   Gamepad2,
 } from "lucide-react";
@@ -450,8 +449,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
   const minPlanPlaylists = getMinPlanForFeature("playlistsEnabled");
   const minPlanStudy = getMinPlanForFeature("flashcardsEnabled");
-  const minPlanChat: PlanId = "pro"; // Chat page bloque les free users
-  const minPlanVoice: PlanId = "pro"; // Voice call gated Pro
+  const minPlanHub: PlanId = "pro"; // Hub (chat + voix) bloque les free users
   const getBadge = (minPlan: PlanId) => {
     const userIdx = PLAN_HIERARCHY.indexOf(userPlan);
     const minIdx = PLAN_HIERARCHY.indexOf(minPlan);
@@ -567,21 +565,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
               collapsed={collapsed}
             />
             <NavItem
-              to="/chat"
-              icon={MessageSquare}
-              label={t.nav.chat}
+              to="/hub"
+              icon={MessageCircle}
+              label="Hub"
               collapsed={collapsed}
-              {...getBadge(minPlanChat)}
-            />
-            <NavItem
-              to="/voice-call"
-              icon={Phone}
-              label={
-                t.nav.voiceCall ||
-                (language === "fr" ? "Appel vocal" : "Voice call")
-              }
-              collapsed={collapsed}
-              {...getBadge(minPlanVoice)}
+              {...getBadge(minPlanHub)}
             />
             <NavItem
               to="/study"

--- a/frontend/src/components/voice/VoiceOverlay.tsx
+++ b/frontend/src/components/voice/VoiceOverlay.tsx
@@ -93,6 +93,8 @@ export interface VoiceOverlayProps {
    * Pass false to require an explicit user click first.
    */
   autoStart?: boolean;
+  /** "floating" (default — bottom-right 380×600) or "fullbleed" (occupies parent container). */
+  presentationMode?: "floating" | "fullbleed";
 }
 
 export interface VoiceOverlayController {
@@ -162,10 +164,12 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
   onVoiceMessage,
   controllerRef,
   autoStart = true,
+  presentationMode = "floating",
 }) => {
   const t = I18N[language];
   const resolvedAgent: VoiceOverlayProps["agentType"] =
     agentType ?? (summaryId ? "explorer" : "companion");
+  const isFullbleed = presentationMode === "fullbleed";
 
   // ── Settings panel collapsible state ──
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -349,8 +353,12 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
             exit={{ opacity: 0, x: 32, y: 32 }}
             transition={{ duration: 0.25, ease: "easeOut" }}
             data-testid="voice-overlay"
-            className="fixed bottom-6 right-6 w-[380px] max-w-[calc(100vw-32px)] h-[600px] max-h-[calc(100vh-48px)] flex flex-col rounded-2xl shadow-2xl bg-[#0c0c14]/95 backdrop-blur-xl border border-white/10 overflow-hidden"
-            style={{ zIndex: 1000 }}
+            className={
+              isFullbleed
+                ? "absolute inset-0 flex flex-col bg-[#0c0c14]/95 backdrop-blur-xl border border-white/10 overflow-hidden"
+                : "fixed bottom-6 right-6 w-[380px] max-w-[calc(100vw-32px)] h-[600px] max-h-[calc(100vh-48px)] flex flex-col rounded-2xl shadow-2xl bg-[#0c0c14]/95 backdrop-blur-xl border border-white/10 overflow-hidden"
+            }
+            style={isFullbleed ? undefined : { zIndex: 1000 }}
           >
             {/* ── Header ── */}
             <header className="flex items-center justify-between gap-3 px-4 py-3 border-b border-white/[0.06] flex-shrink-0">

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -1,0 +1,340 @@
+/**
+ * Hub Chat IA + Voice unifié — page racine /hub.
+ *
+ * Fusionne ChatPage et VoiceCallPage en une expérience single column :
+ *   ☰ HubHeader · SummaryCollapsible · Timeline · InputBar
+ *   + ConversationsDrawer overlay · VideoPiPPlayer · CallModeFullBleed
+ *
+ * Backend : timeline unifiée déjà en place (PR #203). Schema HubMessage
+ * mappé depuis ChatMessage côté API (source/voice_session_id/time_in_call_secs).
+ */
+import React, { useCallback, useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+import { videoApi, chatApi } from "../services/api";
+import { useAuth } from "../hooks/useAuth";
+import { useTranslation } from "../hooks/useTranslation";
+import { useTTSContext } from "../contexts/TTSContext";
+import { useVoiceEnabled } from "../components/voice/hooks/useVoiceEnabled";
+import {
+  type VoiceOverlayController,
+  type VoiceOverlayMessage,
+} from "../components/voice/VoiceOverlay";
+import DoodleBackground from "../components/DoodleBackground";
+import { SEO } from "../components/SEO";
+import { sanitizeTitle } from "../utils/sanitize";
+import { useHubStore } from "../store/hubStore";
+import { HubHeader } from "../components/hub/HubHeader";
+import { SummaryCollapsible } from "../components/hub/SummaryCollapsible";
+import { Timeline } from "../components/hub/Timeline";
+import { InputBar } from "../components/hub/InputBar";
+import { ConversationsDrawer } from "../components/hub/ConversationsDrawer";
+import { VideoPiPPlayer } from "../components/hub/VideoPiPPlayer";
+import { CallModeFullBleed } from "../components/hub/CallModeFullBleed";
+import type { HubConversation, HubMessage } from "../components/hub/types";
+
+const newId = () =>
+  typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `m-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const HubPage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlConvId = searchParams.get("conv");
+  const urlSummaryId = searchParams.get("summary");
+
+  const { language } = useTranslation();
+  const { user: _user } = useAuth();
+  const { autoPlayEnabled, playText, stopPlaying } = useTTSContext();
+  const { voiceEnabled } = useVoiceEnabled();
+
+  const {
+    conversations,
+    activeConvId,
+    messages,
+    summaryContext,
+    drawerOpen,
+    voiceCallOpen,
+    pipExpanded,
+    setConversations,
+    setActiveConv,
+    setMessages,
+    appendMessage,
+    setSummaryContext,
+    toggleDrawer,
+    setPipExpanded,
+    setVoiceCallOpen,
+  } = useHubStore();
+
+  const [isThinking, setIsThinking] = React.useState(false);
+  const voiceControllerRef = useRef<VoiceOverlayController | null>(null);
+
+  // ── Fetch conversations (mapped from videoApi.getHistory) ──
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await videoApi.getHistory({ limit: 50, page: 1 });
+        if (cancelled) return;
+        const convs: HubConversation[] = (resp.items || []).map(
+          (item: any) => ({
+            id: item.id,
+            summary_id: item.id,
+            title: sanitizeTitle(item.video_title) || "Sans titre",
+            video_source: (item.platform === "tiktok"
+              ? "tiktok"
+              : "youtube") as "youtube" | "tiktok",
+            video_thumbnail_url: item.thumbnail_url ?? null,
+            last_snippet: undefined,
+            updated_at: item.created_at,
+          }),
+        );
+        setConversations(convs);
+        // Auto-select if URL has ?conv=<id> or ?summary=<id>
+        const target =
+          urlConvId !== null
+            ? Number(urlConvId)
+            : urlSummaryId !== null
+              ? Number(urlSummaryId)
+              : null;
+        if (target && convs.find((c) => c.id === target)) {
+          setActiveConv(target);
+        }
+      } catch (err) {
+        console.error("[HubPage] fetch conversations failed:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setConversations, setActiveConv, urlConvId, urlSummaryId]);
+
+  // ── Fetch messages + summary context when activeConv changes ──
+  useEffect(() => {
+    if (activeConvId === null) {
+      setSummaryContext(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const history = await chatApi.getHistory(activeConvId);
+        if (cancelled) return;
+        const mapped: HubMessage[] = (history || []).map(
+          (m: any, i: number) => {
+            const source: HubMessage["source"] =
+              m.source === "voice"
+                ? m.voice_speaker === "user"
+                  ? "voice_user"
+                  : "voice_agent"
+                : "text";
+            return {
+              id: m.id ? `history-${m.id}` : `history-${i}`,
+              role: m.role,
+              content: m.content,
+              sources: m.sources,
+              web_search_used: m.web_search_used,
+              source,
+              voice_session_id: m.voice_session_id ?? null,
+              time_in_call_secs: m.time_in_call_secs,
+              timestamp: new Date(m.created_at ?? Date.now()).getTime(),
+            };
+          },
+        );
+        setMessages(mapped);
+
+        // Build a minimal summary context from conversation + first available data
+        const conv = conversations.find((c) => c.id === activeConvId);
+        if (conv && conv.summary_id !== null) {
+          setSummaryContext({
+            summary_id: conv.summary_id,
+            video_title: conv.title,
+            video_channel: "",
+            video_duration_secs: 0,
+            video_source: conv.video_source ?? "youtube",
+            video_thumbnail_url: conv.video_thumbnail_url ?? null,
+            short_summary: conv.last_snippet ?? "",
+            citations: [],
+          });
+        }
+      } catch (err) {
+        console.error("[HubPage] fetch messages failed:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeConvId, conversations, setMessages, setSummaryContext]);
+
+  // ── Auto-play TTS on assistant text messages ──
+  const prevCountRef = useRef(messages.length);
+  useEffect(() => {
+    if (messages.length > prevCountRef.current && autoPlayEnabled) {
+      const last = messages[messages.length - 1];
+      if (
+        last?.role === "assistant" &&
+        last.source !== "voice_agent" &&
+        typeof last.content === "string"
+      ) {
+        playText(last.content.slice(0, 5000));
+      }
+    }
+    prevCountRef.current = messages.length;
+  }, [messages, autoPlayEnabled, playText]);
+
+  // ── Handle text send (route A: voice active = inject; B: REST) ──
+  const handleSend = useCallback(
+    async (text: string) => {
+      if (!activeConvId) return;
+      const ctrl = voiceControllerRef.current;
+      const voiceActive = !!ctrl?.isActive;
+
+      stopPlaying();
+
+      const userMsg: HubMessage = {
+        id: newId(),
+        role: "user",
+        content: text,
+        source: voiceActive ? "voice_user" : "text",
+        voice_session_id: voiceActive
+          ? (ctrl?.voiceSessionId ?? null)
+          : undefined,
+        timestamp: Date.now(),
+      };
+      appendMessage(userMsg);
+
+      if (voiceActive && ctrl) {
+        try {
+          ctrl.sendUserMessage(text);
+        } catch (err) {
+          console.warn("[HubPage] sendUserMessage failed:", err);
+        }
+        return;
+      }
+
+      setIsThinking(true);
+      try {
+        const resp = await chatApi.send(activeConvId, text, false);
+        appendMessage({
+          id: newId(),
+          role: "assistant",
+          content: resp.response || "",
+          sources: resp.sources,
+          web_search_used: resp.web_search_used,
+          source: "text",
+          timestamp: Date.now(),
+        });
+      } catch (err) {
+        console.error("[HubPage] chat send failed:", err);
+        appendMessage({
+          id: newId(),
+          role: "assistant",
+          content: "❌ Une erreur est survenue. Veuillez réessayer.",
+          source: "text",
+          timestamp: Date.now(),
+        });
+      } finally {
+        setIsThinking(false);
+      }
+    },
+    [activeConvId, appendMessage, stopPlaying],
+  );
+
+  // ── Handle voice transcript turn ──
+  const handleVoiceMessage = useCallback(
+    (msg: VoiceOverlayMessage) => {
+      appendMessage({
+        id: newId(),
+        role: msg.source === "user" ? "user" : "assistant",
+        content: msg.text,
+        source: msg.source === "user" ? "voice_user" : "voice_agent",
+        voice_session_id: msg.voiceSessionId,
+        time_in_call_secs: msg.timeInCallSecs,
+        timestamp: Date.now(),
+      });
+    },
+    [appendMessage],
+  );
+
+  // ── Handle PTT (hold mic) → in v1, switch to call mode briefly is overkill,
+  //    just open the call so user can speak. Real audio capture for PTT note
+  //    bubbles is V2 (requires server-side transcription endpoint). ──
+  const handlePttHoldComplete = useCallback(
+    (_durationSecs: number) => {
+      if (!voiceEnabled) return;
+      setVoiceCallOpen(true);
+    },
+    [voiceEnabled, setVoiceCallOpen],
+  );
+
+  const activeConv = conversations.find((c) => c.id === activeConvId) ?? null;
+
+  return (
+    <div className="relative h-screen flex flex-col overflow-hidden bg-[#0a0a0f]">
+      <DoodleBackground variant="default" className="!opacity-[0.18]" />
+      <SEO title="Hub" path="/hub" />
+
+      <HubHeader
+        onMenuClick={toggleDrawer}
+        title={activeConv?.title ?? "Hub"}
+        subtitle={
+          activeConv?.video_source
+            ? `${activeConv.video_source.toUpperCase()}`
+            : undefined
+        }
+        pipSlot={
+          activeConv?.summary_id ? (
+            <VideoPiPPlayer
+              thumbnailUrl={activeConv.video_thumbnail_url ?? null}
+              title={activeConv.title}
+              durationSecs={summaryContext?.video_duration_secs ?? 0}
+              expanded={pipExpanded}
+              onExpand={() => setPipExpanded(true)}
+              onShrink={() => setPipExpanded(false)}
+            />
+          ) : null
+        }
+      />
+
+      <div className="relative flex-1 flex flex-col overflow-hidden">
+        {summaryContext && <SummaryCollapsible context={summaryContext} />}
+        <Timeline messages={messages} isThinking={isThinking} />
+        <InputBar
+          onSend={handleSend}
+          onCallToggle={() => setVoiceCallOpen(!voiceCallOpen)}
+          onPttHoldComplete={handlePttHoldComplete}
+          disabled={!activeConvId}
+        />
+
+        <ConversationsDrawer
+          open={drawerOpen}
+          onClose={toggleDrawer}
+          conversations={conversations}
+          activeConvId={activeConvId}
+          onSelect={(id) => {
+            setActiveConv(id);
+            setSearchParams({ conv: String(id) });
+          }}
+          onNewConv={() => {
+            setActiveConv(null);
+            setSearchParams({});
+          }}
+        />
+
+        {voiceEnabled && (
+          <CallModeFullBleed
+            open={voiceCallOpen}
+            onClose={() => setVoiceCallOpen(false)}
+            summaryId={activeConv?.summary_id ?? null}
+            title={activeConv?.title ?? null}
+            subtitle={null}
+            onVoiceMessage={handleVoiceMessage}
+            controllerRef={voiceControllerRef}
+            language={language as "fr" | "en"}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HubPage;

--- a/frontend/src/pages/__tests__/HubPage.test.tsx
+++ b/frontend/src/pages/__tests__/HubPage.test.tsx
@@ -1,0 +1,88 @@
+// frontend/src/pages/__tests__/HubPage.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import HubPage from "../HubPage";
+import { useHubStore } from "../../store/hubStore";
+
+vi.mock("../../services/api", () => ({
+  videoApi: {
+    getHistory: vi.fn().mockResolvedValue({ items: [] }),
+  },
+  chatApi: {
+    getHistory: vi.fn().mockResolvedValue([]),
+    send: vi.fn(),
+  },
+  voiceApi: {
+    appendTranscript: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: { plan: "pro", preferences: { has_completed_onboarding: true } },
+    loading: false,
+  }),
+}));
+
+vi.mock("../../hooks/useTranslation", () => ({
+  useTranslation: () => ({ language: "fr", t: { empty_states: {} } }),
+}));
+
+vi.mock("../../components/voice/VoiceOverlay", () => ({
+  VoiceOverlay: () => null,
+}));
+
+vi.mock("../../components/voice/hooks/useVoiceEnabled", () => ({
+  useVoiceEnabled: () => ({ voiceEnabled: true }),
+}));
+
+vi.mock("../../contexts/TTSContext", () => ({
+  useTTSContext: () => ({
+    autoPlayEnabled: false,
+    playText: vi.fn(),
+    stopPlaying: vi.fn(),
+  }),
+}));
+
+// DoodleBackground uses useTheme() which throws outside ThemeProvider — mock it.
+vi.mock("../../components/DoodleBackground", () => ({
+  default: () => null,
+}));
+
+// SEO uses react-helmet-async which complains without HelmetProvider — mock it.
+vi.mock("../../components/SEO", () => ({
+  SEO: () => null,
+}));
+
+beforeEach(() => {
+  useHubStore.getState().reset();
+});
+
+describe("HubPage", () => {
+  it("renders empty state when no conversation is active", async () => {
+    render(
+      <MemoryRouter initialEntries={["/hub"]}>
+        <HubPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/posez votre première question/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders the InputBar at the bottom", async () => {
+    render(
+      <MemoryRouter initialEntries={["/hub"]}>
+        <HubPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText(/posez votre question/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/store/__tests__/hubStore.test.ts
+++ b/frontend/src/store/__tests__/hubStore.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useHubStore } from "../hubStore";
+
+describe("hubStore", () => {
+  beforeEach(() => {
+    useHubStore.getState().reset();
+  });
+
+  it("initial state has no active conversation and drawer closed", () => {
+    const s = useHubStore.getState();
+    expect(s.activeConvId).toBeNull();
+    expect(s.drawerOpen).toBe(false);
+    expect(s.voiceCallOpen).toBe(false);
+    expect(s.pipExpanded).toBe(false);
+    expect(s.summaryExpanded).toBe(false);
+    expect(s.voiceState).toBe("idle");
+    expect(s.messages).toEqual([]);
+    expect(s.conversations).toEqual([]);
+  });
+
+  it("setActiveConv switches activeConvId and clears messages", () => {
+    useHubStore.setState({
+      messages: [
+        { id: "m1", role: "user", content: "hi", source: "text", timestamp: 1 },
+      ],
+    });
+    useHubStore.getState().setActiveConv(42);
+    expect(useHubStore.getState().activeConvId).toBe(42);
+    expect(useHubStore.getState().messages).toEqual([]);
+  });
+
+  it("appendMessage pushes to messages immutably", () => {
+    useHubStore.getState().appendMessage({
+      id: "m1",
+      role: "user",
+      content: "hi",
+      source: "text",
+      timestamp: 1,
+    });
+    expect(useHubStore.getState().messages).toHaveLength(1);
+    expect(useHubStore.getState().messages[0].id).toBe("m1");
+  });
+
+  it("toggleDrawer flips drawerOpen", () => {
+    useHubStore.getState().toggleDrawer();
+    expect(useHubStore.getState().drawerOpen).toBe(true);
+    useHubStore.getState().toggleDrawer();
+    expect(useHubStore.getState().drawerOpen).toBe(false);
+  });
+
+  it("setVoiceState updates voiceState", () => {
+    useHubStore.getState().setVoiceState("call_active");
+    expect(useHubStore.getState().voiceState).toBe("call_active");
+  });
+});

--- a/frontend/src/store/hubStore.ts
+++ b/frontend/src/store/hubStore.ts
@@ -1,0 +1,106 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import type {
+  HubConversation,
+  HubMessage,
+  HubSummaryContext,
+  HubVoiceState,
+} from "../components/hub/types";
+
+interface HubState {
+  conversations: HubConversation[];
+  activeConvId: number | null;
+  messages: HubMessage[];
+  summaryContext: HubSummaryContext | null;
+  drawerOpen: boolean;
+  summaryExpanded: boolean;
+  pipExpanded: boolean;
+  voiceCallOpen: boolean;
+  voiceState: HubVoiceState;
+
+  setConversations: (convs: HubConversation[]) => void;
+  setActiveConv: (id: number | null) => void;
+  setMessages: (msgs: HubMessage[]) => void;
+  appendMessage: (msg: HubMessage) => void;
+  setSummaryContext: (ctx: HubSummaryContext | null) => void;
+  toggleDrawer: () => void;
+  toggleSummary: () => void;
+  setPipExpanded: (v: boolean) => void;
+  setVoiceCallOpen: (v: boolean) => void;
+  setVoiceState: (s: HubVoiceState) => void;
+  reset: () => void;
+}
+
+const INITIAL: Pick<
+  HubState,
+  | "conversations"
+  | "activeConvId"
+  | "messages"
+  | "summaryContext"
+  | "drawerOpen"
+  | "summaryExpanded"
+  | "pipExpanded"
+  | "voiceCallOpen"
+  | "voiceState"
+> = {
+  conversations: [],
+  activeConvId: null,
+  messages: [],
+  summaryContext: null,
+  drawerOpen: false,
+  summaryExpanded: false,
+  pipExpanded: false,
+  voiceCallOpen: false,
+  voiceState: "idle",
+};
+
+export const useHubStore = create<HubState>()(
+  immer((set) => ({
+    ...INITIAL,
+    setConversations: (convs) =>
+      set((s) => {
+        s.conversations = convs;
+      }),
+    setActiveConv: (id) =>
+      set((s) => {
+        s.activeConvId = id;
+        s.messages = [];
+      }),
+    setMessages: (msgs) =>
+      set((s) => {
+        s.messages = msgs;
+      }),
+    appendMessage: (msg) =>
+      set((s) => {
+        s.messages.push(msg);
+      }),
+    setSummaryContext: (ctx) =>
+      set((s) => {
+        s.summaryContext = ctx;
+      }),
+    toggleDrawer: () =>
+      set((s) => {
+        s.drawerOpen = !s.drawerOpen;
+      }),
+    toggleSummary: () =>
+      set((s) => {
+        s.summaryExpanded = !s.summaryExpanded;
+      }),
+    setPipExpanded: (v) =>
+      set((s) => {
+        s.pipExpanded = v;
+      }),
+    setVoiceCallOpen: (v) =>
+      set((s) => {
+        s.voiceCallOpen = v;
+      }),
+    setVoiceState: (st) =>
+      set((s) => {
+        s.voiceState = st;
+      }),
+    reset: () =>
+      set((s) => {
+        Object.assign(s, INITIAL);
+      }),
+  })),
+);


### PR DESCRIPTION
## Summary

Fuses `/chat` (ChatPage) and `/voice-call` (VoiceCallPage) into a single `/hub` (HubPage) where text and voice coexist in one timeline. Single column adaptive layout, drawer left for conversations history, PiP draggable top-right, Full Call mode bottom-sheet that wraps the existing VoiceOverlay (PR #126) without breaking it.

Reuses `VoiceOverlay` + `useVoiceChat` (PR #126) and the unified backend timeline (PR #203). Direction visuelle = v2 indigo (Editorial Thread + ciblé Voice-first/Ambient).

- **Spec** : `docs/superpowers/specs/2026-04-30-unified-chat-voice-hub-design.md`
- **Plan** : `docs/superpowers/plans/2026-04-30-unified-hub-chat-voice.md`
- **Reco design source** : `/tmp/claude-design-hub/hub-design-research.html` (Claude Design — analyse 10 références + 3 directions + reco Editorial Thread)

## What changed

**12 nouveaux composants** dans `frontend/src/components/hub/` :
- `types.ts` (HubMessage, HubConversation, HubSummaryContext, HubVoiceState)
- `VoiceWaveformBars`, `VoiceBubble`, `MessageBubble` (4 variants tu/IA × text/voice)
- `SummaryCollapsible` (citations cyan timestamp), `Timeline` (fil chrono + thinking dots)
- `HubHeader` (sticky topbar), `InputBar` (PTT hold + 📞 Full Call)
- `ConversationsDrawer` (search + groupBy date), `VideoPiPPlayer` (draggable + expand)
- `CallModeFullBleed` (wraps VoiceOverlay)
- `frontend/src/store/hubStore.ts` (Zustand+Immer)
- `frontend/src/pages/HubPage.tsx` (assembly avec voice integration)
- `frontend/e2e/hub-unified.spec.ts` (E2E Playwright)

**Modifications minimales** :
- `frontend/src/components/voice/VoiceOverlay.tsx` : ajout prop optionnelle `presentationMode?: "floating" | "fullbleed"` (default `"floating"` = comportement actuel inchangé).
- `frontend/src/components/layout/Sidebar.tsx` : "Chat IA" + "Appel Vocal" → "Hub" (icône MessageCircle).
- `frontend/src/App.tsx` : route lazy `/hub` + redirects `/chat` → `/hub` et `/voice-call` → `/hub`.

**Conservation rollback** : `ChatPage.tsx` et `VoiceCallPage.tsx` **gardés sur disque** (juste plus référencés dans `App.tsx`). Suppression différée à J+30 dans une PR séparée.

## Test plan

- [ ] `npm run typecheck` zéro erreur dans le scope hub (5 erreurs pré-existantes dans `__tests__/mocks/api-mocks.ts` non liées)
- [ ] `npm run lint` zéro warning nouveau (5 erreurs pré-existantes dans App.tsx non liées)
- [ ] `npm run test` — 37/37 hub tests verts (12 fichiers tests : VoiceWaveformBars, VoiceBubble, MessageBubble, SummaryCollapsible, VideoPiPPlayer, HubHeader, InputBar, ConversationsDrawer, CallModeFullBleed, Timeline, hubStore, HubPage)
- [ ] `npm run build` — build prod réussi
- [ ] Vercel preview chargée et validée visuellement (Maxime)
- [ ] `/chat` redirige vers `/hub`
- [ ] `/voice-call` redirige vers `/hub`
- [ ] Hamburger ouvre drawer ; sélection conv charge messages
- [ ] Send texte → réponse via REST `chatApi.send`
- [ ] PTT hold > 0.4s ouvre Full Call mode (Pro plan)
- [ ] PiP draggable + expandable
- [ ] Voice transcript turns mergent dans timeline (testé manuellement avec call actif)

## Out of scope (PRs séparées)

- **Mobile mirror** : plan séparé à venir après validation web (`mobile/src/screens/HubScreen.tsx` + composants RN, drawer via `react-navigation`, PiP via `react-native-video`).
- **Suppression `ChatPage.tsx` + `VoiceCallPage.tsx`** : J+30 quand redirect rodé.
- **Harmonisation `SidebarNav.tsx` + `BottomNav.tsx`** : ces 2 nav files secondaires référencent encore `/voice-call` mais sont fonctionnels grâce au redirect 301. À nettoyer dans une PR cosmétique.
- **Backend changes** : ZÉRO — la timeline unifiée est déjà en place via PR #203.
- **Extension Chrome** : V1.2 (PR #173) conservée — décision design.

## Pré-existants relevés (non causés par cette PR)

- 11 test failures dans `frontend/src/components/voice/__tests__/VoiceOverlay.test.tsx` (HelmetProvider context manquant) — confirmé par baseline test pre/post mes changements (identique).
- `any` dans `frontend/src/components/hub/__tests__/CallModeFullBleed.test.tsx` ligne 6 (verbatim du plan, trivial à fixer plus tard).

## Décisions design qui ont guidé la PR

- **Direction visuelle** : v2 indigo (Editorial Thread + emprunts ciblés Voice-first et Ambient) — palette indigo `#6366f1` / violet `#8b5cf6` / cyan `#06b6d4`, glassmorphism uniquement sur surfaces flottantes (drawer, sheets, PiP), pas sur les bulles.
- **Voice = mode parmi d'autres** : pas de takeover full-screen, Full Call en bottom-sheet 90vh qui laisse voir un peu du contexte derrière (backdrop blur).
- **Timeline unifiée** : 4 types de bulles (tu/IA × text/voice) dans la même timeline chronologique via `timestamp`. Plus de séparation visuelle voice/texte au niveau conversation — juste icônes + style des bulles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)