### PR TITLE
feat(tts): Phase 7 Mistral-First — TTS policy + ElevenLabs hard-pin Quick Voice Call

### DIFF
--- a/backend/docs/architecture/tts-policy.md
+++ b/backend/docs/architecture/tts-policy.md
@@ -1,0 +1,108 @@
+# TTS Provider Policy
+
+**Status** : Active — Phase 7 of the Mistral-First migration (2026-05-02)
+**Spec source** : `01-Projects/DeepSight/Specs/2026-05-02-mistral-first-migration-design.md`
+
+This document formalises which TTS provider DeepSight uses for which surface,
+and pins the choice technically so accidental migrations cannot regress the
+real-time voice experience.
+
+---
+
+## Quick Voice Call (real-time conversational voice)
+
+**Provider unique : ElevenLabs `eleven_flash_v2_5`** (or other `eleven_*`
+variants — Turbo, Multilingual — at the user's preference, all served by
+ElevenLabs Conversational AI).
+
+### Reasons
+
+- Latency < 200ms (critical for real-time conversation — Flash v2.5 hits
+  ~150ms first-byte, Turbo v2.5 ~300ms).
+- Premium voices already catalogued in Voice Packs (PR #29
+  `elevenlabs-voice-packs`, mergée prod 2026-04).
+- ElevenLabs Conversational AI handles STT + LLM streaming + TTS as a single
+  agent loop — replacing it would require rebuilding turn-taking, VAD,
+  interruption handling, LiveKit JWT signaling, etc.
+- No migration is planned in the current roadmap.
+
+### Files concerned
+
+- `backend/src/voice/router.py` — the `/api/voice/*` endpoints (notably
+  `POST /api/voice/session` and the companion / debate session creators).
+  Provider is structurally pinned: the route invokes
+  `voice.elevenlabs.ElevenLabsClient` directly. There is no multi-provider
+  selector here.
+- `backend/src/voice/elevenlabs.py` — `ElevenLabsClient.create_conversation_agent()`
+  hardcodes the ElevenLabs API base URL (`api.elevenlabs.io/v1`) and the
+  default model `eleven_flash_v2_5`. The HARD-PIN guard is implemented here
+  and in the session-creation site.
+- `backend/src/voice/schemas.py` — `VoicePreferencesRequest.voice_chat_model`
+  Pydantic validator restricts user-selectable models to
+  `{eleven_multilingual_v2, eleven_turbo_v2_5, eleven_flash_v2_5}`. Any other
+  value raises 422.
+- `backend/src/tts/providers.py` — block `ElevenLabsTTSProvider` (around
+  L67-L157) covers the **non-conversational** TTS path; the voice-call path
+  does not transit through `tts/providers.py`.
+
+### Rule
+
+**Do not migrate `/api/voice/*` (Quick Voice Call, Voice Companion, Debate
+voice) routes to another TTS provider without explicit product validation.**
+Voxtral TTS is excluded from this surface. Any contributor proposing such a
+migration must:
+
+1. Demonstrate p95 first-byte latency ≤ 200ms on French + English under load.
+2. Re-cap voices in Voice Packs and ensure premium parity.
+3. Ship a feature flag with instant rollback to ElevenLabs.
+
+---
+
+## Async TTS / audio summaries (future)
+
+**Candidate provider : Voxtral TTS (`voxtral-mini-tts-2603`)** — Mistral AI's
+TTS model — for cost reduction.
+
+- Implementation already drafted in
+  `backend/src/tts/providers.py::VoxtralTTSProvider` (secondary in the
+  fallback chain). Used today only when ElevenLabs is unavailable AND the
+  Voxtral voice IDs are configured.
+- **Out of scope for the Mistral-First v1 migration.** A dedicated sprint
+  will:
+  - Pre-create Voxtral voices via the Mistral Voices API.
+  - Calibrate quality vs ElevenLabs on French audio summaries.
+  - Decide whether to flip Voxtral to primary on `POST /api/tts/summary/*`
+    only (keeping voice-call untouched).
+
+---
+
+## Generic / non-conversational TTS (current production)
+
+Routes : `POST /api/tts`, `POST /api/tts/summary/{summary_id}`,
+`POST /api/tts/dub/{summary_id}`.
+
+Multi-provider chain via `tts.providers.get_tts_provider()`:
+
+- **Primary** : ElevenLabs `eleven_multilingual_v2` (highest quality, all
+  languages).
+- **Secondary** : Voxtral `voxtral-mini-tts-2603` (only when configured).
+- **Fallback** : OpenAI `tts-1` (when ElevenLabs circuit breaker is open and
+  Voxtral is unavailable).
+
+The fallback chain is unchanged by the Mistral-First v1 migration.
+
+---
+
+## Mistral-First migration context
+
+Phase 7 of the migration (this document) makes the policy explicit and adds
+a technical hard-pin guard on the voice-call session-creation path so that:
+
+- A future contributor cannot accidentally route Quick Voice Call through
+  `tts.providers.get_tts_provider()` (which would let the
+  Voxtral/OpenAI fallback chain handle conversational voice).
+- The session creator emits the `X-TTS-Provider: elevenlabs` response header
+  so observability dashboards can detect any provider anomaly.
+
+See the migration spec for the full context:
+`01-Projects/DeepSight/Specs/2026-05-02-mistral-first-migration-design.md`.

