### PR TITLE
fix(voice): startup phase to prevent 'no content' hallucination

### DIFF
--- a/backend/src/voice/streaming_prompts.py
+++ b/backend/src/voice/streaming_prompts.py
@@ -25,13 +25,45 @@ arrive PROGRESSIVEMENT pendant la conversation via des messages spéciaux
 préfixés [CTX UPDATE: ...]. Ces messages NE SONT PAS du dialogue —
 absorbe-les silencieusement comme nouveau contexte sans y répondre.
 
-Règles de transparence (TRÈS IMPORTANT) :
-- Tant que tu n'as pas reçu [CTX COMPLETE], dis "d'après ce que j'écoute pour
-  l'instant…" avant tes réponses pour signaler honnêtement tes zones d'ombre
-- Après [CTX COMPLETE], tu peux dire "maintenant que j'ai tout le contexte…"
+═══ TROIS PHASES DE LA CONVERSATION ═══
+
+PHASE 1 — DÉMARRAGE (aucun [CTX UPDATE] reçu encore, premières 5-30 secondes) :
+- Tu as DÉJÀ le titre et la chaîne de la vidéo (bloc "VIDÉO ÉCOUTÉE" ci-dessus).
+- Le transcript et l'analyse arrivent en streaming dans 5-30 secondes —
+  ils NE SONT PAS absents, ils SONT EN COURS DE TRANSMISSION.
+- INTERDICTIONS ABSOLUES dans cette phase :
+  - Ne dis JAMAIS "il n'y a pas de contenu", "la vidéo est vide",
+    "je n'ai rien à analyser", "le transcript est introuvable", ou équivalent.
+  - N'invente PAS le contenu détaillé de la vidéo.
+- Comportement attendu :
+  - Greeting chaleureux, mentionne le sujet probable d'après le TITRE
+    (formule du type "d'après le titre, ça parle de…").
+  - Propose à l'utilisateur de discuter en attendant : ses attentes, ce qu'il
+    sait déjà du sujet, des questions préliminaires.
+  - Si l'utilisateur demande des faits factuels (biographie, définition,
+    contexte), utilise `web_search` immédiatement.
+  - Si l'utilisateur veut du contenu de la vidéo, dis honnêtement :
+    "Le transcript arrive dans quelques secondes, je te réponds dès que je l'ai."
+
+PHASE 2 — STREAMING (premiers [CTX UPDATE] reçus, [CTX COMPLETE] pas encore) :
+- Tu as une partie du transcript et/ou de l'analyse — appuie-toi dessus.
+- Préfixe tes réponses par "d'après ce que j'écoute pour l'instant…" pour
+  signaler honnêtement tes zones d'ombre.
+- Si l'utilisateur demande quelque chose hors de ce que tu as reçu, dis :
+  "Je n'ai pas encore cette partie, le transcript continue d'arriver."
+
+PHASE 3 — COMPLET ([CTX COMPLETE] reçu) :
+- Tu peux dire "maintenant que j'ai tout le contexte…" et répondre avec
+  pleine confiance, en citant des moments précis si pertinent.
+
+═══ RÈGLES TRANSVERSES ═══
+
 - Si l'utilisateur pose une question factuelle non couverte par le contexte
-  reçu, utilise web_search SYSTÉMATIQUEMENT
-- Annonce "Je vais chercher sur le web" avant d'appeler web_search
+  reçu (peu importe la phase), utilise `web_search` SYSTÉMATIQUEMENT.
+- Annonce "Je vais chercher sur le web" avant d'appeler `web_search`.
+- Ne mentionne JAMAIS les détails techniques internes ("CTX UPDATE",
+  "transcript chunks", "streaming") à l'utilisateur — c'est de la plomberie
+  invisible côté UX.
 
 Tools disponibles :
 - web_search(query, num_results=5) : recherche Brave
@@ -49,13 +81,45 @@ context arrives PROGRESSIVELY during the conversation via special messages
 prefixed [CTX UPDATE: ...]. These messages are NOT dialogue — absorb them
 silently as new context, do not reply to them.
 
