### PR TITLE
feat(hub): hub-first navigation — converge post-analyse + open-analysis vers /hub

### DIFF
--- a/frontend/e2e/hub-first-navigation.spec.ts
+++ b/frontend/e2e/hub-first-navigation.spec.ts
@@ -1,0 +1,102 @@
+// frontend/e2e/hub-first-navigation.spec.ts
+//
+// Hub-first navigation : vérifie que les chemins post-analyse / open-analysis
+// convergent vers `/hub`, et que le paramètre `?open_summary=1` rend le bloc
+// résumé déroulé d'emblée.
+//
+// Les 3 scenarios ci-dessous reposent sur l'existence d'au moins une analyse
+// pour le test user. Sans ça, ils sont marqués `skipped` plutôt qu'échec —
+// fidèle au pattern de `hub-unified.spec.ts`.
+
+import { test, expect } from "@playwright/test";
+
+const TEST_USER = {
+  email: process.env.E2E_USER ?? "e2e@deepsight.test",
+  password: process.env.E2E_PASS ?? "test1234",
+};
+
+async function login(page: import("@playwright/test").Page) {
+  await page.goto("/login");
+  await page.fill('input[type="email"]', TEST_USER.email);
+  await page.fill('input[type="password"]', TEST_USER.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/dashboard/);
+}
+
+/**
+ * Récupère l'id de la première analyse disponible via le drawer du hub.
+ * Retourne `null` si le test user n'a aucune conversation.
+ */
+async function pickFirstSummaryId(
+  page: import("@playwright/test").Page,
+): Promise<number | null> {
+  await page.goto("/hub");
+  await page.click('button[aria-label="Conversations"]');
+  const firstConv = page.locator("aside button[data-conv-id]").first();
+  if (!(await firstConv.isVisible())) return null;
+  const raw = await firstConv.getAttribute("data-conv-id");
+  return raw ? Number(raw) : null;
+}
+
+test.describe("Hub-first navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("?open_summary=1 renders the summary already expanded", async ({
+    page,
+  }) => {
+    const summaryId = await pickFirstSummaryId(page);
+    if (summaryId === null) {
+      test.skip(true, "test user has no analyses");
+      return;
+    }
+
+    await page.goto(`/hub?summary=${summaryId}&open_summary=1`);
+
+    // The "RÉSUMÉ" pill is always present, but the citations row only shows
+    // when the panel is in the open state.
+    await expect(page.getByText("RÉSUMÉ")).toBeVisible();
+    // Citations are timestamps formatted MM:SS — at least one MM:SS pill
+    // visible is the open-state proof.
+    await expect(page.locator("text=/^\\d{2}:\\d{2}$/").first()).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("?summary=ID without open_summary keeps the summary collapsed", async ({
+    page,
+  }) => {
+    const summaryId = await pickFirstSummaryId(page);
+    if (summaryId === null) {
+      test.skip(true, "test user has no analyses");
+      return;
+    }
+
+    await page.goto(`/hub?summary=${summaryId}`);
+    await expect(page.getByText("RÉSUMÉ")).toBeVisible();
+    // Citations should NOT be visible when collapsed.
+    await expect(page.locator("text=/^\\d{2}:\\d{2}$/").first()).toBeHidden();
+  });
+
+  test("Dashboard recent-analyses click lands on /hub with summary param", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+
+    // The "Recent Analyses" section renders cards that call onOpenAnalysis on
+    // click. We pick the first available card by data-summary-id; if none,
+    // the test user has no recent analyses and we skip.
+    const card = page.locator("[data-recent-analysis-id]").first();
+    if (!(await card.isVisible())) {
+      test.skip(true, "no recent analyses for test user");
+      return;
+    }
+    const expectedId = await card.getAttribute("data-recent-analysis-id");
+    await card.click();
+
+    await expect(page).toHaveURL(
+      new RegExp(`/hub\\?summary=${expectedId ?? "\\d+"}`),
+    );
+  });
+});

--- a/frontend/src/components/hub/SummaryCollapsible.tsx
+++ b/frontend/src/components/hub/SummaryCollapsible.tsx
@@ -1,5 +1,5 @@
 // frontend/src/components/hub/SummaryCollapsible.tsx
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronDown } from "lucide-react";
 import type { HubSummaryContext } from "./types";