--- a/backend/src/voice/elevenlabs.py
+++ b/backend/src/voice/elevenlabs.py
@@ -4,6 +4,13 @@ Phase 2 kickstart — API client for agent creation and signed URL generation.
 
 Uses the ElevenLabs Conversational AI API:
 https://elevenlabs.io/docs/api-reference/conversational-ai
+
+# HARD-PIN: ElevenLabs only for voice-call (see backend/docs/architecture/tts-policy.md)
+# This module is the single entry point for Quick Voice Call agent creation.
+# Voice-call routes (`/api/voice/session`, companion, debate) MUST NOT route
+# through `tts.providers.get_tts_provider()` (which would let the
+# Voxtral/OpenAI fallback chain handle conversational voice — breaking the
+# < 200ms latency requirement). Phase 7 of the Mistral-First migration.
 """
 
 from __future__ import annotations
@@ -13,6 +20,27 @@ from typing import Optional
 import httpx
 
 from core.logging import logger
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HARD-PIN constants — voice-call provider policy (Phase 7 / 2026-05-02)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# The single TTS provider authorised on Quick Voice Call routes. Any change
+# requires explicit product validation — see backend/docs/architecture/tts-policy.md.
+VOICE_CALL_PROVIDER: str = "elevenlabs"
+
+# Whitelist of ElevenLabs model_ids accepted by the conversational agent
+# creator. Mirrors the Pydantic validator in voice/schemas.py — duplicated
+# here on purpose so a future contributor cannot bypass the schema by calling
+# `create_conversation_agent` directly with a non-ElevenLabs model.
+ALLOWED_VOICE_CALL_MODELS: frozenset[str] = frozenset(
+    {
+        "eleven_flash_v2_5",       # ~150ms first-byte — recommended
+        "eleven_turbo_v2_5",       # ~300ms — current default
+        "eleven_multilingual_v2",  # higher quality, higher latency
+    }
+)
 
 
 class ElevenLabsClient:
@@ -61,9 +89,27 @@ class ElevenLabsClient:
             turn_config: ElevenLabs turn configuration (mode, turn_timeout, interruptions, eagerness).
 
         Raises:
-            ValueError: on 401 (invalid API key).
+            ValueError: on 401 (invalid API key) or invalid model_id (HARD-PIN).
             httpx.HTTPStatusError: on 429 (rate limit) or 5xx.
         """
