### PR TITLE
feat(mobile): Le Tuteur V2 mobile lite — bottom-sheet text-only

### DIFF
--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -31,6 +31,8 @@ import { ActionBar } from "@/components/analysis/ActionBar";
 import { ConversationScreen } from "@/components/conversation";
 import { DoodleBackground } from "@/components/ui/DoodleBackground";
 import { VoiceButton } from "@/components/voice/VoiceButton";
+import { TutorButton } from "@/components/tutor/TutorButton";
+import { TutorBottomSheet } from "@/components/tutor/TutorBottomSheet";
 import { ExportMenu } from "@/components/export";
 import { AcademicSourcesSection } from "@/components/academic";
 import { FactCheckButton } from "@/components/factcheck";
@@ -67,6 +69,7 @@ export default function AnalysisDetailScreen() {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isVoiceVisible, setIsVoiceVisible] = useState(false);
   const [isExportVisible, setIsExportVisible] = useState(false);
+  const [isTutorVisible, setIsTutorVisible] = useState(false);
   const [tabBarWidth, setTabBarWidth] = useState(0);
   const scrollY = useSharedValue(0);
   const tabIndicatorX = useSharedValue(initialTabIndex);
@@ -663,6 +666,11 @@ export default function AnalysisDetailScreen() {
       {/* Action Bar — masquée en fullscreen */}
       {!isFullscreen && summary && (
         <View>
+          <TutorButton
+            onPress={() => setIsTutorVisible(true)}
+            disabled={!summary.title}
+            style={styles.tutorButtonInline}
+          />
           <ActionBar
             summaryId={summary.id}
             title={summary.title}
@@ -671,6 +679,18 @@ export default function AnalysisDetailScreen() {
             onFavoriteChange={setIsFavorite}
           />
         </View>
+      )}
+
+      {/* Tuteur V2 mobile lite — bottom-sheet text-only sur le concept de l'analyse */}
+      {summary && (
+        <TutorBottomSheet
+          isOpen={isTutorVisible}
+          onClose={() => setIsTutorVisible(false)}
+          conceptTerm={summary.title ?? null}
+          conceptDef={summary.title ?? null}
+          summaryId={Number(summary.id)}
+          sourceVideoTitle={summary.title ?? undefined}
+        />
       )}
 
       {/* Export Menu */}
@@ -774,6 +794,10 @@ export default function AnalysisDetailScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
+  tutorButtonInline: {
+    marginHorizontal: sp.lg,
+    marginBottom: sp.sm,
+  },
   // Headers
   header: {
     flexDirection: "row",

--- a/mobile/src/components/tutor/TutorBottomSheet.tsx
+++ b/mobile/src/components/tutor/TutorBottomSheet.tsx
@@ -1,0 +1,108 @@
+// mobile/src/components/tutor/TutorBottomSheet.tsx
+//
+// Root du Tuteur V2 mobile lite : bottom-sheet avec mini-chat texte.
+// Utilise SimpleBottomSheet (Expo Go compatible) — pas de @gorhom/bottom-sheet
+// pour cohérence avec les autres bottom-sheets du projet (VoiceSettings, etc.).
+//
+// Props :
+// - isOpen : ouvre/ferme le sheet (controlled).
+// - onClose : callback fermeture (déclenche endSession + reset state).
+// - conceptTerm / conceptDef : concept à approfondir (passés à startSession).
+// - summaryId / sourceVideoTitle : contexte optionnel (analyse en cours).
+//
+// Workflow auto :
+//   isOpen=false → idle, sheet hidden
+//   isOpen=true  → snapToIndex(0), startSession() auto, render TutorMiniChat
+//   onClose      → endSession() async (best effort) + reset state
+
+import React, { useEffect, useRef } from "react";
+import { View, StyleSheet } from "react-native";
+import {
+  SimpleBottomSheet,
+  type SimpleBottomSheetRef,
+} from "../ui/SimpleBottomSheet";
+import { useTheme } from "@/contexts/ThemeContext";
+import { useTutor } from "./useTutor";
+import { TutorMiniChat } from "./TutorMiniChat";
+
+interface TutorBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  conceptTerm: string | null;
+  conceptDef: string | null;
+  summaryId?: number;
+  sourceVideoTitle?: string;
+}
+
+export const TutorBottomSheet: React.FC<TutorBottomSheetProps> = ({
+  isOpen,
+  onClose,
+  conceptTerm,
+  conceptDef,
+  summaryId,
+  sourceVideoTitle,
+}) => {
+  const { colors } = useTheme();
+  const sheetRef = useRef<SimpleBottomSheetRef>(null);
+  const tutor = useTutor();
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (isOpen && conceptTerm && conceptDef) {
+      sheetRef.current?.snapToIndex(0);
+      if (!startedRef.current && tutor.phase === "idle") {
+        startedRef.current = true;
+        void tutor.startSession({
+          concept_term: conceptTerm,
+          concept_def: conceptDef,
+          summary_id: summaryId,
+          source_video_title: sourceVideoTitle,
+        });
+      }
+    }
+    if (!isOpen) {
+      sheetRef.current?.close();
+    }
+  }, [isOpen, conceptTerm, conceptDef, summaryId, sourceVideoTitle, tutor]);
+
+  const handleClose = () => {
+    if (tutor.sessionId) {
+      void tutor.endSession();
+    }
+    startedRef.current = false;
+    onClose();
+  };
+
+  if (!conceptTerm) return null;
+
+  return (
+    <SimpleBottomSheet
+      ref={sheetRef}
+      snapPoint="75%"
+      backgroundStyle={{ backgroundColor: colors.bgPrimary }}
+      handleIndicatorStyle={{ backgroundColor: colors.borderLight }}
+      onClose={handleClose}
+    >
+      <View
+        style={[styles.content, { backgroundColor: colors.bgPrimary }]}
+        testID="tutor-bottom-sheet"
+      >
+        <TutorMiniChat
+          conceptTerm={conceptTerm}
+          messages={tutor.messages}
+          loading={tutor.loading}
+          error={tutor.error}
+          onSubmit={tutor.submitTextTurn}
+        />
+      </View>
+    </SimpleBottomSheet>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+  },
+});
+
+export default TutorBottomSheet;

