### PR TITLE
fix(cache): cache analyse strict (model + deep_research) + transcript instantané UX

### DIFF
--- a/backend/src/services/video_content_cache.py
+++ b/backend/src/services/video_content_cache.py
@@ -238,33 +238,65 @@ class VideoContentCacheService:
     # ANALYSIS
     # ═══════════════════════════════════════════════════════════════
 
-    async def get_analysis(self, platform: str, video_id: str, mode: str, language: str) -> Optional[dict]:
-        """Récupère une analyse depuis le cache L1/L2."""
-        key = _build_key("analysis", platform, video_id, mode=mode, language=language)
+    @staticmethod
+    def _make_analysis_mode_key(mode: str, model: Optional[str], deep_research: bool) -> str:
+        """Encode model + deep_research dans la clé `mode` pour différencier les analyses
+        qui dépendent des paramètres user (plan/model/deep_research). Sans ça, deux users
+        avec des paramètres différents partageraient la même analyse — faux conceptuellement.
+        """
+        return f"{mode}|m={model or 'default'}|dr={int(bool(deep_research))}"
+
+    async def get_analysis(
+        self,
+        platform: str,
+        video_id: str,
+        mode: str,
+        language: str,
+        model: Optional[str] = None,
+        deep_research: bool = False,
+    ) -> Optional[dict]:
+        """Récupère une analyse depuis le cache L1/L2.
+
+        La clé inclut model + deep_research : deux users avec mêmes (mode, lang) mais
+        modèles Mistral différents (small vs large) ou deep_research différent NE
+        partagent PAS le cache.
+        """
+        mode_key = self._make_analysis_mode_key(mode, model, deep_research)
+        key = _build_key("analysis", platform, video_id, mode=mode_key, language=language)
 
         data = await self._redis_get(key)
         if data is not None:
-            logger.info("Cache HIT L1 analysis %s/%s mode=%s lang=%s", platform, video_id, mode, language)
+            logger.info("Cache HIT L1 analysis %s/%s mode=%s lang=%s", platform, video_id, mode_key, language)
             self._record_stat("analysis", "l1")
             return data
 
-        data = await self._pg_get_analysis(platform, video_id, mode, language)
+        data = await self._pg_get_analysis(platform, video_id, mode_key, language)
         if data is not None:
-            logger.info("Cache HIT L2 analysis %s/%s mode=%s lang=%s", platform, video_id, mode, language)
+            logger.info("Cache HIT L2 analysis %s/%s mode=%s lang=%s", platform, video_id, mode_key, language)
             await self._redis_set(key, data, "analysis")
             self._record_stat("analysis", "l2")
             return data
 
-        logger.info("Cache MISS analysis %s/%s mode=%s lang=%s", platform, video_id, mode, language)
+        logger.info("Cache MISS analysis %s/%s mode=%s lang=%s", platform, video_id, mode_key, language)
         self._record_stat("analysis", "miss")
         return None
 