+        # HARD-PIN: ElevenLabs only for voice-call (see tts-policy.md)
+        # Defence in depth — even if a caller bypasses the Pydantic schema in
+        # voice/schemas.py, this guard prevents a non-ElevenLabs model from
+        # reaching the ElevenLabs API (which would 4xx anyway, but the explicit
+        # error here is clearer and observable).
+        if model_id not in ALLOWED_VOICE_CALL_MODELS:
+            logger.error(
+                "voice_call.hard_pin_violation",
+                extra={
+                    "rejected_model": model_id,
+                    "allowed": sorted(ALLOWED_VOICE_CALL_MODELS),
+                },
+            )
+            raise ValueError(
+                f"Voice-call provider is hard-pinned to ElevenLabs. "
+                f"model_id={model_id!r} is not allowed. "
+                f"See backend/docs/architecture/tts-policy.md."
+            )
         # ── TTS config (flat properties since API update April 2026) ──
         tts_config: dict = {
             "voice_id": voice_id,

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 import httpx
 import stripe
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -62,7 +62,12 @@ from voice.quota import (
     check_voice_quota,
     deduct_voice_usage,
 )
-from voice.elevenlabs import ElevenLabsClient, get_elevenlabs_client
+from voice.elevenlabs import (
+    ElevenLabsClient,
+    get_elevenlabs_client,
+    VOICE_CALL_PROVIDER,
+    ALLOWED_VOICE_CALL_MODELS,
+)
 from voice.streaming_orchestrator import (
     create_production_orchestrator,
     PUBSUB_CHANNEL_PREFIX,
@@ -1062,6 +1067,7 @@ async def _run_main_analysis_for_video(
 @router.post("/session", response_model=VoiceSessionResponse)
 async def create_voice_session(
     request: VoiceSessionRequest,
+    response: Response = None,  # type: ignore[assignment] # FastAPI injects automatically; default keeps unit tests calling create_voice_session() directly working
     background_tasks: BackgroundTasks = None,  # type: ignore[assignment]
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
@@ -1892,6 +1898,22 @@ async def create_voice_session(
         voice_settings = user_prefs.to_voice_settings()
         voice_chat_model = user_prefs.voice_chat_model or "eleven_turbo_v2_5"
 
+        # HARD-PIN: ElevenLabs only for voice-call (see backend/docs/architecture/tts-policy.md)
+        # Defence in depth — if a future contributor introduces a bypass that lets
+        # `voice_chat_model` be set from a request body field (today it comes only
+        # from validated user_prefs), this clamp ensures only ElevenLabs models
+        # ever reach `client.create_conversation_agent`. Phase 7 / Mistral-First.
+        if voice_chat_model not in ALLOWED_VOICE_CALL_MODELS:
+            logger.warning(
+                "voice_call.model_clamped_to_default",
+                extra={
+                    "user_id": current_user.id,
+                    "rejected_model": voice_chat_model,
+                    "fallback": "eleven_turbo_v2_5",
+                },
+            )
+            voice_chat_model = "eleven_turbo_v2_5"
+
         # ── Build turn configuration from user preferences (Phase 1: PTT) ──
         from voice.preferences import get_voice_chat_speed_preset, CONCISENESS_INJECTION_FR, CONCISENESS_INJECTION_EN
 
@@ -2008,6 +2030,11 @@ async def create_voice_session(
     max_session_minutes = plan_limits.get("max_session_minutes", 10)
     quota_remaining_seconds = quota_info.get("seconds_remaining", 0) if isinstance(quota_info, dict) else 0
     quota_remaining_minutes = round(quota_remaining_seconds / 60.0, 2)
+
+    # HARD-PIN observability: emit X-TTS-Provider header so dashboards can
+    # detect any provider anomaly on Quick Voice Call. See tts-policy.md.
+    if response is not None:
+        response.headers["X-TTS-Provider"] = VOICE_CALL_PROVIDER
 
     return VoiceSessionResponse(
         session_id=voice_session.id,

--- a/backend/tests/tts/test_voice_call_provider_pin.py
+++ b/backend/tests/tts/test_voice_call_provider_pin.py
@@ -1,0 +1,166 @@
+"""
+Phase 7 — Voice-call hard-pin to ElevenLabs.
+
+These tests guard the policy documented in
+``backend/docs/architecture/tts-policy.md``: Quick Voice Call (and the other
+``/api/voice/*`` session creators) MUST go through ElevenLabs Conversational
+AI — never through the multi-provider chain in ``tts/providers.py``.
+
+The pin is enforced in three places, each verified here:
+
+1. ``voice.elevenlabs`` exposes ``VOICE_CALL_PROVIDER`` and a whitelist of
+   allowed model_ids.
+2. ``voice.elevenlabs.ElevenLabsClient.create_conversation_agent`` raises
+   ``ValueError`` when called with a non-ElevenLabs model_id (defence in
+   depth — even if the Pydantic schema is bypassed).
+3. The voice session route is annotated to emit the
+   ``X-TTS-Provider: elevenlabs`` response header (observability).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Make ``backend/src`` importable like the other test files in this folder.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Constants exist and reflect the policy
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVoiceCallProviderConstants:
+    def test_voice_call_provider_is_elevenlabs(self):
+        from voice.elevenlabs import VOICE_CALL_PROVIDER
+
+        assert VOICE_CALL_PROVIDER == "elevenlabs"
+
+    def test_allowed_models_only_elevenlabs(self):
+        from voice.elevenlabs import ALLOWED_VOICE_CALL_MODELS
+
+        # All accepted ids are ElevenLabs models — the prefix is the
+        # marker. No openai/voxtral/etc. should ever sneak in.
+        assert ALLOWED_VOICE_CALL_MODELS, "Whitelist must not be empty"
+        for model_id in ALLOWED_VOICE_CALL_MODELS:
+            assert model_id.startswith("eleven_"), (
+                f"Non-ElevenLabs model_id {model_id!r} leaked into the "
+                f"voice-call whitelist — see tts-policy.md"
+            )
+
+    def test_flash_v2_5_is_allowed(self):
+        """The recommended low-latency model must remain whitelisted."""
+        from voice.elevenlabs import ALLOWED_VOICE_CALL_MODELS
+
+        assert "eleven_flash_v2_5" in ALLOWED_VOICE_CALL_MODELS
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. ``create_conversation_agent`` rejects non-ElevenLabs models
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCreateConversationAgentHardPin:
+    @pytest.mark.asyncio
+    async def test_rejects_openai_model(self):
+        from voice.elevenlabs import ElevenLabsClient
+
+        client = ElevenLabsClient(api_key="dummy")
+        try:
+            with pytest.raises(ValueError, match="hard-pinned to ElevenLabs"):
+                await client.create_conversation_agent(
+                    system_prompt="You are a test agent.",
+                    tools=[],
+                    voice_id="voice-test",
+                    model_id="tts-1",  # OpenAI model — must be rejected
+                )
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_rejects_voxtral_model(self):
+        from voice.elevenlabs import ElevenLabsClient
+
+        client = ElevenLabsClient(api_key="dummy")
+        try:
+            with pytest.raises(ValueError, match="hard-pinned to ElevenLabs"):
+                await client.create_conversation_agent(
+                    system_prompt="You are a test agent.",
+                    tools=[],
+                    voice_id="voice-test",
+                    model_id="voxtral-mini-tts-2603",  # Mistral model — rejected
+                )
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_rejects_arbitrary_string(self):
+        from voice.elevenlabs import ElevenLabsClient
+
+        client = ElevenLabsClient(api_key="dummy")
+        try:
+            with pytest.raises(ValueError, match="hard-pinned to ElevenLabs"):
+                await client.create_conversation_agent(
+                    system_prompt="You are a test agent.",
+                    tools=[],
+                    voice_id="voice-test",
+                    model_id="anthropic-claude",
+                )
+        finally:
+            await client.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Route emits the X-TTS-Provider observability header
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVoiceSessionRouteEmitsHeader:
+    """Static guard — ensure the route source actually sets the header.
+
+    A full integration test of ``POST /api/voice/session`` requires DB +
+    Redis + ElevenLabs + JWT plumbing; the conftest in this folder is
+    minimal. The header instruction is mechanically grep-able, so a
+    string-level test gives a low-friction regression guard that
+    triggers immediately if a future refactor removes the line.
+    """
+
+    def test_route_sets_x_tts_provider_header(self):
+        # Locate router.py relative to the test file (works regardless of cwd)
+        router_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "src",
+            "voice",
+            "router.py",
+        )
+        with open(router_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert 'response.headers["X-TTS-Provider"] = VOICE_CALL_PROVIDER' in content, (
+            "Voice session route must emit X-TTS-Provider observability "
+            "header — see backend/docs/architecture/tts-policy.md (Phase 7)."
+        )
+
+    def test_router_imports_hard_pin_constants(self):
+        router_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "src",
+            "voice",
+            "router.py",
+        )
+        with open(router_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert "VOICE_CALL_PROVIDER" in content, (
+            "voice/router.py must import VOICE_CALL_PROVIDER (hard-pin)"
+        )
+        assert "ALLOWED_VOICE_CALL_MODELS" in content, (
+            "voice/router.py must import ALLOWED_VOICE_CALL_MODELS (hard-pin)"
+        )


### PR DESCRIPTION
## Phase 7 — TTS policy + ElevenLabs hard-pin Quick Voice Call

Documente la politique TTS multi-provider de DeepSight et **pin techniquement ElevenLabs** sur Quick Voice Call (latence < 200ms requise).

## Changes
- **Nouveau** : `backend/docs/architecture/tts-policy.md` (108 lignes) — politique formelle multi-provider
- `backend/src/voice/elevenlabs.py` : constantes `VOICE_CALL_PROVIDER` + `ALLOWED_VOICE_CALL_MODELS`, `create_conversation_agent` rejette tout `model_id` non-ElevenLabs (`ValueError`)
- `backend/src/voice/router.py` : clamp `voice_chat_model` + header observabilité `X-TTS-Provider: elevenlabs` sur `POST /api/voice/session`
- **Nouveau** : `backend/tests/tts/test_voice_call_provider_pin.py` (8 tests)

## Tests
- **TTS : 26/26 verts**
- **Voice-call : 23/23 verts** (`-k "voice_call or quick_voice_call"`)
- **E2E `test_quick_voice_call_e2e` : OK**
- Diff : +350 / -3 (4 fichiers)

## Découverte architecturale
Quick Voice Call **ne transite PAS par `tts/providers.py`**. Elle utilise `voice/elevenlabs.py::ElevenLabsClient` directement (URL `api.elevenlabs.io/v1/convai/agents/create` hardcodée). Le pin était donc déjà structurel ; cette PR le rend explicite, observable (header), et testé.

## Routes pinées
- `POST /api/voice/session` (création agent ElevenLabs Conversational AI) — endpoint principal qui crée l'agent
- Autres endpoints `/api/voice/*` (companion, debate, transcripts) consomment l'agent existant — pas de pin nécessaire

## À noter (hors scope, à signaler)
1. **5 tests pré-existants cassés sur `origin/main`** (vérifié via `git stash`) :
   - `test_streaming_orchestrator*` (3) — ordre événements `ctx_failed` vs `ctx_complete`
   - `test_streaming_orchestrator_v2` (1)
   - `test_streaming_prompts_v2::test_streaming_prompt_size_under_5kb` (prompt FR FR a grossi 5 KB → 6.7 KB)
   À traiter séparément par l'équipe streaming voice.
2. **Modèle voice par défaut** = `eleven_turbo_v2_5` (~300ms), pas `eleven_flash_v2_5` (~150ms) comme la spec laissait entendre. Les deux sont ElevenLabs (donc dans whitelist) — à clarifier produit si la latence Flash est requise.

## Test plan
- [ ] Quick Voice Call démarre normalement (ElevenLabs)
- [ ] Tenter de forcer un autre provider via API → ignoré ou rejeté `ValueError`
- [ ] Header `X-TTS-Provider: elevenlabs` présent dans `/api/voice/session` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)