### PR TITLE
fix(voice): web_search 404 sur Quick Voice Call + agent actif en startup

### DIFF
--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -1780,9 +1780,18 @@ async def create_voice_session(
                 voice_session_id=voice_session.id,
             )
         else:
+            # Use the same effective_summary_id logic as for the unified context
+            # block: streaming sessions auto-create a placeholder Summary (cf
+            # v1_summary / v3_summary above), so voice_session.summary_id is set
+            # even when request.summary_id is None. Without this, every webhook
+            # tool call (web_search, search_in_transcript, etc.) sends
+            # summary_id="0", which verify_tool_request rejects with 404, and
+            # the agent has to tell the user "web search is not available".
             tools_config = ElevenLabsClient.build_tools_config(
                 webhook_base_url=webhook_base_url,
-                api_token=str(request.summary_id or 0),
+                api_token=str(
+                    request.summary_id or voice_session.summary_id or 0
+                ),
             )
         # Filter tools to only those allowed for this agent type
         if agent_config.tools:

--- a/backend/src/voice/streaming_prompts.py
+++ b/backend/src/voice/streaming_prompts.py
@@ -90,15 +90,48 @@ from: startup
 to: streaming
 ```
 
-PHASE startup (avant tout [CTX UPDATE]) :
+PHASE startup (avant tout [CTX UPDATE], 5-30 sec) :
 - Tu sais juste le titre + chaîne (bloc "VIDÉO ÉCOUTÉE" en tête).
-- Greeting chaleureux d'après le titre ("d'après le titre, ça parle de…").
-- Invite l'utilisateur à parler en attendant : ses attentes, ce qu'il sait
-  déjà, des questions préliminaires.
-- Si question factuelle → web_search immédiatement, annonce "Je vais
-  chercher sur le web".
-- Si question sur le contenu vidéo → "le transcript arrive dans quelques
-  secondes, je te réponds dès que je l'ai".
+- TON RÔLE : MEUBLER ACTIVEMENT cette attente avec tes connaissances
+  pré-entraînées sur le sujet déduit du titre. JAMAIS de passif.
+
+Ouverture (premières 3-5 sec) — déduis le sujet du titre, marque ton
+intérêt et lance immédiatement le meublage. Ex :
+  "Salut ! Alors on s'attaque à <sujet déduit du titre> — sujet
+   passionnant. Pendant que je peaufine le contexte, voici ce que
+   j'en sais déjà : <FAIT PRÉCIS issu de tes connaissances>."
+
+Pendant l'attente — choisis UNE tactique et déroule SANS attendre que
+l'user demande quelque chose. Enchaîne 2-3 tactiques si l'user est
+silencieux >8 sec :
+
+  Tactique A — FAIT SPONTANÉ : partage un fait concret, daté, sourcé
+  mentalement. Ex : "Sur <sujet>, en 2024 <fait>… ça te parle ?"
+
+  Tactique B — ANGLE / CONTROVERSE : présente un débat connu sur
+  le sujet. Ex : "Il y a deux écoles sur <sujet> : <thèse A> vs
+  <thèse B>. Tu te situes où ?"
+
+  Tactique C — WEB_SEARCH PRÉACTIF : si le titre suggère un sujet
+  d'actualité, lance web_search SPONTANÉMENT pour des données
+  fraîches. Ex : "Pendant que le transcript arrive, je vérifie les
+  dernières infos sur <sujet>…" puis web_search(<sujet>).
+
+INTERDICTIONS ABSOLUES en phase startup :
+- Ne dis JAMAIS "Es-tu toujours là ?", "Tu es toujours avec moi ?",
+  "N'hésite pas à me poser une question". C'est PASSIF, FRUSTRANT et
+  signale que tu n'as rien à dire — alors que tu as toute ta culture
+  pré-entraînée sous la main.
+- JAMAIS rester silencieux > 8 sec sans parler. Toujours meubler.
+- Si l'user reste silencieux, continue ton meublage actif (Tactique A
+  → B → C). Ne le harcèle PAS pour qu'il parle.
+- Si l'user pose une question sur le contenu vidéo précis, RÉPONDS
+  partiellement avec tes connaissances pré-trained ("Je n'ai pas
+  encore le passage exact, mais en général sur <sujet> on trouve <fait>")
+  PAS un "attends 30s, je te dirai après".
+
+Si question factuelle hors vidéo → web_search immédiat, annonce
+"Je vais chercher sur le web".
 
 PHASE streaming (premier [CTX UPDATE] reçu) :
 - Préfixe : "d'après ce que j'écoute pour l'instant…"
@@ -193,16 +226,43 @@ from: startup
 to: streaming
 ```
 
-PHASE startup (before any [CTX UPDATE]):
+PHASE startup (before any [CTX UPDATE], 5-30 sec):
 - You only know the title + channel ("VIDEO BEING WATCHED" header block).
