### PR TITLE
perf(mobile): memoization + FlashList migrations + lazy loading

### DIFF
--- a/mobile/app/(tabs)/subscription.tsx
+++ b/mobile/app/(tabs)/subscription.tsx
@@ -8,7 +8,7 @@
  * Apple Pay fonctionne automatiquement via le Stripe Checkout Web
  * lorsqu'on ouvre l'URL dans expo-web-browser sur iOS.
  */
-import React, { useCallback, useState } from "react";
+import React, { Suspense, lazy, useCallback, useState } from "react";
 import {
   View,
   Text,
@@ -33,7 +33,11 @@ import { OfflineCache, CachePriority } from "@/services/OfflineCache";
 import { useIsOffline } from "@/hooks/useNetworkStatus";
 import { DoodleBackground } from "@/components/ui/DoodleBackground";
 import { CreditPacksModal } from "@/components/billing";
-import VoiceAddonModal from "@/components/voice/VoiceAddonModal";
+
+// VoiceAddonModal is heavy (depends on billing API + LinearGradient + several
+// inputs) and only rendered when the user taps "Voice add-on" — defer the
+// module load until then to keep this tab's first-paint snappy.
+const VoiceAddonModal = lazy(() => import("@/components/voice/VoiceAddonModal"));
 import { sp, borderRadius } from "@/theme/spacing";
 import { fontFamily, fontSize } from "@/theme/typography";
 import { palette } from "@/theme/colors";
@@ -774,10 +778,14 @@ export default function SubscriptionScreen() {
         visible={creditPacksVisible}
         onClose={() => setCreditPacksVisible(false)}
       />
-      <VoiceAddonModal
-        visible={voiceAddonVisible}
-        onClose={() => setVoiceAddonVisible(false)}
-      />
+      {voiceAddonVisible && (
+        <Suspense fallback={null}>
+          <VoiceAddonModal
+            visible={voiceAddonVisible}
+            onClose={() => setVoiceAddonVisible(false)}
+          />
+        </Suspense>
+      )}
     </View>
   );
 }

--- a/mobile/src/components/FreshnessIndicator.tsx
+++ b/mobile/src/components/FreshnessIndicator.tsx
@@ -90,14 +90,14 @@ const formatRelativeTime = (days: number, isEn: boolean): string => {
     : `Il y a ${years} an${years > 1 ? "s" : ""}`;
 };
 
