### PR TITLE
feat(stt): Phase 1 Mistral-First — Voxtral STT optimisé

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -142,7 +142,10 @@ class _DeepSightSettings(BaseSettings):
     ELEVENLABS_MODEL_ID: str = "eleven_flash_v2_5"
 
     # -- Voxtral TTS (Mistral) --
-    VOXTRAL_MODEL: str = "voxtral-mini-tts-2603"
+    # Renamed from VOXTRAL_MODEL → VOXTRAL_TTS_MODEL (Mistral-First Phase 1, Task 1.4)
+    # to clarify that this is the *TTS* (text-to-speech) model. STT now uses
+    # voxtral-mini-2602 (transcribe-only) — see transcripts/youtube.py.
+    VOXTRAL_TTS_MODEL: str = "voxtral-mini-tts-2603"
     VOXTRAL_VOICE_FR_FEMALE: str = ""  # voice_id created via Mistral Voices API
     VOXTRAL_VOICE_FR_MALE: str = ""
     VOXTRAL_VOICE_EN_FEMALE: str = ""

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -177,6 +177,10 @@ class _DeepSightSettings(BaseSettings):
     # -- Transcript --
     YTDLP_COOKIES_PATH: str = ""
     MAX_DURATION_FOR_STT: int = Field(default=1200)
+    # Plan-aware STT duration caps (Mistral-First Phase 1)
+    MAX_DURATION_FOR_STT_FREE: int = Field(default=1200)  # 20 min
+    MAX_DURATION_FOR_STT_PRO: int = Field(default=2400)  # 40 min
+    MAX_DURATION_FOR_STT_EXPERT: int = Field(default=3600)  # 60 min
 
     @property
     def is_production(self) -> bool:
@@ -892,6 +896,34 @@ HEALTH_CHECK_SECRET = _settings.HEALTH_CHECK_SECRET
 # =============================================================================
 
 MAX_DURATION_FOR_STT = _settings.MAX_DURATION_FOR_STT
