### PR TITLE
feat(hub): migrate residual /dashboard?id=X navs to /hub

### DIFF
--- a/frontend/src/components/DashboardInsight.tsx
+++ b/frontend/src/components/DashboardInsight.tsx
@@ -49,7 +49,7 @@ export const DashboardInsight: React.FC = () => {
 
   const handleTermClick = useCallback(() => {
     if (currentWord?.source === "history" && currentWord?.summaryId) {
-      navigate(`/dashboard?id=${currentWord.summaryId}`);
+      navigate(`/hub?summary=${currentWord.summaryId}&open_summary=1`);
     }
   }, [currentWord, navigate]);
 

--- a/frontend/src/components/DidYouKnowCard.tsx
+++ b/frontend/src/components/DidYouKnowCard.tsx
@@ -84,7 +84,7 @@ export const DidYouKnowCard: React.FC = () => {
 
   const handleTermClick = useCallback(() => {
     if (displayedWord?.source === "history" && displayedWord?.summaryId) {
-      navigate(`/dashboard?id=${displayedWord.summaryId}`);
+      navigate(`/hub?summary=${displayedWord.summaryId}&open_summary=1`);
     }
   }, [displayedWord, navigate]);
 

--- a/frontend/src/components/LoadingWord.tsx
+++ b/frontend/src/components/LoadingWord.tsx
@@ -230,7 +230,7 @@ export const LoadingWordWidget: React.FC<LoadingWordProps> = ({
   // Navigation vers l'analyse source
   const handleTermClick = () => {
     if (isClickable && displayedWord.summaryId) {
-      navigate(`/dashboard?id=${displayedWord.summaryId}`);
+      navigate(`/hub?summary=${displayedWord.summaryId}&open_summary=1`);
     }
   };
 
@@ -411,7 +411,7 @@ export const LoadingWordCompact: React.FC<{ className?: string }> = ({
 
   const handleClick = () => {
     if (isClickable && currentWord.summaryId) {
-      navigate(`/dashboard?id=${currentWord.summaryId}`);
+      navigate(`/hub?summary=${currentWord.summaryId}&open_summary=1`);
     }
   };
 
@@ -628,7 +628,7 @@ export const LoadingWordGlobal: React.FC = () => {
 
   const handleClick = () => {
     if (isClickable && currentWord.summaryId) {
-      navigate(`/dashboard?id=${currentWord.summaryId}`);
+      navigate(`/hub?summary=${currentWord.summaryId}&open_summary=1`);
     }
   };
 

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -92,7 +92,7 @@ export function NotificationBell({
     if (notification.data?.action_url) {
       navigate(notification.data.action_url);
     } else if (notification.data?.summary_id) {
-      navigate(`/dashboard?id=${notification.data.summary_id}`);
+      navigate(`/hub?summary=${notification.data.summary_id}&open_summary=1`);
     }
     markAsRead(index);
     setIsOpen(false);

--- a/frontend/src/components/SidebarInsight.tsx
+++ b/frontend/src/components/SidebarInsight.tsx
@@ -57,7 +57,7 @@ export const SidebarInsight: React.FC<SidebarInsightProps> = ({
 
   const handleClick = useCallback(() => {
     if (localWord?.source === "history" && localWord?.summaryId) {
-      navigate(`/dashboard?id=${localWord.summaryId}`);
+      navigate(`/hub?summary=${localWord.summaryId}&open_summary=1`);
     } else if (localWord?.wikiUrl) {
       window.open(localWord.wikiUrl, "_blank", "noopener,noreferrer");
     }

--- a/frontend/src/components/WhackAMole/FactRevealCard.tsx
+++ b/frontend/src/components/WhackAMole/FactRevealCard.tsx
@@ -45,7 +45,7 @@ export const FactRevealCard: React.FC<FactRevealCardProps> = ({
 
   const handleTermClick = () => {
     if (isClickable) {
-      navigate(`/dashboard?id=${fact.summaryId}`);
+      navigate(`/hub?summary=${fact.summaryId}&open_summary=1`);
       onDismiss();
     }
   };

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -522,7 +522,9 @@ export const AnalyticsPage: React.FC = () => {
                 return (
                   <div
                     key={analysis.id}
-                    onClick={() => navigate(`/dashboard?id=${analysis.id}`)}
+                    onClick={() =>
+                      navigate(`/hub?summary=${analysis.id}&open_summary=1`)
+                    }
                     className="flex items-center gap-4 p-3 rounded-xl bg-bg-tertiary/50 hover:bg-bg-tertiary transition-all cursor-pointer group"
                   >
                     {/* Thumbnail */}

--- a/frontend/src/pages/PlaylistDetailPage.tsx
+++ b/frontend/src/pages/PlaylistDetailPage.tsx
@@ -1478,7 +1478,7 @@ export const PlaylistDetailPage: React.FC = () => {
                   playlistId={id!}
                   onClose={() => setSelectedVideoId(null)}
                   onOpenInDashboard={() =>
-                    navigate(`/dashboard?id=${selectedVideo.id}`)
+                    navigate(`/hub?summary=${selectedVideo.id}&open_summary=1`)
                   }
                   language={language}
                 />

--- a/frontend/src/pages/StudyPage.tsx
+++ b/frontend/src/pages/StudyPage.tsx
@@ -403,7 +403,10 @@ export const StudyPage: React.FC = () => {
   }, []);
 
   const handleBack = () => {
-    navigate(`/dashboard?id=${summaryId}`);
+    // Hub-first : retour vers la conv hub (pas le panel Dashboard).
+    // Pas de open_summary=1 — l'utilisateur connaît déjà l'analyse après
+    // une session de révision, on n'a pas besoin de dérouler le résumé.
+    navigate(`/hub?summary=${summaryId}`);
   };
 
   // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Contexte

Follow-up à #222 (hub-first navigation). Migre les **10 occurrences résiduelles** de \`navigate(\`/dashboard?id=X\`)\` vers le hub.

## Changements (10 navs, 9 fichiers)

### 9 sources "discovery" → \`/hub?summary=X&open_summary=1\` (résumé déroulé)

- \`DashboardInsight.tsx\`
- \`DidYouKnowCard.tsx\`
- \`LoadingWord.tsx\` (3 occurrences — lignes 233, 414, 631)
- \`NotificationBell.tsx\` (click sur notification d'analyse)
- \`SidebarInsight.tsx\`
- \`WhackAMole/FactRevealCard.tsx\`
- \`AnalyticsPage.tsx\` (analyses récentes click)
- \`PlaylistDetailPage.tsx\` (\`onOpenInDashboard\` prop — wording legacy, comportement mis à jour)

### 1 source "retour" → \`/hub?summary=X\` (sans open_summary=1)

- \`StudyPage.tsx\` \`handleBack\` : retour après session révision. L'utilisateur connaît déjà l'analyse, pas besoin de redérouler le résumé.

## Effet

- **Hub-first complet** : plus aucun composant interne ne pousse l'utilisateur vers le panel Dashboard via \`?id=X\`.
- Le panel Dashboard reste fonctionnel pour les utilisateurs arrivant directement par URL (\`/dashboard?id=X\` continue de fonctionner — c'est juste qu'on ne génère plus ce lien nulle part).

## Vérifications

- [x] \`npx tsc --noEmit -p tsconfig.app.json\` : zéro nouvelle erreur dans le scope (toutes les erreurs visibles sont du tech-debt pré-existant non touché : LoadingWord/NotificationBell/Playlist/Study).
- [x] \`grep -r \"navigate(\\`/dashboard?id=\"\` : **0 occurrence restante** dans \`frontend/src/\`.
- [x] Vitest : pas de régression sur les tests existants.

## Test plan

- [ ] Click sur un mot \"Le Saviez-Vous\" (DashboardInsight/SidebarInsight/DidYouKnow) → ouvre /hub avec résumé déroulé
- [ ] Click sur LoadingWord pendant un chargement → /hub résumé déroulé
- [ ] Click sur fact card (WhackAMole) → /hub résumé déroulé
- [ ] Click sur notification d'analyse → /hub résumé déroulé
- [ ] Click sur recent analysis dans /analytics → /hub résumé déroulé
- [ ] PlaylistDetailPage → bouton \"Ouvrir dans Dashboard\" → /hub résumé déroulé
- [ ] StudyPage → bouton retour après session → /hub avec résumé fermé (juste ouvrir la conv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)