-    async def set_analysis(self, platform: str, video_id: str, mode: str, language: str, data: dict) -> None:
-        """Stocke une analyse dans L1 + L2."""
-        key = _build_key("analysis", platform, video_id, mode=mode, language=language)
+    async def set_analysis(
+        self,
+        platform: str,
+        video_id: str,
+        mode: str,
+        language: str,
+        data: dict,
+        model: Optional[str] = None,
+        deep_research: bool = False,
+    ) -> None:
+        """Stocke une analyse dans L1 + L2 sous une clé qui inclut model + deep_research."""
+        mode_key = self._make_analysis_mode_key(mode, model, deep_research)
+        key = _build_key("analysis", platform, video_id, mode=mode_key, language=language)
         await asyncio.gather(
             self._redis_set(key, data, "analysis"),
-            self._pg_upsert_analysis(platform, video_id, mode, language, data),
+            self._pg_upsert_analysis(platform, video_id, mode_key, language, data),
             return_exceptions=True,
         )
 

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -910,7 +910,17 @@ async def analyze_video(
             _vcache = get_video_cache()
             if _vcache is not None:
                 _analysis_lang = request.lang or "fr"
-                _cached = await _vcache.get_analysis(platform, video_id, request.mode, _analysis_lang)
+                # Cache key inclut model + deep_research : deux users avec mêmes
+                # (mode, lang) mais modèle Mistral ou deep_research différents NE
+                # partagent PAS l'analyse (params user-spécifiques).
+                _cached = await _vcache.get_analysis(
+                    platform,
+                    video_id,
+                    request.mode,
+                    _analysis_lang,
+                    model=model,
+                    deep_research=deep_research,
+                )
                 if _cached and _cached.get("summary_content"):
                     # Sauvegarder dans l'historique utilisateur (gratuit, source=cache)
                     _cache_summary_id = await save_summary(
@@ -2751,6 +2761,10 @@ async def _analyze_video_background_v6(
                         transcript_timestamped = _cached_t.get("transcript_timestamped")
                         detected_lang = _cached_t.get("detected_lang")
                         if transcript:
+                            # Transcript instantané (cross-user) → on saute l'extraction
+                            # et la barre avance directement de 20 % à 50 %.
+                            _task_store[task_id]["progress"] = 50
+                            _task_store[task_id]["message"] = "📝 Transcript trouvé"
                             logger.info(
                                 f"💾 [GLOBAL CACHE HIT] Transcript for {platform}/{video_id}: {len(transcript)} chars"
                             )
@@ -3232,6 +3246,8 @@ async def _analyze_video_background_v6(
                                 "reliability_score": reliability,
                                 "enrichment_data": enrichment_metadata,
                             },
+                            model=model,
+                            deep_research=deep_research,
                         )
                 except Exception as _vce:
                     logger.error(f"⚠️ [GLOBAL CACHE] Analysis cache set failed: {_vce}")


### PR DESCRIPTION
## Résumé

Deux changements liés autour du cache vidéo cross-user :

1. **Cache d'analyse plus strict** — la clé inclut désormais `model` et `deep_research`. Avant, deux users avec des plans différents (mistral-small vs mistral-large) ou avec/sans deep_research partageaient la même analyse cachée → un user Expert pouvait recevoir l'analyse d'un user Free. Faux conceptuellement.

2. **Transcript instantané UX** — quand le transcript est trouvé en cache (cross-user), la barre de progression saute directement de 20 % à 50 % avec le message « 📝 Transcript trouvé ». L'user voit que l'étape d'extraction (Supadata / yt-dlp) est skippée et seul le LLM Mistral tourne (5-30 s au lieu de plusieurs minutes).

## Avant / Après — clé Redis

- **Avant** : `vcache:analysis:youtube:VIDEO_ID:standard:fr`
- **Après** : `vcache:analysis:youtube:VIDEO_ID:standard|m=mistral-medium-2508|dr=0:fr`

## Fichiers modifiés

- `backend/src/services/video_content_cache.py`
  - `_make_analysis_mode_key(mode, model, deep_research)` encode les params dans la clé `mode`.
  - `get_analysis()` et `set_analysis()` acceptent maintenant `model` et `deep_research`.
- `backend/src/videos/router.py`
  - Les deux call-sites (`get_analysis` L913, `set_analysis` L3213) passent `model` et `deep_research`.
  - Bloc transcript HIT (L2748) : progress 20 → 50 + message « 📝 Transcript trouvé ».

## Backward-compat

- Pas de migration DB. La colonne PG `mode` est `VARCHAR` et accepte la string enrichie.
- Les anciennes entrées Redis (`mode=standard`) deviennent orphelines, ignorées au prochain check (clé différente), et expirent naturellement (TTL 3 j).
- Le cache **transcript** reste cross-user inchangé (le transcript est invariant entre users).
- Le cache analyse **per-user** 7 jours (L965-994) reste intact (même user, mêmes params, pas de re-débit crédit).

## Test plan

- [ ] User Free analyse vidéo X mode=standard → cache SET avec clé `...|m=mistral-small-2603|dr=0`.
- [ ] User Expert analyse vidéo X mode=standard, deep_research=true → cache MISS (clé `...|m=mistral-large-2512|dr=1` différente) → analyse fait normalement avec mistral-large.
- [ ] User Free relance X mode=standard → cache HIT (même clé).
- [ ] Vérifier dans Redis prod après déploiement : `KEYS vcache:analysis:*` doit montrer la nouvelle structure.
- [ ] Lancer une analyse sur une vidéo avec transcript déjà caché → barre saute à 50 % avec message « 📝 Transcript trouvé », puis Mistral tourne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)