--- a/mobile/src/components/tutor/TutorButton.tsx
+++ b/mobile/src/components/tutor/TutorButton.tsx
@@ -1,0 +1,103 @@
+// mobile/src/components/tutor/TutorButton.tsx
+//
+// Bouton entry-point réutilisable pour ouvrir le Tuteur V2 mobile lite.
+// Aligné sur le design system mobile (theme tokens dark first).
+
+import React from "react";
+import {
+  Pressable,
+  Text,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+
+interface TutorButtonProps {
+  onPress: () => void;
+  disabled?: boolean;
+  /** Override du label par défaut (FR). */
+  label?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+export const TutorButton: React.FC<TutorButtonProps> = ({
+  onPress,
+  disabled = false,
+  label = "Approfondir avec le Tuteur",
+  style,
+}) => {
+  const { colors } = useTheme();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityLabel={label}
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      testID="tutor-button"
+      style={({ pressed }) => [
+        styles.button,
+        {
+          backgroundColor: colors.glassBg,
+          borderColor: colors.borderLight,
+          opacity: disabled ? 0.5 : pressed ? 0.85 : 1,
+        },
+        style,
+      ]}
+    >
+      <View style={styles.iconWrap}>
+        <Ionicons
+          name="school-outline"
+          size={20}
+          color={colors.accentPrimary}
+        />
+      </View>
+      <Text
+        style={[styles.label, { color: colors.textPrimary }]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+      <Ionicons
+        name="chevron-forward"
+        size={18}
+        color={colors.textTertiary}
+        style={styles.chevron}
+      />
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: sp.md,
+    paddingHorizontal: sp.lg,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    gap: sp.md,
+  },
+  iconWrap: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  label: {
+    flex: 1,
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.base,
+  },
+  chevron: {
+    marginLeft: sp.xs,
+  },
+});
+
+export default TutorButton;

--- a/mobile/src/components/tutor/TutorMiniChat.tsx
+++ b/mobile/src/components/tutor/TutorMiniChat.tsx
@@ -1,0 +1,329 @@
+// mobile/src/components/tutor/TutorMiniChat.tsx
+//
+// UI mini-chat texte du Tuteur V2 mobile lite.
+// Header (concept_term en titre) + ScrollView messages (bubbles) + input bar.
+
+import React, { useEffect, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  ActivityIndicator,
+  StyleSheet,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize, lineHeight } from "@/theme/typography";
+import type { TutorTurn } from "../../types/tutor";
+
+interface TutorMiniChatProps {
+  conceptTerm: string;
+  messages: TutorTurn[];
+  loading: boolean;
+  error: string | null;
+  onSubmit: (text: string) => void;
+}
+
+export const TutorMiniChat: React.FC<TutorMiniChatProps> = ({
+  conceptTerm,
+  messages,
+  loading,
+  error,
+  onSubmit,
+}) => {
+  const { colors } = useTheme();
+  const [draft, setDraft] = useState("");
+  const scrollRef = useRef<ScrollView>(null);
+
+  // Auto-scroll vers le bas à chaque nouveau message ou changement loading
+  useEffect(() => {
+    const id = setTimeout(() => {
+      scrollRef.current?.scrollToEnd({ animated: true });
+    }, 50);
+    return () => clearTimeout(id);
+  }, [messages.length, loading]);
+
+  const trimmed = draft.trim();
+  const canSubmit = trimmed.length > 0 && !loading;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onSubmit(trimmed);
+    setDraft("");
+  };
+
+  return (
+    <View style={styles.root} testID="tutor-mini-chat">
+      {/* Header */}
+      <View
+        style={[styles.header, { borderBottomColor: colors.borderLight }]}
+        testID="tutor-mini-chat-header"
+      >
+        <Text
+          style={[styles.headerTitle, { color: colors.textPrimary }]}
+          numberOfLines={1}
+        >
+          {conceptTerm}
+        </Text>
+        <Text
+          style={[styles.headerSubtitle, { color: colors.textTertiary }]}
+          numberOfLines={1}
+        >
+          Tuteur
+        </Text>
+      </View>
+
+      {/* Error banner */}
+      {error ? (
+        <View
+          style={[
+            styles.errorBanner,
+            {
+              backgroundColor: colors.glassBg,
+              borderColor: colors.accentError,
+            },
+          ]}
+          testID="tutor-mini-chat-error"
+        >
+          <Ionicons
+            name="alert-circle-outline"
+            size={16}
+            color={colors.accentError}
+          />
+          <Text
+            style={[styles.errorText, { color: colors.textSecondary }]}
+            numberOfLines={2}
+          >
+            {error}
+          </Text>
+        </View>
+      ) : null}
+
+      {/* Messages */}
+      <ScrollView
+        ref={scrollRef}
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        testID="tutor-mini-chat-scroll"
+      >
+        {messages.map((msg, idx) => (
+          <View
+            key={`${msg.timestamp_ms}-${idx}`}
+            style={[
+              styles.bubbleRow,
+              msg.role === "user" ? styles.bubbleRowUser : styles.bubbleRowAi,
+            ]}
+            testID={`tutor-bubble-${msg.role}-${idx}`}
+          >
+            <View
+              style={[
+                styles.bubble,
+                msg.role === "user"
+                  ? {
+                      backgroundColor: colors.accentPrimary,
+                      borderTopRightRadius: borderRadius.sm,
+                    }
+                  : {
+                      backgroundColor: colors.bgSecondary,
+                      borderTopLeftRadius: borderRadius.sm,
+                      borderWidth: 1,
+                      borderColor: colors.borderLight,
+                    },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.bubbleText,
+                  {
+                    color: msg.role === "user" ? "#ffffff" : colors.textPrimary,
+                  },
+                ]}
+              >
+                {msg.content}
+              </Text>
+            </View>
+          </View>
+        ))}
+
+        {loading ? (
+          <View
+            style={[styles.bubbleRow, styles.bubbleRowAi]}
+            testID="tutor-mini-chat-loading"
+          >
+            <View
+              style={[
+                styles.bubble,
+                styles.bubbleLoading,
+                {
+                  backgroundColor: colors.bgSecondary,
+                  borderColor: colors.borderLight,
+                },
+              ]}
+            >
+              <ActivityIndicator size="small" color={colors.accentPrimary} />
+            </View>
+          </View>
+        ) : null}
+      </ScrollView>
+
+      {/* Input bar */}
+      <View
+        style={[
+          styles.inputBar,
+          {
+            backgroundColor: colors.bgPrimary,
+            borderTopColor: colors.borderLight,
+          },
+        ]}
+      >
+        <TextInput
+          style={[
+            styles.input,
+            {
+              color: colors.textPrimary,
+              backgroundColor: colors.bgSecondary,
+              borderColor: colors.borderLight,
+            },
+          ]}
+          value={draft}
+          onChangeText={setDraft}
+          placeholder="Pose ta question..."
+          placeholderTextColor={colors.textTertiary}
+          multiline
+          maxLength={500}
+          editable={!loading}
+          onSubmitEditing={handleSubmit}
+          accessibilityLabel="Question pour le Tuteur"
+          testID="tutor-mini-chat-input"
+        />
+        <Pressable
+          onPress={handleSubmit}
+          disabled={!canSubmit}
+          accessibilityLabel="Envoyer"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !canSubmit }}
+          testID="tutor-mini-chat-send"
+          style={({ pressed }) => [
+            styles.sendBtn,
+            {
+              backgroundColor: canSubmit
+                ? colors.accentPrimary
+                : colors.bgTertiary,
+              opacity: !canSubmit ? 0.6 : pressed ? 0.85 : 1,
+            },
+          ]}
+        >
+          <Ionicons
+            name="send"
+            size={18}
+            color={canSubmit ? "#ffffff" : colors.textTertiary}
+          />
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: sp.lg,
+    paddingBottom: sp.md,
+    borderBottomWidth: 1,
+  },
+  headerTitle: {
+    fontFamily: fontFamily.bodyBold,
+    fontSize: fontSize.lg,
+    lineHeight: fontSize.lg * lineHeight.snug,
+  },
+  headerSubtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+    marginTop: 2,
+  },
+  errorBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+    marginHorizontal: sp.lg,
+    marginTop: sp.sm,
+    paddingVertical: sp.sm,
+    paddingHorizontal: sp.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+  },
+  errorText: {
+    flex: 1,
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: sp.lg,
+    gap: sp.sm,
+  },
+  bubbleRow: {
+    flexDirection: "row",
+    marginBottom: sp.xs,
+  },
+  bubbleRowUser: {
+    justifyContent: "flex-end",
+  },
+  bubbleRowAi: {
+    justifyContent: "flex-start",
+  },
+  bubble: {
+    maxWidth: "85%",
+    paddingVertical: sp.sm,
+    paddingHorizontal: sp.md,
+    borderRadius: borderRadius.lg,
+  },
+  bubbleLoading: {
+    paddingVertical: sp.md,
+    paddingHorizontal: sp.lg,
+    minWidth: 60,
+    alignItems: "center",
+    borderWidth: 1,
+  },
+  bubbleText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.base,
+    lineHeight: fontSize.base * lineHeight.normal,
+  },
+  inputBar: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: sp.sm,
+    paddingHorizontal: sp.lg,
+    paddingVertical: sp.md,
+    borderTopWidth: 1,
+  },
+  input: {
+    flex: 1,
+    minHeight: 40,
+    maxHeight: 120,
+    paddingVertical: sp.sm,
+    paddingHorizontal: sp.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.base,
+  },
+  sendBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+
+export default TutorMiniChat;

