### PR TITLE
feat(analysis): Phase 4 Mistral-First — Magistral pour épistémique Expert (flag OFF)

### DIFF
--- a/backend/docs/architecture/epistemic-markers.md
+++ b/backend/docs/architecture/epistemic-markers.md
@@ -1,0 +1,135 @@
+# Marqueurs épistémiques (SOLID / PLAUSIBLE / UNCERTAIN / À VÉRIFIER)
+
+_Phase 4 de la migration "Mistral-First" — 2026-05-02_
+
+## Contexte
+
+DeepSight produit des analyses sourcées et nuancées. Pour le tier **Expert** (plan
+Expert v2 19.99 €/mois), le résumé final intègre des marqueurs épistémiques
+explicites qui qualifient chaque affirmation :
+
+- `[SOLID]` : affirmation directement supportée par la transcription, sans extrapolation
+- `[PLAUSIBLE]` : extrapolation raisonnable mais non strictement prouvée
+- `[UNCERTAIN]` : interprétation possible mais ambiguë / contestée
+- `[À VÉRIFIER]` : claim qui mériterait une vérification externe
+
+Le but : améliorer la **transparence épistémique** du résumé. Magistral, modèle de
+raisonnement chain-of-thought de Mistral, justifie nativement ses étapes de
+raisonnement et améliore donc la cohérence des marqueurs apposés.
+
+## Modèle utilisé selon le plan
+
+| Plan code-side | Plan v2 affiché    | Tier de durée | Modèle synthèse (flag OFF) | Modèle synthèse (flag ON)            |
+| -------------- | ------------------ | ------------- | -------------------------- | ------------------------------------ |
+| `free`         | Free (0 €)         | tous          | `mistral-small-2603`       | `mistral-small-2603` (inchangé)      |
+| `plus`         | Pro (8.99 €)       | tous          | `mistral-medium-2508`      | `mistral-medium-2508` (inchangé)     |
+| `pro`          | Expert (19.99 €)   | tous          | `mistral-large-2512`       | **`magistral-medium-2509`** (Magistral) |
+
+> **Note de mapping legacy** : dans `videos/duration_router.get_optimal_model()`,
+> le paramètre `user_plan="expert"` (Pricing v2) est normalisé vers le code interne
+> `"pro"`. Le check Magistral est donc effectué AVANT normalisation, sur le
+> `raw_plan` original, pour distinguer Expert v2 de Pro legacy.
+
+## Modèle Magistral retenu
+
+- Nom officiel : `magistral-medium-2509` (Magistral Medium 1.2, v25.09)
+- Status : Premier (frontier-class multimodal reasoning)
+- Source officielle : https://docs.mistral.ai/getting-started/models/models_overview/
+- Vérifié le : 2026-05-02
+- Hébergement : Mistral AI SAS — UE — DPA actif sur le compte DeepSight
+
+## Stratégie de routage
+
+**Option A retenue** : override Expert-only **hors** chaîne de fallback.
+
+```python
+# Dans videos/duration_router.get_optimal_model()
+if (
+    task == "synthesis"
+    and MAGISTRAL_EPISTEMIC_ENABLED
+    and raw_plan in MAGISTRAL_EPISTEMIC_TIERS
+):
+    return MAGISTRAL_EPISTEMIC_MODEL, default_max_tokens
+```
+
+- **Pourquoi pas modifier `MISTRAL_FALLBACK_ORDER`** : Magistral est plus coûteux
+  et plus lent que `mistral-large-2512`. L'inclure dans la chaîne ferait baisser
+  des plans non-Expert dessus en cas de 429 sur les autres modèles. On veut
+  un usage **strictement opt-in Expert**.
+- **Comportement en cas d'échec Magistral** : `llm_complete()` voit un 429/5xx
+  et tombe automatiquement sur la chaîne existante :
+  `mistral-large-2512 → mistral-medium-2508 → mistral-small-2603 → deepseek-chat`.
+  Aucun code supplémentaire requis.
+
+## Activation Magistral
+
+Le flag est **désactivé par défaut**. Les variables sont lues depuis
+`core/config.py` (env-driven via `os.getenv`) :
+
+```bash
+# .env.production
+MAGISTRAL_EPISTEMIC_ENABLED=true
+MAGISTRAL_EPISTEMIC_MODEL=magistral-medium-2509   # optionnel, valeur par défaut
+MAGISTRAL_EPISTEMIC_TIERS=expert                  # optionnel, valeur par défaut
+```
+
+**Procédure d'activation** :
+
+1. Validation qualité manuelle préalable sur **10 vidéos diverses** (FR + EN, courte +
+   longue, factuel + opinion) — comparer marqueurs Magistral vs `mistral-large-2512`
+2. Mettre `MAGISTRAL_EPISTEMIC_ENABLED=true` dans `/opt/deepsight/repo/.env.production`
+3. Recharger le container backend : `docker exec repo-backend-1 kill -HUP 1`
+   (reload uvicorn workers) ou full restart `docker restart repo-backend-1`
+4. Vérifier les logs : un événement structuré `magistral_epistemic_override` doit
+   apparaître à chaque synthèse Expert
+
+## Rollback
+
+Setter `MAGISTRAL_EPISTEMIC_ENABLED=false` dans `.env.production` puis recharger
+le container → rollback instantané sans `git revert`.
+
+```bash
+ssh root@89.167.23.214
+sed -i 's/^MAGISTRAL_EPISTEMIC_ENABLED=.*/MAGISTRAL_EPISTEMIC_ENABLED=false/' /opt/deepsight/repo/.env.production
+docker restart repo-backend-1
+```
+
+## Tests
+
+Suite : `backend/tests/test_magistral_epistemic_routing.py`
+
+| Test                                              | Vérifie                                                      |
+| ------------------------------------------------- | ------------------------------------------------------------ |
+| `test_expert_tier_uses_magistral_when_enabled`    | Flag ON + plan="expert" → Magistral                          |
+| `test_expert_tier_falls_back_to_large_when_disabled` | Flag OFF + plan="expert" → `mistral-large-2512`              |
+| `test_pro_tier_unchanged_when_flag_on`            | Flag ON + plan="plus" (Pro v2) → `mistral-medium-2508`       |
+| `test_free_tier_unchanged_when_flag_on`           | Flag ON + plan="free" → `mistral-small-2603`                 |
+| `test_default_flag_is_off`                        | Garantie : `MAGISTRAL_EPISTEMIC_ENABLED is False` par défaut |
+| `test_expert_tier_only_for_synthesis_task`        | Flag ON + task="chunk_analysis" → JAMAIS Magistral (coût)    |
+
+## Observabilité
+
+Quand le flag est ON et qu'une synthèse Expert utilise Magistral, un log
+structuré est émis :
+
+```json
+{
+  "event": "magistral_epistemic_override",
+  "tier": "long",
+  "raw_plan": "expert",
+  "task": "synthesis",
+  "model": "magistral-medium-2509",
+  "max_tokens": 6000,
+  "transcript_words": 18000,
+  "reason": "expert_tier_epistemic_markers_enabled"
+}
+```
+
+Filtre Sentry / Hetzner pour suivre l'adoption :
+`docker logs repo-backend-1 --tail 1000 | grep magistral_epistemic_override`
+
+## Liens
+
+- Plan complet : `docs/superpowers/plans/2026-05-02-mistral-first-migration.md`
+- Spec : `01-Projects/DeepSight/Specs/2026-05-02-mistral-first-migration-design.md` (vault Obsidian)
+- Doc officielle Mistral : https://docs.mistral.ai/capabilities/reasoning/

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -691,6 +691,37 @@ MISTRAL_AGENT_ENABLED = True  # Set False to force Brave-only pipeline
 # Modèle de modération contenu
 MISTRAL_MODERATION_MODEL = "mistral-moderation-latest"
 
