### PR TITLE
feat(hub): replace Loader2 with branded DeepSight aurora spinner

### DIFF
--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -34,7 +34,7 @@ import { SourcesShelf } from "../components/hub/SourcesShelf";
 import { NewConversationModal } from "../components/hub/NewConversationModal";
 import { HubAnalysisPanel } from "../components/hub/HubAnalysisPanel";
 import { useAnalyzeAndOpenHub } from "../hooks/useAnalyzeAndOpenHub";
-import { Loader2 } from "lucide-react";
+import { LoadingSpinner } from "../components/LoadingSpinner";
 import type { HubConversation, HubMessage } from "../components/hub/types";
 
 const newId = () =>
@@ -524,9 +524,8 @@ const HubPage: React.FC = () => {
         {analyzingTaskId && !activeConvId ? (
           <div className="flex-1 flex items-center justify-center px-6">
             <div className="max-w-md w-full text-center">
-              <div className="relative mx-auto mb-5 w-16 h-16">
-                <div className="absolute inset-0 rounded-full bg-indigo-500/20 blur-xl animate-pulse" />
-                <Loader2 className="relative w-16 h-16 text-indigo-400 mx-auto animate-spin" />
+              <div className="mx-auto mb-5 flex justify-center">
+                <LoadingSpinner size="md" label="Analyse en cours" />
               </div>
               <p className="text-base text-white font-medium mb-1.5">
                 Analyse en cours


### PR DESCRIPTION
## Summary

Quand l'utilisateur lance une analyse depuis le hub (state `?analyzing=<task_id>`), le placeholder affichait un `Loader2` lucide générique (cercle violet). On le remplace par le spinner DeepSight `LoadingSpinner size="md"` — logo aurora qui tourne avec effets flames+sparks, déjà utilisé partout ailleurs dans l'app.

## Avant / Après

- **Avant** : `<Loader2 className="w-16 h-16 text-indigo-400 animate-spin" />` (cercle violet générique)
- **Après** : `<LoadingSpinner size="md" label="Analyse en cours" />` (logo DeepSight aurora 96px + flames + sparks)

## Changes

- `frontend/src/pages/HubPage.tsx` :
  - import `Loader2` → `LoadingSpinner` (depuis `../components/LoadingSpinner`)
  - bloc `<Loader2 ... />` + halo blur → `<LoadingSpinner size="md" />` (déjà gère son propre halo / pulse / sparks)
- Reste du placeholder inchangé (texte "Analyse en cours" + message backend + barre de progression + footer "L'analyse continue même si vous fermez l'onglet").

## Test plan

- [ ] Lancer une analyse depuis le hub → placeholder affiche le spinner DeepSight (logo qui tourne) et plus le cercle violet générique
- [ ] Le `accessible-name` "Analyse en cours" est bien propagé via le `label` prop
- [ ] Vérifier que `npm run typecheck` passe (déjà OK localement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)