### PR TITLE
feat(mobile): Hub polish — animations + haptic + micro-interactions

### DIFF
--- a/mobile/__tests__/components/conversation/ContextProgressBanner.test.tsx
+++ b/mobile/__tests__/components/conversation/ContextProgressBanner.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Tests for ContextProgressBanner.
+ * Verifies render per state (streaming vs complete) + clamped progress.
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+import { ContextProgressBanner } from "../../../src/components/conversation/ContextProgressBanner";
+
+describe("ContextProgressBanner", () => {
+  it("renders streaming label with floor(progress)%", () => {
+    const { getByText, getByTestId } = render(
+      <ContextProgressBanner progress={42.7} complete={false} />,
+    );
+    expect(getByTestId("context-progress-banner")).toBeTruthy();
+    expect(getByText(/Analyse en cours : 42%/)).toBeTruthy();
+  });
+
+  it("renders complete label when complete=true", () => {
+    const { getByText } = render(
+      <ContextProgressBanner progress={100} complete={true} />,
+    );
+    expect(getByText(/Contexte vidéo complet/)).toBeTruthy();
+  });
+
+  it("does NOT render the streaming label once complete", () => {
+    const { queryByText } = render(
+      <ContextProgressBanner progress={100} complete={true} />,
+    );
+    expect(queryByText(/Analyse en cours/)).toBeNull();
+  });
+
+  it("clamps progress > 100 to 100% in label", () => {
+    const { getByText } = render(
+      <ContextProgressBanner progress={150} complete={false} />,
+    );
+    expect(getByText(/Analyse en cours : 100%/)).toBeTruthy();
+  });
+
+  it("clamps progress < 0 to 0% in label", () => {
+    const { getByText } = render(
+      <ContextProgressBanner progress={-25} complete={false} />,
+    );
+    expect(getByText(/Analyse en cours : 0%/)).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/components/conversation/ConversationFeedBubble.test.tsx
+++ b/mobile/__tests__/components/conversation/ConversationFeedBubble.test.tsx
@@ -2,9 +2,12 @@
  * Tests for ConversationFeedBubble.
  * Verifies bubble rendering : user text, assistant text (markdown),
  * assistant voice (with mic badge), audio user invisible.
+ *
+ * Polish (mai 2026) : long-press copy + haptic + onCopy callback.
  */
 import React from "react";
-import { render } from "@testing-library/react-native";
+import { act, fireEvent, render } from "@testing-library/react-native";
+import * as Clipboard from "expo-clipboard";
 
 // Mock ThemeContext (avoid loading storage / async-storage chain)
 jest.mock("../../../src/contexts/ThemeContext", () => {
@@ -31,7 +34,20 @@ jest.mock("react-native-markdown-display", () => {
   };
 });
 
+jest.mock("../../../src/utils/haptics", () => ({
+  haptics: {
+    selection: jest.fn(() => Promise.resolve()),
+    light: jest.fn(() => Promise.resolve()),
+    medium: jest.fn(() => Promise.resolve()),
+    heavy: jest.fn(() => Promise.resolve()),
+    success: jest.fn(() => Promise.resolve()),
+    warning: jest.fn(() => Promise.resolve()),
+    error: jest.fn(() => Promise.resolve()),
+  },
+}));
+
 import { ConversationFeedBubble } from "../../../src/components/conversation/ConversationFeedBubble";
+import { haptics } from "../../../src/utils/haptics";
 import type { UnifiedMessage } from "../../../src/hooks/useConversation";
 
 const baseTimestamp = Date.now();
@@ -62,6 +78,10 @@ const assistantVoiceMessage: UnifiedMessage = {
 };
 
 describe("ConversationFeedBubble", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders user text bubble (with content)", () => {
     const { getByText } = render(
       <ConversationFeedBubble message={userTextMessage} />,
@@ -96,5 +116,59 @@ describe("ConversationFeedBubble", () => {
       <ConversationFeedBubble message={userTextMessage} />,
     );
     expect(queryByTestId("voice-badge-mic")).toBeNull();
+  });
+
+  it("long-press on user bubble copies content to clipboard + haptic success", async () => {
+    const onCopy = jest.fn();
+    (Clipboard.setStringAsync as jest.Mock).mockResolvedValueOnce(true);
+    const { getByLabelText } = render(
+      <ConversationFeedBubble message={userTextMessage} onCopy={onCopy} />,
+    );
+    const bubble = getByLabelText(/Vous.*hello world/);
+    await act(async () => {
+      fireEvent(bubble, "longPress");
+    });
+    expect(Clipboard.setStringAsync).toHaveBeenCalledWith("hello world");
+    expect(haptics.success).toHaveBeenCalled();
+    expect(onCopy).toHaveBeenCalledWith("hello world");
+  });
+
+  it("long-press on assistant bubble copies content + onCopy callback", async () => {
+    const onCopy = jest.fn();
+    (Clipboard.setStringAsync as jest.Mock).mockResolvedValueOnce(true);
+    const { getByLabelText } = render(
+      <ConversationFeedBubble
+        message={assistantTextMessage}
+        onCopy={onCopy}
+      />,
+    );
+    const bubble = getByLabelText(/Assistant.*bold/);
+    await act(async () => {
+      fireEvent(bubble, "longPress");
+    });
+    expect(Clipboard.setStringAsync).toHaveBeenCalledWith("**bold** reply");
+    expect(onCopy).toHaveBeenCalledWith("**bold** reply");
+  });
+
+  it("long-press fires haptics.error on clipboard failure", async () => {
+    (Clipboard.setStringAsync as jest.Mock).mockRejectedValueOnce(
+      new Error("clipboard unavailable"),
+    );
+    const { getByLabelText } = render(
+      <ConversationFeedBubble message={userTextMessage} />,
+    );
+    const bubble = getByLabelText(/Vous/);
+    await act(async () => {
+      fireEvent(bubble, "longPress");
+    });
+    expect(haptics.error).toHaveBeenCalled();
+    expect(haptics.success).not.toHaveBeenCalled();
+  });
+
+  it("accessibility label includes role + voice tag for voice agent message", () => {
+    const { getByLabelText } = render(
+      <ConversationFeedBubble message={assistantVoiceMessage} />,
+    );
+    expect(getByLabelText(/Assistant \(voix\).*spoken reply/)).toBeTruthy();
   });
 });

--- a/mobile/__tests__/components/conversation/ConversationHeader.test.tsx
+++ b/mobile/__tests__/components/conversation/ConversationHeader.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for ConversationHeader.
+ * Verifies callbacks + haptics on settings/close + title rendering.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+jest.mock("../../../src/contexts/ThemeContext", () => {
+  const { darkColors } = jest.requireActual("../../../src/theme/colors");
+  return {
+    useTheme: () => ({
+      colors: darkColors,
+      isDark: true,
+      theme: "dark" as const,
+      setTheme: jest.fn(),
+      toggleTheme: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("../../../src/components/voice/VoiceQuotaBadge", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    VoiceQuotaBadge: ({ minutesRemaining }: { minutesRemaining: number }) =>
+      React.createElement(View, {
+        testID: "voice-quota-badge",
+        accessibilityLabel: `${minutesRemaining} minutes`,
+      }),
+  };
+});
+
+jest.mock("../../../src/utils/haptics", () => ({
+  haptics: {
+    selection: jest.fn(() => Promise.resolve()),
+    light: jest.fn(() => Promise.resolve()),
+    medium: jest.fn(() => Promise.resolve()),
+    heavy: jest.fn(() => Promise.resolve()),
+    success: jest.fn(() => Promise.resolve()),
+    warning: jest.fn(() => Promise.resolve()),
+    error: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { ConversationHeader } from "../../../src/components/conversation/ConversationHeader";
+import { haptics } from "../../../src/utils/haptics";
+
+const baseProps = {
+  videoTitle: "Comment programmer en TypeScript",
+  channelName: "Tech Channel",
+  platform: "youtube" as const,
+  remainingMinutes: 12,
+  onOpenSettings: jest.fn(),
+  onOpenAddon: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("ConversationHeader", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders title + channel", () => {
+    const { getByText } = render(<ConversationHeader {...baseProps} />);
+    expect(getByText("Comment programmer en TypeScript")).toBeTruthy();
+    expect(getByText("Tech Channel")).toBeTruthy();
+  });
+
+  it("renders YT badge for youtube platform", () => {
+    const { getByText } = render(<ConversationHeader {...baseProps} />);
+    expect(getByText("YT")).toBeTruthy();
+  });
+
+  it("renders TikTok badge for tiktok platform", () => {
+    const { getByText } = render(
+      <ConversationHeader {...baseProps} platform="tiktok" />,
+    );
+    expect(getByText("TikTok")).toBeTruthy();
+  });
+
+  it("renders Live badge for live platform", () => {
+    const { getByText } = render(
+      <ConversationHeader {...baseProps} platform="live" />,
+    );
+    expect(getByText("Live")).toBeTruthy();
+  });
+
+  it("fires haptics.light + onOpenSettings on settings tap", () => {
+    const onOpenSettings = jest.fn();
+    const { getByTestId } = render(
+      <ConversationHeader {...baseProps} onOpenSettings={onOpenSettings} />,
+    );
+    fireEvent.press(getByTestId("header-settings"));
+    expect(haptics.light).toHaveBeenCalled();
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires haptics.light + onClose on close tap", () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <ConversationHeader {...baseProps} onClose={onClose} />,
+    );
+    fireEvent.press(getByTestId("header-close"));
+    expect(haptics.light).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders VoiceQuotaBadge with remainingMinutes", () => {
+    const { getByLabelText } = render(
+      <ConversationHeader {...baseProps} remainingMinutes={42} />,
+    );
+    expect(getByLabelText("42 minutes")).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/components/conversation/EmptyConversationSuggestions.test.tsx
+++ b/mobile/__tests__/components/conversation/EmptyConversationSuggestions.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for EmptyConversationSuggestions.
+ * Verifies render of default suggestions, custom override, and onSelect + haptic.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+jest.mock("../../../src/contexts/ThemeContext", () => {
+  const { darkColors } = jest.requireActual("../../../src/theme/colors");
+  return {
+    useTheme: () => ({
+      colors: darkColors,
+      isDark: true,
+      theme: "dark" as const,
+      setTheme: jest.fn(),
+      toggleTheme: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("../../../src/utils/haptics", () => ({
+  haptics: {
+    selection: jest.fn(() => Promise.resolve()),
+    light: jest.fn(() => Promise.resolve()),
+    medium: jest.fn(() => Promise.resolve()),
+    heavy: jest.fn(() => Promise.resolve()),
+    success: jest.fn(() => Promise.resolve()),
+    warning: jest.fn(() => Promise.resolve()),
+    error: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { EmptyConversationSuggestions } from "../../../src/components/conversation/EmptyConversationSuggestions";
+import { haptics } from "../../../src/utils/haptics";
+
+describe("EmptyConversationSuggestions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the container + heading", () => {
+    const onSelect = jest.fn();
+    const { getByTestId, getByText } = render(
+      <EmptyConversationSuggestions onSelect={onSelect} />,
+    );
+    expect(getByTestId("empty-conversation-suggestions")).toBeTruthy();
+    expect(getByText("Suggestions pour démarrer")).toBeTruthy();
+  });
+
+  it("renders 3 default suggestion chips", () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <EmptyConversationSuggestions onSelect={onSelect} />,
+    );
+    expect(getByText("Quels sont les points clés ?")).toBeTruthy();
+    expect(getByText("Résume en 3 points")).toBeTruthy();
+    expect(getByText("Quelles sources cite la vidéo ?")).toBeTruthy();
+  });
+
+  it("calls onSelect with the chip text + haptics.light on tap", () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(
+      <EmptyConversationSuggestions onSelect={onSelect} />,
+    );
+    fireEvent.press(getByTestId("suggestion-chip-1"));
+    expect(haptics.light).toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledWith("Résume en 3 points");
+  });
+
+  it("uses custom suggestions array when provided", () => {
+    const onSelect = jest.fn();
+    const custom = ["Q1 ?", "Q2 ?"];
+    const { getByText, queryByText } = render(
+      <EmptyConversationSuggestions onSelect={onSelect} suggestions={custom} />,
+    );
+    expect(getByText("Q1 ?")).toBeTruthy();
+    expect(getByText("Q2 ?")).toBeTruthy();
+    expect(queryByText("Quels sont les points clés ?")).toBeNull();
+  });
+
+  it("caps the list at 4 chips for vertical density", () => {
+    const onSelect = jest.fn();
+    const custom = ["A", "B", "C", "D", "E", "F"];
+    const { queryByText } = render(
+      <EmptyConversationSuggestions onSelect={onSelect} suggestions={custom} />,
+    );
+    expect(queryByText("A")).toBeTruthy();
+    expect(queryByText("D")).toBeTruthy();
+    expect(queryByText("E")).toBeNull();
+    expect(queryByText("F")).toBeNull();
+  });
+});

--- a/mobile/__tests__/components/conversation/EndedToast.test.tsx
+++ b/mobile/__tests__/components/conversation/EndedToast.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Tests for EndedToast.
+ * Verifies render + duration formatting + haptic success on mount.
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+jest.mock("../../../src/contexts/ThemeContext", () => {
+  const { darkColors } = jest.requireActual("../../../src/theme/colors");
+  return {
+    useTheme: () => ({
+      colors: darkColors,
+      isDark: true,
+      theme: "dark" as const,
+      setTheme: jest.fn(),
+      toggleTheme: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("../../../src/utils/haptics", () => ({
+  haptics: {
+    selection: jest.fn(() => Promise.resolve()),
+    light: jest.fn(() => Promise.resolve()),
+    medium: jest.fn(() => Promise.resolve()),
+    heavy: jest.fn(() => Promise.resolve()),
+    success: jest.fn(() => Promise.resolve()),
+    warning: jest.fn(() => Promise.resolve()),
+    error: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { EndedToast } from "../../../src/components/conversation/EndedToast";
+import { haptics } from "../../../src/utils/haptics";
+
+describe("EndedToast", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the toast container", () => {
+    const { getByTestId } = render(<EndedToast durationSeconds={75} />);
+    expect(getByTestId("ended-toast")).toBeTruthy();
+  });
+
+  it("formats duration as MM:SS in label", () => {
+    const { getByText } = render(<EndedToast durationSeconds={75} />);
+    expect(getByText(/Appel terminé · 01:15 min/)).toBeTruthy();
+  });
+
+  it("formats duration < 60s with leading zero minutes", () => {
+    const { getByText } = render(<EndedToast durationSeconds={45} />);
+    expect(getByText(/Appel terminé · 00:45 min/)).toBeTruthy();
+  });
+
+  it("fires haptics.success on mount", () => {
+    render(<EndedToast durationSeconds={30} />);
+    expect(haptics.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the auto-dismiss progress bar", () => {
+    const { getByTestId } = render(<EndedToast durationSeconds={30} />);
+    expect(getByTestId("ended-toast-progress")).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/components/conversation/MiniActionBar.test.tsx
+++ b/mobile/__tests__/components/conversation/MiniActionBar.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for MiniActionBar.
+ * Verifies callbacks + haptics per button + isUpgrading + isFavorite states.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+jest.mock("../../../src/contexts/ThemeContext", () => {
+  const { darkColors } = jest.requireActual("../../../src/theme/colors");
+  return {
+    useTheme: () => ({
+      colors: darkColors,
+      isDark: true,
+      theme: "dark" as const,
+      setTheme: jest.fn(),
+      toggleTheme: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("../../../src/components/ui/DeepSightSpinner", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    DeepSightSpinner: () => React.createElement(View, { testID: "spinner" }),
+  };
+});
+
+jest.mock("../../../src/utils/haptics", () => ({
+  haptics: {
+    selection: jest.fn(() => Promise.resolve()),
+    light: jest.fn(() => Promise.resolve()),
+    medium: jest.fn(() => Promise.resolve()),
+    heavy: jest.fn(() => Promise.resolve()),
+    success: jest.fn(() => Promise.resolve()),
+    warning: jest.fn(() => Promise.resolve()),
+    error: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { MiniActionBar } from "../../../src/components/conversation/MiniActionBar";
+import { haptics } from "../../../src/utils/haptics";
+
+const baseProps = {
+  isFavorite: false,
+  onViewAnalysis: jest.fn(),
+  onToggleFavorite: jest.fn(),
+  onShare: jest.fn(),
+};
+
+describe("MiniActionBar", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders all 3 actions", () => {
+    const { getByTestId } = render(<MiniActionBar {...baseProps} />);
+    expect(getByTestId("mini-action-favorite")).toBeTruthy();
+    expect(getByTestId("mini-action-view-analysis")).toBeTruthy();
+    expect(getByTestId("mini-action-share")).toBeTruthy();
+  });
+
+  it("fires haptics.light + onToggleFavorite on Favori tap", () => {
+    const onToggleFavorite = jest.fn();
+    const { getByTestId } = render(
+      <MiniActionBar {...baseProps} onToggleFavorite={onToggleFavorite} />,
+    );
+    fireEvent.press(getByTestId("mini-action-favorite"));
+    expect(haptics.light).toHaveBeenCalled();
+    expect(onToggleFavorite).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires haptics.medium + onViewAnalysis on Analyse complète tap", () => {
+    const onViewAnalysis = jest.fn();
+    const { getByTestId } = render(
+      <MiniActionBar {...baseProps} onViewAnalysis={onViewAnalysis} />,
+    );
+    fireEvent.press(getByTestId("mini-action-view-analysis"));
+    expect(haptics.medium).toHaveBeenCalled();
+    expect(onViewAnalysis).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires haptics.light + onShare on Partager tap", () => {
+    const onShare = jest.fn();
+    const { getByTestId } = render(
+      <MiniActionBar {...baseProps} onShare={onShare} />,
+    );
+    fireEvent.press(getByTestId("mini-action-share"));
+    expect(haptics.light).toHaveBeenCalled();
+    expect(onShare).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders spinner when isUpgrading=true", () => {
+    const { getByTestId, queryByText } = render(
+      <MiniActionBar {...baseProps} isUpgrading={true} />,
+    );
+    expect(getByTestId("spinner")).toBeTruthy();
+    expect(queryByText("Lancement...")).toBeTruthy();
+  });
+
+  it("disables Analyse complète tap when isUpgrading=true", () => {
+    const onViewAnalysis = jest.fn();
+    const { getByTestId } = render(
+      <MiniActionBar
+        {...baseProps}
+        isUpgrading={true}
+        onViewAnalysis={onViewAnalysis}
+      />,
+    );
+    fireEvent.press(getByTestId("mini-action-view-analysis"));
+    expect(onViewAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("disables Analyse complète tap when canViewAnalysis=false", () => {
+    const onViewAnalysis = jest.fn();
+    const { getByTestId } = render(
+      <MiniActionBar
+        {...baseProps}
+        canViewAnalysis={false}
+        onViewAnalysis={onViewAnalysis}
+      />,
+    );
+    fireEvent.press(getByTestId("mini-action-view-analysis"));
+    expect(onViewAnalysis).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/__tests__/components/conversation/VoiceControls.test.tsx
+++ b/mobile/__tests__/components/conversation/VoiceControls.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for VoiceControls — focus on testable behaviors :
+ * - haptics fired on Mute / End / Upgrade taps
+ * - haptics.success fired on live → ended state transition
+ * - callbacks invoked
+ * - rendering per voiceMode
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+jest.mock("../../../src/contexts/ThemeContext", () => {
+  const { darkColors } = jest.requireActual("../../../src/theme/colors");
+  return {
+    useTheme: () => ({
+      colors: darkColors,
+      isDark: true,
+      theme: "dark" as const,
+      setTheme: jest.fn(),
+      toggleTheme: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("../../../src/components/voice/VoiceAddonModal", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ visible }: { visible: boolean }) =>
+      visible ? React.createElement(View, { testID: "addon-modal" }) : null,
+  };
+});
+
+jest.mock("../../../src/utils/haptics", () => ({
+  haptics: {
+    selection: jest.fn(() => Promise.resolve()),
+    light: jest.fn(() => Promise.resolve()),
+    medium: jest.fn(() => Promise.resolve()),
+    heavy: jest.fn(() => Promise.resolve()),
+    success: jest.fn(() => Promise.resolve()),
+    warning: jest.fn(() => Promise.resolve()),
+    error: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { VoiceControls } from "../../../src/components/conversation/VoiceControls";
+import { haptics } from "../../../src/utils/haptics";
+
+const baseProps = {
+  isMuted: false,
+  elapsedSeconds: 12,
+  remainingMinutes: 5,
+  onToggleMute: jest.fn(),
+  onEnd: jest.fn(),
+};
+
+describe("VoiceControls", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders 'off' label when voiceMode === off", () => {
+    const { getByText } = render(
+      <VoiceControls voiceMode="off" {...baseProps} />,
+    );
+    expect(getByText("Appel non démarré")).toBeTruthy();
+  });
+
+  it("renders nothing when voiceMode === ended", () => {
+    const { toJSON } = render(
+      <VoiceControls voiceMode="ended" {...baseProps} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders quota_exceeded card with upgrade CTA", () => {
+    const { getByLabelText } = render(
+      <VoiceControls voiceMode="quota_exceeded" {...baseProps} />,
+    );
+    expect(getByLabelText("Acheter des minutes")).toBeTruthy();
+  });
+
+  it("fires haptics.medium and onToggleMute on mute tap (live)", () => {
+    const onToggleMute = jest.fn();
+    const { getByLabelText } = render(
+      <VoiceControls
+        voiceMode="live"
+        {...baseProps}
+        onToggleMute={onToggleMute}
+      />,
+    );
+    fireEvent.press(getByLabelText("Couper micro"));
+    expect(haptics.medium).toHaveBeenCalled();
+    expect(onToggleMute).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires haptics.medium and onEnd on End tap (live)", () => {
+    const onEnd = jest.fn();
+    const { getByLabelText } = render(
+      <VoiceControls voiceMode="live" {...baseProps} onEnd={onEnd} />,
+    );
+    fireEvent.press(getByLabelText("Terminer l'appel"));
+    expect(haptics.medium).toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens VoiceAddonModal + fires haptic on Upgrade tap (quota_exceeded)", () => {
+    const { getByLabelText, getByTestId } = render(
+      <VoiceControls voiceMode="quota_exceeded" {...baseProps} />,
+    );
+    fireEvent.press(getByLabelText("Acheter des minutes"));
+    expect(haptics.medium).toHaveBeenCalled();
+    expect(getByTestId("addon-modal")).toBeTruthy();
+  });
+
+  it("fires haptics.success when transitioning live → ended", () => {
+    const { rerender } = render(
+      <VoiceControls voiceMode="live" {...baseProps} />,
+    );
+    expect(haptics.success).not.toHaveBeenCalled();
+    rerender(<VoiceControls voiceMode="ended" {...baseProps} />);
+    expect(haptics.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire haptics.success when transitioning off → live", () => {
+    const { rerender } = render(
+      <VoiceControls voiceMode="off" {...baseProps} />,
+    );
+    rerender(<VoiceControls voiceMode="live" {...baseProps} />);
+    expect(haptics.success).not.toHaveBeenCalled();
+  });
+
+  it("renders correct mute label when isMuted=true", () => {
+    const { getByLabelText } = render(
+      <VoiceControls voiceMode="live" {...baseProps} isMuted={true} />,
+    );
+    expect(getByLabelText("Réactiver micro")).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/utils/haptics.test.ts
+++ b/mobile/__tests__/utils/haptics.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the `haptics` helper wrapper.
+ * Verifies each method maps to the expected expo-haptics call.
+ */
+import * as Haptics from "expo-haptics";
+import { haptics } from "../../src/utils/haptics";
+
+describe("haptics helper", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("selection() calls Haptics.selectionAsync", async () => {
+    await haptics.selection();
+    expect(Haptics.selectionAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("light() calls impactAsync with Light style", async () => {
+    await haptics.light();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(
+      Haptics.ImpactFeedbackStyle.Light,
+    );
+  });
+
+  it("medium() calls impactAsync with Medium style", async () => {
+    await haptics.medium();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(
+      Haptics.ImpactFeedbackStyle.Medium,
+    );
+  });
+
+  it("heavy() calls impactAsync with Heavy style", async () => {
+    await haptics.heavy();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(
+      Haptics.ImpactFeedbackStyle.Heavy,
+    );
+  });
+
+  it("success() calls notificationAsync with Success type", async () => {
+    await haptics.success();
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+      Haptics.NotificationFeedbackType.Success,
+    );
+  });
+
+  it("warning() calls notificationAsync with Warning type", async () => {
+    await haptics.warning();
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+      Haptics.NotificationFeedbackType.Warning,
+    );
+  });
+
+  it("error() calls notificationAsync with Error type", async () => {
+    await haptics.error();
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+      Haptics.NotificationFeedbackType.Error,
+    );
+  });
+
+  it("swallows errors thrown by expo-haptics", async () => {
+    (Haptics.impactAsync as jest.Mock).mockRejectedValueOnce(
+      new Error("no haptic engine"),
+    );
+    await expect(haptics.medium()).resolves.toBeUndefined();
+  });
+});

--- a/mobile/src/components/conversation/ContextProgressBanner.tsx
+++ b/mobile/src/components/conversation/ContextProgressBanner.tsx
@@ -5,11 +5,25 @@
  * Voice Call V3 sur vidéo fraîche). Visualise les events SSE
  * `transcript_chunk` / `analysis_partial` / `ctx_complete`.
  *
- * Repris de la section `contextProgressContainer` de `VoiceScreen.tsx`.
+ * Polish (mai 2026) :
+ * - Pulse opacity sur le label tant que la barre n'est pas complete (effet "live")
+ * - Shimmer animé sur la fill bar (overlay translateX)
+ * - Animation d'entrée FadeIn / sortie FadeOut quand passage à complete
+ * - Couleurs ambre #f5b400 sur fond sombre : ratio contraste ~9:1 (AAA)
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { View, Text, StyleSheet } from "react-native";
+import Animated, {
+  FadeIn,
+  FadeOut,
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withSequence,
+  withTiming,
+  Easing,
+} from "react-native-reanimated";
 import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize } from "../../theme/typography";
 
@@ -18,12 +32,55 @@ interface ContextProgressBannerProps {
   complete: boolean;
 }
 
+const ACCENT = "#f5b400";
+
 export const ContextProgressBanner: React.FC<ContextProgressBannerProps> = ({
   progress,
   complete,
 }) => {
+  // Pulse opacity sur le label tant que streaming actif
+  const labelOpacity = useSharedValue(1);
+  // Shimmer translate sur la fill bar
+  const shimmerX = useSharedValue(-100);
+
+  useEffect(() => {
+    if (complete) {
+      labelOpacity.value = withTiming(1, { duration: 200 });
+      shimmerX.value = -100;
+      return;
+    }
+    labelOpacity.value = withRepeat(
+      withSequence(
+        withTiming(0.55, { duration: 800, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1, { duration: 800, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1,
+      false,
+    );
+    shimmerX.value = withRepeat(
+      withTiming(120, {
+        duration: 1400,
+        easing: Easing.inOut(Easing.ease),
+      }),
+      -1,
+      false,
+    );
+  }, [complete, labelOpacity, shimmerX]);
+
+  const labelStyle = useAnimatedStyle(() => ({
+    opacity: labelOpacity.value,
+  }));
+
+  const shimmerStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: `${shimmerX.value}%` as unknown as number }],
+  }));
+
+  const clampedProgress = Math.max(0, Math.min(100, progress));
+
   return (
-    <View
+    <Animated.View
+      entering={FadeIn.duration(220)}
+      exiting={FadeOut.duration(180)}
       testID="context-progress-banner"
       style={[
         styles.container,
@@ -35,10 +92,10 @@ export const ContextProgressBanner: React.FC<ContextProgressBannerProps> = ({
     >
       {!complete ? (
         <>
-          <Text style={[styles.label, { color: "#f5b400" }]}>
-            🎙️ J'écoute la vidéo en même temps que toi · Analyse en cours :{" "}
-            {Math.floor(progress)}%
-          </Text>
+          <Animated.Text style={[styles.label, { color: ACCENT }, labelStyle]}>
+            J'écoute la vidéo en même temps que toi · Analyse en cours :{" "}
+            {Math.floor(clampedProgress)}%
+          </Animated.Text>
           <View
             style={[
               styles.track,
@@ -49,19 +106,24 @@ export const ContextProgressBanner: React.FC<ContextProgressBannerProps> = ({
               style={[
                 styles.fill,
                 {
-                  backgroundColor: "#f5b400",
-                  width: `${Math.max(0, Math.min(100, progress))}%`,
+                  backgroundColor: ACCENT,
+                  width: `${clampedProgress}%`,
                 },
               ]}
-            />
+            >
+              <Animated.View
+                pointerEvents="none"
+                style={[styles.shimmer, shimmerStyle]}
+              />
+            </View>
           </View>
         </>
       ) : (
-        <Text style={[styles.label, { color: "#f5b400" }]}>
+        <Text style={[styles.label, { color: ACCENT }]}>
           ✓ Contexte vidéo complet
         </Text>
       )}
-    </View>
+    </Animated.View>
   );
 };
 
@@ -88,6 +150,15 @@ const styles = StyleSheet.create({
   fill: {
     height: "100%",
     borderRadius: 2,
+    overflow: "hidden",
+  },
+  shimmer: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    bottom: 0,
+    width: "60%",
+    backgroundColor: "rgba(255,255,255,0.35)",
   },
 });
 

--- a/mobile/src/components/conversation/ConversationFeedBubble.tsx
+++ b/mobile/src/components/conversation/ConversationFeedBubble.tsx
@@ -4,55 +4,162 @@
  * Rend :
  * - User text : bulle indigo, alignée à droite
  * - Assistant text : bulle card (bg + border), alignée gauche, markdown via ChatMarkdown
- * - Assistant voice : idem assistant text + badge 🎙️ (icône mic + label "voix")
+ * - Assistant voice : idem assistant text + badge mic (icône + label "voix")
  *
  * Note : audio user (`source='voice'` + `voiceSpeaker='user'`) est filtré en
  * amont par `useConversation` (règle UX DeepSight). Cette bulle n'a donc pas
  * de cas "user voice" à gérer.
+ *
+ * Polish (mai 2026) :
+ * - Animation entrée FadeInDown.springify() (Reanimated 4 layout animation)
+ * - Long-press → copy content to clipboard + haptic success
+ * - Pulse subtle sur le badge mic des messages voice agent récents (<2s)
+ * - Accessibilité enrichie (rôle text + label complet)
  */
 
-import React, { memo } from "react";
-import { View, Text, StyleSheet } from "react-native";
+import React, { memo, useCallback, useEffect, useMemo } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import Animated, {
+  FadeInDown,
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withSequence,
+  withTiming,
+  Easing,
+} from "react-native-reanimated";
+import * as Clipboard from "expo-clipboard";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../contexts/ThemeContext";
 import { ChatMarkdown } from "../analysis/ChatMarkdown";
 import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize, lineHeight } from "../../theme/typography";
 import { palette } from "../../theme/colors";
+import { haptics } from "../../utils/haptics";
 import type { UnifiedMessage } from "../../hooks/useConversation";
 
 interface ConversationFeedBubbleProps {
   message: UnifiedMessage;
+  /** Optional callback fired after a successful long-press copy.
+   *  Parent typically shows a toast "Copié". */
+  onCopy?: (content: string) => void;
 }
+
+const formatTimestamp = (ts: number): string => {
+  if (!ts) return "";
+  try {
+    const d = new Date(ts);
+    return `${String(d.getHours()).padStart(2, "0")}:${String(
+      d.getMinutes(),
+    ).padStart(2, "0")}`;
+  } catch {
+    return "";
+  }
+};
+
+// ─── Pulsing mic badge for very-recent voice agent messages ───
+const PulsingMicBadge: React.FC<{
+  isFresh: boolean;
+  borderColor: string;
+  iconColor: string;
+  textColor: string;
+}> = ({ isFresh, borderColor, iconColor, textColor }) => {
+  const pulse = useSharedValue(1);
+
+  useEffect(() => {
+    if (!isFresh) return;
+    pulse.value = withRepeat(
+      withSequence(
+        withTiming(1.08, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+      ),
+      3, // 3 cycles puis stop (~3.6s)
+      false,
+    );
+  }, [isFresh, pulse]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: pulse.value }],
+  }));
+
+  return (
+    <Animated.View
+      testID="voice-badge-mic"
+      style={[styles.voiceBadge, { borderColor }, animatedStyle]}
+    >
+      <Ionicons name="mic-outline" size={11} color={iconColor} />
+      <Text style={[styles.voiceBadgeLabel, { color: textColor }]}>voix</Text>
+    </Animated.View>
+  );
+};
 
 const ConversationFeedBubbleImpl: React.FC<ConversationFeedBubbleProps> = ({
   message,
+  onCopy,
 }) => {
   const { colors, isDark } = useTheme();
   const isUser = message.role === "user";
   const isVoiceAgent =
     message.source === "voice" && message.voiceSpeaker === "agent";
 
+  // Détecter si la bulle vient juste d'arriver (timestamp < 2s)
+  // Important : valeur figée au mount (un re-render ne doit pas relancer le pulse).
+  const isFreshVoice = useMemo(() => {
+    if (!isVoiceAgent) return false;
+    if (!message.timestamp) return false;
+    return Date.now() - message.timestamp < 2000;
+  }, [isVoiceAgent, message.timestamp]);
+
+  const handleLongPress = useCallback(async () => {
+    try {
+      await Clipboard.setStringAsync(message.content);
+      haptics.success();
+      onCopy?.(message.content);
+    } catch {
+      haptics.error();
+    }
+  }, [message.content, onCopy]);
+
+  const accessibilityLabel = useMemo(() => {
+    const role = isUser ? "Vous" : "Assistant";
+    const time = formatTimestamp(message.timestamp);
+    const voiceTag = isVoiceAgent ? " (voix)" : "";
+    const timeTag = time ? ` à ${time}` : "";
+    return `${role}${voiceTag}${timeTag} : ${message.content}`;
+  }, [isUser, isVoiceAgent, message.timestamp, message.content]);
+
   if (isUser) {
     return (
-      <View
-        style={[
-          styles.bubble,
-          styles.bubbleUser,
-          { backgroundColor: palette.indigo, borderColor: "transparent" },
-        ]}
-      >
-        <Text style={[styles.bubbleText, { color: palette.white }]} selectable>
-          {message.content}
-        </Text>
-      </View>
+      <Animated.View entering={FadeInDown.duration(250).springify()}>
+        <Pressable
+          onLongPress={handleLongPress}
+          delayLongPress={400}
+          accessibilityRole="text"
+          accessibilityLabel={accessibilityLabel}
+          accessibilityHint="Maintenir pour copier"
+          style={[
+            styles.bubble,
+            styles.bubbleUser,
+            { backgroundColor: palette.indigo, borderColor: "transparent" },
+          ]}
+        >
+          <Text style={[styles.bubbleText, { color: palette.white }]} selectable>
+            {message.content}
+          </Text>
+        </Pressable>
+      </Animated.View>
     );
   }
 
   // Assistant (texte ou voice agent)
   return (
-    <View>
-      <View
+    <Animated.View entering={FadeInDown.duration(250).springify()}>
+      <Pressable
+        onLongPress={handleLongPress}
+        delayLongPress={400}
+        accessibilityRole="text"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint="Maintenir pour copier"
         style={[
           styles.bubble,
           styles.bubbleAssistant,
@@ -64,26 +171,16 @@ const ConversationFeedBubbleImpl: React.FC<ConversationFeedBubbleProps> = ({
           textColor={colors.textPrimary}
           isDark={isDark}
         />
-      </View>
+      </Pressable>
       {isVoiceAgent ? (
-        <View
-          testID="voice-badge-mic"
-          style={[
-            styles.voiceBadge,
-            { borderColor: colors.borderLight },
-          ]}
-        >
-          <Ionicons
-            name="mic-outline"
-            size={11}
-            color={colors.textTertiary}
-          />
-          <Text style={[styles.voiceBadgeLabel, { color: colors.textTertiary }]}>
-            voix
-          </Text>
-        </View>
+        <PulsingMicBadge
+          isFresh={isFreshVoice}
+          borderColor={colors.borderLight}
+          iconColor={colors.textTertiary}
+          textColor={colors.textTertiary}
+        />
       ) : null}
-    </View>
+    </Animated.View>
   );
 };
 

--- a/mobile/src/components/conversation/ConversationHeader.tsx
+++ b/mobile/src/components/conversation/ConversationHeader.tsx
@@ -3,16 +3,38 @@
  * title (videoTitle) + plateforme badge + VoiceQuotaBadge + settings + close.
  *
  * Repris du pattern header de VoiceScreen.tsx (lignes 502-560).
+ *
+ * Polish (mai 2026) :
+ * - Settings icon : rotation 90° au press (Reanimated withSpring)
+ * - Title onPress : scroll horizontal smooth pour les titres tronqués (long videos)
+ * - Press scale 0.92 sur close button
+ * - haptics.light sur settings, selection sur title, light sur close
+ * - VoiceQuotaBadge déjà animé via son onPress (haptic interne)
  */
 
-import React from "react";
-import { View, Text, Pressable, StyleSheet, Platform } from "react-native";
+import React, { useRef, useState } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ScrollView,
+  type LayoutChangeEvent,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from "react-native";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
 import { Ionicons } from "@expo/vector-icons";
-import * as Haptics from "expo-haptics";
 import { useTheme } from "../../contexts/ThemeContext";
 import { VoiceQuotaBadge } from "../voice/VoiceQuotaBadge";
 import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize } from "../../theme/typography";
+import { haptics } from "../../utils/haptics";
 
 type Platform_ = "youtube" | "tiktok" | "live";
 
@@ -46,22 +68,88 @@ export const ConversationHeader: React.FC<ConversationHeaderProps> = ({
   const { colors } = useTheme();
   const badge = platformBadge(platform);
 
+  // Settings icon rotation
+  const settingsRotation = useSharedValue(0);
+  const settingsStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${settingsRotation.value}deg` }],
+  }));
+
+  // Close button press scale
+  const closeScale = useSharedValue(1);
+  const closeStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: closeScale.value }],
+  }));
+
+  // Title horizontal scroll (overflow long titles)
+  const titleScrollRef = useRef<ScrollView | null>(null);
+  const [titleContentWidth, setTitleContentWidth] = useState(0);
+  const [titleViewportWidth, setTitleViewportWidth] = useState(0);
+  const [titleScrollX, setTitleScrollX] = useState(0);
+
+  const titleOverflows = titleContentWidth > titleViewportWidth + 4;
+
   const handleSettings = () => {
-    if (Platform.OS !== "web") {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
-    }
+    haptics.light();
+    settingsRotation.value = withSpring(
+      settingsRotation.value === 0 ? 90 : 0,
+      { damping: 12, stiffness: 220 },
+    );
     onOpenSettings();
+  };
+
+  const handleClosePressIn = () => {
+    closeScale.value = withTiming(0.92, { duration: 80 });
+  };
+  const handleClosePressOut = () => {
+    closeScale.value = withSpring(1, { damping: 12, stiffness: 240 });
+  };
+  const handleClose = () => {
+    haptics.light();
+    onClose();
+  };
+
+  const handleTitlePress = () => {
+    if (!titleOverflows || !titleScrollRef.current) return;
+    haptics.selection();
+    // Toggle between start (0) and end of overflowing content
+    const targetX =
+      titleScrollX > 4
+        ? 0
+        : Math.max(0, titleContentWidth - titleViewportWidth);
+    titleScrollRef.current.scrollTo({ x: targetX, animated: true });
+  };
+
+  const handleTitleScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    setTitleScrollX(e.nativeEvent.contentOffset.x);
+  };
+
+  const handleTitleLayout = (e: LayoutChangeEvent) => {
+    setTitleViewportWidth(e.nativeEvent.layout.width);
   };
 
   return (
     <View style={[styles.header, { borderBottomColor: colors.border }]}>
-      <View style={styles.titles}>
-        <Text
-          numberOfLines={1}
-          style={[styles.title, { color: colors.textPrimary }]}
+      <Pressable
+        style={styles.titles}
+        onPress={handleTitlePress}
+        onLayout={handleTitleLayout}
+        accessibilityRole="header"
+        accessibilityLabel={`${videoTitle}${channelName ? ` — ${channelName}` : ""}`}
+      >
+        <ScrollView
+          ref={titleScrollRef}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          scrollEnabled={titleOverflows}
+          onScroll={handleTitleScroll}
+          onContentSizeChange={(w) => setTitleContentWidth(w)}
+          scrollEventThrottle={16}
+          contentContainerStyle={styles.titleScrollContent}
         >
-          {videoTitle}
-        </Text>
+          <Text style={[styles.title, { color: colors.textPrimary }]}>
+            {videoTitle}
+          </Text>
+        </ScrollView>
         {channelName ? (
           <Text
             numberOfLines={1}
@@ -70,7 +158,7 @@ export const ConversationHeader: React.FC<ConversationHeaderProps> = ({
             {channelName}
           </Text>
         ) : null}
-      </View>
+      </Pressable>
       <View style={[styles.badge, { backgroundColor: badge.bg }]}>
         <Text style={styles.badgeText}>{badge.label}</Text>
       </View>
@@ -81,6 +169,7 @@ export const ConversationHeader: React.FC<ConversationHeaderProps> = ({
       <Pressable
         onPress={handleSettings}
         hitSlop={12}
+        testID="header-settings"
         style={({ pressed }) => [
           styles.iconBtn,
           {
@@ -91,27 +180,34 @@ export const ConversationHeader: React.FC<ConversationHeaderProps> = ({
         accessibilityRole="button"
         accessibilityLabel="Paramètres vocaux"
       >
-        <Ionicons
-          name="settings-outline"
-          size={18}
-          color={colors.textSecondary}
-        />
+        <Animated.View style={settingsStyle}>
+          <Ionicons
+            name="settings-outline"
+            size={18}
+            color={colors.textSecondary}
+          />
+        </Animated.View>
       </Pressable>
-      <Pressable
-        onPress={onClose}
-        hitSlop={12}
-        style={({ pressed }) => [
-          styles.iconBtn,
-          {
-            backgroundColor: colors.bgTertiary,
-            opacity: pressed ? 0.7 : 1,
-          },
-        ]}
-        accessibilityRole="button"
-        accessibilityLabel="Fermer"
-      >
-        <Ionicons name="close" size={20} color={colors.textSecondary} />
-      </Pressable>
+      <Animated.View style={closeStyle}>
+        <Pressable
+          onPress={handleClose}
+          onPressIn={handleClosePressIn}
+          onPressOut={handleClosePressOut}
+          hitSlop={12}
+          testID="header-close"
+          style={({ pressed }) => [
+            styles.iconBtn,
+            {
+              backgroundColor: colors.bgTertiary,
+              opacity: pressed ? 0.7 : 1,
+            },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Fermer"
+        >
+          <Ionicons name="close" size={20} color={colors.textSecondary} />
+        </Pressable>
+      </Animated.View>
     </View>
   );
 };
@@ -128,6 +224,9 @@ const styles = StyleSheet.create({
   titles: {
     flex: 1,
     marginRight: sp.xs,
+  },
+  titleScrollContent: {
+    alignItems: "center",
   },
   title: {
     fontFamily: fontFamily.bodySemiBold,

--- a/mobile/src/components/conversation/EmptyConversationSuggestions.tsx
+++ b/mobile/src/components/conversation/EmptyConversationSuggestions.tsx
@@ -1,0 +1,163 @@
+/**
+ * EmptyConversationSuggestions — 3 chips suggestions cliquables animées
+ * affichées dans le ConversationFeed quand `messages.length === 0`.
+ *
+ * Le main thread Claude intégrera ce composant dans ConversationFeed
+ * (côté Agent D ne touche pas au scope empty state) après merge.
+ *
+ * Design :
+ * - Chip = Pressable avec border indigo subtle, fond légèrement teinté
+ * - Animation entrée FadeInUp staggered (delay = index * 100ms)
+ * - Press scale 0.95 + haptics.light au tap
+ *
+ * Spec : `docs/superpowers/specs/2026-05-02-quick-chat-call-unified-design.md`
+ */
+
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import Animated, {
+  FadeInUp,
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withSpring,
+} from "react-native-reanimated";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../contexts/ThemeContext";
+import { sp, borderRadius } from "../../theme/spacing";
+import { fontFamily, fontSize } from "../../theme/typography";
+import { palette } from "../../theme/colors";
+import { haptics } from "../../utils/haptics";
+
+const DEFAULT_SUGGESTIONS: readonly string[] = [
+  "Quels sont les points clés ?",
+  "Résume en 3 points",
+  "Quelles sources cite la vidéo ?",
+] as const;
+
+export interface EmptyConversationSuggestionsProps {
+  /** Callback fired when a chip is tapped. The string is the suggestion. */
+  onSelect: (suggestion: string) => void;
+  /** Optional video title for future contextual suggestions (unused yet). */
+  videoTitle?: string;
+  /** Override default suggestions (max 4 displayed for vertical density). */
+  suggestions?: readonly string[];
+}
+
+interface SuggestionChipProps {
+  text: string;
+  index: number;
+  borderColor: string;
+  bgColor: string;
+  textColor: string;
+  onPress: () => void;
+}
+
+const SuggestionChip: React.FC<SuggestionChipProps> = ({
+  text,
+  index,
+  borderColor,
+  bgColor,
+  textColor,
+  onPress,
+}) => {
+  const scale = useSharedValue(1);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+  const onPressIn = () => {
+    scale.value = withTiming(0.95, { duration: 80 });
+  };
+  const onPressOut = () => {
+    scale.value = withSpring(1, { damping: 12, stiffness: 240 });
+  };
+
+  return (
+    <Animated.View
+      entering={FadeInUp.delay(index * 100).duration(280)}
+      style={animatedStyle}
+    >
+      <Pressable
+        onPress={onPress}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        testID={`suggestion-chip-${index}`}
+        style={[styles.chip, { borderColor, backgroundColor: bgColor }]}
+        accessibilityRole="button"
+        accessibilityLabel={`Suggestion : ${text}`}
+      >
+        <Ionicons name="sparkles-outline" size={14} color={palette.indigo} />
+        <Text style={[styles.chipText, { color: textColor }]}>{text}</Text>
+      </Pressable>
+    </Animated.View>
+  );
+};
+
+export const EmptyConversationSuggestions: React.FC<
+  EmptyConversationSuggestionsProps
+> = ({ onSelect, suggestions = DEFAULT_SUGGESTIONS }) => {
+  const { colors } = useTheme();
+
+  // Garde les 4 premiers max (densité verticale).
+  const items = suggestions.slice(0, 4);
+
+  const handleSelect = (text: string) => {
+    haptics.light();
+    onSelect(text);
+  };
+
+  return (
+    <View testID="empty-conversation-suggestions" style={styles.container}>
+      <Text style={[styles.heading, { color: colors.textTertiary }]}>
+        Suggestions pour démarrer
+      </Text>
+      <View style={styles.list}>
+        {items.map((text, i) => (
+          <SuggestionChip
+            key={text}
+            text={text}
+            index={i}
+            borderColor={palette.indigo + "40"}
+            bgColor={palette.indigo + "15"}
+            textColor={colors.textPrimary}
+            onPress={() => handleSelect(text)}
+          />
+        ))}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: sp.lg,
+    paddingVertical: sp.lg,
+    gap: sp.sm,
+  },
+  heading: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.xs,
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+    marginBottom: sp.xs,
+  },
+  list: {
+    gap: sp.xs,
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.sm + 2,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    alignSelf: "flex-start",
+  },
+  chipText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.sm,
+  },
+});
+
+export default EmptyConversationSuggestions;

--- a/mobile/src/components/conversation/EndedToast.tsx
+++ b/mobile/src/components/conversation/EndedToast.tsx
@@ -1,24 +1,39 @@
 /**
- * EndedToast — Toast "✅ Appel terminé · X:XX min" auto-dismiss 3s.
+ * EndedToast — Toast "Appel terminé · X:XX min" auto-dismiss 3s.
  *
- * Affiché quand `voiceMode === 'ended'`. Animation Reanimated FadeIn
- * (300ms) puis FadeOut (300ms) après 3s.
+ * Affiché quand `voiceMode === 'ended'`. Animation Reanimated FadeInDown
+ * springify (300ms) puis FadeOut (200ms) après ~3s.
+ *
+ * Polish (mai 2026) :
+ * - haptics.success fired au mount
+ * - barre progress qui se vide visuellement (3s) — feedback de auto-dismiss
+ * - FadeInDown entering (springify) + FadeOut exiting plus court
  *
  * Le auto-dismiss vers `voiceMode = 'off'` est géré par useConversation
  * (state machine). Ce composant ne fait que l'affichage.
  */
 
-import React from "react";
-import { Text, StyleSheet } from "react-native";
-import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import React, { useEffect } from "react";
+import { Text, View, StyleSheet } from "react-native";
+import Animated, {
+  FadeInDown,
+  FadeOut,
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+} from "react-native-reanimated";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../contexts/ThemeContext";
 import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize } from "../../theme/typography";
 import { palette } from "../../theme/colors";
+import { haptics } from "../../utils/haptics";
 
 interface EndedToastProps {
   durationSeconds: number;
+  /** Auto-dismiss duration (ms). Defaults to 3000. */
+  autoDismissMs?: number;
 }
 
 const formatDuration = (totalSeconds: number): string => {
@@ -27,13 +42,30 @@ const formatDuration = (totalSeconds: number): string => {
   return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 };
 
-export const EndedToast: React.FC<EndedToastProps> = ({ durationSeconds }) => {
+export const EndedToast: React.FC<EndedToastProps> = ({
+  durationSeconds,
+  autoDismissMs = 3000,
+}) => {
   const { colors } = useTheme();
+  const progress = useSharedValue(1);
+
+  // Haptic success au mount + démarrage de la barre progress (1 → 0)
+  useEffect(() => {
+    haptics.success();
+    progress.value = withTiming(0, {
+      duration: autoDismissMs,
+      easing: Easing.linear,
+    });
+  }, [progress, autoDismissMs]);
+
+  const progressStyle = useAnimatedStyle(() => ({
+    width: `${Math.max(0, progress.value * 100)}%`,
+  }));
 
   return (
     <Animated.View
-      entering={FadeIn.duration(300)}
-      exiting={FadeOut.duration(300)}
+      entering={FadeInDown.duration(300).springify()}
+      exiting={FadeOut.duration(200)}
       testID="ended-toast"
       style={[
         styles.container,
@@ -43,33 +75,63 @@ export const EndedToast: React.FC<EndedToastProps> = ({ durationSeconds }) => {
         },
       ]}
     >
-      <Ionicons
-        name="checkmark-circle-outline"
-        size={18}
-        color={palette.green}
-      />
-      <Text style={[styles.label, { color: colors.textPrimary }]}>
-        Appel terminé · {formatDuration(durationSeconds)} min
-      </Text>
+      <View style={styles.row}>
+        <Ionicons
+          name="checkmark-circle-outline"
+          size={18}
+          color={palette.green}
+        />
+        <Text style={[styles.label, { color: colors.textPrimary }]}>
+          Appel terminé · {formatDuration(durationSeconds)} min
+        </Text>
+      </View>
+      <View
+        style={[
+          styles.progressTrack,
+          { backgroundColor: "rgba(16,185,129,0.15)" },
+        ]}
+      >
+        <Animated.View
+          testID="ended-toast-progress"
+          style={[
+            styles.progressFill,
+            { backgroundColor: palette.green },
+            progressStyle,
+          ]}
+        />
+      </View>
     </Animated.View>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: sp.sm,
     paddingHorizontal: sp.lg,
-    paddingVertical: sp.md,
+    paddingTop: sp.md,
+    paddingBottom: sp.sm,
     marginHorizontal: sp.lg,
     marginVertical: sp.xs,
     borderRadius: borderRadius.lg,
     borderWidth: 1,
   },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+    marginBottom: sp.sm,
+  },
   label: {
     fontFamily: fontFamily.bodySemiBold,
     fontSize: fontSize.sm,
+  },
+  progressTrack: {
+    height: 2,
+    borderRadius: 1,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 1,
   },
 });
 

--- a/mobile/src/components/conversation/MiniActionBar.tsx
+++ b/mobile/src/components/conversation/MiniActionBar.tsx
@@ -1,20 +1,34 @@
 /**
  * MiniActionBar — 3 actions sticky au-dessus de l'input :
- * - 📊 Analyse complète (CTA principal, indigo) → onViewAnalysis
- * - ⭐ Favori (toggle) → onToggleFavorite
- * - ↗ Partager → onShare
+ * - Favori (toggle filled/outlined) → onToggleFavorite
+ * - Analyse complète (CTA principal, indigo) → onViewAnalysis
+ * - Partager → onShare
  *
  * Refactor du `miniActionBar` existant de QuickChatScreen.tsx.
+ *
+ * Polish (mai 2026) :
+ * - Press scale 0.95 + spring back sur chaque bouton
+ * - Haptics light sur les actions secondaires (Favori, Partager)
+ * - Haptics medium sur le CTA principal (Analyse complète)
+ * - Loading state visible (DeepSightSpinner) quand isUpgrading
+ * - Variant favori filled/outlined avec couleur amber sur filled
  */
 
 import React from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withSpring,
+} from "react-native-reanimated";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../contexts/ThemeContext";
 import { DeepSightSpinner } from "../ui/DeepSightSpinner";
 import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize } from "../../theme/typography";
 import { palette } from "../../theme/colors";
+import { haptics } from "../../utils/haptics";
 
 interface MiniActionBarProps {
   isFavorite: boolean;
@@ -24,6 +38,57 @@ interface MiniActionBarProps {
   onToggleFavorite: () => void;
   onShare: () => void;
 }
+
+// ─── Reusable press-scale wrapper ───
+interface PressScaleProps {
+  onPress: () => void;
+  disabled?: boolean;
+  accessibilityLabel: string;
+  style?: object;
+  children: React.ReactNode;
+  testID?: string;
+}
+
+const PressScale: React.FC<PressScaleProps> = ({
+  onPress,
+  disabled,
+  accessibilityLabel,
+  style,
+  children,
+  testID,
+}) => {
+  const scale = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  const onPressIn = () => {
+    if (disabled) return;
+    scale.value = withTiming(0.95, { duration: 80 });
+  };
+  const onPressOut = () => {
+    scale.value = withSpring(1, { damping: 12, stiffness: 240 });
+  };
+
+  return (
+    <Animated.View style={animatedStyle}>
+      <Pressable
+        testID={testID}
+        onPress={onPress}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        disabled={disabled}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: !!disabled }}
+        style={style}
+      >
+        {children}
+      </Pressable>
+    </Animated.View>
+  );
+};
 
 export const MiniActionBar: React.FC<MiniActionBarProps> = ({
   isFavorite,
@@ -35,27 +100,49 @@ export const MiniActionBar: React.FC<MiniActionBarProps> = ({
 }) => {
   const { colors } = useTheme();
 
+  const handleFavorite = () => {
+    haptics.light();
+    onToggleFavorite();
+  };
+
+  const handleViewAnalysis = () => {
+    haptics.medium();
+    onViewAnalysis();
+  };
+
+  const handleShare = () => {
+    haptics.light();
+    onShare();
+  };
+
   return (
     <View style={[styles.bar, { borderTopColor: colors.border }]}>
-      <Pressable
-        onPress={onToggleFavorite}
-        style={styles.miniAction}
+      <PressScale
+        onPress={handleFavorite}
         accessibilityLabel="Favori"
-        accessibilityRole="button"
+        style={styles.miniAction}
+        testID="mini-action-favorite"
       >
         <Ionicons
           name={isFavorite ? "star" : "star-outline"}
           size={18}
           color={isFavorite ? palette.amber : colors.textTertiary}
         />
-        <Text style={[styles.miniActionText, { color: colors.textTertiary }]}>
-          Favori
+        <Text
+          style={[
+            styles.miniActionText,
+            { color: isFavorite ? palette.amber : colors.textTertiary },
+          ]}
+        >
+          {isFavorite ? "Favori" : "Favori"}
         </Text>
-      </Pressable>
+      </PressScale>
 
-      <Pressable
-        onPress={onViewAnalysis}
+      <PressScale
+        onPress={handleViewAnalysis}
         disabled={isUpgrading || !canViewAnalysis}
+        accessibilityLabel="Voir l'analyse complète"
+        testID="mini-action-view-analysis"
         style={[
           styles.upgradeAction,
           {
@@ -64,8 +151,6 @@ export const MiniActionBar: React.FC<MiniActionBarProps> = ({
             opacity: !canViewAnalysis ? 0.4 : 1,
           },
         ]}
-        accessibilityLabel="Voir l'analyse complète"
-        accessibilityRole="button"
       >
         {isUpgrading ? (
           <DeepSightSpinner size="xs" speed="fast" />
@@ -79,13 +164,13 @@ export const MiniActionBar: React.FC<MiniActionBarProps> = ({
         <Text style={[styles.upgradeActionText, { color: palette.indigo }]}>
           {isUpgrading ? "Lancement..." : "Analyse complète"}
         </Text>
-      </Pressable>
+      </PressScale>
 
-      <Pressable
-        onPress={onShare}
-        style={styles.miniAction}
+      <PressScale
+        onPress={handleShare}
         accessibilityLabel="Partager"
-        accessibilityRole="button"
+        testID="mini-action-share"
+        style={styles.miniAction}
       >
         <Ionicons
           name="share-outline"
@@ -95,7 +180,7 @@ export const MiniActionBar: React.FC<MiniActionBarProps> = ({
         <Text style={[styles.miniActionText, { color: colors.textTertiary }]}>
           Partager
         </Text>
-      </Pressable>
+      </PressScale>
     </View>
   );
 };

--- a/mobile/src/components/conversation/VoiceControls.tsx
+++ b/mobile/src/components/conversation/VoiceControls.tsx
@@ -7,28 +7,34 @@
  * - 'ended' : ne rend rien (l'EndedToast s'affiche par-dessus)
  * - 'quota_exceeded' : card warning + bouton "Acheter des minutes"
  *
- * Les composants visuels (PulsingCircle, WaveformPlaceholder) sont repris
- * du legacy `VoiceScreen.tsx` (sera supprimé en Task 7).
+ * Polish (mai 2026) :
+ * - Pulse "respiration" sur le bouton mic en mode 'live'
+ * - Glow background animé pendant l'appel
+ * - Haptic feedback (medium tap, success on transition live → ended)
+ * - Press-scale 0.95 sur le CTA "Acheter des minutes" (quota exceeded)
+ * - Transitions FadeIn/FadeOut entre états
  */
 
-import React, { useEffect, useState } from "react";
-import { View, Text, Pressable, StyleSheet, Platform } from "react-native";
+import React, { useEffect, useRef, useState } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
 import Animated, {
-  type SharedValue,
+  FadeIn,
+  FadeOut,
   useSharedValue,
   useAnimatedStyle,
   withRepeat,
   withTiming,
   withSequence,
   withDelay,
+  withSpring,
   Easing,
 } from "react-native-reanimated";
 import { Ionicons } from "@expo/vector-icons";
-import * as Haptics from "expo-haptics";
 import { useTheme } from "../../contexts/ThemeContext";
 import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize } from "../../theme/typography";
 import { palette } from "../../theme/colors";
+import { haptics } from "../../utils/haptics";
 import VoiceAddonModal from "../voice/VoiceAddonModal";
 import type { VoiceMode } from "../../hooks/useConversation";
 
@@ -97,6 +103,85 @@ const Waveform: React.FC<{ color: string }> = ({ color }) => {
   );
 };
 
+// ─── Mic pulse "respiration" (mode live) ───
+const PulsingMicIcon: React.FC<{
+  isMuted: boolean;
+  iconColor: string;
+}> = ({ isMuted, iconColor }) => {
+  const pulse = useSharedValue(1);
+
+  useEffect(() => {
+    if (isMuted) {
+      pulse.value = withTiming(1, { duration: 200 });
+      return;
+    }
+    pulse.value = withRepeat(
+      withSequence(
+        withTiming(1.15, {
+          duration: 700,
+          easing: Easing.inOut(Easing.ease),
+        }),
+        withTiming(1, {
+          duration: 700,
+          easing: Easing.inOut(Easing.ease),
+        }),
+      ),
+      -1,
+      false,
+    );
+  }, [isMuted, pulse]);
+
+  const pulseStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: pulse.value }],
+  }));
+
+  return (
+    <Animated.View style={pulseStyle}>
+      <Ionicons
+        name={isMuted ? "mic-off" : "mic"}
+        size={20}
+        color={iconColor}
+      />
+    </Animated.View>
+  );
+};
+
+// ─── CTA Acheter (press-scale animation) ───
+const UpgradeButton: React.FC<{
+  bg: string;
+  onPress: () => void;
+}> = ({ bg, onPress }) => {
+  const scale = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  const onPressIn = () => {
+    scale.value = withTiming(0.95, { duration: 80 });
+  };
+  const onPressOut = () => {
+    scale.value = withSpring(1, { damping: 10, stiffness: 220 });
+  };
+
+  return (
+    <Animated.View style={animatedStyle}>
+      <Pressable
+        onPress={onPress}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        style={[styles.upgradeBtn, { backgroundColor: bg }]}
+        accessibilityRole="button"
+        accessibilityLabel="Acheter des minutes"
+      >
+        <Text style={[styles.upgradeBtnText, { color: palette.white }]}>
+          Acheter des minutes
+        </Text>
+      </Pressable>
+    </Animated.View>
+  );
+};
+
 export const VoiceControls: React.FC<VoiceControlsProps> = ({
   voiceMode,
   isMuted,
@@ -107,6 +192,37 @@ export const VoiceControls: React.FC<VoiceControlsProps> = ({
 }) => {
   const { colors } = useTheme();
   const [addonVisible, setAddonVisible] = useState(false);
+  const previousModeRef = useRef<VoiceMode>(voiceMode);
+
+  // Glow background pendant un appel actif
+  const glow = useSharedValue(0);
+  useEffect(() => {
+    if (voiceMode === "live") {
+      glow.value = withRepeat(
+        withSequence(
+          withTiming(1, { duration: 1400, easing: Easing.inOut(Easing.ease) }),
+          withTiming(0, { duration: 1400, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false,
+      );
+    } else {
+      glow.value = withTiming(0, { duration: 200 });
+    }
+  }, [voiceMode, glow]);
+
+  const glowStyle = useAnimatedStyle(() => ({
+    opacity: glow.value * 0.45,
+  }));
+
+  // Haptic transition live → ended
+  useEffect(() => {
+    const prev = previousModeRef.current;
+    if (prev === "live" && voiceMode === "ended") {
+      haptics.success();
+    }
+    previousModeRef.current = voiceMode;
+  }, [voiceMode]);
 
   if (voiceMode === "ended") {
     // L'EndedToast est rendu séparément par le parent.
@@ -115,7 +231,9 @@ export const VoiceControls: React.FC<VoiceControlsProps> = ({
 
   if (voiceMode === "off") {
     return (
-      <View
+      <Animated.View
+        entering={FadeIn.duration(180)}
+        exiting={FadeOut.duration(140)}
         style={[
           styles.container,
           {
@@ -128,13 +246,15 @@ export const VoiceControls: React.FC<VoiceControlsProps> = ({
         <Text style={[styles.offLabel, { color: colors.textTertiary }]}>
           Appel non démarré
         </Text>
-      </View>
+      </Animated.View>
     );
   }
 
   if (voiceMode === "quota_exceeded") {
     return (
-      <View
+      <Animated.View
+        entering={FadeIn.duration(200)}
+        exiting={FadeOut.duration(140)}
         style={[
           styles.container,
           styles.quotaContainer,
@@ -145,49 +265,38 @@ export const VoiceControls: React.FC<VoiceControlsProps> = ({
         ]}
       >
         <Text style={[styles.quotaLabel, { color: "#fca5a5" }]}>
-          ⚠ Quota voice épuisé
+          Quota voice epuise
         </Text>
-        <Pressable
+        <UpgradeButton
+          bg={colors.accentPrimary}
           onPress={() => {
-            if (Platform.OS !== "web") {
-              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(
-                () => {},
-              );
-            }
+            haptics.medium();
             setAddonVisible(true);
           }}
-          style={({ pressed }) => [
-            styles.upgradeBtn,
-            {
-              backgroundColor: colors.accentPrimary,
-              opacity: pressed ? 0.85 : 1,
-            },
-          ]}
-          accessibilityRole="button"
-          accessibilityLabel="Acheter des minutes"
-        >
-          <Text style={[styles.upgradeBtnText, { color: palette.white }]}>
-            Acheter des minutes
-          </Text>
-        </Pressable>
+        />
         <VoiceAddonModal
           visible={addonVisible}
           onClose={() => setAddonVisible(false)}
         />
-      </View>
+      </Animated.View>
     );
   }
 
   // voiceMode === 'live'
   const handleEnd = () => {
-    if (Platform.OS !== "web") {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => {});
-    }
+    haptics.medium();
     onEnd();
   };
 
+  const handleMuteToggle = () => {
+    haptics.medium();
+    onToggleMute();
+  };
+
   return (
-    <View
+    <Animated.View
+      entering={FadeIn.duration(200)}
+      exiting={FadeOut.duration(140)}
       style={[
         styles.container,
         styles.liveContainer,
@@ -197,9 +306,21 @@ export const VoiceControls: React.FC<VoiceControlsProps> = ({
         },
       ]}
     >
+      {/* Glow background (pulse pendant l'appel) */}
+      <Animated.View
+        pointerEvents="none"
+        style={[
+          styles.glow,
+          {
+            backgroundColor: colors.accentPrimary,
+            borderRadius: borderRadius.lg,
+          },
+          glowStyle,
+        ]}
+      />
       {/* Mute */}
       <Pressable
-        onPress={onToggleMute}
+        onPress={handleMuteToggle}
         style={({ pressed }) => [
           styles.iconBtn,
           {
@@ -210,10 +331,9 @@ export const VoiceControls: React.FC<VoiceControlsProps> = ({
         accessibilityRole="button"
         accessibilityLabel={isMuted ? "Réactiver micro" : "Couper micro"}
       >
-        <Ionicons
-          name={isMuted ? "mic-off" : "mic"}
-          size={20}
-          color={isMuted ? palette.red : colors.textPrimary}
+        <PulsingMicIcon
+          isMuted={isMuted}
+          iconColor={isMuted ? palette.red : colors.textPrimary}
         />
       </Pressable>
 
@@ -238,7 +358,7 @@ export const VoiceControls: React.FC<VoiceControlsProps> = ({
       >
         <Ionicons name="stop" size={18} color={palette.white} />
       </Pressable>
-    </View>
+    </Animated.View>
   );
 };
 
@@ -253,6 +373,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: sp.sm,
+    overflow: "hidden",
   },
   liveContainer: {
     justifyContent: "space-between",
@@ -317,6 +438,13 @@ const styles = StyleSheet.create({
     backgroundColor: palette.red,
     alignItems: "center",
     justifyContent: "center",
+  },
+  glow: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
 });
 

--- a/mobile/src/components/conversation/index.ts
+++ b/mobile/src/components/conversation/index.ts
@@ -13,4 +13,6 @@ export { ContextProgressBanner } from "./ContextProgressBanner";
 export { VoiceControls } from "./VoiceControls";
 export { EndedToast } from "./EndedToast";
 export { MiniActionBar } from "./MiniActionBar";
+export { EmptyConversationSuggestions } from "./EmptyConversationSuggestions";
+export type { EmptyConversationSuggestionsProps } from "./EmptyConversationSuggestions";
 export type { VoiceMode, UnifiedMessage } from "../../hooks/useConversation";

--- a/mobile/src/utils/haptics.ts
+++ b/mobile/src/utils/haptics.ts
@@ -1,0 +1,61 @@
+/**
+ * haptics — wrapper centralisé autour de `expo-haptics`.
+ *
+ * Toutes les méthodes sont sûres : elles avalent les rejections (web ou
+ * appareils sans haptic engine) et ne tombent jamais dans le main thread.
+ *
+ * Préférence d'usage :
+ * - `selection()` : tap sur item dans une liste / chip, intensité minimale
+ * - `light()`     : tap secondaire (favori, settings, share)
+ * - `medium()`    : tap principal (mute, dismiss toast, copy success)
+ * - `success()`   : confirmation positive (call ended OK, message envoyé)
+ * - `warning()`   : avertissement non bloquant
+ * - `error()`     : action refusée / quota épuisé
+ *
+ * Sur web, `Platform.OS === 'web'` court-circuite — aucun appel natif.
+ */
+
+import { Platform } from "react-native";
+import * as Haptics from "expo-haptics";
+
+const isWeb = Platform.OS === "web";
+
+const safeCall = (fn: () => Promise<void> | void): Promise<void> => {
+  if (isWeb) return Promise.resolve();
+  try {
+    const result = fn();
+    if (result && typeof (result as Promise<void>).catch === "function") {
+      return (result as Promise<void>).catch(() => {
+        /* swallow — haptic engine may be unavailable */
+      });
+    }
+    return Promise.resolve();
+  } catch {
+    /* swallow sync throw */
+    return Promise.resolve();
+  }
+};
+
+export const haptics = {
+  selection: (): Promise<void> => safeCall(() => Haptics.selectionAsync()),
+  light: (): Promise<void> =>
+    safeCall(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)),
+  medium: (): Promise<void> =>
+    safeCall(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)),
+  heavy: (): Promise<void> =>
+    safeCall(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)),
+  success: (): Promise<void> =>
+    safeCall(() =>
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success),
+    ),
+  warning: (): Promise<void> =>
+    safeCall(() =>
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning),
+    ),
+  error: (): Promise<void> =>
+    safeCall(() =>
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error),
+    ),
+};
+
+export default haptics;


### PR DESCRIPTION
## Summary
Polish UX du Hub (ConversationScreen) — animations Reanimated 4, haptic feedback `expo-haptics`, micro-interactions, accessibility. Scope strictement disjoint d'Agent D (UX fix structurel mergé PR #274).

## 8 goals atteints

| Goal | Composant | Apport |
|---|---|---|
| #1 | NEW `mobile/src/utils/haptics.ts` | Wrapper centralisé `expo-haptics` (selection/light/medium/heavy/success/warning/error), web-safe |
| #2 | `VoiceControls.tsx` | Pulse mic + glow `live`, transitions Fade, press-scale upgrade, haptic medium/success |
| #3 | `ConversationFeedBubble.tsx` | `FadeInDown.springify` entrée, long-press → `expo-clipboard` copy + haptic, pulse mic <2s, a11y enrichi |
| #4 | `ContextProgressBanner.tsx` | Pulse opacity label + shimmer `translateX`, Fade transitions `complete` |
| #5 | `EndedToast.tsx` | `FadeInDown.springify` + `haptic.success` mount + barre auto-dismiss 3s |
| #6 | `MiniActionBar.tsx` | PressScale wrapper réutilisable, haptic light/medium, spinner `isUpgrading`, a11y |
| #7 | `ConversationHeader.tsx` | Settings rotation 90°, title scroll horizontal sur overflow, close press-scale, haptics |
| #8 | NEW `EmptyConversationSuggestions.tsx` | 3 chips animées `FadeInUp` staggered, press-scale, exposé via `conversation/index.ts` |

## Tests
- **+45 nouveaux tests Jest** (10 suites conversation+haptics)
- **325 passing total** mobile (vs 280 baseline). 5 fails `VoiceButton.*` préexistants tracked vault.
- Typecheck `tsc --noEmit` : 0 erreur

## Note d'intégration post-merge
`EmptyConversationSuggestions` est **autonome et exposé** via `conversation/index.ts`. L'intégration dans `ConversationFeed` (`ListEmptyComponent` quand `messages.length === 0`) sera faite **post-merge par main thread** (Agent D ne touchait pas l'empty state).

## Coordination
- Aucun fichier scope Agent D (`_layout.tsx`, `analysis/[id].tsx`, `ConversationScreen.tsx`, `ConversationFeed.tsx`, `ConversationInput.tsx`, écrans tabs, navigation/) touché.
- `expo-haptics` + `expo-clipboard` déjà installés (Expo SDK 54).
- VoiceControls migré vers helper haptics centralisé (cohérence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>