### PR TITLE
fix(hub): scrollable analysis panel + sticky tab bar

### DIFF
--- a/frontend/src/components/AnalysisHub/index.tsx
+++ b/frontend/src/components/AnalysisHub/index.tsx
@@ -239,7 +239,7 @@ export const AnalysisHub: React.FC<AnalysisHubProps> = ({
     <div className="card overflow-hidden">
       {/* Tab Bar — hidden if only one tab */}
       {visibleTabs.length > 1 && (
-        <div className="flex border-b border-border-subtle overflow-x-auto scrollbar-hide">
+        <div className="sticky top-0 z-10 flex border-b border-border-subtle overflow-x-auto scrollbar-hide bg-[#12121a]/95 backdrop-blur-sm">
           {visibleTabs.map((tab) => {
             const isActive = activeTab === tab.id;
             const Icon = tab.icon;

--- a/frontend/src/components/hub/HubAnalysisPanel.tsx
+++ b/frontend/src/components/hub/HubAnalysisPanel.tsx
@@ -90,27 +90,29 @@ export const HubAnalysisPanel: React.FC<HubAnalysisPanelProps> = ({
   return (
     <div className="px-4 mb-3 w-full max-w-3xl mx-auto">
       <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
-        <AnalysisHub
-          selectedSummary={selectedSummary}
-          reliabilityData={reliability}
-          reliabilityLoading={reliabilityLoading}
-          user={analysisUser}
-          language={language}
-          concepts={concepts}
-          onTimecodeClick={handleTimecodeClick}
-          onOpenChat={handleOpenChat}
-          onNavigate={handleNavigate}
-          enabledTabs={[
-            "synthesis",
-            "reliability",
-            "quiz",
-            "flashcards",
-            "geo",
-          ]}
-          showKeywords
-          showStudyTools={false}
-          showVoice={false}
-        />
+        <div className="max-h-[60vh] overflow-y-auto overscroll-contain">
+          <AnalysisHub
+            selectedSummary={selectedSummary}
+            reliabilityData={reliability}
+            reliabilityLoading={reliabilityLoading}
+            user={analysisUser}
+            language={language}
+            concepts={concepts}
+            onTimecodeClick={handleTimecodeClick}
+            onOpenChat={handleOpenChat}
+            onNavigate={handleNavigate}
+            enabledTabs={[
+              "synthesis",
+              "reliability",
+              "quiz",
+              "flashcards",
+              "geo",
+            ]}
+            showKeywords
+            showStudyTools={false}
+            showVoice={false}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Fixe le problème UX signalé sur `https://www.deepsightsynthesis.com/hub?conv=N` : quand l'utilisateur déroule l'analyse détaillée, il ne pouvait pas scroller jusqu'au bout **et** accéder au chat en même temps. Le panneau d'analyse débordait et poussait `Timeline` + `InputBar` hors de l'écran.

- `HubAnalysisPanel` enveloppe maintenant `AnalysisHub` dans un `max-h-[60vh] overflow-y-auto overscroll-contain` → l'analyse scrolle indépendamment, le chat + barre d'input restent toujours visibles.
- `AnalysisHub` tab bar passe en `sticky top-0 z-10` avec fond `bg-[#12121a]/95 backdrop-blur-sm` → les onglets Synthèse/Quiz/Flashcards/Fiabilité/GEO restent accessibles pendant le scroll.

Aucun impact sur `DashboardPage` qui utilise aussi `AnalysisHub` : son parent ne scroll pas, donc le `sticky` n''a aucun effet visuel.

## Test plan

- [ ] Ouvrir `/hub?conv=<id>` avec une vidéo dont la synthèse est longue
- [ ] Cliquer sur l''onglet Synthèse → contenu scrollable, onglets restent en haut
- [ ] InputBar du chat toujours cliquable, Timeline visible
- [ ] Vérifier sur mobile (375px) que le scroll fonctionne aussi
- [ ] Vérifier `DashboardPage` (avec onglets Synthèse) : aucune régression visuelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)