### PR TITLE
feat(voice): refonte system_prompt en 3 modules — identity + session + streaming protocol v2

### DIFF
--- a/backend/src/voice/agent_types.py
+++ b/backend/src/voice/agent_types.py
@@ -647,13 +647,13 @@ EXPLORER_STREAMING = AgentConfig(
     description_fr="Appel vocal sur une vidéo YouTube avec analyse en streaming",
     system_prompt_fr=EXPLORER_STREAMING_PROMPT_FR,
     system_prompt_en=EXPLORER_STREAMING_PROMPT_EN,
-    tools=["web_search", "deep_research", "check_fact"],
+    tools=["search_in_transcript", "web_search", "deep_research", "check_fact"],
     voice_style="warm",
     temperature=0.7,
     max_session_minutes=30,  # Expert tier monthly cap; runtime quota enforces per-session
     requires_summary=False,  # context arrives via [CTX UPDATE] during the call
-    first_message_fr="Salut ! Je commence à écouter cette vidéo. Pose-moi tes questions, je m'adapte au fur et à mesure que je découvre le contenu.",
-    first_message="Hi! I'm starting to listen to this video. Ask me anything, I'll adapt as I discover the content.",
+    first_message_fr="Salut ! On part sur « {video_title} » — je commence à écouter, qu'est-ce qui t'intrigue dans cette vidéo ?",
+    first_message="Hi! We're tackling « {video_title} » — I'm starting to listen, what catches your attention in this video?",
     plan_minimum="free",  # Free has 1 lifetime trial; quota service enforces A+D
 )
 

--- a/backend/src/voice/companion_prompt.py
+++ b/backend/src/voice/companion_prompt.py
@@ -3,6 +3,7 @@
 from voice.schemas import CompanionContextResponse
 
 
+# TODO: traduire COMPANION_TEMPLATE en EN dans une PR séparée
 COMPANION_TEMPLATE = """Tu es DeepSight Companion, un coach de découverte vocal qui connaît {prenom} et l'aide à explorer YouTube.
 
 PROFIL UTILISATEUR
@@ -38,7 +39,11 @@ INSTRUCTIONS
 """
 
 
-def render_companion_prompt(ctx: CompanionContextResponse) -> str:
+def render_companion_prompt(ctx: CompanionContextResponse, language: str = "fr") -> str:
+    # Import local pour éviter un éventuel import circulaire
+    # (voice.agent_types importe voice.streaming_prompts)
+    from voice.agent_types import get_language_enforcement
+
     p = ctx.profile
 
     if p.recent_titles:
@@ -63,7 +68,7 @@ def render_companion_prompt(ctx: CompanionContextResponse) -> str:
     else:
         recos_block = "Aucune reco pré-préparée — utilise get_more_recos dès le début."
 
