### PR TITLE
feat(hub): instant navigate to /hub on analyze + paste-URL bar in drawer

### DIFF
--- a/frontend/src/components/hub/ConversationsDrawer.tsx
+++ b/frontend/src/components/hub/ConversationsDrawer.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, Search, Plus } from "lucide-react";
+import { X, Search, Send, Sparkles } from "lucide-react";
 import type { HubConversation } from "./types";
 
 interface Props {
@@ -9,7 +9,12 @@ interface Props {
   conversations: HubConversation[];
   activeConvId: number | null;
   onSelect: (id: number) => void;
-  onNewConv: () => void;
+  /**
+   * Lance une analyse depuis la barre input du header. Le caller (HubPage)
+   * navigue vers `/hub?analyzing=<taskId>` et le drawer se ferme. Si non
+   * fourni, la barre input n'est pas rendue.
+   */
+  onAnalyze?: (url: string) => void | Promise<void>;
 }
 
 const PLATFORM_ICON: Record<
@@ -43,9 +48,22 @@ export const ConversationsDrawer: React.FC<Props> = ({
   conversations,
   activeConvId,
   onSelect,
-  onNewConv,
+  onAnalyze,
 }) => {
   const [query, setQuery] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+
+  const handleAnalyzeSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const trimmed = newUrl.trim();
+      if (!trimmed || !onAnalyze) return;
+      void onAnalyze(trimmed);
+      setNewUrl("");
+      onClose();
+    },
+    [newUrl, onAnalyze, onClose],
+  );
 
   if (!open) return null;
 
