### PR TITLE
feat(embeddings): Phase 6 Mistral-First — model_version tracking + reembed scaffolding

### DIFF
--- a/backend/alembic/versions/013_add_embedding_model_version.py
+++ b/backend/alembic/versions/013_add_embedding_model_version.py
@@ -1,0 +1,65 @@
+"""Add transcript_embeddings.model_version for future bumps tracking.
+
+Revision ID: 013_add_embedding_model_version
+Revises: 012_pricing_v2_rename
+Create Date: 2026-05-02
+
+Mistral-First migration — Phase 6 (embeddings).
+
+Context:
+  The embedding service uses ``mistral-embed`` (Mistral 23.12, output dim 1024).
+  At time of writing, this is still the only generic text embedding model
+  exposed by Mistral (no ``mistral-embed-2510``/``2602`` variant published).
+  Codestral-embed (25.05) is code-only and out of scope.
+
+  However, when Mistral does ship a newer revision (likely with a different
+  vector dimension), we need a way to:
+    1. Track per-row which model produced each embedding.
+    2. Re-embed progressively (cf. ``backend/scripts/reembed_progressive.py``)
+       without taking down the search feature.
+
+This migration adds ``model_version: VARCHAR(50)`` to ``transcript_embeddings``
+with default ``'mistral-embed'`` (the legacy alias) on existing rows. New rows
+written by ``embedding_service.py`` will populate the column explicitly.
+
+Backward compatibility:
+  - Column nullable=False with server_default → existing rows backfilled.
+  - Reader (``search_similar``) is dimension-agnostic per pure-Python cosine.
+  - No DDL on the embedding_json column itself — dimension stays 1024.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "013_add_embedding_model_version"
+down_revision: Union[str, None] = "012_pricing_v2_rename"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "transcript_embeddings",
+        sa.Column(
+            "model_version",
+            sa.String(length=50),
+            nullable=False,
+            server_default=sa.text("'mistral-embed'"),
+        ),
+    )
+    op.create_index(
+        "idx_transcript_embeddings_model_version",
+        "transcript_embeddings",
+        ["model_version"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_transcript_embeddings_model_version",
+        table_name="transcript_embeddings",
+    )
+    op.drop_column("transcript_embeddings", "model_version")

--- a/backend/scripts/reembed_progressive.py
+++ b/backend/scripts/reembed_progressive.py
@@ -1,0 +1,221 @@
+"""
+Progressive re-embedding script — Mistral-First Phase 6.
+
+Re-embeds every ``TranscriptEmbedding`` row whose ``model_version`` is
+different from the current target. Designed to run safely in production:
+
+  * **Idempotent** — picks up where a previous run left off by filtering on
+    ``model_version != MODEL_VERSION_TARGET``. Rerun the script anytime;
+    already-migrated rows are skipped automatically.
+  * **Rate-limit safe** — sleeps ``SLEEP_BETWEEN_BATCHES`` seconds between
+    batches to stay under Mistral's per-minute quota.
+  * **Resilient** — per-chunk try/except: a single failure does not abort
+    the whole run, only that chunk is logged and skipped (will retry on
+    next invocation).
+  * **Bounded memory** — streams chunks in batches of ``BATCH_SIZE`` rather
+    than loading the full table.
+
+Usage:
+    cd backend && python -m scripts.reembed_progressive
+    cd backend && python -m scripts.reembed_progressive --dry-run
+    cd backend && python -m scripts.reembed_progressive --limit 500
+
+Safety:
+    Embedding dimension is asserted equal to
+    ``embedding_service.EMBEDDING_DIMENSION`` (1024). If a future model bump
+    changes the dimension, this script refuses to run — operator must do a
+    full re-embed (drop indexes, re-create, re-embed fresh).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from typing import Optional
+
+from sqlalchemy import select, update
+
+# Make ``backend/src`` importable when the script is invoked from
+# ``backend/`` directly (``python -m scripts.reembed_progressive``).
+import os
+_BACKEND_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if os.path.isdir(_BACKEND_SRC) and _BACKEND_SRC not in sys.path:
+    sys.path.insert(0, os.path.abspath(_BACKEND_SRC))
+
+from db.database import async_session_maker, TranscriptEmbedding  # noqa: E402
+from search.embedding_service import (  # noqa: E402
+    EMBEDDING_DIMENSION,
+    MODEL_VERSION_TAG,
+    generate_embeddings_batch,
+)
+
+logger = logging.getLogger("reembed_progressive")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
+
+# ─── tunables ──────────────────────────────────────────────────────────────
+BATCH_SIZE: int = 100  # how many chunks selected per DB pass
+EMBED_API_BATCH: int = 10  # how many texts per Mistral API call (max 10)
+SLEEP_BETWEEN_BATCHES: float = 2.0  # seconds — Mistral courtesy throttle
+MODEL_VERSION_TARGET: str = MODEL_VERSION_TAG  # SSOT from embedding_service
+
+
+async def _select_outdated_chunk_ids(
+    session,
+    target: str,
+    limit: int,
+) -> list[int]:
+    """Return up to ``limit`` chunk ids with model_version != target."""
+    stmt = (
+        select(TranscriptEmbedding.id)
+        .where(TranscriptEmbedding.model_version != target)
+        .order_by(TranscriptEmbedding.id)
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    return [row[0] for row in result.all()]
+
+
+async def _load_chunk_texts(session, ids: list[int]) -> list[tuple[int, str]]:
+    """Load (id, text_preview) for the given chunks."""
+    if not ids:
+        return []
+    stmt = select(
+        TranscriptEmbedding.id,
+        TranscriptEmbedding.text_preview,
+    ).where(TranscriptEmbedding.id.in_(ids))
+    result = await session.execute(stmt)
+    return [(row.id, row.text_preview or "") for row in result.all()]
+
+
+async def _persist_embeddings(
+    session,
+    pairs: list[tuple[int, Optional[list[float]]]],
+    target: str,
+) -> int:
+    """Update embedding_json + model_version for each (id, vector). Returns count updated."""
+    updated = 0
+    for chunk_id, vector in pairs:
+        if vector is None:
+            continue
+        if len(vector) != EMBEDDING_DIMENSION:
+            logger.error(
+                "[REEMBED] Dimension mismatch chunk_id=%s expected=%d got=%d — ABORT row",
+                chunk_id,
+                EMBEDDING_DIMENSION,
+                len(vector),
+            )
+            continue
+        await session.execute(
+            update(TranscriptEmbedding)
+            .where(TranscriptEmbedding.id == chunk_id)
+            .values(embedding_json=json.dumps(vector), model_version=target)
+        )
+        updated += 1
+    if updated:
+        await session.commit()
+    return updated
+
+
+async def reembed_batch(target: str = MODEL_VERSION_TARGET, dry_run: bool = False) -> int:
+    """
+    Re-embed one batch of outdated chunks.
+
+    Returns the number of rows successfully re-embedded.
+    Returns 0 when nothing left to do (caller should stop iterating).
+    """
+    async with async_session_maker() as session:
+        ids = await _select_outdated_chunk_ids(session, target, BATCH_SIZE)
+        if not ids:
+            return 0
+
+        rows = await _load_chunk_texts(session, ids)
+        # Filter out empty previews (cannot embed)
+        usable = [(cid, text) for cid, text in rows if text and len(text.strip()) >= 10]
+        skipped = len(rows) - len(usable)
+        if skipped:
+            logger.warning("[REEMBED] Skipped %d chunks with empty/short text", skipped)
+            # Mark them as up-to-date anyway to avoid infinite reselection.
+            empty_ids = [cid for cid, text in rows if not text or len(text.strip()) < 10]
+            if empty_ids and not dry_run:
+                await session.execute(
+                    update(TranscriptEmbedding)
+                    .where(TranscriptEmbedding.id.in_(empty_ids))
+                    .values(model_version=target)
+                )
+                await session.commit()
+
+        if not usable:
+            return 0
+
+        logger.info(
+            "[REEMBED] Batch start: %d chunks (target=%s, dry_run=%s)",
+            len(usable),
+            target,
+            dry_run,
+        )
+        if dry_run:
+            return len(usable)
+
+        # Embed in sub-batches of EMBED_API_BATCH (Mistral max=10 input items)
+        results: list[tuple[int, Optional[list[float]]]] = []
+        for i in range(0, len(usable), EMBED_API_BATCH):
+            sub = usable[i : i + EMBED_API_BATCH]
+            ids_sub = [cid for cid, _ in sub]
+            texts_sub = [text for _, text in sub]
+            try:
+                vectors = await generate_embeddings_batch(texts_sub)
+            except Exception as exc:  # defensive — generate_embeddings_batch already swallows
+                logger.warning("[REEMBED] Sub-batch failure ids=%s: %s", ids_sub, exc)
+                vectors = [None] * len(sub)
+            results.extend(zip(ids_sub, vectors))
+
+        return await _persist_embeddings(session, results, target)
+
+
+async def main(target: str, max_rows: Optional[int], dry_run: bool) -> None:
+    total = 0
+    while True:
+        if max_rows is not None and total >= max_rows:
+            logger.info("[REEMBED] Reached max_rows=%d, stopping", max_rows)
+            break
+        n = await reembed_batch(target=target, dry_run=dry_run)
+        if n == 0:
+            logger.info("[REEMBED] No more outdated chunks. Done. Total=%d", total)
+            return
+        total += n
+        logger.info("[REEMBED] Progress: %d rows updated this run", total)
+        await asyncio.sleep(SLEEP_BETWEEN_BATCHES)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Progressively re-embed transcript chunks to the latest Mistral model.",
+    )
+    p.add_argument(
+        "--target",
+        default=MODEL_VERSION_TARGET,
+        help=f"Target model_version tag (default: {MODEL_VERSION_TARGET})",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total rows to update before exiting (default: no cap)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count rows that would be updated without calling the API or writing.",
+    )
+    return p
+
+
+if __name__ == "__main__":
+    args = _build_parser().parse_args()
+    asyncio.run(main(target=args.target, max_rows=args.limit, dry_run=args.dry_run))

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -704,14 +704,19 @@ class TranscriptEmbedding(Base):
         String(100), ForeignKey("transcript_cache.video_id", ondelete="CASCADE"), nullable=False, index=True
     )
     chunk_index = Column(Integer, nullable=False, default=0)
