### PR TITLE
docs+lint: Semantic Search V1 backend doc + ruff fixes (post #292)

### DIFF
--- a/backend/src/auth/email.py
+++ b/backend/src/auth/email.py
@@ -5,7 +5,7 @@ Templates live in backend/src/templates/emails/ and extend `_base.html`.
 """
 
 from typing import Optional
-from core.config import APP_NAME, FRONTEND_URL
+from core.config import FRONTEND_URL
 
 
 async def send_email(

--- a/backend/src/billing/voice_packs_service.py
+++ b/backend/src/billing/voice_packs_service.py
@@ -14,7 +14,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db.database import (
     User,
     VoiceCreditPack,
-    VoiceQuotaStreaming,
 )
 from billing.voice_quota import (
     TOP_TIER_PLANS,

--- a/backend/src/search/embedding_service.py
+++ b/backend/src/search/embedding_service.py
@@ -193,7 +193,7 @@ async def embed_summary(summary_id: int) -> bool:
     Returns True si succès, False si Summary introuvable ou échec embed.
     """
     from db.database import async_session_maker, Summary, SummaryEmbedding
-    from sqlalchemy import select, delete as sa_delete
+    from sqlalchemy import delete as sa_delete
 
     async with async_session_maker() as session:
         summary = await session.get(Summary, summary_id)

--- a/backend/src/search/global_search.py
+++ b/backend/src/search/global_search.py
@@ -8,11 +8,10 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import select
-from sqlalchemy.orm import joinedload
 
 from db.database import (
     async_session_maker,
@@ -22,7 +21,6 @@ from db.database import (
     FlashcardEmbedding,
     QuizQuestion,
     QuizEmbedding,
-    ChatMessage,
     ChatEmbedding,
     TranscriptEmbedding,
     TranscriptCache,

--- a/backend/src/search/router.py
+++ b/backend/src/search/router.py
@@ -29,7 +29,7 @@ from .recent_queries import (
     push_recent_query,
     clear_recent_queries,
 )
-from .within_search import search_within, NotOwnerError, WithinMatch
+from .within_search import search_within, NotOwnerError
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/transcripts/ultra_resilient.py
+++ b/backend/src/transcripts/ultra_resilient.py
@@ -36,11 +36,7 @@ from core.config import (
     TRANSCRIPT_CONFIG,
 )
 
-# Helper partagé YouTube + TikTok — défini dans audio_utils pour ré-utilisation.
-# Re-export pour compat avec d'éventuels imports existants.
-from transcripts.audio_utils import _yt_dlp_extra_args  # noqa: F401
-
-
+# Helper partagé YouTube + TikTok — local definition (audio_utils version shadowed).
 def _yt_dlp_extra_args() -> list:
     """Common yt-dlp flags for IP-banned environments: proxy + cookies.
 

--- a/backend/src/tutor/service.py
+++ b/backend/src/tutor/service.py
@@ -5,15 +5,13 @@ V1 : sessions en Redis avec TTL 1h. Pas de table SQL.
 V1.1 : ajout helper TTS ElevenLabs (synthesize_audio_data_url).
 """
 import base64
-import json
 import uuid
 import time
 import logging
 from typing import Optional
 import httpx
 import redis.asyncio as aioredis
-from tutor.schemas import TutorSessionState, TutorTurn, TutorMode, TutorLang
-from tutor.prompts import build_tutor_system_prompt, TUTOR_PERSONA_VERSION
+from tutor.schemas import TutorSessionState, TutorTurn
 from core.config import get_elevenlabs_key
 
 

--- a/backend/src/voice/prompt_session.py
+++ b/backend/src/voice/prompt_session.py
@@ -27,7 +27,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.logging import logger
-from db.database import FlashcardReview, Summary, User
+from db.database import FlashcardReview, Summary
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Constantes

--- a/docs/CLAUDE-BACKEND.md
+++ b/docs/CLAUDE-BACKEND.md
@@ -445,3 +445,82 @@ async def get_user_summary(db: AsyncSession, user_id: int, summary_id: int) -> S
 - Secrets hardcodés → toujours via `config.py`
 - SQL brut sans paramétrage → SQLAlchemy ORM
 - `print()` → utiliser le logger structuré
+
+---
+
+## 🔍 Semantic Search V1 (mai 2026)
+
+Étend le moteur sémantique de DeepSight (avant : transcripts only) à tout le contenu personnel d'un user.
+
+### Sources indexées (5 types)
+
+| Source | Table embedding | Granularité | Trigger |
+|---|---|---|---|
+| Synthèse | `summary_embeddings` | 1 par section du `structured_index` (fallback chunks 500 mots) | `videos/service.py` après création Summary |
+| Transcript | `transcript_embeddings` (existant) | 1 par chunk 500 mots | `transcripts/cache_db.py` (existant) |
+| Flashcard | `flashcard_embeddings` | 1 par flashcard (Q+A concaténés) | `study/router.py:generate_flashcards` |
+| Quiz | `quiz_embeddings` | 1 par question (énoncé + bonne réponse) | `study/router.py:generate_quiz` |
+| Chat turn | `chat_embeddings` | 1 par paire user+agent (skip <30 tokens) | `chat/router.py` (legacy+stream) + `chat/service.py:process_chat_message_v4` (path V4 prod dominant) |
+
+**Matérialisation flashcards/quiz** : avant V1 ces deux étaient générés à la volée sans persistance. Maintenant `Flashcard` et `QuizQuestion` sont persistés en DB à chaque génération (delete-then-insert pour idempotence).
+
+### Stack technique
+
+- **Provider** : `mistral-embed` (1024-dim, v23.12)
+- **Storage** : JSON Text dans Postgres (pas pgvector V1 — pragmatique pour scope personnel <5k passages/user)
+- **Cosine** : pure Python (`embedding_service.py:_cosine_similarity`)
+- **Cache query** : Redis 24h sur `hash(query)`
+- **Cache tooltip** : PG 7 jours sur `sha256(query+passage_text+summary_id)`
+- **Filtre** : `user_id` au niveau SQL (jamais cross-user en V1)
+
+### Endpoints (`/api/search/`)
+
+| Méthode | Path | Auth | Description |
+|---|---|---|---|
+| POST | `/global` | tous plans | Recherche cross-source flat list, filtres (platform/lang/category/dates/favorites/playlist/source_types) |
+| POST | `/within/{summary_id}` | owner only | Recherche intra-analyse, ownership check **avant** validation query (sécurité contre leak d'existence) |
+| POST | `/explain-passage` | Pro+Expert | Tooltip IA Mistral `mistral-small-latest` (2 phrases, max_tokens 200, cache PG 7j) |
+| GET | `/recent-queries` | tous plans | 10 dernières queries du user (Redis LIST, TTL 90j, fallback in-memory) |
+| DELETE | `/recent-queries` | tous plans | Vider l'historique recherche |
+| POST | `/semantic` | tous plans | **Legacy** — endpoint transcripts-only conservé pour backward compat |
+
+Push automatique fire-and-forget de la query depuis `/global` → `recent_queries`.
+
+### Feature flag
+
+- `SEMANTIC_SEARCH_V1_ENABLED` env var (default `false`) → permet rollback instantané : les endpoints répondent toujours mais le frontend cache l'onglet Search via `is_semantic_search_v1_enabled()`.
+- `semantic_search_tooltip` dans `plan_config.py` :
+  - Free : `False` (Free voit upsell côté UI)
+  - Pro : `True` web + mobile, `False` extension
+  - Expert : idem Pro
+
+### Backfill prod
+
+Script `backend/scripts/backfill_search_index.py` (idempotent, rate-limited 2s entre batches Mistral).
+
+```bash
+# Sur le VPS Hetzner :
+docker cp /opt/deepsight/repo/backend/scripts/. repo-backend-1:/app/scripts/
+docker exec -d repo-backend-1 sh -c 'cd /app && nohup python -m scripts.backfill_search_index --all-users --batch-size 50 > /tmp/backfill.log 2>&1 &'
+docker exec repo-backend-1 tail -f /tmp/backfill.log
+```
+
+**Note Dockerfile** : le dossier `scripts/` n'est PAS copié par le Dockerfile actuel (`deploy/hetzner/Dockerfile` ligne 32 = `COPY src/`). Pour les futurs runs, soit ajouter `COPY scripts/ ./scripts/` dans le Dockerfile, soit refaire le `docker cp` à chaque rebuild.
+
+### Migration Alembic 015
+
+Tables créées : `flashcards`, `quiz_questions`, `summary_embeddings`, `flashcard_embeddings`, `quiz_embeddings`, `chat_embeddings`, `explain_passage_cache`. Toutes avec `ON DELETE CASCADE` depuis `users`/`summaries`.
+
+⚠️ En prod, les tables sont créées par `Base.metadata.create_all()` au boot avant que la migration soit lancée. Au déploiement, faire `alembic stamp 015_add_search_index_tables` (sans `upgrade`) si les tables existent déjà.
+
+### Performance attendue
+
+- ~80-120ms par query pour <1k passages (cosine pure Python)
+- Au-delà de 5k passages/user → migrer vers pgvector (V2)
+- Coûts Mistral : ~$0.0001/query embedding + $0.0005/tooltip (cache 7j)
+
+### Références
+
+- Spec : `docs/superpowers/specs/2026-05-03-semantic-search-design.md`
+- Plan d'implémentation : `docs/superpowers/plans/2026-05-03-semantic-search-v1-phase1-backend.md`
+- Mergé via PR #292 (2026-05-03), backfill prod le même jour (140 summaries + 80 chat turns indexés en ~30s)


### PR DESCRIPTION
## Summary

Post-merge follow-up de PR #292 (Semantic Search V1 Phase 1 backend) qui a été mergée avant que CI complète. Deux concerns combinés :

### 1. Doc backend `CLAUDE-BACKEND.md`

Nouvelle section **🔍 Semantic Search V1 (mai 2026)** documentant :
- Les 5 sources indexées (synthesis/transcript/flashcards/quiz/chat) avec triggers
- Stack technique (mistral-embed 1024-dim, JSON Postgres, cosine pure Python)
- Les 6 endpoints `/api/search/*`
- Feature flags (`SEMANTIC_SEARCH_V1_ENABLED` + `semantic_search_tooltip` × plans)
- Backfill prod (incl. workaround docker cp pour le dossier `scripts/` non copié par le Dockerfile)
- Migration stamping note (les tables existaient déjà via `Base.metadata.create_all()`)
- Perf attendue + références spec/plan

### 2. Ruff `--fix` (14 lint errors)

5 issues mineures de PR #292 + 9 pré-existantes sur main (auth/email, billing, transcripts, tutor, voice). Toutes mécaniques :
- F401 unused imports (13 lignes supprimées)
- F811 redefinition dans `transcripts/ultra_resilient.py` (suppression du re-export `# noqa: F401` shadowé par un `def` local avec vraie logique — gardé le def)

**Ruff `All checks passed!` post-fix**. Aucun changement comportemental.

## Test plan

- [ ] CI Lint & Type Check vert
- [ ] Backend Pytest vert (les tests semantic search V1 sont déjà en main via #292)
- [ ] Vercel preview build ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)