### PR TITLE
feat(mobile): integrate EmptyConversationSuggestions into ConversationFeed empty state

### DIFF
--- a/mobile/src/components/conversation/ConversationFeed.tsx
+++ b/mobile/src/components/conversation/ConversationFeed.tsx
@@ -31,6 +31,7 @@ import { fontFamily, fontSize } from "../../theme/typography";
 import { palette } from "../../theme/colors";
 import { DeepSightSpinner } from "../ui/DeepSightSpinner";
 import { ConversationFeedBubble } from "./ConversationFeedBubble";
+import { EmptyConversationSuggestions } from "./EmptyConversationSuggestions";
 import type { UnifiedMessage } from "../../hooks/useConversation";
 
 const SUGGESTED_QUESTIONS = [
@@ -138,28 +139,7 @@ export const ConversationFeed: React.FC<ConversationFeedProps> = ({
         <Text style={[styles.welcomeSubtitle, { color: colors.textTertiary }]}>
           Pose une question sur cette vidéo...
         </Text>
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.suggestionsRow}
-          style={styles.suggestionsScroll}
-        >
-          {SUGGESTED_QUESTIONS.map((q) => (
-            <Pressable
-              key={q}
-              onPress={() => onSuggestionPress(q)}
-              style={[
-                styles.suggestionChip,
-                { borderColor: palette.cyan + "4D" },
-              ]}
-              accessibilityLabel={q}
-            >
-              <Text style={[styles.suggestionText, { color: palette.cyan }]}>
-                {q}
-              </Text>
-            </Pressable>
-          ))}
-        </ScrollView>
+        <EmptyConversationSuggestions onSelect={onSuggestionPress} />
       </View>
     );
   }


### PR DESCRIPTION
## Summary
Intégration du composant `EmptyConversationSuggestions` (créé par Agent E dans PR #275) dans `ConversationFeed.tsx` empty state.

Avant : inline `<ScrollView horizontal>` avec 3 `<Pressable>` + textes hardcodés `SUGGESTED_QUESTIONS`.
Après : `<EmptyConversationSuggestions onSelect={onSuggestionPress} />` (FadeInUp staggered + haptic + press scale).

Le path `messages.length < 3` (compact horizontal scroll) reste inchangé — UX différente (réutilisation rapide vs empty state).

## Changes
- 1 fichier modifié : `mobile/src/components/conversation/ConversationFeed.tsx` (+1 import, -32 lines de JSX inline / +2 lines composant)

## Tests
Aucun nouveau test (intégration triviale, EmptyConversationSuggestions a ses propres tests dans PR #275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>