### PR TITLE
fix(study): null-checks + Flashcard.tags + SessionResultsProps

### DIFF
--- a/frontend/src/components/Study/FlashcardDeck.tsx
+++ b/frontend/src/components/Study/FlashcardDeck.tsx
@@ -31,6 +31,7 @@ export interface Flashcard {
   front: string;
   back: string;
   id?: string | number;
+  tags?: string[];
 }
 
 interface FlashcardDeckProps {

--- a/frontend/src/components/Study/SessionResults.tsx
+++ b/frontend/src/components/Study/SessionResults.tsx
@@ -12,7 +12,7 @@ interface SessionResultsProps {
   accuracy: number;
   newBadges: string[];
   onClose: () => void;
-  onContinue: () => void;
+  onContinue?: () => void;
 }
 
 interface StatItem {
@@ -127,13 +127,15 @@ export const SessionResults: React.FC<SessionResultsProps> = ({
         >
           Retour au hub
         </button>
-        <button
-          type="button"
-          onClick={onContinue}
-          className="flex-1 px-4 py-2.5 rounded-xl bg-gradient-to-r from-indigo-500 to-violet-500 text-sm font-semibold text-white shadow-lg shadow-indigo-500/25 transition-transform hover:scale-[1.02] active:scale-[0.98]"
-        >
-          Continuer (+10 XP)
-        </button>
+        {onContinue && (
+          <button
+            type="button"
+            onClick={onContinue}
+            className="flex-1 px-4 py-2.5 rounded-xl bg-gradient-to-r from-indigo-500 to-violet-500 text-sm font-semibold text-white shadow-lg shadow-indigo-500/25 transition-transform hover:scale-[1.02] active:scale-[0.98]"
+          >
+            Continuer (+10 XP)
+          </button>
+        )}
       </div>
     </motion.div>
   );

--- a/frontend/src/pages/StudyPage.tsx
+++ b/frontend/src/pages/StudyPage.tsx
@@ -538,8 +538,8 @@ export const StudyPage: React.FC = () => {
 
   const currentProgress =
     activeTab === "flashcards" ? flashcardProgress : quizProgress;
-  const hasFlashcards = studyData.flashcards.length > 0;
-  const hasQuiz = studyData.quiz.length > 0;
+  const hasFlashcards = (studyData?.flashcards.length ?? 0) > 0;
+  const hasQuiz = (studyData?.quiz.length ?? 0) > 0;
 
   // ═════════════════════════════════════════════════════════════════════════════
   // RENDER — Main
@@ -588,14 +588,14 @@ export const StudyPage: React.FC = () => {
 
         {/* Video title */}
         <h2 className="text-xl font-bold text-white text-center mb-6 line-clamp-2">
-          {studyData.videoTitle}
+          {studyData?.videoTitle ?? ""}
         </h2>
 
         {/* 💡 Warm-Up Card — avant le début de l'étude */}
         {showWarmUp && !isSessionMode && !showResults && (
           <AnimatePresence>
             <StudyWarmUp
-              category={studyData.flashcards[0]?.tags?.[0]}
+              category={studyData?.flashcards[0]?.tags?.[0]}
               onStart={() => setShowWarmUp(false)}
             />
           </AnimatePresence>
@@ -800,7 +800,7 @@ export const StudyPage: React.FC = () => {
                 {texts.flashcards}
                 {hasFlashcards && (
                   <span className="ml-1 px-2 py-0.5 rounded-full bg-gray-700 text-xs">
-                    {studyData.flashcards.length}
+                    {studyData?.flashcards.length ?? 0}
                   </span>
                 )}
               </button>
@@ -822,7 +822,7 @@ export const StudyPage: React.FC = () => {
                 {texts.quiz}
                 {hasQuiz && (
                   <span className="ml-1 px-2 py-0.5 rounded-full bg-gray-700 text-xs">
-                    {studyData.quiz.length}
+                    {studyData?.quiz.length ?? 0}
                   </span>
                 )}
               </button>
@@ -857,8 +857,8 @@ export const StudyPage: React.FC = () => {
                   score={finalScore.correct}
                   total={
                     activeTab === "flashcards"
-                      ? studyData.flashcards.length
-                      : studyData.quiz.length
+                      ? (studyData?.flashcards.length ?? 0)
+                      : (studyData?.quiz.length ?? 0)
                   }
                   correct={finalScore.correct}
                   incorrect={finalScore.incorrect}
@@ -869,7 +869,7 @@ export const StudyPage: React.FC = () => {
               ) : activeTab === "flashcards" ? (
                 hasFlashcards ? (
                   <FlashcardDeck
-                    flashcards={studyData.flashcards}
+                    flashcards={studyData?.flashcards ?? []}
                     onProgress={handleFlashcardProgress}
                     onComplete={handleFlashcardComplete}
                     language={language}
@@ -879,7 +879,7 @@ export const StudyPage: React.FC = () => {
                 )
               ) : hasQuiz ? (
                 <QuizQuestion
-                  questions={studyData.quiz}
+                  questions={studyData?.quiz ?? []}
                   onProgress={handleQuizProgress}
                   onComplete={handleQuizComplete}
                   language={language}


### PR DESCRIPTION
## Summary

Tech-debt cleanup: resolve all 12 pre-existing typecheck errors in `frontend/src/pages/StudyPage.tsx`, broken down into 3 categories.

### TS18047 — `studyData` possibly null (10 occurrences)

Strategy: **optional chaining + fallbacks**, NOT early-return.

Why: the FSRS session mode must render even when `studyData` is still `null`. The `useEffect` at lines 268-282 only fetches the video title in `autoSession` mode (after the session render), so the JSX above (video title, warm-up card) and the tabs below it can run with `studyData === null`. An early `if (!studyData) return null;` would break the session flow entry point (`/study/:id?session=true`).

Patches applied:
- Line 541-542: `(studyData?.flashcards.length ?? 0) > 0` for `hasFlashcards`/`hasQuiz`
- Line 591: `{studyData?.videoTitle ?? ""}` for the title heading
- Line 598: `studyData?.flashcards[0]?.tags?.[0]` for warm-up category
- Lines 803, 825: tab badge counts → `studyData?.flashcards.length ?? 0`
- Lines 860-861: ScoreCard `total` → `studyData?.flashcards.length ?? 0` / `studyData?.quiz.length ?? 0`
- Lines 872, 882: FlashcardDeck `flashcards={studyData?.flashcards ?? []}` and QuizQuestion `questions={studyData?.quiz ?? []}`

### TS2339 — `Property 'tags' does not exist on type 'Flashcard'`

Strategy: **type widening** (add `tags?: string[]` to `Flashcard` interface in `FlashcardDeck.tsx`).

Why: the StudyPage already calls `studyData?.flashcards[0]?.tags?.[0]` to derive a warm-up category for the `StudyWarmUp` component. The sibling type `FlashcardItem` in `types/study.ts` already exposes a `category?: string`, so adding optional `tags` keeps the door open for the backend feature without breaking any current consumer (existing flashcards just don't pass it).

### TS2741 — `Property 'onContinue' is missing` on `SessionResultsProps`

Strategy: **make prop optional** + conditionally render the secondary CTA.

Why: `StudyPage` only wires `onClose={handleExitSession}` and has no distinct "continue" semantics — the session FSRS flow ends one card at a time and the "+10 XP" button has no handler in the current parent. Forcing the prop required would push parents to pass a dummy handler. Cleaner to:
1. `onContinue?: () => void` in `SessionResultsProps`
2. `{onContinue && <button ...>Continuer (+10 XP)</button>}` in JSX

This preserves the bonus-XP CTA capability for any future parent that wires it, without forcing parents to pass a no-op handler today.

## Verdict

- `npx tsc --noEmit -p tsconfig.app.json | grep StudyPage.tsx` → **0 errors** (was 11)
- `SessionResults.tsx` and `FlashcardDeck.tsx` also clean
- Other typecheck errors elsewhere (DebatePage, History, Settings, api.ts...) are pre-existing and **out of scope**.
- Vitest: no test file matches `StudyPage|SessionResults|FlashcardDeck` — nothing to break, nothing to validate.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` → no error reported on the 3 files
- [x] `npx vitest run StudyPage SessionResults FlashcardDeck` → no test files (existing repo state)
- [ ] Manual smoke (post-merge): load `/study/:id` (regular flow + `?session=true`) and confirm warm-up card, session screen, results screen render without runtime errors

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>