### PR TITLE
test(e2e): add data-attrs for hub-first navigation E2E selectors

### DIFF
--- a/frontend/src/components/RecentAnalysesSection.tsx
+++ b/frontend/src/components/RecentAnalysesSection.tsx
@@ -15,7 +15,7 @@ import { sanitizeTitle } from "../utils/sanitize";
 interface RecentAnalysesSectionProps {
   language: "fr" | "en";
   onVideoSelect: (videoId: string) => void;
-  /** Navigate to the analysis detail (e.g. /history?open=summaryId) */
+  /** Navigate to the analysis conversation in the hub (e.g. /hub?summary=summaryId) */
   onOpenAnalysis?: (summaryId: number, videoId: string) => void;
   hidden?: boolean;
 }
@@ -98,6 +98,7 @@ export const RecentAnalysesSection: React.FC<RecentAnalysesSectionProps> = ({
         {recent.map((item) => (
           <button
             key={item.id}
+            data-recent-analysis-id={item.id}
             onClick={() =>
               onOpenAnalysis
                 ? onOpenAnalysis(item.id, item.video_id)

--- a/frontend/src/components/hub/ConversationsDrawer.tsx
+++ b/frontend/src/components/hub/ConversationsDrawer.tsx
@@ -67,6 +67,7 @@ export const ConversationsDrawer: React.FC<Props> = ({
           <button
             key={c.id}
             type="button"
+            data-conv-id={c.id}
             onClick={() => {
               onSelect(c.id);
               onClose();


### PR DESCRIPTION
## Contexte

Suit PR #222 (hub-first navigation, mergée) qui a livré \`frontend/e2e/hub-first-navigation.spec.ts\` avec 3 scenarios. Les sélecteurs reposent sur deux \`data-*\` attributes qui n'existent pas encore dans le DOM — sans eux, les 3 scenarios skippent en CI.

## Changements

- \`components/hub/ConversationsDrawer.tsx\` : ajout \`data-conv-id={c.id}\` sur le \`<button>\` conversation. Utilisé par \`pickFirstSummaryId()\` dans le spec E2E pour récupérer un id réel.
- \`components/RecentAnalysesSection.tsx\` : ajout \`data-recent-analysis-id={item.id}\` sur la card. Utilisé par scenario 3.
- Bonus : commentaire JSDoc \`onOpenAnalysis\` mis à jour (\`/history?open=\` → \`/hub?summary=\`, obsolète depuis PR #222).

## Effet

- E2E hub-first scenarios passent en CI au lieu de skip silencieusement (à condition que le test user ait au moins une analyse).
- Aucun changement visuel utilisateur (data-attrs ne touchent pas au rendu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)