### PR TITLE
feat(analysis): channel context (50 videos) injected into Mistral for YouTube + TikTok

### DIFF
--- a/backend/alembic/versions/014_add_channel_contexts.py
+++ b/backend/alembic/versions/014_add_channel_contexts.py
@@ -1,0 +1,94 @@
+"""Add channel_contexts table — cache des contextes de chaîne YouTube/TikTok.
+
+Revision ID: 014_add_channel_contexts
+Revises: 013_add_embedding_model_version
+Create Date: 2026-05-03
+
+Channel Context — feature qui injecte le contexte de la chaîne (jusqu'à
+50 vidéos : titres + descriptions + tags + métadonnées chaîne) dans les
+analyses Mistral, pour permettre au modèle de calibrer son analyse
+(chaîne poubelle / dangereuse / divertissement / éducative).
+
+Schema:
+  - PRIMARY KEY composite (channel_id, platform) — un seul contexte par
+    couple chaîne/plateforme, refresh par upsert (ON CONFLICT).
+  - JSON columns (tags, categories, last_videos) → JSONB sur PostgreSQL,
+    TEXT sérialisé sur SQLite (cf. patterns migrations 009/010).
+  - last_videos NOT NULL : la liste des dernières vidéos est la donnée
+    centrale du contexte ; un contexte sans vidéos n'a pas de sens.
+  - expires_at NOT NULL + index dédié pour la purge périodique
+    (TTL côté application, pas de TRIGGER PG).
+  - CHECK platform IN ('youtube', 'tiktok') — cohérent avec les autres
+    tables platform-aware (transcript_cache, debate_analyses).
+
+Backward compatibility :
+  - Nouvelle table, aucune donnée existante → pas de backfill.
+  - Downgrade simple : drop_table.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "014_add_channel_contexts"
+down_revision: Union[str, None] = "013_add_embedding_model_version"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "channel_contexts",
+        sa.Column("channel_id", sa.String(length=128), nullable=False),
+        sa.Column("platform", sa.String(length=16), nullable=False),
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("subscriber_count", sa.BigInteger(), nullable=True),
+        sa.Column("video_count", sa.Integer(), nullable=True),
+        sa.Column(
+            "tags",
+            sa.JSON(),
+            nullable=True,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column(
+            "categories",
+            sa.JSON(),
+            nullable=True,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column("last_videos", sa.JSON(), nullable=False),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint(
+            "channel_id", "platform", name="pk_channel_contexts"
+        ),
+        sa.CheckConstraint(
+            "platform IN ('youtube', 'tiktok')",
+            name="ck_channel_contexts_platform",
+        ),
+    )
+    op.create_index(
+        "idx_channel_contexts_expires_at",
+        "channel_contexts",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_channel_contexts_expires_at",
+        table_name="channel_contexts",
+    )
+    op.drop_table("channel_contexts")

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -10,6 +10,7 @@ from typing import AsyncGenerator
 from sqlalchemy import (
     Column,
     Integer,
+    BigInteger,
     String,
     Text,
     Float,
@@ -19,6 +20,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     UniqueConstraint,
+    CheckConstraint,
     text,
     JSON,
 )
@@ -717,6 +719,44 @@ class TranscriptEmbedding(Base):
         UniqueConstraint("video_id", "chunk_index", name="uix_embedding_video_chunk"),
         Index("idx_transcript_embeddings_video", "video_id"),
         Index("idx_transcript_embeddings_model_version", "model_version"),
+    )
+
+
+class ChannelContext(Base):
+    """
+    📺 Cache du contexte de chaîne (YouTube/TikTok), cross-user.
+
+    Stocke jusqu'à ~50 vidéos récentes (titres + descriptions + tags +
+    métadonnées chaîne) pour permettre à Mistral de calibrer son analyse
+    (chaîne poubelle / dangereuse / divertissement / éducative).
+
+    Clé primaire composite (channel_id, platform) — refresh par upsert
+    (ON CONFLICT). TTL géré côté application via ``expires_at`` + purge.
+    Cf. migration 014_add_channel_contexts.
+    """
+
+    __tablename__ = "channel_contexts"
+
+    channel_id = Column(String(128), primary_key=True, nullable=False)
+    platform = Column(String(16), primary_key=True, nullable=False)
+    name = Column(Text)
+    description = Column(Text)
+    subscriber_count = Column(BigInteger)
+    video_count = Column(Integer)
+    # JSON cross-DB : JSONB sur PostgreSQL, TEXT sérialisé sur SQLite.
+    tags = Column(JSON, nullable=True, default=list, server_default="[]")
+    categories = Column(JSON, nullable=True, default=list, server_default="[]")
+    # last_videos : liste d'objets {title, description, tags, view_count, upload_date}
+    last_videos = Column(JSON, nullable=False)
+    fetched_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "platform IN ('youtube', 'tiktok')",
+            name="ck_channel_contexts_platform",
+        ),
+        Index("idx_channel_contexts_expires_at", "expires_at"),
     )
 
 

--- a/backend/src/services/channel_content_cache.py
+++ b/backend/src/services/channel_content_cache.py
@@ -1,0 +1,451 @@
+"""
++---------------------------------------------------------------------+
+|  ChannelContentCacheService — Cache 2-tiers L1 (Redis) + L2 (PG)    |
+|                                                                      |
+|  Cache du contexte de chaîne (YouTube/TikTok), cross-user.          |
+|                                                                      |
+|  Pattern (cf. ``transcripts/cache.py`` pour l'inspiration) :        |
+|    GET:                                                              |
+|      - Try L1 (Redis via core.cache.cache_service) → hit: return    |
+|      - Miss → try L2 (table channel_contexts via async_session_maker)|
+|        - HIT + expires_at > now → warm L1, return                   |
+|        - HIT + expires_at <= now → fall through                     |
+|      - Miss → call get_channel_context / get_tiktok_account_context |
+|      - Service OK (dict) → upsert L2 + L1 → return                  |
+|      - Service KO (None) → return None (NE PAS cacher les échecs)   |
+|                                                                      |
+|  Clé Redis L1 : ``vcache:channel_context:{platform}:{channel_id}``  |
+|  TTL Redis L1 + PG L2 : 7 jours.                                    |
+|                                                                      |
+|  Note ``CACHE_KEY_PREFIX`` : on garde le préfixe ``vcache:`` cohérent|
+|  avec ``video_content_cache.py`` et la note de cache cross-user.    |
++---------------------------------------------------------------------+
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import ChannelContext, async_session_maker
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constantes publiques
+# ---------------------------------------------------------------------------
+
+#: TTL appliqué à la fois sur Redis L1 et sur la colonne ``expires_at`` (PG L2).
+CHANNEL_CONTEXT_TTL_SECONDS: int = 7 * 24 * 3600  # 7 jours
+
+#: Préfixe de clé cohérent avec ``video_content_cache.py`` (``vcache:...``).
+CACHE_KEY_PREFIX: str = "vcache:channel_context"
+
+#: Plateformes supportées (alignées sur ``CHECK`` constraint en DB).
+_SUPPORTED_PLATFORMS = ("youtube", "tiktok")
+
+
+# ---------------------------------------------------------------------------
+# Helpers de clé
+# ---------------------------------------------------------------------------
+
+
+def build_channel_cache_key(platform: str, channel_id: str) -> str:
+    """Construit la clé Redis L1 pour un (platform, channel_id).
+
+    Exemple :
+        >>> build_channel_cache_key("youtube", "UCabc")
+        'vcache:channel_context:youtube:UCabc'
+    """
+    return f"{CACHE_KEY_PREFIX}:{platform}:{channel_id}"
+
+
+# ---------------------------------------------------------------------------
+# Lazy imports — Redis (core.cache) + services fetch
+#
+# On importe lazy pour :
+#   - éviter les circular imports (transcripts/* dépendent déjà de core/*) ;
+#   - permettre aux tests de monkeypatch facilement les helpers ci-dessous
+#     sans devoir patcher ``core.cache.cache_service`` au global.
+# ---------------------------------------------------------------------------
+
+
+def _get_cache_service():
+    """Retourne ``core.cache.cache_service`` ou ``None`` si indispo."""
+    try:
+        from core.cache import cache_service
+
+        return cache_service
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Redis L1 helpers
+# ---------------------------------------------------------------------------
+
+
+async def get_channel_context_from_redis(
+    platform: str, channel_id: str
+) -> Optional[Dict[str, Any]]:
+    """Lit le contexte chaîne depuis Redis L1.
+
+    Retourne ``None`` sur miss, sur erreur Redis, ou si la valeur stockée
+    n'est pas un dict valide.
+    """
+    cache_service = _get_cache_service()
+    if cache_service is None:
+        return None
+
+    key = build_channel_cache_key(platform, channel_id)
+    try:
+        value = await cache_service.get(key)
+    except Exception as exc:  # noqa: BLE001 — best-effort cache layer
+        logger.warning("[CHANNEL-CACHE] Redis GET failed key=%s: %s", key, exc)
+        return None
+
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        logger.warning(
+            "[CHANNEL-CACHE] Redis stored a non-dict value at key=%s (type=%s) — ignoring",
+            key,
+            type(value).__name__,
+        )
+        return None
+    return value
+
+
+async def set_channel_context_to_redis(
+    platform: str, channel_id: str, ctx: Dict[str, Any]
+) -> None:
+    """Écrit le contexte chaîne dans Redis L1 avec TTL 7 jours."""
+    cache_service = _get_cache_service()
+    if cache_service is None:
+        return
+
+    key = build_channel_cache_key(platform, channel_id)
+    try:
+        await cache_service.set(key, ctx, ttl=CHANNEL_CONTEXT_TTL_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[CHANNEL-CACHE] Redis SET failed key=%s: %s", key, exc)
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL L2 helpers (via SQLAlchemy + ChannelContext model)
+# ---------------------------------------------------------------------------
+
+
+def _row_to_dict(row: ChannelContext) -> Dict[str, Any]:
+    """Convertit une ligne ``ChannelContext`` en dict au shape unifié.
+
+    Aligné avec ``transcripts/youtube_channel.get_channel_context`` et
+    ``transcripts/tiktok.get_tiktok_account_context``.
+    """
+    return {
+        "channel_id": row.channel_id,
+        "platform": row.platform,
+        "name": row.name,
+        "description": row.description,
+        "subscriber_count": row.subscriber_count,
+        "video_count": row.video_count,
+        "tags": list(row.tags) if row.tags is not None else [],
+        "categories": list(row.categories) if row.categories is not None else [],
+        "last_videos": list(row.last_videos) if row.last_videos is not None else [],
+    }
+
+
+def _utcnow_naive() -> datetime:
+    """``datetime.utcnow()`` sans tz (cohérent avec le pattern test_channel_contexts).
+
+    SQLite stocke ``DateTime(timezone=True)`` sans tz info native ; on
+    travaille donc en UTC naïf pour rester portable PG / SQLite dans le
+    cadre des tests.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def get_channel_context_from_db(
+    platform: str,
+    channel_id: str,
+    *,
+    session: Optional[AsyncSession] = None,
+) -> Optional[Dict[str, Any]]:
+    """Lit le contexte chaîne depuis PG L2 (table ``channel_contexts``).
+
+    Retourne le dict reconstruit si :
+        - la ligne existe
+        - ``expires_at > now``  (TTL non expiré)
+
+    Retourne ``None`` sinon (miss / expiré / erreur DB).
+
+    ``session`` peut être injectée (utile pour les tests). Sinon une
+    nouvelle session est ouverte via ``async_session_maker()``.
+    """
+
+    async def _read(s: AsyncSession) -> Optional[Dict[str, Any]]:
+        result = await s.execute(
+            select(ChannelContext).where(
+                ChannelContext.channel_id == channel_id,
+                ChannelContext.platform == platform,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+
+        # TTL check — expires_at > now ?
+        expires = row.expires_at
+        if expires is None:
+            return None
+        # Normaliser en datetime naïf UTC pour comparaison portable
+        if isinstance(expires, datetime) and expires.tzinfo is not None:
+            expires = expires.astimezone(timezone.utc).replace(tzinfo=None)
+
+        if expires <= _utcnow_naive():
+            logger.debug(
+                "[CHANNEL-CACHE] L2 expired for %s/%s (expires_at=%s)",
+                platform,
+                channel_id,
+                expires,
+            )
+            return None
+
+        return _row_to_dict(row)
+
+    try:
+        if session is not None:
+            return await _read(session)
+        async with async_session_maker() as s:
+            return await _read(s)
+    except Exception as exc:  # noqa: BLE001 — défense en profondeur
+        logger.warning(
+            "[CHANNEL-CACHE] L2 read failed for %s/%s: %s", platform, channel_id, exc
+        )
+        return None
+
+
+async def upsert_channel_context_to_db(
+    platform: str,
+    channel_id: str,
+    ctx: Dict[str, Any],
+    ttl_seconds: int = CHANNEL_CONTEXT_TTL_SECONDS,
+    *,
+    session: Optional[AsyncSession] = None,
+) -> None:
+    """Upsert atomique dans la table ``channel_contexts``.
+
+    Pattern ``INSERT ... ON CONFLICT (channel_id, platform) DO UPDATE`` via
+    ``sqlalchemy.dialects.sqlite.insert`` (compatible avec le pattern de
+    ``test_channel_contexts.py``). Sur PostgreSQL en prod, l'identifiant de
+    conflit ``(channel_id, platform)`` correspond à la PK composite — un
+    upsert via ``sqlite_insert`` produit du SQL incorrect sous PG, donc on
+    branche selon le dialecte de la session.
+
+    ``fetched_at`` et ``expires_at`` sont **toujours explicitement** posés
+    par cette fonction (jamais laissés au server_default), pour rester
+    déterministes vis-à-vis du TTL caller-controlled.
+    """
+    now = _utcnow_naive()
+    expires = now + timedelta(seconds=ttl_seconds)
+
+    values = {
+        "channel_id": channel_id,
+        "platform": platform,
+        "name": ctx.get("name"),
+        "description": ctx.get("description"),
+        "subscriber_count": ctx.get("subscriber_count"),
+        "video_count": ctx.get("video_count"),
+        "tags": ctx.get("tags") or [],
+        "categories": ctx.get("categories") or [],
+        "last_videos": ctx.get("last_videos") or [],
+        "fetched_at": now,
+        "expires_at": expires,
+    }
+
+    async def _write(s: AsyncSession) -> None:
+        dialect_name = s.bind.dialect.name if s.bind is not None else "sqlite"
+
+        if dialect_name == "postgresql":
+            from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+            stmt = pg_insert(ChannelContext.__table__).values(**values)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["channel_id", "platform"],
+                set_={
+                    "name": stmt.excluded.name,
+                    "description": stmt.excluded.description,
+                    "subscriber_count": stmt.excluded.subscriber_count,
+                    "video_count": stmt.excluded.video_count,
+                    "tags": stmt.excluded.tags,
+                    "categories": stmt.excluded.categories,
+                    "last_videos": stmt.excluded.last_videos,
+                    "fetched_at": stmt.excluded.fetched_at,
+                    "expires_at": stmt.excluded.expires_at,
+                },
+            )
+        else:
+            # SQLite (tests + dev local) — même API ON CONFLICT
+            stmt = sqlite_insert(ChannelContext.__table__).values(**values)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["channel_id", "platform"],
+                set_={
+                    "name": stmt.excluded.name,
+                    "description": stmt.excluded.description,
+                    "subscriber_count": stmt.excluded.subscriber_count,
+                    "video_count": stmt.excluded.video_count,
+                    "tags": stmt.excluded.tags,
+                    "categories": stmt.excluded.categories,
+                    "last_videos": stmt.excluded.last_videos,
+                    "fetched_at": stmt.excluded.fetched_at,
+                    "expires_at": stmt.excluded.expires_at,
+                },
+            )
+
+        await s.execute(stmt)
+        await s.commit()
+
+    try:
+        if session is not None:
+            await _write(session)
+            return
+        async with async_session_maker() as s:
+            await _write(s)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[CHANNEL-CACHE] L2 upsert failed for %s/%s: %s",
+            platform,
+            channel_id,
+            exc,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Service fetch (lazy import — évite cycles + accélère startup)
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_from_service(
+    platform: str, channel_id: str, *, limit: int
+) -> Optional[Dict[str, Any]]:
+    """Appelle le service fetch sous-jacent selon la plateforme."""
+    if platform == "youtube":
+        from transcripts.youtube_channel import get_channel_context  # lazy
+
+        return await get_channel_context(channel_id, limit=limit)
+    if platform == "tiktok":
+        from transcripts.tiktok import get_tiktok_account_context  # lazy
+
+        return await get_tiktok_account_context(channel_id, limit=limit)
+
+    logger.warning("[CHANNEL-CACHE] Unsupported platform=%s", platform)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# API publique — get_or_fetch_channel_context
+# ---------------------------------------------------------------------------
+
+
+async def get_or_fetch_channel_context(
+    platform: str,
+    channel_id: str,
+    *,
+    force_refresh: bool = False,
+    limit: int = 50,
+    session: Optional[AsyncSession] = None,
+) -> Optional[Dict[str, Any]]:
+    """Récupère le contexte chaîne avec cache 2-tiers Redis L1 + PG L2.
+
+    Stratégie :
+        1. Si ``force_refresh=False`` → check Redis L1
+            - HIT → return dict
+        2. Check PG L2 (table ``channel_contexts``)
+            - HIT + ``expires_at > now`` → populate Redis L1 + return
+            - HIT + ``expires_at <= now`` → considéré comme miss
+        3. Miss complet → appelle ``get_channel_context`` (yt) ou
+           ``get_tiktok_account_context`` (tt)
+            - Service OK (dict) → upsert PG L2 + set Redis L1 → return
+            - Service KO (None) → return None (PAS de cache négatif)
+
+    Si ``force_refresh=True``, on saute L1 ET L2 et on tape directement le
+    service pour rafraîchir le cache.
+
+    Args:
+        platform: ``"youtube"`` ou ``"tiktok"``.
+        channel_id: ID YouTube canonique (``UCxxx``) / handle (``@xxx``)
+            pour YouTube, OU username TikTok pour TikTok.
+        force_refresh: si ``True``, ignore les caches et rafraîchit.
+        limit: nombre max de vidéos récentes à fetcher (défaut 50).
+        session: session DB optionnelle (utile pour tests).
+
+    Returns:
+        Le dict au shape unifié ou ``None`` si fetch raté.
+    """
+    if not platform or platform not in _SUPPORTED_PLATFORMS:
+        logger.warning("[CHANNEL-CACHE] Invalid platform=%r", platform)
+        return None
+    if not channel_id or not isinstance(channel_id, str):
+        logger.warning("[CHANNEL-CACHE] Invalid channel_id=%r", channel_id)
+        return None
+
+    # ── 1) Redis L1 ──────────────────────────────────────────────────────
+    if not force_refresh:
+        cached = await get_channel_context_from_redis(platform, channel_id)
+        if cached is not None:
+            logger.debug(
+                "[CHANNEL-CACHE] L1 HIT %s/%s", platform, channel_id
+            )
+            return cached
+
+    # ── 2) PG L2 ────────────────────────────────────────────────────────
+    if not force_refresh:
+        db_cached = await get_channel_context_from_db(
+            platform, channel_id, session=session
+        )
+        if db_cached is not None:
+            logger.debug(
+                "[CHANNEL-CACHE] L2 HIT %s/%s — warming L1", platform, channel_id
+            )
+            # Warm L1 best-effort
+            await set_channel_context_to_redis(platform, channel_id, db_cached)
+            return db_cached
+
+    # ── 3) Full miss → service fetch ────────────────────────────────────
+    logger.debug(
+        "[CHANNEL-CACHE] MISS %s/%s — calling underlying service (force_refresh=%s)",
+        platform,
+        channel_id,
+        force_refresh,
+    )
+    fresh = await _fetch_from_service(platform, channel_id, limit=limit)
+    if fresh is None:
+        logger.info(
+            "[CHANNEL-CACHE] Service returned None for %s/%s — not caching",
+            platform,
+            channel_id,
+        )
+        return None
+
+    # Populate L2 puis L1 (L2 d'abord car authoritative)
+    await upsert_channel_context_to_db(platform, channel_id, fresh, session=session)
+    await set_channel_context_to_redis(platform, channel_id, fresh)
+    return fresh
+
+
+__all__ = [
+    "CHANNEL_CONTEXT_TTL_SECONDS",
+    "CACHE_KEY_PREFIX",
+    "build_channel_cache_key",
+    "get_channel_context_from_redis",
+    "set_channel_context_to_redis",
+    "get_channel_context_from_db",
+    "upsert_channel_context_to_db",
+    "get_or_fetch_channel_context",
+]

--- a/backend/src/transcripts/tiktok.py
+++ b/backend/src/transcripts/tiktok.py
@@ -1021,3 +1021,273 @@ def detect_platform(url: str) -> str:
     if is_tiktok_url(url):
         return "tiktok"
     return "youtube"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 👤 ACCOUNT CONTEXT (métadonnées compte + N derniers posts)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Regex pour extraire les hashtags d'une caption TikTok (ex: "Salut #fyp #viral")
+_HASHTAG_RE = re.compile(r"#([\wÀ-￿]+)", re.UNICODE)
+# Regex pour extraire le username depuis une URL TikTok (ex: ".../@charlidamelio/video/...")
+_TIKTOK_USERNAME_FROM_URL_RE = re.compile(r"tiktok\.com/@([\w.\-]+)", re.IGNORECASE)
+
+
+def _normalize_tiktok_username(username: str) -> str:
+    """Strip whitespace + leading '@' d'un username TikTok."""
+    if not username:
+        return ""
+    return username.strip().lstrip("@").strip()
+
+
+def _extract_hashtags(text: str) -> list:
+    """Extrait les hashtags d'un texte (sans le #). Préserve l'ordre, dedup."""
+    if not text:
+        return []
+    seen = set()
+    tags: list = []
+    for match in _HASHTAG_RE.findall(text):
+        tag = match.strip()
+        if not tag:
+            continue
+        # Dédup case-insensitive mais on garde la casse originale
+        key = tag.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        tags.append(tag)
+    return tags
+
+
+def extract_tiktok_username_from_video_metadata(metadata: Dict[str, Any]) -> Optional[str]:
+    """
+    Extrait le username TikTok depuis les métadonnées d'une vidéo
+    (output de get_tiktok_video_info() ou yt-dlp brut).
+
+    Priorité des champs candidats :
+        1. uploader_id (yt-dlp brut, ex: "charlidamelio")
+        2. webpage_url / url contenant "/@username/"
+        3. uploader (peut être display name OU handle)
+        4. channel (peut être display name OU handle)
+
+    Returns:
+        username sans "@" et sans whitespace, ou None si introuvable.
+    """
+    if not metadata or not isinstance(metadata, dict):
+        return None
+
+    # 1. uploader_id (yt-dlp natif, le plus fiable)
+    uploader_id = metadata.get("uploader_id")
+    if uploader_id and isinstance(uploader_id, str):
+        normalized = _normalize_tiktok_username(uploader_id)
+        if normalized:
+            return normalized
+
+    # 2. webpage_url / url contenant /@username/
+    for url_field in ("webpage_url", "url", "original_url"):
+        url_val = metadata.get(url_field)
+        if url_val and isinstance(url_val, str):
+            match = _TIKTOK_USERNAME_FROM_URL_RE.search(url_val)
+            if match:
+                normalized = _normalize_tiktok_username(match.group(1))
+                if normalized:
+                    return normalized
+
+    # 3. uploader (peut être un handle)
+    uploader = metadata.get("uploader")
+    if uploader and isinstance(uploader, str):
+        normalized = _normalize_tiktok_username(uploader)
+        if normalized:
+            return normalized
+
+    # 4. channel (fallback)
+    channel = metadata.get("channel")
+    if channel and isinstance(channel, str):
+        normalized = _normalize_tiktok_username(channel)
+        if normalized:
+            return normalized
+
+    return None
+
+
+async def get_tiktok_account_context(username: str, limit: int = 50) -> Optional[Dict[str, Any]]:
+    """
+    Récupère le contexte d'un compte TikTok : métadonnées + N derniers posts.
+
+    Le shape retourné est strictement IDENTIQUE à get_channel_context() YouTube
+    pour permettre l'injection unifiée dans le prompt Mistral.
+
+    Args:
+        username: handle TikTok sans @ (ex: "charlidamelio") OU avec @ (sera normalisé)
+        limit: nombre maximum de posts à récupérer (défaut 50)
+
+    Returns:
+        dict shape:
+        {
+            "channel_id": str,                # username (sans @)
+            "platform": "tiktok",
+            "name": str,                      # display name (channel/uploader)
+            "description": str,               # bio
+            "subscriber_count": int | None,   # follower_count
+            "video_count": int | None,
+            "tags": list[str],                # vide pour TikTok
+            "categories": list[str],          # vide pour TikTok
+            "last_videos": [
+                {
+                    "title": str,             # caption courte / titre
+                    "description": str,       # caption complète tronquée 200ch
+                    "tags": list[str],        # hashtags extraits
+                    "view_count": int | None,
+                    "upload_date": str | None,  # YYYYMMDD format yt-dlp
+                },
+                ...
+            ],
+        }
+
+        Returns None on failure (compte privé, suspendu, rate limit, yt-dlp error).
+    """
+    normalized_username = _normalize_tiktok_username(username)
+    if not normalized_username:
+        logger.warning("[TIKTOK] get_tiktok_account_context: empty username")
+        return None
+
+    safe_limit = max(1, min(limit, 200))  # bornes raisonnables
+    account_url = f"https://www.tiktok.com/@{normalized_username}"
+
+    logger.info(f"[TIKTOK] Fetching account context for @{normalized_username} (limit={safe_limit})")
+
+    try:
+        loop = asyncio.get_event_loop()
+
+        def _fetch_account():
+            cmd = [
+                "yt-dlp",
+                *_yt_dlp_extra_args(),
+                "--flat-playlist",
+                "--dump-single-json",
+                "--playlistend",
+                str(safe_limit),
+                "--no-warnings",
+                "--skip-download",
+                account_url,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            if result.returncode != 0:
+                stderr = (result.stderr or "")[:300]
+                logger.warning(
+                    f"[TIKTOK] yt-dlp account fetch failed for @{normalized_username}: {stderr}"
+                )
+                return None
+            try:
+                return json.loads(result.stdout)
+            except json.JSONDecodeError as e:
+                logger.warning(f"[TIKTOK] yt-dlp account JSON parse error: {e}")
+                return None
+
+        data = await asyncio.wait_for(
+            loop.run_in_executor(audio_executor, _fetch_account),
+            timeout=60,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(f"[TIKTOK] Account fetch timeout for @{normalized_username}")
+        return None
+    except Exception as e:
+        logger.error(f"[TIKTOK] Account fetch error for @{normalized_username}: {e}")
+        return None
+
+    if not data or not isinstance(data, dict):
+        return None
+
+    # Métadonnées du compte (champs yt-dlp pour une page de compte TikTok)
+    display_name = (
+        data.get("channel")
+        or data.get("uploader")
+        or data.get("title")
+        or normalized_username
+    )
+    description = data.get("description", "") or ""
+    subscriber_count = (
+        data.get("channel_follower_count")
+        or data.get("uploader_follower_count")
+        or data.get("follower_count")
+    )
+    # Convertir en int si possible
+    if subscriber_count is not None:
+        try:
+            subscriber_count = int(subscriber_count)
+        except (TypeError, ValueError):
+            subscriber_count = None
+
+    entries = data.get("entries") or []
+    if not isinstance(entries, list):
+        entries = []
+
+    last_videos: list = []
+    for entry in entries[:safe_limit]:
+        if not entry or not isinstance(entry, dict):
+            continue
+        # TikTok = caption avec hashtags inline. yt-dlp expose generalement
+        # `title` (souvent égal à la caption) et `description`.
+        raw_title = entry.get("title") or entry.get("description") or ""
+        raw_description = entry.get("description") or entry.get("title") or ""
+
+        # Title : conservé brut (cohérence shape avec YouTube channel context)
+        title = raw_title or ""
+
+        # Description : tronquée à 200 chars (cohérence YouTube channel context)
+        description_field = raw_description or ""
+        if len(description_field) > 200:
+            description_field = description_field[:200]
+
+        # Hashtags : on les extrait du texte le plus riche
+        hashtag_source = raw_description if len(raw_description or "") >= len(raw_title or "") else raw_title
+        tags = _extract_hashtags(hashtag_source or "")
+
+        view_count = entry.get("view_count")
+        if view_count is not None:
+            try:
+                view_count = int(view_count)
+            except (TypeError, ValueError):
+                view_count = None
+
+        upload_date = entry.get("upload_date")
+        if upload_date is not None and not isinstance(upload_date, str):
+            upload_date = str(upload_date)
+
+        last_videos.append(
+            {
+                "title": title,
+                "description": description_field,
+                "tags": tags,
+                "view_count": view_count,
+                "upload_date": upload_date,
+            }
+        )
+
+    # video_count : on prend playlist_count si dispo, sinon le nombre d'entries
+    raw_video_count = data.get("playlist_count") or data.get("video_count")
+    if raw_video_count is not None:
+        try:
+            video_count = int(raw_video_count)
+        except (TypeError, ValueError):
+            video_count = len(last_videos) or None
+    else:
+        video_count = len(last_videos) or None
+
+    result = {
+        "channel_id": normalized_username,
+        "platform": "tiktok",
+        "name": str(display_name)[:200] if display_name else normalized_username,
+        "description": str(description)[:2000] if description else "",
+        "subscriber_count": subscriber_count,
+        "video_count": video_count,
+        "tags": [],         # TikTok n'a pas de tags compte
+        "categories": [],   # TikTok n'a pas de catégories compte
+        "last_videos": last_videos,
+    }
+
+    logger.info(
+        f"[TIKTOK] Account context OK for @{normalized_username}: "
+        f"{len(last_videos)} posts, followers={subscriber_count}"
+    )
+    return result

--- a/backend/src/transcripts/youtube_channel.py
+++ b/backend/src/transcripts/youtube_channel.py
@@ -1,0 +1,253 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  📺 YOUTUBE CHANNEL CONTEXT SERVICE                                                ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Récupère métadonnées + N derniers uploads d'une chaîne YouTube via yt-dlp        ║
+║  pour injection dans le contexte d'analyse Mistral.                                ║
+║                                                                                    ║
+║  Usage produit :                                                                   ║
+║  • Permet à Mistral de comprendre si une vidéo est représentative ou exception    ║
+║  • Permet de classifier la chaîne (poubelle/dangereuse/divertissement/éducative)  ║
+║                                                                                    ║
+║  API publique :                                                                    ║
+║  • get_channel_context(channel_id, limit=50) -> dict | None                       ║
+║  • extract_channel_id_from_video_metadata(metadata) -> str | None                 ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any, Optional
+
+from transcripts.audio_utils import _yt_dlp_extra_args
+
+logger = logging.getLogger(__name__)
+
+# Timeout global pour l'invocation yt-dlp d'une chaîne (s)
+_YTDLP_TIMEOUT_S = 60
+
+# Tronquage des descriptions d'uploads pour éviter d'exploser le contexte LLM
+_VIDEO_DESCRIPTION_MAX_CHARS = 200
+
+# Régex pour extraire un ID de chaîne UCxxx depuis une URL `youtube.com/channel/UCxxx[...]`
+_CHANNEL_ID_FROM_URL_RE = re.compile(r"/channel/(UC[A-Za-z0-9_-]{20,})")
+
+
+def _build_channel_url(channel_id: str) -> str:
+    """Construit l'URL `/videos` adaptée au format de l'identifiant.
+
+    yt-dlp accepte indifféremment :
+    - https://www.youtube.com/channel/UCxxx/videos    (ID canonique UCxxx)
+    - https://www.youtube.com/@handle/videos          (handle, commence par @)
+
+    Pour tout autre format (ex. nom legacy), on retombe sur `/channel/`.
+    """
+    if channel_id.startswith("@"):
+        # Le handle conserve son préfixe `@` dans l'URL.
+        return f"https://www.youtube.com/{channel_id}/videos"
+    return f"https://www.youtube.com/channel/{channel_id}/videos"
+
+
+async def _run_ytdlp_channel(channel_url: str, limit: int) -> Optional[dict[str, Any]]:
+    """Lance `yt-dlp --flat-playlist --dump-single-json` sur l'URL chaîne.
+
+    Retourne le dict JSON parsé, ou None en cas d'échec (timeout, returncode != 0,
+    JSON invalide, exécutable absent, etc.).
+    """
+    cmd = [
+        "yt-dlp",
+        "--flat-playlist",
+        "--dump-single-json",
+        "--playlistend",
+        str(limit),
+        "--no-warnings",
+        "--skip-download",
+        *_yt_dlp_extra_args(),
+        channel_url,
+    ]
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        logger.warning("yt-dlp executable not found on PATH; cannot fetch channel %s", channel_url)
+        return None
+    except Exception as exc:  # défense en profondeur — spawn imprévu
+        logger.warning("Failed to spawn yt-dlp for %s: %s", channel_url, exc)
+        return None
+
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_YTDLP_TIMEOUT_S)
+    except asyncio.TimeoutError:
+        logger.warning("yt-dlp channel fetch timed out (>%ss) for %s", _YTDLP_TIMEOUT_S, channel_url)
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+        return None
+
+    if proc.returncode != 0:
+        stderr_text = (stderr or b"").decode("utf-8", errors="replace").strip()
+        logger.warning(
+            "yt-dlp channel fetch failed (rc=%s) for %s: %s",
+            proc.returncode,
+            channel_url,
+            stderr_text[:300],
+        )
+        return None
+
+    try:
+        return json.loads(stdout.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:
+        logger.warning("yt-dlp returned invalid JSON for %s: %s", channel_url, exc)
+        return None
+
+
+def _parse_channel_payload(
+    channel_id: str,
+    payload: dict[str, Any],
+    limit: int,
+) -> dict[str, Any]:
+    """Convertit le JSON yt-dlp en dict canonique 'channel context'."""
+    entries = payload.get("entries") or []
+
+    last_videos: list[dict[str, Any]] = []
+    for entry in entries[:limit]:
+        if not isinstance(entry, dict):
+            continue
+        description = entry.get("description") or ""
+        if len(description) > _VIDEO_DESCRIPTION_MAX_CHARS:
+            description = description[:_VIDEO_DESCRIPTION_MAX_CHARS]
+        last_videos.append(
+            {
+                "title": entry.get("title") or "",
+                "description": description,
+                "tags": list(entry.get("tags") or []),
+                "view_count": entry.get("view_count"),
+                "upload_date": entry.get("upload_date"),
+            }
+        )
+
+    return {
+        "channel_id": channel_id,
+        "platform": "youtube",
+        "name": payload.get("channel") or payload.get("uploader") or payload.get("title") or "",
+        "description": payload.get("description") or "",
+        "subscriber_count": payload.get("channel_follower_count"),
+        "video_count": payload.get("playlist_count"),
+        "tags": list(payload.get("tags") or []),
+        "categories": list(payload.get("categories") or []),
+        "last_videos": last_videos,
+    }
+
+
+async def get_channel_context(channel_id: str, limit: int = 50) -> Optional[dict[str, Any]]:
+    """Fetch métadonnées + N derniers uploads d'une chaîne YouTube.
+
+    Args:
+        channel_id: ID canonique (`UCxxx...`) ou handle (`@xxx`) d'une chaîne YouTube.
+        limit: nombre max d'uploads à remonter dans `last_videos` (défaut 50).
+
+    Returns:
+        Un dict de la forme :
+
+            {
+                "channel_id": str,
+                "platform": "youtube",
+                "name": str,
+                "description": str,
+                "subscriber_count": int | None,
+                "video_count": int | None,
+                "tags": list[str],
+                "categories": list[str],
+                "last_videos": [
+                    {
+                        "title": str,
+                        "description": str,           # tronqué à 200 chars
+                        "tags": list[str],
+                        "view_count": int | None,
+                        "upload_date": str | None,    # YYYYMMDD (format yt-dlp)
+                    },
+                    ...
+                ],
+            }
+
+        ou `None` en cas d'échec (chaîne privée/supprimée, rate-limit, timeout, etc.).
+    """
+    if not channel_id or not isinstance(channel_id, str):
+        logger.debug("get_channel_context: channel_id vide/invalide -> None")
+        return None
+    if limit <= 0:
+        logger.debug("get_channel_context: limit<=0 -> None")
+        return None
+
+    url_primary = _build_channel_url(channel_id)
+    payload = await _run_ytdlp_channel(url_primary, limit)
+
+    # Fallback : si l'utilisateur a passé un handle SANS le préfixe `@`, retenter
+    # avec `@`. yt-dlp accepte aussi `youtube.com/<handle>` mais sans `@` cela
+    # échoue silencieusement pour la plupart des handles modernes.
+    if payload is None and not channel_id.startswith("@") and not channel_id.startswith("UC"):
+        url_handle = f"https://www.youtube.com/@{channel_id}/videos"
+        logger.info("Retrying channel fetch with handle URL: %s", url_handle)
+        payload = await _run_ytdlp_channel(url_handle, limit)
+
+    if payload is None:
+        return None
+
+    try:
+        return _parse_channel_payload(channel_id, payload, limit)
+    except Exception as exc:  # défense en profondeur — payload yt-dlp inattendu
+        logger.warning("Failed to parse yt-dlp channel payload for %s: %s", channel_id, exc)
+        return None
+
+
+def extract_channel_id_from_video_metadata(metadata: dict[str, Any]) -> Optional[str]:
+    """Extrait l'ID de chaîne depuis le metadata d'une vidéo (output de
+    `get_video_info_ytdlp`).
+
+    Ordre de préférence :
+    1. champ direct `channel_id` (le plus fiable, ex: `UCxxx...`)
+    2. parse de `channel_url` (`https://www.youtube.com/channel/UCxxx`)
+    3. fallback `uploader_id` (peut être un handle `@xxx` ou un nom legacy)
+
+    Returns:
+        L'ID canonique `UCxxx...` ou un handle `@xxx`, ou `None` si rien de
+        exploitable.
+    """
+    if not isinstance(metadata, dict):
+        return None
+
+    direct = metadata.get("channel_id")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+
+    channel_url = metadata.get("channel_url") or metadata.get("uploader_url")
+    if isinstance(channel_url, str) and channel_url:
+        match = _CHANNEL_ID_FROM_URL_RE.search(channel_url)
+        if match:
+            return match.group(1)
+        # `youtube.com/@handle` -> handle préfixé `@`
+        handle_match = re.search(r"youtube\.com/(@[A-Za-z0-9._-]+)", channel_url)
+        if handle_match:
+            return handle_match.group(1)
+
+    uploader_id = metadata.get("uploader_id")
+    if isinstance(uploader_id, str) and uploader_id.strip():
+        return uploader_id.strip()
+
+    return None
+
+
+__all__ = [
+    "get_channel_context",
+    "extract_channel_id_from_video_metadata",
+]

--- a/backend/src/videos/analysis.py
+++ b/backend/src/videos/analysis.py
@@ -1503,6 +1503,175 @@ def get_transcript_limit(duration: int, mode: str) -> int:
     return min(base, 300000)
 
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🏷️ CONTEXTE CHAÎNE — Directive système + helper de formatage
+# ═══════════════════════════════════════════════════════════════════════════════
+
+CHANNEL_CONTEXT_DIRECTIVE_FR = """
+═══════════════════════════════════════════════════════════════════════════════
+🏷️ CONTEXTE CHAÎNE — DIRECTIVE OBLIGATOIRE
+═══════════════════════════════════════════════════════════════════════════════
+Tu reçois en plus un contexte sur la chaîne YouTube/TikTok du vidéaste (jusqu'à 50 dernières vidéos avec titres, descriptions, tags, ainsi que les métadonnées de la chaîne). Tu DOIS produire en fin d'analyse une section `## Contexte chaîne` qui :
+- Classifie la chaîne dans une de ces catégories : divertissement / éducative / informative / promotionnelle / militante / poubelle (low-effort, clickbait massif, désinformation) / dangereuse (incitations, haine, complotisme dur) / autre (à préciser)
+- Indique si la vidéo analysée est représentative de la chaîne ou une exception (signal fort/faible)
+- Décrit en 1-2 phrases les intentions probables du vidéaste à la lumière de l'ensemble de ses contenus
+- Reste neutre et factuel — pas de jugement moral, juste classification descriptive
+
+Si aucun contexte chaîne n'est fourni, ne génère PAS cette section.
+"""
+
+CHANNEL_CONTEXT_DIRECTIVE_EN = """
+═══════════════════════════════════════════════════════════════════════════════
+🏷️ CHANNEL CONTEXT — MANDATORY DIRECTIVE
+═══════════════════════════════════════════════════════════════════════════════
+You also receive context about the video creator's YouTube/TikTok channel (up to 50 latest videos with titles, descriptions, tags, plus channel metadata). You MUST produce at the end of your analysis a `## Channel Context` section that:
+- Classifies the channel into one of these categories: entertainment / educational / informative / promotional / activist / low-quality (low-effort, massive clickbait, misinformation) / dangerous (incitement, hate, hard conspiracy) / other (to specify)
+- Indicates whether the analyzed video is representative of the channel or an exception (strong/weak signal)
+- Describes in 1-2 sentences the creator's probable intentions in light of their overall content
+- Remains neutral and factual — no moral judgment, just descriptive classification
+
+If no channel context is provided, do NOT generate this section.
+"""
+
+
+def _format_channel_context_block(ctx: Optional[Dict], language: str = "fr") -> str:
+    """
+    Formate un bloc texte du contexte chaîne pour injection dans le user_prompt.
+
+    - Tronque la description chaîne à 500 chars.
+    - Tronque les descriptions de chaque vidéo à 200 chars.
+    - Gère proprement les valeurs manquantes (None, listes vides, etc.).
+    - Si ctx est None ou vide, retourne une chaîne vide (l'appelant ne doit
+      alors PAS append ce bloc au prompt).
+
+    Args:
+        ctx: dict au shape unifié `{channel_id, platform, name, description,
+            subscriber_count, video_count, tags, categories, last_videos}`.
+        language: "fr" ou "en" pour les libellés.
+
+    Returns:
+        Bloc texte formaté (avec saut de ligne en tête) ou "" si ctx vide.
+    """
+    if not ctx or not isinstance(ctx, dict):
+        return ""
+
+    is_fr = language == "fr"
+
+    # Helpers locaux pour formattage défensif
+    def _fmt_count(value) -> str:
+        if value is None:
+            return "n/a"
+        try:
+            return _format_view_count(int(value)) or str(int(value))
+        except (TypeError, ValueError):
+            return "n/a"
+
+    def _join_list(value) -> str:
+        if not value or not isinstance(value, list):
+            return "n/a"
+        items = [str(v) for v in value if v is not None and str(v).strip()]
+        return ", ".join(items) if items else "n/a"
+
+    platform = str(ctx.get("platform") or "n/a")
+    name = str(ctx.get("name") or "").strip() or "n/a"
+    description = str(ctx.get("description") or "").strip()
+    if len(description) > 500:
+        description = description[:500] + "..."
+    if not description:
+        description = "n/a"
+
+    subs_str = _fmt_count(ctx.get("subscriber_count"))
+    vcount_str = _fmt_count(ctx.get("video_count"))
+    tags_str = _join_list(ctx.get("tags"))
+    cats_str = _join_list(ctx.get("categories"))
+
+    last_videos = ctx.get("last_videos") or []
+    if not isinstance(last_videos, list):
+        last_videos = []
+
+    if is_fr:
+        header = (
+            "\n\n═══════════════════════════════════════════════════════════════════════════════\n"
+            "### Contexte chaîne (référence)\n"
+            "═══════════════════════════════════════════════════════════════════════════════\n"
+            f"- Plateforme : {platform}\n"
+            f"- Nom : {name}\n"
+            f"- Description : {description}\n"
+            f"- Abonnés : {subs_str}\n"
+            f"- Total vidéos : {vcount_str}\n"
+            f"- Tags chaîne : {tags_str}\n"
+            f"- Catégories : {cats_str}\n"
+        )
+        if last_videos:
+            header += f"\n#### {len(last_videos)} dernières vidéos de la chaîne :\n"
+        else:
+            header += "\n#### Aucune vidéo récente disponible.\n"
+    else:
+        header = (
+            "\n\n═══════════════════════════════════════════════════════════════════════════════\n"
+            "### Channel Context (reference)\n"
+            "═══════════════════════════════════════════════════════════════════════════════\n"
+            f"- Platform: {platform}\n"
+            f"- Name: {name}\n"
+            f"- Description: {description}\n"
+            f"- Subscribers: {subs_str}\n"
+            f"- Total videos: {vcount_str}\n"
+            f"- Channel tags: {tags_str}\n"
+            f"- Categories: {cats_str}\n"
+        )
+        if last_videos:
+            header += f"\n#### {len(last_videos)} latest videos from the channel:\n"
+        else:
+            header += "\n#### No recent videos available.\n"
+
+    lines = [header]
+    for idx, v in enumerate(last_videos, 1):
+        if not isinstance(v, dict):
+            continue
+        title = str(v.get("title") or "").strip() or ("(sans titre)" if is_fr else "(untitled)")
+        upload_date = v.get("upload_date") or ""
+        if upload_date:
+            upload_label = f"[{upload_date}] "
+        else:
+            upload_label = ""
+
+        view_count = v.get("view_count")
+        if view_count is None:
+            views_label = "n/a"
+        else:
+            try:
+                views_label = _format_view_count(int(view_count)) or str(int(view_count))
+            except (TypeError, ValueError):
+                views_label = "n/a"
+
+        if is_fr:
+            views_suffix = f"({views_label} vues)" if views_label != "n/a" else "(vues n/a)"
+        else:
+            views_suffix = f"({views_label} views)" if views_label != "n/a" else "(views n/a)"
+
+        v_tags = _join_list(v.get("tags"))
+        v_desc = str(v.get("description") or "").strip()
+        if len(v_desc) > 200:
+            v_desc = v_desc[:200] + "..."
+        if not v_desc:
+            v_desc = "n/a"
+
+        if is_fr:
+            lines.append(
+                f"{idx}. {upload_label}{title} {views_suffix}\n"
+                f"   Tags: {v_tags}\n"
+                f"   Description: {v_desc}\n"
+            )
+        else:
+            lines.append(
+                f"{idx}. {upload_label}{title} {views_suffix}\n"
+                f"   Tags: {v_tags}\n"
+                f"   Description: {v_desc}\n"
+            )
+
+    return "".join(lines)
+
+
 def build_analysis_prompt(
     title: str,
     transcript: str,
@@ -1524,6 +1693,8 @@ def build_analysis_prompt(
     engagement_rate: float = 0.0,
     content_type: str = "video",
     chapters: list = None,
+    # 🏷️ v8.0: Contexte chaîne (calibration analyse Mistral)
+    channel_context: Optional[Dict] = None,
 ) -> Tuple[str, str]:
     """
     Construit le prompt système et utilisateur pour l'analyse.
@@ -1682,6 +1853,7 @@ C'est une fonctionnalité ESSENTIELLE de Deep Sight. Sans [[concepts]], la répo
 📊 LONGUEUR CIBLE : {min_words}-{max_words} mots
 
 🌐 RÉPONDS ENTIÈREMENT EN FRANÇAIS IMPECCABLE.
+{CHANNEL_CONTEXT_DIRECTIVE_FR}
 """
 
         platform_label = "TikTok" if platform == "tiktok" else "YouTube"
@@ -1758,6 +1930,7 @@ This is an ESSENTIAL feature of Deep Sight. Without [[concepts]], the response i
 TARGET LENGTH: {min_words}-{max_words} words
 
 RESPOND ENTIRELY IN ENGLISH.
+{CHANNEL_CONTEXT_DIRECTIVE_EN}
 """
 
         platform_label = "TikTok" if platform == "tiktok" else "YouTube"
@@ -1797,6 +1970,15 @@ RESPOND ENTIRELY IN ENGLISH.
 
 {content_instruction_en}"""
 
+    # 🏷️ v8.0: Append le bloc contexte chaîne (si fourni) — APRÈS le user_prompt
+    # Note : l'injection web_context est faite par generate_summary() en aval,
+    # donc le bloc chaîne est injecté ici pour qu'il soit présent dans les
+    # appels directs à build_analysis_prompt aussi (tests + appels manuels).
+    # generate_summary() ré-append ensuite éventuellement le web_context.
+    channel_block = _format_channel_context_block(channel_context, language=lang)
+    if channel_block:
+        user_prompt = user_prompt + channel_block
+
     return system_prompt, user_prompt
 
 
@@ -1831,6 +2013,8 @@ async def generate_summary(
     engagement_rate: float = 0.0,
     content_type: str = "video",
     chapters: list = None,
+    # 🏷️ v8.0: Contexte chaîne (calibration analyse Mistral)
+    channel_context: Optional[Dict] = None,
 ) -> Optional[str]:
     """
     Génère un résumé avec Mistral AI.
@@ -1880,6 +2064,7 @@ async def generate_summary(
         engagement_rate=engagement_rate,
         content_type=content_type,
         chapters=chapters,
+        channel_context=channel_context,
     )
 
     # 🆕 v3.0: Injecter le contexte web dans le prompt utilisateur

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -2670,6 +2670,16 @@ async def _analyze_video_background_v2_1(
             pass
 
 
+async def _async_none():
+    """Helper async qui résout immédiatement sur None.
+
+    Utilisé pour rendre les branches optionnelles (ex: contexte chaîne quand
+    aucun channel_id n'est extractible) compatibles avec ``asyncio.gather``
+    sans logique conditionnelle dispersée.
+    """
+    return None
+
+
 async def _analyze_video_background_v6(
     task_id: str,
     video_id: str,
@@ -2749,6 +2759,38 @@ async def _analyze_video_background_v6(
                 raise Exception("Could not fetch video info")
 
             logger.info(f"✅ Video info: {video_info.get('title', 'Unknown')[:50]}")
+
+            # 🏷️ v8.0: Extraire l'ID de chaîne (channel_id YouTube ou username TikTok)
+            # → utilisé en étape 3+4 pour fetch le contexte chaîne en parallèle.
+            # Imports lazy : évitent les coûts de chargement quand la feature ne tire pas.
+            _channel_external_id: Optional[str] = None
+            try:
+                if platform == "tiktok":
+                    from transcripts.tiktok import (
+                        extract_tiktok_username_from_video_metadata as _extract_chan_id,
+                    )
+
+                    _channel_external_id = _extract_chan_id(video_info)
+                else:
+                    from transcripts.youtube_channel import (
+                        extract_channel_id_from_video_metadata as _extract_chan_id,
+                    )
+
+                    _channel_external_id = _extract_chan_id(video_info)
+            except Exception as _ce:
+                # Fail-safe : aucune erreur ne doit bloquer l'analyse principale.
+                logger.warning(f"[CHANNEL-CTX] Failed to extract channel id: {_ce}")
+                _channel_external_id = None
+
+            if _channel_external_id:
+                logger.info(
+                    f"🏷️ [CHANNEL-CTX] Resolved channel id for {platform}: {_channel_external_id}"
+                )
+            else:
+                logger.info(
+                    f"🏷️ [CHANNEL-CTX] No channel id resolvable for {platform}/{video_id} — "
+                    "context fetch will be skipped"
+                )
 
             # ═══════════════════════════════════════════════════════════════════
             # 2. EXTRAIRE LA TRANSCRIPTION (avec global cache check)
@@ -2942,12 +2984,66 @@ async def _analyze_video_background_v6(
                     logger.error(f"⚠️ [v5.0] PRE-ANALYSIS failed (continuing without): {e}")
                     return None, [], enrichment_level
 
-            # ⚡ Lancer les deux en parallèle
-            (category, confidence), (_web_ctx, _enrich_src, _) = await asyncio.gather(
-                _detect_category_async(), _enrich_web_async()
+            # 🏷️ v8.0 — Fetch contexte chaîne (async, lazy import)
+            async def _fetch_channel_context_async():
+                if not _channel_external_id:
+                    return None
+                try:
+                    from services.channel_content_cache import (
+                        get_or_fetch_channel_context as _get_chan_ctx,
+                    )
+
+                    ctx = await _get_chan_ctx(platform, _channel_external_id, limit=50)
+                    if ctx:
+                        logger.info(
+                            f"✅ [CHANNEL-CTX] Fetched context for {platform}/"
+                            f"{_channel_external_id}: name='{ctx.get('name', '')[:40]}', "
+                            f"{len(ctx.get('last_videos') or [])} recent videos"
+                        )
+                    else:
+                        logger.warning(
+                            f"⚠️ [CHANNEL-CTX] No context returned for {platform}/{_channel_external_id}"
+                        )
+                    return ctx
+                except Exception as e:
+                    logger.error(
+                        f"⚠️ [CHANNEL-CTX] Fetch failed (continuing without): {e}"
+                    )
+                    return None
+
+            # ⚡ Lancer les trois en parallèle (return_exceptions=True pour fail-safe)
+            results = await asyncio.gather(
+                _detect_category_async(),
+                _enrich_web_async(),
+                _fetch_channel_context_async(),
+                return_exceptions=True,
             )
+
+            # Unpack catégorie (avec safety)
+            cat_result = results[0]
+            if isinstance(cat_result, Exception):
+                logger.error(f"⚠️ [v6.1] Category detection failed: {cat_result}")
+                category, confidence = (category or "general", 0.5)
+            else:
+                category, confidence = cat_result
+
+            # Unpack enrichissement web (avec safety)
+            web_result = results[1]
+            if isinstance(web_result, Exception):
+                logger.error(f"⚠️ [v6.1] Web enrichment failed: {web_result}")
+                _web_ctx, _enrich_src = None, []
+            else:
+                _web_ctx, _enrich_src, _ = web_result
             web_context = _web_ctx
             enrichment_sources = _enrich_src
+
+            # Unpack contexte chaîne (avec safety)
+            chan_result = results[2]
+            if isinstance(chan_result, Exception):
+                logger.error(f"⚠️ [v6.1] Channel context fetch raised: {chan_result}")
+                channel_context = None
+            else:
+                channel_context = chan_result
 
             _task_store[task_id]["progress"] = 45
             logger.info("⚡ [v6.1] Category + web enrichment computed in PARALLEL")
@@ -3033,6 +3129,7 @@ async def _analyze_video_background_v6(
                         share_count=video_info.get("share_count") or 0,
                         content_type=video_info.get("content_type", "video"),
                         chapters=video_info.get("chapters"),
+                        channel_context=channel_context,
                     )
             else:
                 # ════════════════════════════════════════════════════════════
@@ -3072,6 +3169,7 @@ async def _analyze_video_background_v6(
                     share_count=video_info.get("share_count") or 0,
                     content_type=video_info.get("content_type", "video"),
                     chapters=video_info.get("chapters"),
+                    channel_context=channel_context,
                 )
 
             if not summary_content:

--- a/backend/tests/db/test_channel_contexts.py
+++ b/backend/tests/db/test_channel_contexts.py
@@ -1,0 +1,230 @@
+"""Tests for the ChannelContext model (migration 014).
+
+Vérifie le contrat du model :
+  1. Insert + retrieve d'une ligne ChannelContext (CRUD basique).
+  2. Upsert via SQLite ``INSERT ... ON CONFLICT (channel_id, platform)
+     DO UPDATE`` : la PK composite est respectée et ``fetched_at`` est
+     bien mis à jour lors d'un refresh.
+  3. ``expires_at`` est strictement postérieur à ``fetched_at`` lors de
+     l'insert (invariant TTL).
+
+Stratégie : SQLite in-memory + ``Base.metadata.create_all`` pour
+matérialiser le schéma sans dépendre d'Alembic (cf. pattern de
+``test_user_preferences_column.py`` / ``test_voice_e2e_unified_timeline.py``).
+
+Notes :
+  - Le pattern upsert testé utilise ``sqlite_insert.on_conflict_do_update``
+    (équivalent fonctionnel de ``INSERT ... ON CONFLICT`` PostgreSQL,
+    cf. core upsert pattern utilisé en prod).
+  - SQLite stocke ``DateTime(timezone=True)`` sans tz info native, donc
+    on compare avec des datetimes naïfs (UTC) pour rester portable.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+@pytest_asyncio.fixture
+async def test_session():
+    """SQLite in-memory + tous les models créés via Base.metadata.create_all."""
+    from db.database import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    SessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with SessionLocal() as session:
+        yield session
+
+    await engine.dispose()
+
+
+def _sample_last_videos() -> list[dict]:
+    """Échantillon réaliste — 2 vidéos avec la shape attendue par la feature."""
+    return [
+        {
+            "title": "Comment l'IA change la science",
+            "description": "Une vidéo de fond sur l'impact de l'IA en recherche.",
+            "tags": ["ia", "science", "recherche"],
+            "view_count": 12500,
+            "upload_date": "20260415",
+        },
+        {
+            "title": "Explorer Mars en 2030",
+            "description": "Mission de la NASA prévue pour 2030.",
+            "tags": ["espace", "mars", "nasa"],
+            "view_count": 84200,
+            "upload_date": "20260420",
+        },
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_channel_context(test_session: AsyncSession):
+    """Insert basique + retrieve via PK composite."""
+    from db.database import ChannelContext
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    expires = now + timedelta(days=7)
+
+    ctx = ChannelContext(
+        channel_id="UC_test_create_001",
+        platform="youtube",
+        name="Test Channel",
+        description="A description",
+        subscriber_count=1_500_000,
+        video_count=420,
+        tags=["science", "tech"],
+        categories=["Education"],
+        last_videos=_sample_last_videos(),
+        fetched_at=now,
+        expires_at=expires,
+    )
+    test_session.add(ctx)
+    await test_session.commit()
+
+    result = await test_session.execute(
+        select(ChannelContext).where(
+            ChannelContext.channel_id == "UC_test_create_001",
+            ChannelContext.platform == "youtube",
+        )
+    )
+    row = result.scalar_one()
+
+    assert row.channel_id == "UC_test_create_001"
+    assert row.platform == "youtube"
+    assert row.name == "Test Channel"
+    assert row.subscriber_count == 1_500_000
+    assert row.video_count == 420
+    assert row.tags == ["science", "tech"]
+    assert row.categories == ["Education"]
+    assert isinstance(row.last_videos, list)
+    assert len(row.last_videos) == 2
+    assert row.last_videos[0]["title"] == "Comment l'IA change la science"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upsert_channel_context(test_session: AsyncSession):
+    """Upsert pattern (ON CONFLICT) : refresh d'un contexte existant.
+
+    Vérifie que :
+      - l'insert initial passe ;
+      - un second insert sur la même PK composite déclenche le DO UPDATE ;
+      - les colonnes sont bien rafraîchies, dont ``fetched_at`` qui doit
+        avancer dans le temps.
+    """
+    from db.database import ChannelContext
+
+    t0 = datetime(2026, 5, 1, 10, 0, 0)
+    t1 = datetime(2026, 5, 2, 10, 0, 0)  # +1 jour
+
+    # ── Insert initial ────────────────────────────────────────────────
+    stmt_insert = sqlite_insert(ChannelContext.__table__).values(
+        channel_id="UC_upsert_001",
+        platform="youtube",
+        name="Initial Name",
+        description="Initial description",
+        subscriber_count=1000,
+        video_count=10,
+        tags=["initial"],
+        categories=["Initial"],
+        last_videos=[{"title": "v1", "description": "", "tags": [], "view_count": 1, "upload_date": "20260101"}],
+        fetched_at=t0,
+        expires_at=t0 + timedelta(days=7),
+    )
+    await test_session.execute(stmt_insert)
+    await test_session.commit()
+
+    # ── Refresh upsert ON CONFLICT DO UPDATE ──────────────────────────
+    new_videos = [
+        {"title": "v2", "description": "fresh", "tags": ["new"], "view_count": 999, "upload_date": "20260502"}
+    ]
+    stmt_upsert = sqlite_insert(ChannelContext.__table__).values(
+        channel_id="UC_upsert_001",
+        platform="youtube",
+        name="Updated Name",
+        description="Updated description",
+        subscriber_count=2000,
+        video_count=20,
+        tags=["updated"],
+        categories=["Updated"],
+        last_videos=new_videos,
+        fetched_at=t1,
+        expires_at=t1 + timedelta(days=7),
+    )
+    stmt_upsert = stmt_upsert.on_conflict_do_update(
+        index_elements=["channel_id", "platform"],
+        set_={
+            "name": stmt_upsert.excluded.name,
+            "description": stmt_upsert.excluded.description,
+            "subscriber_count": stmt_upsert.excluded.subscriber_count,
+            "video_count": stmt_upsert.excluded.video_count,
+            "tags": stmt_upsert.excluded.tags,
+            "categories": stmt_upsert.excluded.categories,
+            "last_videos": stmt_upsert.excluded.last_videos,
+            "fetched_at": stmt_upsert.excluded.fetched_at,
+            "expires_at": stmt_upsert.excluded.expires_at,
+        },
+    )
+    await test_session.execute(stmt_upsert)
+    await test_session.commit()
+
+    # ── Vérification : single row, valeurs rafraîchies ────────────────
+    rows = (
+        await test_session.execute(
+            select(ChannelContext).where(
+                ChannelContext.channel_id == "UC_upsert_001",
+                ChannelContext.platform == "youtube",
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1, "PK composite violée — l'upsert a inséré une 2e ligne"
+
+    row = rows[0]
+    assert row.name == "Updated Name"
+    assert row.description == "Updated description"
+    assert row.subscriber_count == 2000
+    assert row.video_count == 20
+    assert row.tags == ["updated"]
+    assert row.categories == ["Updated"]
+    assert row.last_videos == new_videos
+    # fetched_at avance bien dans le temps après le refresh
+    assert row.fetched_at == t1
+    assert row.fetched_at > t0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_expires_at_in_future(test_session: AsyncSession):
+    """Invariant TTL : expires_at doit être strictement > fetched_at."""
+    from db.database import ChannelContext
+
+    fetched = datetime(2026, 5, 3, 12, 0, 0)
+    expires = fetched + timedelta(days=7)
+
+    ctx = ChannelContext(
+        channel_id="UC_ttl_001",
+        platform="tiktok",
+        name="TTL Channel",
+        last_videos=_sample_last_videos(),
+        fetched_at=fetched,
+        expires_at=expires,
+    )
+    test_session.add(ctx)
+    await test_session.commit()
+    await test_session.refresh(ctx)
+
+    assert ctx.expires_at > ctx.fetched_at, (
+        f"expires_at ({ctx.expires_at}) doit être > fetched_at ({ctx.fetched_at})"
+    )
+    # Marge raisonnable : au moins quelques minutes dans le futur
+    assert (ctx.expires_at - ctx.fetched_at) >= timedelta(minutes=1)

--- a/backend/tests/services/test_channel_content_cache.py
+++ b/backend/tests/services/test_channel_content_cache.py
@@ -1,0 +1,508 @@
+"""Tests for ``services/channel_content_cache.py``.
+
+Stratégie :
+  - SQLite in-memory pour PG L2 (cf. pattern de ``test_channel_contexts.py``).
+  - Monkeypatch des helpers Redis L1 (``get_/set_channel_context_from_redis``)
+    pour ne pas dépendre d'un Redis réel ni du singleton ``cache_service``.
+  - Monkeypatch des fetchers (``get_channel_context``, ``get_tiktok_account_context``)
+    pour contrôler ce que le cache reçoit en miss.
+
+Couvre :
+  1. Redis L1 hit → return direct, jamais de PG ni service touché.
+  2. Redis miss + PG hit → populate L1 + return.
+  3. Redis miss + PG row expirée → fall through service.
+  4. Full miss → service appelé → upsert PG + set L1.
+  5. Full miss + service None → ni écriture PG ni Redis.
+  6. force_refresh=True → skip L1 et L2 même si HIT.
+  7. platform="youtube" routes vers ``get_channel_context``.
+  8. platform="tiktok" routes vers ``get_tiktok_account_context``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def test_engine():
+    """SQLite in-memory engine (file: shared :memory:) avec tous les models créés."""
+    from db.database import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def test_session(test_engine) -> AsyncSession:
+    """Session SQLAlchemy ouverte sur l'engine in-memory."""
+    SessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with SessionLocal() as session:
+        yield session
+
+
+def _sample_ctx(channel_id: str = "UC_test_001", platform: str = "youtube") -> Dict[str, Any]:
+    """Dict au shape unifié — utilisé comme entrée valide du fetcher."""
+    return {
+        "channel_id": channel_id,
+        "platform": platform,
+        "name": "Channel " + channel_id,
+        "description": "A description",
+        "subscriber_count": 1234,
+        "video_count": 56,
+        "tags": ["tag1", "tag2"],
+        "categories": ["Education"],
+        "last_videos": [
+            {
+                "title": "v1",
+                "description": "d1",
+                "tags": ["a"],
+                "view_count": 10,
+                "upload_date": "20260501",
+            }
+        ],
+    }
+
+
+class _RedisStub:
+    """Mini Redis fake : in-memory dict, async API alignée sur core.cache."""
+
+    def __init__(self) -> None:
+        self.store: Dict[str, Any] = {}
+        self.get_calls: List[str] = []
+        self.set_calls: List[tuple] = []
+
+    async def get(self, key: str) -> Optional[Any]:
+        self.get_calls.append(key)
+        return self.store.get(key)
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        self.set_calls.append((key, value, ttl))
+        self.store[key] = value
+
+    async def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+
+@pytest.fixture
+def redis_stub(monkeypatch) -> _RedisStub:
+    """Patche les helpers Redis du module pour utiliser un stub in-memory.
+
+    On patche directement les fonctions exposées (``get_channel_context_from_redis``
+    / ``set_channel_context_to_redis``) : c'est plus simple et plus robuste que
+    de monter un faux ``core.cache.cache_service``.
+    """
+    from services import channel_content_cache as ccc
+
+    stub = _RedisStub()
+
+    async def fake_get(platform: str, channel_id: str):
+        return await stub.get(ccc.build_channel_cache_key(platform, channel_id))
+
+    async def fake_set(platform: str, channel_id: str, ctx: Dict[str, Any]):
+        await stub.set(
+            ccc.build_channel_cache_key(platform, channel_id),
+            ctx,
+            ttl=ccc.CHANNEL_CONTEXT_TTL_SECONDS,
+        )
+
+    monkeypatch.setattr(ccc, "get_channel_context_from_redis", fake_get)
+    monkeypatch.setattr(ccc, "set_channel_context_to_redis", fake_set)
+    return stub
+
+
+@pytest.fixture
+def patched_session(monkeypatch, test_engine):
+    """Patche ``async_session_maker`` du module pour pointer sur l'engine in-memory.
+
+    Utile pour tester ``get_or_fetch_channel_context()`` sans devoir injecter
+    une session manuellement à chaque appel.
+    """
+    from services import channel_content_cache as ccc
+
+    SessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(ccc, "async_session_maker", SessionLocal)
+    return SessionLocal
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Helpers d'écriture directe en DB pour pré-conditionner les tests
+# ───────────────────────────────────────────────────────────────────────────
+
+
+async def _insert_db_row(
+    session: AsyncSession,
+    *,
+    channel_id: str,
+    platform: str,
+    expires_at: datetime,
+    fetched_at: Optional[datetime] = None,
+    name: str = "From DB",
+):
+    """Insert direct via le model ChannelContext (pour pré-conditionner les tests)."""
+    from db.database import ChannelContext
+
+    fetched_at = fetched_at or (expires_at - timedelta(days=1))
+    row = ChannelContext(
+        channel_id=channel_id,
+        platform=platform,
+        name=name,
+        description="from DB",
+        subscriber_count=999,
+        video_count=42,
+        tags=["from_db"],
+        categories=["DB"],
+        last_videos=[
+            {
+                "title": "db-v1",
+                "description": "db-d1",
+                "tags": ["db"],
+                "view_count": 1,
+                "upload_date": "20260101",
+            }
+        ],
+        fetched_at=fetched_at,
+        expires_at=expires_at,
+    )
+    session.add(row)
+    await session.commit()
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Tests
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redis_hit_returns_directly(monkeypatch, redis_stub, patched_session):
+    """Redis L1 HIT : retourne directement, sans toucher PG ni service."""
+    from services import channel_content_cache as ccc
+
+    expected = _sample_ctx("UC_redis_hit_001", "youtube")
+    redis_stub.store[ccc.build_channel_cache_key("youtube", "UC_redis_hit_001")] = expected
+
+    # Sentinelle : si PG ou service est appelé, on rate le test
+    pg_called = False
+    service_called = False
+
+    async def fake_pg_get(platform, channel_id, *, session=None):
+        nonlocal pg_called
+        pg_called = True
+        return None
+
+    async def fake_fetch(platform, channel_id, *, limit):
+        nonlocal service_called
+        service_called = True
+        return None
+
+    monkeypatch.setattr(ccc, "get_channel_context_from_db", fake_pg_get)
+    monkeypatch.setattr(ccc, "_fetch_from_service", fake_fetch)
+
+    result = await ccc.get_or_fetch_channel_context("youtube", "UC_redis_hit_001")
+
+    assert result == expected, "Le résultat doit être l'objet stocké en Redis L1"
+    assert pg_called is False, "PG ne doit PAS être touché en cas de L1 HIT"
+    assert service_called is False, "Service ne doit PAS être appelé en cas de L1 HIT"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redis_miss_pg_hit_populates_redis(
+    monkeypatch, redis_stub, patched_session, test_session: AsyncSession
+):
+    """Redis MISS + PG HIT (non expiré) → return + Redis L1 populated."""
+    from services import channel_content_cache as ccc
+
+    channel_id = "UC_pg_hit_001"
+    platform = "youtube"
+    future = datetime.utcnow() + timedelta(days=3)
+    await _insert_db_row(
+        test_session,
+        channel_id=channel_id,
+        platform=platform,
+        expires_at=future,
+        name="Channel From DB",
+    )
+
+    # Sentinelle : service ne doit pas être appelé en cas de L2 HIT
+    service_called = False
+
+    async def fake_fetch(p, c, *, limit):
+        nonlocal service_called
+        service_called = True
+        return None
+
+    monkeypatch.setattr(ccc, "_fetch_from_service", fake_fetch)
+
+    result = await ccc.get_or_fetch_channel_context(platform, channel_id)
+
+    assert result is not None
+    assert result["channel_id"] == channel_id
+    assert result["name"] == "Channel From DB"
+    assert service_called is False
+    # Redis L1 doit être populé
+    key = ccc.build_channel_cache_key(platform, channel_id)
+    assert key in redis_stub.store
+    assert redis_stub.store[key]["channel_id"] == channel_id
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redis_miss_pg_expired_falls_through(
+    monkeypatch, redis_stub, patched_session, test_session: AsyncSession
+):
+    """PG row avec expires_at < now → considéré comme miss → service appelé."""
+    from services import channel_content_cache as ccc
+
+    channel_id = "UC_pg_expired_001"
+    platform = "youtube"
+    past = datetime.utcnow() - timedelta(days=1)
+    await _insert_db_row(
+        test_session,
+        channel_id=channel_id,
+        platform=platform,
+        expires_at=past,  # expirée
+        fetched_at=past - timedelta(days=8),
+        name="Old Cached",
+    )
+
+    fresh = _sample_ctx(channel_id, platform)
+    fresh["name"] = "Fresh from service"
+    fetch_calls: List[tuple] = []
+
+    async def fake_fetch(p, c, *, limit):
+        fetch_calls.append((p, c, limit))
+        return fresh
+
+    monkeypatch.setattr(ccc, "_fetch_from_service", fake_fetch)
+
+    result = await ccc.get_or_fetch_channel_context(platform, channel_id)
+
+    assert result is not None
+    assert result["name"] == "Fresh from service", "Doit venir du service, pas de la DB expirée"
+    assert len(fetch_calls) == 1, "Le service doit avoir été appelé exactement une fois"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_full_miss_calls_service_and_populates_both_layers(
+    monkeypatch, redis_stub, patched_session, test_session: AsyncSession
+):
+    """Full miss : service appelé → PG row créée + Redis L1 set."""
+    from services import channel_content_cache as ccc
+    from db.database import ChannelContext
+
+    channel_id = "UC_full_miss_001"
+    platform = "youtube"
+    fresh = _sample_ctx(channel_id, platform)
+
+    fetch_calls: List[tuple] = []
+
+    async def fake_fetch(p, c, *, limit):
+        fetch_calls.append((p, c, limit))
+        return fresh
+
+    monkeypatch.setattr(ccc, "_fetch_from_service", fake_fetch)
+
+    result = await ccc.get_or_fetch_channel_context(platform, channel_id)
+
+    assert result == fresh
+    assert fetch_calls == [(platform, channel_id, 50)]
+
+    # Vérifier qu'une row a bien été créée en PG
+    db_row = (
+        await test_session.execute(
+            select(ChannelContext).where(
+                ChannelContext.channel_id == channel_id,
+                ChannelContext.platform == platform,
+            )
+        )
+    ).scalar_one()
+    assert db_row.name == fresh["name"]
+    assert db_row.subscriber_count == fresh["subscriber_count"]
+    assert db_row.last_videos == fresh["last_videos"]
+    # expires_at doit être strictement futur
+    expires = db_row.expires_at
+    if expires.tzinfo is not None:
+        expires = expires.astimezone(timezone.utc).replace(tzinfo=None)
+    assert expires > datetime.utcnow()
+
+    # Vérifier Redis L1
+    key = ccc.build_channel_cache_key(platform, channel_id)
+    assert key in redis_stub.store
+    assert redis_stub.store[key] == fresh
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_full_miss_service_returns_none_no_cache_write(
+    monkeypatch, redis_stub, patched_session, test_session: AsyncSession
+):
+    """Service retourne None → ni PG ni Redis ne doit être écrit."""
+    from services import channel_content_cache as ccc
+    from db.database import ChannelContext
+
+    channel_id = "UC_service_fail_001"
+    platform = "youtube"
+
+    async def fake_fetch(p, c, *, limit):
+        return None  # échec
+
+    monkeypatch.setattr(ccc, "_fetch_from_service", fake_fetch)
+
+    result = await ccc.get_or_fetch_channel_context(platform, channel_id)
+
+    assert result is None
+
+    # PG : pas de row
+    db_row = (
+        await test_session.execute(
+            select(ChannelContext).where(
+                ChannelContext.channel_id == channel_id,
+                ChannelContext.platform == platform,
+            )
+        )
+    ).scalar_one_or_none()
+    assert db_row is None, "Aucune row PG ne doit être créée si le service échoue"
+
+    # Redis : pas de set
+    key = ccc.build_channel_cache_key(platform, channel_id)
+    assert key not in redis_stub.store, "Aucune écriture Redis ne doit avoir lieu"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_force_refresh_skips_redis_and_pg(
+    monkeypatch, redis_stub, patched_session, test_session: AsyncSession
+):
+    """force_refresh=True : ignore L1 et L2 même quand les deux sont HIT."""
+    from services import channel_content_cache as ccc
+
+    channel_id = "UC_force_001"
+    platform = "youtube"
+
+    # Pré-condition : Redis L1 HIT
+    stale = _sample_ctx(channel_id, platform)
+    stale["name"] = "stale from redis"
+    redis_stub.store[ccc.build_channel_cache_key(platform, channel_id)] = stale
+
+    # Pré-condition : PG L2 HIT (non expiré)
+    future = datetime.utcnow() + timedelta(days=3)
+    await _insert_db_row(
+        test_session,
+        channel_id=channel_id,
+        platform=platform,
+        expires_at=future,
+        name="stale from pg",
+    )
+
+    # Sentinelles : on doit appeler le service même si caches HIT
+    fresh = _sample_ctx(channel_id, platform)
+    fresh["name"] = "fresh refreshed"
+    fetch_calls: List[tuple] = []
+
+    async def fake_fetch(p, c, *, limit):
+        fetch_calls.append((p, c, limit))
+        return fresh
+
+    monkeypatch.setattr(ccc, "_fetch_from_service", fake_fetch)
+
+    result = await ccc.get_or_fetch_channel_context(
+        platform, channel_id, force_refresh=True
+    )
+
+    assert result == fresh, "force_refresh doit retourner le fresh, PAS le stale L1/L2"
+    assert len(fetch_calls) == 1, "Le service doit être appelé même si caches HIT"
+
+    # Le L1 doit avoir été remis à jour avec le fresh
+    key = ccc.build_channel_cache_key(platform, channel_id)
+    assert redis_stub.store[key]["name"] == "fresh refreshed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_youtube_routes_to_youtube_channel_service(
+    monkeypatch, redis_stub, patched_session
+):
+    """platform="youtube" → ``transcripts.youtube_channel.get_channel_context`` appelé."""
+    from services import channel_content_cache as ccc
+
+    channel_id = "UC_route_yt_001"
+    fresh = _sample_ctx(channel_id, "youtube")
+
+    yt_calls: List[tuple] = []
+    tt_calls: List[tuple] = []
+
+    async def fake_yt(channel_id_arg, limit=50):
+        yt_calls.append((channel_id_arg, limit))
+        return fresh
+
+    async def fake_tt(username_arg, limit=50):
+        tt_calls.append((username_arg, limit))
+        return None
+
+    # Patch via les modules cibles (ce que ``_fetch_from_service`` importe lazy)
+    import transcripts.youtube_channel as yt_mod
+    import transcripts.tiktok as tt_mod
+
+    monkeypatch.setattr(yt_mod, "get_channel_context", fake_yt)
+    monkeypatch.setattr(tt_mod, "get_tiktok_account_context", fake_tt)
+
+    result = await ccc.get_or_fetch_channel_context("youtube", channel_id)
+
+    assert result == fresh
+    assert yt_calls == [(channel_id, 50)], "YouTube service doit avoir été appelé"
+    assert tt_calls == [], "TikTok service ne doit PAS avoir été appelé"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tiktok_routes_to_tiktok_account_service(
+    monkeypatch, redis_stub, patched_session
+):
+    """platform="tiktok" → ``transcripts.tiktok.get_tiktok_account_context`` appelé."""
+    from services import channel_content_cache as ccc
+
+    username = "charlidamelio"
+    fresh = _sample_ctx(username, "tiktok")
+
+    yt_calls: List[tuple] = []
+    tt_calls: List[tuple] = []
+
+    async def fake_yt(channel_id_arg, limit=50):
+        yt_calls.append((channel_id_arg, limit))
+        return None
+
+    async def fake_tt(username_arg, limit=50):
+        tt_calls.append((username_arg, limit))
+        return fresh
+
+    import transcripts.youtube_channel as yt_mod
+    import transcripts.tiktok as tt_mod
+
+    monkeypatch.setattr(yt_mod, "get_channel_context", fake_yt)
+    monkeypatch.setattr(tt_mod, "get_tiktok_account_context", fake_tt)
+
+    result = await ccc.get_or_fetch_channel_context("tiktok", username)
+
+    assert result == fresh
+    assert tt_calls == [(username, 50)], "TikTok service doit avoir été appelé"
+    assert yt_calls == [], "YouTube service ne doit PAS avoir été appelé"

--- a/backend/tests/transcripts/test_tiktok_account.py
+++ b/backend/tests/transcripts/test_tiktok_account.py
@@ -1,0 +1,400 @@
+"""
+Tests for TikTok account context extraction.
+
+Covers:
+- get_tiktok_account_context() — fetch metadata + N derniers posts via yt-dlp
+- extract_tiktok_username_from_video_metadata() — helper to extract username
+  from video metadata
+- Hashtag parsing, description truncation, @ prefix stripping, error handling
+"""
+
+import json
+import os
+import subprocess as real_subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make src importable for transcripts.tiktok
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers — fake subprocess.run results
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_completed_process(returncode: int, stdout: str = "", stderr: str = ""):
+    """Build a fake CompletedProcess returned by subprocess.run mock."""
+    cp = MagicMock(spec=real_subprocess.CompletedProcess)
+    cp.returncode = returncode
+    cp.stdout = stdout
+    cp.stderr = stderr
+    return cp
+
+
+def _make_account_payload(username: str, entries: list, **overrides) -> dict:
+    """Build a yt-dlp --dump-single-json payload for a TikTok account."""
+    payload = {
+        "channel": overrides.get("channel", username),
+        "uploader": overrides.get("uploader", username),
+        "uploader_id": username,
+        "description": overrides.get("description", f"Bio test for @{username}"),
+        "channel_follower_count": overrides.get("channel_follower_count", 1234567),
+        "playlist_count": overrides.get("playlist_count", len(entries)),
+        "entries": entries,
+    }
+    payload.update({k: v for k, v in overrides.items() if k not in payload})
+    return payload
+
+
+def _make_entry(
+    title: str = "Sample TikTok #fyp",
+    description: str = None,
+    view_count: int = 50000,
+    upload_date: str = "20260301",
+):
+    """Build a single yt-dlp entry for a TikTok post."""
+    return {
+        "id": "1234567890",
+        "title": title,
+        "description": description if description is not None else title,
+        "view_count": view_count,
+        "upload_date": upload_date,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# get_tiktok_account_context()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetTiktokAccountContext:
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_success(self):
+        """Mock yt-dlp returning 50 valid entries → full dict shape."""
+        from transcripts import tiktok
+
+        username = "charlidamelio"
+        entries = [
+            _make_entry(
+                title=f"Post {i} #fyp #viral",
+                view_count=10_000 * (i + 1),
+                upload_date=f"2026030{(i % 9) + 1}",
+            )
+            for i in range(50)
+        ]
+        payload = _make_account_payload(username, entries, channel="charli d'amelio")
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context(username, limit=50)
+
+        assert ctx is not None
+        # Top-level shape — must mirror YouTube get_channel_context()
+        assert ctx["channel_id"] == "charlidamelio"
+        assert ctx["platform"] == "tiktok"
+        assert ctx["name"] == "charli d'amelio"
+        assert ctx["description"].startswith("Bio test")
+        assert ctx["subscriber_count"] == 1234567
+        assert ctx["video_count"] == 50
+        assert ctx["tags"] == []
+        assert ctx["categories"] == []
+        # last_videos
+        assert isinstance(ctx["last_videos"], list)
+        assert len(ctx["last_videos"]) == 50
+        first = ctx["last_videos"][0]
+        assert set(first.keys()) == {"title", "description", "tags", "view_count", "upload_date"}
+        assert "fyp" in first["tags"]
+        assert "viral" in first["tags"]
+        assert first["view_count"] == 10_000
+        assert first["upload_date"] == "20260301"
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_strips_at_prefix(self):
+        """`@charlidamelio` should be normalized to `charlidamelio`."""
+        from transcripts import tiktok
+
+        captured_cmd = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            captured_cmd["cmd"] = cmd
+            payload = _make_account_payload("charlidamelio", [_make_entry()])
+            return _make_completed_process(0, stdout=json.dumps(payload))
+
+        with patch.object(tiktok.subprocess, "run", side_effect=fake_run):
+            ctx = await tiktok.get_tiktok_account_context("@charlidamelio", limit=10)
+
+        assert ctx is not None
+        assert ctx["channel_id"] == "charlidamelio"
+        # The URL passed to yt-dlp must NOT contain a double @@
+        url_arg = captured_cmd["cmd"][-1]
+        assert url_arg == "https://www.tiktok.com/@charlidamelio"
+        assert "@@" not in url_arg
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_strips_whitespace(self):
+        """Leading/trailing whitespace on the username should be stripped."""
+        from transcripts import tiktok
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(
+                0, stdout=json.dumps(_make_account_payload("charlidamelio", []))
+            ),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("  @charlidamelio  ")
+
+        assert ctx is not None
+        assert ctx["channel_id"] == "charlidamelio"
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_extracts_hashtags(self):
+        """Caption 'Test #fyp #viral' must yield tags=['fyp','viral']."""
+        from transcripts import tiktok
+
+        entry = _make_entry(
+            title="Test #fyp #viral", description="Test #fyp #viral"
+        )
+        payload = _make_account_payload("user1", [entry])
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("user1")
+
+        assert ctx is not None
+        assert len(ctx["last_videos"]) == 1
+        tags = ctx["last_videos"][0]["tags"]
+        assert "fyp" in tags
+        assert "viral" in tags
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_dedupes_hashtags(self):
+        """Repeated hashtags (case-insensitive) should be dedup'd."""
+        from transcripts import tiktok
+
+        entry = _make_entry(
+            title="Test #fyp #FYP #viral #fyp",
+            description="Test #fyp #FYP #viral #fyp",
+        )
+        payload = _make_account_payload("user1", [entry])
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("user1")
+
+        tags = ctx["last_videos"][0]["tags"]
+        # case-insensitive dedup: only one fyp/FYP variant kept
+        lowered = [t.lower() for t in tags]
+        assert lowered.count("fyp") == 1
+        assert "viral" in lowered
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_truncates_descriptions(self):
+        """Description > 200 chars must be truncated to exactly 200 chars."""
+        from transcripts import tiktok
+
+        long_desc = "A" * 500
+        entry = _make_entry(title="Short title", description=long_desc)
+        payload = _make_account_payload("user1", [entry])
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("user1")
+
+        assert ctx is not None
+        desc = ctx["last_videos"][0]["description"]
+        assert len(desc) == 200
+        # Same convention as YouTube channel context: hard truncate, no "..." suffix
+        assert desc == "A" * 200
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_handles_private(self):
+        """yt-dlp non-zero returncode (private/banned) → return None."""
+        from transcripts import tiktok
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(
+                1, stdout="", stderr="ERROR: This account is private"
+            ),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("private_user")
+
+        assert ctx is None
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_handles_invalid_json(self):
+        """yt-dlp success but garbled stdout → return None."""
+        from transcripts import tiktok
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout="not-json {garbage"),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("user1")
+
+        assert ctx is None
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_empty_username(self):
+        """Empty username returns None without invoking yt-dlp."""
+        from transcripts import tiktok
+
+        with patch.object(tiktok.subprocess, "run") as mock_run:
+            ctx = await tiktok.get_tiktok_account_context("")
+            assert ctx is None
+            ctx2 = await tiktok.get_tiktok_account_context("@")
+            assert ctx2 is None
+            mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_handles_no_entries(self):
+        """Account with zero posts (entries=[]) returns valid dict, last_videos=[]."""
+        from transcripts import tiktok
+
+        payload = _make_account_payload("user1", [])
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("user1")
+
+        assert ctx is not None
+        assert ctx["last_videos"] == []
+        assert ctx["channel_id"] == "user1"
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_respects_limit_arg(self):
+        """`--playlistend N` must reflect the limit argument."""
+        from transcripts import tiktok
+
+        captured_cmd = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            captured_cmd["cmd"] = cmd
+            return _make_completed_process(
+                0, stdout=json.dumps(_make_account_payload("user1", []))
+            )
+
+        with patch.object(tiktok.subprocess, "run", side_effect=fake_run):
+            await tiktok.get_tiktok_account_context("user1", limit=20)
+
+        cmd = captured_cmd["cmd"]
+        # find --playlistend index
+        idx = cmd.index("--playlistend")
+        assert cmd[idx + 1] == "20"
+
+    @pytest.mark.asyncio
+    async def test_get_tiktok_account_context_returns_youtube_compatible_shape(self):
+        """Strict shape check — must mirror YouTube get_channel_context() exactly."""
+        from transcripts import tiktok
+
+        payload = _make_account_payload("user1", [_make_entry()])
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("user1")
+
+        assert ctx is not None
+        expected_top_keys = {
+            "channel_id",
+            "platform",
+            "name",
+            "description",
+            "subscriber_count",
+            "video_count",
+            "tags",
+            "categories",
+            "last_videos",
+        }
+        assert set(ctx.keys()) == expected_top_keys
+        assert ctx["platform"] == "tiktok"
+        assert isinstance(ctx["tags"], list)
+        assert isinstance(ctx["categories"], list)
+        assert isinstance(ctx["last_videos"], list)
+        # last_videos[*] shape
+        expected_video_keys = {"title", "description", "tags", "view_count", "upload_date"}
+        for v in ctx["last_videos"]:
+            assert set(v.keys()) == expected_video_keys
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# extract_tiktok_username_from_video_metadata()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExtractTiktokUsernameFromMetadata:
+
+    def test_extract_username_from_uploader_id(self):
+        """uploader_id is the most reliable yt-dlp field."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        metadata = {
+            "uploader_id": "charlidamelio",
+            "uploader": "Charli D'Amelio",
+            "channel": "Charli D'Amelio",
+            "webpage_url": "https://www.tiktok.com/@charlidamelio/video/123",
+        }
+        assert extract_tiktok_username_from_video_metadata(metadata) == "charlidamelio"
+
+    def test_extract_username_from_webpage_url(self):
+        """If uploader_id missing, parse the webpage_url."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        metadata = {
+            "uploader": "Some Display Name",
+            "webpage_url": "https://www.tiktok.com/@bellathorne/video/7234567890",
+        }
+        assert extract_tiktok_username_from_video_metadata(metadata) == "bellathorne"
+
+    def test_extract_username_from_channel_fallback(self):
+        """channel as last-resort fallback."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        metadata = {"channel": "khaby.lame"}
+        assert extract_tiktok_username_from_video_metadata(metadata) == "khaby.lame"
+
+    def test_extract_username_strips_at_prefix(self):
+        """A leading '@' must be stripped."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        metadata = {"uploader_id": "@charlidamelio"}
+        assert extract_tiktok_username_from_video_metadata(metadata) == "charlidamelio"
+
+    def test_extract_username_returns_none_when_missing(self):
+        """Empty / unrelated metadata returns None."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        assert extract_tiktok_username_from_video_metadata({}) is None
+        assert extract_tiktok_username_from_video_metadata(None) is None
+        assert extract_tiktok_username_from_video_metadata({"unrelated": "field"}) is None
+
+    def test_extract_username_priority_uploader_id_over_url(self):
+        """If both present, uploader_id wins (it's the canonical handle)."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        metadata = {
+            "uploader_id": "real_handle",
+            "webpage_url": "https://www.tiktok.com/@redirected_handle/video/123",
+        }
+        assert extract_tiktok_username_from_video_metadata(metadata) == "real_handle"
+
+    def test_extract_username_handles_dots_and_underscores(self):
+        """TikTok handles can include '.', '_', '-'."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        metadata = {"uploader_id": "user.name_42"}
+        assert extract_tiktok_username_from_video_metadata(metadata) == "user.name_42"

--- a/backend/tests/transcripts/test_youtube_channel.py
+++ b/backend/tests/transcripts/test_youtube_channel.py
@@ -1,0 +1,368 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS: youtube_channel — Channel context fetcher                               ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couverture :                                                                      ║
+║  • get_channel_context : succès complet, troncature descriptions, échec, timeout  ║
+║  • extract_channel_id_from_video_metadata : 3 chemins (direct/url/uploader_id)    ║
+║                                                                                    ║
+║  ⚠️ AUCUN appel réseau / aucun lancement réel de yt-dlp — tout est mocké via      ║
+║     monkeypatch sur asyncio.create_subprocess_exec.                               ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Aligne le sys.path comme les autres tests (src en priorité)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from transcripts import youtube_channel  # noqa: E402
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧰 HELPERS — fake subprocess pour mocker create_subprocess_exec
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_fake_process(
+    *,
+    returncode: int = 0,
+    stdout_bytes: bytes = b"{}",
+    stderr_bytes: bytes = b"",
+    communicate_raises: Exception | None = None,
+):
+    """Construit un faux process retourné par create_subprocess_exec.
+
+    Implémente strictement les méthodes utilisées par notre code :
+    - communicate() awaitable
+    - kill() / wait()
+    - attribut returncode
+    """
+    proc = MagicMock()
+    proc.returncode = returncode
+
+    if communicate_raises is not None:
+
+        async def _communicate():
+            raise communicate_raises
+
+        proc.communicate = _communicate
+    else:
+        proc.communicate = AsyncMock(return_value=(stdout_bytes, stderr_bytes))
+
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock(return_value=returncode)
+    return proc
+
+
+def _build_fake_payload(num_entries: int = 50, long_description: bool = False) -> dict[str, Any]:
+    """Construit un payload yt-dlp `--dump-single-json --flat-playlist` plausible."""
+    entries = []
+    base_desc = "x" * 500 if long_description else "Description courte de la vidéo"
+    for i in range(num_entries):
+        entries.append(
+            {
+                "_type": "url",
+                "id": f"vid{i:03d}",
+                "title": f"Video Title {i}",
+                "description": base_desc,
+                "tags": [f"tag{i}", "common"],
+                "view_count": 1000 + i,
+                "upload_date": f"2026010{i % 10}",
+            }
+        )
+
+    return {
+        "channel": "Test Channel Name",
+        "uploader": "Test Channel Name",
+        "description": "Description complète de la chaîne",
+        "channel_follower_count": 123456,
+        "playlist_count": 250,
+        "tags": ["science", "education"],
+        "categories": ["Education"],
+        "entries": entries,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✅ TESTS get_channel_context
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetChannelContext:
+    async def test_get_channel_context_success(self, monkeypatch):
+        """Mock subprocess retournant un JSON valide avec 50 entries -> parsing OK."""
+        payload = _build_fake_payload(num_entries=50)
+        fake_proc = _make_fake_process(
+            returncode=0,
+            stdout_bytes=json.dumps(payload).encode("utf-8"),
+        )
+
+        captured_args: dict[str, Any] = {}
+
+        async def fake_create_subprocess_exec(*cmd, stdout=None, stderr=None, **kwargs):
+            captured_args["cmd"] = cmd
+            captured_args["stdout"] = stdout
+            captured_args["stderr"] = stderr
+            return fake_proc
+
+        monkeypatch.setattr(
+            youtube_channel.asyncio,
+            "create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+
+        result = await youtube_channel.get_channel_context("UCabcdefghijklmnopqrstuv", limit=50)
+
+        # Shape complète
+        assert result is not None
+        assert result["channel_id"] == "UCabcdefghijklmnopqrstuv"
+        assert result["platform"] == "youtube"
+        assert result["name"] == "Test Channel Name"
+        assert result["description"] == "Description complète de la chaîne"
+        assert result["subscriber_count"] == 123456
+        assert result["video_count"] == 250
+        assert result["tags"] == ["science", "education"]
+        assert result["categories"] == ["Education"]
+        assert len(result["last_videos"]) == 50
+
+        first_video = result["last_videos"][0]
+        assert first_video["title"] == "Video Title 0"
+        assert first_video["description"] == "Description courte de la vidéo"
+        assert first_video["tags"] == ["tag0", "common"]
+        assert first_video["view_count"] == 1000
+        assert first_video["upload_date"] == "20260100"
+
+        # Vérifie que la commande yt-dlp est correctement formée
+        cmd = captured_args["cmd"]
+        assert cmd[0] == "yt-dlp"
+        assert "--flat-playlist" in cmd
+        assert "--dump-single-json" in cmd
+        assert "--playlistend" in cmd
+        idx = cmd.index("--playlistend")
+        assert cmd[idx + 1] == "50"
+        assert "--no-warnings" in cmd
+        assert "--skip-download" in cmd
+        # URL canonique pour un UC...
+        assert cmd[-1] == "https://www.youtube.com/channel/UCabcdefghijklmnopqrstuv/videos"
+
+    async def test_get_channel_context_truncates_descriptions(self, monkeypatch):
+        """Descriptions > 200 chars -> tronquées à exactement 200 chars."""
+        payload = _build_fake_payload(num_entries=3, long_description=True)
+        fake_proc = _make_fake_process(
+            returncode=0,
+            stdout_bytes=json.dumps(payload).encode("utf-8"),
+        )
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            return fake_proc
+
+        monkeypatch.setattr(
+            youtube_channel.asyncio,
+            "create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+
+        result = await youtube_channel.get_channel_context("UCabcdefghijklmnopqrstuv", limit=10)
+
+        assert result is not None
+        for video in result["last_videos"]:
+            assert len(video["description"]) == 200
+            assert video["description"] == "x" * 200
+
+    async def test_get_channel_context_handles_failure(self, monkeypatch):
+        """returncode != 0 -> log warning + return None."""
+        fake_proc = _make_fake_process(
+            returncode=1,
+            stdout_bytes=b"",
+            stderr_bytes=b"ERROR: channel does not exist",
+        )
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            return fake_proc
+
+        monkeypatch.setattr(
+            youtube_channel.asyncio,
+            "create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+
+        result = await youtube_channel.get_channel_context("UCdoesnotexist1234567890", limit=50)
+        assert result is None
+
+    async def test_get_channel_context_handles_timeout(self, monkeypatch):
+        """asyncio.TimeoutError pendant communicate() -> return None + kill du proc."""
+        fake_proc = _make_fake_process(
+            returncode=0,
+            communicate_raises=asyncio.TimeoutError(),
+        )
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            return fake_proc
+
+        # Court-circuite asyncio.wait_for pour qu'il propage le TimeoutError
+        # immédiatement (évite d'attendre 60s réelles).
+        async def fake_wait_for(coro, timeout):
+            # On attend la coroutine pour déclencher l'exception, puis on relève.
+            try:
+                return await coro
+            finally:
+                # Le test garantit que communicate raise déjà.
+                pass
+
+        monkeypatch.setattr(
+            youtube_channel.asyncio,
+            "create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+        monkeypatch.setattr(youtube_channel.asyncio, "wait_for", fake_wait_for)
+
+        result = await youtube_channel.get_channel_context("UCxxxxxxxxxxxxxxxxxxxxxx", limit=50)
+        assert result is None
+        # Vérifie qu'on a bien tenté de tuer le process
+        fake_proc.kill.assert_called_once()
+
+    async def test_get_channel_context_handles_invalid_json(self, monkeypatch):
+        """Sortie non-JSON -> return None (json.JSONDecodeError catché)."""
+        fake_proc = _make_fake_process(
+            returncode=0,
+            stdout_bytes=b"not a json {{{",
+        )
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            return fake_proc
+
+        monkeypatch.setattr(
+            youtube_channel.asyncio,
+            "create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+
+        result = await youtube_channel.get_channel_context("UCxxxxxxxxxxxxxxxxxxxxxx", limit=50)
+        assert result is None
+
+    async def test_get_channel_context_handle_url(self, monkeypatch):
+        """Un channel_id préfixé `@` -> URL `youtube.com/@xxx/videos`."""
+        payload = _build_fake_payload(num_entries=2)
+        fake_proc = _make_fake_process(
+            returncode=0,
+            stdout_bytes=json.dumps(payload).encode("utf-8"),
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            captured["cmd"] = cmd
+            return fake_proc
+
+        monkeypatch.setattr(
+            youtube_channel.asyncio,
+            "create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+
+        result = await youtube_channel.get_channel_context("@MrBeast", limit=5)
+        assert result is not None
+        assert captured["cmd"][-1] == "https://www.youtube.com/@MrBeast/videos"
+
+    async def test_get_channel_context_executable_missing(self, monkeypatch):
+        """yt-dlp absent du PATH (FileNotFoundError) -> return None proprement."""
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            raise FileNotFoundError("yt-dlp not found")
+
+        monkeypatch.setattr(
+            youtube_channel.asyncio,
+            "create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+
+        result = await youtube_channel.get_channel_context("UCxxxxxxxxxxxxxxxxxxxxxx", limit=50)
+        assert result is None
+
+    async def test_get_channel_context_empty_channel_id(self, monkeypatch):
+        """channel_id vide -> return None sans même tenter le subprocess."""
+        called = {"v": False}
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            called["v"] = True
+            return _make_fake_process()
+
+        monkeypatch.setattr(
+            youtube_channel.asyncio,
+            "create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+
+        assert await youtube_channel.get_channel_context("", limit=50) is None
+        assert called["v"] is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✅ TESTS extract_channel_id_from_video_metadata
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExtractChannelIdFromMetadata:
+    def test_direct_channel_id_field(self):
+        """Si `channel_id` est présent, il est retourné en priorité."""
+        metadata = {
+            "channel_id": "UCabcdefghijklmnopqrstuv",
+            "channel_url": "https://www.youtube.com/channel/UCotherIdShouldBeIgnored",
+            "uploader_id": "@SomeHandle",
+        }
+        assert (
+            youtube_channel.extract_channel_id_from_video_metadata(metadata)
+            == "UCabcdefghijklmnopqrstuv"
+        )
+
+    def test_parse_from_channel_url(self):
+        """Pas de `channel_id` -> parse depuis `channel_url`."""
+        metadata = {
+            "channel_url": "https://www.youtube.com/channel/UCfromUrlAaaaaaaaaaaaaa/videos",
+            "uploader_id": "@SomeHandle",
+        }
+        assert (
+            youtube_channel.extract_channel_id_from_video_metadata(metadata)
+            == "UCfromUrlAaaaaaaaaaaaaa"
+        )
+
+    def test_parse_handle_from_channel_url(self):
+        """`channel_url` au format `youtube.com/@handle` -> retourne `@handle`."""
+        metadata = {
+            "channel_url": "https://www.youtube.com/@MrBeast",
+            "uploader_id": "fallback_should_not_be_used",
+        }
+        assert (
+            youtube_channel.extract_channel_id_from_video_metadata(metadata) == "@MrBeast"
+        )
+
+    def test_fallback_uploader_id(self):
+        """Pas de `channel_id` ni de `channel_url` parseable -> `uploader_id`."""
+        metadata = {
+            "channel_url": None,
+            "uploader_id": "@FallbackHandle",
+        }
+        assert (
+            youtube_channel.extract_channel_id_from_video_metadata(metadata)
+            == "@FallbackHandle"
+        )
+
+    def test_returns_none_when_nothing(self):
+        """Aucun champ exploitable -> None."""
+        assert youtube_channel.extract_channel_id_from_video_metadata({}) is None
+        assert youtube_channel.extract_channel_id_from_video_metadata({"unrelated": 1}) is None
+
+    def test_returns_none_when_not_dict(self):
+        """Entrée non-dict -> None (défense en profondeur)."""
+        assert youtube_channel.extract_channel_id_from_video_metadata(None) is None  # type: ignore[arg-type]
+        assert youtube_channel.extract_channel_id_from_video_metadata("UCxxx") is None  # type: ignore[arg-type]

--- a/backend/tests/videos/test_channel_context_injection.py
+++ b/backend/tests/videos/test_channel_context_injection.py
@@ -1,0 +1,471 @@
+"""
+Tests d'injection du contexte chaîne dans le pipeline d'analyse Mistral.
+
+Couvre :
+- _format_channel_context_block() — formatage défensif (FR/EN, troncatures, valeurs manquantes)
+- build_analysis_prompt() — injection système + user (FR/EN), absence si None
+- Helpers d'extraction channel_id depuis metadata vidéo (YouTube + TikTok)
+- Pipeline fail-safe : channel_context=None ne casse pas generate_summary
+
+Note : ces tests sont focalisés sur la nouvelle feature et n'instrumentent
+pas le pipeline complet `_analyze_video_background_v6` (trop fragile à mocker).
+La couverture pipeline se limite aux helpers d'extraction + à un test ciblé
+de fail-safe.
+"""
+
+import os
+import sys
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Ensure src/ is on the path
+_src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Fixtures
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_channel_context(
+    *,
+    n_videos: int = 50,
+    long_desc: bool = False,
+    long_video_descs: bool = False,
+    platform: str = "youtube",
+    missing_fields: bool = False,
+) -> Dict[str, Any]:
+    """Construit un dict channel_context au shape unifié pour tests."""
+    description = "A " * 600 if long_desc else "Chaîne YouTube spécialisée vulgarisation scientifique."
+    last_videos = []
+    for i in range(n_videos):
+        v_desc = ("Description " + ("très longue " * 30)) if long_video_descs else f"Description courte vidéo {i}"
+        last_videos.append(
+            {
+                "title": f"Vidéo {i} — Sujet captivant",
+                "description": v_desc,
+                "tags": [f"tag{i}", "science", "vulgarisation"],
+                "view_count": 12345 + i * 100,
+                "upload_date": f"2026010{(i % 9) + 1}",
+            }
+        )
+
+    if missing_fields:
+        return {
+            "channel_id": "UCabc123",
+            "platform": platform,
+            "name": "ChaîneTest",
+            "description": "",  # vide
+            "subscriber_count": None,  # missing
+            "video_count": None,
+            "tags": [],
+            "categories": [],
+            "last_videos": [],
+        }
+
+    return {
+        "channel_id": "UCabc123" if platform == "youtube" else "charlidamelio",
+        "platform": platform,
+        "name": "Chaîne Vulgarisation",
+        "description": description,
+        "subscriber_count": 1_500_000,
+        "video_count": 234,
+        "tags": ["science", "vulgarisation", "physique"],
+        "categories": ["Education", "Science & Technology"],
+        "last_videos": last_videos,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Tests : build_analysis_prompt — directive système + bloc user
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBuildPromptWithChannelContext:
+    """Tests de l'injection channel_context dans build_analysis_prompt()."""
+
+    def test_build_prompt_with_channel_context_fr(self):
+        """FR : avec channel_context, system_prompt contient directive + user_prompt contient bloc."""
+        from videos.analysis import build_analysis_prompt
+
+        ctx = _make_channel_context(n_videos=50, platform="youtube")
+
+        sys_prompt, user_prompt = build_analysis_prompt(
+            title="Test vidéo",
+            transcript="Lorem ipsum " * 100,
+            category="general",
+            lang="fr",
+            mode="standard",
+            duration=600,
+            channel="ChaîneTest",
+            description="Description vidéo",
+            platform="youtube",
+            upload_date="20260301",
+            view_count=10_000,
+            channel_context=ctx,
+        )
+
+        # System prompt : directive contexte chaîne présente
+        assert "## Contexte chaîne" in sys_prompt or "Contexte chaîne" in sys_prompt
+        assert "Classifie la chaîne" in sys_prompt
+        assert "divertissement" in sys_prompt
+        assert "éducative" in sys_prompt
+        assert "poubelle" in sys_prompt
+        assert "dangereuse" in sys_prompt
+        assert "représentative" in sys_prompt
+
+        # User prompt : bloc contexte chaîne après le bloc transcript
+        assert "### Contexte chaîne (référence)" in user_prompt
+        assert "Plateforme : youtube" in user_prompt
+        assert "Nom : Chaîne Vulgarisation" in user_prompt
+        assert "Abonnés :" in user_prompt
+        assert "Catégories :" in user_prompt
+
+        # Les 50 vidéos doivent être listées (par numéro)
+        assert "1. " in user_prompt
+        assert "50. " in user_prompt or "50." in user_prompt
+        # Avant-dernière vidéo aussi
+        assert "25." in user_prompt
+        # Mention du compte
+        assert "50 dernières vidéos" in user_prompt
+
+    def test_build_prompt_with_channel_context_truncates_video_descriptions(self):
+        """Descriptions vidéos > 200ch dans les last_videos doivent être tronquées."""
+        from videos.analysis import build_analysis_prompt
+
+        ctx = _make_channel_context(n_videos=3, long_video_descs=True)
+        _, user_prompt = build_analysis_prompt(
+            title="X",
+            transcript="t",
+            category="general",
+            lang="fr",
+            mode="standard",
+            channel_context=ctx,
+        )
+
+        # Le marqueur de troncature doit être présent
+        assert "..." in user_prompt
+        # Aucun morceau de "très longue " répété 30 fois ne doit subsister
+        # (200 chars < répétition complète 30 * 12 chars = 360)
+        assert ("très longue " * 30) not in user_prompt
+
+    def test_build_prompt_without_channel_context(self):
+        """Sans channel_context : directive système présente, bloc user ABSENT."""
+        from videos.analysis import build_analysis_prompt
+
+        sys_prompt, user_prompt = build_analysis_prompt(
+            title="Test",
+            transcript="t",
+            category="general",
+            lang="fr",
+            mode="standard",
+            channel_context=None,
+        )
+
+        # Directive toujours présente côté système (politique conditionnelle)
+        assert "Contexte chaîne" in sys_prompt
+        assert "Si aucun contexte chaîne n'est fourni" in sys_prompt or "Si aucun contexte" in sys_prompt
+
+        # Bloc user_prompt ABSENT
+        assert "### Contexte chaîne (référence)" not in user_prompt
+        assert "Channel Context (reference)" not in user_prompt
+
+    def test_build_prompt_with_empty_channel_context_dict(self):
+        """ctx == {} : doit être traité comme None côté user_prompt (pas de bloc)."""
+        from videos.analysis import build_analysis_prompt
+
+        _, user_prompt = build_analysis_prompt(
+            title="Test",
+            transcript="t",
+            category="general",
+            lang="fr",
+            mode="standard",
+            channel_context={},
+        )
+
+        # Bloc user_prompt ABSENT (dict vide → pas de header)
+        assert "### Contexte chaîne (référence)" not in user_prompt
+
+    def test_build_prompt_with_channel_context_en(self):
+        """EN : système + user en anglais avec libellés appropriés."""
+        from videos.analysis import build_analysis_prompt
+
+        ctx = _make_channel_context(n_videos=10, platform="youtube")
+
+        sys_prompt, user_prompt = build_analysis_prompt(
+            title="Test video",
+            transcript="content " * 100,
+            category="general",
+            lang="en",
+            mode="standard",
+            duration=600,
+            channel="TestChannel",
+            description="Video description",
+            platform="youtube",
+            channel_context=ctx,
+        )
+
+        # System prompt : directive en anglais
+        assert "Channel Context" in sys_prompt or "## Channel Context" in sys_prompt
+        assert "entertainment" in sys_prompt
+        assert "educational" in sys_prompt
+        assert "low-quality" in sys_prompt
+        assert "dangerous" in sys_prompt
+        assert "representative" in sys_prompt
+
+        # User prompt : bloc anglais
+        assert "### Channel Context (reference)" in user_prompt
+        assert "Platform: youtube" in user_prompt
+        assert "Subscribers:" in user_prompt
+        assert "Categories:" in user_prompt
+        assert "10 latest videos" in user_prompt
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Tests : helper _format_channel_context_block (défensif)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFormatChannelContextBlock:
+    """Tests du helper _format_channel_context_block()."""
+
+    def test_format_handles_missing_fields(self):
+        """subscriber_count=None, tags=[], etc. → pas de crash, libellés 'n/a'."""
+        from videos.analysis import _format_channel_context_block
+
+        ctx = _make_channel_context(missing_fields=True)
+        block = _format_channel_context_block(ctx, language="fr")
+
+        assert block  # non vide
+        assert "n/a" in block  # remplace les valeurs manquantes
+        assert "Abonnés : n/a" in block
+        assert "Total vidéos : n/a" in block
+        assert "Tags chaîne : n/a" in block
+        assert "Catégories : n/a" in block
+
+    def test_format_truncates_long_channel_description(self):
+        """Description chaîne > 500 chars → tronquée."""
+        from videos.analysis import _format_channel_context_block
+
+        ctx = _make_channel_context(long_desc=True)
+        block = _format_channel_context_block(ctx, language="fr")
+
+        # Une longue description doit avoir le marqueur de troncature
+        assert "..." in block
+
+    def test_format_returns_empty_for_none(self):
+        """ctx=None → str vide."""
+        from videos.analysis import _format_channel_context_block
+
+        assert _format_channel_context_block(None, language="fr") == ""
+        assert _format_channel_context_block({}, language="fr") == ""
+
+    def test_format_handles_invalid_video_entries(self):
+        """last_videos contient des entrées non-dict → ignorées sans crash."""
+        from videos.analysis import _format_channel_context_block
+
+        ctx = {
+            "channel_id": "UCxx",
+            "platform": "youtube",
+            "name": "Test",
+            "description": "desc",
+            "subscriber_count": 100,
+            "video_count": 5,
+            "tags": ["a"],
+            "categories": ["b"],
+            "last_videos": [
+                {"title": "V1", "description": "d", "tags": [], "view_count": 1, "upload_date": "20260101"},
+                "not-a-dict",
+                None,
+                {"title": "V2", "description": "d", "tags": [], "view_count": None, "upload_date": None},
+            ],
+        }
+        block = _format_channel_context_block(ctx, language="fr")
+        assert "V1" in block
+        assert "V2" in block
+
+    def test_format_en_uses_english_labels(self):
+        """language='en' → labels anglais."""
+        from videos.analysis import _format_channel_context_block
+
+        ctx = _make_channel_context(n_videos=2)
+        block = _format_channel_context_block(ctx, language="en")
+
+        assert "### Channel Context (reference)" in block
+        assert "Platform:" in block
+        assert "Subscribers:" in block
+        assert "Categories:" in block
+        assert "latest videos" in block
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Tests : helpers d'extraction channel_id depuis metadata vidéo
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExtractChannelIdHelpers:
+    """Tests d'extraction d'ID chaîne (utilisés en étape 1 du pipeline)."""
+
+    def test_pipeline_extracts_channel_id_from_youtube_metadata(self):
+        """YouTube metadata avec `channel_id` direct → extrait correctement."""
+        from transcripts.youtube_channel import extract_channel_id_from_video_metadata
+
+        metadata = {
+            "channel_id": "UCxxYouTube123456789",
+            "channel_url": "https://www.youtube.com/channel/UCxxYouTube123456789",
+            "uploader_id": "@somehandle",
+        }
+        chan_id = extract_channel_id_from_video_metadata(metadata)
+        assert chan_id == "UCxxYouTube123456789"
+
+    def test_youtube_channel_id_via_url_parse(self):
+        """Pas de `channel_id` direct → parse depuis `channel_url`."""
+        from transcripts.youtube_channel import extract_channel_id_from_video_metadata
+
+        metadata = {
+            "channel_url": "https://www.youtube.com/channel/UCabcDEF12345678901234",
+        }
+        chan_id = extract_channel_id_from_video_metadata(metadata)
+        assert chan_id == "UCabcDEF12345678901234"
+
+    def test_youtube_channel_id_returns_none_for_invalid_metadata(self):
+        """Metadata vide / None → None."""
+        from transcripts.youtube_channel import extract_channel_id_from_video_metadata
+
+        assert extract_channel_id_from_video_metadata({}) is None
+        assert extract_channel_id_from_video_metadata(None) is None  # type: ignore[arg-type]
+
+    def test_pipeline_extracts_username_from_tiktok_metadata(self):
+        """TikTok metadata avec uploader_id → username extrait."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        metadata = {
+            "uploader_id": "charlidamelio",
+            "webpage_url": "https://www.tiktok.com/@charlidamelio/video/12345",
+        }
+        username = extract_tiktok_username_from_video_metadata(metadata)
+        assert username == "charlidamelio"
+
+    def test_tiktok_username_via_webpage_url(self):
+        """Pas de uploader_id, parse depuis URL."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        metadata = {
+            "webpage_url": "https://www.tiktok.com/@some_user/video/9999",
+        }
+        username = extract_tiktok_username_from_video_metadata(metadata)
+        assert username == "some_user"
+
+    def test_tiktok_username_returns_none_for_empty(self):
+        """Metadata vide → None."""
+        from transcripts.tiktok import extract_tiktok_username_from_video_metadata
+
+        assert extract_tiktok_username_from_video_metadata({}) is None
+        assert extract_tiktok_username_from_video_metadata(None) is None  # type: ignore[arg-type]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Tests : pipeline fail-safe (generate_summary continue si channel_context None)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_pipeline_continues_if_channel_context_fetch_fails():
+    """generate_summary doit fonctionner avec channel_context=None (fail-safe).
+
+    Mock l'appel LLM pour ne pas dépendre du réseau. On vérifie que
+    generate_summary appelle bien build_analysis_prompt avec channel_context=None
+    et que le résultat reste exploitable.
+    """
+    from videos import analysis as analysis_mod
+
+    # Mock llm_complete : retourne un résumé bidon
+    fake_result = type(
+        "FakeLLMResult",
+        (),
+        {
+            "content": "## Résumé\n\nContenu factice.",
+            "tokens_total": 100,
+            "fallback_used": False,
+            "provider": "mistral",
+            "model_used": "mistral-small-2603",
+        },
+    )()
+
+    with patch.object(
+        analysis_mod, "llm_complete", new=AsyncMock(return_value=fake_result)
+    ), patch.object(analysis_mod, "get_mistral_key", return_value="fake-key"):
+
+        # Désactiver le cache pour éviter side-effects
+        analysis_mod.CACHE_AVAILABLE = False
+
+        result = await analysis_mod.generate_summary(
+            title="Test",
+            transcript="content " * 50,
+            category="general",
+            lang="fr",
+            mode="standard",
+            duration=300,
+            channel="TestChan",
+            description="desc",
+            channel_context=None,  # explicite : aucun contexte
+        )
+
+        assert result is not None
+        assert "Résumé" in result or "Contenu" in result
+
+        # Vérifier que llm_complete a bien été appelé
+        analysis_mod.llm_complete.assert_called_once()
+        call_kwargs = analysis_mod.llm_complete.call_args.kwargs
+        # Le user_prompt ne doit PAS contenir le bloc contexte chaîne
+        messages = call_kwargs.get("messages", [])
+        user_msg = next((m for m in messages if m.get("role") == "user"), {})
+        assert "### Contexte chaîne (référence)" not in user_msg.get("content", "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_passes_channel_context_to_prompt():
+    """Si on passe channel_context à generate_summary, le bloc DOIT apparaître."""
+    from videos import analysis as analysis_mod
+
+    fake_result = type(
+        "FakeLLMResult",
+        (),
+        {
+            "content": "## Résumé\n\nOK.",
+            "tokens_total": 50,
+            "fallback_used": False,
+            "provider": "mistral",
+            "model_used": "mistral-small-2603",
+        },
+    )()
+
+    ctx = _make_channel_context(n_videos=5, platform="youtube")
+
+    with patch.object(
+        analysis_mod, "llm_complete", new=AsyncMock(return_value=fake_result)
+    ), patch.object(analysis_mod, "get_mistral_key", return_value="fake-key"):
+        analysis_mod.CACHE_AVAILABLE = False
+
+        await analysis_mod.generate_summary(
+            title="Test",
+            transcript="content " * 50,
+            category="general",
+            lang="fr",
+            mode="standard",
+            channel_context=ctx,
+        )
+
+        analysis_mod.llm_complete.assert_called_once()
+        call_kwargs = analysis_mod.llm_complete.call_args.kwargs
+        messages = call_kwargs.get("messages", [])
+        user_msg = next((m for m in messages if m.get("role") == "user"), {})
+        sys_msg = next((m for m in messages if m.get("role") == "system"), {})
+
+        assert "### Contexte chaîne (référence)" in user_msg.get("content", "")
+        assert "Chaîne Vulgarisation" in user_msg.get("content", "")
+        assert "Contexte chaîne" in sys_msg.get("content", "")


### PR DESCRIPTION
## Summary

- Inject **channel-level context** (up to 50 latest videos + metadata) into Mistral analyses on YouTube and TikTok
- New `## Contexte chaîne` / `## Channel Context` section in generated summaries (FR + EN)
- Goal: avoid out-of-context bias by letting Mistral judge if a video is representative of the channel and classify the channel (entertainment / educational / informative / promotional / activist / low-quality / dangerous / other)

## Architecture

| Layer | File | Description |
|---|---|---|
| Fetch YouTube | `backend/src/transcripts/youtube_channel.py` (new) | yt-dlp `--flat-playlist` on `/channel/{id}/videos` or `/@{handle}/videos`, helper `extract_channel_id_from_video_metadata` |
| Fetch TikTok | `backend/src/transcripts/tiktok.py` (extended) | yt-dlp on `/@{username}`, hashtag extraction, helper `extract_tiktok_username_from_video_metadata` |
| DB | `backend/alembic/versions/014_add_channel_contexts.py` (new) + model `ChannelContext` in `db/database.py` | Composite PK `(channel_id, platform)`, JSONB `last_videos`/`tags`/`categories`, indexed on `expires_at` |
| Cache | `backend/src/services/channel_content_cache.py` (new) | 2-tier: Redis L1 (`vcache:channel_context:{platform}:{id}`) + Postgres L2, 7-day TTL, dialect-aware upsert (PG/SQLite portable) |
| Pipeline | `backend/src/videos/router.py` `_analyze_video_background_v6` | Step 1 extracts external_id, steps 3+4 `asyncio.gather` extended with channel fetch, passed to `generate_summary` step 5 |
| Prompt | `backend/src/videos/analysis.py` `build_analysis_prompt` + `_format_channel_context_block` | New `channel_context: dict \| None = None` parameter (backward compatible), system directive (FR + EN) + user prompt block |

## Unified shape (YouTube + TikTok)

```python
{
    "channel_id": str,
    "platform": "youtube" | "tiktok",
    "name": str,
    "description": str,
    "subscriber_count": int | None,
    "video_count": int | None,
    "tags": list[str],
    "categories": list[str],
    "last_videos": [{"title", "description" (200ch), "tags", "view_count", "upload_date"}, ...],
}
```

## Failure modes

- Private/suspended channel, rate-limited yt-dlp, timeout → `get_or_fetch_channel_context()` returns `None`
- `None` propagates to `build_analysis_prompt(channel_context=None)` → block omitted from user prompt; system directive instructs Mistral not to generate the section
- Analysis always completes, never blocked by channel fetch failure

## Scope intentionally limited

Only `_analyze_video_background_v6` is instrumented. Pipelines `_v2`, `_v2_1`, `_analyze_raw_text_background`, `_analyze_images_background` are **left untouched**: signatures of `build_analysis_prompt` / `generate_summary` are backward compatible (default `None`), so all existing callers work as before. Extension to other pipelines = separate sprint.

## Test plan

- [x] 62 tests passing, 0 regressions
  - 14 `test_youtube_channel.py`
  - 19 `test_tiktok_account.py`
  - 3 `test_channel_contexts.py` (DB)
  - 8 `test_channel_content_cache.py`
  - 18 `test_channel_context_injection.py`
- [ ] Migration 014 applies cleanly on Hetzner prod (auto via `entrypoint.sh` + `RUN_MIGRATIONS=true`)
- [ ] E2E smoke: analyze 1 YouTube video + 1 TikTok video on staging/prod, verify `## Contexte chaîne` section is generated and matches the channel
- [ ] E2E edge case: analyze a video from a private/deleted channel, verify analysis completes without the section

## Notes

- Migration 014 not yet applied locally (no need for tests, which use SQLite `Base.metadata.create_all`)
- Cost: yt-dlp fetch ~1-2s per channel, cached 7 days, so amortized after first hit
- Token cost: ~3-8k tokens added to Mistral prompt depending on channel size (50 videos × titles + 200ch descriptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)