### PR TITLE
feat(hub): hydrate real summary via videoApi.getSummary

### DIFF
--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -196,6 +196,7 @@ const HubPage: React.FC = () => {
         const convs = useHubStore.getState().conversations;
         const conv = convs.find((c) => c.id === activeConvId);
         if (conv && conv.summary_id !== null) {
+          // Set minimal context immediately for fast UI
           setSummaryContext({
             summary_id: conv.summary_id,
             video_title: conv.title,
@@ -206,6 +207,25 @@ const HubPage: React.FC = () => {
             short_summary: conv.last_snippet ?? "",
             citations: [],
           });
+          // Hydrate with real summary content (async, fire-and-forget)
+          videoApi
+            .getSummary(conv.summary_id)
+            .then((s) => {
+              if (cancelled) return;
+              setSummaryContext({
+                summary_id: s.id,
+                video_title: s.video_title,
+                video_channel: s.video_channel ?? "",
+                video_duration_secs: s.video_duration ?? 0,
+                video_source: s.platform === "tiktok" ? "tiktok" : "youtube",
+                video_thumbnail_url: s.thumbnail_url ?? null,
+                short_summary: s.summary_content ?? "",
+                citations: [],
+              });
+            })
+            .catch((err) => {
+              console.warn("[HubPage] fetch full summary failed:", err);
+            });
         }
       } catch (err) {
         console.error("[HubPage] fetch messages failed:", err);


### PR DESCRIPTION
Hub /hub affiche maintenant le **vrai contenu** du résumé vidéo (via videoApi.getSummary) au lieu de la coquille vide précédente.

Pattern: minimal context immédiat (UI rapide) → puis fetch async non bloquant qui hydrate summaryContext avec summary_content, video_channel, video_duration, thumbnail_url réels.

🤖 Fondation #1 demandée par Maxime pour la refonte UX hub. Les autres items (modal Nouvelle conversation, refonte page accueil) sont gérés par la session 'merge hub' en parallèle.