### PR TITLE
feat(moderation): Phase 2 Mistral-First — Mistral Moderation câblée (log_only)

### DIFF
--- a/backend/src/chat/router.py
+++ b/backend/src/chat/router.py
@@ -25,6 +25,7 @@ from db.database import get_session, User, Summary
 from auth.dependencies import get_current_user
 from videos.service import get_summary_by_id
 from core.config import PLAN_LIMITS
+from core.moderation_service import moderate_text, MODERATION_MODE
 
 from .service import (
     check_chat_quota,
@@ -154,6 +155,18 @@ async def ask_question_v4(
     - Expert: Analyse exhaustive multi-sources
     """
     print(f"💬 [CHAT v4.0] Question from user {current_user.id} (plan: {current_user.plan})", flush=True)
+
+    # 🛡️ Phase 2 — Mistral moderation (log_only par défaut, fail-open)
+    moderation = await moderate_text(request.question)
+    if not moderation.allowed:
+        # Mode enforce : le contenu a flagged au moins une catégorie
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "content_policy_violation",
+                "categories": moderation.flagged_categories,
+            },
+        )
 
     # Utiliser la nouvelle fonction v4 si disponible
     if V4_AVAILABLE:
@@ -332,6 +345,17 @@ async def ask_question_stream(
     Pose une question avec réponse en streaming (Server-Sent Events).
     Note: Le streaming n'inclut pas l'enrichissement Perplexity.
     """
+    # 🛡️ Phase 2 — Mistral moderation (log_only par défaut, fail-open)
+    moderation = await moderate_text(request.question)
+    if not moderation.allowed:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "content_policy_violation",
+                "categories": moderation.flagged_categories,
+            },
+        )
+
     # Vérifier le quota
     can_ask, reason, quota_info = await check_chat_quota(session, current_user.id, request.summary_id)
 

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -178,6 +178,13 @@ class _DeepSightSettings(BaseSettings):
     YTDLP_COOKIES_PATH: str = ""
     MAX_DURATION_FOR_STT: int = Field(default=1200)
 
+    # -- Moderation (Mistral content safety) --
+    # Mode log_only par défaut : la modération calcule les scores et les log,
+    # mais n'empêche pas la requête d'aboutir. Bascule en `enforce` après
+    # 7 jours de calibration (verif faux positifs sur français familier).
+    MODERATION_ENABLED: bool = True
+    MODERATION_MODE: str = "log_only"  # log_only | enforce
+
     @property
     def is_production(self) -> bool:
         return self.ENV == "production" or self.RAILWAY_ENVIRONMENT is not None
@@ -690,6 +697,12 @@ MISTRAL_AGENT_ENABLED = True  # Set False to force Brave-only pipeline
 
 # Modèle de modération contenu
 MISTRAL_MODERATION_MODEL = "mistral-moderation-latest"
+
+# Modération — Phase 2 migration Mistral-First
+# log_only : calcule + log les scores mais laisse passer (calibration)
+# enforce  : bloque les contenus flagged (raise HTTP 400)
+MODERATION_ENABLED: bool = _settings.MODERATION_ENABLED
+MODERATION_MODE: str = _settings.MODERATION_MODE
 
 
 def resolve_mistral_model(model_id: str) -> str:

--- a/backend/src/core/moderation_service.py
+++ b/backend/src/core/moderation_service.py
@@ -1,0 +1,230 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🛡️ MODERATION SERVICE — Phase 2 Mistral-First Migration                          ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Wrapper autour de l'API mistral-moderation-latest pour modérer le contenu        ║
+║  utilisateur (chat, analyse vidéo, débat) AVANT envoi aux LLMs principaux.        ║
+║                                                                                    ║
+║  Modes :                                                                           ║
+║  • log_only (défaut) : calcule les scores et les log, mais laisse passer.         ║
+║    Permet de calibrer les seuils sans bloquer les utilisateurs (faux positifs).   ║
+║  • enforce          : bloque les contenus flagged (raise HTTP côté router).       ║
+║                                                                                    ║
+║  Fail-open : si l'API Mistral plante (timeout, 5xx, etc.), on laisse passer       ║
+║  pour ne PAS bloquer le service. La modération est un filet de sécurité, pas      ║
+║  un point de défaillance critique.                                                 ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import httpx
+
+from core.config import (
+    MISTRAL_MODERATION_MODEL,
+    MODERATION_ENABLED,
+    MODERATION_MODE,
+    get_mistral_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ⚙️ CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+MISTRAL_MODERATION_URL = "https://api.mistral.ai/v1/moderations"
+MODERATION_TIMEOUT_SECONDS = 10.0
+
+# Seuils de blocage (mode enforce). Seuls les scores >= seuil flag la catégorie.
+# Calibrage : sexuel/violence montent vite sur du langage adulte/familier français,
+# donc on garde des seuils plus tolérants. Hate/dangerous/self_harm restent stricts.
+THRESHOLDS: Dict[str, float] = {
+    "hate": 0.5,
+    "sexual": 0.7,
+    "dangerous": 0.5,
+    "self_harm": 0.5,
+    "violence": 0.7,
+}
+
+# Mistral renvoie des catégories avec des noms longs ; on les normalise vers les
+# clés courtes utilisées dans THRESHOLDS pour l'application des seuils.
+_CATEGORY_ALIASES: Dict[str, str] = {
+    "hate_and_discrimination": "hate",
+    "hate": "hate",
+    "sexual": "sexual",
+    "dangerous_and_criminal_content": "dangerous",
+    "dangerous": "dangerous",
+    "selfharm": "self_harm",
+    "self_harm": "self_harm",
+    "violence_and_threats": "violence",
+    "violence": "violence",
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 DATACLASS — Résultat de modération
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class ModerationResult:
+    """Résultat d'une vérification de modération.
+
+    Attributes:
+        allowed: True si le contenu peut passer (en mode log_only, toujours True
+                 sauf si MODERATION_ENABLED est False et qu'on a un appel.
+                 En mode enforce, False si une catégorie dépasse son seuil).
+        flagged_categories: Liste des catégories au-dessus du seuil (toujours
+                            renseignée même en log_only, pour les logs).
+        raw_scores: Scores bruts renvoyés par l'API Mistral.
+    """
+
+    allowed: bool
+    flagged_categories: List[str] = field(default_factory=list)
+    raw_scores: Dict[str, float] = field(default_factory=dict)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 APPEL API MISTRAL
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _call_mistral(input_text: str) -> Dict[str, Any]:
+    """Appelle l'API Mistral Moderations.
+
+    Lève une exception si l'API plante / timeout — c'est l'appelant
+    (`moderate_text`) qui gère le fail-open.
+    """
+    api_key = get_mistral_key()
+    if not api_key:
+        raise RuntimeError("MISTRAL_API_KEY not configured")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": MISTRAL_MODERATION_MODEL,
+        "input": input_text,
+    }
+
+    async with httpx.AsyncClient(timeout=MODERATION_TIMEOUT_SECONDS) as client:
+        response = await client.post(
+            MISTRAL_MODERATION_URL,
+            headers=headers,
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔍 EXTRACTION DES SCORES + APPLICATION DES SEUILS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _extract_scores_and_flags(api_response: Dict[str, Any]) -> tuple[Dict[str, float], List[str]]:
+    """Extrait les scores bruts et applique les seuils pour calculer flagged_categories."""
+    results = api_response.get("results") or []
+    if not results:
+        return {}, []
+
+    first = results[0] if isinstance(results, list) else {}
+    raw_scores: Dict[str, float] = first.get("category_scores") or {}
+
+    flagged: List[str] = []
+    seen: set[str] = set()
+    for raw_cat, score in raw_scores.items():
+        try:
+            score_f = float(score)
+        except (TypeError, ValueError):
+            continue
+        canonical = _CATEGORY_ALIASES.get(raw_cat, raw_cat)
+        threshold = THRESHOLDS.get(canonical)
+        if threshold is None:
+            # Catégorie non couverte par nos seuils (ex: pii, financial, law,
+            # health) — on ne flag pas, on log juste.
+            continue
+        if score_f >= threshold and canonical not in seen:
+            flagged.append(canonical)
+            seen.add(canonical)
+
+    return raw_scores, flagged
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛡️ FONCTION PRINCIPALE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def moderate_text(text: str) -> ModerationResult:
+    """Modère un texte utilisateur via Mistral Moderations.
+
+    Comportement :
+    - Si `MODERATION_ENABLED=False` → retourne immédiatement allowed=True
+      sans appel HTTP.
+    - Si l'API Mistral plante → fail-open (allowed=True, log warning).
+    - En mode `log_only` → toujours allowed=True, mais `flagged_categories`
+      est rempli pour les logs.
+    - En mode `enforce` → allowed=False si au moins une catégorie est flagged.
+
+    Args:
+        text: Le contenu à modérer (question chat, prompt débat, etc.)
+
+    Returns:
+        ModerationResult avec allowed, flagged_categories, raw_scores.
+    """
+    # Garde-fou : modération désactivée
+    if not MODERATION_ENABLED:
+        return ModerationResult(allowed=True, flagged_categories=[], raw_scores={})
+
+    # Garde-fou : input vide
+    if not text or not text.strip():
+        return ModerationResult(allowed=True, flagged_categories=[], raw_scores={})
+
+    # Appel API Mistral avec fail-open
+    try:
+        api_response = await _call_mistral(text)
+    except Exception as exc:
+        logger.warning(
+            "[moderation] API call failed (fail-open): %s",
+            exc,
+            extra={"moderation_mode": MODERATION_MODE},
+        )
+        return ModerationResult(allowed=True, flagged_categories=[], raw_scores={})
+
+    # Extraction + application seuils
+    raw_scores, flagged = _extract_scores_and_flags(api_response)
+
+    # Décision selon le mode
+    is_log_only = MODERATION_MODE.lower() == "log_only"
+    allowed = True if is_log_only else (len(flagged) == 0)
+
+    # Logging structuré
+    if flagged:
+        prefix = "[moderation/log_only]" if is_log_only else "[moderation]"
+        logger.warning(
+            "%s flagged categories=%s scores=%s allowed=%s",
+            prefix,
+            flagged,
+            {k: round(v, 3) for k, v in raw_scores.items() if k in _CATEGORY_ALIASES},
+            allowed,
+        )
+    else:
+        logger.debug(
+            "[moderation] clean text scores=%s mode=%s",
+            {k: round(v, 3) for k, v in raw_scores.items()},
+            MODERATION_MODE,
+        )
+
+    return ModerationResult(
+        allowed=allowed,
+        flagged_categories=flagged,
+        raw_scores=dict(raw_scores),
+    )

--- a/backend/src/debate/router.py
+++ b/backend/src/debate/router.py
@@ -26,6 +26,7 @@ from core.http_client import shared_http_client
 from auth.dependencies import get_current_user, require_credits
 from core.config import PLAN_LIMITS
 from core.llm_provider import llm_complete
+from core.moderation_service import moderate_text
 from videos.web_search_provider import web_search_and_synthesize
 from core.credits import deduct_credits
 from db.database import (
@@ -1084,6 +1085,17 @@ async def debate_chat(
     Chat contextuel dans le cadre d'un débat.
     Le contexte inclut les thèses, arguments et fact-check des 2 vidéos.
     """
+    # 🛡️ Phase 2 — Mistral moderation sur le message utilisateur
+    moderation = await moderate_text(request.message)
+    if not moderation.allowed:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "content_policy_violation",
+                "categories": moderation.flagged_categories,
+            },
+        )
+
     debate = await _get_debate_owned(db, request.debate_id, current_user.id)
 
     if debate.status != "completed":

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -33,6 +33,7 @@ from auth.dependencies import (
 from core.config import PLAN_LIMITS, CATEGORIES, get_mistral_key
 from core.http_client import shared_http_client
 from core.logging import logger
+from core.moderation_service import moderate_text
 
 # Import du système de sécurité
 try:
@@ -1093,6 +1094,18 @@ async def analyze_video_v2(
     """
     logger.info(f"📥 [v2.0] Analyze request: {request.url} by user {current_user.id}")
 
+    # 🛡️ Phase 2 — Mistral moderation sur le user_prompt (si présent)
+    if getattr(request, "user_prompt", None):
+        moderation = await moderate_text(request.user_prompt)
+        if not moderation.allowed:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "content_policy_violation",
+                    "categories": moderation.flagged_categories,
+                },
+            )
+
     # 🎵 Détecter la plateforme
     platform = detect_platform(request.url)
 
@@ -1781,6 +1794,18 @@ async def analyze_video_v2_1(
             status_code=501,
             detail={"code": "feature_unavailable", "message": "Advanced analysis features are not available"},
         )
+
+    # 🛡️ Phase 2 — Mistral moderation sur le user_prompt (si présent)
+    if getattr(request, "user_prompt", None):
+        moderation = await moderate_text(request.user_prompt)
+        if not moderation.allowed:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "content_policy_violation",
+                    "categories": moderation.flagged_categories,
+                },
+            )
 
     # 🎵 Détecter la plateforme (YouTube ou TikTok)
     platform = detect_platform(request.url)