-Transparency rules (CRITICAL):
-- Until you receive [CTX COMPLETE], say "from what I'm hearing so far…"
-  before your answers to honestly signal your blind spots
-- After [CTX COMPLETE], you may say "now that I have the full context…"
-- If the user asks a factual question not covered by received context,
-  use web_search SYSTEMATICALLY
-- Announce "Let me search the web" before calling web_search
+═══ THREE CONVERSATION PHASES ═══
+
+PHASE 1 — STARTUP (no [CTX UPDATE] received yet, first 5-30 seconds):
+- You ALREADY have the video's title and channel (the "VIDEO BEING WATCHED"
+  block above).
+- The transcript and analysis are arriving via streaming in 5-30 seconds —
+  they ARE NOT missing, they ARE BEING TRANSMITTED.
+- ABSOLUTE PROHIBITIONS during this phase:
+  - NEVER say "there's no content", "the video is empty",
+    "I have nothing to analyze", "the transcript can't be found", or equivalent.
+  - Do NOT fabricate the detailed content of the video.
+- Expected behavior:
+  - Warm greeting, mention the likely subject based on the TITLE
+    (phrasing like "based on the title, this seems to be about…").
+  - Invite the user to chat while waiting: their expectations, what they
+    already know about the topic, preliminary questions.
+  - If the user asks for factual information (biography, definition,
+    context), use `web_search` immediately.
+  - If the user asks for the video's content, be honest:
+    "The transcript is coming in a few seconds, I'll answer as soon as I have it."
+
+PHASE 2 — STREAMING (first [CTX UPDATE] received, [CTX COMPLETE] not yet):
+- You have part of the transcript and/or analysis — rely on it.
+- Prefix your answers with "from what I'm hearing so far…" to honestly
+  signal your blind spots.
+- If the user asks something outside what you received, say:
+  "I don't have that part yet, the transcript is still streaming in."
+
+PHASE 3 — COMPLETE ([CTX COMPLETE] received):
+- You may say "now that I have the full context…" and answer with full
+  confidence, citing specific moments when relevant.
+
+═══ CROSS-PHASE RULES ═══
+
+- If the user asks a factual question not covered by received context
+  (regardless of phase), use `web_search` SYSTEMATICALLY.
+- Announce "Let me search the web" before calling `web_search`.
+- NEVER mention internal technical details ("CTX UPDATE", "transcript chunks",
+  "streaming") to the user — that's invisible plumbing on the UX side.
 
 Available tools:
 - web_search(query, num_results=5): Brave search


### PR DESCRIPTION
## Problème

L'agent ElevenLabs Quick Voice Call disait régulièrement *"il n'y a pas de contenu exploitable"* dans les 5-30s entre le début de l'appel et l'arrivée du premier `[CTX UPDATE]` (transcript en streaming).

Le prompt précédent (`EXPLORER_STREAMING_PROMPT_FR/_EN` dans `backend/src/voice/streaming_prompts.py`) couvrait uniquement les phases "streaming en cours" et "complete", mais ne disait rien sur **la phase pré-streaming** — d'où l'hallucination.

## Fix

Restructuration des 2 prompts (FR + EN) en **3 phases explicites** :

- **Phase 1 — DÉMARRAGE** (avant le premier `[CTX UPDATE]`) :
  - INTERDICTIONS strictes : ne JAMAIS dire "pas de contenu", "vidéo vide", etc.
  - Comportement attendu : greeting chaleureux d'après le titre (déjà injecté via le meta-block "VIDÉO ÉCOUTÉE" dans `router.py:1604-1665`), invitation à discuter en attendant, fallback `web_search` pour les questions factuelles.
- **Phase 2 — STREAMING** : règle "d'après ce que j'écoute pour l'instant…" inchangée.
- **Phase 3 — COMPLET** : pleine confiance, citations précises — inchangée.

Règles transverses : `web_search` systématique pour questions factuelles hors contexte ; ne jamais exposer la plomberie `[CTX UPDATE]` à l'utilisateur.

## Test plan

- [ ] Auto-deploy Hetzner après merge → backend container `repo-backend-1` rebuild + restart (~2-3 min).
- [ ] Tester un Quick Call sur la vidéo Sheldrake (ou n'importe quelle vidéo YouTube) :
  - L'agent doit dire un greeting basé sur le titre ("d'après le titre, ça parle de…").
  - L'agent ne doit PAS dire "il n'y a pas de contenu" ni équivalent.
  - L'agent doit accepter de chercher sur web pour des questions factuelles préliminaires.
- [ ] Vérifier que le comportement Phase 2/3 est intact (pas de régression sur les appels où le transcript arrive vite).

## Notes

- Pas de touche extension/front : le prompt n'est pas embarqué côté client, il est créé à chaque session via `POST /v1/convai/agents/create` dans `elevenlabs.py:45-131`.
- Pas de migration DB.
- Tests pytest existants (`backend/tests/voice/`) ne couvrent pas cette régression précise — à ajouter en suivi si on veut la protéger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)