### PR TITLE
feat(mobile): UX fix — fullscreen + keyboard dismiss + scroll harmonization

### DIFF
--- a/mobile/__tests__/components/DismissKeyboardView.test.tsx
+++ b/mobile/__tests__/components/DismissKeyboardView.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Tests for DismissKeyboardView — wrapper qui dismiss le clavier
+ * lorsqu'un tap atteint le wrapper sans être absorbé par un enfant.
+ */
+import React from "react";
+import { Keyboard, Text, TextInput } from "react-native";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { DismissKeyboardView } from "../../src/components/ui/DismissKeyboardView";
+
+describe("DismissKeyboardView", () => {
+  beforeEach(() => {
+    jest.spyOn(Keyboard, "dismiss").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders its children", () => {
+    render(
+      <DismissKeyboardView>
+        <Text>child-content</Text>
+      </DismissKeyboardView>,
+    );
+    expect(screen.getByText("child-content")).toBeTruthy();
+  });
+
+  it("calls Keyboard.dismiss when the wrapper is pressed", () => {
+    render(
+      <DismissKeyboardView testID="wrap">
+        <Text>child</Text>
+      </DismissKeyboardView>,
+    );
+
+    fireEvent.press(screen.getByTestId("wrap"));
+    expect(Keyboard.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dismiss the keyboard when a child input is focused", () => {
+    render(
+      <DismissKeyboardView testID="wrap">
+        <TextInput testID="input" placeholder="type" />
+      </DismissKeyboardView>,
+    );
+
+    fireEvent(screen.getByTestId("input"), "focus");
+    expect(Keyboard.dismiss).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/__tests__/hooks/useTabBarFootprint.test.ts
+++ b/mobile/__tests__/hooks/useTabBarFootprint.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for useTabBarFootprint — TAB_BAR_HEIGHT + safe-area bottom + sp.md.
+ */
+import { renderHook } from "@testing-library/react-native";
+
+const mockInsets = jest.fn();
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => mockInsets(),
+}));
+
+import { useTabBarFootprint } from "../../src/hooks/useTabBarFootprint";
+
+describe("useTabBarFootprint", () => {
+  beforeEach(() => {
+    mockInsets.mockReset();
+  });
+
+  it("returns TAB_BAR_HEIGHT + insets.bottom + sp.md when bottom inset is large", () => {
+    // 56 + 34 (iPhone home indicator) + 12 (sp.md) = 102
+    mockInsets.mockReturnValue({ top: 0, bottom: 34, left: 0, right: 0 });
+    const { result } = renderHook(() => useTabBarFootprint());
+    expect(result.current).toBe(102);
+  });
+
+  it("uses sp.sm (8) as floor when device has no bottom safe area", () => {
+    // 56 + max(0, 8) + 12 = 76
+    mockInsets.mockReturnValue({ top: 0, bottom: 0, left: 0, right: 0 });
+    const { result } = renderHook(() => useTabBarFootprint());
+    expect(result.current).toBe(76);
+  });
+
+  it("clamps small insets to sp.sm floor", () => {
+    // 56 + max(2, 8) + 12 = 76
+    mockInsets.mockReturnValue({ top: 0, bottom: 2, left: 0, right: 0 });
+    const { result } = renderHook(() => useTabBarFootprint());
+    expect(result.current).toBe(76);
+  });
+});

--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -20,6 +20,7 @@ import { resetCircuitBreaker } from "@/services/RetryService";
 import { OfflineCache, CachePriority } from "@/services/OfflineCache";
 import { useIsOffline } from "@/hooks/useNetworkStatus";
 import { useAnalysisStore } from "@/stores/analysisStore";
+import { useTabBarStore } from "@/stores/tabBarStore";
 import type { AnalysisSummary } from "@/types";
 import { AnalysisSkeleton } from "@/components/ui/SkeletonLoader";
 import { VideoPlayer } from "@/components/analysis/VideoPlayer";
@@ -259,6 +260,14 @@ export default function AnalysisDetailScreen() {
   const handleToggleFullscreen = useCallback(() => {
     setIsFullscreen((prev) => !prev);
   }, []);
+
+  // Cacher la TabBar globale en mode fullscreen — restaurée au démontage.
+  // Ce store pilote `<CustomTabBar>` directement (cf. tabBarStore.ts).
+  const setTabBarHidden = useTabBarStore((s) => s.setTabBarHidden);
+  React.useEffect(() => {
+    setTabBarHidden(isFullscreen);
+    return () => setTabBarHidden(false);
+  }, [isFullscreen, setTabBarHidden]);
 
   // Sync PagerView page after fullscreen toggle — the conditional rendering
   // (`!isFullscreen && Pager` vs `isFullscreen && Pager`) causes React to
@@ -705,7 +714,10 @@ export default function AnalysisDetailScreen() {
       )}
 
       {/* ── MODE FULLSCREEN ──────────────────────────────── */}
-      {/* paddingBottom du container est 0 → l'overlay couvre l'écran entier */}
+      {/* paddingBottom du container est 0 → l'overlay couvre l'écran entier.
+          La TabBar globale est cachée via tabBarStore (cf. useEffect ci-dessus)
+          donc on n'a plus besoin de réserver TAB_BAR_HEIGHT — seul le safe area
+          bottom suffit. */}
       {isFullscreen && (
         <View
           style={[
@@ -713,9 +725,7 @@ export default function AnalysisDetailScreen() {
             {
               backgroundColor: colors.bgPrimary,
               paddingTop: insets.top,
-              // TAB_BAR_HEIGHT : le CustomTabBar est position:absolute bottom:0
-              // il chevauche le contenu fullscreen → on réserve sa hauteur
-              paddingBottom: insets.bottom + TAB_BAR_HEIGHT,
+              paddingBottom: insets.bottom,
             },
           ]}
         >

--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -172,6 +172,10 @@ export default function AnalysisDetailScreen() {
     store.resetAnalysis();
     if (backTo === "library") {
       router.replace("/(tabs)/library");
+    } else if (backTo === "study") {
+      router.replace("/(tabs)/study");
+    } else if (backTo === "home") {
+      router.replace("/(tabs)");
     } else {
       router.back();
     }

--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef, useState } from "react";
 import { View, Text, Pressable, StatusBar, StyleSheet } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import PagerView from "react-native-pager-view";
 import Animated, {
@@ -40,7 +41,6 @@ import { usePlan } from "@/contexts/PlanContext";
 
 const TAB_LABELS = ["Résumé", "Sources", "Chat"] as const;
 const TAB_COUNT = TAB_LABELS.length;
-const TAB_BAR_HEIGHT = 60;
 
 export default function AnalysisDetailScreen() {
   const { id, backTo, initialTab, quickChat } = useLocalSearchParams<{
@@ -52,6 +52,7 @@ export default function AnalysisDetailScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const insets = useSafeAreaInsets();
+  const tabBarFootprint = useTabBarFootprint();
   const { colors, isDark } = useTheme();
   const store = useAnalysisStore();
   const isOffline = useIsOffline();
@@ -374,6 +375,9 @@ export default function AnalysisDetailScreen() {
           isLoading={isLoading && canFetchSummary}
           error={error && !isProcessing ? "Erreur de chargement" : null}
           onRetry={() => refetch()}
+          // Le container parent réserve déjà la footprint TabBar — le scroll
+          // du content peut donc se contenter d'une marge respiration.
+          bottomPadding={isFullscreen ? insets.bottom + sp.lg : sp["2xl"]}
         />
       </View>
       <View key="sources" style={styles.page}>
@@ -577,10 +581,9 @@ export default function AnalysisDetailScreen() {
         styles.container,
         {
           backgroundColor: colors.bgPrimary,
-          // En fullscreen : paddingBottom=0 pour que l'overlay absolu atteigne le bas de l'écran
-          paddingBottom: isFullscreen
-            ? 0
-            : TAB_BAR_HEIGHT + Math.max(insets.bottom, sp.sm),
+          // En fullscreen : paddingBottom=0 pour que l'overlay absolu atteigne le bas de l'écran.
+          // En mode normal : footprint partagé pour ne jamais cacher le dernier élément derrière la TabBar.
+          paddingBottom: isFullscreen ? 0 : tabBarFootprint,
         },
       ]}
     >

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -16,6 +16,7 @@ import Animated, {
   withSpring,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
 import type { SimpleBottomSheetRef } from "@/components/ui/SimpleBottomSheet";
 import { router } from "expo-router";
 import { Image } from "expo-image";
@@ -56,6 +57,7 @@ const TABS: { key: InputMode; label: string; icon: string }[] = [
 
 export default function HomeScreen() {
   const insets = useSafeAreaInsets();
+  const tabBarFootprint = useTabBarFootprint();
   const { colors, isDark } = useTheme();
   const user = useAuthStore((s) => s.user);
   const { logout } = useAuth();
@@ -205,7 +207,7 @@ export default function HomeScreen() {
           styles.scrollContent,
           {
             paddingTop: insets.top + sp.md,
-            paddingBottom: 80 + Math.max(insets.bottom, sp.md),
+            paddingBottom: tabBarFootprint,
           },
         ]}
         refreshControl={

--- a/mobile/app/(tabs)/library.tsx
+++ b/mobile/app/(tabs)/library.tsx
@@ -373,6 +373,7 @@ export default function LibraryScreen() {
             ...styles.listContent,
             paddingBottom: tabBarFootprint,
           }}
+          keyboardShouldPersistTaps="handled"
           onEndReached={handleLoadMore}
           onEndReachedThreshold={0.3}
           ListEmptyComponent={renderEmpty}

--- a/mobile/app/(tabs)/library.tsx
+++ b/mobile/app/(tabs)/library.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { FlashList } from "@shopify/flash-list";
 import { Ionicons } from "@expo/vector-icons";
@@ -35,6 +36,7 @@ const QUERY_KEY_BASE = "library";
 export default function LibraryScreen() {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
+  const tabBarFootprint = useTabBarFootprint();
   const router = useRouter();
   const queryClient = useQueryClient();
   const isOffline = useIsOffline();
@@ -367,7 +369,10 @@ export default function LibraryScreen() {
           data={filteredItems}
           renderItem={renderItem}
           keyExtractor={(item) => item.id}
-          contentContainerStyle={styles.listContent}
+          contentContainerStyle={{
+            ...styles.listContent,
+            paddingBottom: tabBarFootprint,
+          }}
           onEndReached={handleLoadMore}
           onEndReachedThreshold={0.3}
           ListEmptyComponent={renderEmpty}
@@ -440,7 +445,6 @@ const styles = StyleSheet.create({
   },
   listContent: {
     paddingHorizontal: sp.lg,
-    paddingBottom: 80,
   },
   emptyContainer: {
     alignItems: "center",

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { View, Text, ScrollView, StyleSheet, Alert } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
 import { useRouter } from "expo-router";
 import Constants from "expo-constants";
 import * as WebBrowser from "expo-web-browser";
@@ -42,6 +43,7 @@ const isPaidPlan = (plan: PlanType): boolean => plan !== "free";
 
 export default function ProfileScreen() {
   const insets = useSafeAreaInsets();
+  const tabBarFootprint = useTabBarFootprint();
   const { colors } = useTheme();
   const { user, logout } = useAuth();
   const router = useRouter();
@@ -91,7 +93,7 @@ export default function ProfileScreen() {
           styles.scrollContent,
           {
             paddingTop: insets.top + sp.lg,
-            paddingBottom: 80 + Math.max(insets.bottom, sp.sm),
+            paddingBottom: tabBarFootprint,
           },
         ]}
         showsVerticalScrollIndicator={false}

--- a/mobile/app/(tabs)/study.tsx
+++ b/mobile/app/(tabs)/study.tsx
@@ -656,7 +656,7 @@ export default function StudyScreen() {
                             pathname: "/(tabs)/analysis/[id]",
                             params: {
                               id: summary.id,
-                              backTo: "library",
+                              backTo: "study",
                               initialTab: "0",
                             },
                           } as any)
@@ -666,7 +666,7 @@ export default function StudyScreen() {
                             pathname: "/(tabs)/analysis/[id]",
                             params: {
                               id: summary.id,
-                              backTo: "library",
+                              backTo: "study",
                               initialTab: "1",
                             },
                           } as any)

--- a/mobile/app/(tabs)/study.tsx
+++ b/mobile/app/(tabs)/study.tsx
@@ -17,6 +17,7 @@ import {
   Keyboard,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import Animated, { FadeInDown } from "react-native-reanimated";
@@ -46,6 +47,7 @@ const FAB_GAP = 16;
 
 export default function StudyScreen() {
   const insets = useSafeAreaInsets();
+  const tabBarFootprint = useTabBarFootprint();
   const { colors } = useTheme();
   const { user } = useAuth();
   const router = useRouter();
@@ -171,7 +173,7 @@ export default function StudyScreen() {
         styles.container,
         {
           backgroundColor: colors.bgPrimary,
-          paddingBottom: 60 + Math.max(insets.bottom, sp.sm),
+          paddingBottom: tabBarFootprint,
         },
       ]}
     >

--- a/mobile/app/(tabs)/study.tsx
+++ b/mobile/app/(tabs)/study.tsx
@@ -185,6 +185,7 @@ export default function StudyScreen() {
           { paddingTop: insets.top + sp.lg },
         ]}
         showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
       >
         {/* Header */}
         <Text style={[styles.title, { color: colors.textPrimary }]}>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -24,6 +24,7 @@ import { AmbientLightLayer } from "../src/components/backgrounds/AmbientLightLay
 import { SunflowerLayer } from "../src/components/backgrounds/SunflowerLayer";
 import { AmbientLightingProvider } from "../src/contexts/AmbientLightingContext";
 import { useAmbientLightingEnabled } from "../src/hooks/useAmbientLightingEnabled";
+import { DismissKeyboardView } from "../src/components/ui/DismissKeyboardView";
 
 // Prevent splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync().catch(() => {});
@@ -188,17 +189,26 @@ function RootNavigator() {
     <AmbientLightingProvider enabled={ambientEnabled}>
       <View style={rootStyles.root}>
         <StatusBar style="light" backgroundColor={darkColors.bgPrimary} />
-        <Stack
-          screenOptions={{
-            headerShown: false,
-            contentStyle: { backgroundColor: "transparent" },
-            animation: "fade",
-          }}
-        >
-          <Stack.Screen name="(auth)" />
-          <Stack.Screen name="(tabs)" />
-          <Stack.Screen name="splash" />
-        </Stack>
+        {/*
+          DismissKeyboardView wraps the navigator so any tap that reaches the
+          background (i.e. not absorbed by an interactive child) dismisses the
+          keyboard. ScrollView/FlatList children should set
+          `keyboardShouldPersistTaps="handled"` to keep their inner buttons
+          tappable while the keyboard is open.
+        */}
+        <DismissKeyboardView>
+          <Stack
+            screenOptions={{
+              headerShown: false,
+              contentStyle: { backgroundColor: "transparent" },
+              animation: "fade",
+            }}
+          >
+            <Stack.Screen name="(auth)" />
+            <Stack.Screen name="(tabs)" />
+            <Stack.Screen name="splash" />
+          </Stack>
+        </DismissKeyboardView>
         {/*
           v3 ambient layers rendered AFTER the Stack → they float ABOVE every
           page background. pointerEvents="none" lets gestures pass through.

--- a/mobile/src/components/analysis/AnalysisContentDisplay.tsx
+++ b/mobile/src/components/analysis/AnalysisContentDisplay.tsx
@@ -49,6 +49,9 @@ interface AnalysisContentDisplayProps {
   /** Legacy props — compat with old AnalysisScreen */
   showEmptyState?: boolean;
   emptyStateMessage?: string;
+  /** ScrollView paddingBottom — défaut 120 (compat). Le parent (analysis/[id])
+   *  peut injecter `useTabBarFootprint()` pour aligner avec la TabBar globale. */
+  bottomPadding?: number;
 }
 
 // ── Epistemic Markers ──────────────────────────────────────────────────────
@@ -199,6 +202,7 @@ export const AnalysisContentDisplay: React.FC<AnalysisContentDisplayProps> = ({
   onRetry,
   showEmptyState = false,
   emptyStateMessage,
+  bottomPadding = 120,
 }) => {
   const { colors, isDark } = useTheme();
   const displayText = isStreaming ? streamingText : content || "";
@@ -641,7 +645,7 @@ export const AnalysisContentDisplay: React.FC<AnalysisContentDisplayProps> = ({
 
       <ScrollView
         style={localStyles.scroll}
-        contentContainerStyle={localStyles.scrollContent}
+        contentContainerStyle={[localStyles.scrollContent, { paddingBottom: bottomPadding }]}
         showsVerticalScrollIndicator={false}
       >
         <Animated.View
@@ -687,7 +691,6 @@ const localStyles = StyleSheet.create({
   scroll: { flex: 1 },
   scrollContent: {
     paddingHorizontal: sp.lg,
-    paddingBottom: 120,
   },
   // Cursor
   cursorRow: {

--- a/mobile/src/components/analysis/ChatView.tsx
+++ b/mobile/src/components/analysis/ChatView.tsx
@@ -324,6 +324,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
         inverted
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
         maxToRenderPerBatch={10}
         windowSize={10}
         removeClippedSubviews={Platform.OS === "android"}

--- a/mobile/src/components/conversation/ConversationFeed.tsx
+++ b/mobile/src/components/conversation/ConversationFeed.tsx
@@ -201,6 +201,7 @@ export const ConversationFeed: React.FC<ConversationFeedProps> = ({
         inverted
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
         maxToRenderPerBatch={10}
         windowSize={10}
         removeClippedSubviews={Platform.OS === "android"}

--- a/mobile/src/components/conversation/ConversationHeader.tsx
+++ b/mobile/src/components/conversation/ConversationHeader.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 import { View, Text, Pressable, StyleSheet, Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { useTheme } from "../../contexts/ThemeContext";
@@ -44,6 +45,7 @@ export const ConversationHeader: React.FC<ConversationHeaderProps> = ({
   onClose,
 }) => {
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const badge = platformBadge(platform);
 
   const handleSettings = () => {
@@ -54,7 +56,15 @@ export const ConversationHeader: React.FC<ConversationHeaderProps> = ({
   };
 
   return (
-    <View style={[styles.header, { borderBottomColor: colors.border }]}>
+    <View
+      style={[
+        styles.header,
+        {
+          borderBottomColor: colors.border,
+          paddingTop: insets.top + sp.sm,
+        },
+      ]}
+    >
       <View style={styles.titles}>
         <Text
           numberOfLines={1}

--- a/mobile/src/components/conversation/ConversationInput.tsx
+++ b/mobile/src/components/conversation/ConversationInput.tsx
@@ -11,6 +11,7 @@
 
 import React from "react";
 import { View, Text, TextInput, Pressable, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../contexts/ThemeContext";
 import { sp, borderRadius } from "../../theme/spacing";
@@ -40,6 +41,7 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
   quotaText,
 }) => {
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const canSend = inputText.trim().length > 0 && !isLoading;
 
   // Placeholder dynamique selon voiceMode
@@ -67,7 +69,14 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
     voiceMode === "ended" || voiceMode === "quota_exceeded";
 
   return (
-    <View style={styles.inputWrapper}>
+    <View
+      style={[
+        styles.inputWrapper,
+        // Edge-to-edge: l'input gère son propre bottom safe area car
+        // ConversationScreen ne pad plus.
+        { paddingBottom: Math.max(insets.bottom, sp.sm) },
+      ]}
+    >
       <View
         style={[
           styles.inputRow,

--- a/mobile/src/components/conversation/ConversationScreen.tsx
+++ b/mobile/src/components/conversation/ConversationScreen.tsx
@@ -19,6 +19,7 @@ import React, { useCallback, useRef, useState } from "react";
 import {
   View,
   Modal,
+  StatusBar,
   StyleSheet,
   KeyboardAvoidingView,
   Platform,
@@ -26,7 +27,6 @@ import {
   Alert,
 } from "react-native";
 import Animated, { FadeIn, SlideInDown } from "react-native-reanimated";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
 import type BottomSheet from "@gorhom/bottom-sheet";
@@ -79,7 +79,6 @@ export const ConversationScreen: React.FC<ConversationScreenProps> = ({
   onClose,
 }) => {
   const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
   const router = useRouter();
   const settingsSheetRef = useRef<BottomSheet | null>(null);
   const [addonVisible, setAddonVisible] = useState(false);
@@ -210,19 +209,21 @@ export const ConversationScreen: React.FC<ConversationScreenProps> = ({
       statusBarTranslucent
       onRequestClose={onClose}
     >
+      {/*
+        Edge-to-edge: la Modal `statusBarTranslucent` couvre toute la hauteur
+        écran, status bar et home indicator inclus. Le composant déclare son
+        propre StatusBar pour conserver les icônes lisibles sur fond bgPrimary.
+        Les paddings safe-area ne sont PLUS appliqués sur l'inner View — c'est
+        au Header (top) et à l'Input (bottom) de gérer leur propre inset.
+      */}
+      <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
       <Animated.View
         entering={FadeIn.duration(duration.slow)}
         style={[styles.root, { backgroundColor: colors.bgPrimary }]}
       >
         <Animated.View
           entering={SlideInDown.duration(duration.slower).springify()}
-          style={[
-            styles.inner,
-            {
-              paddingTop: insets.top,
-              paddingBottom: insets.bottom,
-            },
-          ]}
+          style={styles.inner}
         >
           <ConversationHeader
             videoTitle={videoTitle}
@@ -237,7 +238,7 @@ export const ConversationScreen: React.FC<ConversationScreenProps> = ({
           <KeyboardAvoidingView
             style={styles.flex}
             behavior={Platform.OS === "ios" ? "padding" : undefined}
-            keyboardVerticalOffset={insets.top + 56}
+            keyboardVerticalOffset={0}
           >
             {conv.streaming ? (
               <ContextProgressBanner

--- a/mobile/src/components/navigation/CustomTabBar.tsx
+++ b/mobile/src/components/navigation/CustomTabBar.tsx
@@ -18,6 +18,7 @@ import Animated, {
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@/contexts/ThemeContext";
+import { useTabBarStore } from "@/stores/tabBarStore";
 import { palette } from "@/theme/colors";
 import { fontFamily, fontSize } from "@/theme/typography";
 
@@ -32,7 +33,7 @@ const ANIM_CONFIG = {
 } as const;
 
 const ICON_SIZE = 22;
-const TAB_BAR_HEIGHT = 56;
+export const TAB_BAR_HEIGHT = 56;
 
 /** Tab definitions — only routes listed here appear in the bar */
 const TAB_META: Record<
@@ -200,6 +201,11 @@ export function CustomTabBar({ state, navigation }: TabBarProps) {
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
   const { isDark } = useTheme();
+  const hidden = useTabBarStore((s) => s.hidden);
+
+  // Hidden en mode fullscreen analyse — l'écran consommateur appelle
+  // setTabBarHidden(true) via useEffect, et false au démontage / sortie.
+  if (hidden) return null;
 
   // Only show routes that have a TAB_META entry
   const visibleRoutes = useMemo(

--- a/mobile/src/components/ui/DismissKeyboardView.tsx
+++ b/mobile/src/components/ui/DismissKeyboardView.tsx
@@ -1,0 +1,50 @@
+/**
+ * DismissKeyboardView — Wrapper qui dismiss le clavier sur tap-outside.
+ *
+ * Posé en racine de l'app au-dessus du `<Slot />`, il intercepte tous les taps
+ * qui ne sont pas absorbés par un enfant interactif (TextInput, Pressable,
+ * Button, ScrollView avec keyboardShouldPersistTaps, etc.). Lorsqu'un tap
+ * "vide" est détecté, on appelle `Keyboard.dismiss()`.
+ *
+ * Pourquoi `Pressable` plutôt que `TouchableWithoutFeedback` ?
+ * - `Pressable` propage correctement aux enfants et coopère avec le système
+ *   de responder de RN sans dépendre du wrap inutile en single child.
+ * - `accessible={false}` empêche le wrapper d'apparaître comme un élément
+ *   focusable pour les lecteurs d'écran.
+ *
+ * NB : on n'utilise PAS `pointerEvents="box-none"` car on a besoin de capter
+ * le tap quand il atteint le wrapper (pas absorbé en amont).
+ */
+
+import React from "react";
+import {
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  type ViewProps,
+} from "react-native";
+
+export const DismissKeyboardView: React.FC<ViewProps> = ({
+  children,
+  style,
+  ...rest
+}) => {
+  return (
+    <Pressable
+      onPress={() => Keyboard.dismiss()}
+      style={[styles.container, style]}
+      accessible={false}
+      android_disableSound
+      android_ripple={null}
+      {...rest}
+    >
+      {children}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+});
+
+export default DismissKeyboardView;

--- a/mobile/src/hooks/useTabBarFootprint.ts
+++ b/mobile/src/hooks/useTabBarFootprint.ts
@@ -1,0 +1,22 @@
+/**
+ * useTabBarFootprint — Hauteur effective réservée par la TabBar globale
+ * (CustomTabBar) au bas de chaque écran tabbed.
+ *
+ * Calcul : TAB_BAR_HEIGHT (56) + safe-area bottom + un peu de marge (`sp.md`).
+ *
+ * À utiliser comme `paddingBottom` du `ScrollView`/`FlatList` racine d'un
+ * écran de l'onglet `(tabs)/...` pour que le dernier élément de la liste
+ * ne soit jamais caché derrière la barre.
+ *
+ * En mode fullscreen (TabBar cachée via `tabBarStore`), n'appelle pas ce
+ * hook : utilise simplement `insets.bottom`.
+ */
+
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { TAB_BAR_HEIGHT } from "../components/navigation/CustomTabBar";
+import { sp } from "../theme/spacing";
+
+export function useTabBarFootprint(): number {
+  const insets = useSafeAreaInsets();
+  return TAB_BAR_HEIGHT + Math.max(insets.bottom, sp.sm) + sp.md;
+}

--- a/mobile/src/stores/tabBarStore.ts
+++ b/mobile/src/stores/tabBarStore.ts
@@ -1,0 +1,24 @@
+/**
+ * tabBarStore — Contrôle global de la visibilité de la TabBar custom.
+ *
+ * Le `<CustomTabBar>` (rendu via `<Tabs tabBar={...}>` dans `(tabs)/_layout.tsx`)
+ * lit `useTabBarStore` pour décider s'il s'affiche. En mode fullscreen analyse,
+ * un écran (`analysis/[id].tsx`) appelle `setTabBarHidden(true)` au montage et
+ * `setTabBarHidden(false)` au démontage / sortie du fullscreen.
+ *
+ * NB : on ne peut pas passer par `useNavigation().setOptions({ tabBarStyle })`
+ * car notre TabBar custom ne lit pas `descriptors[].options.tabBarStyle`. Un
+ * store global Zustand est la voie la plus simple et explicite.
+ */
+
+import { create } from "zustand";
+
+export interface TabBarStore {
+  hidden: boolean;
+  setTabBarHidden: (hidden: boolean) => void;
+}
+
+export const useTabBarStore = create<TabBarStore>((set) => ({
+  hidden: false,
+  setTabBarHidden: (hidden) => set({ hidden }),
+}));


### PR DESCRIPTION
## Summary
Audit UX préalable identifie 6 issues high severity. Toutes fixées en 6 commits atomiques.

| Issue | Fix |
|---|---|
| #1 TabBar visible en fullscreen analyse | Pivot architectural : `tabBarStore` Zustand consommé par `<CustomTabBar>` (custom render n'honore pas `setOptions({tabBarStyle})`) |
| #2 `handleBack` ne gère pas `backTo=study` | Ajout routes `study/home/library` + `VideoStudyCard` passe `backTo: "study"` |
| #3 Tap-outside dismiss clavier global | `<DismissKeyboardView>` (Pressable) wrappe le Stack racine dans `_layout.tsx` |
| #4 `ConversationScreen` pas edge-to-edge | Retire paddings inner, `<StatusBar translucent>`, Header gère `insets.top`, Input gère `insets.bottom`, `keyboardVerticalOffset → 0` |
| #5 `paddingBottom` hard-coded incohérent | `useTabBarFootprint()` hook (SSOT `TAB_BAR_HEIGHT`) appliqué à 5 écrans + `AnalysisContentDisplay` `bottomPadding` prop |
| #6 `keyboardShouldPersistTaps` manquant | Ajouté sur ScrollView/FlatList contenant TextInput (study, library, ChatView, ConversationFeed) |

## Tests
- **+6 tests Jest** : 3 DismissKeyboardView + 3 useTabBarFootprint
- **272/277 passing** (5 fails `VoiceButton.*` préexistants tracked vault, hors scope confirmé)
- Typecheck `tsc --noEmit` : 0 erreur

## Smoke testing à valider sur device (post-merge OTA)
- Animation Modal ConversationScreen edge-to-edge (`SlideInDown + FadeIn`)
- `keyboardVerticalOffset=0` sur Android avec gesture nav
- TabBar hide/show transition fullscreen analyse
- DismissKeyboardView wrappant Stack — vérifier pas de blocage navigation Expo Router

## Verbatim user déclencheur
> "audit aussi Les problèmes de navigation et les écrans d'analyses qui ne peuvent pas s'afficher en grand écran et sur toute la page... le hub soit en plein écran, mais qu'on puisse quand même appuyer pour écrire, mais que, quand on écrive, ça ne cache pas. Le texte ou alors on puisse appuyer sur le texte pour enlever le clavier, etc., partout sur l'application."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>