### PR TITLE
chore(mobile): bump iOS buildNumber 5→6 for TestFlight

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.deepsight.app",
-      "buildNumber": "5",
+      "buildNumber": "6",
       "appleTeamId": "XGPXQ9KQ2G",
       "associatedDomains": [
         "applinks:deepsightsynthesis.com",


### PR DESCRIPTION
Bump iOS buildNumber pour TestFlight build après hotfix Tutor #289.

Inclut sur main : Hub web redesign + Tutor V1.0/V1.1 + audio voice + import hotfix.
Pas de bump version (1.1.0 conservé) → OTA compat preserved.