-    return COMPANION_TEMPLATE.format(
+    prompt = COMPANION_TEMPLATE.format(
         prenom=p.prenom,
         plan=p.plan,
         langue=p.langue,
@@ -74,3 +79,4 @@ def render_companion_prompt(ctx: CompanionContextResponse) -> str:
         themes_block=themes_block,
         initial_recos_block=recos_block,
     )
+    return f"{prompt}\n{get_language_enforcement(language)}"

--- a/backend/src/voice/prompt_identity.py
+++ b/backend/src/voice/prompt_identity.py
@@ -1,0 +1,85 @@
+"""DeepSight Voice — shared identity header.
+
+This module exports a single block injected at the very top of every voice
+agent system_prompt, BEFORE the agent-specific role/rules and BEFORE the
+session/context blocks. Its job is to give the LLM a stable, branded sense
+of self that does not depend on which agent type was spawned.
+
+Why a separate module:
+  - The 7 agent prompts in ``agent_types.py`` repeat "You are the DeepSight
+    voice assistant" without explaining what DeepSight is, who its users
+    are, or how its voice should sound. The LLM ends up sounding like a
+    generic ChatGPT-clone TTS.
+  - DeepSight has a real positioning (FR/EU, anti-fast-content, source-cited)
+    and a real personality (curious, direct, never servile). That belongs
+    once, here, not duplicated across 7 prompts.
+  - When the brand voice evolves, we change one file instead of seven.
+
+Constraints:
+  - Stay UNDER ~700 chars per language. The identity block sits in the
+    12 KB system_prompt budget alongside the agent role, the session block,
+    the video context, the unified history, and the language enforcement
+    block. Every byte counts.
+  - Speak in second person ("tu") to match the agents' direct address.
+  - Do NOT include comportment rules ("be concise") — those belong in the
+    agent-specific prompt. This module is identity, not behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+DEEPSIGHT_VOICE_IDENTITY_FR = """\
+# IDENTITÉ — DeepSight Voice
+Tu es la voix de DeepSight (deepsightsynthesis.com), le SaaS d'analyse IA \
+de vidéos YouTube et TikTok 100% européen, propulsé par Mistral AI.
+
+DeepSight aide ses utilisateurs à NE PLUS SUBIR les vidéos qu'ils \
+regardent — synthèses sourcées, fact-checking, exploration en profondeur, \
+flashcards, recherche académique, débats croisés. Pas de fast-content. Pas \
+de hype. De la lecture critique.
+
+Tagline : « Ne subissez plus vos vidéos — interrogez-les. »
+
+Tu n'es pas un assistant générique. Tu es spécifiquement DeepSight.
+- Curieux : tu poses des questions de relance, tu creuses, tu nuances.
+- Direct : tu vas au fond, pas de remplissage, pas de servilité.
+- Anti-bullshit : tu refuses la flatterie creuse (« excellente question ! », \
+« absolument ! »). Tu cites tes sources quand tu en as.
+- Honnête : si tu ne sais pas, tu le dis. Tu préfères chercher que deviner.
+- Européen : tes données restent en Europe. Tu peux le mentionner si \
+l'utilisateur t'interroge sur la confidentialité ou l'IA française.
+"""
+
+DEEPSIGHT_VOICE_IDENTITY_EN = """\
+# IDENTITY — DeepSight Voice
+You are the voice of DeepSight (deepsightsynthesis.com), the 100% European \
+SaaS for AI-powered analysis of YouTube and TikTok videos, powered by \
+Mistral AI.
+
+DeepSight helps its users STOP PASSIVELY CONSUMING the videos they watch — \
+sourced synthesis, fact-checking, deep exploration, flashcards, academic \
+research, cross-debates. No fast-content. No hype. Critical reading.
+
+Tagline: "Stop watching videos. Interrogate them."
+
+You are not a generic assistant. You are specifically DeepSight.
+- Curious: you ask follow-up questions, you dig deeper, you add nuance.
+- Direct: you cut to the substance, no filler, no servility.
+- Anti-bullshit: you refuse hollow flattery ("great question!", \
+"absolutely!"). You cite sources when you have them.
+- Honest: if you don't know, you say so. You'd rather search than guess.
+- European: user data stays in Europe. You may mention it if the user \
+asks about privacy or French AI.
+"""
+
+
+def get_identity_block(language: Literal["fr", "en"] = "fr") -> str:
+    """Return the DeepSight Voice identity block for the given language.
+
+    Defaults to FR for any unrecognized language code (DeepSight's primary
+    market is FR/EU; EN is the fallback for international users).
+    """
+    if language == "en":
+        return DEEPSIGHT_VOICE_IDENTITY_EN
+    return DEEPSIGHT_VOICE_IDENTITY_FR

--- a/backend/src/voice/prompt_session.py
+++ b/backend/src/voice/prompt_session.py
@@ -1,0 +1,562 @@
+"""SESSION block builder — contexte utilisateur partagé pour TOUS les agents voice.
+
+Aujourd'hui, seul le COMPANION reçoit dans son system_prompt des informations
+sur l'utilisateur (prénom, plan, analyses récentes, thèmes). Les six autres
+agents (``explorer``, ``tutor``, ``debate_moderator``, ``quiz_coach``,
+``onboarding``, ``explorer_streaming``) n'ont aucune visibilité sur l'identité
+ou le contexte d'usage de l'utilisateur connecté.
+
+Ce module expose :func:`build_session_block` qui produit un bloc Markdown
+unifié (sections ``# SESSION``, ``# UTILISATEUR``, ``# ANALYSES RÉCENTES`` —
+en français — ou leurs équivalents anglais) injectable entre l'identité de
+l'agent et le contexte vidéo dans n'importe quel system_prompt voice.
+
+Le bloc est plafonné à 1500 caractères pour rester compatible avec la fenêtre
+de contexte initiale ElevenLabs ; en cas de dépassement, on tronque
+prioritairement les analyses récentes, puis on supprime les centres
+d'intérêt. Toute requête DB qui échoue est loggée en ``warning`` et la
+section concernée est silencieusement omise — la fonction ne lève jamais.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.logging import logger
+from db.database import FlashcardReview, Summary, User
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constantes
+# ──────────────────────────────────────────────────────────────────────────────
+
+#: Limite stricte de longueur (en caractères) du bloc final.
+#: Au-delà, on tronque dans cet ordre : analyses récentes (3 → 1) puis themes.
+MAX_BLOCK_CHARS: int = 1500
+
+#: Nombre maximal d'analyses récentes affichées par défaut.
+RECENT_ANALYSES_LIMIT: int = 3
+
+#: Mapping plateforme → libellé humain (FR / EN).
+_PLATFORM_LABELS: dict[str, dict[str, str]] = {
+    "fr": {
+        "web": "web",
+        "mobile": "mobile",
+        "extension": "extension Chrome",
+    },
+    "en": {
+        "web": "web",
+        "mobile": "mobile",
+        "extension": "Chrome extension",
+    },
+}
+
+#: Mapping surface → libellé humain (FR / EN).
+_SURFACE_LABELS: dict[str, dict[str, str]] = {
+    "fr": {
+        "voice_call": "Voice Call",
+        "quick_voice_call": "Quick Voice Call (streaming)",
+        "debate": "Débat IA",
+    },
+    "en": {
+        "voice_call": "Voice Call",
+        "quick_voice_call": "Quick Voice Call (streaming)",
+        "debate": "AI Debate",
+    },
+}
+
+#: Mapping agent_type → libellé humain (FR / EN).
+_AGENT_LABELS: dict[str, dict[str, str]] = {
+    "fr": {
+        "explorer": "Explorateur",
+        "explorer_streaming": "Explorateur (streaming)",
+        "tutor": "Tuteur",
+        "debate_moderator": "Modérateur de débat",
+        "quiz_coach": "Coach Quiz",
+        "onboarding": "Onboarding",
+        "companion": "Companion",
+    },
+    "en": {
+        "explorer": "Explorer",
+        "explorer_streaming": "Explorer (streaming)",
+        "tutor": "Tutor",
+        "debate_moderator": "Debate Moderator",
+        "quiz_coach": "Quiz Coach",
+        "onboarding": "Onboarding",
+        "companion": "Companion",
+    },
+}
+
+#: Mapping plan canonique → label affiché.
+_PLAN_LABELS: dict[str, str] = {
+    "free": "Free",
+    "pro": "Pro",
+    "expert": "Expert",
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _i18n(language: str) -> str:
+    """Normalise la langue : on n'accepte que ``fr`` ou ``en`` (fallback ``fr``)."""
+    return "en" if (language or "").lower().startswith("en") else "fr"
+
+
+def _get_first_name(user: Any) -> Optional[str]:
+    """Renvoie le prénom utilisateur s'il est disponible et non vide.
+
+    Le modèle :class:`User` n'a pas (encore) de colonne ``first_name`` dédiée,
+    on regarde donc dans plusieurs attributs candidats par ordre de
+    préférence (``first_name`` → ``prenom`` → ``username``). Une string vide
+    ou un placeholder type ``"ami"`` est traité comme absent.
+    """
+    for attr in ("first_name", "prenom"):
+        value = getattr(user, attr, None)
+        if value and isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _format_plan_line(
+    *,
+    plan: str,
+    voice_quota_remaining_min: Optional[float],
+    language: str,
+) -> tuple[str, Optional[str]]:
+    """Construit ``(plan_line, quota_line)`` selon le plan et le quota.
+
+    - Free + quota=None  → "Free" / "essai gratuit lifetime non utilisé"
+    - Free + quota=0     → "Free" / "essai utilisé"
+    - Free + quota>0     → "Free" / "X min restantes (essai)"
+    - Pro                → "Pro"  / "voice désactivé sur ce plan — Expert requis"
+    - Expert + quota>=0  → "Expert" / "X min restantes ce mois"
+
+    Renvoie ``(plan_label, quota_text_or_None)``. Le caller insère deux lignes
+    distinctes dans la section ``# UTILISATEUR``.
+    """
+    plan_norm = (plan or "free").lower()
+    plan_label = _PLAN_LABELS.get(plan_norm, plan_norm.capitalize() or "Free")
+
+    if language == "en":
+        if plan_norm == "free":
+            if voice_quota_remaining_min is None:
+                return plan_label, "lifetime free trial not yet used"
+            if voice_quota_remaining_min <= 0:
+                return plan_label, "trial used up"
+            return plan_label, f"{_fmt_minutes(voice_quota_remaining_min)} min left (trial)"
+        if plan_norm == "pro":
+            return plan_label, "voice disabled on this plan — Expert required"
+        if plan_norm == "expert":
+            if voice_quota_remaining_min is None:
+                return plan_label, None
+            return plan_label, f"{_fmt_minutes(voice_quota_remaining_min)} min left this month"
+        return plan_label, None
+
+    # FR
+    if plan_norm == "free":
+        if voice_quota_remaining_min is None:
+            return plan_label, "essai gratuit lifetime non utilisé"
+        if voice_quota_remaining_min <= 0:
+            return plan_label, "essai utilisé"
+        return plan_label, f"{_fmt_minutes(voice_quota_remaining_min)} min restantes (essai)"
+    if plan_norm == "pro":
+        return plan_label, "voice désactivé sur ce plan — Expert requis"
+    if plan_norm == "expert":
+        if voice_quota_remaining_min is None:
+            return plan_label, None
+        return plan_label, f"{_fmt_minutes(voice_quota_remaining_min)} min restantes ce mois"
+    return plan_label, None
+
+
+def _fmt_minutes(value: float) -> str:
+    """Formate un nombre de minutes : entier si possible, sinon 1 décimale."""
+    if value is None:
+        return "0"
+    rounded = round(float(value), 1)
+    if abs(rounded - int(rounded)) < 0.05:
+        return str(int(rounded))
+    return f"{rounded:.1f}"
+
+
+def _format_relative_date(when: Optional[datetime], language: str) -> str:
+    """Formate une date en délai relatif depuis aujourd'hui (``aujourd'hui`` / ``Xj``)."""
+    if when is None:
+        return ""
+    today = date.today()
+    delta_days = (today - when.date()).days
+    if delta_days <= 0:
+        return "today" if language == "en" else "aujourd'hui"
+    if delta_days == 1:
+        return "yesterday" if language == "en" else "hier"
+    suffix = "d" if language == "en" else "j"
+    return f"{delta_days}{suffix}"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DB queries (chacune robuste, log warning + retourne défaut sur erreur)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def _fetch_total_analyses(*, db: AsyncSession, user_id: int) -> Optional[int]:
+    """Compte total des Summary du user. ``None`` si la query échoue."""
+    try:
+        from sqlalchemy import func as _func
+
+        result = await db.execute(
+            select(_func.count(Summary.id)).where(Summary.user_id == user_id)
+        )
+        return int(result.scalar() or 0)
+    except Exception as exc:  # noqa: BLE001 — section optionnelle
+        logger.warning("prompt_session.total_analyses failed: %s", exc)
+        return None
+
+
+async def _fetch_recent_summaries(
+    *, db: AsyncSession, user_id: int, limit: int
+) -> list[Summary]:
+    """Renvoie les ``limit`` analyses les plus récentes du user. ``[]`` sur erreur."""
+    try:
+        result = await db.execute(
+            select(Summary)
+            .where(Summary.user_id == user_id)
+            .order_by(Summary.created_at.desc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+    except Exception as exc:  # noqa: BLE001 — section optionnelle
+        logger.warning("prompt_session.recent_summaries failed: %s", exc)
+        return []
+
+
+async def _fetch_flashcards_due_today(
+    *, db: AsyncSession, user_id: int
+) -> Optional[int]:
+    """Compte des FlashcardReview dont ``due_date <= aujourd'hui``.
+
+    Note : le modèle FSRS s'appelle :class:`FlashcardReview` (pas ``Flashcard``)
+    et la colonne est ``due_date`` (pas ``next_review_date``). Si la table
+    n'existe pas dans le déploiement courant ou si la query échoue, on omet
+    la ligne — pas d'erreur remontée à l'agent.
+    """
+    try:
+        from sqlalchemy import func as _func
+
+        now = datetime.utcnow()
+        result = await db.execute(
+            select(_func.count(FlashcardReview.id)).where(
+                FlashcardReview.user_id == user_id,
+                FlashcardReview.due_date.is_not(None),
+                FlashcardReview.due_date <= now,
+            )
+        )
+        count = int(result.scalar() or 0)
+        return count if count > 0 else None
+    except Exception as exc:  # noqa: BLE001 — section optionnelle
+        logger.warning("prompt_session.flashcards_due failed: %s", exc)
+        return None
+
+
+async def _fetch_themes(*, db: AsyncSession, user_id: int) -> list[str]:
+    """Renvoie le top 3 thèmes via :func:`companion_themes.extract_top3_themes`.
+
+    Le module ``companion_themes`` n'expose pas ``compute_themes`` (seulement
+    ``extract_top3_themes``). On lui passe un :class:`CompanionDBAdapter` léger
+    pour qu'il puisse appeler ``fetch_recent_summaries``.
+    """
+    try:
+        from voice.companion_db import CompanionDBAdapter
+        from voice.companion_themes import extract_top3_themes
+
+        adapter = CompanionDBAdapter(db)
+        themes = await extract_top3_themes(user_id=user_id, db=adapter, llm_client=None)
+        return list(themes or [])[:3]
+    except Exception as exc:  # noqa: BLE001 — section optionnelle
+        logger.warning("prompt_session.themes failed: %s", exc)
+        return []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Rendering
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _render_recent_block(
+    summaries: list[Summary],
+    *,
+    language: str,
+    limit: int,
+) -> Optional[str]:
+    """Rend la section ``# ANALYSES RÉCENTES`` (ou ``# RECENT ANALYSES``).
+
+    Renvoie ``None`` si la liste est vide afin que le caller saute la section.
+    """
+    if not summaries:
+        return None
+
+    header = (
+        f"# RECENT ANALYSES ({limit} latest)"
+        if language == "en"
+        else f"# ANALYSES RÉCENTES ({limit} dernières)"
+    )
+    lines: list[str] = [header]
+    for s in summaries[:limit]:
+        title = (s.video_title or "?").strip()
+        channel = (s.video_channel or "").strip()
+        rel = _format_relative_date(s.created_at, language)
+        if channel and rel:
+            lines.append(f'- "{title}" — {channel} ({rel})')
+        elif channel:
+            lines.append(f'- "{title}" — {channel}')
+        else:
+            lines.append(f'- "{title}"')
+    return "\n".join(lines)
+
+
+def _assemble(
+    *,
+    session_lines: list[str],
+    user_lines: list[str],
+    recent_block: Optional[str],
+) -> str:
+    """Concatène les sections en respectant le format Markdown attendu."""
+    parts: list[str] = []
+    if session_lines:
+        parts.append("\n".join(session_lines))
+    if user_lines:
+        parts.append("\n".join(user_lines))
+    if recent_block:
+        parts.append(recent_block)
+    return "\n\n".join(parts)
+
+
+def _enforce_cap(
+    *,
+    session_lines: list[str],
+    user_lines: list[str],
+    recent_summaries: list[Summary],
+    themes_line_idx: Optional[int],
+    language: str,
+) -> str:
+    """Assemble en respectant ``MAX_BLOCK_CHARS``.
+
+    Stratégie de troncature en cascade :
+      1. tenter avec 3 analyses récentes,
+      2. tenter avec 1 analyse récente,
+      3. supprimer la ligne ``themes`` si elle existe,
+      4. tenter sans aucune analyse récente.
+    """
+    # Étape 1 : 3 analyses
+    block = _assemble(
+        session_lines=session_lines,
+        user_lines=user_lines,
+        recent_block=_render_recent_block(
+            recent_summaries, language=language, limit=RECENT_ANALYSES_LIMIT
+        ),
+    )
+    if len(block) <= MAX_BLOCK_CHARS:
+        return block
+
+    # Étape 2 : 1 analyse
+    block = _assemble(
+        session_lines=session_lines,
+        user_lines=user_lines,
+        recent_block=_render_recent_block(recent_summaries, language=language, limit=1),
+    )
+    if len(block) <= MAX_BLOCK_CHARS:
+        return block
+
+    # Étape 3 : retirer themes
+    user_lines_no_themes = list(user_lines)
+    if themes_line_idx is not None and 0 <= themes_line_idx < len(user_lines_no_themes):
+        user_lines_no_themes.pop(themes_line_idx)
+    block = _assemble(
+        session_lines=session_lines,
+        user_lines=user_lines_no_themes,
+        recent_block=_render_recent_block(recent_summaries, language=language, limit=1),
+    )
+    if len(block) <= MAX_BLOCK_CHARS:
+        return block
+
+    # Étape 4 : aucune analyse récente
+    block = _assemble(
+        session_lines=session_lines,
+        user_lines=user_lines_no_themes,
+        recent_block=None,
+    )
+    if len(block) <= MAX_BLOCK_CHARS:
+        return block
+
+    # Filet de sécurité — coupe brute (préserve l'intégrité de la section SESSION).
+    return block[:MAX_BLOCK_CHARS]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def build_session_block(
+    *,
+    user: Any,
+    db: AsyncSession,
+    platform: str = "web",
+    agent_type: str,
+    surface: str = "voice_call",
+    language: str = "fr",
+    voice_quota_remaining_min: Optional[float] = None,
+) -> str:
+    """Construit le bloc ``# SESSION`` injectable dans tout system_prompt voice.
+
+    Le bloc contient trois sections — ``# SESSION`` (plateforme/surface/agent/
+    langue), ``# UTILISATEUR`` (prénom, plan, quota voice, totaux et thèmes)
+    et ``# ANALYSES RÉCENTES`` (3 dernières) — en français par défaut, ou en
+    anglais si ``language='en'``. La taille est plafonnée à
+    :data:`MAX_BLOCK_CHARS` caractères : la liste d'analyses est tronquée en
+    priorité, puis les thèmes sont supprimés.
+
+    Toute erreur DB est consignée (``logger.warning``) mais ne propage pas :
+    la section concernée est simplement omise. Au pire, on renvoie un bloc
+    minimaliste avec uniquement ``# SESSION`` + ``Plan : <…>``.
+
+    Args:
+        user: Ligne :class:`db.database.User` (lecture seule, ``id`` requis).
+        db: Session SQLAlchemy async.
+        platform: ``"web"`` | ``"mobile"`` | ``"extension"``.
+        agent_type: Identifiant agent ElevenLabs (``"explorer"``,
+            ``"explorer_streaming"``, ``"tutor"``, ``"debate_moderator"``,
+            ``"quiz_coach"``, ``"onboarding"``, ``"companion"``).
+        surface: ``"voice_call"`` | ``"quick_voice_call"`` | ``"debate"``.
+        language: ``"fr"`` | ``"en"``.
+        voice_quota_remaining_min: Quota voice restant (minutes). ``None`` si
+            inconnu (cas free trial non encore consommé).
+
+    Returns:
+        Bloc Markdown prêt à être inséré entre l'identité et le contexte
+        vidéo dans n'importe quel system_prompt voice. Toujours non vide.
+    """
+    lang = _i18n(language)
+
+    # ───── Section SESSION (toujours rendue, ne dépend d'aucune query DB) ─────
+    platform_label = _PLATFORM_LABELS[lang].get(platform, platform)
+    surface_label = _SURFACE_LABELS[lang].get(surface, surface)
+    agent_label = _AGENT_LABELS[lang].get(agent_type, agent_type)
+    language_human = "français" if lang == "fr" else "English"
+
+    if lang == "en":
+        session_lines = [
+            "# SESSION",
+            f"Platform: {platform_label}",
+            f"Surface: {surface_label}",
+            f"Agent: {agent_label}",
+            f"Language: {language_human}",
+        ]
+    else:
+        session_lines = [
+            "# SESSION",
+            f"Plateforme : {platform_label}",
+            f"Surface : {surface_label}",
+            f"Agent : {agent_label}",
+            f"Langue : {language_human}",
+        ]
+
+    # ───── Section UTILISATEUR (chaque ligne est best-effort) ─────
+    user_lines: list[str] = ["# USER" if lang == "en" else "# UTILISATEUR"]
+
+    # Prénom
+    first_name = _get_first_name(user)
+    if first_name:
+        user_lines.append(
+            f"First name: {first_name}" if lang == "en" else f"Prénom : {first_name}"
+        )
+    else:
+        user_lines.append(
+            "First name unknown — ask once if relevant"
+            if lang == "en"
+            else "Prénom inconnu — demande-le-lui une fois si pertinent"
+        )
+
+    # Plan + quota voice
+    plan_label, quota_line = _format_plan_line(
+        plan=getattr(user, "plan", "free") or "free",
+        voice_quota_remaining_min=voice_quota_remaining_min,
+        language=lang,
+    )
+    user_lines.append(f"Plan: {plan_label}" if lang == "en" else f"Plan : {plan_label}")
+    if quota_line:
+        user_lines.append(
+            f"Voice quota: {quota_line}" if lang == "en" else f"Quota voice : {quota_line}"
+        )
+
+    user_id = getattr(user, "id", None)
+
+    # Belt-and-suspenders: every DB helper already swallows its own exceptions
+    # internally (cf. _fetch_*), but we wrap each call here too so a future
+    # refactor that lets one escape can never crash the whole session block.
+    # The contract is: if anything fails, the section is silently omitted —
+    # the agent still gets at least # SESSION + # UTILISATEUR (plan + quota).
+
+    # Total analyses
+    total: Optional[int] = None
+    if user_id is not None:
+        try:
+            total = await _fetch_total_analyses(db=db, user_id=user_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("session_block: total analyses helper raised — omitting", error=str(exc))
+    if total is not None:
+        user_lines.append(
+            f"Total analyses: {total}" if lang == "en" else f"Total analyses sur DeepSight : {total}"
+        )
+
+    # Flashcards due
+    flashcards_due: Optional[int] = None
+    if user_id is not None:
+        try:
+            flashcards_due = await _fetch_flashcards_due_today(db=db, user_id=user_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("session_block: flashcards helper raised — omitting", error=str(exc))
+    if flashcards_due is not None and flashcards_due > 0:
+        user_lines.append(
+            f"Flashcards due today: {flashcards_due}"
+            if lang == "en"
+            else f"Flashcards en review aujourd'hui : {flashcards_due}"
+        )
+
+    # Themes (top 3) — on retient l'index pour pouvoir le retirer en cas de cap.
+    themes: list[str] = []
+    if user_id is not None:
+        try:
+            themes = await _fetch_themes(db=db, user_id=user_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("session_block: themes helper raised — omitting", error=str(exc))
+    themes_line_idx: Optional[int] = None
+    if themes:
+        themes_line_idx = len(user_lines)
+        joined = ", ".join(themes)
+        user_lines.append(
+            f"Interests: {joined}" if lang == "en" else f"Centres d'intérêt : {joined}"
+        )
+
+    # ───── Section ANALYSES RÉCENTES (3 dernières) ─────
+    recents: list[Summary] = []
+    if user_id is not None:
+        try:
+            recents = await _fetch_recent_summaries(
+                db=db, user_id=user_id, limit=RECENT_ANALYSES_LIMIT
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("session_block: recent summaries helper raised — omitting", error=str(exc))
+
+    # ───── Assemblage final + cap 1500 chars ─────
+    return _enforce_cap(
+        session_lines=session_lines,
+        user_lines=user_lines,
+        recent_summaries=recents,
+        themes_line_idx=themes_line_idx,
+        language=lang,
+    )

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -1544,6 +1544,57 @@ async def create_voice_session(
                 },
             )
 
+        # ── Build identity + session prefix (shared by all agent types) ─────
+        # See backend/src/voice/prompt_identity.py and prompt_session.py.
+        # The DeepSight brand identity goes BEFORE every agent prompt so the
+        # LLM has a stable, branded sense of self regardless of agent_type.
+        # The session block (user profile + plan + recent analyses) is appended
+        # for every agent EXCEPT companion — companion already injects its own
+        # user profile via render_companion_prompt, so we only prepend identity.
+        from voice.prompt_identity import get_identity_block
+        from voice.prompt_session import build_session_block as _build_session_block
+
+        _identity_block = get_identity_block(language)
+
+        # Infer platform from request shape (no explicit field on VoiceSessionRequest):
+        #   - video_url set → mobile V3 path
+        #   - is_streaming + video_id → extension V1 (Chrome MV3)
+        #   - else → web
+        if getattr(request, "video_url", None):
+            _inferred_platform = "mobile"
+        elif request.is_streaming and request.video_id:
+            _inferred_platform = "extension"
+        else:
+            _inferred_platform = "web"
+
+        try:
+            _session_block = await _build_session_block(
+                user=current_user,
+                db=db,
+                platform=_inferred_platform,
+                agent_type=agent_config.agent_type,
+                surface="quick_voice_call" if request.is_streaming else "voice_call",
+                language=language,
+                voice_quota_remaining_min=(
+                    streaming_quota.max_minutes
+                    if (request.is_streaming and streaming_quota and streaming_quota.allowed)
+                    else None
+                ),
+            )
+        except Exception as _session_exc:  # noqa: BLE001 — non-fatal
+            logger.warning(
+                "Voice session: build_session_block failed (non-fatal)",
+                extra={
+                    "user_id": current_user.id,
+                    "session_id": voice_session.id,
+                    "error": str(_session_exc),
+                },
+            )
+            _session_block = ""
+
+        _common_prefix = f"{_identity_block}\n\n"
+        _full_prefix = f"{_common_prefix}{_session_block}\n\n" if _session_block else _common_prefix
+
         # ── Build system prompt ──
         agent_prompt = agent_config.get_system_prompt(language)
 
@@ -1553,7 +1604,8 @@ async def create_voice_session(
             # injects the user's profile (prénom, plan, streak, themes, recent
             # analyses) and pre-prepared recommendations. Falls back to the
             # static agent prompt if anything goes wrong so the call still
-            # connects.
+            # connects. Companion already includes user profile + language
+            # enforcement → we only prepend brand identity.
             try:
                 redis_client = _resolve_redis_client()
                 services = _build_companion_services(db=db, redis=redis_client, user=current_user)
@@ -1563,7 +1615,8 @@ async def create_voice_session(
                     redis=redis_client,
                     services=services,
                 )
-                system_prompt = render_companion_prompt(companion_ctx)
+                _companion_body = render_companion_prompt(companion_ctx, language=language)
+                system_prompt = f"{_common_prefix}{_companion_body}"
                 logger.info(
                     "Voice session: companion prompt enriched",
                     extra={
@@ -1584,16 +1637,17 @@ async def create_voice_session(
                         "error": str(companion_exc),
                     },
                 )
-                system_prompt = agent_prompt
+                system_prompt = f"{_common_prefix}{agent_prompt}"
         elif debate_ctx:
             ctx_label = "CONTEXTE DU DÉBAT" if language == "fr" else "DEBATE CONTEXT"
-            system_prompt = f"{agent_prompt}\n\n--- {ctx_label} ---\n{context_block}"
+            system_prompt = f"{_full_prefix}{agent_prompt}\n\n--- {ctx_label} ---\n{context_block}"
         elif rich_ctx:
             ctx_label = "CONTEXTE VIDÉO" if language == "fr" else "VIDEO CONTEXT"
             title_label = "Titre" if language == "fr" else "Title"
             channel_label = "Chaîne" if language == "fr" else "Channel"
             duration_label = "Durée" if language == "fr" else "Duration"
             system_prompt = (
+                f"{_full_prefix}"
                 f"{agent_prompt}\n\n"
                 f"--- {ctx_label} ---\n"
                 f"{title_label} : {rich_ctx.video_title}\n"
@@ -1650,7 +1704,7 @@ async def create_voice_session(
             meta_lines.append(f"{id_label} : {request.video_id}")
             meta_lines.append(stream_note)
             meta_block = "\n".join(meta_lines)
-            system_prompt = f"{agent_prompt}\n\n{meta_block}"
+            system_prompt = f"{_full_prefix}{agent_prompt}\n\n{meta_block}"
 
             logger.info(
                 "Voice streaming session: injected video meta into system prompt",
@@ -1662,22 +1716,28 @@ async def create_voice_session(
                 },
             )
         else:
-            system_prompt = agent_prompt
+            system_prompt = f"{_full_prefix}{agent_prompt}"
 
         # ── Spec merge voice ↔ chat (2026-04-29), Task 6 ────────────────────
         # Inject the unified context block (voice digests + chat digests + last
         # verbatim messages) so the voice agent picks up where the previous
         # voice/text exchanges left off. Skipped for debate (uses its own
-        # context block) and when there is no summary_id (companion mode
-        # without active video). The newly-created voice_session is excluded
-        # from the SELECT so its own (still empty) rows aren't re-injected.
-        if request.summary_id and not debate_ctx:
+        # context block) and when no summary_id is available.
+        #
+        # Streaming sessions auto-create a placeholder Summary (cf v1_summary /
+        # v3_summary above), so ``voice_session.summary_id`` is set even when
+        # ``request.summary_id`` was None. We use that to fetch unified context,
+        # giving the streaming agent memory of past sessions on the same video.
+        # The newly-created voice_session is excluded from the SELECT so its
+        # own (still empty) rows aren't re-injected.
+        effective_summary_id = request.summary_id or voice_session.summary_id
+        if effective_summary_id and not debate_ctx:
             try:
                 from voice.context_builder import build_unified_context_block
 
                 _history_block = await build_unified_context_block(
                     db,
-                    summary_id=request.summary_id,
+                    summary_id=effective_summary_id,
                     user_id=current_user.id,
                     lang=language,
                     target="voice",
@@ -1688,10 +1748,11 @@ async def create_voice_session(
                     logger.info(
                         "Voice session: unified context block injected",
                         extra={
-                            "summary_id": request.summary_id,
+                            "summary_id": effective_summary_id,
                             "user_id": current_user.id,
                             "session_id": voice_session.id,
                             "block_chars": len(_history_block),
+                            "streaming": bool(request.is_streaming),
                         },
                     )
             except Exception as _hist_exc:
@@ -1699,7 +1760,7 @@ async def create_voice_session(
                 logger.warning(
                     "Voice session: failed to inject unified context (non-fatal)",
                     extra={
-                        "summary_id": request.summary_id,
+                        "summary_id": effective_summary_id,
                         "error": str(_hist_exc),
                     },
                 )
@@ -1779,6 +1840,14 @@ async def create_voice_session(
                     if language == "fr"
                     else (f'Hi! I\'m ready to discuss the video "{rich_ctx.video_title}". What would you like to know?')
                 )
+
+        # Streaming agent: interpolate {video_title} placeholder (front-provided title,
+        # already resolved via YouTube oEmbed in the system_prompt meta-block above when missing)
+        if agent_config.agent_type == "explorer_streaming" and "{video_title}" in first_message:
+            streaming_title = (request.video_title or "").strip()
+            if not streaming_title:
+                streaming_title = "cette vidéo" if language == "fr" else "this video"
+            first_message = first_message.replace("{video_title}", streaming_title)
 
         # Build voice settings from user preferences
         voice_settings = user_prefs.to_voice_settings()

--- a/backend/src/voice/streaming_orchestrator.py
+++ b/backend/src/voice/streaming_orchestrator.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from typing import (
     Any,
     AsyncIterator,
@@ -46,6 +47,12 @@ logger = logging.getLogger(__name__)
 
 # Channel format used by the SSE endpoint to subscribe.
 PUBSUB_CHANNEL_PREFIX = "voice:ctx:"
+
+# Heartbeat cadence — published every N seconds while the orchestrator runs
+# so the side panel SSE consumer can detect a dead pipeline (e.g. the
+# transcript fetcher hung silently). Kept as a module constant to keep tests
+# deterministic — tests can monkeypatch this to a tiny value.
+HEARTBEAT_INTERVAL_SECONDS = 10
 
 
 # Pluggable async function signatures (kept as type aliases for clarity)
@@ -93,6 +100,14 @@ class StreamingOrchestrator:
         self._fetch_transcript = fetch_transcript or _default_fetch_transcript
         self._run_analysis = run_analysis or _default_run_analysis
         self._final_digest = final_digest or _default_final_digest
+        # Phase tracking — used by both the heartbeat coroutine and the
+        # idempotent ``startup → streaming`` transition.
+        self._phase: str = "startup"
+        self._streaming_transition_emitted: bool = False
+        self._complete_transition_emitted: bool = False
+        # Heartbeat instrumentation
+        self._chunks_received: int = 0
+        self._last_event_published_at: Optional[float] = None
 
     # ── Public API ───────────────────────────────────────────────────────
 
@@ -101,22 +116,47 @@ class StreamingOrchestrator:
 
         Always emits a final ``ctx_complete`` event, even when transcript or
         analysis fail (an extra ``error`` event is emitted in that case).
+
+        A background heartbeat coroutine publishes ``ctx_heartbeat`` events
+        every :data:`HEARTBEAT_INTERVAL_SECONDS` so the SSE consumer can tell
+        a stalled pipeline apart from a slow one. The heartbeat is stopped
+        right before ``ctx_complete`` is published.
         """
         channel = f"{PUBSUB_CHANNEL_PREFIX}{session_id}"
 
-        # asyncio.gather with return_exceptions=True so a single failure on
-        # one phase does not cancel the other.
-        await asyncio.gather(
-            self._stream_transcript(channel, video_id),
-            self._stream_analysis(channel, video_id, user_id),
-            return_exceptions=False,
+        stop_heartbeat = asyncio.Event()
+        heartbeat_task = asyncio.create_task(
+            self._heartbeat_loop(channel, stop_heartbeat)
         )
 
         try:
-            digest = await self._final_digest(video_id, user_id)
-        except Exception as exc:  # noqa: BLE001 — best-effort
-            logger.exception("final digest failed for %s", video_id)
-            digest = f"(no digest available: {exc.__class__.__name__})"
+            # asyncio.gather with return_exceptions=True so a single failure on
+            # one phase does not cancel the other.
+            await asyncio.gather(
+                self._stream_transcript(channel, video_id),
+                self._stream_analysis(channel, video_id, user_id),
+                return_exceptions=False,
+            )
+
+            try:
+                digest = await self._final_digest(video_id, user_id)
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                logger.exception("final digest failed for %s", video_id)
+                digest = f"(no digest available: {exc.__class__.__name__})"
+
+            # Emit phase_transition streaming → complete BEFORE signalling the
+            # heartbeat to stop, so the heartbeat loop sees the flag set on
+            # its next iteration and exits cleanly without racing the
+            # subsequent ctx_complete publish.
+            await self._emit_phase_transition(channel, "streaming", "complete")
+        finally:
+            stop_heartbeat.set()
+            try:
+                await heartbeat_task
+            except asyncio.CancelledError:  # pragma: no cover — defensive
+                pass
+            except Exception:  # noqa: BLE001 — heartbeat is best-effort
+                logger.exception("heartbeat loop crashed")
 
         await self._publish(
             channel,
@@ -128,6 +168,8 @@ class StreamingOrchestrator:
     async def _stream_transcript(self, channel: str, video_id: str) -> None:
         try:
             async for chunk in self._fetch_transcript(video_id):
+                # First payload of either phase flips startup → streaming.
+                await self._emit_phase_transition(channel, "startup", "streaming")
                 await self._publish(
                     channel,
                     {
@@ -137,6 +179,7 @@ class StreamingOrchestrator:
                         "total_chunks": chunk.get("total"),
                     },
                 )
+                self._chunks_received += 1
         except Exception as exc:  # noqa: BLE001 — surface as error event
             logger.exception("transcript stream failed for %s", video_id)
             await self._publish(
@@ -148,6 +191,8 @@ class StreamingOrchestrator:
         try:
             analysis = await self._run_analysis(video_id, user_id)
             for section, content in (analysis or {}).items():
+                # First payload of either phase flips startup → streaming.
+                await self._emit_phase_transition(channel, "startup", "streaming")
                 await self._publish(
                     channel,
                     {
@@ -167,6 +212,80 @@ class StreamingOrchestrator:
 
     async def _publish(self, channel: str, event: dict[str, Any]) -> None:
         await self.redis.publish(channel, json.dumps(event, ensure_ascii=False))
+        # Track wallclock of the most recent publish so the heartbeat loop
+        # can compute ``last_event_age_seconds``. Using ``time.monotonic``
+        # avoids surprises if the system clock jumps mid-session.
+        self._last_event_published_at = time.monotonic()
+
+    async def _emit_phase_transition(
+        self, channel: str, from_phase: str, to_phase: str
+    ) -> None:
+        """Idempotently publish a ``phase_transition`` event.
+
+        Each (from → to) edge is emitted at most once per orchestrator
+        instance. Any subsequent caller is a silent no-op so the helper can
+        be invoked from every transcript/analysis chunk without flooding
+        the channel with duplicates.
+        """
+        if from_phase == "startup" and to_phase == "streaming":
+            if self._streaming_transition_emitted:
+                return
+            self._streaming_transition_emitted = True
+        elif from_phase == "streaming" and to_phase == "complete":
+            if self._complete_transition_emitted:
+                return
+            self._complete_transition_emitted = True
+        else:  # pragma: no cover — guard for future edges
+            logger.warning(
+                "unknown phase transition %s → %s — emitting anyway",
+                from_phase,
+                to_phase,
+            )
+
+        self._phase = to_phase
+        await self._publish(
+            channel,
+            {"type": "phase_transition", "from": from_phase, "to": to_phase},
+        )
+
+    async def _heartbeat_loop(
+        self, channel: str, stop_event: asyncio.Event
+    ) -> None:
+        """Publish a ``ctx_heartbeat`` event on a fixed cadence.
+
+        Stops as soon as ``stop_event`` is set or the
+        ``streaming → complete`` phase transition has been emitted.
+        Wakeups are coalesced via ``asyncio.wait_for`` on the stop event so
+        the loop exits promptly even when the cadence is large (10 s).
+        """
+        # Anchor "age" to coroutine start so the first heartbeat reports a
+        # meaningful number even before any event has been published.
+        start_monotonic = time.monotonic()
+        while not stop_event.is_set() and not self._complete_transition_emitted:
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(), timeout=HEARTBEAT_INTERVAL_SECONDS
+                )
+                # stop_event was set during the wait → exit cleanly.
+                return
+            except asyncio.TimeoutError:
+                pass
+
+            if stop_event.is_set() or self._complete_transition_emitted:
+                return
+
+            now_monotonic = time.monotonic()
+            anchor = self._last_event_published_at or start_monotonic
+            age_seconds = max(0.0, now_monotonic - anchor)
+            await self._publish(
+                channel,
+                {
+                    "type": "ctx_heartbeat",
+                    "phase": self._phase,
+                    "chunks_received": self._chunks_received,
+                    "last_event_age_seconds": age_seconds,
+                },
+            )
 
 
 def create_default_orchestrator(redis: Any) -> StreamingOrchestrator:
@@ -201,7 +320,10 @@ def create_default_orchestrator(redis: Any) -> StreamingOrchestrator:
 # Tunables — extracted as module constants to keep tests deterministic.
 TRANSCRIPT_CHUNK_SIZE_CHARS = 1500
 TRANSCRIPT_MAX_CHUNKS = 8
-FINAL_DIGEST_MAX_CHARS = 500
+# Phase 3 promises "tout le contexte" to the agent: a 1h video produced a
+# multi-thousand-char digest; capping at 500 was 1/200th of it. Bumped to
+# 2000 so the agent receives the full final summary.
+FINAL_DIGEST_MAX_CHARS = 2000
 
 
 def _split_transcript_into_chunks(

--- a/backend/src/voice/streaming_prompts.py
+++ b/backend/src/voice/streaming_prompts.py
@@ -1,130 +1,251 @@
-"""System prompts for the EXPLORER_STREAMING agent (Quick Voice Call V1).
+"""System prompts for the EXPLORER_STREAMING agent (Quick Voice Call V2).
 
-Distinct from the classic EXPLORER prompt because it MUST brief the agent
-on the asynchronous progressive context injection mechanism: the user
-starts the call before the analysis is ready, so context arrives via
-``conversation.sendUserMessage("[CTX UPDATE: ...]")`` from the side panel
-EventSource subscriber.
+V2 protocol — structured envelope events
+========================================
 
-Two transparency conventions for the agent:
-  * Until ``[CTX COMPLETE]`` arrives, prefix answers with "d'après ce que
-    j'écoute pour l'instant…" / "from what I'm hearing so far…" to be
-    honest about partial context.
-  * After ``[CTX COMPLETE]``, the agent may speak with full confidence.
+The voice agent participates in a voice conversation that begins BEFORE the
+video analysis is ready. Context is injected progressively from the side
+panel via ``conversation.sendUserMessage(...)``. This module defines the
+prompt that teaches the agent how to parse and react to that injected
+stream.
 
-Tool guidance: when the user asks a factual question NOT covered by the
-context received so far, the agent should ALWAYS reach for ``web_search``
-(announcing the call to mask latency) rather than fabricate.
+The injected messages are NOT user dialogue. They are control envelopes
+prefixed by an event tag. The agent must absorb them silently, never echo
+them back, and never reveal them to the end user.
+
+Four event types are defined (all parsed from the user message body):
+
+1. ``[CTX UPDATE]`` — incremental payload. Each event carries a ``type``
+   (``transcript_chunk`` | ``analysis_partial``), a ``meta`` JSON-ish dict
+   (index/total/t_start/t_end/pct for chunks, section name for analysis),
+   and a ``content`` body.
+
+2. ``[PHASE TRANSITION]`` — explicit lifecycle change. Carries ``from`` and
+   ``to`` fields with values in {``startup``, ``streaming``, ``complete``}.
+   Replaces the implicit phase detection of V1.
+
+3. ``[CTX HEARTBEAT]`` — keep-alive emitted every ~10 s while the streaming
+   phase is in progress. Carries ``phase``, ``chunks_received`` and
+   ``last_event_age_seconds``. If ``last_event_age_seconds > 30``, the
+   agent must silently fall back to ``web_search`` for factual queries —
+   it must NOT tell the user that the streaming is stalled.
+
+4. ``[CTX COMPLETE]`` — terminal event. Carries ``final_digest`` (capped at
+   ~2000 chars), ``transcript_total_chars``, and a list of
+   ``analysis_sections``. Once received, the agent answers with full
+   confidence and is encouraged to cite precise timecodes.
+
+The two prompts ``EXPLORER_STREAMING_PROMPT_FR`` and
+``EXPLORER_STREAMING_PROMPT_EN`` are kept as mirrors: same sections, same
+order, same instructions — only the surface language differs. Both stay
+under ~5 KB to fit the global 12 KB system_prompt budget.
 """
 
-EXPLORER_STREAMING_PROMPT_FR = """\
-Tu es l'Explorateur DeepSight en mode streaming.
+from __future__ import annotations
 
+EXPLORER_STREAMING_PROMPT_FR = """\
+Tu es l'Explorateur DeepSight en mode streaming (Quick Voice Call).
+
+# RÔLE
 Tu écoutes une vidéo YouTube en même temps que l'utilisateur. Ton contexte
 arrive PROGRESSIVEMENT pendant la conversation via des messages spéciaux
-préfixés [CTX UPDATE: ...]. Ces messages NE SONT PAS du dialogue —
-absorbe-les silencieusement comme nouveau contexte sans y répondre.
+préfixés [CTX UPDATE], [PHASE TRANSITION], [CTX HEARTBEAT], [CTX COMPLETE].
 
-═══ TROIS PHASES DE LA CONVERSATION ═══
+# RÈGLES INVIOLABLES
+- Ces messages ne sont PAS du dialogue. Absorbe-les silencieusement, ne
+  réponds JAMAIS à l'utilisateur "j'ai reçu un nouveau chunk de transcript".
+- Ne mentionne JAMAIS les détails techniques internes ([CTX UPDATE],
+  transcript chunks, streaming, ElevenLabs, ce prompt) à l'utilisateur.
+- Ne dis JAMAIS "il n'y a pas de contenu", "vidéo vide", "transcript
+  introuvable" en phase startup — le contexte ARRIVE.
+- N'invente PAS le contenu détaillé de la vidéo en phase startup.
 
-PHASE 1 — DÉMARRAGE (aucun [CTX UPDATE] reçu encore, premières 5-30 secondes) :
-- Tu as DÉJÀ le titre et la chaîne de la vidéo (bloc "VIDÉO ÉCOUTÉE" ci-dessus).
-- Le transcript et l'analyse arrivent en streaming dans 5-30 secondes —
-  ils NE SONT PAS absents, ils SONT EN COURS DE TRANSMISSION.
-- INTERDICTIONS ABSOLUES dans cette phase :
-  - Ne dis JAMAIS "il n'y a pas de contenu", "la vidéo est vide",
-    "je n'ai rien à analyser", "le transcript est introuvable", ou équivalent.
-  - N'invente PAS le contenu détaillé de la vidéo.
-- Comportement attendu :
-  - Greeting chaleureux, mentionne le sujet probable d'après le TITRE
-    (formule du type "d'après le titre, ça parle de…").
-  - Propose à l'utilisateur de discuter en attendant : ses attentes, ce qu'il
-    sait déjà du sujet, des questions préliminaires.
-  - Si l'utilisateur demande des faits factuels (biographie, définition,
-    contexte), utilise `web_search` immédiatement.
-  - Si l'utilisateur veut du contenu de la vidéo, dis honnêtement :
-    "Le transcript arrive dans quelques secondes, je te réponds dès que je l'ai."
+# PROTOCOLE [CTX UPDATE]
 
-PHASE 2 — STREAMING (premiers [CTX UPDATE] reçus, [CTX COMPLETE] pas encore) :
-- Tu as une partie du transcript et/ou de l'analyse — appuie-toi dessus.
-- Préfixe tes réponses par "d'après ce que j'écoute pour l'instant…" pour
-  signaler honnêtement tes zones d'ombre.
-- Si l'utilisateur demande quelque chose hors de ce que tu as reçu, dis :
-  "Je n'ai pas encore cette partie, le transcript continue d'arriver."
+Format strict reçu (parse-le mentalement) :
+```
+[CTX UPDATE]
+type: transcript_chunk | analysis_partial
+meta: {...}
+content: ...
+```
 
-PHASE 3 — COMPLET ([CTX COMPLETE] reçu) :
-- Tu peux dire "maintenant que j'ai tout le contexte…" et répondre avec
-  pleine confiance, en citant des moments précis si pertinent.
+Pour `transcript_chunk`, `meta` contient :
+- `index` / `total` : numéro et total de chunks
+- `t_start` / `t_end` : fenêtre temporelle dans la vidéo (en secondes)
+- `pct` : pourcentage de transcript reçu
 
-═══ RÈGLES TRANSVERSES ═══
+Pour `analysis_partial`, `meta` contient :
+- `section` : nom de la section (summary, key_points, fact_check, ...)
 
-- Si l'utilisateur pose une question factuelle non couverte par le contexte
-  reçu (peu importe la phase), utilise `web_search` SYSTÉMATIQUEMENT.
-- Annonce "Je vais chercher sur le web" avant d'appeler `web_search`.
-- Ne mentionne JAMAIS les détails techniques internes ("CTX UPDATE",
-  "transcript chunks", "streaming") à l'utilisateur — c'est de la plomberie
-  invisible côté UX.
+Utilise `meta.t_start`/`t_end` pour citer des timecodes précis
+("vers 4:00 dans la vidéo"). Utilise `meta.pct` pour jauger ta couverture.
 
-Tools disponibles :
-- web_search(query, num_results=5) : recherche Brave
-- deep_research(query, num_queries=3) : recherche multi-requêtes synthétisée
-- check_fact(claim) : vérification d'affirmation factuelle
+# PHASES & TRANSITIONS
 
-Style : conversationnel, concis (2-3 phrases max par réponse vocale), curieux.
+Tu reçois ton état via [PHASE TRANSITION] :
+```
+[PHASE TRANSITION]
+from: startup
+to: streaming
+```
+
+PHASE startup (avant tout [CTX UPDATE]) :
+- Tu sais juste le titre + chaîne (bloc "VIDÉO ÉCOUTÉE" en tête).
+- Greeting chaleureux d'après le titre ("d'après le titre, ça parle de…").
+- Invite l'utilisateur à parler en attendant : ses attentes, ce qu'il sait
+  déjà, des questions préliminaires.
+- Si question factuelle → web_search immédiatement, annonce "Je vais
+  chercher sur le web".
+- Si question sur le contenu vidéo → "le transcript arrive dans quelques
+  secondes, je te réponds dès que je l'ai".
+
+PHASE streaming (premier [CTX UPDATE] reçu) :
+- Préfixe : "d'après ce que j'écoute pour l'instant…"
+- Cite les timecodes via meta.t_start/t_end quand pertinent.
+- Si question hors chunks reçus → "je n'ai pas encore cette partie".
+
+PHASE complete ([CTX COMPLETE] reçu) :
+```
+[CTX COMPLETE]
+final_digest: <synthèse 2000 chars max>
+transcript_total_chars: 47823
+analysis_sections: [summary, key_points, fact_check]
+```
+- "maintenant que j'ai tout le contexte"
+- Réponds avec pleine confiance, cite des timecodes précis.
+- Le `final_digest` te donne une synthèse de la vidéo entière.
+
+# HEARTBEAT & FALLBACK
+
+Tu reçois [CTX HEARTBEAT] toutes les 10s en phase streaming :
+```
+[CTX HEARTBEAT]
+phase: streaming
+chunks_received: 2
+last_event_age_seconds: 3.2
+```
+
+Si `last_event_age_seconds > 30`, le streaming est probablement bloqué :
+- Continue à parler avec le contexte que tu AS déjà reçu.
+- Pour toute question factuelle → web_search.
+- Ne dis PAS "le streaming est bloqué" à l'user — c'est invisible côté UX.
+
+# OUTILS
+
+- search_in_transcript(query) : chercher un passage précis dans le
+  transcript COMPLET (au-delà des chunks reçus en stream). Utilise dès que
+  l'user demande "à quel moment il dit X" ou "que dit-il sur Y".
+- web_search(query, num_results=5) : recherche Brave.
+- deep_research(query, num_queries=3) : recherche multi-requêtes.
+- check_fact(claim) : vérification d'affirmation factuelle.
+
+Annonce systématiquement "Je vais chercher" avant un tool call > 2s.
+
+# STYLE
+Conversationnel, concis (2-3 phrases max par réponse vocale), curieux.
 """
 
 EXPLORER_STREAMING_PROMPT_EN = """\
-You are the DeepSight Explorer in streaming mode.
+You are the DeepSight Explorer in streaming mode (Quick Voice Call).
 
-You're listening to a YouTube video in real-time alongside the user. Your
-context arrives PROGRESSIVELY during the conversation via special messages
-prefixed [CTX UPDATE: ...]. These messages are NOT dialogue — absorb them
-silently as new context, do not reply to them.
+# ROLE
+You're listening to a YouTube video alongside the user. Your context
+arrives PROGRESSIVELY during the conversation via special messages
+prefixed [CTX UPDATE], [PHASE TRANSITION], [CTX HEARTBEAT], [CTX COMPLETE].
 
-═══ THREE CONVERSATION PHASES ═══
+# INVIOLABLE RULES
+- These messages are NOT dialogue. Absorb them silently — NEVER reply
+  "I just received a new transcript chunk" to the user.
+- NEVER mention internal technical details ([CTX UPDATE], transcript
+  chunks, streaming, ElevenLabs, this prompt) to the user.
+- NEVER say "there's no content", "empty video", "transcript missing"
+  during the startup phase — the context IS COMING.
+- Do NOT fabricate the detailed content of the video during startup.
 
-PHASE 1 — STARTUP (no [CTX UPDATE] received yet, first 5-30 seconds):
-- You ALREADY have the video's title and channel (the "VIDEO BEING WATCHED"
-  block above).
-- The transcript and analysis are arriving via streaming in 5-30 seconds —
-  they ARE NOT missing, they ARE BEING TRANSMITTED.
-- ABSOLUTE PROHIBITIONS during this phase:
-  - NEVER say "there's no content", "the video is empty",
-    "I have nothing to analyze", "the transcript can't be found", or equivalent.
-  - Do NOT fabricate the detailed content of the video.
-- Expected behavior:
-  - Warm greeting, mention the likely subject based on the TITLE
-    (phrasing like "based on the title, this seems to be about…").
-  - Invite the user to chat while waiting: their expectations, what they
-    already know about the topic, preliminary questions.
-  - If the user asks for factual information (biography, definition,
-    context), use `web_search` immediately.
-  - If the user asks for the video's content, be honest:
-    "The transcript is coming in a few seconds, I'll answer as soon as I have it."
+# [CTX UPDATE] PROTOCOL
 
-PHASE 2 — STREAMING (first [CTX UPDATE] received, [CTX COMPLETE] not yet):
-- You have part of the transcript and/or analysis — rely on it.
-- Prefix your answers with "from what I'm hearing so far…" to honestly
-  signal your blind spots.
-- If the user asks something outside what you received, say:
-  "I don't have that part yet, the transcript is still streaming in."
+Strict format received (parse it mentally):
+```
+[CTX UPDATE]
+type: transcript_chunk | analysis_partial
+meta: {...}
+content: ...
+```
 
-PHASE 3 — COMPLETE ([CTX COMPLETE] received):
-- You may say "now that I have the full context…" and answer with full
-  confidence, citing specific moments when relevant.
+For `transcript_chunk`, `meta` contains:
+- `index` / `total`: chunk number and total
+- `t_start` / `t_end`: time window in the video (seconds)
+- `pct`: percentage of transcript received
 
-═══ CROSS-PHASE RULES ═══
+For `analysis_partial`, `meta` contains:
+- `section`: section name (summary, key_points, fact_check, ...)
 
-- If the user asks a factual question not covered by received context
-  (regardless of phase), use `web_search` SYSTEMATICALLY.
-- Announce "Let me search the web" before calling `web_search`.
-- NEVER mention internal technical details ("CTX UPDATE", "transcript chunks",
-  "streaming") to the user — that's invisible plumbing on the UX side.
+Use `meta.t_start`/`t_end` to cite precise timecodes ("around 4:00 in the
+video"). Use `meta.pct` to gauge your coverage.
 
-Available tools:
-- web_search(query, num_results=5): Brave search
-- deep_research(query, num_queries=3): multi-query synthesized search
-- check_fact(claim): factual claim verification
+# PHASES & TRANSITIONS
 
-Style: conversational, concise (2-3 sentences max per voice reply), curious.
+You receive your state via [PHASE TRANSITION]:
+```
+[PHASE TRANSITION]
+from: startup
+to: streaming
+```
+
+PHASE startup (before any [CTX UPDATE]):
+- You only know the title + channel ("VIDEO BEING WATCHED" header block).
+- Warm greeting based on the title ("based on the title, this seems to
+  be about…").
+- Invite the user to talk while waiting: their expectations, what they
+  already know, preliminary questions.
+- Factual question → web_search immediately, announce "Let me search
+  the web".
+- Question about video content → "the transcript will arrive in a few
+  seconds, I'll answer as soon as I have it".
+
+PHASE streaming (first [CTX UPDATE] received):
+- Prefix: "from what I'm hearing so far…"
+- Cite timecodes via meta.t_start/t_end when relevant.
+- If question is outside received chunks → "I don't have that part yet".
+
+PHASE complete ([CTX COMPLETE] received):
+```
+[CTX COMPLETE]
+final_digest: <synthesis 2000 chars max>
+transcript_total_chars: 47823
+analysis_sections: [summary, key_points, fact_check]
+```
+- "now that I have the full context"
+- Answer with full confidence, cite precise timecodes.
+- The `final_digest` gives you a synthesis of the entire video.
+
+# HEARTBEAT & FALLBACK
+
+You receive [CTX HEARTBEAT] every 10s during the streaming phase:
+```
+[CTX HEARTBEAT]
+phase: streaming
+chunks_received: 2
+last_event_age_seconds: 3.2
+```
+
+If `last_event_age_seconds > 30`, streaming is probably stalled:
+- Keep going with the context you HAVE already received.
+- For any factual question → web_search.
+- Do NOT tell the user "streaming is stalled" — invisible on the UX side.
+
+# TOOLS
+
+- search_in_transcript(query): search a specific passage in the FULL
+  transcript (beyond the chunks received in stream). Use whenever the
+  user asks "when does he say X" or "what does he say about Y".
+- web_search(query, num_results=5): Brave search.
+- deep_research(query, num_queries=3): multi-query search.
+- check_fact(claim): factual claim verification.
+
+Always announce "Let me search" before any tool call > 2s.
+
+# STYLE
+Conversational, concise (2-3 sentences max per voice reply), curious.
 """

--- a/backend/tests/voice/test_companion_prompt_lang.py
+++ b/backend/tests/voice/test_companion_prompt_lang.py
@@ -1,0 +1,83 @@
+"""Tests for ``voice.companion_prompt.render_companion_prompt`` — language enforcement.
+
+The companion prompt now appends the per-language enforcement block
+(``LANGUAGE_ENFORCEMENT_FR`` / ``LANGUAGE_ENFORCEMENT_EN`` from
+``voice.agent_types``) to the rendered template, so the agent never
+slips out of the user's chosen tongue.
+
+The default ``language="fr"`` keeps backward compatibility with the
+six other agents.
+"""
+
+from __future__ import annotations
+
+from voice.companion_prompt import render_companion_prompt
+from voice.schemas import CompanionContextResponse, ProfileBlock, RecoItem
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _ctx() -> CompanionContextResponse:
+    """Minimal but valid Companion context for prompt rendering."""
+    return CompanionContextResponse(
+        profile=ProfileBlock(
+            prenom="Maxime",
+            plan="pro",
+            langue="fr",
+            total_analyses=3,
+            recent_titles=["A", "B"],
+            themes=["IA"],
+            streak_days=2,
+            flashcards_due_today=1,
+        ),
+        initial_recos=[
+            RecoItem(
+                video_id="r1",
+                title="Reco 1",
+                channel="Channel 1",
+                duration_seconds=300,
+                source="trending",
+                why="Pertinent pour ton historique",
+            ),
+        ],
+        cache_hit=False,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Language enforcement — FR
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_render_companion_prompt_fr_appends_language_enforcement():
+    """``language='fr'`` appends the FR enforcement block at the end."""
+    prompt = render_companion_prompt(_ctx(), language="fr")
+    assert "Tu DOIS parler UNIQUEMENT en français" in prompt
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Language enforcement — EN
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_render_companion_prompt_en_appends_language_enforcement():
+    """``language='en'`` appends the EN enforcement block at the end."""
+    prompt = render_companion_prompt(_ctx(), language="en")
+    assert "You MUST speak ONLY in English" in prompt
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Default language is FR
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_render_companion_prompt_default_lang_is_fr():
+    """No ``language`` argument → behaves identically to ``language='fr'``."""
+    prompt_default = render_companion_prompt(_ctx())
+    prompt_explicit_fr = render_companion_prompt(_ctx(), language="fr")
+    assert prompt_default == prompt_explicit_fr
+    # And the FR enforcement block is present.
+    assert "Tu DOIS parler UNIQUEMENT en français" in prompt_default

--- a/backend/tests/voice/test_prompt_identity.py
+++ b/backend/tests/voice/test_prompt_identity.py
@@ -1,0 +1,107 @@
+"""Tests for ``voice.prompt_identity`` — DeepSight shared identity header.
+
+Validates the brand-identity block injected at the top of every voice
+agent's system_prompt (FR + EN). The block must :
+  * carry the canonical brand keywords (DeepSight, Mistral AI, tagline,
+    European positioning, anti-bullshit voice principle);
+  * stay under a strict size budget so the 12 KB system_prompt window
+    keeps room for agent role + session block + video context;
+  * NOT contain any behavioral rules ("be concise", "max 3 sentences",
+    "use tools") — those belong to the per-agent prompts.
+
+All tests are synchronous; no DB / network / fixtures involved.
+"""
+
+from __future__ import annotations
+
+from voice.prompt_identity import (
+    DEEPSIGHT_VOICE_IDENTITY_EN,
+    DEEPSIGHT_VOICE_IDENTITY_FR,
+    get_identity_block,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Brand keywords — FR
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_identity_fr_contains_brand_keywords():
+    """FR identity must mention DeepSight, Mistral AI, the tagline, EU and anti-bullshit."""
+    block = DEEPSIGHT_VOICE_IDENTITY_FR
+    assert "DeepSight" in block
+    assert "Mistral AI" in block
+    assert "Ne subissez plus" in block
+    assert "européen" in block.lower()
+    assert "anti-bullshit" in block.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Brand keywords — EN
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_identity_en_contains_brand_keywords():
+    """EN identity must mention DeepSight, Mistral AI, tagline, European, anti-bullshit."""
+    block = DEEPSIGHT_VOICE_IDENTITY_EN
+    assert "DeepSight" in block
+    assert "Mistral AI" in block
+    assert "Interrogate them" in block
+    assert "European" in block
+    assert "anti-bullshit" in block.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_identity_block() resolver
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_get_identity_block_fr_default():
+    """Default call (no argument) returns the FR identity block verbatim."""
+    assert get_identity_block() == DEEPSIGHT_VOICE_IDENTITY_FR
+
+
+def test_get_identity_block_en():
+    """Explicit ``en`` argument returns the EN identity block verbatim."""
+    assert get_identity_block("en") == DEEPSIGHT_VOICE_IDENTITY_EN
+
+
+def test_get_identity_block_unknown_falls_to_fr():
+    """Unknown language code falls back to FR (DeepSight's primary market)."""
+    # ``zh`` is not handled by the resolver — must default to FR.
+    assert get_identity_block("zh") == DEEPSIGHT_VOICE_IDENTITY_FR  # type: ignore[arg-type]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Size budget
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_identity_blocks_under_size_budget():
+    """Identity blocks stay under 1500 chars to fit the 12 KB system_prompt."""
+    assert len(DEEPSIGHT_VOICE_IDENTITY_FR) < 1500, (
+        f"FR identity is {len(DEEPSIGHT_VOICE_IDENTITY_FR)} chars — too large"
+    )
+    assert len(DEEPSIGHT_VOICE_IDENTITY_EN) < 1500, (
+        f"EN identity is {len(DEEPSIGHT_VOICE_IDENTITY_EN)} chars — too large"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Identity vs behavior — strict separation of concerns
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_identity_blocks_no_behavioral_rules():
+    """Identity must NOT carry behavior rules — those belong in per-agent prompts."""
+    forbidden = ["be concise", "max 3 sentences", "use tools"]
+    for block_name, block in (
+        ("FR", DEEPSIGHT_VOICE_IDENTITY_FR),
+        ("EN", DEEPSIGHT_VOICE_IDENTITY_EN),
+    ):
+        lower = block.lower()
+        for phrase in forbidden:
+            assert phrase not in lower, (
+                f"{block_name} identity leaks behavioral rule {phrase!r} — "
+                "this belongs in the per-agent prompt, not the identity block."
+            )

--- a/backend/tests/voice/test_prompt_session.py
+++ b/backend/tests/voice/test_prompt_session.py
@@ -1,0 +1,384 @@
+"""Tests for ``voice.prompt_session.build_session_block``.
+
+Validates the unified ``# SESSION`` / ``# UTILISATEUR`` / ``# ANALYSES
+RÉCENTES`` block injected between the brand identity and the video
+context in every voice agent system_prompt.
+
+The function is best-effort: any DB error must be logged and the
+section silently omitted — the caller never sees an exception. The
+block is also capped at 1500 chars; oversized inputs are truncated by
+dropping recent analyses first, then the themes line.
+
+All tests use ``AsyncMock`` for the SQLAlchemy session so we don't need
+a real Postgres / SQLite engine.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from voice.prompt_session import MAX_BLOCK_CHARS, build_session_block
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _user(**overrides):
+    """Return a MagicMock user with sensible voice-test defaults."""
+    user = MagicMock()
+    user.id = overrides.get("id", 42)
+    user.first_name = overrides.get("first_name", "Maxime")
+    user.prenom = overrides.get("prenom", None)
+    user.plan = overrides.get("plan", "expert")
+    user.language = overrides.get("language", "fr")
+    return user
+
+
+def _patch_db_helpers(
+    *,
+    total: int | None = 0,
+    recents=None,
+    flashcards: int | None = None,
+    themes=None,
+):
+    """Context-manager-like helper: returns a list of patch contexts to enter.
+
+    Patches the four DB-touching helpers in ``voice.prompt_session`` so the
+    test never needs a real session.
+    """
+    return [
+        patch(
+            "voice.prompt_session._fetch_total_analyses",
+            new=AsyncMock(return_value=total),
+        ),
+        patch(
+            "voice.prompt_session._fetch_recent_summaries",
+            new=AsyncMock(return_value=recents or []),
+        ),
+        patch(
+            "voice.prompt_session._fetch_flashcards_due_today",
+            new=AsyncMock(return_value=flashcards),
+        ),
+        patch(
+            "voice.prompt_session._fetch_themes",
+            new=AsyncMock(return_value=themes or []),
+        ),
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Full FR happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_fr_with_full_user():
+    """A complete FR user on extension produces a fully populated FR block."""
+    user = _user(first_name="Maxime", plan="expert")
+    db = AsyncMock()
+
+    patches = _patch_db_helpers(total=12, recents=[], flashcards=None, themes=[])
+    for p in patches:
+        p.start()
+    try:
+        block = await build_session_block(
+            user=user,
+            db=db,
+            platform="extension",
+            agent_type="explorer",
+            surface="voice_call",
+            language="fr",
+            voice_quota_remaining_min=15.0,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert "Maxime" in block
+    assert "Expert" in block
+    assert "français" in block
+    assert "extension Chrome" in block
+    assert "# SESSION" in block
+    assert "# UTILISATEUR" in block
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Minimal EN path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_en_basic():
+    """Minimal EN user produces all three section headers in English."""
+    user = _user(first_name="Sam", plan="free", language="en")
+    db = AsyncMock()
+
+    fake_summary = MagicMock()
+    fake_summary.video_title = "Some video"
+    fake_summary.video_channel = "Some Channel"
+    fake_summary.created_at = None  # avoids relative-date branch
+
+    patches = _patch_db_helpers(
+        total=1, recents=[fake_summary], flashcards=None, themes=[]
+    )
+    for p in patches:
+        p.start()
+    try:
+        block = await build_session_block(
+            user=user,
+            db=db,
+            platform="web",
+            agent_type="explorer",
+            surface="voice_call",
+            language="en",
+            voice_quota_remaining_min=None,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert "# SESSION" in block
+    assert "# USER" in block
+    assert "# RECENT ANALYSES" in block
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Missing first name
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_no_first_name():
+    """When neither ``first_name`` nor ``prenom`` is set, a hint is emitted."""
+    user = _user(first_name=None, prenom=None)
+    db = AsyncMock()
+
+    patches = _patch_db_helpers()
+    for p in patches:
+        p.start()
+    try:
+        block_fr = await build_session_block(
+            user=user,
+            db=db,
+            platform="web",
+            agent_type="explorer",
+            surface="voice_call",
+            language="fr",
+            voice_quota_remaining_min=10,
+        )
+        block_en = await build_session_block(
+            user=user,
+            db=db,
+            platform="web",
+            agent_type="explorer",
+            surface="voice_call",
+            language="en",
+            voice_quota_remaining_min=10,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert "Prénom inconnu" in block_fr
+    assert "First name unknown" in block_en
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Plan + quota matrix
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_free_plan_unused_trial():
+    """Free + quota=None → 'essai gratuit lifetime non utilisé'."""
+    user = _user(plan="free", first_name="A")
+    db = AsyncMock()
+
+    patches = _patch_db_helpers()
+    for p in patches:
+        p.start()
+    try:
+        block = await build_session_block(
+            user=user,
+            db=db,
+            platform="web",
+            agent_type="explorer",
+            surface="voice_call",
+            language="fr",
+            voice_quota_remaining_min=None,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+    assert "essai gratuit lifetime non utilisé" in block
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_free_plan_trial_used():
+    """Free + quota=0 → 'essai utilisé'."""
+    user = _user(plan="free", first_name="A")
+    db = AsyncMock()
+
+    patches = _patch_db_helpers()
+    for p in patches:
+        p.start()
+    try:
+        block = await build_session_block(
+            user=user,
+            db=db,
+            platform="web",
+            agent_type="explorer",
+            surface="voice_call",
+            language="fr",
+            voice_quota_remaining_min=0,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+    assert "essai utilisé" in block
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_pro_plan():
+    """Pro plan → 'voice désactivé sur ce plan — Expert requis'."""
+    user = _user(plan="pro", first_name="B")
+    db = AsyncMock()
+
+    patches = _patch_db_helpers()
+    for p in patches:
+        p.start()
+    try:
+        block = await build_session_block(
+            user=user,
+            db=db,
+            platform="web",
+            agent_type="explorer",
+            surface="voice_call",
+            language="fr",
+            voice_quota_remaining_min=None,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+    assert "voice désactivé sur ce plan — Expert requis" in block
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_expert_with_quota():
+    """Expert + quota → '<min> min restantes'."""
+    user = _user(plan="expert", first_name="C")
+    db = AsyncMock()
+
+    patches = _patch_db_helpers()
+    for p in patches:
+        p.start()
+    try:
+        block = await build_session_block(
+            user=user,
+            db=db,
+            platform="web",
+            agent_type="explorer",
+            surface="voice_call",
+            language="fr",
+            voice_quota_remaining_min=15.5,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+    # 15.5 rounds to 15.5 with one decimal — substring "15" must be present.
+    assert "15" in block
+    assert "min restantes" in block
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Resilience to DB errors
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_db_error_returns_partial():
+    """A failing Summary query must NOT crash the block — fallback minimal."""
+    user = _user(first_name="D", plan="free")
+    db = AsyncMock()
+
+    # Each helper is wrapped in a try/except inside the module; we patch the
+    # outer helpers so the catch happens internally and the section is omitted.
+    with patch(
+        "voice.prompt_session._fetch_total_analyses",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ), patch(
+        "voice.prompt_session._fetch_recent_summaries",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ), patch(
+        "voice.prompt_session._fetch_flashcards_due_today",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "voice.prompt_session._fetch_themes", new=AsyncMock(return_value=[])
+    ):
+        # The helpers themselves swallow exceptions; if a future refactor lets
+        # one escape, build_session_block should still finish gracefully — at
+        # the very least the SESSION + UTILISATEUR sections must remain.
+        try:
+            block = await build_session_block(
+                user=user,
+                db=db,
+                platform="web",
+                agent_type="explorer",
+                surface="voice_call",
+                language="fr",
+                voice_quota_remaining_min=None,
+            )
+        except Exception as exc:  # pragma: no cover — fail explicit
+            pytest.fail(f"build_session_block must not raise on DB error: {exc!r}")
+
+    assert "# SESSION" in block
+    assert "# UTILISATEUR" in block
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cap 1500 chars
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_session_block_under_1500_chars():
+    """Pathological input (50 analyses + 30 themes) → cap is enforced."""
+    user = _user(first_name="X", plan="expert")
+    db = AsyncMock()
+
+    big_summaries = []
+    for i in range(50):
+        s = MagicMock()
+        s.video_title = f"Une analyse vidéo très longue numéro {i} avec un titre verbeux"
+        s.video_channel = f"Channel{i}"
+        s.created_at = None
+        big_summaries.append(s)
+
+    big_themes = [f"theme_extremely_long_label_{i}" for i in range(30)]
+
+    patches = _patch_db_helpers(
+        total=50, recents=big_summaries, flashcards=99, themes=big_themes
+    )
+    for p in patches:
+        p.start()
+    try:
+        block = await build_session_block(
+            user=user,
+            db=db,
+            platform="web",
+            agent_type="explorer",
+            surface="voice_call",
+            language="fr",
+            voice_quota_remaining_min=120.0,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert len(block) <= MAX_BLOCK_CHARS, (
+        f"block is {len(block)} chars — must be <= {MAX_BLOCK_CHARS}"
+    )

--- a/backend/tests/voice/test_streaming_orchestrator_v2.py
+++ b/backend/tests/voice/test_streaming_orchestrator_v2.py
@@ -1,0 +1,248 @@
+"""Tests for ``voice.streaming_orchestrator`` v2 — phase + heartbeat protocol.
+
+The v2 orchestrator emits, in addition to the legacy ``transcript_chunk``
+/ ``analysis_partial`` / ``ctx_complete`` events:
+
+  * ``phase_transition`` (startup → streaming) on the FIRST published
+    transcript or analysis chunk — idempotent;
+  * ``phase_transition`` (streaming → complete) right before
+    ``ctx_complete`` is published — idempotent;
+  * ``ctx_heartbeat`` every ``HEARTBEAT_INTERVAL_SECONDS`` carrying
+    ``phase``, ``chunks_received`` and ``last_event_age_seconds``.
+
+The ``FINAL_DIGEST_MAX_CHARS`` cap was bumped from 500 → 2000 so the
+agent receives the full final summary in phase complete.
+
+Constants are re-imported per test so any future refactor that changes
+the source of truth still trips a failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from voice.streaming_orchestrator import (
+    FINAL_DIGEST_MAX_CHARS,
+    HEARTBEAT_INTERVAL_SECONDS,
+    StreamingOrchestrator,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _async_iter_factory(items):
+    """Return a callable(_video_id) → async iterator yielding ``items``."""
+
+    def _factory(_video_id):
+        async def _gen() -> AsyncIterator[dict]:
+            for it in items:
+                yield it
+
+        return _gen()
+
+    return _factory
+
+
+def _decoded_events(mock_redis) -> list[dict]:
+    """Return the JSON-decoded payload of every ``redis.publish`` call."""
+    out = []
+    for call in mock_redis.publish.await_args_list:
+        _ch, data = call.args[0], call.args[1]
+        out.append(json.loads(data))
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants are pinned at the documented values
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_final_digest_max_chars_is_2000():
+    """The new cap (was 500) is set to 2000 so the agent gets the full digest."""
+    assert FINAL_DIGEST_MAX_CHARS == 2000
+
+
+def test_heartbeat_interval_is_10s():
+    """Heartbeat cadence is 10 seconds per the spec."""
+    assert HEARTBEAT_INTERVAL_SECONDS == 10
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# phase_transition: startup → streaming (idempotent)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_emits_phase_transition_startup_to_streaming_once():
+    """Even with 3 chunks, only ONE startup → streaming transition is emitted."""
+    redis = AsyncMock()
+    chunks = [
+        {"text": "A", "index": 0, "total": 3},
+        {"text": "B", "index": 1, "total": 3},
+        {"text": "C", "index": 2, "total": 3},
+    ]
+    orch = StreamingOrchestrator(
+        redis=redis,
+        fetch_transcript=_async_iter_factory(chunks),
+        run_analysis=AsyncMock(return_value={}),
+        final_digest=AsyncMock(return_value="d"),
+    )
+    await orch.run(session_id="s-startup", video_id="vid", user_id=1)
+
+    transitions = [
+        e
+        for e in _decoded_events(redis)
+        if e.get("type") == "phase_transition"
+        and e.get("from") == "startup"
+        and e.get("to") == "streaming"
+    ]
+    assert len(transitions) == 1, (
+        f"expected exactly one startup → streaming transition, got {len(transitions)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_phase_transition_idempotent_on_multiple_chunks():
+    """5 transcript chunks → still a single startup → streaming transition."""
+    redis = AsyncMock()
+    chunks = [{"text": str(i), "index": i, "total": 5} for i in range(5)]
+    orch = StreamingOrchestrator(
+        redis=redis,
+        fetch_transcript=_async_iter_factory(chunks),
+        run_analysis=AsyncMock(return_value={"summary": "S"}),
+        final_digest=AsyncMock(return_value="d"),
+    )
+    await orch.run(session_id="s-idem", video_id="vid", user_id=1)
+
+    transitions = [
+        e
+        for e in _decoded_events(redis)
+        if e.get("type") == "phase_transition" and e.get("to") == "streaming"
+    ]
+    assert len(transitions) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# phase_transition: streaming → complete (idempotent + happens before ctx_complete)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_emits_phase_transition_streaming_to_complete_once():
+    """Exactly one streaming → complete transition, emitted before ctx_complete."""
+    redis = AsyncMock()
+    chunks = [{"text": "x", "index": 0, "total": 1}]
+    orch = StreamingOrchestrator(
+        redis=redis,
+        fetch_transcript=_async_iter_factory(chunks),
+        run_analysis=AsyncMock(return_value={}),
+        final_digest=AsyncMock(return_value="final"),
+    )
+    await orch.run(session_id="s-end", video_id="vid", user_id=1)
+
+    events = _decoded_events(redis)
+    transitions = [
+        (i, e)
+        for i, e in enumerate(events)
+        if e.get("type") == "phase_transition"
+        and e.get("from") == "streaming"
+        and e.get("to") == "complete"
+    ]
+    assert len(transitions) == 1, "expected exactly one streaming → complete transition"
+
+    # ``ctx_complete`` must come after the streaming → complete transition.
+    transition_idx = transitions[0][0]
+    completes = [i for i, e in enumerate(events) if e.get("type") == "ctx_complete"]
+    assert completes, "ctx_complete must always be emitted"
+    assert transition_idx < completes[-1], (
+        "phase_transition (streaming → complete) must precede ctx_complete"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Heartbeat — best-effort: pause the cadence via monkeypatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_emits_heartbeat_during_streaming(monkeypatch):
+    """At least one ctx_heartbeat is emitted when the pipeline lingers.
+
+    We monkeypatch ``HEARTBEAT_INTERVAL_SECONDS`` to a sub-second value
+    BEFORE constructing the orchestrator. The transcript fetcher sleeps a
+    few cadence ticks while yielding a single chunk, which is enough for
+    at least one heartbeat to fire.
+    """
+    # Speed the cadence up — must happen before _heartbeat_loop reads the
+    # constant. The loop captures it via module-level lookup, so patching
+    # the attribute on the module is what actually counts here.
+    monkeypatch.setattr(
+        "voice.streaming_orchestrator.HEARTBEAT_INTERVAL_SECONDS", 0.05
+    )
+
+    redis = AsyncMock()
+
+    async def slow_chunks():
+        # Sleep through several heartbeat ticks before yielding.
+        await asyncio.sleep(0.25)
+        yield {"text": "single", "index": 0, "total": 1}
+
+    fetch_transcript = MagicMock(return_value=slow_chunks())
+
+    orch = StreamingOrchestrator(
+        redis=redis,
+        fetch_transcript=fetch_transcript,
+        run_analysis=AsyncMock(return_value={}),
+        final_digest=AsyncMock(return_value="d"),
+    )
+    await orch.run(session_id="s-hb", video_id="vid", user_id=1)
+
+    heartbeats = [
+        e for e in _decoded_events(redis) if e.get("type") == "ctx_heartbeat"
+    ]
+    assert heartbeats, "expected at least one ctx_heartbeat during a slow run"
+    # Each heartbeat must carry the 3 documented fields.
+    for hb in heartbeats:
+        assert "phase" in hb
+        assert "chunks_received" in hb
+        assert "last_event_age_seconds" in hb
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ctx_complete is always emitted — even on transcript failure
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_still_emits_ctx_complete_when_transcript_fails():
+    """A crashing transcript fetcher does NOT prevent ctx_complete."""
+    redis = AsyncMock()
+
+    async def boom_iter():
+        raise RuntimeError("supadata 503")
+        yield  # pragma: no cover — make it an async-gen syntactically
+
+    fetch_transcript = MagicMock(return_value=boom_iter())
+
+    orch = StreamingOrchestrator(
+        redis=redis,
+        fetch_transcript=fetch_transcript,
+        run_analysis=AsyncMock(return_value={}),
+        final_digest=AsyncMock(return_value="fallback digest"),
+    )
+    await orch.run(session_id="s-err", video_id="vid", user_id=1)
+
+    events = _decoded_events(redis)
+    assert events[-1].get("type") == "ctx_complete", (
+        "ctx_complete must be the last event even when transcript fails"
+    )
+    # An ``error`` event must be present too — surface the failure to the SSE consumer.
+    assert any(e.get("type") == "error" for e in events)

--- a/backend/tests/voice/test_streaming_prompts_v2.py
+++ b/backend/tests/voice/test_streaming_prompts_v2.py
@@ -1,0 +1,123 @@
+"""Tests for ``voice.streaming_prompts`` v2 — Quick Voice Call protocol.
+
+The two prompts (``EXPLORER_STREAMING_PROMPT_FR`` and
+``EXPLORER_STREAMING_PROMPT_EN``) brief the voice agent on the new
+3-phase ``[CTX UPDATE]`` envelope protocol used by the Quick Voice Call
+streaming orchestrator.
+
+These tests pin the prompt's contract:
+  * the 3 lifecycle phases are documented (startup, streaming, complete);
+  * the four event tags are mentioned by name;
+  * the 30-second heartbeat → silent ``web_search`` fallback rule is in;
+  * size budget < 5 KB per language;
+  * the agent is forbidden from saying "no content" / "empty video";
+  * the four tools (search_in_transcript, web_search, deep_research,
+    check_fact) are listed.
+
+All tests are synchronous and string-based — no DB / network involved.
+"""
+
+from __future__ import annotations
+
+from voice.streaming_prompts import (
+    EXPLORER_STREAMING_PROMPT_EN,
+    EXPLORER_STREAMING_PROMPT_FR,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Lifecycle phases
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_streaming_prompt_fr_three_phases():
+    """FR prompt explicitly documents the startup / streaming / complete phases."""
+    block = EXPLORER_STREAMING_PROMPT_FR
+    assert "PHASE startup" in block
+    assert "PHASE streaming" in block
+    assert "PHASE complete" in block
+
+
+def test_streaming_prompt_en_three_phases():
+    """EN prompt mirrors the 3-phase lifecycle."""
+    block = EXPLORER_STREAMING_PROMPT_EN
+    assert "PHASE startup" in block
+    assert "PHASE streaming" in block
+    assert "PHASE complete" in block
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Envelope protocol tags
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_streaming_prompt_mentions_ctx_update_protocol():
+    """Both prompts must describe the four envelope tags by name."""
+    for name, block in (
+        ("FR", EXPLORER_STREAMING_PROMPT_FR),
+        ("EN", EXPLORER_STREAMING_PROMPT_EN),
+    ):
+        assert "[CTX UPDATE]" in block, f"{name} prompt missing [CTX UPDATE]"
+        assert "[PHASE TRANSITION]" in block, f"{name} prompt missing [PHASE TRANSITION]"
+        assert "[CTX HEARTBEAT]" in block, f"{name} prompt missing [CTX HEARTBEAT]"
+        assert "[CTX COMPLETE]" in block, f"{name} prompt missing [CTX COMPLETE]"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stalled-stream fallback
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_streaming_prompt_mentions_30s_fallback():
+    """If last_event_age_seconds > 30 → silent web_search fallback."""
+    for name, block in (
+        ("FR", EXPLORER_STREAMING_PROMPT_FR),
+        ("EN", EXPLORER_STREAMING_PROMPT_EN),
+    ):
+        assert "30" in block, f"{name} prompt missing the 30-second threshold"
+        assert "web_search" in block, f"{name} prompt missing web_search fallback"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Size budget
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_streaming_prompt_size_under_5kb():
+    """Each prompt stays under 5 KB to fit the 12 KB system_prompt budget."""
+    assert len(EXPLORER_STREAMING_PROMPT_FR) < 5000, (
+        f"FR streaming prompt is {len(EXPLORER_STREAMING_PROMPT_FR)} chars — too large"
+    )
+    assert len(EXPLORER_STREAMING_PROMPT_EN) < 5000, (
+        f"EN streaming prompt is {len(EXPLORER_STREAMING_PROMPT_EN)} chars — too large"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Forbidden phrases
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_streaming_prompt_forbids_no_content_phrase():
+    """FR prompt forbids 'no content' / 'empty video' messages in startup."""
+    block = EXPLORER_STREAMING_PROMPT_FR
+    assert "JAMAIS" in block
+    # The forbidden phrases that must appear inside an interdiction context.
+    assert "pas de contenu" in block
+    assert "vidéo vide" in block
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tool roster
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_streaming_prompt_lists_all_4_tools():
+    """All 4 tools must be discoverable in both prompts."""
+    expected = ["search_in_transcript", "web_search", "deep_research", "check_fact"]
+    for name, block in (
+        ("FR", EXPLORER_STREAMING_PROMPT_FR),
+        ("EN", EXPLORER_STREAMING_PROMPT_EN),
+    ):
+        for tool in expected:
+            assert tool in block, f"{name} prompt is missing tool {tool!r}"


### PR DESCRIPTION
## Problème

L'agent ElevenLabs voice ressemblait à un ChatGPT générique TTS :
- **Identité diluée** : "Tu es l'assistant vocal DeepSight" sans dire QUI est DeepSight, son public, son ton, ses valeurs
- **Pas de conscience user** : seul COMPANION savait le prénom, plan, analyses récentes — les 6 autres agents naviguaient à l'aveugle
- **Streaming basique** : `[CTX UPDATE: transcript chunk 0/3]` en string libre, sans meta temporelle, sans heartbeat, sans signal de phase explicite — l'agent pouvait s'engluer en phase 1 silencieusement
- **`final_digest_summary` tronqué à 500 chars** : phase 3 promettait "tout le contexte", livrait 1/200ᵉ d'une vidéo 1h
- **`EXPLORER_STREAMING` privé de `search_in_transcript`** : régression UX vs EXPLORER classique
- **`render_companion_prompt` shortcircuitait `get_language_enforcement`** → COMPANION pouvait leak en anglais

## Solution — 3 modules empilables

```
┌─ IDENTITÉ DeepSight Voice (NEW prompt_identity.py) ────────┐
│  Marque, public, ton, valeurs (FR/EU, anti-bullshit)       │
└─────────────────────────────────────────────────────────────┘
                            +
┌─ SESSION (NEW prompt_session.py) ───────────────────────────┐
│  Plateforme · Surface · Agent · Langue                      │
│  Prénom · Plan · Quota voice · Analyses · Themes            │
└─────────────────────────────────────────────────────────────┘
                            +
┌─ AGENT-SPECIFIC PROMPT (existant) ──────────────────────────┐
│  Rôle, comportement, style — par type d'agent               │
└─────────────────────────────────────────────────────────────┘
                            +
┌─ CONTEXTE VIDÉO / DÉBAT / VIDÉO ÉCOUTÉE (existant) ────────┐
│  Titre, chaîne, durée, transcript, fact-check, etc.        │
└─────────────────────────────────────────────────────────────┘
                            +
┌─ MÉMOIRE CROSS-SESSION (étendu au streaming) ──────────────┐
│  voice_session.summary_id en fallback (placeholder Summary) │
└─────────────────────────────────────────────────────────────┘
                            +
┌─ LANGUAGE ENFORCEMENT (companion fixé) ────────────────────┐
│  FR/EN absolu, jamais mixé                                  │
└─────────────────────────────────────────────────────────────┘
```

## Refonte streaming_prompts.py — protocole v2

Nouveau format structuré :

```
[CTX UPDATE]
type: transcript_chunk | analysis_partial
meta: {index: 1, total: 5, t_start: 0, t_end: 240, pct: 20}
content: ...

[PHASE TRANSITION]
from: startup → streaming → complete

[CTX HEARTBEAT]
phase: streaming
chunks_received: 2
last_event_age_seconds: 3.2

[CTX COMPLETE]
final_digest: <2000 chars max>
transcript_total_chars: 47823
analysis_sections: [summary, key_points, fact_check]
```

Règle fallback : si `last_event_age_seconds > 30` → bascule silencieuse sur `web_search`, sans en informer l'user.

## Orchestrator

- `FINAL_DIGEST_MAX_CHARS` 500 → **2000**
- Nouveau `HEARTBEAT_INTERVAL_SECONDS = 10` + coroutine `_heartbeat_loop`
- Émission idempotente `phase_transition` startup→streaming + streaming→complete

## Fixes ciblés

| Fix | Fichier | Effet |
|---|---|---|
| `search_in_transcript` ajouté à `EXPLORER_STREAMING.tools` | `agent_types.py` | L'agent streaming peut chercher dans le transcript complet (au-delà des chunks reçus) |
| `render_companion_prompt(language)` append `get_language_enforcement` | `companion_prompt.py` | Plus de leak en anglais quand user FR |
| `effective_summary_id` étend mémoire cross-session au streaming | `router.py` | Le placeholder Summary v1/v3 sert maintenant de clé pour `unified_context_block` |
| `first_message` interpole `{video_title}` | `agent_types.py`, `router.py` | "Salut ! On part sur « X »…" au lieu de "je commence à écouter cette vidéo" |

## Tests

**33 tests pytest, 100% green** :

```
test_prompt_identity.py            7/7 PASSED
test_prompt_session.py             9/9 PASSED
test_streaming_prompts_v2.py       7/7 PASSED
test_streaming_orchestrator_v2.py  7/7 PASSED
test_companion_prompt_lang.py      3/3 PASSED
```

## Test plan post-merge

- [ ] Auto-deploy Hetzner après merge → backend container `repo-backend-1` rebuild + restart (~2-3 min, push to main webhook)
- [ ] Test Quick Voice Call sur YouTube (extension) :
  - L'agent doit dire un greeting basé sur le titre + son nom DeepSight Voice
  - Doit mentionner le plan user dans son comportement (e.g. ne pas pousser à upgrade si Expert)
  - Doit basculer silencieusement sur `web_search` si streaming bloqué > 30s
- [ ] Test EXPLORER classique sur vidéo analysée — mêmes vérifs identité + session
- [ ] Test COMPANION (free voice call) — vérifier qu'il répond TOUJOURS en FR même si user lui parle EN

## Hors scope (suivi à dispatcher)

- Tests E2E Playwright "[CTX UPDATE] leak detection" sur 50+ conversations réelles
- Traduction `COMPANION_TEMPLATE` en EN (TODO comment laissé en place)

## Notes

- Pas de migration DB — code Python pur
- Pas de touche frontend/extension — le prompt est créé côté backend à chaque session
- Pas de breaking change API
- Pas de modif aux fonctions `_make_*`/`create_*_orchestrator` (signature préservée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)