@@ -4765,6 +4790,23 @@ async def analyze_images(
         raise HTTPException(status_code=400, detail="Maximum 10 images par analyse")
     if len(request.images) < 1:
         raise HTTPException(status_code=400, detail="Au moins 1 image requise")
+
+    # 🛡️ Phase 2 — Mistral moderation sur title + context utilisateur (si présents)
+    user_text_parts = []
+    if request.title:
+        user_text_parts.append(request.title)
+    if request.context:
+        user_text_parts.append(request.context)
+    if user_text_parts:
+        moderation = await moderate_text(" ".join(user_text_parts))
+        if not moderation.allowed:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "content_policy_violation",
+                    "categories": moderation.flagged_categories,
+                },
+            )
 
     # Valider les tailles (base64 → ~1.37x taille originale, donc 14MB en b64 ≈ 10MB réel)
     MAX_B64_SIZE = 14_000_000

--- a/backend/tests/test_chat_moderation_integration.py
+++ b/backend/tests/test_chat_moderation_integration.py
@@ -1,0 +1,123 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🛡️ TEST CHAT MODERATION INTEGRATION — Phase 2 Mistral-First                      ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Vérifie que le hook moderation est bien câblé dans /api/chat/ask :                ║
+║  • mode log_only : la requête passe (200) malgré flagged                          ║
+║  • mode enforce  : la requête retourne 400 avec content_policy_violation          ║
+║  • appel moderate_text bien effectué avec le bon texte                            ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import os
+import sys
+import importlib
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+@pytest.mark.asyncio
+async def test_chat_ask_calls_moderation_hook():
+    """Vérifie que moderate_text est appelé avec request.question avant le routing v4."""
+    chat_router_mod = importlib.import_module('chat.router')
+
+    # Construire un user mock minimal
+    user = MagicMock()
+    user.id = 1
+    user.plan = "pro"
+    user.email_verified = True
+
+    # Construire un session mock
+    session = AsyncMock()
+
+    # Construire la request
+    request = chat_router_mod.ChatRequest(
+        question="Bonjour, peux-tu m'expliquer cette vidéo ?",
+        summary_id=42,
+        mode="standard",
+        use_web_search=False,
+    )
+
+    # Mock moderate_text → allowed=True
+    fake_result = MagicMock()
+    fake_result.allowed = True
+    fake_result.flagged_categories = []
+    fake_moderate = AsyncMock(return_value=fake_result)
+
+    # Mock process_chat_message_v4 pour court-circuiter le pipeline complet
+    fake_process = AsyncMock(return_value={
+        "response": "Test response",
+        "web_search_used": False,
+        "sources": [],
+        "enrichment_level": "none",
+        "quota_info": {},
+    })
+
+    with patch.object(chat_router_mod, 'moderate_text', fake_moderate):
+        with patch.object(chat_router_mod, 'V4_AVAILABLE', True):
+            with patch.object(chat_router_mod, 'process_chat_message_v4', fake_process):
+                response = await chat_router_mod.ask_question_v4(
+                    request=request,
+                    current_user=user,
+                    session=session,
+                )
+
+    # moderate_text doit avoir été appelé avec le texte de la question
+    fake_moderate.assert_awaited_once()
+    call_args = fake_moderate.await_args
+    assert call_args.args[0] == "Bonjour, peux-tu m'expliquer cette vidéo ?"
+
+    # Pipeline normal doit avoir tourné
+    fake_process.assert_awaited_once()
+    assert response.response == "Test response"
+
+
+@pytest.mark.asyncio
+async def test_chat_ask_blocks_when_moderation_denies():
+    """Si moderate_text renvoie allowed=False, l'endpoint raise HTTP 400."""
+    from fastapi import HTTPException
+    chat_router_mod = importlib.import_module('chat.router')
+
+    user = MagicMock()
+    user.id = 1
+    user.plan = "pro"
+
+    session = AsyncMock()
+
+    request = chat_router_mod.ChatRequest(
+        question="[contenu interdit mocké]",
+        summary_id=42,
+        mode="standard",
+        use_web_search=False,
+    )
+
+    # Mock moderate_text → allowed=False
+    fake_result = MagicMock()
+    fake_result.allowed = False
+    fake_result.flagged_categories = ["hate"]
+    fake_moderate = AsyncMock(return_value=fake_result)
+
+    fake_process = AsyncMock()  # ne doit JAMAIS être appelé
+
+    with patch.object(chat_router_mod, 'moderate_text', fake_moderate):
+        with patch.object(chat_router_mod, 'V4_AVAILABLE', True):
+            with patch.object(chat_router_mod, 'process_chat_message_v4', fake_process):
+                with pytest.raises(HTTPException) as exc_info:
+                    await chat_router_mod.ask_question_v4(
+                        request=request,
+                        current_user=user,
+                        session=session,
+                    )
+
+    assert exc_info.value.status_code == 400
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail["error"] == "content_policy_violation"
+    assert detail["categories"] == ["hate"]
+    fake_process.assert_not_awaited()

