### PR TITLE
fix(tutor): correct imports in service.py (router was 404 in prod)

### DIFF
--- a/backend/src/tutor/service.py
+++ b/backend/src/tutor/service.py
@@ -12,8 +12,8 @@ import logging
 from typing import Optional
 import httpx
 import redis.asyncio as aioredis
-from src.tutor.schemas import TutorSessionState, TutorTurn, TutorMode, TutorLang
-from src.tutor.prompts import build_tutor_system_prompt, TUTOR_PERSONA_VERSION
+from tutor.schemas import TutorSessionState, TutorTurn, TutorMode, TutorLang
+from tutor.prompts import build_tutor_system_prompt, TUTOR_PERSONA_VERSION
 from core.config import get_elevenlabs_key
 
 


### PR DESCRIPTION
Bug critique introduit dans PR #285 — `from src.tutor.` au lieu de `from tutor.` dans `backend/src/tutor/service.py` empêchait le router Tutor d'être chargé en prod (logs : `⚠️ Tutor router not available: No module named 'src'`). Tous les endpoints `/api/tutor/*` renvoyaient 404.

Fix : 2 lignes (schemas + prompts imports). Tested local + prod confirmation expected post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)