### PR TITLE
feat(hub): embed AnalysisHub below summary (concepts + reliability + study tabs)

### DIFF
--- a/frontend/src/components/hub/HubAnalysisPanel.tsx
+++ b/frontend/src/components/hub/HubAnalysisPanel.tsx
@@ -1,0 +1,117 @@
+// frontend/src/components/hub/HubAnalysisPanel.tsx
+//
+// Wrapper inline du composant AnalysisHub pour l'embed dans /hub, juste sous
+// le SummaryCollapsible et au-dessus de la Timeline. Remplace l'ancien
+// HubToolbox léger (3 boutons) par le panneau complet à 5 onglets : Synthèse
+// (avec mots-clés), Quiz, Flashcards, Fiabilité, GEO.
+//
+// Style : container `rounded-2xl border-white/10 bg-white/[0.02]`, largeur
+// `max-w-3xl mx-auto` pour s'aligner sur la Timeline et SummaryCollapsible.
+// Les onglets sont contrôlés par AnalysisHub lui-même (state local).
+//
+// Props : `selectedSummary` (Summary complet) + `concepts` + `reliability` +
+// `reliabilityLoading` injectés depuis HubPage (qui les hydrate dans le
+// hubStore via les API videoApi/reliabilityApi).
+//
+// Callbacks v1 :
+//   - onTimecodeClick : no-op (l'utilisateur clique sur les timecodes du
+//     SummaryCollapsible qui sont déjà câblés). V2 : wire au PiP player.
+//   - onOpenChat : no-op (l'InputBar du Hub est déjà visible en bas — on
+//     pourrait scroll-to-input + autofocus en V2).
+
+import React, { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { AnalysisHub } from "../AnalysisHub";
+import type {
+  Summary,
+  EnrichedConcept,
+  ReliabilityResult,
+  User,
+} from "../../services/api";
+
+interface HubAnalysisPanelProps {
+  /** Summary complet (hydraté via videoApi.getSummary). */
+  selectedSummary: Summary | null;
+  /** Concepts enrichis (hydratés via videoApi.getEnrichedConcepts). */
+  concepts: EnrichedConcept[];
+  /** Reliability data (hydraté via reliabilityApi.getReliability). */
+  reliability: ReliabilityResult | null;
+  /** True pendant le fetch reliability. */
+  reliabilityLoading: boolean;
+  /** Utilisateur courant — utilisé par AnalysisHub pour les gates plan/credits. */
+  user: User | null;
+  /** Langue UI. */
+  language: "fr" | "en";
+}
+
+/**
+ * Renders nothing if there's nothing to show. We require AT LEAST a
+ * `selectedSummary` to render — without it, AnalysisHub has no synthesis to
+ * display. We then show the panel as soon as there is content (concepts) or a
+ * reliability result, OR if the user is authenticated (so empty states like
+ * "Generate quiz" remain accessible). For a guest viewing a fresh analysis
+ * with no concepts/reliability cached yet, we still render so the synthesis
+ * tab shows the markdown content.
+ */
+export const HubAnalysisPanel: React.FC<HubAnalysisPanelProps> = ({
+  selectedSummary,
+  concepts,
+  reliability,
+  reliabilityLoading,
+  user,
+  language,
+}) => {
+  const navigate = useNavigate();
+
+  const handleNavigate = useCallback(
+    (path: string) => {
+      navigate(path);
+    },
+    [navigate],
+  );
+
+  // v1 no-ops : timecodes du Hub passent déjà via SummaryCollapsible, et
+  // l'InputBar est toujours présente en bas du Hub.
+  const handleTimecodeClick = useCallback((_seconds: number) => {
+    /* no-op */
+  }, []);
+  const handleOpenChat = useCallback((_msg?: string) => {
+    /* no-op */
+  }, []);
+
+  if (!selectedSummary) return null;
+
+  // Adapter `User | null` au shape attendu par AnalysisHubProps : `{ plan?, credits? }`.
+  const analysisUser = {
+    plan: user?.plan,
+    credits: user?.credits,
+  };
+
+  return (
+    <div className="px-4 mb-3 w-full max-w-3xl mx-auto">
+      <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
+        <AnalysisHub
+          selectedSummary={selectedSummary}
+          reliabilityData={reliability}
+          reliabilityLoading={reliabilityLoading}
+          user={analysisUser}
+          language={language}
+          concepts={concepts}
+          onTimecodeClick={handleTimecodeClick}
+          onOpenChat={handleOpenChat}
+          onNavigate={handleNavigate}
+          enabledTabs={[
+            "synthesis",
+            "reliability",
+            "quiz",
+            "flashcards",
+            "geo",
+          ]}
+          showKeywords
+          showStudyTools={false}
+          showVoice={false}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/hub/__tests__/HubAnalysisPanel.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubAnalysisPanel.test.tsx
@@ -1,0 +1,142 @@
+// frontend/src/components/hub/__tests__/HubAnalysisPanel.test.tsx
+//
+// Smoke tests pour le wrapper HubAnalysisPanel. On mock AnalysisHub pour
+// isoler la logique du wrapper (gating sur selectedSummary, props passées,
+// container styling) — l'AnalysisHub lui-même est testé via la suite
+// AnalysisHub/* à part.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HubAnalysisPanel } from "../HubAnalysisPanel";
+import type {
+  Summary,
+  EnrichedConcept,
+  ReliabilityResult,
+  User,
+} from "../../../services/api";
+
+// Mock AnalysisHub: on capture les props pour vérifier le wiring sans avoir
+// à monter toute l'arborescence (Markdown, Concepts, etc.).
+vi.mock("../../AnalysisHub", () => ({
+  AnalysisHub: (props: {
+    selectedSummary: Summary;
+    concepts: EnrichedConcept[];
+    reliabilityData: ReliabilityResult | null;
+    enabledTabs?: string[];
+  }) => (
+    <div data-testid="analysis-hub-mock">
+      <span data-testid="ah-summary-id">{props.selectedSummary.id}</span>
+      <span data-testid="ah-concepts-count">{props.concepts.length}</span>
+      <span data-testid="ah-tabs">
+        {(props.enabledTabs ?? []).join(",")}
+      </span>
+      <span data-testid="ah-has-reliability">
+        {props.reliabilityData ? "yes" : "no"}
+      </span>
+    </div>
+  ),
+}));
+
+const summary: Summary = {
+  id: 42,
+  video_id: "abc123",
+  video_title: "Test Video",
+  video_channel: "Test Channel",
+  summary_content: "Long markdown content here.",
+  created_at: "2026-04-30T00:00:00Z",
+  platform: "youtube",
+};
+
+const concept: EnrichedConcept = {
+  term: "Conscience phénoménale",
+  definition: "Expérience subjective.",
+  category: "philosophy",
+  category_label: "Philosophie",
+  category_icon: "🧠",
+  context_relevance: "Concept central de la vidéo.",
+  sources: [],
+  confidence: 0.9,
+  provider: "mistral",
+};
+
+const fakeUser: User = {
+  id: 1,
+  username: "tester",
+  email: "test@example.com",
+  email_verified: true,
+  plan: "pro",
+  credits: 30,
+  credits_monthly: 30,
+  is_admin: false,
+  total_videos: 0,
+  total_words: 0,
+  total_playlists: 0,
+  created_at: "2026-04-30T00:00:00Z",
+};
+
+interface PanelOverrides {
+  selectedSummary?: Summary | null;
+  concepts?: EnrichedConcept[];
+  reliability?: ReliabilityResult | null;
+  reliabilityLoading?: boolean;
+  user?: User | null;
+}
+
+const renderPanel = (overrides: PanelOverrides = {}) => {
+  // Use `in` checks instead of `??` so callers can explicitly pass `null` to
+  // override defaults (e.g. selectedSummary: null for the empty-state test).
+  const selectedSummary =
+    "selectedSummary" in overrides ? overrides.selectedSummary! : summary;
+  const concepts =
+    "concepts" in overrides ? overrides.concepts! : [concept];
+  const reliability =
+    "reliability" in overrides ? overrides.reliability! : null;
+  const reliabilityLoading = overrides.reliabilityLoading ?? false;
+  const user = "user" in overrides ? overrides.user! : fakeUser;
+  return render(
+    <MemoryRouter>
+      <HubAnalysisPanel
+        selectedSummary={selectedSummary}
+        concepts={concepts}
+        reliability={reliability}
+        reliabilityLoading={reliabilityLoading}
+        user={user}
+        language="fr"
+      />
+    </MemoryRouter>,
+  );
+};
+
+describe("HubAnalysisPanel", () => {
+  // Vitest + globals=true relies on RTL's auto-cleanup via the `afterEach`
+  // hook, but to keep these specs hermetic we still call cleanup explicitly
+  // — defensive against ordering surprises.
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when selectedSummary is null", () => {
+    const { container } = renderPanel({ selectedSummary: null });
+    expect(screen.queryByTestId("analysis-hub-mock")).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the AnalysisHub container when summary + concepts are passed", () => {
+    renderPanel();
+    expect(screen.getByTestId("analysis-hub-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("ah-summary-id")).toHaveTextContent("42");
+    expect(screen.getByTestId("ah-concepts-count")).toHaveTextContent("1");
+    // The 5 tabs are explicitly enabled by HubAnalysisPanel.
+    expect(screen.getByTestId("ah-tabs")).toHaveTextContent(
+      "synthesis,reliability,quiz,flashcards,geo",
+    );
+  });
+
+  it("does not crash with empty concepts array (just shows synthesis tab content)", () => {
+    renderPanel({ concepts: [] });
+    expect(screen.getByTestId("analysis-hub-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("ah-concepts-count")).toHaveTextContent("0");
+    // No reliability data → still renders, AnalysisHub handles its own empty state.
+    expect(screen.getByTestId("ah-has-reliability")).toHaveTextContent("no");
+  });
+});

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -10,7 +10,7 @@
  */
 import React, { useCallback, useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { videoApi, chatApi } from "../services/api";
+import { videoApi, chatApi, reliabilityApi } from "../services/api";
 import { useAuth } from "../hooks/useAuth";
 import { useTranslation } from "../hooks/useTranslation";
 import { useTTSContext } from "../contexts/TTSContext";
@@ -32,7 +32,7 @@ import { VideoPiPPlayer } from "../components/hub/VideoPiPPlayer";
 import { CallModeFullBleed } from "../components/hub/CallModeFullBleed";
 import { SourcesShelf } from "../components/hub/SourcesShelf";
 import { NewConversationModal } from "../components/hub/NewConversationModal";
-import { HubToolbox } from "../components/hub/HubToolbox";
+import { HubAnalysisPanel } from "../components/hub/HubAnalysisPanel";
 import { useAnalyzeAndOpenHub } from "../hooks/useAnalyzeAndOpenHub";
 import { Loader2 } from "lucide-react";
 import type { HubConversation, HubMessage } from "../components/hub/types";
@@ -100,7 +100,7 @@ const HubPage: React.FC = () => {
   const openSummaryFromUrl = searchParams.get("open_summary") === "1";
 
   const { language } = useTranslation();
-  const { user: _user } = useAuth();
+  const { user } = useAuth();
   const { autoPlayEnabled, playText, stopPlaying } = useTTSContext();
   const { voiceEnabled } = useVoiceEnabled();
 
@@ -109,6 +109,10 @@ const HubPage: React.FC = () => {
     activeConvId,
     messages,
     summaryContext,
+    fullSummary,
+    concepts,
+    reliability,
+    reliabilityLoading,
     drawerOpen,
     voiceCallOpen,
     pipExpanded,
@@ -118,6 +122,10 @@ const HubPage: React.FC = () => {
     setMessages,
     appendMessage,
     setSummaryContext,
+    setFullSummary,
+    setConcepts,
+    setReliability,
+    setReliabilityLoading,
     toggleDrawer,
     setPipExpanded,
     setVoiceCallOpen,
@@ -259,6 +267,10 @@ const HubPage: React.FC = () => {
   useEffect(() => {
     if (activeConvId === null) {
       setSummaryContext(null);
+      setFullSummary(null);
+      setConcepts([]);
+      setReliability(null);
+      setReliabilityLoading(false);
       return;
     }
     let cancelled = false;
@@ -303,11 +315,14 @@ const HubPage: React.FC = () => {
             short_summary: conv.last_snippet ?? "",
             citations: [],
           });
-          // Hydrate with real summary content (async, fire-and-forget)
+          // Hydrate with real summary content + concepts + reliability in
+          // parallel. Used by the AnalysisHub embed below the SummaryCollapsible
+          // (fact-check / mots-clés / quiz / flashcards / GEO).
           videoApi
             .getSummary(conv.summary_id)
             .then((s) => {
               if (cancelled) return;
+              setFullSummary(s);
               setSummaryContext({
                 summary_id: s.id,
                 video_title: s.video_title,
@@ -321,6 +336,35 @@ const HubPage: React.FC = () => {
             })
             .catch((err) => {
               console.warn("[HubPage] fetch full summary failed:", err);
+              if (!cancelled) setFullSummary(null);
+            });
+
+          videoApi
+            .getEnrichedConcepts(conv.summary_id)
+            .then((resp) => {
+              if (cancelled) return;
+              setConcepts(resp.concepts ?? []);
+            })
+            .catch((err) => {
+              // Concepts endpoint may be unavailable / 404 / plan-gated — fail
+              // silent and show an empty array so the page still renders.
+              console.warn("[HubPage] fetch concepts failed:", err);
+              if (!cancelled) setConcepts([]);
+            });
+
+          setReliabilityLoading(true);
+          reliabilityApi
+            .getReliability(conv.summary_id)
+            .then((r) => {
+              if (cancelled) return;
+              setReliability(r);
+            })
+            .catch((err) => {
+              console.warn("[HubPage] fetch reliability failed:", err);
+              if (!cancelled) setReliability(null);
+            })
+            .finally(() => {
+              if (!cancelled) setReliabilityLoading(false);
             });
         }
       } catch (err) {
@@ -330,7 +374,15 @@ const HubPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [activeConvId, setMessages, setSummaryContext]);
+  }, [
+    activeConvId,
+    setMessages,
+    setSummaryContext,
+    setFullSummary,
+    setConcepts,
+    setReliability,
+    setReliabilityLoading,
+  ]);
 
   // ── Auto-play TTS on assistant text messages ──
   const prevCountRef = useRef(messages.length);
@@ -509,9 +561,13 @@ const HubPage: React.FC = () => {
               />
             )}
             {summaryContext && (
-              <HubToolbox
-                summaryId={summaryContext.summary_id}
-                videoTitle={summaryContext.video_title}
+              <HubAnalysisPanel
+                selectedSummary={fullSummary}
+                concepts={concepts}
+                reliability={reliability}
+                reliabilityLoading={reliabilityLoading}
+                user={user}
+                language={language as "fr" | "en"}
               />
             )}
             <Timeline

--- a/frontend/src/store/hubStore.ts
+++ b/frontend/src/store/hubStore.ts
@@ -6,12 +6,29 @@ import type {
   HubSummaryContext,
   HubVoiceState,
 } from "../components/hub/types";
+import type {
+  Summary,
+  EnrichedConcept,
+  ReliabilityResult,
+} from "../services/api";
 
 interface HubState {
   conversations: HubConversation[];
   activeConvId: number | null;
   messages: HubMessage[];
   summaryContext: HubSummaryContext | null;
+  /**
+   * Full Summary object hydrated from videoApi.getSummary (used by AnalysisHub
+   * embed below the SummaryCollapsible). Distinct from `summaryContext` which
+   * is a lighter projection used by the SummaryCollapsible header.
+   */
+  fullSummary: Summary | null;
+  /** Concepts enrichis fetchés depuis videoApi.getEnrichedConcepts. */
+  concepts: EnrichedConcept[];
+  /** Résultat fiabilité fetché depuis reliabilityApi.getReliability. */
+  reliability: ReliabilityResult | null;
+  /** True pendant le fetch de la fiabilité. */
+  reliabilityLoading: boolean;
   drawerOpen: boolean;
   summaryExpanded: boolean;
   pipExpanded: boolean;
@@ -27,6 +44,10 @@ interface HubState {
   setMessages: (msgs: HubMessage[]) => void;
   appendMessage: (msg: HubMessage) => void;
   setSummaryContext: (ctx: HubSummaryContext | null) => void;
+  setFullSummary: (s: Summary | null) => void;
+  setConcepts: (concepts: EnrichedConcept[]) => void;
+  setReliability: (r: ReliabilityResult | null) => void;
+  setReliabilityLoading: (v: boolean) => void;
   toggleDrawer: () => void;
   toggleSummary: () => void;
   setPipExpanded: (v: boolean) => void;
@@ -43,6 +64,10 @@ const INITIAL: Pick<
   | "activeConvId"
   | "messages"
   | "summaryContext"
+  | "fullSummary"
+  | "concepts"
+  | "reliability"
+  | "reliabilityLoading"
   | "drawerOpen"
   | "summaryExpanded"
   | "pipExpanded"
@@ -55,6 +80,10 @@ const INITIAL: Pick<
   activeConvId: null,
   messages: [],
   summaryContext: null,
+  fullSummary: null,
+  concepts: [],
+  reliability: null,
+  reliabilityLoading: false,
   drawerOpen: false,
   summaryExpanded: false,
   pipExpanded: false,
@@ -87,6 +116,22 @@ export const useHubStore = create<HubState>()(
     setSummaryContext: (ctx) =>
       set((s) => {
         s.summaryContext = ctx;
+      }),
+    setFullSummary: (full) =>
+      set((s) => {
+        s.fullSummary = full;
+      }),
+    setConcepts: (concepts) =>
+      set((s) => {
+        s.concepts = concepts;
+      }),
+    setReliability: (r) =>
+      set((s) => {
+        s.reliability = r;
+      }),
+    setReliabilityLoading: (v) =>
+      set((s) => {
+        s.reliabilityLoading = v;
       }),
     toggleDrawer: () =>
       set((s) => {


### PR DESCRIPTION
## Summary

User feedback (Wispr Flow):
> "Tout ce qui se fait afficher avant doit s'afficher aussi en dessous du résumé quand on scroll en bas. C'est-à-dire les mots clés et les autres infos qu'il y avait avant."

Restores the full AnalysisHub (5 tabs : Synthèse + mots-clés, Quiz, Flashcards, Fiabilité / fact-check, GEO) inline below the SummaryCollapsible in `/hub`, replacing the lightweight 3-button HubToolbox. The user had this on the legacy DashboardPage before — now it's back inside the Hub.

- **hubStore** : 4 nouveaux slots Zustand (`fullSummary`, `concepts`, `reliability`, `reliabilityLoading`) hydratés depuis `videoApi.getSummary` + `videoApi.getEnrichedConcepts` + `reliabilityApi.getReliability` quand `activeConvId` change. Reset à null/[]/false quand pas de conv active.
- **HubAnalysisPanel** : wrapper inline minimaliste autour de `AnalysisHub`, container `rounded-2xl border-white/10 bg-white/[0.02]` aligné sur Timeline (`max-w-3xl mx-auto`). Cache les boutons toolbar `Voice` (déjà dans Hub) et `StudyTools` (Quiz/Flashcards en onglets dédiés), garde `Keywords`. Callbacks `onTimecodeClick` / `onOpenChat` no-op pour v1 (les citations du SummaryCollapsible et l'InputBar du Hub couvrent déjà ces flows).
- **HubPage** : useEffect existant étendu pour fetch `getSummary` + `getEnrichedConcepts` + `getReliability` en parallèle (fail-silent sur erreurs : empty concepts / null reliability ne cassent pas la page).

## Test plan

- [x] 3 nouveaux tests `HubAnalysisPanel.test.tsx` (mock AnalysisHub) :
  - renders nothing when `selectedSummary` is null
  - renders AnalysisHub container when summary + concepts passed
  - doesn't crash with empty concepts array
- [x] Hub regression : 43 → 46 tests, all green
- [x] Typecheck zero new errors dans le scope (`hub*`, `HubPage`, `hubStore`)
- [x] HubToolbox import + usage retirés de HubPage (fichier conservé pour usage futur)
- [ ] Manual : reload `/hub?conv=<id>` → vérifier que les 5 onglets s'affichent sous le SummaryCollapsible, que la timeline reste accessible en scrollant, et que les onglets Quiz/Flashcards déclenchent leur génération à la demande.

🤖 Generated with [Claude Code](https://claude.com/claude-code)