--- a/backend/tests/test_moderation_service.py
+++ b/backend/tests/test_moderation_service.py
@@ -1,0 +1,197 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🛡️ TEST MODERATION SERVICE — Phase 2 Mistral-First Migration                     ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Tests TDD du service de modération basé sur mistral-moderation-latest.            ║
+║                                                                                    ║
+║  Couverture:                                                                       ║
+║  • Texte safe (tous scores 0)         → allowed=True                              ║
+║  • Texte unsafe en mode enforce       → allowed=False + flagged_categories        ║
+║  • Texte unsafe en mode log_only      → allowed=True + flagged_categories logged  ║
+║  • Modération désactivée              → pas d'appel HTTP                          ║
+║  • Erreur API Mistral                 → fail open (allowed=True)                  ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import os
+import sys
+import importlib
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Configuration env minimale pour pouvoir importer config + service
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 HELPERS — Réponses Mistral mockées
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Réponse Mistral pour un texte safe (tous scores ~0)
+SAFE_MISTRAL_RESPONSE = {
+    "id": "mod-test-safe",
+    "model": "mistral-moderation-latest",
+    "results": [
+        {
+            "categories": {
+                "sexual": False,
+                "hate_and_discrimination": False,
+                "violence_and_threats": False,
+                "dangerous_and_criminal_content": False,
+                "selfharm": False,
+                "health": False,
+                "financial": False,
+                "law": False,
+                "pii": False,
+            },
+            "category_scores": {
+                "sexual": 0.001,
+                "hate_and_discrimination": 0.002,
+                "violence_and_threats": 0.001,
+                "dangerous_and_criminal_content": 0.001,
+                "selfharm": 0.001,
+                "health": 0.001,
+                "financial": 0.001,
+                "law": 0.001,
+                "pii": 0.001,
+            },
+        }
+    ],
+}
+
+# Réponse Mistral pour un texte unsafe (hate=0.95)
+UNSAFE_HATE_MISTRAL_RESPONSE = {
+    "id": "mod-test-unsafe",
+    "model": "mistral-moderation-latest",
+    "results": [
+        {
+            "categories": {
+                "sexual": False,
+                "hate_and_discrimination": True,
+                "violence_and_threats": False,
+                "dangerous_and_criminal_content": False,
+                "selfharm": False,
+                "health": False,
+                "financial": False,
+                "law": False,
+                "pii": False,
+            },
+            "category_scores": {
+                "sexual": 0.01,
+                "hate_and_discrimination": 0.95,
+                "violence_and_threats": 0.05,
+                "dangerous_and_criminal_content": 0.02,
+                "selfharm": 0.01,
+                "health": 0.01,
+                "financial": 0.01,
+                "law": 0.01,
+                "pii": 0.01,
+            },
+        }
+    ],
+}
+
+
+def _fresh_module():
+    """Recharge le module pour appliquer les patches de config."""
+    if 'core.moderation_service' in sys.modules:
+        importlib.reload(sys.modules['core.moderation_service'])
+    return importlib.import_module('core.moderation_service')
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✅ TEST 1 — Texte safe passe toujours
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_moderate_text_safe_passes():
+    """Mistral renvoie tous scores ~0 → result.allowed is True."""
+    mod = _fresh_module()
+
+    with patch.object(mod, '_call_mistral', AsyncMock(return_value=SAFE_MISTRAL_RESPONSE)):
+        with patch.object(mod, 'MODERATION_ENABLED', True):
+            with patch.object(mod, 'MODERATION_MODE', 'enforce'):
+                result = await mod.moderate_text("Bonjour, peux-tu m'expliquer cette vidéo ?")
+
+    assert result.allowed is True
+    assert result.flagged_categories == []
+    assert isinstance(result.raw_scores, dict)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✅ TEST 2 — Texte unsafe BLOQUÉ en mode enforce
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_moderate_text_unsafe_blocks_in_enforce_mode():
+    """Mistral renvoie hate=0.95 → en mode enforce, allowed=False."""
+    mod = _fresh_module()
+
+    with patch.object(mod, '_call_mistral', AsyncMock(return_value=UNSAFE_HATE_MISTRAL_RESPONSE)):
+        with patch.object(mod, 'MODERATION_ENABLED', True):
+            with patch.object(mod, 'MODERATION_MODE', 'enforce'):
+                result = await mod.moderate_text("[texte haineux mocké]")
+
+    assert result.allowed is False
+    assert "hate" in result.flagged_categories or "hate_and_discrimination" in result.flagged_categories
+    assert len(result.flagged_categories) >= 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✅ TEST 3 — Mode log_only laisse passer même si flagged
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_moderate_text_unsafe_passes_in_log_only_mode():
+    """Même input flagged, mode log_only → allowed=True mais flagged_categories rempli."""
+    mod = _fresh_module()
+
+    with patch.object(mod, '_call_mistral', AsyncMock(return_value=UNSAFE_HATE_MISTRAL_RESPONSE)):
+        with patch.object(mod, 'MODERATION_ENABLED', True):
+            with patch.object(mod, 'MODERATION_MODE', 'log_only'):
+                result = await mod.moderate_text("[texte haineux mocké]")
+
+    assert result.allowed is True  # log_only laisse passer
+    assert len(result.flagged_categories) >= 1  # mais on log les catégories
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✅ TEST 4 — Modération désactivée → pas d'appel HTTP
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_moderation_disabled_skips_call():
+    """MODERATION_ENABLED=False → pas d'appel HTTP, allowed=True direct."""
+    mod = _fresh_module()
+
+    fake_call = AsyncMock(return_value=UNSAFE_HATE_MISTRAL_RESPONSE)
+    with patch.object(mod, '_call_mistral', fake_call):
+        with patch.object(mod, 'MODERATION_ENABLED', False):
+            with patch.object(mod, 'MODERATION_MODE', 'enforce'):
+                result = await mod.moderate_text("Anything goes")
+
+    assert result.allowed is True
+    assert result.flagged_categories == []
+    fake_call.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✅ TEST 5 — Fail open : si l'API plante, on laisse passer
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_moderation_fail_open_on_api_error():
+    """Mistral throw → allowed=True (fail open) pour ne pas bloquer le service."""
+    mod = _fresh_module()
+
+    with patch.object(mod, '_call_mistral', AsyncMock(side_effect=Exception("API timeout"))):
+        with patch.object(mod, 'MODERATION_ENABLED', True):
+            with patch.object(mod, 'MODERATION_MODE', 'enforce'):
+                result = await mod.moderate_text("Question normale")
+
+    assert result.allowed is True  # fail open : un Mistral down ne bloque pas
+    assert result.flagged_categories == []