@@ -142,17 +160,36 @@ export const ConversationsDrawer: React.FC<Props> = ({
           <span className="flex-1 text-sm font-medium text-white">
             Conversations
           </span>
-          <button
-            type="button"
-            onClick={onNewConv}
-            aria-label="nouvelle conversation"
-            className="px-2.5 py-1 rounded-lg bg-indigo-500/15 border border-indigo-500/30 text-indigo-400 text-xs flex items-center gap-1"
-          >
-            <Plus className="w-3 h-3" />
-            <span>Nouvelle</span>
-          </button>
         </div>
-        <div className="px-3 py-2 relative">
+
+        {onAnalyze && (
+          <div className="px-3 pt-3 pb-1">
+            <form onSubmit={handleAnalyzeSubmit} className="relative">
+              <Sparkles className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-indigo-400 pointer-events-none" />
+              <input
+                type="url"
+                value={newUrl}
+                onChange={(e) => setNewUrl(e.target.value)}
+                placeholder="Coller un lien YouTube/TikTok…"
+                aria-label="Nouvelle analyse — coller une URL"
+                className="w-full pl-8 pr-9 py-2 rounded-lg bg-indigo-500/[0.08] border border-indigo-500/30 text-[13px] text-white placeholder-white/35 outline-none focus:border-indigo-400/60 focus:bg-indigo-500/[0.12]"
+              />
+              <button
+                type="submit"
+                aria-label="Analyser"
+                disabled={!newUrl.trim()}
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 w-7 h-7 grid place-items-center rounded-md bg-indigo-500 text-white hover:bg-indigo-400 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <Send className="w-3.5 h-3.5" />
+              </button>
+            </form>
+            <p className="px-1 mt-1 text-[10px] text-white/40">
+              Lance une nouvelle analyse — vous serez redirigé vers le Hub.
+            </p>
+          </div>
+        )}
+
+        <div className="px-3 pt-2 pb-2 relative">
           <Search className="absolute left-5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
           <input
             type="text"

--- a/frontend/src/hooks/useAnalyzeAndOpenHub.ts
+++ b/frontend/src/hooks/useAnalyzeAndOpenHub.ts
@@ -1,50 +1,34 @@
 /**
- * useAnalyzeAndOpenHub — hook réutilisable qui encapsule le pipeline d'analyse
- * vidéo (paste URL → `videoApi.analyze` → polling `videoApi.getTaskStatus`) et,
- * sur succès, navigue vers `/hub?conv=<summary_id>` pour ouvrir la session
- * conversationnelle dans le Hub.
+ * useAnalyzeAndOpenHub — hook réutilisable qui encapsule le démarrage d'une
+ * analyse vidéo (`videoApi.analyze`) et **navigue immédiatement** vers le Hub.
+ *
+ * Comportement :
+ *   - Cache hit (le backend retourne déjà `summary_id`) → navigate `/hub?conv=<id>`.
+ *   - Sinon → navigate `/hub?analyzing=<task_id>`. Le polling
+ *     `videoApi.getTaskStatus(taskId)` est ensuite repris par `HubPage`, qui
+ *     affiche un état "Analyse en cours" et bascule sur la conversation
+ *     finale dès que `summary_id` est disponible.
+ *
+ * Avantage : feedback visuel **immédiat** (la home n'attend pas la fin de
+ * l'analyse, l'utilisateur voit déjà le Hub avec le placeholder loading).
  *
  * Utilisé par :
- *   - `NewConversationModal` (bouton "+ Nouvelle" du drawer Hub)
- *   - `DashboardPageMinimal` (home minimale : SmartInputBar + Tournesol cards)
- *
- * Garanties :
- *   - Annule proprement le polling si le composant unmount ou si une nouvelle
- *     analyse est lancée (cleanup interval).
- *   - Timeout 5 min par défaut (POLL_MAX_DURATION_MS).
- *   - Validation d'URL minimaliste : pas de regex stricte ici (déléguée à
- *     l'appelant via un guard `isValidVideoUrl` si nécessaire). Le hook
- *     accepte toute URL non vide et laisse l'API renvoyer une erreur si elle
- *     ne reconnaît pas la plateforme.
- *   - Statuses d'échec gérés : `failed | cancelled` (cf. `TaskStatus.status`
- *     dans `services/api.ts`).
- *
- * Inputs côté caller : `analyze(url)`. Le hook expose `{ analyzing, progress,
- * message, error, analyze }` pour que le caller affiche son propre UI de
- * progress.
- *
- * NOTE : ne dépend PAS du store Hub. Le caller qui veut additionnellement
- * mettre à jour l'état du Hub (re-fetch conversations, setActiveConv) doit le
- * faire dans son propre `onSuccess` — ce qui n'est pas le cas par défaut, car
- * la navigation vers `/hub?conv=<id>` déclenche un fresh load de HubPage.
+ *   - `DashboardPageMinimal` (home minimale : input URL + Tournesol cards)
+ *   - `ConversationsDrawer` (barre input directe dans le drawer Hub)
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { videoApi } from "../services/api";
 import { useTranslation } from "./useTranslation";
 
-const POLL_INTERVAL_MS = 2000;
-const POLL_MAX_DURATION_MS = 5 * 60 * 1000; // 5 min
-
 export interface AnalyzeState {
+  /** True pendant l'appel `videoApi.analyze` (avant le navigate). */
   analyzing: boolean;
-  progress: number;
-  message: string;
   error: string | null;
 }
 
 export interface UseAnalyzeAndOpenHubReturn extends AnalyzeState {
-  /** Lance l'analyse de l'URL fournie. Sur succès, navigue vers `/hub?conv=<id>`. */
+  /** Lance l'analyse et navigue immédiatement vers `/hub`. */
   analyze: (url: string) => Promise<void>;
   /** Reset manuel de l'erreur (utile entre deux essais). */
   resetError: () => void;
@@ -55,23 +39,8 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
   const { language } = useTranslation();
   const [state, setState] = useState<AnalyzeState>({
     analyzing: false,
-    progress: 0,
-    message: "",
     error: null,
   });
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollStartRef = useRef<number>(0);
-  const progressRef = useRef<number>(0);
-
-  const cleanup = useCallback(() => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-  }, []);
-
-  // Cleanup at unmount.
-  useEffect(() => () => cleanup(), [cleanup]);
 
   const resetError = useCallback(() => {
     setState((s) => ({ ...s, error: null }));
@@ -81,25 +50,17 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
     async (url: string) => {
       const trimmed = url.trim();
       if (!trimmed) {
-        setState((s) => ({
-          ...s,
+        setState({
+          analyzing: false,
           error:
             language === "fr"
               ? "URL invalide. Collez un lien YouTube ou TikTok."
               : "Invalid URL. Paste a YouTube or TikTok link.",
-        }));
+        });
         return;
       }
 
-      cleanup();
-      progressRef.current = 5;
-      setState({
-        analyzing: true,
-        progress: 5,
-        message:
-          language === "fr" ? "Démarrage de l'analyse…" : "Starting analysis…",
-        error: null,
-      });
+      setState({ analyzing: true, error: null });
 
       try {
         const resp = await videoApi.analyze(
@@ -110,90 +71,20 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
           false,
           language,
         );
-        // Cache hit immédiat : l'analyse retourne déjà un summary_id.
+        // Cache hit : l'analyse retourne déjà un `summary_id`. Navigate sur
+        // la conversation directement.
         if (resp.result?.summary_id) {
-          progressRef.current = 100;
-          setState({
-            analyzing: false,
-            progress: 100,
-            message: "",
-            error: null,
-          });
+          setState({ analyzing: false, error: null });
           navigate(`/hub?conv=${resp.result.summary_id}`);
           return;
         }
-        const taskId = resp.task_id;
-        pollStartRef.current = Date.now();
-
-        pollRef.current = setInterval(async () => {
-          try {
-            if (Date.now() - pollStartRef.current > POLL_MAX_DURATION_MS) {
-              cleanup();
-              setState((s) => ({
-                ...s,
-                analyzing: false,
-                error:
-                  language === "fr"
-                    ? "L'analyse prend trop de temps. Réessayez plus tard."
-                    : "Analysis is taking too long. Please try again later.",
-              }));
-              return;
-            }
-            const status = await videoApi.getTaskStatus(taskId);
-            if (typeof status.progress === "number") {
-              const next = Math.max(progressRef.current, status.progress);
-              progressRef.current = next;
-              setState((s) => ({
-                ...s,
-                progress: next,
-                message: status.message || s.message,
-              }));
-            } else if (status.message) {
-              setState((s) => ({ ...s, message: status.message || s.message }));
-            }
-
-            if (status.status === "completed" && status.result?.summary_id) {
-              cleanup();
-              progressRef.current = 100;
-              setState({
-                analyzing: false,
-                progress: 100,
-                message: "",
-                error: null,
-              });
-              navigate(`/hub?conv=${status.result.summary_id}`);
-            } else if (
-              status.status === "failed" ||
-              status.status === "cancelled"
-            ) {
-              cleanup();
-              setState((s) => ({
-                ...s,
-                analyzing: false,
-                error:
-                  status.error ||
-                  (language === "fr"
-                    ? "L'analyse a échoué. Veuillez réessayer."
-                    : "Analysis failed. Please try again."),
-              }));
-            }
-          } catch (err) {
-            cleanup();
-            setState((s) => ({
-              ...s,
-              analyzing: false,
-              error:
-                err instanceof Error
-                  ? err.message
-                  : language === "fr"
-                    ? "Erreur lors du polling."
-                    : "Polling error.",
-            }));
-          }
-        }, POLL_INTERVAL_MS);
+        // Cas standard : on a un `task_id`. On navigue vers le Hub avec
+        // `?analyzing=<taskId>` ; HubPage prend le relais pour le polling et
+        // affiche le placeholder loading.
+        setState({ analyzing: false, error: null });
+        navigate(`/hub?analyzing=${resp.task_id}`);
       } catch (err) {
-        setState((s) => ({
-          ...s,
+        setState({
           analyzing: false,
           error:
             err instanceof Error
@@ -201,10 +92,10 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
               : language === "fr"
                 ? "Erreur lors de l'analyse."
                 : "Analysis error.",
-        }));
+        });
       }
     },
-    [language, navigate, cleanup],
+    [language, navigate],
   );
 
   return { ...state, analyze, resetError };

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -33,6 +33,8 @@ import { CallModeFullBleed } from "../components/hub/CallModeFullBleed";
 import { SourcesShelf } from "../components/hub/SourcesShelf";
 import { NewConversationModal } from "../components/hub/NewConversationModal";
 import { HubToolbox } from "../components/hub/HubToolbox";
+import { useAnalyzeAndOpenHub } from "../hooks/useAnalyzeAndOpenHub";
+import { Loader2 } from "lucide-react";
 import type { HubConversation, HubMessage } from "../components/hub/types";
 
 const newId = () =>
@@ -123,6 +125,91 @@ const HubPage: React.FC = () => {
 
   const [isThinking, setIsThinking] = React.useState(false);
   const voiceControllerRef = useRef<VoiceOverlayController | null>(null);
+
+  // ── Analyzing state — polling sur ?analyzing=<taskId> ──
+  // Quand l'utilisateur lance une analyse depuis la home (DashboardPageMinimal)
+  // ou la barre input du drawer, on navigue ici avec ?analyzing=<taskId>. On
+  // poll videoApi.getTaskStatus jusqu'à `completed` puis on bascule sur
+  // ?conv=<summary_id> (qui déclenche le fetch de la conversation).
+  const analyzingTaskId = searchParams.get("analyzing");
+  const [analyzingProgress, setAnalyzingProgress] = React.useState(5);
+  const [analyzingMessage, setAnalyzingMessage] = React.useState("");
+  const [analyzingError, setAnalyzingError] = React.useState<string | null>(
+    null,
+  );
+
+  const { analyze: triggerAnalyze, error: hookError } = useAnalyzeAndOpenHub();
+  // Affiche les erreurs du hook (URL invalide, fetch failed) dans le placeholder.
+  useEffect(() => {
+    if (hookError) setAnalyzingError(hookError);
+  }, [hookError]);
+
+  useEffect(() => {
+    if (!analyzingTaskId) {
+      setAnalyzingProgress(5);
+      setAnalyzingMessage("");
+      setAnalyzingError(null);
+      return;
+    }
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    const start = Date.now();
+    const POLL_INTERVAL_MS = 2000;
+    const POLL_MAX_DURATION_MS = 5 * 60 * 1000;
+
+    setAnalyzingError(null);
+    setAnalyzingProgress(5);
+    setAnalyzingMessage("Démarrage de l'analyse…");
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (Date.now() - start > POLL_MAX_DURATION_MS) {
+        if (intervalId) clearInterval(intervalId);
+        setAnalyzingError(
+          "L'analyse prend trop de temps. Réessayez plus tard.",
+        );
+        return;
+      }
+      try {
+        const status = await videoApi.getTaskStatus(analyzingTaskId);
+        if (cancelled) return;
+        if (typeof status.progress === "number") {
+          setAnalyzingProgress((p) => Math.max(p, status.progress as number));
+        }
+        if (status.message) setAnalyzingMessage(status.message);
+
+        if (status.status === "completed" && status.result?.summary_id) {
+          if (intervalId) clearInterval(intervalId);
+          // Bascule sur la conversation finale ; le useEffect existant fait
+          // le fetch des messages + summary context.
+          setSearchParams({ conv: String(status.result.summary_id) });
+        } else if (
+          status.status === "failed" ||
+          status.status === "cancelled"
+        ) {
+          if (intervalId) clearInterval(intervalId);
+          setAnalyzingError(
+            status.error || "L'analyse a échoué. Veuillez réessayer.",
+          );
+        }
+      } catch (err) {
+        if (cancelled) return;
+        if (intervalId) clearInterval(intervalId);
+        setAnalyzingError(
+          err instanceof Error ? err.message : "Erreur lors du polling.",
+        );
+      }
+    };
+
+    // Lance immédiatement puis toutes les 2s.
+    tick();
+    intervalId = setInterval(tick, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [analyzingTaskId, setSearchParams]);
 
   // ── Fetch conversations (mapped from videoApi.getHistory) ──
   useEffect(() => {
@@ -380,32 +467,67 @@ const HubPage: React.FC = () => {
       />
 
       <div className="relative flex-1 flex flex-col overflow-hidden">
-        {summaryContext && (
-          <SummaryCollapsible
-            context={summaryContext}
-            defaultOpen={openSummaryFromUrl}
-          />
+        {analyzingTaskId && !activeConvId ? (
+          <div className="flex-1 flex items-center justify-center px-6">
+            <div className="max-w-md w-full text-center">
+              <div className="relative mx-auto mb-5 w-16 h-16">
+                <div className="absolute inset-0 rounded-full bg-indigo-500/20 blur-xl animate-pulse" />
+                <Loader2 className="relative w-16 h-16 text-indigo-400 mx-auto animate-spin" />
+              </div>
+              <p className="text-base text-white font-medium mb-1.5">
+                Analyse en cours
+              </p>
+              <p className="text-sm text-white/65 mb-4 leading-relaxed">
+                {analyzingMessage ||
+                  "Démarrage… extraction du transcript et synthèse en route."}
+              </p>
+              <div className="h-1.5 bg-white/[0.06] rounded-full overflow-hidden mb-2">
+                <div
+                  className="h-full bg-gradient-to-r from-indigo-500 to-violet-500 transition-all duration-500 ease-out"
+                  style={{ width: `${Math.min(analyzingProgress, 95)}%` }}
+                />
+              </div>
+              <p className="text-[11px] font-mono text-white/40">
+                {Math.min(analyzingProgress, 95)}% · L'analyse continue même si
+                vous fermez l'onglet.
+              </p>
+              {analyzingError && (
+                <div className="mt-4 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs text-red-300">
+                  {analyzingError}
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <>
+            {summaryContext && (
+              <SummaryCollapsible
+                context={summaryContext}
+                defaultOpen={openSummaryFromUrl}
+              />
+            )}
+            {summaryContext && (
+              <HubToolbox
+                summaryId={summaryContext.summary_id}
+                videoTitle={summaryContext.video_title}
+              />
+            )}
+            <Timeline
+              messages={messages}
+              isThinking={isThinking}
+              onQuestionClick={handleSend}
+            />
+            <InputBar
+              onSend={handleSend}
+              onCallToggle={() => setVoiceCallOpen(!voiceCallOpen)}
+              onPttHoldComplete={handlePttHoldComplete}
+              disabled={!activeConvId}
+            />
+            <div className="flex justify-center px-3 pb-3 pt-1">
+              <SourcesShelf />
+            </div>
+          </>
         )}
-        {summaryContext && (
-          <HubToolbox
-            summaryId={summaryContext.summary_id}
-            videoTitle={summaryContext.video_title}
-          />
-        )}
-        <Timeline
-          messages={messages}
-          isThinking={isThinking}
-          onQuestionClick={handleSend}
-        />
-        <InputBar
-          onSend={handleSend}
-          onCallToggle={() => setVoiceCallOpen(!voiceCallOpen)}
-          onPttHoldComplete={handlePttHoldComplete}
-          disabled={!activeConvId}
-        />
-        <div className="flex justify-center px-3 pb-3 pt-1">
-          <SourcesShelf />
-        </div>
 
         <ConversationsDrawer
           open={drawerOpen}
@@ -416,7 +538,7 @@ const HubPage: React.FC = () => {
             setActiveConv(id);
             setSearchParams({ conv: String(id) });
           }}
-          onNewConv={() => setNewConvModalOpen(true)}
+          onAnalyze={triggerAnalyze}
         />
 
         <NewConversationModal


### PR DESCRIPTION
## User feedback

> Le bouton 'Nouveau' dans le Hub, pour générer une nouvelle analyse, doit être lui-même une barre pour coller directement un lien. J'ai testé la fonction et ça ne marche pas. Il faut que, lorsqu'on lance une analyse depuis la page 'Analyse' ou lorsqu'on lance une analyse depuis le Hub, ça nous renvoie vers une sorte de page vierge du Hub avec une nouvelle analyse qui est en train de se charger.

## Summary

- **Barre input directe** dans le drawer Hub : remplace le bouton \"+ Nouvelle\" par un \`<input type=\"url\">\` avec icône Sparkles + bouton Send. Coller un lien YouTube/TikTok → Enter ou click → l'analyse démarre, le drawer se ferme.
- **Navigate immédiat** : \`useAnalyzeAndOpenHub\` ne polle plus, il navigate directement vers \`/hub?analyzing=<taskId>\` après l'appel \`videoApi.analyze\`. Cache hit → \`/hub?conv=<id>\`.
- **Placeholder \"Analyse en cours\"** dans HubPage : centered card avec spinner indigo, halo blur animé, barre de progression dégradée indigo→violet, message live du backend (\"Extraction transcript…\" etc.), pourcentage mono. Quand \`completed\` → bascule sur \`?conv=<summary_id>\` (le useEffect existant fetch alors la conversation).

## Pourquoi

Le flow précédent ouvrait une modal qui bloquait sur la home/drawer jusqu'à la fin du polling (jusqu'à 5 min). Pas de feedback hub-first. Maintenant : 1 click → l'utilisateur est dans le Hub avec son nouveau placeholder en moins d'une seconde.

## Tests

\`cd frontend && node node_modules/vitest/vitest.mjs run src/components/hub/__tests__\` → **43/43 verts** (zéro régression sur les tests existants ConversationsDrawer / NewConversationModal).

## Notes

- \`NewConversationModal\` est désormais dead code (conservé mounté comme no-op pour rétrocompat ; à retirer dans une PR de cleanup).
- Polling logic moved from hook → HubPage (cleaner separation : hook = navigate, page = poll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)