+
+# Plan-aware STT duration caps (Mistral-First Phase 1)
+# Voxtral can handle up to 3h audio, so tier upgrades unlock longer videos.
+MAX_DURATION_FOR_STT_FREE = _settings.MAX_DURATION_FOR_STT_FREE
+MAX_DURATION_FOR_STT_PRO = _settings.MAX_DURATION_FOR_STT_PRO
+MAX_DURATION_FOR_STT_EXPERT = _settings.MAX_DURATION_FOR_STT_EXPERT
+
+
+def get_max_stt_duration(plan: str) -> int:
+    """
+    Return max STT duration (seconds) allowed for the given plan.
+
+    Free / Starter: 20 min
+    Student / Pro:  40 min
+    Expert:         60 min
+
+    Unknown plans fall back to Free.
+    """
+    if not plan:
+        return MAX_DURATION_FOR_STT_FREE
+    return {
+        "free": MAX_DURATION_FOR_STT_FREE,
+        "starter": MAX_DURATION_FOR_STT_FREE,
+        "student": MAX_DURATION_FOR_STT_PRO,
+        "pro": MAX_DURATION_FOR_STT_PRO,
+        "expert": MAX_DURATION_FOR_STT_EXPERT,
+    }.get(plan.lower(), MAX_DURATION_FOR_STT_FREE)
+
 
 TRANSCRIPT_CONFIG = {
     "circuit_breaker_failure_threshold": 5,

--- a/backend/src/transcripts/audio_utils.py
+++ b/backend/src/transcripts/audio_utils.py
@@ -216,7 +216,9 @@ async def transcribe_audio_groq(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 VOXTRAL_STT_URL = "https://api.mistral.ai/v1/audio/transcriptions"
-VOXTRAL_STT_MODEL = "voxtral-mini-latest"
+# v7.3 — Switch to transcribe-only model (faster + cheaper than chat-tuned voxtral-mini-latest)
+# Official doc: https://docs.mistral.ai/models/voxtral-mini-transcribe-26-02
+VOXTRAL_STT_MODEL = "voxtral-mini-2602"
 
 
 async def transcribe_audio_voxtral(

--- a/backend/src/transcripts/youtube.py
+++ b/backend/src/transcripts/youtube.py
@@ -2541,6 +2541,48 @@ async def _get_transcript_with_timestamps_inner(
             return simple, timestamped, lang
 
     # ═══════════════════════════════════════════════════════════════════════════════
+    # PHASE 1.5: VOXTRAL SHORT-CIRCUIT (Mistral-First Phase 1, Task 1.3)
+    # No captions detected by Supadata/Phase 1 → skip directly to Voxtral STT
+    # if duration fits the plan cap. Saves 5-30s vs trying yt-dlp first when
+    # the video has no captions at all.
+    # ═══════════════════════════════════════════════════════════════════════════════
+    from core.config import get_max_stt_duration as _get_max_stt_duration
+
+    _short_circuit_cap = _get_max_stt_duration(user_plan or "free")
+    _voxtral_cb = get_circuit_breaker("voxtral_stt")
+    if (
+        duration > 0
+        and duration <= _short_circuit_cap
+        and _voxtral_cb.can_execute()
+    ):
+        print("", flush=True)
+        print(
+            f"🎙️ PHASE 1.5: No captions detected by Supadata, short-circuiting to Voxtral STT "
+            f"(duration={duration}s ≤ cap={_short_circuit_cap}s, plan={user_plan or 'free'})",
+            flush=True,
+        )
+        print("─" * 50, flush=True)
+        try:
+            sc_simple, sc_timestamped, sc_lang = await get_transcript_voxtral(video_id)
+            if sc_simple and sc_timestamped:
+                _voxtral_cb.record_success()
+                print("✅ SUCCESS with Voxtral STT (Phase 1.5 short-circuit)", flush=True)
+                print(f"{'=' * 70}", flush=True)
+                await _cache_success(video_id, sc_simple, sc_timestamped, sc_lang, "Voxtral STT (short-circuit)")
+                return sc_simple, sc_timestamped, sc_lang
+            else:
+                print("  ❌ [Voxtral short-circuit] Empty result, falling back to Phase 2", flush=True)
+        except Exception as e:
+            print(
+                f"  ⚠️ [Voxtral short-circuit] Failed ({type(e).__name__}): {str(e)[:200]} — "
+                f"falling back to Phase 2",
+                flush=True,
+            )
+            # Don't record failure on circuit breaker — Phase 3 will retry the same provider
+            # only if the short-circuit timed out / network failed. Real STT errors will
+            # be recorded there. We want to give yt-dlp a chance before giving up on Voxtral.
+
+    # ═══════════════════════════════════════════════════════════════════════════════
     # PHASE 2: yt-dlp (séquentiel, plus lent mais fiable)
     # ═══════════════════════════════════════════════════════════════════════════════
     print("", flush=True)
@@ -2584,8 +2626,7 @@ async def _get_transcript_with_timestamps_inner(
     # Duration guard: plan-aware cap (Mistral-First Phase 1).
     # Free=20min / Pro=40min / Expert=60min. Voxtral handles up to 3h, so the
     # caps reflect business policy (paid tiers unlock longer audio), not API limits.
-    from core.config import get_max_stt_duration as _get_max_stt_duration
-
+    # _get_max_stt_duration is already imported above at the Phase 1.5 short-circuit.
     max_stt_duration = _get_max_stt_duration(user_plan or "free")
     if duration > 0 and duration > max_stt_duration:
         print(

--- a/backend/src/transcripts/youtube.py
+++ b/backend/src/transcripts/youtube.py
@@ -1558,7 +1558,9 @@ async def get_transcript_whisper(video_id: str) -> Tuple[Optional[str], Optional
 # ═══════════════════════════════════════════════════════════════════════════════
 
 VOXTRAL_STT_URL = "https://api.mistral.ai/v1/audio/transcriptions"
-VOXTRAL_STT_MODEL = "voxtral-mini-latest"
+# v7.3 — Switch to transcribe-only model (faster + cheaper than chat-tuned voxtral-mini-latest)
+# Official doc: https://docs.mistral.ai/models/voxtral-mini-transcribe-26-02
+VOXTRAL_STT_MODEL = "voxtral-mini-2602"
 VOXTRAL_MAX_FILE_SIZE = 500 * 1024 * 1024  # 500MB (Mistral est très généreux)
 
 
@@ -1578,7 +1580,7 @@ async def get_transcript_voxtral(
     - Multilingue 13 langues avec détection auto
 
     API: POST /v1/audio/transcriptions (multipart/form-data)
-    Model: voxtral-mini-latest
+    Model: voxtral-mini-2602 (transcribe-only, fine-tuned for STT)
     """
     mistral_key = get_mistral_key()
     if not mistral_key:

--- a/backend/src/transcripts/youtube.py
+++ b/backend/src/transcripts/youtube.py
@@ -2325,7 +2325,11 @@ async def _compress_audio(audio_data: bytes, audio_ext: str, source_name: str = 
 
 
 async def get_transcript_with_timestamps(
-    video_id: str, supadata_key: str = None, is_short: bool = False, duration: int = 0
+    video_id: str,
+    supadata_key: str = None,
+    is_short: bool = False,
+    duration: int = 0,
+    user_plan: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """
     🎯 FONCTION PRINCIPALE v7.1 - Supadata PRIORITAIRE + STT pour TOUTES vidéos
@@ -2353,11 +2357,15 @@ async def get_transcript_with_timestamps(
     """
     # 🚦 Semaphore: limite les extractions concurrentes pour protéger les APIs
     async with _extraction_semaphore:
-        return await _get_transcript_with_timestamps_inner(video_id, supadata_key, is_short, duration)
+        return await _get_transcript_with_timestamps_inner(video_id, supadata_key, is_short, duration, user_plan)
 
 
 async def _get_transcript_with_timestamps_inner(
-    video_id: str, supadata_key: str = None, is_short: bool = False, duration: int = 0
+    video_id: str,
+    supadata_key: str = None,
+    is_short: bool = False,
+    duration: int = 0,
+    user_plan: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """Inner function — exécutée sous le semaphore de concurrence."""
     print("", flush=True)
@@ -2573,10 +2581,16 @@ async def _get_transcript_with_timestamps_inner(
     print(f"📋 PHASE 3: Audio STT (last resort{' — SHORT' if is_short else ' — full video'})", flush=True)
     print("─" * 50, flush=True)
 
-    # Duration guard: skip all STT providers for videos longer than MAX_DURATION_FOR_STT
-    if duration > 0 and duration > MAX_DURATION_FOR_STT:
+    # Duration guard: plan-aware cap (Mistral-First Phase 1).
+    # Free=20min / Pro=40min / Expert=60min. Voxtral handles up to 3h, so the
+    # caps reflect business policy (paid tiers unlock longer audio), not API limits.
+    from core.config import get_max_stt_duration as _get_max_stt_duration
+
+    max_stt_duration = _get_max_stt_duration(user_plan or "free")
+    if duration > 0 and duration > max_stt_duration:
         print(
-            f"  ⏭️ [STT] Skipped ALL STT providers: video duration {duration}s > MAX_DURATION_FOR_STT {MAX_DURATION_FOR_STT}s",
+            f"  ⏭️ [STT] Skipped ALL STT providers: video duration {duration}s > "
+            f"max_stt_duration {max_stt_duration}s for plan={user_plan or 'free'}",
             flush=True,
         )
     else:

--- a/backend/src/tts/providers.py
+++ b/backend/src/tts/providers.py
@@ -328,7 +328,7 @@ class VoxtralTTSProvider(TTSProvider):
 
         from core.config import _settings
 
-        resolved_model = model_id or _settings.VOXTRAL_MODEL
+        resolved_model = model_id or _settings.VOXTRAL_TTS_MODEL
 
         payload = {
             "model": resolved_model,
@@ -425,7 +425,7 @@ class VoxtralTTSProvider(TTSProvider):
         from core.config import _settings
 
         payload = {
-            "model": _settings.VOXTRAL_MODEL,
+            "model": _settings.VOXTRAL_TTS_MODEL,
             "input": text,
             "voice_id": resolved_voice,
             "response_format": "mp3",

--- a/backend/src/tts/router.py
+++ b/backend/src/tts/router.py
@@ -540,7 +540,7 @@ async def tts_status():
             },
             "voxtral": {
                 "available": voxtral_available,
-                "model": _settings.VOXTRAL_MODEL,
+                "model": _settings.VOXTRAL_TTS_MODEL,
             },
             "openai": {
                 "available": openai_available,

--- a/backend/tests/transcripts/test_stt_routing.py
+++ b/backend/tests/transcripts/test_stt_routing.py
@@ -92,3 +92,66 @@ class TestGetMaxSttDuration:
         from core.config import MAX_DURATION_FOR_STT_EXPERT, MAX_DURATION_FOR_STT_FREE
 
         assert MAX_DURATION_FOR_STT_EXPERT == MAX_DURATION_FOR_STT_FREE * 3
+
+
+# =============================================================================
+# Phase 1.5 short-circuit (Voxtral before Phase 2 yt-dlp when no captions)
+# =============================================================================
+
+
+class TestVoxtralShortCircuit:
+    """Verify that Voxtral STT is attempted as Phase 1.5 short-circuit, before
+    Phase 2 yt-dlp methods, when Supadata + Phase 1 parallel methods all fail."""
+
+    def test_short_circuit_present_in_source(self):
+        """The Phase 1.5 block must exist between Phase 1 and Phase 2."""
+        import inspect
+
+        from transcripts import youtube
+
+        source = inspect.getsource(youtube._get_transcript_with_timestamps_inner)
+        assert "PHASE 1.5" in source, "Phase 1.5 short-circuit block not found"
+        assert "short-circuit" in source.lower(), "short-circuit keyword missing in source"
+
+    def test_short_circuit_runs_before_phase2(self):
+        """Phase 1.5 (Voxtral short-circuit) must appear before Phase 2 yt-dlp."""
+        import inspect
+
+        from transcripts import youtube
+
+        source = inspect.getsource(youtube._get_transcript_with_timestamps_inner)
+        sc_pos = source.find("PHASE 1.5")
+        phase2_pos = source.find("PHASE 2: yt-dlp")
+        assert sc_pos > 0, "Phase 1.5 not found"
+        assert phase2_pos > 0, "Phase 2 yt-dlp marker not found"
+        assert sc_pos < phase2_pos, "Phase 1.5 short-circuit must run BEFORE Phase 2 yt-dlp"
+
+    def test_short_circuit_logs_no_captions_message(self):
+        """The short-circuit must log explicitly that captions are missing."""
+        import inspect
+
+        from transcripts import youtube
+
+        source = inspect.getsource(youtube._get_transcript_with_timestamps_inner)
+        assert "No captions detected by Supadata" in source
+
+    def test_short_circuit_uses_plan_aware_cap(self):
+        """Phase 1.5 must respect the plan-aware duration cap (not always run)."""
+        import inspect
+
+        from transcripts import youtube
+
+        source = inspect.getsource(youtube._get_transcript_with_timestamps_inner)
+        # The short-circuit block must use _get_max_stt_duration (plan-aware)
+        assert "_get_max_stt_duration" in source
+
+    def test_get_transcript_with_timestamps_accepts_user_plan(self):
+        """Public API must accept optional user_plan kwarg (backward compat)."""
+        import inspect
+
+        from transcripts.youtube import get_transcript_with_timestamps
+
+        sig = inspect.signature(get_transcript_with_timestamps)
+        assert "user_plan" in sig.parameters, "user_plan kwarg missing from public function"
+        # Must default to None for backward compat with existing callers
+        assert sig.parameters["user_plan"].default is None

--- a/backend/tests/transcripts/test_stt_routing.py
+++ b/backend/tests/transcripts/test_stt_routing.py
@@ -1,0 +1,94 @@
+"""
+Tests for plan-aware STT duration routing (Mistral-First Phase 1, Task 1.2).
+
+Verifies that get_max_stt_duration() returns the correct cap per plan tier:
+- free / starter      → 1200s (20 min)
+- student / pro       → 2400s (40 min)
+- expert              → 3600s (60 min)
+- unknown / None / "" → falls back to free
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+class TestGetMaxSttDuration:
+    """Plan-aware duration cap routing for Voxtral STT."""
+
+    def test_free_plan_returns_1200(self):
+        from core.config import get_max_stt_duration
+
+        assert get_max_stt_duration("free") == 1200
+
+    def test_starter_plan_returns_1200(self):
+        from core.config import get_max_stt_duration
+
+        # Legacy starter tier is mapped to free duration cap
+        assert get_max_stt_duration("starter") == 1200
+
+    def test_student_plan_returns_2400(self):
+        from core.config import get_max_stt_duration
+
+        # Student promo plan benefits from Pro-level duration cap
+        assert get_max_stt_duration("student") == 2400
+
+    def test_pro_plan_returns_2400(self):
+        from core.config import get_max_stt_duration
+
+        assert get_max_stt_duration("pro") == 2400
+
+    def test_expert_plan_returns_3600(self):
+        from core.config import get_max_stt_duration
+
+        assert get_max_stt_duration("expert") == 3600
+
+    def test_unknown_plan_falls_back_to_free(self):
+        from core.config import get_max_stt_duration
+
+        assert get_max_stt_duration("enterprise") == 1200
+        assert get_max_stt_duration("foobar") == 1200
+
+    def test_none_falls_back_to_free(self):
+        from core.config import get_max_stt_duration
+
+        assert get_max_stt_duration(None) == 1200
+
+    def test_empty_string_falls_back_to_free(self):
+        from core.config import get_max_stt_duration
+
+        assert get_max_stt_duration("") == 1200
+
+    def test_case_insensitive(self):
+        from core.config import get_max_stt_duration
+
+        assert get_max_stt_duration("PRO") == 2400
+        assert get_max_stt_duration("Expert") == 3600
+        assert get_max_stt_duration("FREE") == 1200
+
+    def test_constants_exposed(self):
+        """Constants should be accessible at module level for direct override."""
+        from core.config import (
+            MAX_DURATION_FOR_STT_EXPERT,
+            MAX_DURATION_FOR_STT_FREE,
+            MAX_DURATION_FOR_STT_PRO,
+        )
+
+        assert MAX_DURATION_FOR_STT_FREE == 1200
+        assert MAX_DURATION_FOR_STT_PRO == 2400
+        assert MAX_DURATION_FOR_STT_EXPERT == 3600
+
+    def test_pro_is_double_free(self):
+        """Document the policy: Pro = 2x Free duration cap."""
+        from core.config import MAX_DURATION_FOR_STT_FREE, MAX_DURATION_FOR_STT_PRO
+
+        assert MAX_DURATION_FOR_STT_PRO == MAX_DURATION_FOR_STT_FREE * 2
+
+    def test_expert_is_triple_free(self):
+        """Document the policy: Expert = 3x Free duration cap."""
+        from core.config import MAX_DURATION_FOR_STT_EXPERT, MAX_DURATION_FOR_STT_FREE
+
+        assert MAX_DURATION_FOR_STT_EXPERT == MAX_DURATION_FOR_STT_FREE * 3


### PR DESCRIPTION
## Phase 1 — Voxtral STT optimisé

Première phase de la migration **Mistral-First** (spec : `Vault/01-Projects/DeepSight/Specs/2026-05-02-mistral-first-migration-design.md` · plan : `docs/superpowers/plans/2026-05-02-mistral-first-migration.md`).

## Changes
- **Modèle STT migré** : `voxtral-mini-2602` (Voxtral Mini Transcribe 2, transcribe-only) — confirmé via doc Mistral
- **`MAX_DURATION_FOR_STT` plan-aware** : 20 min Free, 40 min Pro, 60 min Expert (`get_max_stt_duration()`)
- **Short-circuit Voxtral** après Phase 1 Supadata si no-captions + durée OK (évite plusieurs secondes de fallbacks texte voués à l'échec)
- **`VOXTRAL_MODEL` renommé `VOXTRAL_TTS_MODEL`** (était activement utilisé sur `tts/providers.py:331,428` + `tts/router.py:543`, ne pas supprimer)

## Tests
- **44/44 tests Voxtral verts** (9 existants + 17 nouveaux `test_stt_routing.py` + 6 TTS + 12 autres)
- Diff : +264 / -13 (6 fichiers)

## Fallbacks préservés
Tous les fallbacks STT existants (Groq Whisper, OpenAI Whisper, Deepgram, AssemblyAI, ElevenLabs Scribe) restent intacts. Cette PR ajoute juste un short-circuit Voxtral plus tôt dans la chaîne.

## Test plan
- [ ] Vidéo YouTube sans captions → Voxtral tenté en premier (vérifier logs `short-circuiting to Voxtral STT`)
- [ ] Vidéo > 60 min en plan Free → skip STT (cap respectée)
- [ ] Vidéo 50 min en plan Expert → STT autorisé (cap 60 min)
- [ ] TTS Voxtral toujours fonctionnel via `VOXTRAL_TTS_MODEL`

## À noter (hors scope, follow-up Phase 1.5)
5 callers de `get_transcript_with_timestamps` (`videos/router.py`, `playlists/pipeline.py`, `tasks/analysis_tasks.py`, etc.) ne passent pas encore `user_plan` → tous restent capés à 20 min (default Free). Pour bénéficier des caps Pro/Expert, à propager dans une mini-PR follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)