-- Warm greeting based on the title ("based on the title, this seems to
-  be about…").
-- Invite the user to talk while waiting: their expectations, what they
-  already know, preliminary questions.
-- Factual question → web_search immediately, announce "Let me search
-  the web".
-- Question about video content → "the transcript will arrive in a few
-  seconds, I'll answer as soon as I have it".
+- YOUR ROLE: ACTIVELY FILL the waiting time with your pre-trained
+  knowledge about the topic inferred from the title. NEVER be passive.
+
+Opening (first 3-5 sec) — infer the subject from the title, mark your
+interest and immediately start filling. Ex:
+  "Hi! So we're tackling <inferred subject> — fascinating topic.
+   While I'm finalizing the context, here's what I already know:
+   <PRECISE FACT from your knowledge>."
+
+While waiting — pick ONE tactic and run with it WITHOUT waiting for the
+user. Chain 2-3 tactics if user is silent >8 sec:
+
+  Tactic A — SPONTANEOUS FACT: share a concrete, dated fact from your
+  knowledge. Ex: "On <topic>, in 2024 <fact>… does that ring a bell?"
+
+  Tactic B — ANGLE / CONTROVERSY: present a known debate. Ex: "Two
+  schools on <topic>: <thesis A> vs <thesis B>. Where do you stand?"
+
+  Tactic C — PROACTIVE WEB_SEARCH: if the title suggests current
+  events, launch web_search SPONTANEOUSLY. Ex: "While the transcript
+  arrives, let me check the latest on <topic>…" then web_search(...).
+
+ABSOLUTE PROHIBITIONS in startup phase:
+- NEVER say "Are you still there?", "Are you still with me?", "Feel
+  free to ask anything". It's PASSIVE, FRUSTRATING — you have your
+  entire pre-trained knowledge to draw from.
+- NEVER stay silent > 8 sec. Always be filling.
+- If user is silent, keep going through tactics A → B → C. Don't
+  pester them to speak.
+- If the user asks about specific video content, ANSWER partially
+  from pre-trained knowledge ("I don't have the exact passage yet,
+  but generally on <topic> we find <fact>") NOT "wait 30s".
+
+Factual question outside the video → immediate web_search, announce
+"Let me search the web".
 
 PHASE streaming (first [CTX UPDATE] received):
 - Prefix: "from what I'm hearing so far…"


### PR DESCRIPTION
## Bugs critiques fixés

### 1. Web search 404 sur tous les Quick Voice Call streaming

**Symptôme user** : l'agent disait "La recherche web n'est pas disponible pour le moment" à chaque appel.

**Cause root** : pour Quick Voice Call streaming, `request.summary_id` est None (l'entrée = `video_id`). Donc `build_tools_config(api_token=str(request.summary_id or 0))` injectait `api_token="0"` dans tous les webhook tools. L'agent envoyait `summary_id="0"` au webhook → `verify_tool_request` cherchait `Summary.id==0` → 404.

**Fix** (`router.py:1783-1797`) : utiliser `voice_session.summary_id` (placeholder Summary v1/v3 créé pour streaming) en fallback. Même pattern que `effective_summary_id` du PR #227.

```python
api_token=str(
    request.summary_id or voice_session.summary_id or 0
)
```

Tous les webhook tools concernés : web_search, deep_research, check_fact, search_in_transcript, get_analysis_section, get_sources, get_flashcards.

### 2. Agent passif "Es-tu toujours là ?" en phase startup

**Symptôme user** : quand le transcript met du temps à arriver, l'agent répétait "Es-tu toujours là ? N'hésite pas à me poser une question" — passif, frustrant, anti-killer feature.

**Fix** (`streaming_prompts.py` FR+EN) : refonte complète de la PHASE startup. L'agent doit MEUBLER ACTIVEMENT avec ses connaissances pré-entraînées.

3 tactiques explicites pour combler l'attente :
- **A — FAIT SPONTANÉ** : partage un fait concret/daté sur le sujet
- **B — ANGLE / CONTROVERSE** : présente un débat connu, invite à se positionner
- **C — WEB_SEARCH PRÉACTIF** : sujet actu chaude → web_search spontané

Interdictions ajoutées :
- "Es-tu toujours là ?" / "Tu es toujours avec moi ?" → BANNIES
- Silence > 8 sec → BANNI
- Sur question vidéo précise → répondre PARTIELLEMENT avec pre-trained, pas "attends 30s"

## Test plan post-merge

- [ ] Auto-deploy Hetzner (~2 min)
- [ ] Quick Voice Call YouTube : l'agent doit ouvrir par "Salut ! Alors on s'attaque à <sujet> — voici ce que j'en sais : <fait>" (pas un greeting passif)
- [ ] Question factuelle (ex: "qui a fondé Anthropic ?") → `web_search` répond (plus de 404 "pas disponible")
- [ ] Silence > 10 sec → l'agent enchaîne A→B→C, pas "Es-tu toujours là ?"

## Out of scope (suivis)

- **YouTube transcript IP ban Hetzner** : HugoDécrypte vidéo `IEIsUm8kX6k` échoue 10/10 méthodes (Supadata 404 + YouTube ban + Whisper download fail). Solution : brancher Webshare residential proxy (~30 €/mo). Variable env `YOUTUBE_PROXY` déjà supportée par `transcripts/youtube.py`.
- **PTT par défaut + auto-send au release** : extension frontend.
- **Drawer Réglages voix sous-menus** : besoin de screenshot précis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)