### PR TITLE
fix(frontend): add missing TS2304 types in services/api.ts (Study module)

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,6 +8,16 @@
  */
 
 import { translateApiError } from "../utils/errorMessages";
+import type {
+  StudyStats,
+  HeatMapData,
+  BadgesData,
+  VideoMasteryData,
+  DueCardsData,
+  ReviewResult,
+  StudySessionData,
+  SessionEndResult,
+} from "../types/gamification";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // ⚙️ CONFIGURATION


### PR DESCRIPTION
## Summary

- Import 8 missing types from existing `frontend/src/types/gamification.ts` into `frontend/src/services/api.ts`.
- Fixes 8 TS2304 (`Cannot find name`) errors on the `gamificationApi` return-type annotations (lines 2991-3042).
- Types involved: `StudyStats`, `HeatMapData`, `BadgesData`, `VideoMasteryData`, `DueCardsData`, `ReviewResult`, `StudySessionData`, `SessionEndResult`.

## Why these types

The 8 types were already defined in `frontend/src/types/gamification.ts` (commented as "aligned with the backend"), but had never been imported into `services/api.ts`. The `gamificationApi` block was annotated against them as `Promise<StudyStats>` etc., relying on names that did not exist in the file scope.

Source verification:
- Backend Pydantic schemas in `backend/src/gamification/router.py` (`StatsResponse`, `HeatMapResponse`, `BadgesResponse`, `VideoMasteryResponse`) and `backend/src/study/schemas.py` (`ReviewResponse`, `DueCardsResponse`, `SessionStartResponse`, `SessionEndResponse`) match the frontend type shapes already in `gamification.ts`.
- No mobile mirror to sync — `mobile/src/services/api.ts` does not yet expose a `gamificationApi`.

## Diff scope

Only `frontend/src/services/api.ts` modified. 10 added lines (the import block). Logic untouched.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json 2>&1 | grep "services/api.ts"` returns **0 lines** post-fix (was 8 TS2304 before).
- [x] Remaining typecheck errors (TS6133 unused, TS2304 `afterEach` in `__tests__/setup.ts`) are pre-existing and out of scope for this td-B task.
- [ ] CI typecheck on PR.