+# =============================================================================
+# MAGISTRAL — Modèle de raisonnement épistémique (Phase 4 migration Mistral-First)
+# =============================================================================
+# Magistral Medium 1.2 (v25.09) = modèle frontier de raisonnement chain-of-thought
+# de Mistral. Utilisé en OVERRIDE Expert-only pour la génération de la synthèse
+# avec marqueurs épistémiques (SOLID/PLAUSIBLE/UNCERTAIN/À VÉRIFIER).
+#
+# Source officielle (vérifié 2026-05-02):
+#   https://docs.mistral.ai/getting-started/models/models_overview/
+#
+# Stratégie: override Expert-only via duration_router.get_optimal_model(),
+# hors MISTRAL_FALLBACK_ORDER. Si Magistral fail (429/5xx), la chaîne de
+# fallback existante (mistral-large-2512 → medium → small → DeepSeek) prend
+# le relais via llm_complete().
+#
+# ROLLOUT: flag par défaut OFF. Activation après validation qualité manuelle
+# sur 10 vidéos avec marqueurs visibles. Toggle = .env MAGISTRAL_EPISTEMIC_ENABLED=true
+# =============================================================================
+
+MAGISTRAL_EPISTEMIC_ENABLED: bool = (
+    os.getenv("MAGISTRAL_EPISTEMIC_ENABLED", "false").lower() == "true"
+)
+MAGISTRAL_EPISTEMIC_MODEL: str = os.getenv(
+    "MAGISTRAL_EPISTEMIC_MODEL", "magistral-medium-2509"
+)
+MAGISTRAL_EPISTEMIC_TIERS: list = [
+    t.strip().lower()
+    for t in os.getenv("MAGISTRAL_EPISTEMIC_TIERS", "expert").split(",")
+    if t.strip()
+]
+
 
 def resolve_mistral_model(model_id: str) -> str:
     """Résout un alias de modèle legacy vers le nouveau modèle."""