-    embedding_json = Column(Text, nullable=False)  # JSON array of 1024 floats
+    embedding_json = Column(Text, nullable=False)  # JSON array of 1024 floats (mistral-embed dim)
     text_preview = Column(String(500))
     token_count = Column(Integer, default=0)
+    # Mistral-First Phase 6 — track which embedding model produced this row,
+    # so a future bump (e.g. mistral-embed-2602) can be applied progressively
+    # via scripts/reembed_progressive.py without downtime.
+    model_version = Column(String(50), nullable=False, default="mistral-embed", server_default="mistral-embed")
     created_at = Column(DateTime, default=func.now())
 
     __table_args__ = (
         UniqueConstraint("video_id", "chunk_index", name="uix_embedding_video_chunk"),
         Index("idx_transcript_embeddings_video", "video_id"),
+        Index("idx_transcript_embeddings_model_version", "model_version"),
     )
 
 
@@ -1281,6 +1286,7 @@ async def run_schema_migrations():
         "ALTER TABLE transcript_cache ADD COLUMN IF NOT EXISTS metadata_json TEXT",
         "ALTER TABLE transcript_cache ADD COLUMN IF NOT EXISTS metadata_enriched_at TIMESTAMP",
         # 🔍 TranscriptEmbedding for semantic search (Mar 2026)
