### PR TITLE
feat(hub): SummaryCollapsible v2 — thumbnail + meta + markdown content

### DIFF
--- a/frontend/src/components/hub/SummaryCollapsible.tsx
+++ b/frontend/src/components/hub/SummaryCollapsible.tsx
@@ -2,6 +2,8 @@
 import React, { useState, useMemo, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronDown } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import type { HubSummaryContext } from "./types";
 
 interface Props {
@@ -15,10 +17,20 @@ interface Props {
   defaultOpen?: boolean;
 }
 
-const formatTs = (s: number) => {
+const formatTs = (s: number): string => {
   const m = Math.floor(s / 60);
   const sec = Math.floor(s % 60);
   return `${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+};
+
+/** Format une durée en secondes en `MM:SS` ou `HH:MM:SS` selon la longueur. */
+const formatDuration = (totalSecs: number): string => {
+  if (!Number.isFinite(totalSecs) || totalSecs <= 0) return "";
+  const h = Math.floor(totalSecs / 3600);
+  const m = Math.floor((totalSecs % 3600) / 60);
+  const s = Math.floor(totalSecs % 60);
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
 };
 
 /** Parse `MM:SS` ou `HH:MM:SS` en secondes. Retourne null si format invalide. */
@@ -66,6 +78,53 @@ const parseInlineCitations = (text: string): ParsedSegment[] => {
   return segments;
 };
 
+/**
+ * Heuristique légère pour détecter si `short_summary` contient assez de syntaxe
+ * markdown (heading, bold, listes) pour valoir un rendu via ReactMarkdown.
+ * Si non → on retombe sur le parser inline (parseInlineCitations).
+ */
+const looksLikeMarkdown = (text: string): boolean => {
+  if (!text) return false;
+  // Heading ## ou ### en début de ligne
+  if (/(^|\n)#{1,3}\s/.test(text)) return true;
+  // Bold ** ou italique *
+  if (/\*\*[^*]+\*\*/.test(text)) return true;
+  // Liste - ou * en début de ligne
+  if (/(^|\n)[-*]\s/.test(text)) return true;
+  // Liste numérotée
+  if (/(^|\n)\d+\.\s/.test(text)) return true;
+  // Lien markdown [text](url)
+  if (/\[[^\]]+\]\([^)]+\)/.test(text)) return true;
+  return false;
+};
+
+/**
+ * Composant pill cyan affichant un timestamp cliquable. Utilisé à la fois pour
+ * les liens markdown `[02:14](#)` et pour les citations inline `[02:14]` du
+ * fallback non-markdown.
+ */
+interface CitationPillProps {
+  secs: number;
+  label?: string;
+  onClick?: (secs: number) => void;
+}
+const CitationPill: React.FC<CitationPillProps> = ({
+  secs,
+  label,
+  onClick,
+}) => (
+  <button
+    type="button"
+    onClick={() => onClick?.(secs)}
+    className="inline-flex font-mono text-[10px] px-1.5 py-[1px] mx-0.5 rounded-[3px] bg-cyan-500/10 text-cyan-300 hover:bg-cyan-500/20 transition-colors align-baseline no-underline"
+  >
+    {formatTs(secs)}
+    {label ? (
+      <span className="ml-1 text-white/55 normal-case">{label}</span>
+    ) : null}
+  </button>
+);
+
 export const SummaryCollapsible: React.FC<Props> = ({
   context,
   onCitationClick,
@@ -74,12 +133,19 @@ export const SummaryCollapsible: React.FC<Props> = ({
   const [open, setOpen] = useState(defaultOpen);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
+  const duration = formatDuration(context.video_duration_secs);
+  const metaLine = [context.video_channel, duration].filter(Boolean).join(" · ");
+
   /** Segments parsés à partir de `short_summary` : timecodes inline → pills. */
   const segments = useMemo(
     () => parseInlineCitations(context.short_summary),
     [context.short_summary],
   );
   const hasInlineCits = segments.some((s) => s.type === "cit");
+  const useMarkdown = useMemo(
+    () => looksLikeMarkdown(context.short_summary),
+    [context.short_summary],
+  );
 
   // Hub-first : quand on arrive avec `?open_summary=1`, scroller le bloc résumé
   // au centre de l'écran après mount (le panneau est déjà déroulé via
@@ -92,6 +158,142 @@ export const SummaryCollapsible: React.FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  /**
+   * Components overrides pour ReactMarkdown — convertit les liens markdown
+   * dont le texte ressemble à un timecode (`[02:14](#)`) en pills cyan
+   * cliquables. Les autres liens restent rendus normalement.
+   */
+  const markdownComponents = useMemo(
+    () => ({
+      a: ({
+        href,
+        children,
+      }: {
+        href?: string;
+        children?: React.ReactNode;
+      }) => {
+        const txt = React.Children.toArray(children).join("");
+        const secs = typeof txt === "string" ? parseTimecodeToSecs(txt) : null;
+        if (secs !== null) {
+          return <CitationPill secs={secs} onClick={onCitationClick} />;
+        }
+        return (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-cyan-300 hover:text-cyan-200 underline"
+          >
+            {children}
+          </a>
+        );
+      },
+      h2: ({ children }: { children?: React.ReactNode }) => (
+        <h2 className="text-base font-semibold text-white mt-3 mb-2">
+          {children}
+        </h2>
+      ),
+      h3: ({ children }: { children?: React.ReactNode }) => (
+        <h3 className="text-sm font-semibold text-white/90 mt-2.5 mb-1.5">
+          {children}
+        </h3>
+      ),
+      p: ({ children }: { children?: React.ReactNode }) => (
+        <p className="mb-2 text-sm text-white/75 leading-[1.55]">{children}</p>
+      ),
+      strong: ({ children }: { children?: React.ReactNode }) => (
+        <strong className="text-white font-semibold">{children}</strong>
+      ),
+      em: ({ children }: { children?: React.ReactNode }) => (
+        <em className="text-white/85 italic">{children}</em>
+      ),
+      ul: ({ children }: { children?: React.ReactNode }) => (
+        <ul className="list-disc pl-5 mb-2 space-y-1 text-sm text-white/75">
+          {children}
+        </ul>
+      ),
+      ol: ({ children }: { children?: React.ReactNode }) => (
+        <ol className="list-decimal pl-5 mb-2 space-y-1 text-sm text-white/75">
+          {children}
+        </ol>
+      ),
+      li: ({ children }: { children?: React.ReactNode }) => (
+        <li className="text-sm text-white/75 leading-[1.55]">{children}</li>
+      ),
+    }),
+    [onCitationClick],
+  );
+
+  const renderExpandedBody = (): React.ReactNode => {
+    if (!context.short_summary || context.short_summary.trim().length === 0) {
+      return (
+        <p className="italic text-white/45 text-sm">
+          Résumé en cours de chargement…
+        </p>
+      );
+    }
+
+    if (useMarkdown) {
+      return (
+        <>
+          <div className="text-sm text-white/75 leading-[1.55]">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={markdownComponents}
+            >
+              {context.short_summary}
+            </ReactMarkdown>
+          </div>
+          {context.citations.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {context.citations.map((c, i) => (
+                <CitationPill
+                  key={`cit-${i}`}
+                  secs={c.ts}
+                  label={c.label}
+                  onClick={onCitationClick}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      );
+    }
+
+    // Fallback non-markdown : parsing inline timecodes [MM:SS] / (MM:SS) → pills
+    return (
+      <>
+        <p className="mb-2 text-sm text-white/75 leading-[1.55]">
+          {hasInlineCits
+            ? segments.map((seg, i) =>
+                seg.type === "cit" && typeof seg.secs === "number" ? (
+                  <CitationPill
+                    key={`cit-${i}`}
+                    secs={seg.secs}
+                    onClick={onCitationClick}
+                  />
+                ) : (
+                  <React.Fragment key={`txt-${i}`}>{seg.value}</React.Fragment>
+                ),
+              )
+            : context.short_summary}
+        </p>
+        {!hasInlineCits && context.citations.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {context.citations.map((c, i) => (
+              <CitationPill
+                key={`cit-${i}`}
+                secs={c.ts}
+                label={c.label}
+                onClick={onCitationClick}
+              />
+            ))}
+          </div>
+        )}
+      </>
+    );
+  };
+
   return (
     <div
       ref={wrapperRef}
@@ -103,16 +305,40 @@ export const SummaryCollapsible: React.FC<Props> = ({
         onClick={() => setOpen((o) => !o)}
         className="w-full flex items-center gap-3 text-left"
       >
-        <span className="font-mono text-[10px] tracking-[.12em] px-2 py-[3px] rounded bg-indigo-500/15 text-indigo-400">
-          RÉSUMÉ
-        </span>
-        <span className="flex-1 text-sm font-medium text-white/85 truncate">
-          {context.short_summary}
-        </span>
+        {/* Thumbnail miniature 40x40, fallback gradient indigo→violet si null */}
+        {context.video_thumbnail_url ? (
+          <img
+            src={context.video_thumbnail_url}
+            alt={context.video_title}
+            className="w-10 h-10 rounded-lg object-cover flex-shrink-0 border border-white/10"
+          />
+        ) : (
+          <div
+            aria-hidden="true"
+            className="w-10 h-10 rounded-lg flex-shrink-0 border border-white/10 bg-gradient-to-br from-indigo-500/40 to-violet-500/40"
+          />
+        )}
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className="font-mono text-[10px] tracking-[.12em] px-2 py-[3px] rounded bg-indigo-500/15 text-indigo-400">
+              RÉSUMÉ
+            </span>
+            {metaLine && (
+              <span className="font-mono text-[10px] text-white/35 truncate">
+                {metaLine}
+              </span>
+            )}
+          </div>
+          <p className="text-sm font-medium text-white/85 truncate">
+            {context.short_summary || context.video_title}
+          </p>
+        </div>
+
         <motion.span
           animate={{ rotate: open ? 180 : 0 }}
           transition={{ duration: 0.2 }}
-          className="text-white/45"
+          className="text-white/45 flex-shrink-0"
         >
           <ChevronDown className="w-3.5 h-3.5" />
         </motion.span>
@@ -127,45 +353,7 @@ export const SummaryCollapsible: React.FC<Props> = ({
             transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
             className="overflow-hidden"
           >
-            <div className="pt-3 text-sm text-white/65 leading-[1.55]">
-              <p className="mb-2">
-                {hasInlineCits
-                  ? segments.map((seg, i) =>
-                      seg.type === "cit" && typeof seg.secs === "number" ? (
-                        <button
-                          key={`cit-${i}`}
-                          type="button"
-                          onClick={() => onCitationClick?.(seg.secs as number)}
-                          className="inline-flex font-mono text-[10px] px-1.5 py-[1px] mx-0.5 rounded-[3px] bg-cyan-500/10 text-cyan-300 hover:bg-cyan-500/20 transition-colors align-baseline"
-                        >
-                          {seg.value}
-                        </button>
-                      ) : (
-                        <React.Fragment key={`txt-${i}`}>
-                          {seg.value}
-                        </React.Fragment>
-                      ),
-                    )
-                  : context.short_summary}
-              </p>
-              {!hasInlineCits && context.citations.length > 0 && (
-                <div className="flex flex-wrap gap-1.5">
-                  {context.citations.map((c, i) => (
-                    <button
-                      key={i}
-                      type="button"
-                      onClick={() => onCitationClick?.(c.ts)}
-                      className="font-mono text-[10px] px-1.5 py-[1px] rounded-[3px] bg-cyan-500/10 text-cyan-300 hover:bg-cyan-500/20 transition-colors"
-                    >
-                      {formatTs(c.ts)}
-                      <span className="ml-1 text-white/55 normal-case">
-                        {c.label}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            <div className="pt-3">{renderExpandedBody()}</div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/components/hub/__tests__/SummaryCollapsible.test.tsx
+++ b/frontend/src/components/hub/__tests__/SummaryCollapsible.test.tsx
@@ -74,4 +74,85 @@ describe("SummaryCollapsible", () => {
     render(<SummaryCollapsible context={ctx} />);
     expect(scrollSpy).not.toHaveBeenCalled();
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // v2 visual additions: thumbnail + meta + markdown content
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it("renders thumbnail image when video_thumbnail_url is provided", () => {
+    const ctxWithThumb = {
+      ...ctx,
+      video_thumbnail_url: "https://example.com/thumb.jpg",
+    };
+    render(<SummaryCollapsible context={ctxWithThumb} />);
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", "https://example.com/thumb.jpg");
+    expect(img).toHaveAttribute("alt", expect.stringMatching(/lex fridman/i));
+  });
+
+  it("renders fallback gradient when video_thumbnail_url is null", () => {
+    render(<SummaryCollapsible context={ctx} />);
+    // No <img> in the collapsed header, just the gradient placeholder div.
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("renders channel and formatted duration in collapsed meta", () => {
+    // 1112 secs = 18:32
+    render(<SummaryCollapsible context={ctx} />);
+    expect(
+      screen.getByText((content) => /lex.*18:32/i.test(content)),
+    ).toBeInTheDocument();
+  });
+
+  it("formats duration over 1 hour as HH:MM:SS", () => {
+    const longCtx = { ...ctx, video_duration_secs: 8580 }; // 2:23:00
+    render(<SummaryCollapsible context={longCtx} />);
+    expect(
+      screen.getByText((content) => /2:23:00/.test(content)),
+    ).toBeInTheDocument();
+  });
+
+  it("renders markdown content when expanded with markdown short_summary", () => {
+    const mdCtx = {
+      ...ctx,
+      short_summary:
+        "## Section\n\nContenu **important** ici. [02:14](#) suivi.",
+      citations: [],
+    };
+    render(<SummaryCollapsible context={mdCtx} />);
+    fireEvent.click(screen.getByRole("button", { name: /résumé/i }));
+    expect(
+      screen.getByRole("heading", { level: 2, name: /section/i }),
+    ).toBeInTheDocument();
+    // "important" apparaît à la fois dans le texte normal et dans le bold ;
+    // on cible précisément l'élément STRONG via une fonction de matcher.
+    const strong = screen.getByText(
+      (_, el) => el?.tagName === "STRONG" && /important/i.test(el.textContent ?? ""),
+    );
+    expect(strong.tagName).toBe("STRONG");
+  });
+
+  it("renders timestamp markdown links as clickable citation pills", () => {
+    const onCitationClick = vi.fn();
+    const mdCtx = {
+      ...ctx,
+      short_summary: "Voir [02:14](#) pour le détail.",
+      citations: [],
+    };
+    render(
+      <SummaryCollapsible context={mdCtx} onCitationClick={onCitationClick} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /résumé/i }));
+    const pill = screen.getByRole("button", { name: /02:14/ });
+    fireEvent.click(pill);
+    expect(onCitationClick).toHaveBeenCalledWith(134);
+  });
+
+  it("shows a loading placeholder when short_summary is empty", () => {
+    const emptyCtx = { ...ctx, short_summary: "", citations: [] };
+    render(<SummaryCollapsible context={emptyCtx} defaultOpen />);
+    expect(
+      screen.getByText(/résumé en cours de chargement/i),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- **Thumbnail miniature 40x40** rounded-lg dans header collapsed (avec fallback gradient indigo→violet quand `video_thumbnail_url` null)
- **Meta inline mono** : `${video_channel} · ${duration}` (formatée HH:MM:SS au-delà d'1h, sinon MM:SS) à côté du badge `RÉSUMÉ`
- **Rendu markdown** du `short_summary` via `react-markdown` + `remark-gfm` quand le contenu contient de la syntaxe markdown (heading/bold/listes/liens) ; fallback parser inline timecode `[MM:SS]` conservé pour les résumés plain text
- **Liens timestamp markdown** `[02:14](#)` rendus en pills cyan cliquables (réutilise `onCitationClick`)
- **Loading placeholder** "Résumé en cours de chargement…" si `short_summary` vide
- **Préserve PR #222** : `defaultOpen` + `scrollIntoView({block:'center', behavior:'smooth'})` au mount

## Test plan

- [x] 6 tests existants (post-PR #222) toujours verts
- [x] 7 nouveaux tests : thumbnail render/fallback, meta channel+duration MM:SS et HH:MM:SS, markdown heading+bold, timestamp pill clickable, loading placeholder
- [x] Régression Hub complète : **40/40 tests verts** (était 33)
- [x] `npx tsc --noEmit` : 0 erreur
- [x] `react-markdown@^9.0.1` + `remark-gfm@^4.0.0` déjà présents dans package.json (utilisés par `EnrichedMarkdown`, `History.tsx`, etc.) — aucune nouvelle install
- [ ] Validation visuelle manuelle dans `/hub` (preview Vercel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)