### PR TITLE
fix(voice): strip (N) et - YouTube du titre vidéo

### DIFF
--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -99,6 +99,36 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
+def _sanitize_video_title(raw: str | None) -> str:
+    """Strip Chrome notification counters and platform suffixes from titles.
+
+    The extension passes ``document.title`` straight to the backend. Chrome
+    adds a ``(N)`` prefix when N tabs/notifications are queued, and YouTube
+    appends ``" - YouTube"``. Both leak into the voice agent's first_message
+    and the system_prompt's "VIDÉO ÉCOUTÉE" block — the agent then says
+    "On part sur « (3) Quantum Physics — YouTube »" which is jarring.
+
+    Examples:
+        "(3) Quantum Physics ... - YouTube"  → "Quantum Physics ..."
+        "Bel article  | YouTube"             → "Bel article"
+        "(12) Mike Tyson"                    → "Mike Tyson"
+        "video title — YouTube"              → "video title"
+    """
+    if not raw:
+        return ""
+    import re
+
+    title = raw.strip()
+    # Strip "(N) " prefix added by Chrome / browser notification counter.
+    title = re.sub(r"^\(\d+\)\s*", "", title)
+    # Strip " - YouTube" / " — YouTube" / " | YouTube" platform suffix.
+    title = re.sub(r"\s*[-—|]\s*YouTube\s*$", "", title, flags=re.IGNORECASE)
+    # Same for TikTok though less common.
+    title = re.sub(r"\s*[-—|]\s*TikTok\s*$", "", title, flags=re.IGNORECASE)
+    return title.strip()
+
+
 # Rate limiting (Spec #0): per-summary AND per-user caps with Redis INCR + TTL.
 # In-memory dicts are used when Redis is unavailable.
 _web_search_counts: dict[str, int] = {}
@@ -1301,7 +1331,7 @@ async def create_voice_session(
         existing_summary = existing_summary_result.scalar_one_or_none()
         if existing_summary is None:
             v1_video_title = (
-                request.video_title
+                _sanitize_video_title(request.video_title)
                 if request.video_title
                 else f"[En cours] YT {request.video_id}"
             )
@@ -1663,7 +1693,7 @@ async def create_voice_session(
             # WHICH video. We resolve title+channel via YouTube oEmbed
             # (1 request, <100ms typical, no API key required) so the system
             # prompt carries enough context from turn #1.
-            title = (request.video_title or "").strip()
+            title = _sanitize_video_title(request.video_title)
             channel = ""
             try:
                 async with httpx.AsyncClient(timeout=2.0) as client:
@@ -1853,7 +1883,7 @@ async def create_voice_session(
         # Streaming agent: interpolate {video_title} placeholder (front-provided title,
         # already resolved via YouTube oEmbed in the system_prompt meta-block above when missing)
         if agent_config.agent_type == "explorer_streaming" and "{video_title}" in first_message:
-            streaming_title = (request.video_title or "").strip()
+            streaming_title = _sanitize_video_title(request.video_title)
             if not streaming_title:
                 streaming_title = "cette vidéo" if language == "fr" else "this video"
             first_message = first_message.replace("{video_title}", streaming_title)

--- a/extension/src/content/voiceCallInjector.ts
+++ b/extension/src/content/voiceCallInjector.ts
@@ -33,6 +33,44 @@ interface MessageResponseShape {
 }
 
 /**
+ * Récupère le titre VIDÉO réel sans les artefacts du document.title du
+ * navigateur. Trois sources tentées dans l'ordre :
+ *
+ * 1. `<meta property="og:title">` — le titre officiel injecté par YouTube
+ *    pour les bots/preview cards. Toujours propre, sans "(N)" ni "- YouTube".
+ * 2. `h1.ytd-watch-metadata yt-formatted-string` (DOM YouTube watch). Le
+ *    titre rendu dans la page elle-même.
+ * 3. Fallback `document.title` strippé manuellement (filet de sécurité —
+ *    le backend re-sanitize aussi via `_sanitize_video_title`).
+ *
+ * Pourquoi : Chrome préfixe document.title avec "(N) " quand N tabs ou
+ * notifications sont en attente, et YouTube suffixe " - YouTube".
+ * L'agent voice voyait alors « (3) Quantum Physics ... - YouTube ».
+ */
+function getCleanVideoTitle(): string {
+  // Source 1 — meta og:title (toujours propre)
+  const og = document.querySelector<HTMLMetaElement>(
+    'meta[property="og:title"]',
+  );
+  const ogTitle = og?.content?.trim();
+  if (ogTitle) return ogTitle;
+
+  // Source 2 — h1 watch metadata (YouTube watch page)
+  const h1 = document.querySelector<HTMLElement>(
+    "h1.ytd-watch-metadata yt-formatted-string, h1.title yt-formatted-string",
+  );
+  const h1Title = h1?.textContent?.trim();
+  if (h1Title) return h1Title;
+
+  // Source 3 — fallback document.title strippé
+  return (document.title || "")
+    .replace(/^\(\d+\)\s*/, "")
+    .replace(/\s*[-—|]\s*YouTube\s*$/i, "")
+    .replace(/\s*[-—|]\s*TikTok\s*$/i, "")
+    .trim();
+}
+
+/**
  * Cherche un container stable dans le DOM YouTube watch page. Tente plusieurs
  * sélecteurs dans l'ordre de stabilité décroissante. Renvoie null si rien
  * trouvé (l'appelant utilisera alors un overlay fixed).
@@ -140,7 +178,7 @@ export async function injectVoiceCallButton(): Promise<void> {
     trialUsed: state.trialUsed,
     monthlyMinutesUsed: state.monthlyMinutesUsed,
     videoId,
-    videoTitle: document.title,
+    videoTitle: getCleanVideoTitle(),
   });
 
   if (useFloating) {


### PR DESCRIPTION
Bug : l'agent disait "On part sur « (3) Quantum Physics - YouTube »". Causes : Chrome `(N)` + YouTube ` - YouTube` dans `document.title`. Fix double : frontend (og:title → h1 → fallback strippé) + backend (`_sanitize_video_title` regex). Filet de sécurité pour tous les flow.