--- a/mobile/src/components/tutor/__tests__/TutorBottomSheet.test.tsx
+++ b/mobile/src/components/tutor/__tests__/TutorBottomSheet.test.tsx
@@ -1,0 +1,133 @@
+// mobile/src/components/tutor/__tests__/TutorBottomSheet.test.tsx
+//
+// Tests intégration : ouverture/fermeture, auto-startSession, props requises.
+
+import React from "react";
+import { render, waitFor } from "@testing-library/react-native";
+import { TutorBottomSheet } from "../TutorBottomSheet";
+import { tutorApi } from "../../../services/api";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+jest.mock("../../../services/api", () => ({
+  tutorApi: {
+    sessionStart: jest.fn(),
+    sessionTurn: jest.fn(),
+    sessionEnd: jest.fn(),
+  },
+}));
+
+const mockedSessionStart = tutorApi.sessionStart as jest.MockedFunction<
+  typeof tutorApi.sessionStart
+>;
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe("TutorBottomSheet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("retourne null si conceptTerm absent", () => {
+    const { queryByTestId } = renderWithTheme(
+      <TutorBottomSheet
+        isOpen
+        onClose={jest.fn()}
+        conceptTerm={null}
+        conceptDef="def"
+      />,
+    );
+    expect(queryByTestId("tutor-bottom-sheet")).toBeNull();
+    expect(mockedSessionStart).not.toHaveBeenCalled();
+  });
+
+  it("ne démarre pas la session quand isOpen=false", () => {
+    renderWithTheme(
+      <TutorBottomSheet
+        isOpen={false}
+        onClose={jest.fn()}
+        conceptTerm="Rasoir d'Occam"
+        conceptDef="parcimonie"
+      />,
+    );
+    expect(mockedSessionStart).not.toHaveBeenCalled();
+  });
+
+  it("démarre la session avec mode=text quand isOpen passe à true", async () => {
+    mockedSessionStart.mockResolvedValueOnce({
+      session_id: "sess_open",
+      first_prompt: "Premier prompt",
+      audio_url: null,
+    });
+
+    const { rerender } = renderWithTheme(
+      <TutorBottomSheet
+        isOpen={false}
+        onClose={jest.fn()}
+        conceptTerm="Rasoir d'Occam"
+        conceptDef="parcimonie"
+        summaryId={123}
+        sourceVideoTitle="Philosophie"
+      />,
+    );
+
+    rerender(
+      <ThemeProvider>
+        <TutorBottomSheet
+          isOpen
+          onClose={jest.fn()}
+          conceptTerm="Rasoir d'Occam"
+          conceptDef="parcimonie"
+          summaryId={123}
+          sourceVideoTitle="Philosophie"
+        />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockedSessionStart).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockedSessionStart).toHaveBeenCalledWith({
+      concept_term: "Rasoir d'Occam",
+      concept_def: "parcimonie",
+      summary_id: 123,
+      source_video_title: "Philosophie",
+      mode: "text",
+      lang: "fr",
+    });
+  });
+
+  it("ne démarre pas la session 2 fois si re-renderisé open", async () => {
+    mockedSessionStart.mockResolvedValueOnce({
+      session_id: "sess_once",
+      first_prompt: "p",
+      audio_url: null,
+    });
+
+    const { rerender } = renderWithTheme(
+      <TutorBottomSheet
+        isOpen
+        onClose={jest.fn()}
+        conceptTerm="C"
+        conceptDef="D"
+      />,
+    );
+
+    await waitFor(() => expect(mockedSessionStart).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <ThemeProvider>
+        <TutorBottomSheet
+          isOpen
+          onClose={jest.fn()}
+          conceptTerm="C"
+          conceptDef="D"
+        />
+      </ThemeProvider>,
+    );
+
+    // Toujours 1 seul appel (startedRef garde la mémoire)
+    expect(mockedSessionStart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/components/tutor/__tests__/useTutor.test.ts
+++ b/mobile/src/components/tutor/__tests__/useTutor.test.ts
@@ -1,0 +1,241 @@
+// mobile/src/components/tutor/__tests__/useTutor.test.ts
+//
+// Tests state machine + async flow du hook V2 mobile lite.
+
+import { renderHook, act } from "@testing-library/react-native";
+import { useTutor } from "../useTutor";
+import { tutorApi } from "../../../services/api";
+
+jest.mock("../../../services/api", () => ({
+  tutorApi: {
+    sessionStart: jest.fn(),
+    sessionTurn: jest.fn(),
+    sessionEnd: jest.fn(),
+  },
+}));
+
+const mockedSessionStart = tutorApi.sessionStart as jest.MockedFunction<
+  typeof tutorApi.sessionStart
+>;
+const mockedSessionTurn = tutorApi.sessionTurn as jest.MockedFunction<
+  typeof tutorApi.sessionTurn
+>;
+const mockedSessionEnd = tutorApi.sessionEnd as jest.MockedFunction<
+  typeof tutorApi.sessionEnd
+>;
+
+describe("useTutor (V2 mobile lite)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("démarre en phase idle avec messages vides", () => {
+    const { result } = renderHook(() => useTutor());
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("startSession passe en phase active + ajoute le 1er prompt", async () => {
+    mockedSessionStart.mockResolvedValueOnce({
+      session_id: "sess_abc",
+      first_prompt: "Comment définiriez-vous ce concept ?",
+      audio_url: null,
+    });
+
+    const { result } = renderHook(() => useTutor());
+
+    await act(async () => {
+      await result.current.startSession({
+        concept_term: "Rasoir d'Occam",
+        concept_def: "Principe de parcimonie",
+        summary_id: 42,
+        source_video_title: "Philosophie 101",
+      });
+    });
+
+    expect(mockedSessionStart).toHaveBeenCalledWith({
+      concept_term: "Rasoir d'Occam",
+      concept_def: "Principe de parcimonie",
+      summary_id: 42,
+      source_video_title: "Philosophie 101",
+      mode: "text",
+      lang: "fr",
+    });
+    expect(result.current.phase).toBe("active");
+    expect(result.current.sessionId).toBe("sess_abc");
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]).toMatchObject({
+      role: "assistant",
+      content: "Comment définiriez-vous ce concept ?",
+    });
+    expect(result.current.conceptTerm).toBe("Rasoir d'Occam");
+  });
+
+  it("submitTextTurn ajoute message user puis assistant", async () => {
+    mockedSessionStart.mockResolvedValueOnce({
+      session_id: "sess_xyz",
+      first_prompt: "Premier prompt",
+      audio_url: null,
+    });
+    mockedSessionTurn.mockResolvedValueOnce({
+      ai_response: "Réponse IA",
+      audio_url: null,
+      turn_count: 1,
+    });
+
+    const { result } = renderHook(() => useTutor());
+
+    await act(async () => {
+      await result.current.startSession({
+        concept_term: "Concept",
+        concept_def: "Definition",
+      });
+    });
+
+    await act(async () => {
+      await result.current.submitTextTurn("Question user");
+    });
+
+    expect(mockedSessionTurn).toHaveBeenCalledWith("sess_xyz", {
+      user_input: "Question user",
+    });
+    // 1er prompt + user + assistant = 3
+    expect(result.current.messages).toHaveLength(3);
+    expect(result.current.messages[1]).toMatchObject({
+      role: "user",
+      content: "Question user",
+    });
+    expect(result.current.messages[2]).toMatchObject({
+      role: "assistant",
+      content: "Réponse IA",
+    });
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("submitTextTurn n'appelle pas l'API si pas de session", async () => {
+    const { result } = renderHook(() => useTutor());
+
+    await act(async () => {
+      await result.current.submitTextTurn("Question orpheline");
+    });
+
+    expect(mockedSessionTurn).not.toHaveBeenCalled();
+    expect(result.current.messages).toHaveLength(0);
+  });
+
+  it("startSession transmet l'erreur dans state.error", async () => {
+    mockedSessionStart.mockRejectedValueOnce(new Error("Quota dépassé"));
+
+    const { result } = renderHook(() => useTutor());
+
+    await act(async () => {
+      await result.current.startSession({
+        concept_term: "X",
+        concept_def: "Y",
+      });
+    });
+
+    expect(result.current.error).toBe("Quota dépassé");
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("submitTextTurn transmet l'erreur dans state.error", async () => {
+    mockedSessionStart.mockResolvedValueOnce({
+      session_id: "sess_err",
+      first_prompt: "p",
+      audio_url: null,
+    });
+    mockedSessionTurn.mockRejectedValueOnce(new Error("Network down"));
+
+    const { result } = renderHook(() => useTutor());
+
+    await act(async () => {
+      await result.current.startSession({
+        concept_term: "T",
+        concept_def: "D",
+      });
+    });
+
+    await act(async () => {
+      await result.current.submitTextTurn("hello");
+    });
+
+    expect(result.current.error).toBe("Network down");
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("endSession appelle l'API et reset l'état", async () => {
+    mockedSessionStart.mockResolvedValueOnce({
+      session_id: "sess_end",
+      first_prompt: "p",
+      audio_url: null,
+    });
+    mockedSessionEnd.mockResolvedValueOnce({
+      duration_sec: 120,
+      turns_count: 2,
+      source_summary_url: null,
+      source_video_title: null,
+    });
+
+    const { result } = renderHook(() => useTutor());
+
+    await act(async () => {
+      await result.current.startSession({
+        concept_term: "T",
+        concept_def: "D",
+      });
+    });
+
+    expect(result.current.sessionId).toBe("sess_end");
+
+    await act(async () => {
+      await result.current.endSession();
+    });
+
+    expect(mockedSessionEnd).toHaveBeenCalledWith("sess_end");
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("endSession ne crash pas si pas de session", async () => {
+    const { result } = renderHook(() => useTutor());
+
+    await act(async () => {
+      await result.current.endSession();
+    });
+
+    expect(mockedSessionEnd).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("idle");
+  });
+
+  it("endSession swallow erreur API (best effort) et reset quand même", async () => {
+    mockedSessionStart.mockResolvedValueOnce({
+      session_id: "sess_swallow",
+      first_prompt: "p",
+      audio_url: null,
+    });
+    mockedSessionEnd.mockRejectedValueOnce(new Error("500 server"));
+
+    const { result } = renderHook(() => useTutor());
+
+    await act(async () => {
+      await result.current.startSession({
+        concept_term: "T",
+        concept_def: "D",
+      });
+    });
+
+    await act(async () => {
+      await result.current.endSession();
+    });
+
+    // L'erreur ne bloque pas la fermeture
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.sessionId).toBeNull();
+  });
+});

--- a/mobile/src/components/tutor/useTutor.ts
+++ b/mobile/src/components/tutor/useTutor.ts
@@ -1,0 +1,194 @@
+// mobile/src/components/tutor/useTutor.ts
+//
+// Hook V2 mobile lite — pattern simplifié vs frontend/src/components/Tutor/useTutor.ts.
+// Phase réduite à "idle" | "active" : text-only, pas de prompting/deep-session.
+// Mode forcé à "text" sur mobile V2 lite (pas de voice côté mobile pour l'instant).
+
+import { useReducer, useCallback } from "react";
+import { tutorApi } from "../../services/api";
+import type { TutorPhase, TutorLang, TutorTurn } from "../../types/tutor";
+
+interface TutorState {
+  phase: TutorPhase;
+  sessionId: string | null;
+  messages: TutorTurn[];
+  conceptTerm: string | null;
+  conceptDef: string | null;
+  summaryId: number | null;
+  sourceVideoTitle: string | null;
+  lang: TutorLang;
+  loading: boolean;
+  error: string | null;
+}
+
+type Action =
+  | { type: "SESSION_STARTING"; lang: TutorLang }
+  | {
+      type: "SESSION_STARTED";
+      session_id: string;
+      first_prompt: string;
+      concept_term: string;
+      concept_def: string;
+      summary_id: number | null;
+      source_video_title: string | null;
+    }
+  | { type: "TURN_PENDING"; user_input: string }
+  | { type: "TURN_DONE"; ai_response: string }
+  | { type: "SESSION_ENDED" }
+  | { type: "ERROR"; message: string };
+
+const initialState: TutorState = {
+  phase: "idle",
+  sessionId: null,
+  messages: [],
+  conceptTerm: null,
+  conceptDef: null,
+  summaryId: null,
+  sourceVideoTitle: null,
+  lang: "fr",
+  loading: false,
+  error: null,
+};
+
+function reducer(state: TutorState, action: Action): TutorState {
+  switch (action.type) {
+    case "SESSION_STARTING":
+      return {
+        ...state,
+        lang: action.lang,
+        loading: true,
+        error: null,
+      };
+    case "SESSION_STARTED":
+      return {
+        ...state,
+        phase: "active",
+        sessionId: action.session_id,
+        conceptTerm: action.concept_term,
+        conceptDef: action.concept_def,
+        summaryId: action.summary_id,
+        sourceVideoTitle: action.source_video_title,
+        messages: [
+          {
+            role: "assistant",
+            content: action.first_prompt,
+            timestamp_ms: Date.now(),
+          },
+        ],
+        loading: false,
+      };
+    case "TURN_PENDING":
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            role: "user",
+            content: action.user_input,
+            timestamp_ms: Date.now(),
+          },
+        ],
+        loading: true,
+      };
+    case "TURN_DONE":
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            role: "assistant",
+            content: action.ai_response,
+            timestamp_ms: Date.now(),
+          },
+        ],
+        loading: false,
+      };
+    case "SESSION_ENDED":
+      return initialState;
+    case "ERROR":
+      return { ...state, error: action.message, loading: false };
+    default:
+      return state;
+  }
+}
+
+interface StartSessionParams {
+  concept_term: string;
+  concept_def: string;
+  summary_id?: number;
+  source_video_title?: string;
+  lang?: TutorLang;
+}
+
+export function useTutor() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const startSession = useCallback(async (params: StartSessionParams) => {
+    const lang = params.lang ?? "fr";
+    dispatch({ type: "SESSION_STARTING", lang });
+    try {
+      const resp = await tutorApi.sessionStart({
+        concept_term: params.concept_term,
+        concept_def: params.concept_def,
+        summary_id: params.summary_id,
+        source_video_title: params.source_video_title,
+        // V2 mobile lite : text-only forcé
+        mode: "text",
+        lang,
+      });
+      dispatch({
+        type: "SESSION_STARTED",
+        session_id: resp.session_id,
+        first_prompt: resp.first_prompt,
+        concept_term: params.concept_term,
+        concept_def: params.concept_def,
+        summary_id: params.summary_id ?? null,
+        source_video_title: params.source_video_title ?? null,
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Erreur de démarrage";
+      dispatch({ type: "ERROR", message });
+    }
+  }, []);
+
+  const submitTextTurn = useCallback(
+    async (user_input: string) => {
+      if (!state.sessionId) return;
+      dispatch({ type: "TURN_PENDING", user_input });
+      try {
+        const resp = await tutorApi.sessionTurn(state.sessionId, {
+          user_input,
+        });
+        dispatch({
+          type: "TURN_DONE",
+          ai_response: resp.ai_response,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Erreur réseau";
+        dispatch({ type: "ERROR", message });
+      }
+    },
+    [state.sessionId],
+  );
+
+  const endSession = useCallback(async () => {
+    if (state.sessionId) {
+      try {
+        await tutorApi.sessionEnd(state.sessionId);
+      } catch (err) {
+        // Best effort — logger mais ne pas bloquer la fermeture UI
+        // eslint-disable-next-line no-console
+        console.warn("[useTutor] endSession failed", err);
+      }
+    }
+    dispatch({ type: "SESSION_ENDED" });
+  }, [state.sessionId]);
+
+  return {
+    ...state,
+    startSession,
+    submitTextTurn,
+    endSession,
+  };
+}

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -2355,6 +2355,66 @@ export const reliabilityApi = {
   },
 };
 
+// ============================================
+// 🎓 TUTOR API — Le Tuteur conversationnel (sessions Redis TTL 1h)
+// V2 mobile lite : text-only, pas de voice (pas de Voxtral/ElevenLabs côté mobile)
+// ============================================
+import type {
+  SessionStartRequest as TutorSessionStartRequest,
+  SessionStartResponse as TutorSessionStartResponse,
+  SessionTurnRequest as TutorSessionTurnRequest,
+  SessionTurnResponse as TutorSessionTurnResponse,
+  SessionEndResponse as TutorSessionEndResponse,
+} from "../types/tutor";
+
+export const tutorApi = {
+  /**
+   * Démarre une session Tutor : crée la session Redis + génère le 1er prompt Magistral.
+   * Endpoint: POST /api/tutor/session/start
+   */
+  async sessionStart(
+    payload: TutorSessionStartRequest,
+  ): Promise<TutorSessionStartResponse> {
+    return request<TutorSessionStartResponse>("/api/tutor/session/start", {
+      method: "POST",
+      body: payload as unknown as Record<string, unknown>,
+      timeout: 60000,
+    });
+  },
+
+  /**
+   * Un tour de conversation : user input → IA response.
+   * Endpoint: POST /api/tutor/session/{session_id}/turn
+   */
+  async sessionTurn(
+    sessionId: string,
+    payload: TutorSessionTurnRequest,
+  ): Promise<TutorSessionTurnResponse> {
+    return request<TutorSessionTurnResponse>(
+      `/api/tutor/session/${sessionId}/turn`,
+      {
+        method: "POST",
+        body: payload as unknown as Record<string, unknown>,
+        timeout: 60000,
+      },
+    );
+  },
+
+  /**
+   * Termine une session : durée, log analytics, supprime Redis.
+   * Endpoint: POST /api/tutor/session/{session_id}/end
+   */
+  async sessionEnd(sessionId: string): Promise<TutorSessionEndResponse> {
+    return request<TutorSessionEndResponse>(
+      `/api/tutor/session/${sessionId}/end`,
+      {
+        method: "POST",
+        body: {},
+      },
+    );
+  },
+};
+
 export default {
   authApi,
   userApi,
@@ -2373,5 +2433,6 @@ export default {
   trendingApi,
   searchApi,
   reliabilityApi,
+  tutorApi,
   ApiError,
 };

--- a/mobile/src/types/tutor.ts
+++ b/mobile/src/types/tutor.ts
@@ -1,0 +1,55 @@
+// mobile/src/types/tutor.ts
+//
+// Le Tuteur V2 mobile lite — types portés depuis frontend/src/types/tutor.ts.
+// Mobile V2 lite : mode TEXT only (pas de voice → pas d'audio_url côté request).
+// TutorPhase simplifié : "idle" | "active" (pas de prompting/deep-session sur mobile lite).
+
+export type TutorMode = "text" | "voice";
+export type TutorLang = "fr" | "en";
+
+/**
+ * Mobile V2 lite : phase simplifiée.
+ * - "idle"   : pas de session active
+ * - "active" : session démarrée (équivalent de "mini-chat" web)
+ */
+export type TutorPhase = "idle" | "active";
+
+export interface TutorTurn {
+  role: "user" | "assistant";
+  content: string;
+  timestamp_ms: number;
+}
+
+export interface SessionStartRequest {
+  concept_term: string;
+  concept_def: string;
+  summary_id?: number;
+  source_video_title?: string;
+  mode: TutorMode;
+  lang: TutorLang;
+}
+
+export interface SessionStartResponse {
+  session_id: string;
+  first_prompt: string;
+  /** V2 lite mobile : toujours null côté text-only — l'API peut renvoyer un URL si voice. */
+  audio_url: string | null;
+}
+
+export interface SessionTurnRequest {
+  user_input?: string;
+  audio_blob_b64?: string;
+}
+
+export interface SessionTurnResponse {
+  ai_response: string;
+  audio_url: string | null;
+  turn_count: number;
+}
+
+export interface SessionEndResponse {
+  duration_sec: number;
+  turns_count: number;
+  source_summary_url: string | null;
+  source_video_title: string | null;
+}


### PR DESCRIPTION
## Summary

Port du **Tuteur V1 web** (PRs #284-#289 mergées 2026-05-03) vers mobile en **mode lite** selon spec [`2026-05-03-le-tuteur-companion-design.md`](../blob/main/docs/superpowers/specs/2026-05-03-le-tuteur-companion-design.md) ligne 272-273.

V2 mobile **lite** = text-only, bottom-sheet (pas fullscreen modal), pas de voice côté mobile (Voxtral/ElevenLabs reste V3+ mobile).

## Architecture

| Brique | Rôle |
|---|---|
| `mobile/src/types/tutor.ts` | Phase simplifiée `"idle" \| "active"` (vs 4 phases web) |
| `mobile/src/components/tutor/useTutor.ts` | Reducer simplifié, mode forcé `"text"`, 3 méthodes (`startSession`, `submitTextTurn`, `endSession`) |
| `mobile/src/components/tutor/TutorBottomSheet.tsx` | Root via `SimpleBottomSheet` (Expo Go compatible), auto-`startSession` à l'ouverture, auto-`endSession` à la fermeture |
| `mobile/src/components/tutor/TutorMiniChat.tsx` | Header `concept_term` + ScrollView bubbles + TextInput + send button |
| `mobile/src/components/tutor/TutorButton.tsx` | Bouton réutilisable, icône `school-outline` + chevron |
| `mobile/src/services/api.ts` (`tutorApi`) | 3 endpoints `/api/tutor/session/{start,turn,end}` (mirror du frontend) |

## Entry point

`mobile/app/(tabs)/analysis/[id].tsx` : bouton `<TutorButton />` inline au-dessus de l'`<ActionBar />` + `<TutorBottomSheet />` au niveau racine du screen. Concept = `summary.title` (V2 lite utilise le titre de l'analyse comme concept par défaut, pas de keyword extraction mobile).

## Pourquoi mobile lite (et pas V1 complet)

Spec ligne 272-273 verrouille V2 = "Mobile lite : Mode Texte uniquement, pas de fullscreen modal mais bottom-sheet".

- Pas de `LoadingWordContext` mobile (ne pas porter pour V2 lite)
- Pas de Voxtral STT / ElevenLabs TTS mobile (reuse infra possible mais hors scope)
- Pas de phase `prompting` ni `deep-session` (text-only direct)
- Plan gating reste géré par le backend (`/api/tutor/session/start` vérifie `is_feature_available(plan, "tutor", "mobile")`)

## Test plan

- [x] `npx jest src/components/tutor` → **13/13 verts** (9 `useTutor.test` + 4 `TutorBottomSheet.test`)
- [x] `npx tsc --noEmit` → 0 nouvelle erreur (9 baseline pré-existantes lighting-engine + RN modules conservées)
- [ ] Smoke iOS Expo Go : ouvrir une analyse → tap "Approfondir avec le Tuteur" → bottom-sheet up → 1er prompt Magistral arrive → envoyer une question → réponse IA s'affiche
- [ ] Smoke Android Expo Go : idem
- [ ] Vérifier que le sheet ferme proprement (endSession appelée) à la fermeture utilisateur

## Dépendances

- Backend `/api/tutor/*` déjà en prod (PR #289 merged 2026-05-03)
- Frontend api.ts mirror `tutorApi` déjà déployé

## Hors scope (V3+ mobile)

- Voice mode (Voxtral STT input + ElevenLabs TTS output) sur mobile
- Widget ambient rotatif (équivalent web `DidYouKnowCard`) sur Home/Library mobile
- Keyword extraction mobile pour rotation passive de concepts
- Mémoire cross-session (table `companion_memory`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)