@@ -7,6 +7,12 @@ import type { HubSummaryContext } from "./types";
 interface Props {
   context: HubSummaryContext;
   onCitationClick?: (timestampSecs: number) => void;
+  /**
+   * Hub-first : si `true`, le bloc résumé est rendu déjà déroulé et son wrapper
+   * est centré à l'écran via `scrollIntoView` au mount. Utilisé quand l'URL
+   * porte `?open_summary=1` (ex : redirect post-analyse).
+   */
+  defaultOpen?: boolean;
 }
 
 const formatTs = (s: number) => {
@@ -63,8 +69,10 @@ const parseInlineCitations = (text: string): ParsedSegment[] => {
 export const SummaryCollapsible: React.FC<Props> = ({
   context,
   onCitationClick,
+  defaultOpen = false,
 }) => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(defaultOpen);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   /** Segments parsés à partir de `short_summary` : timecodes inline → pills. */
   const segments = useMemo(
@@ -73,8 +81,22 @@ export const SummaryCollapsible: React.FC<Props> = ({
   );
   const hasInlineCits = segments.some((s) => s.type === "cit");
 
+  // Hub-first : quand on arrive avec `?open_summary=1`, scroller le bloc résumé
+  // au centre de l'écran après mount (le panneau est déjà déroulé via
+  // `useState(defaultOpen)`). On ne le fait qu'une fois.
+  useEffect(() => {
+    if (!defaultOpen) return;
+    const node = wrapperRef.current;
+    if (!node || typeof node.scrollIntoView !== "function") return;
+    node.scrollIntoView({ block: "center", behavior: "smooth" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <div className="mx-4 my-3 px-4 py-3 bg-white/[0.04] border border-white/10 rounded-[14px]">
+    <div
+      ref={wrapperRef}
+      className="mx-4 my-3 px-4 py-3 bg-white/[0.04] border border-white/10 rounded-[14px]"
+    >
       <button
         type="button"
         aria-label="Résumé"

--- a/frontend/src/components/hub/__tests__/SummaryCollapsible.test.tsx
+++ b/frontend/src/components/hub/__tests__/SummaryCollapsible.test.tsx
@@ -40,4 +40,38 @@ describe("SummaryCollapsible", () => {
     fireEvent.click(screen.getByText("02:14"));
     expect(onCitationClick).toHaveBeenCalledWith(134);
   });
+
+  it("renders the citations panel already open when defaultOpen is true", () => {
+    render(<SummaryCollapsible context={ctx} defaultOpen />);
+    // Citations are only rendered while the panel is expanded — finding them
+    // proves the panel mounted in the open state.
+    expect(screen.getByText("02:14")).toBeInTheDocument();
+    expect(screen.getByText("07:48")).toBeInTheDocument();
+  });
+
+  it("calls scrollIntoView at mount when defaultOpen is true", () => {
+    const scrollSpy = vi.fn();
+    // jsdom does not implement scrollIntoView; install a stub before render.
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      value: scrollSpy,
+      configurable: true,
+      writable: true,
+    });
+    render(<SummaryCollapsible context={ctx} defaultOpen />);
+    expect(scrollSpy).toHaveBeenCalledWith({
+      block: "center",
+      behavior: "smooth",
+    });
+  });
+
+  it("does not call scrollIntoView when defaultOpen is false", () => {
+    const scrollSpy = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      value: scrollSpy,
+      configurable: true,
+      writable: true,
+    });
+    render(<SummaryCollapsible context={ctx} />);
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -410,8 +410,8 @@ export const DashboardPage: React.FC = () => {
       const response = await videoApi.quickChat(chatUrl, language);
 
       if (response.summary_id) {
-        // Naviguer directement vers le chat avec ce summary_id
-        navigate(`/chat?summary=${response.summary_id}`);
+        // Hub-first : ouvrir directement la conv dans le hub avec le résumé déroulé.
+        navigate(`/hub?summary=${response.summary_id}&open_summary=1`);
       }
     } catch (err: any) {
       setError(
@@ -1668,7 +1668,7 @@ export const DashboardPage: React.FC = () => {
                     });
                   }}
                   onOpenAnalysis={(summaryId) => {
-                    navigate(`/history?open=${summaryId}`);
+                    navigate(`/hub?summary=${summaryId}`);
                   }}
                 />
               </div>

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -89,6 +89,10 @@ const HubPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const urlConvId = searchParams.get("conv");
   const urlSummaryId = searchParams.get("summary");
+  // Hub-first : `?open_summary=1` ouvre le bloc résumé déroulé d'emblée et
+  // scrolle le wrapper au centre. Utilisé après une analyse fraîche (Quick
+  // Chat) pour que l'utilisateur arrive directement sur le résumé.
+  const openSummaryFromUrl = searchParams.get("open_summary") === "1";
 
   const { language } = useTranslation();
   const { user: _user } = useAuth();
@@ -352,7 +356,12 @@ const HubPage: React.FC = () => {
       />
 
       <div className="relative flex-1 flex flex-col overflow-hidden">
-        {summaryContext && <SummaryCollapsible context={summaryContext} />}
+        {summaryContext && (
+          <SummaryCollapsible
+            context={summaryContext}
+            defaultOpen={openSummaryFromUrl}
+          />
+        )}
         <Timeline messages={messages} isThinking={isThinking} />
         <InputBar
           onSend={handleSend}


### PR DESCRIPTION
## Contexte

Le hub conversationnel `/hub` (chat texte + voice call ElevenLabs + résumé inline + drawer + PiP) est mergé en prod depuis la PR #214 ; les routes legacy `/chat` et `/voice-call` redirigent déjà vers `/hub`.

Cette PR finit le chantier en faisant converger les 2 derniers chemins de navigation web vers le hub.

## Changements

### Nav post-analyse → `/hub` (Dashboard)

- `DashboardPage.tsx:412` : `navigate(\`/chat?summary=${response.summary_id}\`)` perdait le param via le redirect `/chat → /hub`. Désormais `navigate(\`/hub?summary=X&open_summary=1\`)` direct, ce qui ouvre la conv active avec le résumé déroulé et centré à l'écran.
- `DashboardPage.tsx:1671` : `navigate(\`/history?open=X\`)` (RecentAnalysesSection) → `navigate(\`/hub?summary=X\`)`.
- Le panel inline de **History.tsx** reste conservé (choix explicite : les utilisateurs arrivant directement sur `/history` voient toujours leur panel side-by-side `selectedVideoDetail`).

### `SummaryCollapsible` : prop `defaultOpen` + scrollIntoView

- Nouvelle prop optionnelle `defaultOpen?: boolean` (default `false`). Quand `true`, le bloc résumé monte déjà déroulé.
- Le wrapper appelle `scrollIntoView({ block: 'center', behavior: 'smooth' })` au mount uniquement quand `defaultOpen=true`.

### `HubPage` : lit `?open_summary=1`

- Lit `searchParams.get('open_summary') === '1'` et passe à `<SummaryCollapsible defaultOpen={...} />`. Le param `summary` était déjà supporté pour auto-sélection de la conversation, on ne touche pas à cette logique.

## Hors scope (signalé)

- **Cards vidéos sans Voice/Flashcards/Quiz** : aucun bouton de ce type n'existe sur les cards web actuelles (`VirtualHistoryList`, `VideoDiscoveryModal`, `RecentAnalysesSection`). Le brief original confondait sans doute avec mobile ou extension.
- **8 navigations résiduelles `/dashboard?id=X`** dans `LoadingWord`, `NotificationBell`, `SidebarInsight`, `DidYouKnowCard`, `WhackAMole/FactRevealCard`, `StudyPage`, `DashboardInsight` : continuent de pointer vers le panel inline du Dashboard. À traiter en PR séparée si souhaité.

## Vérifications

- [x] `npx vitest run src/components/hub/` → 10 fichiers, **33 tests verts** (3 nouveaux pour `defaultOpen` + `scrollIntoView`).
- [x] `npx tsc --noEmit -p tsconfig.app.json` → **zéro nouvelle erreur dans le scope** (DashboardPage 414/1671, HubPage, SummaryCollapsible, e2e/hub-first-navigation). Les erreurs visibles sont du tech-debt pré-existant sur main (History/Playlist/Study/api.ts).
- [ ] Validation visuelle preview Vercel par Maxime — preview auto-build sur cette PR.

## Test plan

- [ ] Quick Chat sur Dashboard → atterrit sur `/hub?summary=X&open_summary=1` avec le bloc RÉSUMÉ déjà déroulé et centré
- [ ] Click sur une recent analysis (Dashboard) → atterrit sur `/hub?summary=X` avec le bloc RÉSUMÉ fermé (et clickable pour dérouler)
- [ ] `/history` direct → panel inline préservé
- [ ] Pas de régression sur le hub existant (drawer, voice call, sources shelf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)