### PR DESCRIPTION
## Phase 2 — Mistral Moderation câblée

`mistral-moderation-latest` (déjà configuré dans `core/config.py:692`, jamais appelé) devient un middleware sur les endpoints utilisateur. **Mode `log_only` par défaut** pendant 7 jours pour calibrer les seuils avant blocage utilisateur.

Suite Wave 2 de la migration Mistral-First (spec : `Vault/01-Projects/DeepSight/Specs/2026-05-02-mistral-first-migration-design.md`).

## Changes
- **Nouveau** : `core/moderation_service.py` (230 lignes)
  - Dataclass `ModerationResult(allowed, flagged_categories, raw_scores)`
  - `THRESHOLDS = {hate: 0.5, sexual: 0.7, dangerous: 0.5, self_harm: 0.5, violence: 0.7}`
  - `_CATEGORY_ALIASES` pour normaliser les noms longs Mistral (`hate_and_discrimination` → `hate`, etc.)
  - Endpoint `https://api.mistral.ai/v1/moderations`, timeout 10s, httpx.AsyncClient
- **Config** dans `core/config.py` :
  - `MODERATION_ENABLED: bool = True`
  - `MODERATION_MODE: str = "log_only"`
- **Hooks sur 6 endpoints** :
  - `POST /api/chat/ask` (modère `request.question`) — `chat/router.py:156`
  - `POST /api/chat/ask/stream` (modère `request.question`) — `chat/router.py:348`
  - `POST /api/videos/analyze/v2` (modère `request.user_prompt` si présent) — `videos/router.py:1097`
  - `POST /api/videos/analyze/v2.1` (modère `request.user_prompt`) — `videos/router.py:1789`
  - `POST /api/videos/analyze/images` (modère `request.title` + `request.context`) — `videos/router.py:4798`
  - `POST /api/debate/chat` (modère `request.message`) — `debate/router.py:1090`

