### PR TITLE
fix(hub+tiktok): titres/thumbnails TikTok + UI Hub plein écran + logo cliquable

### DIFF
--- a/backend/src/transcripts/tiktok.py
+++ b/backend/src/transcripts/tiktok.py
@@ -177,10 +177,38 @@ def extract_tiktok_video_id(url: str) -> Optional[str]:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+async def _enrich_info_via_oembed(info: Dict[str, Any], url: str) -> Dict[str, Any]:
+    """
+    Complète un dict d'info TikTok via l'API oEmbed publique si le titre est
+    générique ou si la thumbnail est manquante. Mute toute exception.
+    """
+    needs_title = not info.get("title") or info.get("title") in ("TikTok Video", "TikTok", "")
+    needs_thumbnail = not info.get("thumbnail_url")
+    if not (needs_title or needs_thumbnail):
+        return info
+    try:
+        oembed = await _get_info_via_oembed(url)
+        if not oembed:
+            return info
+        if needs_title:
+            oembed_title = oembed.get("title")
+            if oembed_title and oembed_title not in ("TikTok Video", "TikTok", ""):
+                info["title"] = oembed_title
+                logger.info(f"[TIKTOK] Title enriched via oEmbed: {oembed_title[:50]}")
+        if needs_thumbnail and oembed.get("thumbnail_url"):
+            info["thumbnail_url"] = oembed["thumbnail_url"]
+            logger.info("[TIKTOK] Thumbnail enriched via oEmbed")
+    except Exception as e:
+        logger.warning(f"[TIKTOK] oEmbed enrichment failed: {e}")
+    return info
+
+
 async def get_tiktok_video_info(url: str) -> Optional[Dict[str, Any]]:
     """
     Récupère les métadonnées d'une vidéo TikTok.
     🆕 v3.0: Supadata metadata en priorité, puis yt-dlp, puis oEmbed.
+    🆕 v3.1: Enrichissement oEmbed systématique si title/thumbnail manquants
+    après Supadata ou yt-dlp (oEmbed est public, pas de blocage IP).
 
     Retourne un dict compatible avec le format get_video_info() de youtube.py:
     {
@@ -245,11 +273,11 @@ async def get_tiktok_video_info(url: str) -> Optional[Dict[str, Any]]:
                     logger.info(
                         f"[TIKTOK] Supadata metadata OK: {data.get('title', '')[:50]} ({duration}s, type={content_type})"
                     )
-                    return {
+                    info = {
                         "video_id": str(vid),
-                        "title": (data.get("title", "TikTok Video") or "TikTok Video")[:500],
+                        "title": (data.get("title", "") or "")[:500],
                         "channel": channel_str,
-                        "thumbnail_url": data.get("thumbnail", ""),
+                        "thumbnail_url": data.get("thumbnail", "") or "",
                         "duration": duration,
                         "upload_date": data.get("uploadDate") or data.get("createdAt"),
                         "description": (data.get("description", "") or "")[:2000],
@@ -269,6 +297,11 @@ async def get_tiktok_video_info(url: str) -> Optional[Dict[str, Any]]:
                         "music_title": music_data.get("title") if isinstance(music_data, dict) else None,
                         "music_author": music_data.get("author") if isinstance(music_data, dict) else None,
                     }
+                    # Enrich via oEmbed if Supadata returned partial data
+                    info = await _enrich_info_via_oembed(info, url)
+                    if not info.get("title"):
+                        info["title"] = "TikTok Video"
+                    return info
                 else:
                     logger.warning(f"[TIKTOK] Supadata metadata error {resp.status_code}")
         except Exception as e:
@@ -341,9 +374,9 @@ async def get_tiktok_video_info(url: str) -> Optional[Dict[str, Any]]:
 
             info = {
                 "video_id": video_id,
-                "title": data.get("title", data.get("description", "TikTok Video"))[:500],
+                "title": (data.get("title") or data.get("description") or "")[:500],
                 "channel": data.get("uploader", data.get("creator", "Unknown")),
-                "thumbnail_url": data.get("thumbnail", ""),
+                "thumbnail_url": data.get("thumbnail", "") or "",
                 "duration": duration,
                 "upload_date": data.get("upload_date"),
                 "description": (data.get("description", "") or "")[:2000],
@@ -355,6 +388,11 @@ async def get_tiktok_video_info(url: str) -> Optional[Dict[str, Any]]:
                 "tags": data.get("tags", []),
                 "categories": ["Social Media"],
             }
+
+            # Enrich via oEmbed if yt-dlp returned partial data
+            info = await _enrich_info_via_oembed(info, url)
+            if not info.get("title"):
+                info["title"] = "TikTok Video"
 
             logger.info(f'[TIKTOK] Info OK ({label}): "{info["title"][:50]}" by {info["channel"]} ({duration}s)')
             _circuit_breaker.record_success()

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3553,7 +3553,14 @@ async def get_summary(
         video_channel=summary.video_channel or "Unknown",
         video_duration=summary.video_duration or 0,
         video_url=summary.video_url or f"https://youtube.com/watch?v={summary.video_id}",
-        thumbnail_url=summary.thumbnail_url or f"https://img.youtube.com/vi/{summary.video_id}/mqdefault.jpg",
+        thumbnail_url=(
+            summary.thumbnail_url
+            or (
+                f"https://img.youtube.com/vi/{summary.video_id}/mqdefault.jpg"
+                if (summary.platform or "youtube") != "tiktok"
+                else ""
+            )
+        ),
         category=summary.category,
         category_confidence=summary.category_confidence,
         lang=summary.lang,

--- a/frontend/src/components/hub/HubAnalysisPanel.tsx
+++ b/frontend/src/components/hub/HubAnalysisPanel.tsx
@@ -88,9 +88,9 @@ export const HubAnalysisPanel: React.FC<HubAnalysisPanelProps> = ({
   };
 
   return (
-    <div className="px-4 mb-3 w-full max-w-3xl mx-auto">
+    <div className="px-4 mb-3 w-full">
       <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
-        <div className="max-h-[60vh] overflow-y-auto overscroll-contain">
+        <div>
           <AnalysisHub
             selectedSummary={selectedSummary}
             reliabilityData={reliability}

--- a/frontend/src/components/hub/HubHeader.tsx
+++ b/frontend/src/components/hub/HubHeader.tsx
@@ -54,7 +54,18 @@ export const HubHeader: React.FC<Props> = ({
       >
         <Menu className="w-4 h-4" />
       </button>
-      <DeepSightLogo size={36} />
+      {onHomeClick ? (
+        <button
+          type="button"
+          onClick={onHomeClick}
+          aria-label="Retour à l'accueil"
+          className="flex-shrink-0 rounded-md hover:opacity-80 transition-opacity focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+        >
+          <DeepSightLogo size={36} />
+        </button>
+      ) : (
+        <DeepSightLogo size={36} />
+      )}
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-white truncate">{title}</p>
         {subtitle && (

--- a/frontend/src/components/hub/InputBar.tsx
+++ b/frontend/src/components/hub/InputBar.tsx
@@ -60,7 +60,7 @@ export const InputBar: React.FC<Props> = ({
   };
 
   return (
-    <div className="relative flex items-center gap-2 px-4 py-3 border-t border-white/10 bg-white/[0.02]">
+    <div className="relative flex items-center gap-2 px-4 py-3 border-t border-white/10 bg-[#0a0a0f]/95 backdrop-blur-xl flex-shrink-0">
       <button
         type="button"
         aria-label="attachments"

--- a/frontend/src/components/hub/Timeline.tsx
+++ b/frontend/src/components/hub/Timeline.tsx
@@ -29,8 +29,8 @@ export const Timeline: React.FC<Props> = ({
 
   if (sorted.length === 0 && !isThinking) {
     return (
-      <div className="flex-1 flex items-center justify-center px-6">
-        <div className="max-w-sm text-center">
+      <div className="px-6 py-12 text-center">
+        <div className="max-w-sm mx-auto">
           <Sparkles className="w-10 h-10 text-white/40 mx-auto mb-3" />
           <p className="text-base text-white/95 font-medium mb-1.5">
             Posez votre première question
@@ -45,7 +45,7 @@ export const Timeline: React.FC<Props> = ({
   }
 
   return (
-    <div className="flex-1 overflow-y-auto px-4 py-5">
+    <div className="px-4 py-5">
       <div className="max-w-3xl mx-auto flex flex-col gap-4">
         {sorted.map((msg) => (
           <MessageBubble

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -24,7 +24,6 @@ import { SEO } from "../components/SEO";
 import { sanitizeTitle } from "../utils/sanitize";
 import { useHubStore } from "../store/hubStore";
 import { HubHeader } from "../components/hub/HubHeader";
-import { SummaryCollapsible } from "../components/hub/SummaryCollapsible";
 import { Timeline } from "../components/hub/Timeline";
 import { InputBar } from "../components/hub/InputBar";
 import { ConversationsDrawer } from "../components/hub/ConversationsDrawer";
@@ -94,10 +93,6 @@ const HubPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const urlConvId = searchParams.get("conv");
   const urlSummaryId = searchParams.get("summary");
-  // Hub-first : `?open_summary=1` ouvre le bloc résumé déroulé d'emblée et
-  // scrolle le wrapper au centre. Utilisé après une analyse fraîche (Quick
-  // Chat) pour que l'utilisateur arrive directement sur le résumé.
-  const openSummaryFromUrl = searchParams.get("open_summary") === "1";
 
   const { language } = useTranslation();
   const { user } = useAuth();
@@ -554,34 +549,30 @@ const HubPage: React.FC = () => {
           </div>
         ) : (
           <>
-            {summaryContext && (
-              <SummaryCollapsible
-                context={summaryContext}
-                defaultOpen={openSummaryFromUrl}
+            <div className="flex-1 overflow-y-auto min-h-0">
+              {summaryContext && (
+                <HubAnalysisPanel
+                  selectedSummary={fullSummary}
+                  concepts={concepts}
+                  reliability={reliability}
+                  reliabilityLoading={reliabilityLoading}
+                  user={user}
+                  language={language as "fr" | "en"}
+                />
+              )}
+              <Timeline
+                messages={messages}
+                isThinking={isThinking}
+                onQuestionClick={handleSend}
               />
-            )}
-            {summaryContext && (
-              <HubAnalysisPanel
-                selectedSummary={fullSummary}
-                concepts={concepts}
-                reliability={reliability}
-                reliabilityLoading={reliabilityLoading}
-                user={user}
-                language={language as "fr" | "en"}
-              />
-            )}
-            <Timeline
-              messages={messages}
-              isThinking={isThinking}
-              onQuestionClick={handleSend}
-            />
+            </div>
             <InputBar
               onSend={handleSend}
               onCallToggle={() => setVoiceCallOpen(!voiceCallOpen)}
               onPttHoldComplete={handlePttHoldComplete}
               disabled={!activeConvId}
             />
-            <div className="flex justify-center px-3 pb-3 pt-1">
+            <div className="flex justify-center px-3 pb-3 pt-1 flex-shrink-0">
               <SourcesShelf />
             </div>
           </>


### PR DESCRIPTION
## Contexte

Audit du 03/05 (`docs/audit/2026-05-03-deepsight-web-audit.md`) + report user 03/05 :

1. Vidéos TikTok analysées affichent titre générique **"TikTok Video"** + miniature manquante
2. Hub `/hub?conv=X` : doublon entre la barre RÉSUMÉ extensible et la fenêtre Synthèse (avec onglets Synthèse/Quiz/Flashcards/Fiabilité/GEO)
3. Synthèse limitée à `max-w-3xl` + `max-h-[60vh]` avec scroll interne (deux scrolls concurrents avec Timeline)
4. Input bar quasi invisible (`bg-white/[0.02]` ≈ 4% d'opacité — audit F5)
5. Logo DeepSight non cliquable (audit F6 partiellement)

## Changements

### Backend
- **`transcripts/tiktok.py`** : nouveau helper `_enrich_info_via_oembed()` qui complète `title` et `thumbnail_url` depuis l'API oEmbed publique TikTok quand Supadata ou yt-dlp renvoient des champs vides ou un titre générique. Appelé après chaque branche Supadata et yt-dlp avant `return`. oEmbed est public, pas de blocage IP Hetzner.
- **`videos/router.py:3556`** (`SummaryResponse`) : le fallback `img.youtube.com/vi/{id}/mqdefault.jpg` ne s'applique plus aux summaries `platform="tiktok"`. Conséquence : les TikToks dont `thumbnail_url` est vide en DB ne renvoient plus une URL YouTube qui retournait 404 — le frontend recevra `""` et pourra afficher son placeholder dédié.

### Frontend Hub
- **`HubPage.tsx`** : retire le rendu `<SummaryCollapsible/>` (la barre RÉSUMÉ extensible faisait doublon avec `HubAnalysisPanel` et exposait du raw markdown — bonus correctif F2 partiel). Wrap `HubAnalysisPanel + Timeline` dans un unique `<div className="flex-1 overflow-y-auto min-h-0">` → scroll global unifié.
- **`HubAnalysisPanel.tsx`** : retire `max-w-3xl mx-auto` et `max-h-[60vh] overflow-y-auto overscroll-contain` → la synthèse occupe toute la largeur dispo et n'a plus de scroll interne (géré par le parent unique).
- **`Timeline.tsx`** : retire `flex-1` et `overflow-y-auto` (parent gère le scroll). Empty state passe en padding centré au lieu de flex-fill.
- **`InputBar.tsx`** : `bg-white/[0.02]` → `bg-[#0a0a0f]/95 backdrop-blur-xl flex-shrink-0`. Toujours visible en bas pendant le scroll de la synthèse (pattern ChatGPT/Claude). Fix F5.
- **`HubHeader.tsx`** : `<DeepSightLogo/>` wrappé dans un `<button onClick={onHomeClick}>` (même handler que le bouton Accueil → `/`). Aria-label "Retour à l'accueil" + focus ring indigo.

## Test plan

- [x] Typecheck frontend : aucune erreur sur les fichiers modifiés (les ~50 erreurs TS du repo sont toutes pré-existantes — DashboardPageLegacy, DebatePage, History, etc).
- [ ] Visuel `/hub?conv=<id_tiktok>` : titre TikTok réel affiché + miniature TikTok visible.
- [ ] Visuel `/hub?conv=<id>` : barre RÉSUMÉ supprimée, synthèse plein-écran, scroll fluide vers Timeline, InputBar visible en bas durant tout le scroll.
- [ ] Click sur le logo DeepSight dans le header Hub → navigation vers `/`.
- [ ] Backend : Hetzner pull + rebuild → analyser une nouvelle vidéo TikTok et vérifier `summary.video_title` ≠ "TikTok Video" et `summary.thumbnail_url` non vide.

## Déploiement

- **Frontend** : auto-deploy Vercel sur merge.
- **Backend** : SSH Hetzner + `cd /opt/deepsight/repo && git pull && docker build && recreate repo-backend-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)