-export const FreshnessIndicator: React.FC<FreshnessIndicatorProps> = ({
+const FreshnessIndicatorComponent: React.FC<FreshnessIndicatorProps> = ({
   publicationDate,
   daysSincePublished,
   freshnessLevel,
   compact = false,
   onPress,
 }) => {
-  const { colors, isDark } = useTheme();
+  const { colors } = useTheme();
   const { language } = useLanguage();
   const isEn = language === "en";
 
@@ -178,6 +178,8 @@ export const FreshnessIndicator: React.FC<FreshnessIndicatorProps> = ({
     </Container>
   );
 };
+
+export const FreshnessIndicator = React.memo(FreshnessIndicatorComponent);
 
 const styles = StyleSheet.create({
   container: {

--- a/mobile/src/components/PlanBadge.tsx
+++ b/mobile/src/components/PlanBadge.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { View, Text, StyleSheet, Pressable, Linking } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
@@ -17,7 +17,7 @@ interface PlanBadgeProps {
   compact?: boolean;
 }
 
-export const PlanBadge: React.FC<PlanBadgeProps> = ({
+const PlanBadgeComponent: React.FC<PlanBadgeProps> = ({
   planName,
   planIcon,
   planColor,
@@ -27,10 +27,10 @@ export const PlanBadge: React.FC<PlanBadgeProps> = ({
 }) => {
   const { colors } = useTheme();
 
-  const handlePress = () => {
+  const handlePress = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     Linking.openURL(UPGRADE_URL);
-  };
+  }, []);
 
   const showUsage = analysesUsed !== undefined && analysesLimit !== undefined;
   const isUnlimited = analysesLimit === -1;
@@ -70,6 +70,8 @@ export const PlanBadge: React.FC<PlanBadgeProps> = ({
     </Pressable>
   );
 };
+
+export const PlanBadge = React.memo(PlanBadgeComponent);
 
 const styles = StyleSheet.create({
   container: {

--- a/mobile/src/components/ReliabilityScore.tsx
+++ b/mobile/src/components/ReliabilityScore.tsx
@@ -44,7 +44,7 @@ const getScoreLabel = (score: number, isEn: boolean): string => {
   return isEn ? "Low" : "Faible";
 };
 
-export const ReliabilityScore: React.FC<ReliabilityScoreProps> = ({
+const ReliabilityScoreComponent: React.FC<ReliabilityScoreProps> = ({
   overallScore,
   confidence,
   factors = [],
@@ -53,7 +53,7 @@ export const ReliabilityScore: React.FC<ReliabilityScoreProps> = ({
   onAnalyze,
   isLoading = false,
 }) => {
-  const { colors, isDark } = useTheme();
+  const { colors } = useTheme();
   const { language } = useLanguage();
   const isEn = language === "en";
 
@@ -345,6 +345,8 @@ export const ReliabilityScore: React.FC<ReliabilityScoreProps> = ({
     </>
   );
 };
+
+export const ReliabilityScore = React.memo(ReliabilityScoreComponent);
 
 const styles = StyleSheet.create({
   container: {

--- a/mobile/src/components/VideoDiscoveryModal.tsx
+++ b/mobile/src/components/VideoDiscoveryModal.tsx
@@ -125,22 +125,25 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
     }
   }, [visible, initialQuery]);
 
-  const handleSelectVideo = (video: DiscoveredVideo) => {
-    Haptics.selectionAsync();
+  const handleSelectVideo = useCallback(
+    (video: DiscoveredVideo) => {
+      Haptics.selectionAsync();
 
-    if (allowMultiSelect) {
-      setSelectedVideos((prev) => {
-        if (prev.includes(video.video_id)) {
-          return prev.filter((id) => id !== video.video_id);
-        }
-        return [...prev, video.video_id];
-      });
-    } else {
-      const url = `https://youtube.com/watch?v=${video.video_id}`;
-      onSelectVideo(video.video_id, url);
-      onClose();
-    }
-  };
+      if (allowMultiSelect) {
+        setSelectedVideos((prev) => {
+          if (prev.includes(video.video_id)) {
+            return prev.filter((id) => id !== video.video_id);
+          }
+          return [...prev, video.video_id];
+        });
+      } else {
+        const url = `https://youtube.com/watch?v=${video.video_id}`;
+        onSelectVideo(video.video_id, url);
+        onClose();
+      }
+    },
+    [allowMultiSelect, onSelectVideo, onClose],
+  );
 
   const handleConfirmMultiple = () => {
     if (onSelectMultiple) {
@@ -283,7 +286,7 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
       </TouchableOpacity>
     );
     },
-    [colors, selectedVideos, allowMultiSelect],
+    [colors, selectedVideos, allowMultiSelect, handleSelectVideo],
   );
 
   const keyExtractor = useCallback(

--- a/mobile/src/components/VideoDiscoveryModal.tsx
+++ b/mobile/src/components/VideoDiscoveryModal.tsx
@@ -1,15 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   View,
   Text,
   StyleSheet,
   Modal,
   TouchableOpacity,
-  FlatList,
   TextInput,
   ActivityIndicator,
   Keyboard,
 } from "react-native";
+import { FlashList } from "@shopify/flash-list";
 import { Ionicons } from "@expo/vector-icons";
 import { Image } from "expo-image";
 import * as Haptics from "expo-haptics";
@@ -175,7 +175,8 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
     return Colors.accentError;
   };
 
-  const renderVideoItem = ({ item }: { item: DiscoveredVideo }) => {
+  const renderVideoItem = useCallback(
+    ({ item }: { item: DiscoveredVideo }) => {
     const isSelected = selectedVideos.includes(item.video_id);
 
     return (
@@ -281,7 +282,14 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
         />
       </TouchableOpacity>
     );
-  };
+    },
+    [colors, selectedVideos, allowMultiSelect],
+  );
+
+  const keyExtractor = useCallback(
+    (item: DiscoveredVideo) => item.video_id,
+    [],
+  );
 
   return (
     <Modal visible={visible} animationType="slide" transparent>
@@ -425,10 +433,10 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
             </View>
           ) : (
             !searchError && (
-              <FlatList
+              <FlashList
                 data={videos}
                 renderItem={renderVideoItem}
-                keyExtractor={(item) => item.video_id}
+                keyExtractor={keyExtractor}
                 keyboardDismissMode="on-drag"
                 keyboardShouldPersistTaps="handled"
                 contentContainerStyle={styles.listContent}

--- a/mobile/src/components/academic/PaperCard.tsx
+++ b/mobile/src/components/academic/PaperCard.tsx
@@ -36,7 +36,7 @@ const SOURCE_NAMES: Record<string, string> = {
   arxiv: "arXiv",
 };
 
-export const PaperCard: React.FC<PaperCardProps> = ({
+const PaperCardComponent: React.FC<PaperCardProps> = ({
   paper,
   onSelect,
   isSelected = false,
@@ -239,6 +239,8 @@ export const PaperCard: React.FC<PaperCardProps> = ({
     </Card>
   );
 };
+
+export const PaperCard = React.memo(PaperCardComponent);
 
 const styles = StyleSheet.create({
   card: {

--- a/mobile/src/components/analysis/EngagementMetrics.tsx
+++ b/mobile/src/components/analysis/EngagementMetrics.tsx
@@ -26,14 +26,15 @@ const MetricBadge: React.FC<{
   value: string;
   bgColor: string;
   textColor: string;
-}> = ({ emoji, value, bgColor, textColor }) => (
+}> = React.memo(({ emoji, value, bgColor, textColor }) => (
   <View style={[styles.badge, { backgroundColor: bgColor }]}>
     <Text style={styles.badgeEmoji}>{emoji}</Text>
     <Text style={[styles.badgeText, { color: textColor }]}>{value}</Text>
   </View>
-);
+));
+MetricBadge.displayName = "MetricBadge";
 
-export const EngagementMetrics: React.FC<EngagementMetricsProps> = ({
+const EngagementMetricsComponent: React.FC<EngagementMetricsProps> = ({
   viewCount,
   likeCount,
   commentCount,
@@ -111,6 +112,8 @@ export const EngagementMetrics: React.FC<EngagementMetricsProps> = ({
     </View>
   );
 };
+
+export const EngagementMetrics = React.memo(EngagementMetricsComponent);
 
 const styles = StyleSheet.create({
   container: {

--- a/mobile/src/components/hub/MessageBubble.tsx
+++ b/mobile/src/components/hub/MessageBubble.tsx
@@ -22,7 +22,7 @@ const DEFAULT_BARS = [
   21, 9, 12, 15, 8, 17, 10,
 ];
 
-export const MessageBubble: React.FC<Props> = ({ msg, bars }) => {
+const MessageBubbleComponent: React.FC<Props> = ({ msg, bars }) => {
   const isUser = msg.role === "user";
   const isVoiceBubble =
     (msg.source === "voice_user" || msg.source === "voice_agent") &&
@@ -82,6 +82,8 @@ export const MessageBubble: React.FC<Props> = ({ msg, bars }) => {
     </View>
   );
 };
+
+export const MessageBubble = React.memo(MessageBubbleComponent);
 
 const styles = StyleSheet.create({
   row: {

--- a/mobile/src/components/hub/Timeline.tsx
+++ b/mobile/src/components/hub/Timeline.tsx
@@ -30,6 +30,14 @@ const ThinkingDots: React.FC = () => {
   );
 };
 
+const keyExtractor = (item: HubMessage) => item.id;
+
+const renderMessage = ({ item }: { item: HubMessage }) => (
+  <View style={styles.itemSpacing}>
+    <MessageBubble msg={item} />
+  </View>
+);
+
 export const Timeline: React.FC<Props> = ({ messages, isThinking }) => {
   const sorted = useMemo(
     () => [...messages].sort((a, b) => a.timestamp - b.timestamp),
@@ -45,6 +53,11 @@ export const Timeline: React.FC<Props> = ({ messages, isThinking }) => {
     }, 50);
     return () => clearTimeout(t);
   }, [sorted.length, isThinking]);
+
+  const footer = useMemo(
+    () => (isThinking ? <ThinkingDots /> : null),
+    [isThinking],
+  );
 
   if (sorted.length === 0 && !isThinking) {
     return (
@@ -64,13 +77,9 @@ export const Timeline: React.FC<Props> = ({ messages, isThinking }) => {
       <FlashList
         ref={listRef}
         data={sorted}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.itemSpacing}>
-            <MessageBubble msg={item} />
-          </View>
-        )}
-        ListFooterComponent={isThinking ? <ThinkingDots /> : null}
+        keyExtractor={keyExtractor}
+        renderItem={renderMessage}
+        ListFooterComponent={footer}
         contentContainerStyle={styles.listContent}
       />
     </View>

--- a/mobile/src/components/hub/VoiceBubble.tsx
+++ b/mobile/src/components/hub/VoiceBubble.tsx
@@ -34,7 +34,7 @@ const formatTime = (s: number) => {
 const TICK_MS = 60; // ~16fps - assez fluide pour une waveform de 8-15s
 const PLAYED_COLOR = "#6366f1";
 
-export const VoiceBubble: React.FC<Props> = ({
+const VoiceBubbleComponent: React.FC<Props> = ({
   durationSecs,
   bars,
   transcript,
@@ -175,6 +175,8 @@ export const VoiceBubble: React.FC<Props> = ({
     </View>
   );
 };
+
+export const VoiceBubble = React.memo(VoiceBubbleComponent);
 
 const styles = StyleSheet.create({
   column: {

--- a/mobile/src/components/library/AnalysisCard.tsx
+++ b/mobile/src/components/library/AnalysisCard.tsx
@@ -53,7 +53,7 @@ const formatDuration = (seconds?: number): string => {
   return `${min}min`;
 };
 
-export const AnalysisCard: React.FC<AnalysisCardProps> = ({
+const AnalysisCardComponent: React.FC<AnalysisCardProps> = ({
   summary,
   isFavorite,
   onPress,
@@ -240,6 +240,8 @@ export const AnalysisCard: React.FC<AnalysisCardProps> = ({
     </View>
   );
 };
+
+export const AnalysisCard = React.memo(AnalysisCardComponent);
 
 const styles = StyleSheet.create({
   swipeWrapper: {

--- a/mobile/src/components/study/FlashcardProgress.tsx
+++ b/mobile/src/components/study/FlashcardProgress.tsx
@@ -39,7 +39,7 @@ interface FlashcardProgressProps {
   strokeColor?: string;
 }
 
-export const FlashcardProgress: React.FC<FlashcardProgressProps> = ({
+const FlashcardProgressComponent: React.FC<FlashcardProgressProps> = ({
   progress,
   size = 64,
   strokeWidth = 5,
@@ -144,6 +144,8 @@ export const FlashcardProgress: React.FC<FlashcardProgressProps> = ({
     </Animated.View>
   );
 };
+
+export const FlashcardProgress = React.memo(FlashcardProgressComponent);
 
 const styles = StyleSheet.create({
   container: {

--- a/mobile/src/components/study/StatsCard.tsx
+++ b/mobile/src/components/study/StatsCard.tsx
@@ -103,7 +103,7 @@ const ScoreMini: React.FC<{ score: number }> = ({ score }) => {
   );
 };
 
-export const StatsCard: React.FC<StatsCardProps> = ({ stats }) => {
+const StatsCardComponent: React.FC<StatsCardProps> = ({ stats }) => {
   const { colors } = useTheme();
   const hasStats = stats.totalStudied > 0;
 
@@ -157,6 +157,8 @@ export const StatsCard: React.FC<StatsCardProps> = ({ stats }) => {
     </Card>
   );
 };
+
+export const StatsCard = React.memo(StatsCardComponent);
 
 const styles = StyleSheet.create({
   row: {

--- a/mobile/src/components/study/VideoStudyCard.tsx
+++ b/mobile/src/components/study/VideoStudyCard.tsx
@@ -45,7 +45,7 @@ const getScoreBadge = (
   return { label: `${score}%`, variant: "error" };
 };
 
-export const VideoStudyCard: React.FC<VideoStudyCardProps> = ({
+const VideoStudyCardComponent: React.FC<VideoStudyCardProps> = ({
   summary,
   progress,
   onFlashcards,
@@ -188,6 +188,8 @@ export const VideoStudyCard: React.FC<VideoStudyCardProps> = ({
   );
 };
 
+export const VideoStudyCard = React.memo(VideoStudyCardComponent);
+
 const styles = StyleSheet.create({
   card: {
     flex: 1,
@@ -261,3 +263,4 @@ const styles = StyleSheet.create({
 });
 
 export default VideoStudyCard;
+

--- a/mobile/src/components/tournesol/TournesolRecommendations.tsx
+++ b/mobile/src/components/tournesol/TournesolRecommendations.tsx
@@ -10,11 +10,11 @@ import {
   View,
   Text,
   StyleSheet,
-  FlatList,
   Pressable,
   ActivityIndicator,
   Linking,
 } from "react-native";
+import { FlashList } from "@shopify/flash-list";
 import { Image } from "expo-image";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
@@ -66,7 +66,7 @@ export function TournesolRecommendations({
   limit = 10,
   refreshTrigger = 0,
 }: Props) {
-  const { colors, isDark } = useTheme();
+  const { colors } = useTheme();
   const router = useRouter();
   const isOffline = useIsOffline();
   const [results, setResults] = useState<TournesolResult[]>([]);
@@ -173,7 +173,8 @@ export function TournesolRecommendations({
     return null; // Silently hide if no data
   }
 
-  const renderCard = ({ item }: { item: TournesolResult }) => {
+  const renderCard = useCallback(
+    ({ item }: { item: TournesolResult }) => {
     const videoId = item.entity.metadata.video_id;
     const score = item.collective_rating.tournesol_score;
     const thumbnail = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
@@ -256,7 +257,14 @@ export function TournesolRecommendations({
         </View>
       </Pressable>
     );
-  };
+    },
+    [colors.bgElevated, colors.border, colors.textPrimary, colors.textTertiary, colors.textMuted, handleVideoPress, language],
+  );
+
+  const keyExtractor = useCallback(
+    (item: TournesolResult) => item.entity.uid,
+    [],
+  );
 
   return (
     <Animated.View
@@ -286,16 +294,18 @@ export function TournesolRecommendations({
       </Text>
 
       {/* Horizontal carousel */}
-      <FlatList
-        data={results}
-        renderItem={renderCard}
-        keyExtractor={(item) => item.entity.uid}
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.list}
-        snapToInterval={220}
-        decelerationRate="fast"
-      />
+      <View style={styles.listWrapper}>
+        <FlashList
+          data={results}
+          renderItem={renderCard}
+          keyExtractor={keyExtractor}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.list}
+          snapToInterval={220}
+          decelerationRate="fast"
+        />
+      </View>
     </Animated.View>
   );
 }
@@ -332,12 +342,15 @@ const styles = StyleSheet.create({
     fontSize: fontSize.xs,
     marginBottom: sp.md,
   },
+  listWrapper: {
+    height: 240,
+  },
   list: {
-    gap: sp.md,
     paddingRight: sp.lg,
   },
   card: {
     width: 200,
+    marginRight: sp.md,
     borderRadius: borderRadius.lg,
     borderWidth: 1,
     overflow: "hidden",

--- a/mobile/src/components/tournesol/TournesolWidget.tsx
+++ b/mobile/src/components/tournesol/TournesolWidget.tsx
@@ -101,7 +101,7 @@ const fetchTournesolScore = async (
   }
 };
 
-export const TournesolWidget: React.FC<TournesolWidgetProps> = ({
+const TournesolWidgetComponent: React.FC<TournesolWidgetProps> = ({
   videoId,
   compact = false,
 }) => {
@@ -312,6 +312,8 @@ export const TournesolWidget: React.FC<TournesolWidgetProps> = ({
     </TouchableOpacity>
   );
 };
+
+export const TournesolWidget = React.memo(TournesolWidgetComponent);
 
 const styles = StyleSheet.create({
   container: {

--- a/mobile/src/components/ui/Avatar.tsx
+++ b/mobile/src/components/ui/Avatar.tsx
@@ -25,7 +25,7 @@ const fontSizes: Record<string, number> = {
   xl: 28,
 };
 
-export const Avatar: React.FC<AvatarProps> = ({
+const AvatarComponent: React.FC<AvatarProps> = ({
   uri,
   name,
   size = "md",
@@ -80,6 +80,8 @@ export const Avatar: React.FC<AvatarProps> = ({
     </View>
   );
 };
+
+export const Avatar = React.memo(AvatarComponent);
 
 const styles = StyleSheet.create({
   image: {

--- a/mobile/src/components/ui/Badge.tsx
+++ b/mobile/src/components/ui/Badge.tsx
@@ -11,7 +11,7 @@ interface BadgeProps {
   textStyle?: TextStyle;
 }
 
-export const Badge: React.FC<BadgeProps> = ({
+const BadgeComponent: React.FC<BadgeProps> = ({
   label,
   variant = "default",
   size = "sm",
@@ -64,6 +64,8 @@ export const Badge: React.FC<BadgeProps> = ({
     </View>
   );
 };
+
+export const Badge = React.memo(BadgeComponent);
 
 const styles = StyleSheet.create({
   badge: {

--- a/mobile/src/components/ui/PlatformBadge.tsx
+++ b/mobile/src/components/ui/PlatformBadge.tsx
@@ -76,7 +76,7 @@ const SIZE_MAP = {
   },
 } as const;
 
-export const PlatformBadge: React.FC<PlatformBadgeProps> = ({
+const PlatformBadgeComponent: React.FC<PlatformBadgeProps> = ({
   platform = "youtube",
   size = "sm",
   showLabel = true,
@@ -145,6 +145,8 @@ export const PlatformBadge: React.FC<PlatformBadgeProps> = ({
     </View>
   );
 };
+
+export const PlatformBadge = React.memo(PlatformBadgeComponent);
 
 /**
  * Détecte la plateforme à partir de l'URL ou du videoId

--- a/mobile/src/components/ui/ThumbnailImage.tsx
+++ b/mobile/src/components/ui/ThumbnailImage.tsx
@@ -30,7 +30,7 @@ const getYouTubeFallbacks = (videoId: string): string[] => [
   `https://img.youtube.com/vi/${videoId}/default.jpg`,
 ];
 
-export const ThumbnailImage: React.FC<ThumbnailImageProps> = ({
+const ThumbnailImageComponent: React.FC<ThumbnailImageProps> = ({
   uri,
   videoId,
   style,
@@ -88,6 +88,8 @@ export const ThumbnailImage: React.FC<ThumbnailImageProps> = ({
     />
   );
 };
+
+export const ThumbnailImage = React.memo(ThumbnailImageComponent);
 
 const styles = StyleSheet.create({
   placeholder: {


### PR DESCRIPTION
## Summary
Optimisations performance mobile ciblées sur scope strictement disjoint d'Agent D (UX fix) et Agent E (Hub polish). 5 commits atomiques, 14 composants memoizés, 2 migrations FlashList, 1 lazy loading.

## Changes

### React.memo (14 composants atomiques)
VideoStudyCard, AnalysisCard, PaperCard, EngagementMetrics + MetricBadge, FlashcardProgress, StatsCard, TournesolWidget, Badge, Avatar, PlatformBadge, ThumbnailImage, FreshnessIndicator, ReliabilityScore, PlanBadge, MessageBubble, VoiceBubble.

### FlashList migrations (2)
- `TournesolRecommendations.tsx` : carousel horizontal (wrapper 240px, marginRight cards car `gap` ignored, renderCard useCallback)
- `VideoDiscoveryModal.tsx` : liste verticale max 20 résultats dans Modal

**Skipped intentionnellement** : CarouselGallery (<10 items), FloatingChat (scrollToEnd legacy), YouTubeSearch (scrollEnabled=false), ConversationFeed (touché par D+E).

### useCallback / useMemo
- Timeline : renderItem + keyExtractor extraits, ListFooter useMemo
- VideoDiscoveryModal : handleSelectVideo

### Lazy loading
- `VoiceAddonModal` → `React.lazy()` + Suspense + mount conditionnel dans subscription.tsx
- ⚠️ Skipped ExportMenu / AcademicSourcesSection / WebEnrichment (scope analysis/[id].tsx = Agent D)

## Tests / typecheck
- 275 passing / 5 fails préexistants (`VoiceButton.*`, identique baseline)
- `tsc --noEmit` : 0 erreur

## Findings non-fixés (tracking pour future PR cleanup)
- **Deps inutilisées** : `@livekit/react-native`, `@livekit/react-native-webrtc`, `livekit-client`, `react-native-keyboard-aware-scroll-view` (Agent D vient de remplacer par DismissKeyboardView), `react-dom` (Expo Router web?)
- **console.log non-guardés `__DEV__`** : 137 occurrences (AuthContext 12, CrashReporting 11, OfflineCache 11, FeatureValidator 13, storage 13)
- **`: any` annotations** : 46 (AnalysisContentDisplay 5, AuthContext 4, useStudy 3, CustomTabBar 4) — 0 dans nouveau code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>