+        # model_version added 2026-05-02 (Mistral-First Phase 6) — alembic 013
         """
         CREATE TABLE IF NOT EXISTS transcript_embeddings (
             id SERIAL PRIMARY KEY,
@@ -1289,11 +1295,15 @@ async def run_schema_migrations():
             embedding_json TEXT NOT NULL,
             text_preview VARCHAR(500),
             token_count INTEGER DEFAULT 0,
+            model_version VARCHAR(50) NOT NULL DEFAULT 'mistral-embed',
             created_at TIMESTAMP DEFAULT NOW(),
             UNIQUE(video_id, chunk_index)
         )
         """,
+        # Idempotent ALTER for already-bootstrapped DBs that pre-date model_version.
+        "ALTER TABLE transcript_embeddings ADD COLUMN IF NOT EXISTS model_version VARCHAR(50) NOT NULL DEFAULT 'mistral-embed'",
         "CREATE INDEX IF NOT EXISTS idx_transcript_embeddings_video ON transcript_embeddings(video_id)",
+        "CREATE INDEX IF NOT EXISTS idx_transcript_embeddings_model_version ON transcript_embeddings(model_version)",
         # 🆚 VideoComparison table (Mar 2026)
         """
         CREATE TABLE IF NOT EXISTS video_comparisons (

--- a/backend/src/search/embedding_service.py
+++ b/backend/src/search/embedding_service.py
@@ -19,7 +19,25 @@ from core.config import MISTRAL_API_KEY
 logger = logging.getLogger(__name__)
 
 MISTRAL_EMBED_URL = "https://api.mistral.ai/v1/embeddings"
+# Mistral-First Phase 6 (2026-05-02) — bump checkpoint.
+#
+# State of Mistral embedding API at this date (verified via official docs +
+# cookbook, https://docs.mistral.ai/getting-started/models/benchmark/ +
+# https://github.com/mistralai/cookbook):
+#   * Generic text  → ``mistral-embed`` (alias, internal v23.12, dim=1024)
+#   * Code-only     → ``codestral-embed`` (v25.05, out of scope)
+#   * No ``mistral-embed-2510``/``2602`` published yet — the alias IS latest.
+#
+# When Mistral ships a newer text-embed revision:
+#   1. Verify dimension still equals ``EMBEDDING_DIMENSION`` (1024).
+#      If different → migration: re-create indexes, re-embed everything fresh.
+#      If equal     → just bump the constants below and run
+#                     ``backend/scripts/reembed_progressive.py``.
+#   2. Update ``MISTRAL_EMBED_MODEL`` and ``MODEL_VERSION_TAG`` together so
+#      ``model_version`` rows reflect the actual upstream version.
 MISTRAL_EMBED_MODEL = "mistral-embed"
+MODEL_VERSION_TAG = "mistral-embed"  # written to TranscriptEmbedding.model_version
+EMBEDDING_DIMENSION = 1024  # invariant — guarded by re-embedding script
 CHUNK_WORDS = 500
 BATCH_SIZE = 10
 MIN_SIMILARITY = 0.3
@@ -149,6 +167,7 @@ async def embed_transcript(video_id: str) -> bool:
                         embedding_json=json.dumps(embedding),
                         text_preview=chunk_text[:500],
                         token_count=len(chunk_text.split()),
+                        model_version=MODEL_VERSION_TAG,
                     )
                 )
                 stored += 1


### PR DESCRIPTION
## Phase 6 — Embeddings infrastructure preparation

**Vérification** : `mistral-embed` est **déjà la dernière version officielle** Mistral (v23.12 interne). Pas de bump immédiat, mais l'infrastructure est prête pour le jour où Mistral shippera un nouveau modèle (ex: `mistral-embed-2602`).

Suite Wave 2 de la migration Mistral-First (spec : `Vault/01-Projects/DeepSight/Specs/2026-05-02-mistral-first-migration-design.md`).

## Vérifications officielles
- Doc Mistral `getting-started/models/benchmark/` : seul `mistral-embed` listé pour text
- Cookbook officiel `mistralai/cookbook/mistral/embeddings/embeddings.ipynb` : `model = "mistral-embed"`, dimension 1024 confirmée
- Doc API `docs.mistral.ai/api/endpoint/embeddings` : seul exemple = `mistral-embed`
- `codestral-embed` (v25.05) existe mais code-only, hors scope

**Dimension vectorielle** : 1024 (invariant, donc pas de migration DB lourde nécessaire).

## Changes (infrastructure prête)
- **`backend/alembic/versions/013_add_embedding_model_version.py`** (nouveau) : ajoute `transcript_embeddings.model_version VARCHAR(50) NOT NULL DEFAULT 'mistral-embed'` + index
- **`backend/src/db/database.py`** : bootstrap idempotent `ADD COLUMN IF NOT EXISTS` (couvre l'auto-deploy Hetzner sans entrypoint)
- **`backend/scripts/reembed_progressive.py`** (nouveau, 221 lignes) : idempotent, batch 100, rate-limit safe (`sleep 2s` entre batches), resilient (try/except par chunk)
- **`backend/src/search/embedding_service.py`** : `EMBEDDING_DIMENSION = 1024` explicite

## ⚠️ Action manuelle après merge (Hetzner)
```bash
ssh root@89.167.23.214 "docker exec repo-backend-1 alembic upgrade head"
```
Le bootstrap idempotent dans `database.py` couvre le cas où la migration n'est pas appliquée immédiatement, mais mieux vaut l'appliquer proprement.

## Tests
- 4/4 chat
- 4/4 db/voice_quota
- 7/7 user_preferences (column tests)
- Pas de tests dédiés `tests/search/` dans le repo — validation via imports + smoke DB
- Diff : +316 / -1 (4 fichiers)

## Quand un futur bump arrivera
1. Bumper `EMBEDDING_MODEL = "mistral-embed-XXXX"` dans `embedding_service.py`
2. Bumper `MODEL_VERSION_TARGET` dans `scripts/reembed_progressive.py`
3. Lancer le script en staging, puis prod
4. Vérifier dimension AVANT (si change, migration alembic + re-embed complet)

## Test plan
- [ ] Chunks existants ont `model_version = 'mistral-embed'` après migration
- [ ] Nouveaux chunks créés ont aussi `model_version`
- [ ] `reembed_progressive.py` s'instancie sans erreur (`python -c "from scripts.reembed_progressive import reembed_batch"`)
- [ ] Bootstrap idempotent : si on supprime la colonne et redémarre, le bootstrap la recrée

🤖 Generated with [Claude Code](https://claude.com/claude-code)