## Tests
- **64/64 PASSED**
  - 5/5 `test_moderation_service.py` (safe pass, unsafe block enforce, unsafe pass log_only, disabled, fail-open)
  - 2/2 `test_chat_moderation_integration.py`
  - 57/57 tests existants chat + video + debate (aucune régression)
- Diff : +641 / -0 (7 fichiers, 3 nouveaux)

## Fail-open
Si l'API Mistral plante (timeout, 5xx, 401) → `moderate_text()` retourne `allowed=True`. **L'utilisateur n'est jamais bloqué par un incident upstream.** Le test `test_ask_quota_exceeded` passe par la vraie API Mistral avec clé invalide → 401 → fail-open déclenché → chat fonctionne quand même.

## À noter
- **Titres vidéo** (provenant de YouTube, créateurs tiers) **ne sont pas modérés** — sémantique : "modérer ce que l'utilisateur écrit"
- **Categories non couvertes** (`pii`, `financial`, `law`, `health`) sont loggées dans `raw_scores` mais ne flag jamais (out-of-scope Phase 2)
- `/quick-chat`, `/analyze` (v1), `/debate/create` ne contiennent pas de free-text utilisateur — pas de hook nécessaire

## Stratégie de déploiement
1. Merger en mode `log_only` (défaut)
2. Observer les logs `[moderation/log_only]` pendant 7 jours
3. Calibrer les seuils par catégorie si trop de faux positifs (notamment français familier)
4. Switcher `MODERATION_MODE=enforce` quand satisfaisant

## Test plan
- [ ] Chat normal → pass (catégories toutes basses)
- [ ] Chat contenu offensant en log_only → laisse passer mais log warning visible
- [ ] Chat contenu offensant après `MODERATION_MODE=enforce` → 400 `content_policy_violation`
- [ ] Mistral API down → fail-open (chat fonctionne quand même)
- [ ] Métriques PostHog `moderation_flagged` à ajouter (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)