--- a/backend/src/videos/duration_router.py
+++ b/backend/src/videos/duration_router.py
@@ -174,6 +174,22 @@ _MODEL_MEDIUM = "mistral-medium-2508"
 _MODEL_LARGE = "mistral-large-2512"
 _MODEL_INTERNAL = "ministral-8b-2512"
 
+# ── Magistral epistemic routing (Phase 4 migration Mistral-First) ──────────────
+# Override Expert-only pour la synthèse finale avec marqueurs épistémiques.
+# Imports depuis core/config (lazy) avec fallback statique si module indisponible
+# (cas tests unitaires sans .env). Les valeurs par défaut sont alignées sur
+# core/config.py — flag OFF, modèle officiel `magistral-medium-2509`, tiers=expert.
+try:
+    from core.config import (
+        MAGISTRAL_EPISTEMIC_ENABLED,
+        MAGISTRAL_EPISTEMIC_MODEL,
+        MAGISTRAL_EPISTEMIC_TIERS,
+    )
+except ImportError:  # pragma: no cover — fallback hors application context
+    MAGISTRAL_EPISTEMIC_ENABLED = False
+    MAGISTRAL_EPISTEMIC_MODEL = "magistral-medium-2509"
+    MAGISTRAL_EPISTEMIC_TIERS = ["expert"]
+
 # Concurrence adaptative par tier pour le chunking parallèle
 CONCURRENT_CHUNKS_BY_TIER = {
     VideoTier.MICRO: 1,
@@ -301,14 +317,53 @@ def get_optimal_model(
     Returns:
         Tuple (model_id, max_tokens)
     """
-    # Normaliser le plan
-    plan = user_plan.lower().strip()
+    # Normaliser le plan — préserver l'identité originale AVANT collapse pour
+    # le check Magistral Expert-only (sinon "expert" → "pro" et on ne peut plus
+    # distinguer Expert v2 19.99 € de Pro legacy).
+    raw_plan = user_plan.lower().strip()
+    plan = raw_plan
     if plan in ("starter", "student", "étudiant"):
         plan = "plus"
     elif plan in ("expert", "equipe", "unlimited", "team"):
         plan = "pro"
     elif plan not in ("free", "plus", "pro"):
         plan = "free"
+
+    # ── Magistral epistemic routing (Phase 4) ────────────────────────────────
+    # Override Expert-only pour la synthèse finale uniquement. Si Magistral
+    # fail (429/5xx), llm_complete() retombe sur la chaîne de fallback existante
+    # (mistral-large-2512 → medium → small → DeepSeek) — pas besoin de modifier
+    # MISTRAL_FALLBACK_ORDER.
+    if (
+        task == "synthesis"
+        and MAGISTRAL_EPISTEMIC_ENABLED
+        and raw_plan in MAGISTRAL_EPISTEMIC_TIERS
+    ):
+        # Reprendre les max_tokens du modèle large (paramétrage Pro/Expert
+        # heavy synthesis) pour ne pas brider Magistral arbitrairement.
+        tier_group_for_tokens = _TIER_GROUP.get(tier, "medium")
+        _, default_max_tokens = _MODEL_MATRIX["synthesis"].get(
+            (tier_group_for_tokens, "pro"), (_MODEL_LARGE, 6000)
+        )
+        # Bonus tokens si transcript ultra-long (cohérent avec logique ci-dessous)
+        if transcript_words > 45000:
+            default_max_tokens = min(default_max_tokens + 2000, 12000)
+        elif transcript_words > 15000:
+            default_max_tokens = min(default_max_tokens + 1000, 10000)
+
+        logger.info(
+            "magistral_epistemic_override",
+            extra={
+                "tier": tier.value,
+                "raw_plan": raw_plan,
+                "task": task,
+                "model": MAGISTRAL_EPISTEMIC_MODEL,
+                "max_tokens": default_max_tokens,
+                "transcript_words": transcript_words,
+                "reason": "expert_tier_epistemic_markers_enabled",
+            },
+        )
+        return MAGISTRAL_EPISTEMIC_MODEL, default_max_tokens
 
     # Déterminer le groupe de tier
     tier_group = _TIER_GROUP.get(tier, "medium")

--- a/backend/tests/test_magistral_epistemic_routing.py
+++ b/backend/tests/test_magistral_epistemic_routing.py
@@ -1,0 +1,162 @@
+"""
+Tests pour le routage Magistral (raisonnement épistémique) sur le tier Expert.
+
+Phase 4 du plan de migration Mistral-First (2026-05-02).
+
+Magistral est utilisé en OVERRIDE du modèle de synthèse pour le tier Expert
+uniquement, lorsque le flag `MAGISTRAL_EPISTEMIC_ENABLED` est True. Le but
+est d'améliorer la justification des marqueurs épistémiques
+(SOLID/PLAUSIBLE/UNCERTAIN/À VÉRIFIER) grâce au raisonnement chain-of-thought
+de Magistral.
+
+Stratégie de routage retenue (Option A):
+- Override Expert-only via `get_optimal_model()` pour `task="synthesis"`
+- Pas de modification de `MISTRAL_FALLBACK_ORDER` → si Magistral fail, la
+  chaîne de fallback existante (large → medium → small → DeepSeek) prend
+  le relais via `llm_complete`.
+- Flag par défaut OFF → les tests non patchés conservent le comportement
+  pré-Phase 4.
+"""
+
+import sys
+import os
+from unittest.mock import patch
+
+import pytest
+
+# Ensure src/ is on the path
+_src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧠 Tests: Routage Expert-only vers Magistral
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMagistralEpistemicRouting:
+    """
+    Vérifie le routage du modèle de synthèse selon le flag
+    MAGISTRAL_EPISTEMIC_ENABLED et le plan utilisateur.
+    """
+
+    def test_expert_tier_uses_magistral_when_enabled(self):
+        """Flag ON + plan="expert" → modèle Magistral pour la synthèse."""
+        from videos import duration_router
+        from videos.duration_router import get_optimal_model, VideoTier
+
+        with patch.object(duration_router, "MAGISTRAL_EPISTEMIC_ENABLED", True), \
+             patch.object(duration_router, "MAGISTRAL_EPISTEMIC_MODEL", "magistral-medium-2509"), \
+             patch.object(duration_router, "MAGISTRAL_EPISTEMIC_TIERS", ["expert"]):
+            model, tokens = get_optimal_model(
+                tier=VideoTier.MEDIUM,
+                user_plan="expert",
+                task="synthesis",
+            )
+            assert model == "magistral-medium-2509", (
+                f"Expected Magistral when flag ON + Expert plan, got {model}"
+            )
+            assert tokens > 0
+
+    def test_expert_tier_falls_back_to_large_when_disabled(self):
+        """Flag OFF + plan="expert" → modèle pré-Phase 4 (mistral-large-2512)."""
+        from videos import duration_router
+        from videos.duration_router import get_optimal_model, VideoTier
+
+        with patch.object(duration_router, "MAGISTRAL_EPISTEMIC_ENABLED", False):
+            # plan="expert" est normalisé en "pro" → matrix synthesis pour pro
+            # tier MEDIUM → group "medium" → ("medium", "pro") → mistral-large-2512
+            model, _ = get_optimal_model(
+                tier=VideoTier.MEDIUM,
+                user_plan="expert",
+                task="synthesis",
+            )
+            assert model == "mistral-large-2512", (
+                f"Expected mistral-large-2512 when flag OFF + Expert plan, got {model}"
+            )
+
+    def test_pro_tier_unchanged_when_flag_on(self):
+        """Flag ON + plan="pro" → toujours mistral-medium-2508 (jamais Magistral)."""
+        from videos import duration_router
+        from videos.duration_router import get_optimal_model, VideoTier
+
+        with patch.object(duration_router, "MAGISTRAL_EPISTEMIC_ENABLED", True), \
+             patch.object(duration_router, "MAGISTRAL_EPISTEMIC_MODEL", "magistral-medium-2509"), \
+             patch.object(duration_router, "MAGISTRAL_EPISTEMIC_TIERS", ["expert"]):
+            # NOTE: dans le code legacy, plan="pro" est traité comme tier le plus haut.
+            # Le sub-agent Phase 3 + plan migration ont confirmé que :
+            # - "pro" (legacy) = tier intermédiaire mappé sur le code value "plus"
+            # - "expert" (nouveau) = tier le plus élevé mappé sur le code value "pro"
+            # La normalisation interne fait : "pro" → "pro" (groupe medium synthesis = large).
+            # Pour le test "tier Pro 8.99 € v2", on utilise "plus" qui mappe sur medium.
+            model, _ = get_optimal_model(
+                tier=VideoTier.MEDIUM,
+                user_plan="plus",  # legacy alias correspondant au plan Pro 8.99 € v2
+                task="synthesis",
+            )
+            # Plan Pro v2 (alias "plus" code-side) ne doit JAMAIS recevoir Magistral
+            assert "magistral" not in model.lower(), (
+                f"Magistral should never route to non-Expert plans, got {model}"
+            )
+            assert model == "mistral-medium-2508", (
+                f"Expected mistral-medium-2508 for Pro v2, got {model}"
+            )
+
+    def test_free_tier_unchanged_when_flag_on(self):
+        """Flag ON + plan="free" → toujours mistral-small-2603 (jamais Magistral)."""
+        from videos import duration_router
+        from videos.duration_router import get_optimal_model, VideoTier
+
+        with patch.object(duration_router, "MAGISTRAL_EPISTEMIC_ENABLED", True), \
+             patch.object(duration_router, "MAGISTRAL_EPISTEMIC_MODEL", "magistral-medium-2509"), \
+             patch.object(duration_router, "MAGISTRAL_EPISTEMIC_TIERS", ["expert"]):
+            # Tier light (SHORT/MICRO) + free → small
+            model, _ = get_optimal_model(
+                tier=VideoTier.SHORT,
+                user_plan="free",
+                task="synthesis",
+            )
+            assert "magistral" not in model.lower(), (
+                f"Magistral should never route to free plan, got {model}"
+            )
+            assert model == "mistral-small-2603", (
+                f"Expected mistral-small-2603 for Free, got {model}"
+            )
+
+    def test_default_flag_is_off(self):
+        """Garantie: flag par défaut OFF → comportement pré-Phase 4 préservé."""
+        from videos.duration_router import (
+            MAGISTRAL_EPISTEMIC_ENABLED,
+            MAGISTRAL_EPISTEMIC_MODEL,
+            MAGISTRAL_EPISTEMIC_TIERS,
+        )
+
+        assert MAGISTRAL_EPISTEMIC_ENABLED is False, (
+            "MAGISTRAL_EPISTEMIC_ENABLED MUST default to False — activation "
+            "requires manual quality validation on 10 videos."
+        )
+        assert MAGISTRAL_EPISTEMIC_MODEL == "magistral-medium-2509", (
+            "Expected magistral-medium-2509 (v25.09 frontier) as official "
+            "Mistral reasoning model name."
+        )
+        assert "expert" in MAGISTRAL_EPISTEMIC_TIERS
+
+    def test_expert_tier_only_for_synthesis_task(self):
+        """Magistral n'override QUE le task=synthesis, pas chunk_analysis."""
+        from videos import duration_router
+        from videos.duration_router import get_optimal_model, VideoTier
+
+        with patch.object(duration_router, "MAGISTRAL_EPISTEMIC_ENABLED", True), \
+             patch.object(duration_router, "MAGISTRAL_EPISTEMIC_MODEL", "magistral-medium-2509"), \
+             patch.object(duration_router, "MAGISTRAL_EPISTEMIC_TIERS", ["expert"]):
+            # chunk_analysis sur Expert → mistral-small (pas Magistral, trop cher
+            # par chunk vu qu'il y a 5-50 appels par vidéo longue)
+            model, _ = get_optimal_model(
+                tier=VideoTier.MEDIUM,
+                user_plan="expert",
+                task="chunk_analysis",
+            )
+            assert "magistral" not in model.lower(), (
+                f"chunk_analysis should NEVER use Magistral (cost), got {model}"
+            )


### PR DESCRIPTION
## Phase 4 — Magistral pour épistémique tier Expert

Routage du tier Expert vers **`magistral-medium-2509`** pour la génération du résumé avec marqueurs SOLID/PLAUSIBLE/UNCERTAIN/À VÉRIFIER. Le raisonnement chain-of-thought transparent doit améliorer la justification de chaque marqueur.

**Flag par défaut OFF** — pas de rollout immédiat au merge. Activation après validation qualité manuelle.

Suite Wave 3 de la migration Mistral-First (spec : `Vault/01-Projects/DeepSight/Specs/2026-05-02-mistral-first-migration-design.md`).

## Modèle retenu
**`magistral-medium-2509`** — Magistral Medium 1.2, v25.09, status Premier, "frontier-class multimodal reasoning model". Vérifié via WebFetch sur `https://docs.mistral.ai/getting-started/models/models_overview/` (Context7 quota épuisé).

Version **pinned** (pas `magistral-medium-latest`) → cohérent avec stratégie déjà appliquée aux autres modèles (`mistral-small-2603`, `mistral-medium-2508`, `mistral-large-2512`).

## Architecture : override Expert-only (pas modification fallback chain)
Magistral ne figure PAS dans `MISTRAL_FALLBACK_ORDER` (découverte Phase 3). Décision : implémentation comme **override Expert-only**, hors fallback chain.

**Justification** :
- Magistral plus coûteux et plus lent que `mistral-large-2512`
- L'inclure en fallback ferait dégringoler des plans non-Expert dessus en cas de 429 → coût inattendu
- Si Magistral fail (429/5xx), `llm_complete()` retombe automatiquement sur la chaîne existante (`mistral-large-2512 → medium → small → DeepSeek`)

## 🔍 Découverte importante
`videos/duration_router.get_optimal_model()` normalise `user_plan="expert"` en `"pro"` **avant** le lookup matrix. Le check Magistral est donc fait sur `raw_plan` (la valeur **avant** normalisation), sinon impossible de distinguer Expert v2 de Pro legacy.

## Changes (385 +/2 −)
- `core/config.py` : `MAGISTRAL_EPISTEMIC_ENABLED` (False default, env-driven), `MAGISTRAL_EPISTEMIC_MODEL`, `MAGISTRAL_EPISTEMIC_TIERS`
- `videos/duration_router.py` : override Expert-only en amont du routing matrix
- **Nouveau** : `docs/architecture/epistemic-markers.md` (135 lignes) — politique + procédure activation/rollback
- **Nouveau** : `tests/test_magistral_epistemic_routing.py` (162 lignes, 6 tests)

## Tests
- **6/6** nouveaux (flag ON/OFF × Expert/Pro/Free × synthesis/chunk_analysis)
- **44/44** existants `tests/videos` (zéro régression)
- **Total : 50/50 verts**

## Activation prod (après validation qualité manuelle)
```bash
ssh root@89.167.23.214
echo "MAGISTRAL_EPISTEMIC_ENABLED=true" >> /opt/deepsight/repo/.env.production
docker restart repo-backend-1
# Rollback instant : remettre false + restart
```

## ⚠️ Validation manuelle requise avant activation
- **10 vidéos avec marqueurs visibles** (politiques, scientifiques, philosophiques, débats)
- Comparer qualité des marqueurs SOLID/PLAUSIBLE/UNCERTAIN avant/après
- **Si qualité ≥** : activer le flag prod
- **Si qualité <** : désactiver sans git revert (le flag suffit)

## Test plan
- [ ] Plan Expert avec flag ON → analyse utilise `magistral-medium-2509`
- [ ] Plan Expert avec flag OFF → comportement actuel (`mistral-large-2512`)
- [ ] Plan Pro / Free → jamais affecté (toujours `medium-2508` / `small-2603`)
- [ ] Magistral fail → fallback vers `mistral-large-2512` automatique

🤖 Generated with [Claude Code](https://claude.com/claude-code)