### PR TITLE
docs(plans): Semantic Search V1 — phases 2/3/4 implementation plans

### DIFF
--- a/backend/src/auth/email.py
+++ b/backend/src/auth/email.py
@@ -5,7 +5,7 @@ Templates live in backend/src/templates/emails/ and extend `_base.html`.
 """
 
 from typing import Optional
-from core.config import APP_NAME, FRONTEND_URL
+from core.config import FRONTEND_URL
 
 
 async def send_email(

--- a/backend/src/billing/voice_packs_service.py
+++ b/backend/src/billing/voice_packs_service.py
@@ -14,7 +14,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db.database import (
     User,
     VoiceCreditPack,
-    VoiceQuotaStreaming,
 )
 from billing.voice_quota import (
     TOP_TIER_PLANS,

--- a/backend/src/search/embedding_service.py
+++ b/backend/src/search/embedding_service.py
@@ -193,7 +193,7 @@ async def embed_summary(summary_id: int) -> bool:
     Returns True si succès, False si Summary introuvable ou échec embed.
     """
     from db.database import async_session_maker, Summary, SummaryEmbedding
-    from sqlalchemy import select, delete as sa_delete
+    from sqlalchemy import delete as sa_delete
 
     async with async_session_maker() as session:
         summary = await session.get(Summary, summary_id)

--- a/backend/src/search/global_search.py
+++ b/backend/src/search/global_search.py
@@ -8,11 +8,10 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import select
-from sqlalchemy.orm import joinedload
 
 from db.database import (
     async_session_maker,
@@ -22,7 +21,6 @@ from db.database import (
     FlashcardEmbedding,
     QuizQuestion,
     QuizEmbedding,
-    ChatMessage,
     ChatEmbedding,
     TranscriptEmbedding,
     TranscriptCache,

--- a/backend/src/search/router.py
+++ b/backend/src/search/router.py
@@ -29,7 +29,7 @@ from .recent_queries import (
     push_recent_query,
     clear_recent_queries,
 )
-from .within_search import search_within, NotOwnerError, WithinMatch
+from .within_search import search_within, NotOwnerError
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/transcripts/ultra_resilient.py
+++ b/backend/src/transcripts/ultra_resilient.py
@@ -36,11 +36,7 @@ from core.config import (
     TRANSCRIPT_CONFIG,
 )
 
-# Helper partagé YouTube + TikTok — défini dans audio_utils pour ré-utilisation.
-# Re-export pour compat avec d'éventuels imports existants.
-from transcripts.audio_utils import _yt_dlp_extra_args  # noqa: F401
-
-
+# Helper partagé YouTube + TikTok — local definition (audio_utils version shadowed).
 def _yt_dlp_extra_args() -> list:
     """Common yt-dlp flags for IP-banned environments: proxy + cookies.
 

--- a/backend/src/tutor/service.py
+++ b/backend/src/tutor/service.py
@@ -5,15 +5,13 @@ V1 : sessions en Redis avec TTL 1h. Pas de table SQL.
 V1.1 : ajout helper TTS ElevenLabs (synthesize_audio_data_url).
 """
 import base64
-import json
 import uuid
 import time
 import logging
 from typing import Optional
 import httpx
 import redis.asyncio as aioredis
-from tutor.schemas import TutorSessionState, TutorTurn, TutorMode, TutorLang
-from tutor.prompts import build_tutor_system_prompt, TUTOR_PERSONA_VERSION
+from tutor.schemas import TutorSessionState, TutorTurn
 from core.config import get_elevenlabs_key
 
 

--- a/backend/src/voice/prompt_session.py
+++ b/backend/src/voice/prompt_session.py
@@ -27,7 +27,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.logging import logger
-from db.database import FlashcardReview, Summary, User
+from db.database import FlashcardReview, Summary
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Constantes

--- a/docs/CLAUDE-BACKEND.md
+++ b/docs/CLAUDE-BACKEND.md
@@ -445,3 +445,82 @@ async def get_user_summary(db: AsyncSession, user_id: int, summary_id: int) -> S
 - Secrets hardcodés → toujours via `config.py`
 - SQL brut sans paramétrage → SQLAlchemy ORM
 - `print()` → utiliser le logger structuré
+
+---
+
+## 🔍 Semantic Search V1 (mai 2026)
+
+Étend le moteur sémantique de DeepSight (avant : transcripts only) à tout le contenu personnel d'un user.
+
+### Sources indexées (5 types)
+
+| Source | Table embedding | Granularité | Trigger |
+|---|---|---|---|
+| Synthèse | `summary_embeddings` | 1 par section du `structured_index` (fallback chunks 500 mots) | `videos/service.py` après création Summary |
+| Transcript | `transcript_embeddings` (existant) | 1 par chunk 500 mots | `transcripts/cache_db.py` (existant) |
+| Flashcard | `flashcard_embeddings` | 1 par flashcard (Q+A concaténés) | `study/router.py:generate_flashcards` |
+| Quiz | `quiz_embeddings` | 1 par question (énoncé + bonne réponse) | `study/router.py:generate_quiz` |
+| Chat turn | `chat_embeddings` | 1 par paire user+agent (skip <30 tokens) | `chat/router.py` (legacy+stream) + `chat/service.py:process_chat_message_v4` (path V4 prod dominant) |
+
+**Matérialisation flashcards/quiz** : avant V1 ces deux étaient générés à la volée sans persistance. Maintenant `Flashcard` et `QuizQuestion` sont persistés en DB à chaque génération (delete-then-insert pour idempotence).
+
+### Stack technique
+
+- **Provider** : `mistral-embed` (1024-dim, v23.12)
+- **Storage** : JSON Text dans Postgres (pas pgvector V1 — pragmatique pour scope personnel <5k passages/user)
+- **Cosine** : pure Python (`embedding_service.py:_cosine_similarity`)
+- **Cache query** : Redis 24h sur `hash(query)`
+- **Cache tooltip** : PG 7 jours sur `sha256(query+passage_text+summary_id)`
+- **Filtre** : `user_id` au niveau SQL (jamais cross-user en V1)
+
+### Endpoints (`/api/search/`)
+
+| Méthode | Path | Auth | Description |
+|---|---|---|---|
+| POST | `/global` | tous plans | Recherche cross-source flat list, filtres (platform/lang/category/dates/favorites/playlist/source_types) |
+| POST | `/within/{summary_id}` | owner only | Recherche intra-analyse, ownership check **avant** validation query (sécurité contre leak d'existence) |
+| POST | `/explain-passage` | Pro+Expert | Tooltip IA Mistral `mistral-small-latest` (2 phrases, max_tokens 200, cache PG 7j) |
+| GET | `/recent-queries` | tous plans | 10 dernières queries du user (Redis LIST, TTL 90j, fallback in-memory) |
+| DELETE | `/recent-queries` | tous plans | Vider l'historique recherche |
+| POST | `/semantic` | tous plans | **Legacy** — endpoint transcripts-only conservé pour backward compat |
+
+Push automatique fire-and-forget de la query depuis `/global` → `recent_queries`.
+
+### Feature flag
+
+- `SEMANTIC_SEARCH_V1_ENABLED` env var (default `false`) → permet rollback instantané : les endpoints répondent toujours mais le frontend cache l'onglet Search via `is_semantic_search_v1_enabled()`.
+- `semantic_search_tooltip` dans `plan_config.py` :
+  - Free : `False` (Free voit upsell côté UI)
+  - Pro : `True` web + mobile, `False` extension
+  - Expert : idem Pro
+
+### Backfill prod
+
+Script `backend/scripts/backfill_search_index.py` (idempotent, rate-limited 2s entre batches Mistral).
+
+```bash
+# Sur le VPS Hetzner :
+docker cp /opt/deepsight/repo/backend/scripts/. repo-backend-1:/app/scripts/
+docker exec -d repo-backend-1 sh -c 'cd /app && nohup python -m scripts.backfill_search_index --all-users --batch-size 50 > /tmp/backfill.log 2>&1 &'
+docker exec repo-backend-1 tail -f /tmp/backfill.log
+```
+
+**Note Dockerfile** : le dossier `scripts/` n'est PAS copié par le Dockerfile actuel (`deploy/hetzner/Dockerfile` ligne 32 = `COPY src/`). Pour les futurs runs, soit ajouter `COPY scripts/ ./scripts/` dans le Dockerfile, soit refaire le `docker cp` à chaque rebuild.
+
+### Migration Alembic 015
+
+Tables créées : `flashcards`, `quiz_questions`, `summary_embeddings`, `flashcard_embeddings`, `quiz_embeddings`, `chat_embeddings`, `explain_passage_cache`. Toutes avec `ON DELETE CASCADE` depuis `users`/`summaries`.
+
+⚠️ En prod, les tables sont créées par `Base.metadata.create_all()` au boot avant que la migration soit lancée. Au déploiement, faire `alembic stamp 015_add_search_index_tables` (sans `upgrade`) si les tables existent déjà.
+
+### Performance attendue
+
+- ~80-120ms par query pour <1k passages (cosine pure Python)
+- Au-delà de 5k passages/user → migrer vers pgvector (V2)
+- Coûts Mistral : ~$0.0001/query embedding + $0.0005/tooltip (cache 7j)
+
+### Références
+
+- Spec : `docs/superpowers/specs/2026-05-03-semantic-search-design.md`
+- Plan d'implémentation : `docs/superpowers/plans/2026-05-03-semantic-search-v1-phase1-backend.md`
+- Mergé via PR #292 (2026-05-03), backfill prod le même jour (140 summaries + 80 chat turns indexés en ~30s)

--- a/docs/superpowers/plans/2026-05-03-semantic-search-v1-phase2-web.md
+++ b/docs/superpowers/plans/2026-05-03-semantic-search-v1-phase2-web.md
@@ -1,0 +1,3889 @@
+# Semantic Search V1 — Phase 2 Web Frontend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Brancher l'app web DeepSight sur les 4 endpoints search backend (Phase 1 mergée via PR #292) en exposant une page `/search` complète + une recherche intra-analyse Cmd+F sémantique avec highlights jaunes, navigation cross-tab et tooltip IA "Pourquoi ce passage matche" pour Pro/Expert.
+
+**Architecture:** Page `/search` lazy-loadée avec layout standard (Sidebar + container) consommant `POST /api/search/global` via TanStack Query (debounce 300ms). Click sur un résultat → `/hub?summaryId={id}&q=...&highlight={passage_id}&tab={tab}` (le Hub est notre page d'analyse — pas de route `/analysis/[id]` dédiée). Un `SemanticHighlightProvider` mount dans `HubPage` détecte les query params, fetch `/api/search/within/{summary_id}` et expose les matches via Context aux tabs visibles. Composant `<HighlightedText>` wrapper autour de `<EnrichedMarkdown>` qui injecte des `<mark>` post-render via traversée DOM dans un container ref. Tooltip IA construit avec Framer Motion (déjà installé) + un positionnement custom léger (pas de `@floating-ui` à ajouter — on évite la dep).
+
+**Tech Stack:** React 18 + TypeScript strict, Vite 5, React Router 6, TanStack Query 5, `@tanstack/react-virtual` (déjà présent — virtual scroll), Framer Motion 12, Tailwind 3, Vitest + Testing Library, Playwright E2E, lucide-react.
+
+**Spec source:** `docs/superpowers/specs/2026-05-03-semantic-search-design.md` — section 4 "Frontend Web (full tier)"
+
+**Backend Phase 1:** Déjà mergée (PR #292). Endpoints disponibles : `POST /api/search/global`, `POST /api/search/within/{summary_id}`, `POST /api/search/explain-passage`, `GET/DELETE /api/search/recent-queries`. Feature flag backend `SEMANTIC_SEARCH_V1_ENABLED` env var (false en prod).
+
+---
+
+## File Structure
+
+### Files créés
+
+| Path                                                                          | Responsibility                                                                     |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `frontend/src/pages/SearchPage.tsx`                                           | Page racine route `/search` — layout Sidebar + SearchInput + Filters + ResultsList |
+| `frontend/src/components/search/SearchInput.tsx`                              | Input + autocomplete (queries récentes localStorage + GET /recent-queries)         |
+| `frontend/src/components/search/SearchFiltersBar.tsx`                         | Pills (type) + bouton expand vers filtres avancés                                  |
+| `frontend/src/components/search/SearchAdvancedFilters.tsx`                    | Plateforme/Lang/Catégorie/Période/Favoris (collapsible)                            |
+| `frontend/src/components/search/SearchResultsList.tsx`                        | Virtual scroll via `@tanstack/react-virtual` + integration empty/loading states    |
+| `frontend/src/components/search/SearchResultCard.tsx`                         | Carte résultat — badge type + thumbnail + score + preview                          |
+| `frontend/src/components/search/SearchEmptyState.tsx`                         | Empty state (no query / 0 résultats) + suggestions queries récentes                |
+| `frontend/src/components/search/SearchTypeBadge.tsx`                          | Badge typé (synthese/flashcard/quiz/chat/transcript) avec couleur+icône            |
+| `frontend/src/components/search/useSemanticSearch.ts`                         | Hook React Query + debounce 300ms + URL state sync                                 |
+| `frontend/src/components/search/useRecentQueries.ts`                          | Hook localStorage + sync GET/DELETE `/api/search/recent-queries`                   |
+| `frontend/src/components/highlight/SemanticHighlightProvider.tsx`             | React Context : matches, navigation index, fetch within, open tooltip              |
+| `frontend/src/components/highlight/SemanticHighlightContext.ts`               | Définition Context + types `Match`, `HighlightState`                               |
+| `frontend/src/components/highlight/useSemanticHighlight.ts`                   | Hook consumer du Context (`useContext`) + helpers                                  |
+| `frontend/src/components/highlight/HighlightedText.tsx`                       | Wrapper React qui post-process le DOM (range API) pour injecter `<mark>` jaunes    |
+| `frontend/src/components/highlight/HighlightNavigationBar.tsx`                | Sticky top — compteur "3/12" + ↑/↓ + close + query display                         |
+| `frontend/src/components/highlight/IntraAnalysisSearchBar.tsx`                | Mini-search bar floating ouverte par Cmd+F dans Hub                                |
+| `frontend/src/components/highlight/ExplainTooltip.tsx`                        | Tooltip IA — call /explain-passage + cache RQ + actions (citer/timecode/voir)      |
+| `frontend/src/components/highlight/ExplainUpsellModal.tsx`                    | Modal upsell free → "Comprendre ce passage avec l'IA"                              |
+| `frontend/src/components/highlight/useCmdFIntercept.ts`                       | Hook `keydown` listener `Cmd/Ctrl+F` scopé à `.analysis-page`                      |
+| `frontend/src/styles/highlight.css`                                           | Styles `.ds-highlight`, `.ds-highlight.flash`, `@keyframes ds-highlight-flash`     |
+| `frontend/src/components/search/__tests__/SearchInput.test.tsx`               | Test debounce + clear + autocomplete                                               |
+| `frontend/src/components/search/__tests__/SearchResultCard.test.tsx`          | Test rendu badge + click → navigate                                                |
+| `frontend/src/components/search/__tests__/useSemanticSearch.test.ts`          | Test hook (mock `searchApi.searchGlobal`)                                          |
+| `frontend/src/components/search/__tests__/SearchFiltersBar.test.tsx`          | Test toggle pills + expand advanced                                                |
+| `frontend/src/components/highlight/__tests__/HighlightedText.test.tsx`        | Test injection `<mark>` post-render                                                |
+| `frontend/src/components/highlight/__tests__/ExplainTooltip.test.tsx`         | Test free upsell vs Pro tooltip + cache                                            |
+| `frontend/src/components/highlight/__tests__/HighlightNavigationBar.test.tsx` | Test compteur + nav ↑/↓                                                            |
+| `frontend/src/pages/__tests__/SearchPage.test.tsx`                            | Test page integration (mock api)                                                   |
+| `frontend/e2e/semantic-search-global.spec.ts`                                 | E2E spec 1 — recherche globale + click → Hub                                       |
+| `frontend/e2e/semantic-search-intra.spec.ts`                                  | E2E spec 2 — Cmd+F intercept + nav matches                                         |
+| `frontend/e2e/semantic-search-tooltip.spec.ts`                                | E2E spec 3 — tooltip IA Pro vs upsell free                                         |
+
+### Files modifiés
+
+| Path                                               | Changes                                                                                                                                                            |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `frontend/src/services/api.ts`                     | Ajouter types `SearchResult`/`SearchFilters`/`WithinMatch`/`ExplainPassageResponse` + 5 méthodes `searchApi.*`                                                     |
+| `frontend/src/App.tsx`                             | Lazy-load `SearchPage`, route `/search` dans le bloc routes protégées, prefetch hint depuis `/dashboard` et `/history`                                             |
+| `frontend/src/components/sidebar/SidebarNav.tsx`   | Ajout item `{ path: "/search", icon: Search, label: "Recherche" }` (composant orphelin mentionné par le spec)                                                      |
+| `frontend/src/components/layout/Sidebar.tsx`       | Ajout `NavItem` Search dans le 1er pill group entre History et Hub (LE sidebar réellement utilisé en prod)                                                         |
+| `frontend/src/config/planPrivileges.ts`            | Ajouter `semanticSearchTooltip: boolean` dans `PlanFeatures` + valeurs par plan + map dans `PLAN_FEATURES`                                                         |
+| `frontend/src/pages/HubPage.tsx`                   | Wrapper `<SemanticHighlightProvider>`, mount `<HighlightNavigationBar>` + `<IntraAnalysisSearchBar>`, classe `analysis-page`, lecture query params q/highlight/tab |
+| `frontend/src/components/hub/HubAnalysisPanel.tsx` | Wrap children avec un container `data-highlight-root` pour scoper la traversée DOM                                                                                 |
+| `frontend/src/components/hub/HubHeader.tsx`        | Ajouter bouton loupe (loop button) qui ouvre `IntraAnalysisSearchBar`                                                                                              |
+| `frontend/src/index.css`                           | Importer `./styles/highlight.css`                                                                                                                                  |
+| `frontend/src/i18n/fr.json` + `en.json`            | Ajouter clés `nav.search`, `search.placeholder`, `search.empty.*`, `search.tooltip.*`, `search.upsell.*`                                                           |
+
+### Hors scope (Phases 3+)
+
+- `mobile/src/config/planPrivileges.ts` — Phase 3
+- `extension/src/sidepanel/components/QuickSearch.tsx` — Phase 4
+- Activation feature flag prod — Phase 5
+
+---
+
+## Conventions globales pour TOUTES les tasks
+
+- **Branche worktree dédiée** : à créer depuis `main` via `git worktree add` au début (Step 0). Nom suggéré : `feat/search-web-phase2`. Si on veut suivre la division spec en 2 sub-agents parallèles, créer 2 branches : `feat/search-page-web` (Tasks 1-10, 19) et `feat/search-highlight-web` (Tasks 11-18). **Ce plan est écrit pour exécution séquentielle par UN sub-agent — split possible mais pas nécessaire**.
+- Commits ASCII propres (pas d'emojis), prefix `feat(search):` / `feat(highlight):` / `test(search):` / `chore(search):` selon scope.
+- Tests Vitest avec `renderWithProviders` depuis `__tests__/test-utils.tsx`.
+- Tous les composants : TypeScript strict, zéro `any`, interfaces (pas type aliases) pour les objets.
+- Functional components uniquement.
+- Toutes les API calls passent par `services/api.ts` — jamais de `fetch()` direct.
+- Tailwind only — pas de CSS modules / styled-components. Une exception : `styles/highlight.css` pour les `@keyframes` (cohérent avec patterns ambient lighting existants).
+- Dark mode first — fond `#0a0a0f`, surfaces `#12121a`, glassmorphism `backdrop-blur-xl bg-white/5 border border-white/10`.
+- Avant chaque commit : `npm run typecheck && npm run lint && npm run test -- --run` doivent passer green dans `frontend/`.
+- Pas de redéploiement de feature flag — le frontend affiche toujours l'onglet Search ; le backend retourne 404 si flag OFF (gracefull empty state).
+- Pas de modification de `mobile/` ni `extension/` dans cette phase.
+- Pas de modification du SSOT pricing : pas de Stripe, pas de plan_config backend.
+
+### Étape Step 0 — Setup worktree (à faire UNE fois en début de session)
+
+- [ ] **Step 0.1: Créer le worktree depuis `main`**
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+git fetch origin main
+git worktree add .worktrees/search-web-phase2 -b feat/search-web-phase2 origin/main
+cd .worktrees/search-web-phase2
+```
+
+Expected : nouveau worktree dans `.worktrees/search-web-phase2/` sur branche `feat/search-web-phase2`.
+
+- [ ] **Step 0.2: Installer dépendances**
+
+```bash
+cd frontend
+npm install
+```
+
+Expected : `node_modules/` régénéré, pas d'erreur.
+
+- [ ] **Step 0.3: Baseline avant tout changement**
+
+```bash
+cd frontend
+npm run typecheck
+npm run lint
+npm run test -- --run
+```
+
+Expected : 3 commandes green (warnings ESLint OK si déjà présents sur main, 0 erreur). Si baseline rouge, **stop** et signaler.
+
+---
+
+## Task 1: Étendre `services/api.ts` — types + méthodes searchApi
+
+**Files:**
+
+- Modify: `frontend/src/services/api.ts`
+
+**Dependencies:** Aucune. C'est la base pour toutes les autres tasks.
+
+- [ ] **Step 1.1: Localiser le bloc SEARCH API existant** (lignes ~2563-2595, contient déjà `searchApi.semanticSearch`).
+
+- [ ] **Step 1.2: Ajouter les nouveaux types juste après les types existants `SemanticSearchResult` et `SemanticSearchResponse`**
+
+```typescript
+// ─── Search V1 — Phase 2 (Global / Within / Explain) ──────────────────────────
+
+export type SearchSourceType =
+  | "summary"
+  | "flashcard"
+  | "quiz"
+  | "chat"
+  | "transcript";
+
+export interface SearchFilters {
+  source_types?: SearchSourceType[];
+  platform?: "youtube" | "tiktok" | "text";
+  lang?: string;
+  category?: string;
+  date_from?: string; // ISO date YYYY-MM-DD
+  date_to?: string;
+  favorites_only?: boolean;
+  playlist_id?: number;
+}
+
+export interface SearchResultMetadata {
+  summary_title?: string;
+  summary_thumbnail?: string;
+  video_id?: string;
+  channel?: string;
+  tab?: "synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript";
+  start_ts?: number;
+  end_ts?: number;
+  anchor?: string;
+  flashcard_id?: number;
+  quiz_question_id?: number;
+}
+
+export interface GlobalSearchResult {
+  source_type: SearchSourceType;
+  source_id: number;
+  summary_id: number;
+  score: number;
+  text_preview: string;
+  source_metadata: SearchResultMetadata;
+}
+
+export interface GlobalSearchResponse {
+  query: string;
+  total_results: number;
+  results: GlobalSearchResult[];
+  searched_at: string;
+}
+
+export interface WithinMatch {
+  source_type: SearchSourceType;
+  source_id: number;
+  text: string;
+  text_html: string; // contient <mark> autour des spans matches
+  start_offset: number;
+  end_offset: number;
+  tab: "synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript";
+  score: number;
+  passage_id: string;
+}
+
+export interface WithinSearchResponse {
+  matches: WithinMatch[];
+}
+
+export interface ExplainPassageResponse {
+  explanation: string;
+  cached: boolean;
+  model_used: string;
+}
+
+export interface RecentQueriesResponse {
+  queries: string[];
+}
+```
+
+- [ ] **Step 1.3: Étendre l'objet `searchApi` (laisser `semanticSearch` legacy pour rétrocompat)**
+
+```typescript
+export const searchApi = {
+  // Legacy — keep for backward compat with /api/search/semantic transcript-only
+  async semanticSearch(
+    query: string,
+    limit: number = 10,
+    category?: string,
+  ): Promise<SemanticSearchResponse> {
+    return request("/api/search/semantic", {
+      method: "POST",
+      body: { query, limit, category },
+    });
+  },
+
+  // V1 Phase 2 — Global cross-source search
+  async searchGlobal(
+    query: string,
+    filters: SearchFilters = {},
+    limit: number = 20,
+  ): Promise<GlobalSearchResponse> {
+    return request("/api/search/global", {
+      method: "POST",
+      body: { query, limit, ...filters },
+    });
+  },
+
+  // V1 Phase 2 — Intra-analysis search
+  async searchWithin(
+    summaryId: number,
+    query: string,
+    sourceTypes?: SearchSourceType[],
+  ): Promise<WithinSearchResponse> {
+    return request(`/api/search/within/${summaryId}`, {
+      method: "POST",
+      body: { query, source_types: sourceTypes },
+    });
+  },
+
+  // V1 Phase 2 — Explain a passage (Pro/Expert only on backend)
+  async explainPassage(
+    summaryId: number,
+    passageText: string,
+    query: string,
+    sourceType: SearchSourceType,
+  ): Promise<ExplainPassageResponse> {
+    return request("/api/search/explain-passage", {
+      method: "POST",
+      body: {
+        summary_id: summaryId,
+        passage_text: passageText,
+        query,
+        source_type: sourceType,
+      },
+    });
+  },
+
+  // V1 Phase 2 — Recent queries (server-side persistence)
+  async getRecentQueries(): Promise<RecentQueriesResponse> {
+    return request("/api/search/recent-queries", { method: "GET" });
+  },
+
+  async clearRecentQueries(): Promise<void> {
+    await request("/api/search/recent-queries", { method: "DELETE" });
+  },
+};
+```
+
+- [ ] **Step 1.4: Run typecheck**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected : 0 erreur.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add frontend/src/services/api.ts
+git commit -m "feat(search): add searchApi.searchGlobal/searchWithin/explainPassage/recentQueries"
+```
+
+---
+
+## Task 2: Ajouter le feature key `semanticSearchTooltip` dans `planPrivileges.ts`
+
+**Files:**
+
+- Modify: `frontend/src/config/planPrivileges.ts`
+
+**Dependencies:** Aucune.
+
+- [ ] **Step 2.1: Étendre l'interface `PlanFeatures` (ligne ~178)**
+
+Ajouter `semanticSearchTooltip: boolean;` à la fin de l'interface, avant la closing brace.
+
+- [ ] **Step 2.2: Ajouter la valeur dans les 3 entrées de `PLAN_FEATURES`**
+
+```typescript
+free: { ...existing, semanticSearchTooltip: false },
+pro:  { ...existing, semanticSearchTooltip: true  },
+expert: { ...existing, semanticSearchTooltip: true },
+```
+
+(Garder l'ordre des autres clés intact — insérer juste avant `factcheck` ou la dernière clé existante du bloc.)
+
+- [ ] **Step 2.3: Vérifier qu'aucun appel `hasFeature(plan, "semanticSearchTooltip")` ne pète au build (la fonction utilise `keyof PlanLimits` mais on a ajouté à `PlanFeatures`)** — pas besoin de toucher à `hasFeature` car cette feature est consultée directement via `PLAN_FEATURES[plan].semanticSearchTooltip`.
+
+- [ ] **Step 2.4: Run typecheck**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected : 0 erreur.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add frontend/src/config/planPrivileges.ts
+git commit -m "feat(search): add semanticSearchTooltip feature flag (free=off, pro/expert=on)"
+```
+
+---
+
+## Task 3: Hook `useSemanticSearch` (debounce 300ms + React Query)
+
+**Files:**
+
+- Create: `frontend/src/components/search/useSemanticSearch.ts`
+- Create: `frontend/src/components/search/__tests__/useSemanticSearch.test.ts`
+
+**Dependencies:** Task 1.
+
+- [ ] **Step 3.1: Créer le dossier `frontend/src/components/search/` et le fichier hook**
+
+```typescript
+// frontend/src/components/search/useSemanticSearch.ts
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  searchApi,
+  type GlobalSearchResponse,
+  type SearchFilters,
+} from "../../services/api";
+
+interface UseSemanticSearchOptions {
+  query: string;
+  filters: SearchFilters;
+  limit?: number;
+  /** debounce ms — defaults to 300, pass 0 to disable for tests */
+  debounceMs?: number;
+  /** disable the query entirely (e.g. when query.length < 2) */
+  enabled?: boolean;
+}
+
+export function useSemanticSearch({
+  query,
+  filters,
+  limit = 20,
+  debounceMs = 300,
+  enabled = true,
+}: UseSemanticSearchOptions) {
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+
+  useEffect(() => {
+    if (debounceMs === 0) {
+      setDebouncedQuery(query);
+      return;
+    }
+    const t = setTimeout(() => setDebouncedQuery(query), debounceMs);
+    return () => clearTimeout(t);
+  }, [query, debounceMs]);
+
+  const trimmed = debouncedQuery.trim();
+  const isEnabled = enabled && trimmed.length >= 2;
+
+  return useQuery<GlobalSearchResponse, Error>({
+    queryKey: ["search", "global", trimmed, filters, limit],
+    queryFn: () => searchApi.searchGlobal(trimmed, filters, limit),
+    enabled: isEnabled,
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    retry: false, // search failures should not silently retry
+  });
+}
+```
+
+- [ ] **Step 3.2: Créer le test (TDD-style)**
+
+```typescript
+// frontend/src/components/search/__tests__/useSemanticSearch.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useSemanticSearch } from "../useSemanticSearch";
+import { searchApi } from "../../../services/api";
+
+vi.mock("../../../services/api", () => ({
+  searchApi: { searchGlobal: vi.fn() },
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return React.createElement(QueryClientProvider, { client: qc }, children);
+};
+
+describe("useSemanticSearch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not call API when query is empty", () => {
+    const { result } = renderHook(
+      () => useSemanticSearch({ query: "", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(searchApi.searchGlobal).not.toHaveBeenCalled();
+  });
+
+  it("does not call API when query has less than 2 chars", () => {
+    renderHook(
+      () => useSemanticSearch({ query: "a", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    expect(searchApi.searchGlobal).not.toHaveBeenCalled();
+  });
+
+  it("calls searchGlobal when query has >= 2 chars", async () => {
+    (searchApi.searchGlobal as any).mockResolvedValue({
+      query: "ai",
+      total_results: 0,
+      results: [],
+      searched_at: "2026-05-03T12:00:00Z",
+    });
+    renderHook(
+      () => useSemanticSearch({ query: "ai", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() =>
+      expect(searchApi.searchGlobal).toHaveBeenCalledWith("ai", {}, 20),
+    );
+  });
+
+  it("debounces input changes", async () => {
+    (searchApi.searchGlobal as any).mockResolvedValue({
+      query: "f",
+      total_results: 0,
+      results: [],
+      searched_at: "x",
+    });
+    const { rerender } = renderHook(
+      ({ q }: { q: string }) =>
+        useSemanticSearch({ query: q, filters: {}, debounceMs: 50 }),
+      { wrapper, initialProps: { q: "ai" } },
+    );
+    rerender({ q: "ais" });
+    rerender({ q: "aist" });
+    // Wait for debounce + fetch
+    await new Promise((r) => setTimeout(r, 100));
+    await waitFor(() => {
+      expect(searchApi.searchGlobal).toHaveBeenCalledTimes(1);
+      expect(searchApi.searchGlobal).toHaveBeenLastCalledWith("aist", {}, 20);
+    });
+  });
+});
+```
+
+- [ ] **Step 3.3: Run test**
+
+```bash
+cd frontend && npm run test -- --run src/components/search/__tests__/useSemanticSearch.test.ts
+```
+
+Expected : 4/4 pass.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add frontend/src/components/search/useSemanticSearch.ts \
+        frontend/src/components/search/__tests__/useSemanticSearch.test.ts
+git commit -m "feat(search): add useSemanticSearch hook with 300ms debounce"
+```
+
+---
+
+## Task 4: Hook `useRecentQueries` (localStorage + sync server)
+
+**Files:**
+
+- Create: `frontend/src/components/search/useRecentQueries.ts`
+
+**Dependencies:** Task 1.
+
+- [ ] **Step 4.1: Créer le hook**
+
+```typescript
+// frontend/src/components/search/useRecentQueries.ts
+import { useCallback, useEffect, useState } from "react";
+import { searchApi } from "../../services/api";
+
+const STORAGE_KEY = "deepsight_recent_queries";
+const MAX_LOCAL = 5;
+
+function readLocal(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr.filter((s) => typeof s === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeLocal(queries: string[]) {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(queries.slice(0, MAX_LOCAL)),
+    );
+  } catch {
+    /* quota / private mode — silent ignore */
+  }
+}
+
+export function useRecentQueries() {
+  const [queries, setQueries] = useState<string[]>(() => readLocal());
+
+  // Sync with server on mount (server has up to 10, merge with local)
+  useEffect(() => {
+    let cancelled = false;
+    searchApi
+      .getRecentQueries()
+      .then(({ queries: server }) => {
+        if (cancelled) return;
+        const merged = Array.from(new Set([...readLocal(), ...server])).slice(
+          0,
+          MAX_LOCAL,
+        );
+        setQueries(merged);
+        writeLocal(merged);
+      })
+      .catch(() => {
+        /* offline / 404 / 401 — keep local */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const addQuery = useCallback((q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) return;
+    setQueries((prev) => {
+      const next = [trimmed, ...prev.filter((x) => x !== trimmed)].slice(
+        0,
+        MAX_LOCAL,
+      );
+      writeLocal(next);
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(async () => {
+    setQueries([]);
+    writeLocal([]);
+    try {
+      await searchApi.clearRecentQueries();
+    } catch {
+      /* swallow */
+    }
+  }, []);
+
+  return { queries, addQuery, clear };
+}
+```
+
+- [ ] **Step 4.2: Run typecheck**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add frontend/src/components/search/useRecentQueries.ts
+git commit -m "feat(search): add useRecentQueries hook with localStorage + server sync"
+```
+
+---
+
+## Task 5: Composant `SearchInput` (input + autocomplete)
+
+**Files:**
+
+- Create: `frontend/src/components/search/SearchInput.tsx`
+- Create: `frontend/src/components/search/__tests__/SearchInput.test.tsx`
+
+**Dependencies:** Task 4.
+
+- [ ] **Step 5.1: Créer `SearchInput.tsx`**
+
+```tsx
+// frontend/src/components/search/SearchInput.tsx
+import React, { useState, useRef } from "react";
+import { Search, X, Clock } from "lucide-react";
+import { useRecentQueries } from "./useRecentQueries";
+
+interface Props {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit?: (q: string) => void;
+  autoFocus?: boolean;
+  placeholder?: string;
+}
+
+export const SearchInput: React.FC<Props> = ({
+  value,
+  onChange,
+  onSubmit,
+  autoFocus = true,
+  placeholder = "Rechercher dans tes analyses…",
+}) => {
+  const [focused, setFocused] = useState(false);
+  const { queries: recent } = useRecentQueries();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const showSuggestions =
+    focused && value.trim().length === 0 && recent.length > 0;
+
+  return (
+    <div className="relative w-full max-w-3xl mx-auto">
+      <div className="relative">
+        <Search
+          className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-white/45 pointer-events-none"
+          aria-hidden
+        />
+        <input
+          ref={inputRef}
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setTimeout(() => setFocused(false), 150)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && onSubmit) onSubmit(value);
+          }}
+          autoFocus={autoFocus}
+          placeholder={placeholder}
+          aria-label={placeholder}
+          className="w-full pl-12 pr-12 py-4 rounded-xl bg-white/5 border border-white/10 backdrop-blur-xl text-white placeholder-white/35 outline-none focus:border-indigo-500/40 focus:bg-white/[0.07] transition-colors"
+        />
+        {value.length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              onChange("");
+              inputRef.current?.focus();
+            }}
+            aria-label="Effacer la recherche"
+            className="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 rounded-md text-white/45 hover:text-white hover:bg-white/5"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+      {showSuggestions && (
+        <ul
+          role="listbox"
+          aria-label="Recherches récentes"
+          className="absolute z-30 left-0 right-0 mt-2 rounded-xl bg-[#12121a] border border-white/10 shadow-2xl overflow-hidden"
+        >
+          {recent.map((q) => (
+            <li key={q}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={false}
+                onMouseDown={(e) => {
+                  e.preventDefault(); // prevent blur before click
+                  onChange(q);
+                  onSubmit?.(q);
+                }}
+                className="w-full flex items-center gap-3 px-4 py-3 text-left text-sm text-white/85 hover:bg-white/5"
+              >
+                <Clock className="w-4 h-4 text-white/40" aria-hidden />
+                <span className="truncate">{q}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 5.2: Créer le test**
+
+```tsx
+// frontend/src/components/search/__tests__/SearchInput.test.tsx
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchInput } from "../SearchInput";
+
+vi.mock("../useRecentQueries", () => ({
+  useRecentQueries: () => ({
+    queries: ["transition énergétique", "crise énergie"],
+    addQuery: vi.fn(),
+    clear: vi.fn(),
+  }),
+}));
+
+afterEach(cleanup);
+
+describe("SearchInput", () => {
+  it("renders placeholder", () => {
+    render(<SearchInput value="" onChange={() => {}} />);
+    expect(screen.getByPlaceholderText(/rechercher/i)).toBeInTheDocument();
+  });
+
+  it("calls onChange when typing", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SearchInput value="" onChange={onChange} autoFocus={false} />);
+    const input = screen.getByRole("searchbox");
+    await user.type(input, "ai");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("shows suggestions when focused with empty value", async () => {
+    const user = userEvent.setup();
+    render(<SearchInput value="" onChange={() => {}} autoFocus={false} />);
+    await user.click(screen.getByRole("searchbox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByText("transition énergétique")).toBeInTheDocument();
+  });
+
+  it("clears value when X button is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SearchInput value="hello" onChange={onChange} autoFocus={false} />);
+    await user.click(screen.getByLabelText(/effacer/i));
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("calls onSubmit when pressing Enter", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <SearchInput
+        value="hello"
+        onChange={() => {}}
+        onSubmit={onSubmit}
+        autoFocus={false}
+      />,
+    );
+    await user.click(screen.getByRole("searchbox"));
+    await user.keyboard("{Enter}");
+    expect(onSubmit).toHaveBeenCalledWith("hello");
+  });
+});
+```
+
+- [ ] **Step 5.3: Run test**
+
+```bash
+cd frontend && npm run test -- --run src/components/search/__tests__/SearchInput.test.tsx
+```
+
+Expected : 5/5 pass.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add frontend/src/components/search/SearchInput.tsx \
+        frontend/src/components/search/__tests__/SearchInput.test.tsx
+git commit -m "feat(search): add SearchInput with recent queries autocomplete"
+```
+
+---
+
+## Task 6: Composants `SearchTypeBadge` + `SearchFiltersBar` + `SearchAdvancedFilters`
+
+**Files:**
+
+- Create: `frontend/src/components/search/SearchTypeBadge.tsx`
+- Create: `frontend/src/components/search/SearchFiltersBar.tsx`
+- Create: `frontend/src/components/search/SearchAdvancedFilters.tsx`
+- Create: `frontend/src/components/search/__tests__/SearchFiltersBar.test.tsx`
+
+**Dependencies:** Task 1.
+
+- [ ] **Step 6.1: Créer `SearchTypeBadge.tsx`**
+
+```tsx
+// frontend/src/components/search/SearchTypeBadge.tsx
+import React from "react";
+import {
+  BookOpen,
+  Brain,
+  BookMarked,
+  MessageCircle,
+  FileText,
+} from "lucide-react";
+import type { SearchSourceType } from "../../services/api";
+
+const TYPE_CONFIG: Record<
+  SearchSourceType,
+  { label: string; icon: typeof BookOpen; bg: string; text: string }
+> = {
+  summary: {
+    label: "Synthèse",
+    icon: BookOpen,
+    bg: "bg-blue-500/15",
+    text: "text-blue-300",
+  },
+  flashcard: {
+    label: "Flashcard",
+    icon: BookMarked,
+    bg: "bg-emerald-500/15",
+    text: "text-emerald-300",
+  },
+  quiz: {
+    label: "Quiz",
+    icon: Brain,
+    bg: "bg-amber-500/15",
+    text: "text-amber-300",
+  },
+  chat: {
+    label: "Chat",
+    icon: MessageCircle,
+    bg: "bg-indigo-500/15",
+    text: "text-indigo-300",
+  },
+  transcript: {
+    label: "Transcript",
+    icon: FileText,
+    bg: "bg-violet-500/15",
+    text: "text-violet-300",
+  },
+};
+
+export const SearchTypeBadge: React.FC<{ type: SearchSourceType }> = ({
+  type,
+}) => {
+  const cfg = TYPE_CONFIG[type];
+  const Icon = cfg.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${cfg.bg} ${cfg.text}`}
+    >
+      <Icon className="w-3 h-3" aria-hidden />
+      {cfg.label}
+    </span>
+  );
+};
+```
+
+- [ ] **Step 6.2: Créer `SearchFiltersBar.tsx` (pills par type + bouton expand)**
+
+```tsx
+// frontend/src/components/search/SearchFiltersBar.tsx
+import React from "react";
+import { SlidersHorizontal } from "lucide-react";
+import type { SearchSourceType, SearchFilters } from "../../services/api";
+
+const ALL_TYPES: SearchSourceType[] = [
+  "summary",
+  "flashcard",
+  "quiz",
+  "chat",
+  "transcript",
+];
+const TYPE_LABELS: Record<SearchSourceType, string> = {
+  summary: "Synthèse",
+  flashcard: "Flashcards",
+  quiz: "Quiz",
+  chat: "Chat",
+  transcript: "Transcripts",
+};
+
+interface Props {
+  filters: SearchFilters;
+  onChange: (next: SearchFilters) => void;
+  countsByType?: Partial<Record<SearchSourceType, number>>;
+  totalCount?: number;
+  onToggleAdvanced: () => void;
+  advancedOpen: boolean;
+}
+
+export const SearchFiltersBar: React.FC<Props> = ({
+  filters,
+  onChange,
+  countsByType = {},
+  totalCount,
+  onToggleAdvanced,
+  advancedOpen,
+}) => {
+  const active = filters.source_types ?? [];
+  const isAll = active.length === 0;
+
+  const toggleAll = () => onChange({ ...filters, source_types: undefined });
+  const toggleType = (t: SearchSourceType) => {
+    const set = new Set(active);
+    set.has(t) ? set.delete(t) : set.add(t);
+    onChange({
+      ...filters,
+      source_types: set.size === 0 ? undefined : Array.from(set),
+    });
+  };
+
+  return (
+    <div className="w-full max-w-3xl mx-auto flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={toggleAll}
+        aria-pressed={isAll}
+        className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+          isAll
+            ? "bg-indigo-500/20 text-indigo-200 border border-indigo-500/40"
+            : "bg-white/5 text-white/65 border border-white/10 hover:bg-white/10"
+        }`}
+      >
+        Tout {totalCount !== undefined ? `(${totalCount})` : ""}
+      </button>
+      {ALL_TYPES.map((t) => {
+        const isActive = active.includes(t);
+        const n = countsByType[t];
+        return (
+          <button
+            key={t}
+            type="button"
+            onClick={() => toggleType(t)}
+            aria-pressed={isActive}
+            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              isActive
+                ? "bg-indigo-500/20 text-indigo-200 border border-indigo-500/40"
+                : "bg-white/5 text-white/65 border border-white/10 hover:bg-white/10"
+            }`}
+          >
+            {TYPE_LABELS[t]}
+            {typeof n === "number" ? ` ${n}` : ""}
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        onClick={onToggleAdvanced}
+        aria-expanded={advancedOpen}
+        className="ml-auto flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-sm text-white/70 hover:text-white hover:bg-white/10"
+      >
+        <SlidersHorizontal className="w-3.5 h-3.5" />
+        Filtres avancés
+      </button>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 6.3: Créer `SearchAdvancedFilters.tsx`**
+
+```tsx
+// frontend/src/components/search/SearchAdvancedFilters.tsx
+import React from "react";
+import type { SearchFilters } from "../../services/api";
+
+interface Props {
+  filters: SearchFilters;
+  onChange: (next: SearchFilters) => void;
+}
+
+export const SearchAdvancedFilters: React.FC<Props> = ({
+  filters,
+  onChange,
+}) => {
+  return (
+    <div className="w-full max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-3 p-4 rounded-xl bg-white/5 border border-white/10 backdrop-blur-xl">
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-white/65">Plateforme</span>
+        <select
+          value={filters.platform ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              platform: (e.target.value ||
+                undefined) as SearchFilters["platform"],
+            })
+          }
+          className="bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+        >
+          <option value="">Toutes</option>
+          <option value="youtube">YouTube</option>
+          <option value="tiktok">TikTok</option>
+          <option value="text">Texte</option>
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-white/65">Langue</span>
+        <select
+          value={filters.lang ?? ""}
+          onChange={(e) =>
+            onChange({ ...filters, lang: e.target.value || undefined })
+          }
+          className="bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+        >
+          <option value="">Toutes</option>
+          <option value="fr">Français</option>
+          <option value="en">English</option>
+          <option value="es">Español</option>
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-white/65">Catégorie</span>
+        <input
+          type="text"
+          value={filters.category ?? ""}
+          onChange={(e) =>
+            onChange({ ...filters, category: e.target.value || undefined })
+          }
+          placeholder="ex: science, politique…"
+          className="bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+        />
+      </label>
+
+      <div className="flex flex-col gap-1 text-sm">
+        <span className="text-white/65">Période</span>
+        <div className="flex gap-2">
+          <input
+            type="date"
+            value={filters.date_from ?? ""}
+            onChange={(e) =>
+              onChange({ ...filters, date_from: e.target.value || undefined })
+            }
+            className="flex-1 bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+          />
+          <input
+            type="date"
+            value={filters.date_to ?? ""}
+            onChange={(e) =>
+              onChange({ ...filters, date_to: e.target.value || undefined })
+            }
+            className="flex-1 bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+          />
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={!!filters.favorites_only}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              favorites_only: e.target.checked || undefined,
+            })
+          }
+        />
+        <span className="text-white/85">Favoris uniquement</span>
+      </label>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 6.4: Créer le test pour `SearchFiltersBar`**
+
+```tsx
+// frontend/src/components/search/__tests__/SearchFiltersBar.test.tsx
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchFiltersBar } from "../SearchFiltersBar";
+
+afterEach(cleanup);
+
+describe("SearchFiltersBar", () => {
+  it("renders 'Tout' active by default when no source_types", () => {
+    render(
+      <SearchFiltersBar
+        filters={{}}
+        onChange={() => {}}
+        onToggleAdvanced={() => {}}
+        advancedOpen={false}
+      />,
+    );
+    const all = screen.getByRole("button", { name: /Tout/ });
+    expect(all).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("toggles a type pill on click", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SearchFiltersBar
+        filters={{}}
+        onChange={onChange}
+        onToggleAdvanced={() => {}}
+        advancedOpen={false}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Synthèse/ }));
+    expect(onChange).toHaveBeenCalledWith({ source_types: ["summary"] });
+  });
+
+  it("expands advanced filters when clicked", async () => {
+    const user = userEvent.setup();
+    const onToggleAdvanced = vi.fn();
+    render(
+      <SearchFiltersBar
+        filters={{}}
+        onChange={() => {}}
+        onToggleAdvanced={onToggleAdvanced}
+        advancedOpen={false}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Filtres avancés/ }));
+    expect(onToggleAdvanced).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 6.5: Run tests**
+
+```bash
+cd frontend && npm run test -- --run src/components/search/__tests__/SearchFiltersBar.test.tsx
+```
+
+Expected : 3/3 pass.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add frontend/src/components/search/SearchTypeBadge.tsx \
+        frontend/src/components/search/SearchFiltersBar.tsx \
+        frontend/src/components/search/SearchAdvancedFilters.tsx \
+        frontend/src/components/search/__tests__/SearchFiltersBar.test.tsx
+git commit -m "feat(search): add SearchTypeBadge + filter pills + advanced filters"
+```
+
+---
+
+## Task 7: `SearchResultCard` + `SearchEmptyState` + `SearchResultsList`
+
+**Files:**
+
+- Create: `frontend/src/components/search/SearchResultCard.tsx`
+- Create: `frontend/src/components/search/SearchEmptyState.tsx`
+- Create: `frontend/src/components/search/SearchResultsList.tsx`
+- Create: `frontend/src/components/search/__tests__/SearchResultCard.test.tsx`
+
+**Dependencies:** Task 1, Task 6.
+
+- [ ] **Step 7.1: Créer `SearchResultCard.tsx`**
+
+```tsx
+// frontend/src/components/search/SearchResultCard.tsx
+import React from "react";
+import { ChevronRight } from "lucide-react";
+import { SearchTypeBadge } from "./SearchTypeBadge";
+import type { GlobalSearchResult } from "../../services/api";
+
+interface Props {
+  result: GlobalSearchResult;
+  query: string;
+  onOpen: (r: GlobalSearchResult) => void;
+}
+
+/** Bold the query terms inside the preview text. */
+function highlight(preview: string, q: string): React.ReactNode {
+  if (!q.trim()) return preview;
+  const re = new RegExp(
+    `(${q.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+    "ig",
+  );
+  const parts = preview.split(re);
+  return parts.map((p, i) =>
+    re.test(p) ? (
+      <mark key={i} className="bg-amber-400/30 text-amber-100 rounded px-0.5">
+        {p}
+      </mark>
+    ) : (
+      <React.Fragment key={i}>{p}</React.Fragment>
+    ),
+  );
+}
+
+export const SearchResultCard: React.FC<Props> = ({
+  result,
+  query,
+  onOpen,
+}) => {
+  const meta = result.source_metadata;
+  const title = meta.summary_title ?? "Analyse sans titre";
+  const channel = meta.channel ?? "";
+  const thumb = meta.summary_thumbnail;
+  const score = (result.score * 100).toFixed(0);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(result)}
+      data-testid="search-result-card"
+      className="w-full text-left flex gap-3 p-3 rounded-xl bg-white/[0.03] border border-white/10 hover:bg-white/5 hover:border-white/20 transition-colors group"
+    >
+      {thumb && (
+        <img
+          src={thumb}
+          alt=""
+          loading="lazy"
+          className="w-24 h-16 sm:w-32 sm:h-20 rounded-md object-cover flex-shrink-0"
+        />
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1 flex-wrap">
+          <SearchTypeBadge type={result.source_type} />
+          <span className="text-[11px] font-mono text-white/40">
+            score {score}%
+          </span>
+        </div>
+        <h3 className="text-sm font-medium text-white truncate">{title}</h3>
+        {channel && <p className="text-xs text-white/45 truncate">{channel}</p>}
+        <p className="text-sm text-white/70 mt-1 line-clamp-2">
+          {highlight(result.text_preview, query)}
+        </p>
+      </div>
+      <ChevronRight className="self-center w-4 h-4 text-white/25 group-hover:text-white/65 flex-shrink-0" />
+    </button>
+  );
+};
+```
+
+- [ ] **Step 7.2: Créer `SearchEmptyState.tsx`**
+
+```tsx
+// frontend/src/components/search/SearchEmptyState.tsx
+import React from "react";
+import { Search as SearchIcon, Inbox } from "lucide-react";
+
+interface Props {
+  variant: "no-query" | "no-results";
+  query?: string;
+  recentQueries?: string[];
+  onPickQuery?: (q: string) => void;
+}
+
+export const SearchEmptyState: React.FC<Props> = ({
+  variant,
+  query,
+  recentQueries = [],
+  onPickQuery,
+}) => {
+  if (variant === "no-query") {
+    return (
+      <div className="text-center py-16">
+        <SearchIcon
+          className="w-10 h-10 text-white/25 mx-auto mb-3"
+          aria-hidden
+        />
+        <p className="text-white/65 mb-1">
+          Cherche dans toutes tes analyses, flashcards, quiz et chats.
+        </p>
+        {recentQueries.length > 0 && (
+          <div className="mt-6">
+            <p className="text-xs text-white/40 mb-2">Recherches récentes</p>
+            <div className="flex flex-wrap gap-2 justify-center">
+              {recentQueries.map((q) => (
+                <button
+                  key={q}
+                  type="button"
+                  onClick={() => onPickQuery?.(q)}
+                  className="px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-sm text-white/70 hover:bg-white/10"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center py-16">
+      <Inbox className="w-10 h-10 text-white/25 mx-auto mb-3" aria-hidden />
+      <p className="text-white/85 mb-1">Aucun résultat pour « {query} »</p>
+      <p className="text-sm text-white/45">
+        Essaie une formulation différente ou retire un filtre.
+      </p>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 7.3: Créer `SearchResultsList.tsx` avec virtual scroll**
+
+```tsx
+// frontend/src/components/search/SearchResultsList.tsx
+import React, { useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { SearchResultCard } from "./SearchResultCard";
+import type { GlobalSearchResult } from "../../services/api";
+
+interface Props {
+  results: GlobalSearchResult[];
+  query: string;
+  onOpen: (r: GlobalSearchResult) => void;
+}
+
+export const SearchResultsList: React.FC<Props> = ({
+  results,
+  query,
+  onOpen,
+}) => {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: results.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 110,
+    overscan: 6,
+  });
+
+  return (
+    <div
+      ref={parentRef}
+      className="w-full max-w-3xl mx-auto overflow-y-auto"
+      style={{ maxHeight: "calc(100vh - 280px)" }}
+    >
+      <div
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          width: "100%",
+          position: "relative",
+        }}
+      >
+        {virtualizer.getVirtualItems().map((vi) => {
+          const r = results[vi.index];
+          return (
+            <div
+              key={`${r.source_type}-${r.source_id}`}
+              data-index={vi.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${vi.start}px)`,
+                paddingBottom: 8,
+              }}
+            >
+              <SearchResultCard result={r} query={query} onOpen={onOpen} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 7.4: Test pour `SearchResultCard`**
+
+```tsx
+// frontend/src/components/search/__tests__/SearchResultCard.test.tsx
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchResultCard } from "../SearchResultCard";
+import type { GlobalSearchResult } from "../../../services/api";
+
+afterEach(cleanup);
+
+const mockResult: GlobalSearchResult = {
+  source_type: "summary",
+  source_id: 42,
+  summary_id: 42,
+  score: 0.91,
+  text_preview:
+    "La transition énergétique impose une refonte du mix électrique européen.",
+  source_metadata: {
+    summary_title: "Crise énergétique EU",
+    channel: "Le Monde",
+    summary_thumbnail: "https://img.example/thumb.jpg",
+    tab: "synthesis",
+  },
+};
+
+describe("SearchResultCard", () => {
+  it("renders title, channel and score", () => {
+    render(<SearchResultCard result={mockResult} query="" onOpen={() => {}} />);
+    expect(screen.getByText("Crise énergétique EU")).toBeInTheDocument();
+    expect(screen.getByText("Le Monde")).toBeInTheDocument();
+    expect(screen.getByText(/score 91%/)).toBeInTheDocument();
+  });
+
+  it("renders the type badge", () => {
+    render(<SearchResultCard result={mockResult} query="" onOpen={() => {}} />);
+    expect(screen.getByText("Synthèse")).toBeInTheDocument();
+  });
+
+  it("calls onOpen when clicked", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(
+      <SearchResultCard result={mockResult} query="énergie" onOpen={onOpen} />,
+    );
+    await user.click(screen.getByTestId("search-result-card"));
+    expect(onOpen).toHaveBeenCalledWith(mockResult);
+  });
+
+  it("highlights the query term in preview", () => {
+    render(
+      <SearchResultCard
+        result={mockResult}
+        query="transition"
+        onOpen={() => {}}
+      />,
+    );
+    const marks = document.querySelectorAll("mark");
+    expect(marks.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 7.5: Run tests**
+
+```bash
+cd frontend && npm run test -- --run src/components/search/__tests__/SearchResultCard.test.tsx
+```
+
+Expected : 4/4 pass.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add frontend/src/components/search/SearchResultCard.tsx \
+        frontend/src/components/search/SearchEmptyState.tsx \
+        frontend/src/components/search/SearchResultsList.tsx \
+        frontend/src/components/search/__tests__/SearchResultCard.test.tsx
+git commit -m "feat(search): add SearchResultCard + EmptyState + virtualized ResultsList"
+```
+
+---
+
+## Task 8: Page `SearchPage` — assembly + URL state + click flow vers Hub
+
+**Files:**
+
+- Create: `frontend/src/pages/SearchPage.tsx`
+- Create: `frontend/src/pages/__tests__/SearchPage.test.tsx`
+
+**Dependencies:** Task 3, Task 4, Task 5, Task 6, Task 7.
+
+- [ ] **Step 8.1: Créer `SearchPage.tsx`**
+
+```tsx
+// frontend/src/pages/SearchPage.tsx
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Sidebar } from "../components/layout/Sidebar";
+import DoodleBackground from "../components/DoodleBackground";
+import { SEO } from "../components/SEO";
+import { DeepSightSpinner } from "../components/ui/DeepSightSpinner";
+import { SearchInput } from "../components/search/SearchInput";
+import { SearchFiltersBar } from "../components/search/SearchFiltersBar";
+import { SearchAdvancedFilters } from "../components/search/SearchAdvancedFilters";
+import { SearchResultsList } from "../components/search/SearchResultsList";
+import { SearchEmptyState } from "../components/search/SearchEmptyState";
+import { useSemanticSearch } from "../components/search/useSemanticSearch";
+import { useRecentQueries } from "../components/search/useRecentQueries";
+import type {
+  GlobalSearchResult,
+  SearchFilters,
+  SearchSourceType,
+} from "../services/api";
+import { analytics } from "../services/analytics";
+
+const SearchPage: React.FC = () => {
+  const [params, setParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { addQuery, queries: recent } = useRecentQueries();
+
+  // URL ⇄ state sync
+  const initialQuery = params.get("q") ?? "";
+  const [query, setQuery] = useState(initialQuery);
+  const initialTypes = useMemo<SearchSourceType[] | undefined>(() => {
+    const raw = params.get("types");
+    if (!raw) return undefined;
+    return raw.split(",").filter(Boolean) as SearchSourceType[];
+  }, [params]);
+  const [filters, setFilters] = useState<SearchFilters>({
+    source_types: initialTypes,
+    platform: (params.get("platform") ||
+      undefined) as SearchFilters["platform"],
+    lang: params.get("lang") || undefined,
+    category: params.get("category") || undefined,
+    favorites_only: params.get("favs") === "1" || undefined,
+  });
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  // Sync state → URL
+  useEffect(() => {
+    const next = new URLSearchParams();
+    if (query) next.set("q", query);
+    if (filters.source_types?.length)
+      next.set("types", filters.source_types.join(","));
+    if (filters.platform) next.set("platform", filters.platform);
+    if (filters.lang) next.set("lang", filters.lang);
+    if (filters.category) next.set("category", filters.category);
+    if (filters.favorites_only) next.set("favs", "1");
+    setParams(next, { replace: true });
+  }, [query, filters, setParams]);
+
+  const { data, isFetching, error } = useSemanticSearch({ query, filters });
+
+  // Track query when results land
+  useEffect(() => {
+    if (data && query.trim().length >= 2) {
+      addQuery(query);
+      analytics.track?.("search_query", {
+        query_length: query.length,
+        results_count: data.total_results,
+        latency_ms: undefined, // backend latency not exposed currently
+        has_filters: Object.keys(filters).some(
+          (k) => (filters as Record<string, unknown>)[k] !== undefined,
+        ),
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.searched_at]);
+
+  const countsByType = useMemo<
+    Partial<Record<SearchSourceType, number>>
+  >(() => {
+    if (!data) return {};
+    const counts: Partial<Record<SearchSourceType, number>> = {};
+    for (const r of data.results) {
+      counts[r.source_type] = (counts[r.source_type] ?? 0) + 1;
+    }
+    return counts;
+  }, [data]);
+
+  const handleOpen = (r: GlobalSearchResult) => {
+    analytics.track?.("search_result_clicked", {
+      position: data?.results.indexOf(r) ?? -1,
+      source_type: r.source_type,
+      score: r.score,
+    });
+    const tab = r.source_metadata.tab ?? "synthesis";
+    const url = new URLSearchParams({
+      summaryId: String(r.summary_id),
+      q: query,
+      highlight: `${r.source_type}-${r.source_id}`,
+      tab,
+    });
+    navigate(`/hub?${url.toString()}`);
+  };
+
+  const isEmptyQuery = query.trim().length < 2;
+  const hasResults = !!data && data.results.length > 0;
+
+  return (
+    <div className="min-h-screen bg-bg-primary text-text-primary relative">
+      <SEO title="Recherche — Deep Sight" noindex />
+      <DoodleBackground />
+      <Sidebar />
+      <main
+        id="main-content"
+        className="lg:pl-[240px] pt-6 pb-12 px-4 sm:px-6 lg:px-8 relative z-10"
+      >
+        <div className="max-w-5xl mx-auto space-y-6">
+          <header>
+            <h1 className="text-2xl sm:text-3xl font-semibold text-white mb-1">
+              Recherche
+            </h1>
+            <p className="text-sm text-white/55">
+              Sémantique sur tes analyses, flashcards, quiz et chats.
+            </p>
+          </header>
+
+          <SearchInput value={query} onChange={setQuery} onSubmit={setQuery} />
+
+          <SearchFiltersBar
+            filters={filters}
+            onChange={setFilters}
+            countsByType={countsByType}
+            totalCount={data?.total_results}
+            onToggleAdvanced={() => setAdvancedOpen((v) => !v)}
+            advancedOpen={advancedOpen}
+          />
+
+          {advancedOpen && (
+            <SearchAdvancedFilters filters={filters} onChange={setFilters} />
+          )}
+
+          {error && (
+            <div className="text-center py-8 text-red-300">
+              Une erreur est survenue. Réessaie dans un instant.
+            </div>
+          )}
+
+          {!error && isFetching && (
+            <div className="flex justify-center py-10">
+              <DeepSightSpinner size="md" />
+            </div>
+          )}
+
+          {!error && !isFetching && isEmptyQuery && (
+            <SearchEmptyState
+              variant="no-query"
+              recentQueries={recent}
+              onPickQuery={(q) => setQuery(q)}
+            />
+          )}
+
+          {!error && !isFetching && !isEmptyQuery && !hasResults && (
+            <SearchEmptyState variant="no-results" query={query} />
+          )}
+
+          {!error && !isFetching && hasResults && data && (
+            <SearchResultsList
+              results={data.results}
+              query={query}
+              onOpen={handleOpen}
+            />
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default SearchPage;
+```
+
+- [ ] **Step 8.2: Créer le test page-level (mock api + RQ wrapper)**
+
+```tsx
+// frontend/src/pages/__tests__/SearchPage.test.tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SearchPage from "../SearchPage";
+import { searchApi } from "../../services/api";
+
+vi.mock("../../services/api", () => ({
+  searchApi: {
+    searchGlobal: vi.fn(),
+    getRecentQueries: vi.fn().mockResolvedValue({ queries: [] }),
+    clearRecentQueries: vi.fn(),
+  },
+}));
+vi.mock("../../components/layout/Sidebar", () => ({ Sidebar: () => null }));
+vi.mock("../../components/DoodleBackground", () => ({ default: () => null }));
+vi.mock("../../components/SEO", () => ({ SEO: () => null }));
+vi.mock("../../services/analytics", () => ({ analytics: { track: vi.fn() } }));
+
+afterEach(cleanup);
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/search"]}>
+        <SearchPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SearchPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows the no-query empty state initially", () => {
+    renderPage();
+    expect(screen.getByText(/cherche dans toutes/i)).toBeInTheDocument();
+  });
+
+  it("calls searchGlobal when typing >= 2 chars", async () => {
+    (searchApi.searchGlobal as any).mockResolvedValue({
+      query: "ai",
+      total_results: 0,
+      results: [],
+      searched_at: "2026-05-03T12:00:00Z",
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByRole("searchbox"), "ai");
+    await waitFor(() => expect(searchApi.searchGlobal).toHaveBeenCalled(), {
+      timeout: 1000,
+    });
+  });
+});
+```
+
+- [ ] **Step 8.3: Run tests**
+
+```bash
+cd frontend && npm run test -- --run src/pages/__tests__/SearchPage.test.tsx
+```
+
+Expected : 2/2 pass.
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add frontend/src/pages/SearchPage.tsx \
+        frontend/src/pages/__tests__/SearchPage.test.tsx
+git commit -m "feat(search): add SearchPage with URL state sync and click flow to /hub"
+```
+
+---
+
+## Task 9: Enregistrer la route `/search` dans `App.tsx` + ajout au sidebar
+
+**Files:**
+
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/layout/Sidebar.tsx`
+- Modify: `frontend/src/components/sidebar/SidebarNav.tsx`
+- Modify: `frontend/src/i18n/fr.json` + `en.json`
+
+**Dependencies:** Task 8.
+
+- [ ] **Step 9.1: Dans `App.tsx`, ajouter le lazy import (après `History`, ligne ~315)**
+
+```typescript
+const SearchPage = lazyWithRetry(() => import("./pages/SearchPage"));
+```
+
+- [ ] **Step 9.2: Ajouter la route protégée juste après `/history`**
+
+```tsx
+<Route
+  path="/search"
+  element={
+    <RouteErrorBoundary variant="full" componentName="SearchPage">
+      <Suspense fallback={<PageSkeleton variant="full" />}>
+        <SearchPage />
+      </Suspense>
+    </RouteErrorBoundary>
+  }
+/>
+```
+
+- [ ] **Step 9.3: Ajouter `/search` au `PREFETCH_MAP` (sous `/dashboard` array, et créer une entrée `"/history": [...]` pour également prefetch /search)**
+
+```typescript
+"/dashboard": [
+  "/history", "/settings", "/debate", "/analytics",
+  "/hub", "/chat", "/voice-call", "/study", "/about",
+  "/search", // ← add
+],
+"/history": ["/dashboard", "/analytics", "/search"],
+```
+
+Et ajouter au `PAGE_LOADERS` :
+
+```typescript
+"/search": () => import("./pages/SearchPage"),
+```
+
+- [ ] **Step 9.4: Modifier `frontend/src/components/layout/Sidebar.tsx` — ajouter le NavItem Search**
+
+Importer `Search` depuis `lucide-react` (ajouter à la liste d'imports existante).
+Dans le 1er pill group, **entre `/history` et `/debate`** :
+
+```tsx
+<NavItem
+  to="/search"
+  icon={Search}
+  label={language === "fr" ? "Recherche" : "Search"}
+  collapsed={collapsed}
+/>
+```
+
+- [ ] **Step 9.5: Modifier `frontend/src/components/sidebar/SidebarNav.tsx` (composant orphelin mentionné par le spec — synchroniser pour cohérence)**
+
+Importer `Search` et ajouter `{ path: "/search", icon: Search, label: "Recherche" }` à `navItems` entre History et Hub.
+
+- [ ] **Step 9.6: Ajouter clés i18n**
+
+Dans `frontend/src/i18n/fr.json`, sous `nav` :
+
+```json
+"search": "Recherche"
+```
+
+Dans `en.json` :
+
+```json
+"search": "Search"
+```
+
+- [ ] **Step 9.7: Run typecheck + lint + tests existants**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test -- --run
+```
+
+Expected : tout green.
+
+- [ ] **Step 9.8: Commit**
+
+```bash
+git add frontend/src/App.tsx \
+        frontend/src/components/layout/Sidebar.tsx \
+        frontend/src/components/sidebar/SidebarNav.tsx \
+        frontend/src/i18n/fr.json frontend/src/i18n/en.json
+git commit -m "feat(search): register /search route + sidebar nav item + i18n"
+```
+
+---
+
+## Task 10: Styles `highlight.css` + import global
+
+**Files:**
+
+- Create: `frontend/src/styles/highlight.css`
+- Modify: `frontend/src/index.css`
+
+**Dependencies:** Aucune.
+
+- [ ] **Step 10.1: Créer `highlight.css` (verbatim depuis le spec section 4.6)**
+
+```css
+/* frontend/src/styles/highlight.css
+   Semantic Search V1 highlight visuals.
+   amber-400 = rgb(251 191 36) ; amber-300 = rgb(252 211 77) */
+
+.ds-highlight {
+  background: rgb(251 191 36 / 0.35);
+  color: rgb(252 211 77);
+  padding: 0 2px;
+  border-radius: 2px;
+  border-bottom: 2px solid rgb(251 191 36);
+  cursor: pointer;
+  transition: background 200ms ease;
+}
+.ds-highlight:hover {
+  background: rgb(251 191 36 / 0.55);
+}
+.ds-highlight.flash {
+  animation: ds-highlight-flash 800ms ease-in-out;
+}
+@keyframes ds-highlight-flash {
+  0%,
+  100% {
+    background: rgb(251 191 36 / 0.35);
+  }
+  50% {
+    background: rgb(251 191 36 / 0.85);
+  }
+}
+
+/* Honour reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ds-highlight.flash {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 10.2: Importer dans `frontend/src/index.css` (en haut, sous les autres `@import`)**
+
+```css
+@import "./styles/highlight.css";
+```
+
+- [ ] **Step 10.3: Build sanity check**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected : pas d'erreur Vite, le CSS est inclus dans le bundle.
+
+- [ ] **Step 10.4: Commit**
+
+```bash
+git add frontend/src/styles/highlight.css frontend/src/index.css
+git commit -m "feat(highlight): add highlight.css with .ds-highlight and flash animation"
+```
+
+---
+
+## Task 11: `SemanticHighlightProvider` + Context + types
+
+**Files:**
+
+- Create: `frontend/src/components/highlight/SemanticHighlightContext.ts`
+- Create: `frontend/src/components/highlight/SemanticHighlightProvider.tsx`
+- Create: `frontend/src/components/highlight/useSemanticHighlight.ts`
+
+**Dependencies:** Task 1.
+
+- [ ] **Step 11.1: Créer `SemanticHighlightContext.ts`**
+
+```typescript
+// frontend/src/components/highlight/SemanticHighlightContext.ts
+import { createContext } from "react";
+import type { WithinMatch } from "../../services/api";
+
+export interface SemanticHighlightState {
+  /** Active query — empty string when search bar closed */
+  query: string;
+  /** Loading state for /api/search/within */
+  loading: boolean;
+  /** Matches across all tabs */
+  matches: WithinMatch[];
+  /** Index in `matches` of the currently focused match (-1 if none) */
+  currentIndex: number;
+  /** Tab to switch to when current match is selected */
+  activeTab: WithinMatch["tab"] | null;
+  /** Open a search session */
+  setQuery: (q: string) => void;
+  /** Close the search session (clears matches) */
+  close: () => void;
+  /** Navigate next/prev match (wraps) */
+  next: () => void;
+  prev: () => void;
+  /** Jump to a specific passage_id (e.g. from search result deeplink) */
+  focus: (passageId: string) => void;
+}
+
+export const SemanticHighlightContext =
+  createContext<SemanticHighlightState | null>(null);
+```
+
+- [ ] **Step 11.2: Créer `SemanticHighlightProvider.tsx`**
+
+```tsx
+// frontend/src/components/highlight/SemanticHighlightProvider.tsx
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { searchApi, type WithinMatch } from "../../services/api";
+import {
+  SemanticHighlightContext,
+  type SemanticHighlightState,
+} from "./SemanticHighlightContext";
+
+interface Props {
+  summaryId: number | null;
+  children: React.ReactNode;
+}
+
+export const SemanticHighlightProvider: React.FC<Props> = ({
+  summaryId,
+  children,
+}) => {
+  const [query, setQueryRaw] = useState("");
+  const [matches, setMatches] = useState<WithinMatch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+  const debounceRef = useRef<number | undefined>(undefined);
+
+  const fetchMatches = useCallback(
+    async (q: string) => {
+      if (!summaryId || q.trim().length < 2) {
+        setMatches([]);
+        setCurrentIndex(-1);
+        return;
+      }
+      setLoading(true);
+      try {
+        const res = await searchApi.searchWithin(summaryId, q.trim());
+        setMatches(res.matches);
+        setCurrentIndex(res.matches.length > 0 ? 0 : -1);
+      } catch {
+        setMatches([]);
+        setCurrentIndex(-1);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [summaryId],
+  );
+
+  const setQuery = useCallback(
+    (q: string) => {
+      setQueryRaw(q);
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = window.setTimeout(() => fetchMatches(q), 200);
+    },
+    [fetchMatches],
+  );
+
+  const close = useCallback(() => {
+    setQueryRaw("");
+    setMatches([]);
+    setCurrentIndex(-1);
+  }, []);
+
+  const next = useCallback(() => {
+    if (matches.length === 0) return;
+    setCurrentIndex((i) => (i + 1) % matches.length);
+  }, [matches.length]);
+
+  const prev = useCallback(() => {
+    if (matches.length === 0) return;
+    setCurrentIndex((i) => (i <= 0 ? matches.length - 1 : i - 1));
+  }, [matches.length]);
+
+  const focus = useCallback(
+    (passageId: string) => {
+      const idx = matches.findIndex((m) => m.passage_id === passageId);
+      if (idx >= 0) setCurrentIndex(idx);
+    },
+    [matches],
+  );
+
+  // Cleanup
+  useEffect(
+    () => () => {
+      window.clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
+  const activeTab = matches[currentIndex]?.tab ?? null;
+
+  const state: SemanticHighlightState = useMemo(
+    () => ({
+      query,
+      loading,
+      matches,
+      currentIndex,
+      activeTab,
+      setQuery,
+      close,
+      next,
+      prev,
+      focus,
+    }),
+    [
+      query,
+      loading,
+      matches,
+      currentIndex,
+      activeTab,
+      setQuery,
+      close,
+      next,
+      prev,
+      focus,
+    ],
+  );
+
+  return (
+    <SemanticHighlightContext.Provider value={state}>
+      {children}
+    </SemanticHighlightContext.Provider>
+  );
+};
+```
+
+- [ ] **Step 11.3: Créer `useSemanticHighlight.ts`**
+
+```typescript
+// frontend/src/components/highlight/useSemanticHighlight.ts
+import { useContext } from "react";
+import {
+  SemanticHighlightContext,
+  type SemanticHighlightState,
+} from "./SemanticHighlightContext";
+
+/** Returns the highlight state, or null if not within a provider. */
+export function useSemanticHighlight(): SemanticHighlightState | null {
+  return useContext(SemanticHighlightContext);
+}
+```
+
+- [ ] **Step 11.4: Run typecheck**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add frontend/src/components/highlight/SemanticHighlightContext.ts \
+        frontend/src/components/highlight/SemanticHighlightProvider.tsx \
+        frontend/src/components/highlight/useSemanticHighlight.ts
+git commit -m "feat(highlight): add SemanticHighlightProvider context with debounced within fetch"
+```
+
+---
+
+## Task 12: `HighlightedText` (DOM post-process pour injecter `<mark>`)
+
+**Files:**
+
+- Create: `frontend/src/components/highlight/HighlightedText.tsx`
+- Create: `frontend/src/components/highlight/__tests__/HighlightedText.test.tsx`
+
+**Dependencies:** Task 10, Task 11.
+
+> **Note technique** : on n'utilise PAS la traversée du DOM via Range (trop fragile avec re-renders React et `react-markdown`). On opère via une **passe de remplacement DOM dans `useEffect`** sur un container `ref`, en wrappant chaque occurrence du texte de match dans un `<mark>`. Pour rester simple et robuste : on utilise les `start_offset` / `end_offset` retournés par le backend dans le tab actif uniquement (string position dans le markdown brut).
+
+> **Approche V1 retenue (pragmatique)** : injecter les `<mark>` après render, en cherchant le passage `text` exact dans les nodes texte du container. C'est correct pour 95% des cas (texte simple, sans inline formatting cassant le span). Les cas où le passage chevauche du markdown inline (gras, lien) seront skippés silencieusement — acceptable pour V1.
+
+- [ ] **Step 12.1: Créer `HighlightedText.tsx`**
+
+```tsx
+// frontend/src/components/highlight/HighlightedText.tsx
+import React, { useEffect, useRef } from "react";
+import { useSemanticHighlight } from "./useSemanticHighlight";
+import type { WithinMatch } from "../../services/api";
+
+interface Props {
+  /** Tab identity — only matches for this tab are rendered */
+  tab: WithinMatch["tab"];
+  /** Click handler (passage_id) — typically opens ExplainTooltip */
+  onMarkClick?: (passageId: string, passage: WithinMatch) => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Wrapper that traverses children DOM after render and wraps text spans
+ * matching `match.text` with <mark className="ds-highlight">.
+ * Idempotent: clears previous marks on every effect run.
+ */
+export const HighlightedText: React.FC<Props> = ({
+  tab,
+  onMarkClick,
+  children,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const ctx = useSemanticHighlight();
+
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+
+    // 1. Strip previous marks (unwrap)
+    root.querySelectorAll("mark.ds-highlight").forEach((m) => {
+      const parent = m.parentNode;
+      if (!parent) return;
+      while (m.firstChild) parent.insertBefore(m.firstChild, m);
+      parent.removeChild(m);
+      parent.normalize();
+    });
+
+    if (!ctx || ctx.matches.length === 0) return;
+
+    const tabMatches = ctx.matches.filter((m) => m.tab === tab);
+    if (tabMatches.length === 0) return;
+
+    // 2. Walk text nodes and wrap exact `text` occurrences
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const targets: { node: Text; match: WithinMatch }[] = [];
+    let node: Node | null = walker.nextNode();
+    while (node) {
+      const txt = node.nodeValue ?? "";
+      for (const m of tabMatches) {
+        const idx = txt.indexOf(m.text);
+        if (idx >= 0) {
+          targets.push({ node: node as Text, match: m });
+          break; // first match per text node — others picked up next pass
+        }
+      }
+      node = walker.nextNode();
+    }
+
+    targets.forEach(({ node: textNode, match }) => {
+      const txt = textNode.nodeValue ?? "";
+      const idx = txt.indexOf(match.text);
+      if (idx < 0) return;
+      const before = txt.slice(0, idx);
+      const after = txt.slice(idx + match.text.length);
+      const parent = textNode.parentNode;
+      if (!parent) return;
+      const mark = document.createElement("mark");
+      mark.className = "ds-highlight";
+      mark.dataset.passageId = match.passage_id;
+      mark.setAttribute(
+        "aria-label",
+        `Passage correspondant : ${match.text.slice(0, 60)}`,
+      );
+      mark.textContent = match.text;
+      if (ctx.matches[ctx.currentIndex]?.passage_id === match.passage_id) {
+        mark.classList.add("flash");
+      }
+      const fragment = document.createDocumentFragment();
+      if (before) fragment.appendChild(document.createTextNode(before));
+      fragment.appendChild(mark);
+      if (after) fragment.appendChild(document.createTextNode(after));
+      parent.replaceChild(fragment, textNode);
+    });
+
+    // 3. Auto-scroll to current
+    if (
+      ctx.currentIndex >= 0 &&
+      tabMatches.includes(ctx.matches[ctx.currentIndex])
+    ) {
+      const target = root.querySelector<HTMLElement>(
+        `mark.ds-highlight[data-passage-id="${ctx.matches[ctx.currentIndex].passage_id}"]`,
+      );
+      target?.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+
+    // 4. Wire click handlers
+    if (onMarkClick) {
+      const handler = (e: Event) => {
+        const target = (e.target as HTMLElement).closest<HTMLElement>(
+          "mark.ds-highlight",
+        );
+        if (!target) return;
+        const id = target.dataset.passageId;
+        if (!id) return;
+        const match = ctx.matches.find((m) => m.passage_id === id);
+        if (match) onMarkClick(id, match);
+      };
+      root.addEventListener("click", handler);
+      return () => root.removeEventListener("click", handler);
+    }
+  }, [ctx?.matches, ctx?.currentIndex, tab, onMarkClick, ctx]);
+
+  return (
+    <div ref={containerRef} data-highlight-tab={tab}>
+      {children}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 12.2: Test unitaire**
+
+```tsx
+// frontend/src/components/highlight/__tests__/HighlightedText.test.tsx
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import React from "react";
+import { HighlightedText } from "../HighlightedText";
+import { SemanticHighlightContext } from "../SemanticHighlightContext";
+import type { WithinMatch } from "../../../services/api";
+
+afterEach(cleanup);
+
+const mockMatch: WithinMatch = {
+  source_type: "summary",
+  source_id: 1,
+  text: "transition énergétique",
+  text_html: "transition énergétique",
+  start_offset: 0,
+  end_offset: 22,
+  tab: "synthesis",
+  score: 0.91,
+  passage_id: "p1",
+};
+
+const wrap =
+  (matches: WithinMatch[], idx = 0) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <SemanticHighlightContext.Provider
+      value={{
+        query: "transition",
+        loading: false,
+        matches,
+        currentIndex: idx,
+        activeTab: "synthesis",
+        setQuery: () => {},
+        close: () => {},
+        next: () => {},
+        prev: () => {},
+        focus: () => {},
+      }}
+    >
+      {children}
+    </SemanticHighlightContext.Provider>
+  );
+
+describe("HighlightedText", () => {
+  it("wraps a matching text span in <mark>", () => {
+    const Wrapper = wrap([mockMatch]);
+    const { container } = render(
+      <Wrapper>
+        <HighlightedText tab="synthesis">
+          <p>La transition énergétique impose une refonte.</p>
+        </HighlightedText>
+      </Wrapper>,
+    );
+    const mark = container.querySelector("mark.ds-highlight");
+    expect(mark).not.toBeNull();
+    expect(mark?.textContent).toBe("transition énergétique");
+    expect(mark?.getAttribute("data-passage-id")).toBe("p1");
+  });
+
+  it("does not wrap when no matches", () => {
+    const Wrapper = wrap([]);
+    const { container } = render(
+      <Wrapper>
+        <HighlightedText tab="synthesis">
+          <p>La transition énergétique.</p>
+        </HighlightedText>
+      </Wrapper>,
+    );
+    expect(container.querySelector("mark.ds-highlight")).toBeNull();
+  });
+
+  it("only wraps for matching tab", () => {
+    const Wrapper = wrap([mockMatch]);
+    const { container } = render(
+      <Wrapper>
+        <HighlightedText tab="quiz">
+          <p>La transition énergétique.</p>
+        </HighlightedText>
+      </Wrapper>,
+    );
+    expect(container.querySelector("mark.ds-highlight")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 12.3: Run tests**
+
+```bash
+cd frontend && npm run test -- --run src/components/highlight/__tests__/HighlightedText.test.tsx
+```
+
+Expected : 3/3 pass.
+
+- [ ] **Step 12.4: Commit**
+
+```bash
+git add frontend/src/components/highlight/HighlightedText.tsx \
+        frontend/src/components/highlight/__tests__/HighlightedText.test.tsx
+git commit -m "feat(highlight): add HighlightedText DOM-walker that injects <mark> spans"
+```
+
+---
+
+## Task 13: `HighlightNavigationBar` (compteur + ↑/↓ + close)
+
+**Files:**
+
+- Create: `frontend/src/components/highlight/HighlightNavigationBar.tsx`
+- Create: `frontend/src/components/highlight/__tests__/HighlightNavigationBar.test.tsx`
+
+**Dependencies:** Task 11.
+
+- [ ] **Step 13.1: Créer le composant**
+
+```tsx
+// frontend/src/components/highlight/HighlightNavigationBar.tsx
+import React, { useEffect } from "react";
+import { ChevronUp, ChevronDown, X } from "lucide-react";
+import { useSemanticHighlight } from "./useSemanticHighlight";
+
+export const HighlightNavigationBar: React.FC = () => {
+  const ctx = useSemanticHighlight();
+
+  // Keyboard shortcuts F3 / Shift+F3 for next/prev (browser standard)
+  useEffect(() => {
+    if (!ctx || ctx.matches.length === 0) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "F3") {
+        e.preventDefault();
+        e.shiftKey ? ctx.prev() : ctx.next();
+      }
+      if (e.key === "Escape" && ctx.query) {
+        e.preventDefault();
+        ctx.close();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [ctx]);
+
+  if (!ctx || ctx.matches.length === 0) return null;
+
+  const total = ctx.matches.length;
+  const current = ctx.currentIndex + 1;
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Résultats de recherche"
+      className="sticky top-[56px] z-40 mx-auto w-full max-w-3xl px-4"
+    >
+      <div className="mt-2 flex items-center gap-2 px-3 py-2 rounded-lg bg-[#12121a]/95 border border-amber-500/30 backdrop-blur-xl shadow-lg">
+        <span
+          className="text-sm font-mono text-amber-300 tabular-nums"
+          aria-live="polite"
+        >
+          {current}/{total}
+        </span>
+        <span className="flex-1 truncate text-xs text-white/55">
+          « {ctx.query} »
+        </span>
+        <button
+          type="button"
+          onClick={ctx.prev}
+          aria-label="Match précédent"
+          aria-keyshortcuts="Shift+F3"
+          className="p-1.5 rounded-md text-white/65 hover:bg-white/5 hover:text-white"
+        >
+          <ChevronUp className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={ctx.next}
+          aria-label="Match suivant"
+          aria-keyshortcuts="F3"
+          className="p-1.5 rounded-md text-white/65 hover:bg-white/5 hover:text-white"
+        >
+          <ChevronDown className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={ctx.close}
+          aria-label="Fermer la recherche"
+          aria-keyshortcuts="Escape"
+          className="p-1.5 rounded-md text-white/65 hover:bg-white/5 hover:text-white"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </nav>
+  );
+};
+```
+
+- [ ] **Step 13.2: Test**
+
+```tsx
+// frontend/src/components/highlight/__tests__/HighlightNavigationBar.test.tsx
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { HighlightNavigationBar } from "../HighlightNavigationBar";
+import { SemanticHighlightContext } from "../SemanticHighlightContext";
+import type { WithinMatch } from "../../../services/api";
+
+afterEach(cleanup);
+
+const mockMatch = (id: string): WithinMatch => ({
+  source_type: "summary",
+  source_id: 1,
+  text: "x",
+  text_html: "x",
+  start_offset: 0,
+  end_offset: 1,
+  tab: "synthesis",
+  score: 0.9,
+  passage_id: id,
+});
+
+function withState(
+  matches: WithinMatch[],
+  idx = 0,
+  fns: Partial<{ next: () => void; prev: () => void; close: () => void }> = {},
+) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <SemanticHighlightContext.Provider
+      value={{
+        query: "ai",
+        loading: false,
+        matches,
+        currentIndex: idx,
+        activeTab: "synthesis",
+        setQuery: () => {},
+        close: fns.close ?? (() => {}),
+        next: fns.next ?? (() => {}),
+        prev: fns.prev ?? (() => {}),
+        focus: () => {},
+      }}
+    >
+      {children}
+    </SemanticHighlightContext.Provider>
+  );
+}
+
+describe("HighlightNavigationBar", () => {
+  it("returns null when no matches", () => {
+    const Wrap = withState([]);
+    const { container } = render(
+      <Wrap>
+        <HighlightNavigationBar />
+      </Wrap>,
+    );
+    expect(container.querySelector("nav")).toBeNull();
+  });
+
+  it("displays counter '1/2'", () => {
+    const Wrap = withState([mockMatch("a"), mockMatch("b")], 0);
+    render(
+      <Wrap>
+        <HighlightNavigationBar />
+      </Wrap>,
+    );
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+  });
+
+  it("calls next/prev/close when buttons clicked", async () => {
+    const user = userEvent.setup();
+    const next = vi.fn();
+    const prev = vi.fn();
+    const close = vi.fn();
+    const Wrap = withState([mockMatch("a"), mockMatch("b")], 0, {
+      next,
+      prev,
+      close,
+    });
+    render(
+      <Wrap>
+        <HighlightNavigationBar />
+      </Wrap>,
+    );
+    await user.click(screen.getByLabelText(/match suivant/i));
+    await user.click(screen.getByLabelText(/match précédent/i));
+    await user.click(screen.getByLabelText(/fermer la recherche/i));
+    expect(next).toHaveBeenCalled();
+    expect(prev).toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 13.3: Run**
+
+```bash
+cd frontend && npm run test -- --run src/components/highlight/__tests__/HighlightNavigationBar.test.tsx
+```
+
+- [ ] **Step 13.4: Commit**
+
+```bash
+git add frontend/src/components/highlight/HighlightNavigationBar.tsx \
+        frontend/src/components/highlight/__tests__/HighlightNavigationBar.test.tsx
+git commit -m "feat(highlight): add HighlightNavigationBar with counter and F3/Esc shortcuts"
+```
+
+---
+
+## Task 14: `IntraAnalysisSearchBar` + hook `useCmdFIntercept`
+
+**Files:**
+
+- Create: `frontend/src/components/highlight/useCmdFIntercept.ts`
+- Create: `frontend/src/components/highlight/IntraAnalysisSearchBar.tsx`
+
+**Dependencies:** Task 11.
+
+- [ ] **Step 14.1: Créer `useCmdFIntercept.ts`**
+
+```typescript
+// frontend/src/components/highlight/useCmdFIntercept.ts
+import { useEffect } from "react";
+
+interface Options {
+  /** CSS selector that must contain the active focus / mouse target for interception */
+  scopeSelector: string;
+  /** Called when Cmd/Ctrl+F is pressed inside scope */
+  onIntercept: () => void;
+  /** Disable the listener (e.g. user is in a textarea) */
+  enabled?: boolean;
+}
+
+export function useCmdFIntercept({
+  scopeSelector,
+  onIntercept,
+  enabled = true,
+}: Options) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      const isCmdF =
+        (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f" && !e.shiftKey;
+      if (!isCmdF) return;
+      const scope = document.querySelector(scopeSelector);
+      if (!scope) return;
+      const active = document.activeElement;
+      const inScope = active
+        ? scope.contains(active) || scope === active
+        : false;
+      // Also intercept if the user is just on the page (no input focused)
+      const onPageNoInputFocused =
+        !active ||
+        active === document.body ||
+        (active instanceof HTMLElement &&
+          !["INPUT", "TEXTAREA"].includes(active.tagName));
+      if (inScope || onPageNoInputFocused) {
+        e.preventDefault();
+        onIntercept();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [scopeSelector, onIntercept, enabled]);
+}
+```
+
+- [ ] **Step 14.2: Créer `IntraAnalysisSearchBar.tsx`**
+
+```tsx
+// frontend/src/components/highlight/IntraAnalysisSearchBar.tsx
+import React, { useEffect, useRef } from "react";
+import { Search, X } from "lucide-react";
+import { useSemanticHighlight } from "./useSemanticHighlight";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const IntraAnalysisSearchBar: React.FC<Props> = ({ open, onClose }) => {
+  const ctx = useSemanticHighlight();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [open]);
+
+  if (!open || !ctx) return null;
+
+  return (
+    <div
+      role="search"
+      aria-label="Recherche dans l'analyse"
+      className="fixed inset-x-0 top-3 z-50 mx-auto w-full max-w-xl px-4"
+    >
+      <div className="flex items-center gap-2 px-3 py-2 rounded-xl bg-[#12121a]/95 border border-white/15 backdrop-blur-xl shadow-2xl">
+        <Search className="w-4 h-4 text-white/55" aria-hidden />
+        <input
+          ref={inputRef}
+          type="search"
+          value={ctx.query}
+          onChange={(e) => ctx.setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              ctx.close();
+              onClose();
+            }
+            if (e.key === "Enter") {
+              e.preventDefault();
+              e.shiftKey ? ctx.prev() : ctx.next();
+            }
+          }}
+          placeholder="Rechercher dans l'analyse…"
+          aria-label="Rechercher dans l'analyse"
+          className="flex-1 bg-transparent text-white placeholder-white/35 outline-none text-sm"
+        />
+        {ctx.loading && (
+          <span className="text-[11px] font-mono text-white/45">…</span>
+        )}
+        {!ctx.loading && ctx.matches.length > 0 && (
+          <span className="text-[11px] font-mono text-amber-300 tabular-nums">
+            {ctx.currentIndex + 1}/{ctx.matches.length}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            ctx.close();
+            onClose();
+          }}
+          aria-label="Fermer"
+          className="p-1.5 rounded-md text-white/55 hover:bg-white/5 hover:text-white"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 14.3: Run typecheck**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+- [ ] **Step 14.4: Commit**
+
+```bash
+git add frontend/src/components/highlight/useCmdFIntercept.ts \
+        frontend/src/components/highlight/IntraAnalysisSearchBar.tsx
+git commit -m "feat(highlight): add IntraAnalysisSearchBar + useCmdFIntercept hook"
+```
+
+---
+
+## Task 15: `ExplainTooltip` + `ExplainUpsellModal`
+
+**Files:**
+
+- Create: `frontend/src/components/highlight/ExplainTooltip.tsx`
+- Create: `frontend/src/components/highlight/ExplainUpsellModal.tsx`
+- Create: `frontend/src/components/highlight/__tests__/ExplainTooltip.test.tsx`
+
+**Dependencies:** Task 1, Task 2.
+
+- [ ] **Step 15.1: Créer `ExplainUpsellModal.tsx`**
+
+```tsx
+// frontend/src/components/highlight/ExplainUpsellModal.tsx
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Sparkles, X } from "lucide-react";
+
+interface Props {
+  open: boolean;
+  passageText: string;
+  onClose: () => void;
+}
+
+export const ExplainUpsellModal: React.FC<Props> = ({
+  open,
+  passageText,
+  onClose,
+}) => {
+  const navigate = useNavigate();
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="explain-upsell-title"
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl bg-[#12121a] border border-white/10 shadow-2xl p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-3">
+          <h2
+            id="explain-upsell-title"
+            className="text-base font-semibold text-white flex items-center gap-2"
+          >
+            <Sparkles className="w-4 h-4 text-indigo-400" />
+            Comprendre ce passage avec l'IA
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Fermer"
+            className="p-1 rounded-md hover:bg-white/5"
+          >
+            <X className="w-4 h-4 text-white/55" />
+          </button>
+        </div>
+        <p className="text-sm text-white/65 mb-3">
+          Le tooltip IA est inclus avec Pro et Expert.
+        </p>
+        <p className="text-sm text-white/85 italic mb-4 line-clamp-3">
+          « {passageText} »
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/upgrade")}
+          className="w-full px-4 py-2.5 rounded-lg bg-gradient-to-r from-indigo-500 to-violet-500 text-white font-medium hover:opacity-95"
+        >
+          Essai gratuit 7 jours →
+        </button>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 15.2: Créer `ExplainTooltip.tsx`**
+
+```tsx
+// frontend/src/components/highlight/ExplainTooltip.tsx
+import React, { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { motion, AnimatePresence } from "framer-motion";
+import { Sparkles, MessageSquare, Clock, ExternalLink, X } from "lucide-react";
+import { searchApi, type WithinMatch } from "../../services/api";
+import { useAuth } from "../../hooks/useAuth";
+import { PLAN_FEATURES, normalizePlanId } from "../../config/planPrivileges";
+import { ExplainUpsellModal } from "./ExplainUpsellModal";
+
+interface Props {
+  open: boolean;
+  match: WithinMatch | null;
+  query: string;
+  summaryId: number;
+  /** Anchor element rectangle (from getBoundingClientRect) for positioning */
+  anchorRect: DOMRect | null;
+  onClose: () => void;
+  onCiteInChat: (passage: string) => void;
+  onSeekTimecode?: (seconds: number) => void;
+  onJumpToTab?: (tab: WithinMatch["tab"]) => void;
+}
+
+export const ExplainTooltip: React.FC<Props> = ({
+  open,
+  match,
+  query,
+  summaryId,
+  anchorRect,
+  onClose,
+  onCiteInChat,
+  onSeekTimecode,
+  onJumpToTab,
+}) => {
+  const { user } = useAuth();
+  const plan = normalizePlanId(user?.plan);
+  const tooltipAllowed = PLAN_FEATURES[plan].semanticSearchTooltip;
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [upsellOpen, setUpsellOpen] = useState(false);
+
+  // Close on outside click / Esc
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (tooltipRef.current && !tooltipRef.current.contains(e.target as Node))
+        onClose();
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onEsc);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onEsc);
+    };
+  }, [open, onClose]);
+
+  // Open upsell instead of fetching for free users
+  useEffect(() => {
+    if (open && match && !tooltipAllowed) setUpsellOpen(true);
+  }, [open, match, tooltipAllowed]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["explain-passage", summaryId, match?.passage_id, query],
+    queryFn: () => {
+      if (!match) return Promise.reject(new Error("no match"));
+      return searchApi.explainPassage(
+        summaryId,
+        match.text,
+        query,
+        match.source_type,
+      );
+    },
+    enabled: open && !!match && tooltipAllowed,
+    staleTime: 60 * 60 * 1000, // 1h cache
+    gcTime: 60 * 60 * 1000,
+    retry: false,
+  });
+
+  if (!open || !match) {
+    return upsellOpen && match ? (
+      <ExplainUpsellModal
+        open
+        passageText={match.text}
+        onClose={() => {
+          setUpsellOpen(false);
+          onClose();
+        }}
+      />
+    ) : null;
+  }
+
+  if (!tooltipAllowed) {
+    return (
+      <ExplainUpsellModal
+        open={upsellOpen}
+        passageText={match.text}
+        onClose={() => {
+          setUpsellOpen(false);
+          onClose();
+        }}
+      />
+    );
+  }
+
+  // Position : prefer above anchor, fallback below
+  const margin = 8;
+  const tooltipMaxWidth = 360;
+  const top = anchorRect
+    ? anchorRect.top - margin - 220 < 0
+      ? anchorRect.bottom + margin
+      : anchorRect.top - margin - 220
+    : 100;
+  const left = anchorRect
+    ? Math.max(
+        8,
+        Math.min(window.innerWidth - tooltipMaxWidth - 8, anchorRect.left),
+      )
+    : 100;
+
+  const tsHint =
+    match.tab === "transcript" || match.tab === "synthesis" ? null : null;
+  const seekableSecs =
+    match.tab === "transcript" || match.tab === "synthesis"
+      ? // try to extract from match text or metadata — V1: skip
+        null
+      : null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        ref={tooltipRef}
+        role="tooltip"
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 6 }}
+        transition={{ duration: 0.15 }}
+        style={{ top, left, maxWidth: tooltipMaxWidth }}
+        className="fixed z-[55] rounded-xl bg-[#12121a] border border-white/15 shadow-2xl backdrop-blur-xl p-3 w-[min(90vw,360px)]"
+      >
+        <div className="flex items-start justify-between mb-2">
+          <span className="inline-flex items-center gap-1 text-[11px] font-medium text-indigo-300">
+            <Sparkles className="w-3 h-3" />
+            IA · Pourquoi ce passage matche
+          </span>
+          <button
+            onClick={onClose}
+            aria-label="Fermer"
+            className="p-0.5 rounded hover:bg-white/5"
+          >
+            <X className="w-3.5 h-3.5 text-white/55" />
+          </button>
+        </div>
+
+        {isLoading && (
+          <div className="space-y-1.5">
+            <div className="h-2.5 bg-white/10 rounded animate-pulse w-full" />
+            <div className="h-2.5 bg-white/10 rounded animate-pulse w-4/5" />
+          </div>
+        )}
+
+        {error && (
+          <p className="text-xs text-red-300">
+            Impossible de générer l'explication.
+          </p>
+        )}
+
+        {data && (
+          <p className="text-sm text-white/85 leading-relaxed">
+            {data.explanation}
+          </p>
+        )}
+
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          <button
+            type="button"
+            onClick={() => {
+              onCiteInChat(`Explique-moi ce passage : ${match.text}`);
+              onClose();
+            }}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-xs text-white/85 hover:bg-white/10"
+          >
+            <MessageSquare className="w-3 h-3" /> Citer dans chat
+          </button>
+          {seekableSecs !== null && onSeekTimecode && (
+            <button
+              type="button"
+              onClick={() => onSeekTimecode(seekableSecs)}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-xs text-white/85 hover:bg-white/10"
+            >
+              <Clock className="w-3 h-3" /> Sauter au timecode
+            </button>
+          )}
+          {onJumpToTab && match.tab !== "synthesis" && (
+            <button
+              type="button"
+              onClick={() => {
+                onJumpToTab(match.tab);
+                onClose();
+              }}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-xs text-white/85 hover:bg-white/10"
+            >
+              <ExternalLink className="w-3 h-3" />
+              Voir dans {match.tab}
+            </button>
+          )}
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+```
+
+- [ ] **Step 15.3: Test ExplainTooltip**
+
+```tsx
+// frontend/src/components/highlight/__tests__/ExplainTooltip.test.tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { ExplainTooltip } from "../ExplainTooltip";
+import { searchApi } from "../../../services/api";
+import type { WithinMatch } from "../../../services/api";
+
+vi.mock("../../../services/api", () => ({
+  searchApi: { explainPassage: vi.fn() },
+}));
+
+// Auth mock — we'll override per-test
+const useAuthMock = vi.fn();
+vi.mock("../../../hooks/useAuth", () => ({ useAuth: () => useAuthMock() }));
+
+afterEach(cleanup);
+
+const mockMatch: WithinMatch = {
+  source_type: "summary",
+  source_id: 1,
+  text: "transition énergétique",
+  text_html: "transition énergétique",
+  start_offset: 0,
+  end_offset: 22,
+  tab: "synthesis",
+  score: 0.91,
+  passage_id: "p1",
+};
+
+function renderTooltip(
+  props: Partial<React.ComponentProps<typeof ExplainTooltip>> = {},
+) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ExplainTooltip
+          open
+          match={mockMatch}
+          query="transition"
+          summaryId={42}
+          anchorRect={null}
+          onClose={() => {}}
+          onCiteInChat={() => {}}
+          {...props}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExplainTooltip", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls explainPassage and renders explanation for Pro", async () => {
+    useAuthMock.mockReturnValue({ user: { plan: "pro" } });
+    (searchApi.explainPassage as any).mockResolvedValue({
+      explanation: "Mentionne directement la transition énergétique.",
+      cached: false,
+      model_used: "mistral-small-latest",
+    });
+    renderTooltip();
+    await waitFor(() =>
+      expect(screen.getByText(/mentionne directement/i)).toBeInTheDocument(),
+    );
+    expect(searchApi.explainPassage).toHaveBeenCalledWith(
+      42,
+      "transition énergétique",
+      "transition",
+      "summary",
+    );
+  });
+
+  it("does NOT call explainPassage and shows upsell for free", async () => {
+    useAuthMock.mockReturnValue({ user: { plan: "free" } });
+    (searchApi.explainPassage as any).mockResolvedValue({
+      explanation: "should-not-render",
+      cached: false,
+      model_used: "x",
+    });
+    renderTooltip();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Comprendre ce passage avec l'IA/i),
+      ).toBeInTheDocument(),
+    );
+    expect(searchApi.explainPassage).not.toHaveBeenCalled();
+  });
+
+  it("close button triggers onClose", async () => {
+    useAuthMock.mockReturnValue({ user: { plan: "pro" } });
+    (searchApi.explainPassage as any).mockResolvedValue({
+      explanation: "x",
+      cached: true,
+      model_used: "mistral-small-latest",
+    });
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderTooltip({ onClose });
+    await waitFor(() => screen.getByText("x"));
+    await user.click(screen.getByLabelText(/fermer/i));
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 15.4: Run tests**
+
+```bash
+cd frontend && npm run test -- --run src/components/highlight/__tests__/ExplainTooltip.test.tsx
+```
+
+Expected : 3/3 pass.
+
+- [ ] **Step 15.5: Commit**
+
+```bash
+git add frontend/src/components/highlight/ExplainTooltip.tsx \
+        frontend/src/components/highlight/ExplainUpsellModal.tsx \
+        frontend/src/components/highlight/__tests__/ExplainTooltip.test.tsx
+git commit -m "feat(highlight): add ExplainTooltip with cache + free plan upsell modal"
+```
+
+---
+
+## Task 16: Wire Hub — provider + nav bar + Cmd+F + read query params
+
+**Files:**
+
+- Modify: `frontend/src/pages/HubPage.tsx`
+- Modify: `frontend/src/components/hub/HubAnalysisPanel.tsx`
+- Modify: `frontend/src/components/hub/HubHeader.tsx`
+
+**Dependencies:** Tasks 11, 12, 13, 14, 15.
+
+- [ ] **Step 16.1: Dans `HubPage.tsx`, ajouter les imports et le wrap provider**
+
+Imports à ajouter :
+
+```tsx
+import { SemanticHighlightProvider } from "../components/highlight/SemanticHighlightProvider";
+import { HighlightNavigationBar } from "../components/highlight/HighlightNavigationBar";
+import { IntraAnalysisSearchBar } from "../components/highlight/IntraAnalysisSearchBar";
+import { ExplainTooltip } from "../components/highlight/ExplainTooltip";
+import { useCmdFIntercept } from "../components/highlight/useCmdFIntercept";
+import { useSemanticHighlight } from "../components/highlight/useSemanticHighlight";
+import type { WithinMatch } from "../services/api";
+```
+
+À l'intérieur du composant `HubPage` (avant le return) :
+
+```tsx
+// Search params côté Hub : ?summaryId=...&q=...&highlight=...&tab=...
+const initialQ = searchParams.get("q") ?? "";
+const initialHighlight = searchParams.get("highlight");
+const initialTabFromSearch = searchParams.get("tab");
+
+// Search bar visibility (Cmd+F)
+const [searchBarOpen, setSearchBarOpen] = useState(initialQ.length > 0);
+useCmdFIntercept({
+  scopeSelector: ".analysis-page",
+  enabled: !!selectedSummary,
+  onIntercept: () => setSearchBarOpen(true),
+});
+
+// Tooltip state
+const [tooltip, setTooltip] = useState<{
+  match: WithinMatch | null;
+  rect: DOMRect | null;
+}>({ match: null, rect: null });
+```
+
+Wrapper le JSX racine avec `<SemanticHighlightProvider>` et ajouter `className="analysis-page"` sur le container racine de l'analyse :
+
+```tsx
+return (
+  <SemanticHighlightProvider summaryId={selectedSummary?.id ?? null}>
+    <div className="analysis-page min-h-screen flex flex-col bg-bg-primary">
+      <HubHeader
+        /* ...existing props... */
+        onSearchClick={() => setSearchBarOpen(true)}
+      />
+      <IntraAnalysisSearchBar
+        open={searchBarOpen}
+        onClose={() => setSearchBarOpen(false)}
+      />
+      <HighlightNavigationBar />
+      {/* ...rest of existing JSX... */}
+      <ExplainTooltip
+        open={!!tooltip.match}
+        match={tooltip.match}
+        query={/* read from highlight ctx */ ""}
+        summaryId={selectedSummary?.id ?? 0}
+        anchorRect={tooltip.rect}
+        onClose={() => setTooltip({ match: null, rect: null })}
+        onCiteInChat={(text) => {
+          /* prefill chat input via existing hubStore */
+          useHubStore.getState().setPrefillMessage?.(text);
+        }}
+        onJumpToTab={(tab) => setActiveTab(tab as TabId)}
+      />
+    </div>
+  </SemanticHighlightProvider>
+);
+```
+
+> **Note** : `query` dans `<ExplainTooltip>` doit venir du highlight context. Comme `useSemanticHighlight()` n'est dispo qu'à l'intérieur du provider, créer un sous-composant interne `<HubBody>` qui fait le `useSemanticHighlight()` et reçoit en prop `tooltip` + setter. Ou simpler : passer `query` directement via tooltip state. Laisser le sub-agent décider de la factorisation cleanest.
+
+- [ ] **Step 16.2: Brancher l'auto-focus du highlight initial (`?highlight=...`)**
+
+Dans le sous-composant qui consomme le highlight context, à mount :
+
+```tsx
+const ctx = useSemanticHighlight();
+useEffect(() => {
+  if (ctx && initialQ && initialHighlight && ctx.matches.length === 0) {
+    ctx.setQuery(initialQ); // triggers fetch
+  }
+}, [initialQ, initialHighlight, ctx]);
+useEffect(() => {
+  if (ctx && initialHighlight && ctx.matches.length > 0) {
+    ctx.focus(initialHighlight);
+  }
+}, [ctx?.matches, initialHighlight]);
+```
+
+Et activer le bon tab :
+
+```tsx
+useEffect(() => {
+  if (initialTabFromSearch && initialTabFromSearch !== activeTab) {
+    setActiveTab(initialTabFromSearch as TabId);
+  }
+}, [initialTabFromSearch]);
+```
+
+- [ ] **Step 16.3: Ajouter `onSearchClick` dans `HubHeader.tsx`**
+
+Étendre `Props` :
+
+```typescript
+onSearchClick?: () => void;
+```
+
+Ajouter un bouton loupe dans la barre, à droite du title (avant `pipSlot`) :
+
+```tsx
+{
+  onSearchClick && (
+    <button
+      type="button"
+      aria-label="Rechercher dans cette analyse"
+      aria-keyshortcuts="Control+F Meta+F"
+      onClick={onSearchClick}
+      className="w-8 h-8 grid place-items-center rounded-lg text-white/65 hover:bg-white/[0.06] hover:text-white"
+    >
+      <Search className="w-4 h-4" />
+    </button>
+  );
+}
+```
+
+(Importer `Search` de `lucide-react`.)
+
+- [ ] **Step 16.4: Wrapper `HubAnalysisPanel.tsx` children avec `<HighlightedText tab={activeTab}>`**
+
+Importer `HighlightedText`. Wrapper le `<AnalysisHub>` :
+
+```tsx
+return (
+  <div className="px-4 py-4 w-full">
+    <HighlightedText
+      tab={activeTab}
+      onMarkClick={(_id, match) => {
+        // Need access to the click target rect — use document.querySelector inline
+        const el = document.querySelector<HTMLElement>(
+          `mark.ds-highlight[data-passage-id="${match.passage_id}"]`,
+        );
+        const rect = el?.getBoundingClientRect() ?? null;
+        // Bubble up to HubPage via a custom event for simplicity
+        window.dispatchEvent(
+          new CustomEvent("ds-highlight-click", { detail: { match, rect } }),
+        );
+      }}
+    >
+      <AnalysisHub /* ...props existants... */ />
+    </HighlightedText>
+  </div>
+);
+```
+
+Et dans `HubPage.tsx`, écouter l'event :
+
+```tsx
+useEffect(() => {
+  const onClick = (e: Event) => {
+    const ce = e as CustomEvent<{ match: WithinMatch; rect: DOMRect }>;
+    setTooltip({ match: ce.detail.match, rect: ce.detail.rect });
+  };
+  window.addEventListener("ds-highlight-click", onClick);
+  return () => window.removeEventListener("ds-highlight-click", onClick);
+}, []);
+```
+
+- [ ] **Step 16.5: Run tests existants Hub pour vérifier non-régression**
+
+```bash
+cd frontend && npm run test -- --run src/pages/__tests__ src/components/hub
+```
+
+Expected : 0 régression. (S'il y a des tests Hub qui utilisent `HubPage`, ils peuvent nécessiter un mock léger pour les nouveaux providers — adapter au cas par cas.)
+
+- [ ] **Step 16.6: Commit**
+
+```bash
+git add frontend/src/pages/HubPage.tsx \
+        frontend/src/components/hub/HubAnalysisPanel.tsx \
+        frontend/src/components/hub/HubHeader.tsx
+git commit -m "feat(highlight): wire SemanticHighlight into Hub (Cmd+F + nav bar + tooltip + deeplink)"
+```
+
+---
+
+## Task 17: i18n — clés FR/EN pour search/tooltip/upsell
+
+**Files:**
+
+- Modify: `frontend/src/i18n/fr.json` + `en.json`
+
+**Dependencies:** Tasks 5, 7, 8, 13, 14, 15.
+
+> **Note** : pendant les tasks 5-15 le code utilise des chaînes inline FR ("Recherche", "Filtres avancés", etc.). Cette task migre vers `t.search.*`. Si la quantité de strings est faible, l'agent peut décider de garder les strings inline pour V1 et juste ajouter `nav.search` (déjà fait task 9). Dans ce cas, **skipper cette task** et marquer comme "i18n V2".
+
+- [ ] **Step 17.1: Ajouter dans `fr.json`**
+
+```json
+"search": {
+  "placeholder": "Rechercher dans tes analyses…",
+  "filters": {
+    "all": "Tout",
+    "summary": "Synthèse",
+    "flashcard": "Flashcards",
+    "quiz": "Quiz",
+    "chat": "Chat",
+    "transcript": "Transcripts",
+    "advanced": "Filtres avancés"
+  },
+  "empty": {
+    "noQuery": "Cherche dans toutes tes analyses, flashcards, quiz et chats.",
+    "noResults": "Aucun résultat pour « {query} »",
+    "recentTitle": "Recherches récentes"
+  },
+  "tooltip": {
+    "title": "IA · Pourquoi ce passage matche",
+    "citeInChat": "Citer dans chat",
+    "seekTimecode": "Sauter au timecode",
+    "viewIn": "Voir dans {tab}",
+    "error": "Impossible de générer l'explication."
+  },
+  "upsell": {
+    "title": "Comprendre ce passage avec l'IA",
+    "body": "Le tooltip IA est inclus avec Pro et Expert.",
+    "cta": "Essai gratuit 7 jours →"
+  }
+}
+```
+
+- [ ] **Step 17.2: Mirror dans `en.json`** (traduire string par string).
+
+- [ ] **Step 17.3: Migrer (optionnel — V2 si scope serré) les strings inline des composants vers `t.search.*` via `useTranslation()`**.
+
+- [ ] **Step 17.4: Run tests**
+
+```bash
+cd frontend && npm run test -- --run
+```
+
+- [ ] **Step 17.5: Commit**
+
+```bash
+git add frontend/src/i18n/fr.json frontend/src/i18n/en.json
+git commit -m "feat(search): add i18n keys for search page, tooltip and upsell"
+```
+
+---
+
+## Task 18: E2E spec 1 — Recherche globale + click → Hub
+
+**Files:**
+
+- Create: `frontend/e2e/semantic-search-global.spec.ts`
+
+**Dependencies:** Tasks 1-9.
+
+- [ ] **Step 18.1: Créer le spec**
+
+```typescript
+// frontend/e2e/semantic-search-global.spec.ts
+import { test, expect } from "@playwright/test";
+
+const TEST_USER = {
+  email: process.env.E2E_USER ?? "e2e@deepsight.test",
+  password: process.env.E2E_PASS ?? "test1234",
+};
+
+test.describe("Semantic Search V1 — Global page", () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the API so the test does not depend on backend data
+    await page.route("**/api/search/global", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          query: "transition",
+          total_results: 1,
+          results: [
+            {
+              source_type: "summary",
+              source_id: 42,
+              summary_id: 42,
+              score: 0.91,
+              text_preview:
+                "La transition énergétique impose une refonte du mix.",
+              source_metadata: {
+                summary_title: "Crise énergétique EU",
+                channel: "Le Monde",
+                tab: "synthesis",
+              },
+            },
+          ],
+          searched_at: new Date().toISOString(),
+        }),
+      });
+    });
+    await page.route("**/api/search/recent-queries", async (route) =>
+      route.fulfill({ status: 200, body: JSON.stringify({ queries: [] }) }),
+    );
+
+    await page.goto("/login");
+    await page.fill('input[type="email"]', TEST_USER.email);
+    await page.fill('input[type="password"]', TEST_USER.password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/dashboard/);
+  });
+
+  test("/search loads, search returns results, click goes to /hub", async ({
+    page,
+  }) => {
+    await page.goto("/search");
+    await expect(
+      page.getByRole("heading", { name: /recherche/i }),
+    ).toBeVisible();
+
+    await page.fill('input[type="search"]', "transition");
+    await expect(page.getByText("Crise énergétique EU")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.getByTestId("search-result-card").first().click();
+    await expect(page).toHaveURL(/\/hub\?.*summaryId=42/);
+    await expect(page).toHaveURL(/highlight=summary-42/);
+  });
+
+  test("'Tout' pill is active by default and toggles type", async ({
+    page,
+  }) => {
+    await page.goto("/search");
+    await page.fill('input[type="search"]', "ai");
+    const allPill = page.getByRole("button", { name: /Tout/ });
+    await expect(allPill).toHaveAttribute("aria-pressed", "true");
+
+    const synthPill = page.getByRole("button", { name: /Synthèse/ });
+    await synthPill.click();
+    await expect(synthPill).toHaveAttribute("aria-pressed", "true");
+  });
+});
+```
+
+- [ ] **Step 18.2: Lancer**
+
+```bash
+cd frontend && npx playwright test e2e/semantic-search-global.spec.ts
+```
+
+Expected : 2/2 pass (avec un user de test seedé OU en skippant via `test.skip(!E2E_USER)` ; le premier `test.beforeEach` peut être commenté pour exécution sans backend si user_test indisponible).
+
+- [ ] **Step 18.3: Commit**
+
+```bash
+git add frontend/e2e/semantic-search-global.spec.ts
+git commit -m "test(search): add e2e spec for global search page and click flow"
+```
+
+---
+
+## Task 19: E2E spec 2 — Cmd+F intercept + intra-analyse navigation
+
+**Files:**
+
+- Create: `frontend/e2e/semantic-search-intra.spec.ts`
+
+**Dependencies:** Task 16.
+
+- [ ] **Step 19.1: Créer le spec**
+
+```typescript
+// frontend/e2e/semantic-search-intra.spec.ts
+import { test, expect } from "@playwright/test";
+
+const TEST_USER = {
+  email: process.env.E2E_USER ?? "e2e@deepsight.test",
+  password: process.env.E2E_PASS ?? "test1234",
+};
+
+test.describe("Semantic Search V1 — Intra-analysis", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/search/within/**", async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          matches: [
+            {
+              source_type: "summary",
+              source_id: 1,
+              text: "transition énergétique",
+              text_html: "transition énergétique",
+              start_offset: 0,
+              end_offset: 22,
+              tab: "synthesis",
+              score: 0.91,
+              passage_id: "s-1",
+            },
+            {
+              source_type: "summary",
+              source_id: 2,
+              text: "transition énergétique",
+              text_html: "transition énergétique",
+              start_offset: 0,
+              end_offset: 22,
+              tab: "synthesis",
+              score: 0.85,
+              passage_id: "s-2",
+            },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto("/login");
+    await page.fill('input[type="email"]', TEST_USER.email);
+    await page.fill('input[type="password"]', TEST_USER.password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/dashboard/);
+  });
+
+  test("Cmd+F opens floating search bar and navigates matches", async ({
+    page,
+  }) => {
+    await page.goto("/hub");
+    // Need an active analysis. If user has none, skip:
+    const drawerBtn = page.getByRole("button", { name: /Conversations/ });
+    await drawerBtn.click();
+    const firstConv = page.locator("aside button").first();
+    if (!(await firstConv.isVisible())) {
+      test.skip(true, "no analysis for test user");
+    }
+    await firstConv.click();
+
+    // Trigger Cmd+F (use Control on Linux/Win)
+    const isMac = process.platform === "darwin";
+    await page.keyboard.press(isMac ? "Meta+F" : "Control+F");
+
+    const intraInput = page.getByRole("searchbox", {
+      name: /rechercher dans l'analyse/i,
+    });
+    await expect(intraInput).toBeVisible();
+
+    await intraInput.fill("transition");
+    await expect(page.getByText("1/2")).toBeVisible({ timeout: 3000 });
+
+    // Press F3 → counter goes to 2/2
+    await page.keyboard.press("F3");
+    await expect(page.getByText("2/2")).toBeVisible();
+
+    // Esc closes the bar
+    await page.keyboard.press("Escape");
+    await expect(intraInput).not.toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 19.2: Lancer**
+
+```bash
+cd frontend && npx playwright test e2e/semantic-search-intra.spec.ts
+```
+
+Expected : 1/1 pass (ou skip si user de test sans analyse).
+
+- [ ] **Step 19.3: Commit**
+
+```bash
+git add frontend/e2e/semantic-search-intra.spec.ts
+git commit -m "test(search): add e2e spec for Cmd+F intra-analysis search and F3 navigation"
+```
+
+---
+
+## Task 20: E2E spec 3 — Tooltip IA Pro vs upsell free
+
+**Files:**
+
+- Create: `frontend/e2e/semantic-search-tooltip.spec.ts`
+
+**Dependencies:** Task 15, Task 16.
+
+- [ ] **Step 20.1: Créer le spec**
+
+```typescript
+// frontend/e2e/semantic-search-tooltip.spec.ts
+import { test, expect } from "@playwright/test";
+
+// This spec mocks BOTH within and explain endpoints, and uses two test users
+// (E2E_USER_PRO and E2E_USER_FREE) — provided via env. If unset, skips.
+
+const PRO = {
+  email: process.env.E2E_USER_PRO ?? "",
+  password: process.env.E2E_PASS_PRO ?? "",
+};
+const FREE = {
+  email: process.env.E2E_USER_FREE ?? "",
+  password: process.env.E2E_PASS_FREE ?? "",
+};
+
+async function loginAndOpenHub(
+  page: any,
+  creds: { email: string; password: string },
+) {
+  await page.goto("/login");
+  await page.fill('input[type="email"]', creds.email);
+  await page.fill('input[type="password"]', creds.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/dashboard/);
+  await page.goto("/hub");
+  const drawer = page.getByRole("button", { name: /Conversations/ });
+  await drawer.click();
+  const first = page.locator("aside button").first();
+  if (!(await first.isVisible())) test.skip(true, "no analysis");
+  await first.click();
+}
+
+async function setupMocks(page: any) {
+  await page.route("**/api/search/within/**", async (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        matches: [
+          {
+            source_type: "summary",
+            source_id: 1,
+            text: "transition",
+            text_html: "transition",
+            start_offset: 0,
+            end_offset: 10,
+            tab: "synthesis",
+            score: 0.9,
+            passage_id: "s-1",
+          },
+        ],
+      }),
+    }),
+  );
+  await page.route("**/api/search/explain-passage", async (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        explanation: "Mentionne directement la transition énergétique.",
+        cached: false,
+        model_used: "mistral-small-latest",
+      }),
+    }),
+  );
+}
+
+test.describe("Semantic Search V1 — Tooltip IA", () => {
+  test.skip(
+    !PRO.email || !FREE.email,
+    "needs E2E_USER_PRO + E2E_USER_FREE envs",
+  );
+
+  test("Pro user gets the tooltip with IA explanation", async ({ page }) => {
+    await setupMocks(page);
+    await loginAndOpenHub(page, PRO);
+
+    const isMac = process.platform === "darwin";
+    await page.keyboard.press(isMac ? "Meta+F" : "Control+F");
+    await page
+      .getByRole("searchbox", { name: /rechercher dans l'analyse/i })
+      .fill("transition");
+    // Wait for highlight to appear, then click it
+    const mark = page.locator("mark.ds-highlight").first();
+    await expect(mark).toBeVisible();
+    await mark.click();
+    await expect(page.getByRole("tooltip")).toBeVisible();
+    await expect(page.getByText(/mentionne directement/i)).toBeVisible();
+  });
+
+  test("Free user sees upsell modal instead of tooltip", async ({ page }) => {
+    await setupMocks(page);
+    await loginAndOpenHub(page, FREE);
+
+    const isMac = process.platform === "darwin";
+    await page.keyboard.press(isMac ? "Meta+F" : "Control+F");
+    await page
+      .getByRole("searchbox", { name: /rechercher dans l'analyse/i })
+      .fill("transition");
+    const mark = page.locator("mark.ds-highlight").first();
+    await mark.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(
+      page.getByText(/Comprendre ce passage avec l'IA/i),
+    ).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 20.2: Lancer**
+
+```bash
+cd frontend && npx playwright test e2e/semantic-search-tooltip.spec.ts
+```
+
+Expected : 2/2 pass si users seeded, sinon skip.
+
+- [ ] **Step 20.3: Commit**
+
+```bash
+git add frontend/e2e/semantic-search-tooltip.spec.ts
+git commit -m "test(search): add e2e spec for IA tooltip Pro vs upsell free"
+```
+
+---
+
+## Task 21: Final validation + cleanup
+
+**Files:** Aucun (validation uniquement)
+
+**Dependencies:** Toutes les tasks précédentes.
+
+- [ ] **Step 21.1: Run full frontend validation**
+
+```bash
+cd frontend
+npm run typecheck
+npm run lint
+npm run test -- --run
+npm run build
+```
+
+Expected : 4/4 green.
+
+- [ ] **Step 21.2: Sanity manuel local**
+
+```bash
+cd frontend && npm run dev
+```
+
+Ouvrir `http://localhost:5173/search` après login → vérifier :
+
+- Page rend, sidebar a "Recherche", input visible
+- Taper >= 2 chars → fetch (peut 404 si flag backend OFF en dev — c'est attendu, juste vérifier qu'il n'y a pas de crash UI)
+
+Ouvrir `/hub`, sélectionner une conversation, presser Cmd/Ctrl+F → la search bar s'ouvre.
+
+- [ ] **Step 21.3: Vérifier la liste des fichiers attendus**
+
+```bash
+git diff main --stat
+```
+
+Doit lister les fichiers énumérés en "Files créés" et "Files modifiés" plus haut.
+
+- [ ] **Step 21.4: Push (sans merger — la branche reste pour review)**
+
+```bash
+git push -u origin feat/search-web-phase2
+```
+
+- [ ] **Step 21.5: (optionnel) Ouvrir la PR**
+
+```bash
+gh pr create --title "feat(search): semantic search V1 phase 2 web frontend" \
+  --body "$(cat <<'EOF'
+## Summary
+- /search page (sidebar nav + filters + virtualized results + recent queries)
+- Intra-analysis Cmd+F search with highlights, navigation bar (F3, Esc) and ExplainTooltip (Pro+) / upsell (free)
+- 5 new searchApi methods + types
+- semanticSearchTooltip plan feature flag (Free=off, Pro/Expert=on)
+
+## Test plan
+- [ ] Vitest unit suites pass: search/* + highlight/* + pages/SearchPage
+- [ ] Playwright: semantic-search-global, semantic-search-intra, semantic-search-tooltip
+- [ ] Manual: /search renders, /hub Cmd+F opens search bar, mark click opens tooltip (or upsell for free)
+- [ ] Backend feature flag SEMANTIC_SEARCH_V1_ENABLED stays OFF in prod for now (Phase 5 activation)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+(Si l'utilisateur préfère merger lui-même, skipper cette étape.)
+
+---
+
+## Récapitulatif des dépendances entre tasks
+
+```
+Task 1 (api.ts) ──────────► Tasks 3, 4, 6, 11, 15
+Task 2 (planPrivileges) ──► Task 15
+
+Task 3 (useSemanticSearch) ──┐
+Task 4 (useRecentQueries) ───┤
+Task 5 (SearchInput) ────────┼──► Task 8 (SearchPage) ──► Task 9 (route + sidebar) ──► Task 18 (e2e global)
+Task 6 (filters) ────────────┤
+Task 7 (results) ────────────┘
+
+Task 10 (highlight.css) ─────┐
+Task 11 (Provider) ──────────┼──► Task 12 (HighlightedText)
+                             ├──► Task 13 (NavBar)        ──┐
+                             ├──► Task 14 (SearchBar+Cmd+F) ┤
+                             └──► Task 15 (ExplainTooltip)  ┤
+                                                            ▼
+                                                   Task 16 (Hub wire)
+                                                            │
+                                                            ▼
+                                              Tasks 19, 20 (e2e intra/tooltip)
+
+Task 17 (i18n) — optional, après 5/7/8/13/14/15 si on migre les strings
+
+Task 21 (final validation) — dernière
+```
+
+## Estimation totale
+
+- **21 tasks** au total (incluant Step 0 setup)
+- **3-5 minutes par step** × ~5 steps moyenne par task = **~15-20 min par task**
+- **Total estimé : 5-7 heures de travail focused** (un sub-agent Opus 4.7)
+- Si scindé en 2 sub-agents parallèles (Tasks 1-10/19 + Tasks 11-16/19-20), durée wall-clock : **3-4h**
+
+## Risques et concerns flaggés pour review humaine
+
+1. **Le composant `frontend/src/components/sidebar/SidebarNav.tsx` mentionné par le spec est ORPHELIN** — il n'est importé nulle part en prod. Le sidebar réel est `frontend/src/components/layout/Sidebar.tsx`. Le plan modifie les 2 par cohérence avec l'intent du spec, mais la modif du fichier orphelin est cosmétique.
+2. **Pas de `@floating-ui/react` dans le projet** — le spec demande `@floating-ui/react` mais on ne l'a pas. Le plan utilise un positionnement custom Framer Motion + DOMRect (déjà installé). Si l'utilisateur veut le polish floating-ui (auto-flip, collision detection), ajouter `npm i @floating-ui/react` et refacto Task 15 — coût : +30 min.
+3. **Le spec dit click flow → `/analysis/{id}?...` mais cette route N'EXISTE PAS dans App.tsx** — la "page d'analyse" est `/hub` avec query params (architecture Hub Unified mergée 2026-05-03). Le plan utilise donc `/hub?summaryId=...&q=...&highlight=...&tab=...`. Confirmer que c'est l'intention.
+4. **L'injection `<mark>` via DOM walker post-render** est pragmatique mais imparfaite : si le passage texte chevauche du markdown inline (gras, lien) il sera skip. C'est V1 acceptable selon le spec mais à monitorer en prod.
+5. **Le tooltip mockup spec montre "Sauter au timecode" mais on ne sait pas extraire le timecode du `WithinMatch.text` sans logique custom** — le plan laisse un `seekableSecs = null` placeholder en V1. Phase 5+ : améliorer en lisant `source_metadata.start_ts` quand backend l'exposera dans within response (actuellement seulement dans global response).
+6. **Les E2E tests dépendent de `E2E_USER` env vars** existants ou seedés. Si le user de test n'a pas d'analyse, les tests skip — c'est aligné avec les patterns existants (`hub-unified.spec.ts`).
+7. **i18n Task 17 est marquée optional** — pour rester strict scope, le plan utilise des strings inline FR partout (sauf `nav.search`). Si UX EN est requis pour le launch, faire la task 17 complètement.
+8. **Pas de mise à jour `posthog`** — les events `search_query` / `search_result_clicked` / etc. utilisent `analytics.track` (helper existant) mais leur définition côté Posthog dashboard est hors scope frontend.

--- a/docs/superpowers/plans/2026-05-03-semantic-search-v1-phase3-mobile.md
+++ b/docs/superpowers/plans/2026-05-03-semantic-search-v1-phase3-mobile.md
@@ -1,0 +1,3053 @@
+# Semantic Search V1 — Phase 3 Mobile (Expo) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apporter la recherche sémantique tri-source (synthèse + flashcards + quiz + chat + transcripts) à l'app mobile Expo SDK 54, avec un nouveau tab `Search` dédié, une recherche intra-analyse via bouton loupe dans le header de `analysis/[id].tsx`, et un `PassageActionSheet` BottomSheet (3 actions tap-friendly) au tap sur un passage surligné. Pas de tooltip IA mobile (tier medium = espace contraint).
+
+**Architecture:** Le backend Phase 1 (PR #292 mergée) expose déjà `POST /api/search/global`, `POST /api/search/within/{summary_id}`, `GET/DELETE /api/search/recent-queries`. Côté mobile, on consomme ces endpoints via `searchApi` étendu dans `services/api.ts`, on alimente l'UI via React Query (debounce 400ms — plus tolérant que web 200ms à cause du clavier mobile), on cache les recent queries dans `AsyncStorage`. Aucun nouveau Zustand store nécessaire — React Query suffit pour l'état serveur, `useState` local pour les filtres, et un nouveau hook léger `useHighlightNav` pour la navigation entre matches dans la page analyse. **Pas d'endpoint `/explain-passage`** consommé : tier mobile = pas de tooltip IA.
+
+**Tech Stack:** Expo SDK 54, React Native 0.81.5, React 19.1, TypeScript strict, Expo Router v2, TanStack Query 5, `@shopify/flash-list` v2.2 (FlashList virtualisée), `@gorhom/bottom-sheet` v5.2 (déjà installé mais on privilégie `SimpleBottomSheet` interne pour cohérence Expo Go), `react-native-reanimated` 4.1, `@react-native-async-storage/async-storage` v2.2, Jest + Testing Library RN, Detox (E2E facultatif).
+
+**Spec source:** `docs/superpowers/specs/2026-05-03-semantic-search-design.md` — focus Section 5 (Mobile).
+
+**Branche worktree:** `feat/search-mobile-phase3` créée depuis `main` (Phase 1 backend déjà mergée). Pas de dépendance avec Phases 2 (web) et 4 (extension) — peut tourner en parallèle.
+
+---
+
+## File Structure
+
+### Files créés
+
+- `mobile/app/(tabs)/search.tsx` — screen racine du nouveau tab
+- `mobile/src/components/search/SearchBar.tsx` — input + suggestions recent queries
+- `mobile/src/components/search/SearchFiltersSheet.tsx` — BottomSheet filtres avancés (pills + dropdowns)
+- `mobile/src/components/search/SearchResultsList.tsx` — FlashList virtualisée
+- `mobile/src/components/search/SearchResultCard.tsx` — carte avec badge type + thumbnail
+- `mobile/src/components/search/SearchEmptyState.tsx` — empty state + suggestions queries récentes
+- `mobile/src/components/search/useSemanticSearch.ts` — hook React Query + debounce 400ms
+- `mobile/src/components/search/useRecentQueries.ts` — hook AsyncStorage + sync API
+- `mobile/src/components/search/index.ts` — barrel export
+- `mobile/src/components/highlight/HighlightedText.tsx` — wrapper Text qui injecte les matches
+- `mobile/src/components/highlight/PassageActionSheet.tsx` — BottomSheet 3 actions (Demander à l'IA, Sauter timecode, Voir dans tab)
+- `mobile/src/components/highlight/HighlightNavigationBar.tsx` — FAB compteur + ↑↓
+- `mobile/src/components/highlight/useHighlightNav.ts` — hook navigation cross-tab matches
+- `mobile/src/components/highlight/SemanticHighlighter.tsx` — Provider state matches + nav (Context React)
+- `mobile/src/components/highlight/index.ts` — barrel export
+- `mobile/src/components/search/__tests__/SearchBar.test.tsx`
+- `mobile/src/components/search/__tests__/SearchResultCard.test.tsx`
+- `mobile/src/components/search/__tests__/useSemanticSearch.test.ts`
+- `mobile/src/components/highlight/__tests__/HighlightedText.test.tsx`
+- `mobile/src/components/highlight/__tests__/PassageActionSheet.test.tsx`
+- `mobile/src/components/highlight/__tests__/useHighlightNav.test.ts`
+- `mobile/e2e/semantic-search.e2e.ts` — Detox flow (optionnel — task 16)
+
+### Files modifiés
+
+- `mobile/src/services/api.ts` — étendre `searchApi` avec `globalSearch`, `withinSearch`, `getRecentQueries`, `clearRecentQueries`
+- `mobile/app/(tabs)/_layout.tsx` — ajout `<Tabs.Screen name="search" />`
+- `mobile/src/components/navigation/CustomTabBar.tsx` — entrée `search` dans `TAB_META`
+- `mobile/app/(tabs)/analysis/[id].tsx` — bouton loupe dans `BackHeader` + intégration `SemanticHighlighter` provider + lecture des params `q` / `highlight` / `tab`
+- `mobile/src/components/analysis/AnalysisContentDisplay.tsx` — wrap les paragraphes avec `<HighlightedText>` quand `SemanticHighlighter` actif
+- `mobile/src/config/planPrivileges.ts` — ajout du flag `semanticSearchTooltip: boolean` dans `PlanFeatures` (mirror du backend, même si non consommé sur mobile — pour cohérence cross-platform et upsell potentiel V1.1)
+- `mobile/app/(tabs)/hub.tsx` — accepter le param `prefillQuery: string` pour pré-remplir le champ Chat depuis l'action sheet "Demander à l'IA"
+- `mobile/src/components/conversation/ConversationContent.tsx` — accepter prop `initialPrompt` et la passer à `ConversationInput` (auto-focus + auto-fill)
+- `mobile/src/components/conversation/ConversationInput.tsx` — accepter prop `initialValue` (pré-remplissage)
+
+### Hors scope cette PR
+
+- Backend `/api/search/explain-passage` — pas consommé sur mobile (pas de tooltip IA tier medium)
+- EAS update prod OTA — réservé à l'orchestration release globale (Phase finale = activation feature flag)
+- Backend FEATURE_SEMANTIC_SEARCH_V1 OFF par défaut sur backend prod ; le mobile checke `/api/features` pour cacher le tab tant que le flag est OFF — l'implémentation du gating front est dans cette PR (Task 14), le toggle backend reste manuel (sshmaire SSH set env var)
+
+---
+
+## Conventions globales pour TOUTES les tasks
+
+- Branche worktree dédiée : `feat/search-mobile-phase3` (depuis `main`)
+- Commits ASCII propres (pas d'emojis), prefix `feat(mobile-search):` / `test(mobile-search):` / `chore(mobile-search):` selon scope
+- Tests Jest + `@testing-library/react-native` v12 (pattern existant dans `mobile/src/components/tutor/__tests__/`)
+- Mocks API via `jest.mock("../../../services/api", () => ({ searchApi: { ... } }))`
+- TypeScript strict, **zéro `any`** — préférer `unknown` puis narrowing
+- Toutes les surfaces interactives : `accessibilityLabel` + `accessibilityRole`
+- Zone de tap minimum 32×32px : `hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}` sur les `<Text>` highlightés
+- Animations via `react-native-reanimated` 4 — JAMAIS `Animated` legacy de RN
+- Listes longues : **toujours `FlashList`** de `@shopify/flash-list` (pas FlatList)
+- Couleurs via `palette` ou `colors` du `useTheme()` — JAMAIS de hex hardcodé en composant
+- `StyleSheet.create({...})` en bas de chaque fichier — pas de styles inline sauf valeurs dynamiques
+- Texte FR par défaut (cf. `useTheme` lang FR primaire) — chaînes en dur acceptable V1, pas d'i18n stricte requise
+
+---
+
+## Task 1 — Étendre `searchApi` dans `mobile/src/services/api.ts`
+
+**Files:**
+
+- Modify: `mobile/src/services/api.ts` (lignes 2289-2320, étendre la section `Search API`)
+
+**Goal:** Ajouter les 4 méthodes consommant les endpoints Phase 1 backend (`globalSearch`, `withinSearch`, `getRecentQueries`, `clearRecentQueries`). Garder l'existant `semanticSearch` (legacy `/api/search/semantic`) pour ne pas casser le `useSearch` existant si appelé ailleurs.
+
+- [ ] **Step 1.1 : TDD — écrire le test d'abord**
+
+Create: `mobile/src/services/__tests__/searchApi.test.ts`
+
+```typescript
+import { searchApi } from "../api";
+
+global.fetch = jest.fn();
+
+describe("searchApi", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+  });
+
+  it("globalSearch envoie POST /api/search/global avec body complet", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: "transition",
+        total_results: 0,
+        results: [],
+        searched_at: "2026-05-03T10:00:00Z",
+      }),
+      headers: new Headers(),
+    });
+    await searchApi.globalSearch({
+      query: "transition",
+      limit: 20,
+      source_types: ["summary", "flashcard"],
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/search/global"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("transition"),
+      }),
+    );
+  });
+
+  it("withinSearch route correctement avec summary_id en path", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ summary_id: 42, query: "x", matches: [] }),
+      headers: new Headers(),
+    });
+    await searchApi.withinSearch(42, { query: "x" });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/search/within/42"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("getRecentQueries fait GET et retourne queries", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ queries: ["a", "b"] }),
+      headers: new Headers(),
+    });
+    const res = await searchApi.getRecentQueries();
+    expect(res.queries).toEqual(["a", "b"]);
+  });
+
+  it("clearRecentQueries fait DELETE", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => null,
+      headers: new Headers(),
+    });
+    await searchApi.clearRecentQueries();
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/search/recent-queries"),
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});
+```
+
+- [ ] **Step 1.2 : Lancer les tests — vérifier qu'ils échouent (4 erreurs : méthodes absentes)**
+
+```bash
+cd mobile && npm run test -- searchApi.test.ts
+```
+
+Attendu : `searchApi.globalSearch is not a function` × 4.
+
+- [ ] **Step 1.3 : Implémenter dans `mobile/src/services/api.ts`**
+
+Localiser le bloc actuel (~ligne 2309-2320) :
+
+```typescript
+export const searchApi = {
+  async semanticSearch(...): Promise<SemanticSearchResponse> { ... }
+};
+```
+
+Le remplacer par (en gardant `semanticSearch` legacy + ajout V1) :
+
+```typescript
+// ============================================
+// Search API V1 — Semantic Search (auth required)
+// ============================================
+export interface SearchSourceType {
+  source_type: "summary" | "flashcard" | "quiz" | "chat" | "transcript";
+}
+
+export interface GlobalSearchRequest {
+  query: string;
+  limit?: number;
+  source_types?: Array<
+    "summary" | "flashcard" | "quiz" | "chat" | "transcript"
+  >;
+  platform?: "youtube" | "tiktok" | "text";
+  lang?: string;
+  category?: string;
+  date_from?: string; // ISO 8601
+  date_to?: string;
+  favorites_only?: boolean;
+  playlist_id?: string;
+}
+
+export interface GlobalSearchResultItem {
+  source_type: "summary" | "flashcard" | "quiz" | "chat" | "transcript";
+  source_id: number;
+  summary_id: number | null;
+  score: number;
+  text_preview: string;
+  source_metadata: {
+    summary_title?: string;
+    summary_thumbnail?: string;
+    video_id?: string;
+    channel?: string;
+    tab?:
+      | "synthesis"
+      | "digest"
+      | "flashcards"
+      | "quiz"
+      | "chat"
+      | "transcript";
+    start_ts?: number;
+    end_ts?: number;
+    anchor?: string;
+    flashcard_id?: number;
+    quiz_question_id?: number;
+  };
+}
+
+export interface GlobalSearchResponse {
+  query: string;
+  total_results: number;
+  results: GlobalSearchResultItem[];
+  searched_at: string;
+}
+
+export interface WithinSearchRequest {
+  query: string;
+  source_types?: Array<
+    "summary" | "flashcard" | "quiz" | "chat" | "transcript"
+  >;
+}
+
+export interface WithinMatchItem {
+  source_type: "summary" | "flashcard" | "quiz" | "chat" | "transcript";
+  source_id: number;
+  summary_id: number;
+  text: string;
+  text_html: string;
+  tab: "synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript";
+  score: number;
+  passage_id: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface WithinSearchResponse {
+  summary_id: number;
+  query: string;
+  matches: WithinMatchItem[];
+}
+
+export interface RecentQueriesResponse {
+  queries: string[];
+}
+
+// LEGACY (existant — gardé pour compat)
+export interface SemanticSearchResult {
+  video_id: string;
+  score: number;
+  text_preview: string;
+  video_title: string;
+  video_channel: string;
+  thumbnail_url: string | null;
+  category: string | null;
+}
+
+export interface SemanticSearchResponse {
+  results: SemanticSearchResult[];
+  query: string;
+  total_results: number;
+  searched_at: string;
+}
+
+export const searchApi = {
+  // ───── V1 (Phase 1 backend mergée) ─────
+  async globalSearch(req: GlobalSearchRequest): Promise<GlobalSearchResponse> {
+    return request("/api/search/global", {
+      method: "POST",
+      body: req as unknown as Record<string, unknown>,
+    });
+  },
+
+  async withinSearch(
+    summaryId: number,
+    req: WithinSearchRequest,
+  ): Promise<WithinSearchResponse> {
+    return request(`/api/search/within/${summaryId}`, {
+      method: "POST",
+      body: req as unknown as Record<string, unknown>,
+    });
+  },
+
+  async getRecentQueries(): Promise<RecentQueriesResponse> {
+    return request("/api/search/recent-queries");
+  },
+
+  async clearRecentQueries(): Promise<void> {
+    await request("/api/search/recent-queries", { method: "DELETE" });
+  },
+
+  // ───── Legacy (gardé pour compat) ─────
+  async semanticSearch(
+    query: string,
+    limit: number = 10,
+    category?: string,
+  ): Promise<SemanticSearchResponse> {
+    return request("/api/search/semantic", {
+      method: "POST",
+      body: { query, limit, category },
+    });
+  },
+};
+```
+
+- [ ] **Step 1.4 : Vérifier que les tests passent**
+
+```bash
+cd mobile && npm run test -- searchApi.test.ts
+```
+
+Attendu : 4/4 verts.
+
+- [ ] **Step 1.5 : Vérifier le typecheck global**
+
+```bash
+cd mobile && npm run typecheck
+```
+
+Attendu : 0 erreur sur les fichiers touchés (les 19 erreurs pré-existantes ne sont pas notre concern, cf. memory `project_deepsight-mobile-refonte`).
+
+- [ ] **Step 1.6 : Commit atomique**
+
+```bash
+git add mobile/src/services/api.ts mobile/src/services/__tests__/searchApi.test.ts
+git commit -m "feat(mobile-search): extend searchApi with V1 endpoints (global/within/recent)"
+```
+
+---
+
+## Task 2 — Tab `search.tsx` + intégration `_layout.tsx` + `CustomTabBar.tsx`
+
+**Files:**
+
+- Create: `mobile/app/(tabs)/search.tsx`
+- Modify: `mobile/app/(tabs)/_layout.tsx`
+- Modify: `mobile/src/components/navigation/CustomTabBar.tsx`
+
+**Goal:** Activer un nouveau tab `Search` (icône loupe) entre `Library` et `Hub` dans la `CustomTabBar`. Le screen `search.tsx` est un squelette qui sera rempli par les composants des tasks suivantes — cette task le rend visible et navigable.
+
+- [ ] **Step 2.1 : Modifier `mobile/app/(tabs)/_layout.tsx`**
+
+Insérer un nouveau `<Tabs.Screen name="search" />` entre `library` et `hub` :
+
+```typescript
+<Tabs.Screen
+  name="library"
+  options={{ title: "Bibliothèque" }}
+/>
+<Tabs.Screen
+  name="search"
+  options={{ title: "Recherche" }}
+/>
+<Tabs.Screen
+  name="hub"
+  options={{ title: "Hub" }}
+/>
+```
+
+- [ ] **Step 2.2 : Modifier `mobile/src/components/navigation/CustomTabBar.tsx`**
+
+Dans le `TAB_META` (lignes 39-65), ajouter une entrée `search` entre `library` et `hub` :
+
+```typescript
+const TAB_META: Record<
+  string,
+  {
+    icon: keyof typeof Ionicons.glyphMap;
+    iconFocused: keyof typeof Ionicons.glyphMap;
+    label: string;
+  }
+> = {
+  index: { icon: "home-outline", iconFocused: "home", label: "Accueil" },
+  library: { icon: "time-outline", iconFocused: "time", label: "Historique" },
+  search: {
+    icon: "search-outline",
+    iconFocused: "search",
+    label: "Rechercher",
+  },
+  hub: {
+    icon: "chatbubbles-outline",
+    iconFocused: "chatbubbles",
+    label: "Hub",
+  },
+  study: { icon: "book-outline", iconFocused: "book", label: "Étude" },
+  subscription: {
+    icon: "sparkles-outline",
+    iconFocused: "sparkles",
+    label: "Abo",
+  },
+  profile: {
+    icon: "settings-outline",
+    iconFocused: "settings",
+    label: "Profil",
+  },
+};
+```
+
+- [ ] **Step 2.3 : Créer le screen squelette `mobile/app/(tabs)/search.tsx`**
+
+```typescript
+/**
+ * mobile/app/(tabs)/search.tsx
+ *
+ * Tab Search — recherche sémantique globale dans tout le contenu personnel
+ * du user (synthèses, flashcards, quiz, chat, transcripts).
+ *
+ * Spec : `docs/superpowers/specs/2026-05-03-semantic-search-design.md` §5
+ */
+
+import React, { useState, useCallback } from "react";
+import { View, Text, StyleSheet, KeyboardAvoidingView, Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@/contexts/ThemeContext";
+import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
+import { sp } from "@/theme/spacing";
+import { fontFamily, fontSize, textStyles } from "@/theme/typography";
+import { DoodleBackground } from "@/components/ui/DoodleBackground";
+import { SearchBar } from "@/components/search/SearchBar";
+import { SearchResultsList } from "@/components/search/SearchResultsList";
+import { SearchEmptyState } from "@/components/search/SearchEmptyState";
+import { useSemanticSearch } from "@/components/search/useSemanticSearch";
+import type { GlobalSearchRequest } from "@/services/api";
+
+export default function SearchScreen() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const tabBarFootprint = useTabBarFootprint();
+
+  const [query, setQuery] = useState("");
+  const [filters, setFilters] = useState<Partial<GlobalSearchRequest>>({});
+  const { data, isLoading, error } = useSemanticSearch(query, filters);
+
+  const handleQueryChange = useCallback((q: string) => setQuery(q), []);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bgPrimary }]}>
+      <DoodleBackground variant="search" density="low" />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={styles.flex}
+        keyboardVerticalOffset={insets.top}
+      >
+        <View style={[styles.header, { paddingTop: insets.top + sp.sm }]}>
+          <Text style={[styles.title, { color: colors.textPrimary }]}>Rechercher</Text>
+          <Text style={[styles.subtitle, { color: colors.textTertiary }]}>
+            Dans tes analyses, flashcards, quiz et chats
+          </Text>
+        </View>
+
+        <View style={styles.searchWrap}>
+          <SearchBar value={query} onChangeText={handleQueryChange} autoFocus />
+        </View>
+
+        {!query.trim() ? (
+          <SearchEmptyState onSelectQuery={handleQueryChange} />
+        ) : (
+          <SearchResultsList
+            results={data?.results ?? []}
+            isLoading={isLoading}
+            error={error}
+            bottomPadding={tabBarFootprint}
+            query={query}
+          />
+        )}
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  flex: { flex: 1 },
+  header: {
+    paddingHorizontal: sp.lg,
+    paddingBottom: sp.sm,
+  },
+  title: { ...textStyles.headingLg },
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    marginTop: 2,
+  },
+  searchWrap: {
+    paddingHorizontal: sp.lg,
+    paddingTop: sp.md,
+  },
+});
+```
+
+Note : `DoodleBackground variant="search"` n'existe peut-être pas — fallback `variant="video"` si besoin (ou ajouter le variant ailleurs en V1.1).
+
+- [ ] **Step 2.4 : Vérifier dans Expo Go**
+
+```bash
+cd mobile && npx expo start --clear
+```
+
+Le tab `Rechercher` apparaît avec icône loupe. La barre de recherche est visible. Sans query, l'empty state placeholder doit être visible (à ce stade un simple `<Text>` avant Task 3 vraiment branchée).
+
+**Note :** comme `useSemanticSearch` n'existe pas encore en task 2, créer un stub minimal :
+
+```typescript
+// Stub temporaire — sera remplacé en Task 7
+export function useSemanticSearch(_q: string, _f: any) {
+  return { data: undefined, isLoading: false, error: null };
+}
+```
+
+ainsi que `SearchBar` / `SearchResultsList` / `SearchEmptyState` stubs minimaux qui retournent `null`. Ces stubs seront remplacés dans les tasks 3, 4, 5, 7. Le but de cette task = naviguer vers le tab sans crash.
+
+- [ ] **Step 2.5 : Commit**
+
+```bash
+git add mobile/app/\(tabs\)/_layout.tsx \
+        mobile/app/\(tabs\)/search.tsx \
+        mobile/src/components/navigation/CustomTabBar.tsx \
+        mobile/src/components/search/
+git commit -m "feat(mobile-search): add Search tab between Library and Hub with skeleton screen"
+```
+
+---
+
+## Task 3 — Composant `SearchBar`
+
+**Files:**
+
+- Create: `mobile/src/components/search/SearchBar.tsx`
+- Create: `mobile/src/components/search/__tests__/SearchBar.test.tsx`
+
+**Goal:** Input cherchable avec auto-focus, debounce externe (le hook `useSemanticSearch` debounce — la SearchBar elle-même propage immédiatement), bouton clear, accessibilité tap-friendly. Style cohérent avec `mobile/src/components/library/SearchBar.tsx` mais autonome (pas la même responsabilité — celle-ci est full-screen, pas un overlay).
+
+- [ ] **Step 3.1 : TDD — test**
+
+Create: `mobile/src/components/search/__tests__/SearchBar.test.tsx`
+
+```typescript
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { SearchBar } from "../SearchBar";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe("SearchBar (search tab)", () => {
+  it("affiche le placeholder par défaut", () => {
+    const { getByPlaceholderText } = renderWithTheme(
+      <SearchBar value="" onChangeText={jest.fn()} />,
+    );
+    expect(getByPlaceholderText(/rechercher/i)).toBeTruthy();
+  });
+
+  it("propage onChangeText à chaque frappe", () => {
+    const onChange = jest.fn();
+    const { getByPlaceholderText } = renderWithTheme(
+      <SearchBar value="" onChangeText={onChange} />,
+    );
+    fireEvent.changeText(getByPlaceholderText(/rechercher/i), "transition");
+    expect(onChange).toHaveBeenCalledWith("transition");
+  });
+
+  it("affiche le bouton clear quand value non vide et le déclenche", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = renderWithTheme(
+      <SearchBar value="abc" onChangeText={onChange} />,
+    );
+    const clearBtn = getByLabelText(/effacer/i);
+    fireEvent.press(clearBtn);
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("ne montre pas le bouton clear si value vide", () => {
+    const { queryByLabelText } = renderWithTheme(
+      <SearchBar value="" onChangeText={jest.fn()} />,
+    );
+    expect(queryByLabelText(/effacer/i)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3.2 : Lancer le test (doit échouer car composant pas implémenté)**
+
+```bash
+cd mobile && npm run test -- search/SearchBar.test.tsx
+```
+
+- [ ] **Step 3.3 : Implémenter `SearchBar`**
+
+Create: `mobile/src/components/search/SearchBar.tsx`
+
+```typescript
+/**
+ * SearchBar — Input principal du tab Search.
+ *
+ * Différences avec `library/SearchBar.tsx` (qui est un overlay temporaire) :
+ *   - Pas d'animation d'apparition (toujours visible dans le tab)
+ *   - Pas de bouton "fermer" — la search bar est la pièce centrale
+ *   - Le debounce est délégué au hook `useSemanticSearch` (parent)
+ *   - autoFocus optionnel pour ouverture du tab
+ */
+
+import React, { useRef, useEffect } from "react";
+import { View, TextInput, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+
+interface SearchBarProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  autoFocus?: boolean;
+  placeholder?: string;
+}
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  value,
+  onChangeText,
+  autoFocus = false,
+  placeholder = "Rechercher dans tes analyses…",
+}) => {
+  const { colors } = useTheme();
+  const inputRef = useRef<TextInput>(null);
+
+  useEffect(() => {
+    if (autoFocus) {
+      const t = setTimeout(() => inputRef.current?.focus(), 120);
+      return () => clearTimeout(t);
+    }
+  }, [autoFocus]);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.glassBg, borderColor: colors.borderFocus },
+      ]}
+    >
+      <Ionicons
+        name="search"
+        size={18}
+        color={colors.textTertiary}
+        style={styles.iconLeft}
+      />
+      <TextInput
+        ref={inputRef}
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={colors.textMuted}
+        style={[styles.input, { color: colors.textPrimary }]}
+        returnKeyType="search"
+        autoCapitalize="none"
+        autoCorrect={false}
+        autoComplete="off"
+        accessibilityLabel="Champ de recherche sémantique"
+      />
+      {value.length > 0 && (
+        <Pressable
+          onPress={() => onChangeText("")}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityLabel="Effacer la recherche"
+          accessibilityRole="button"
+        >
+          <Ionicons name="close-circle" size={20} color={colors.textTertiary} />
+        </Pressable>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    paddingHorizontal: sp.md,
+    height: 48,
+  },
+  iconLeft: { marginRight: sp.sm },
+  input: {
+    flex: 1,
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.base,
+    paddingVertical: 0,
+  },
+});
+```
+
+- [ ] **Step 3.4 : Tests verts**
+
+```bash
+cd mobile && npm run test -- search/SearchBar.test.tsx
+```
+
+- [ ] **Step 3.5 : Commit**
+
+```bash
+git add mobile/src/components/search/SearchBar.tsx mobile/src/components/search/__tests__/SearchBar.test.tsx
+git commit -m "feat(mobile-search): add SearchBar component with auto-focus and clear button"
+```
+
+---
+
+## Task 4 — Composant `SearchResultsList` (FlashList virtualisée)
+
+**Files:**
+
+- Create: `mobile/src/components/search/SearchResultsList.tsx`
+
+**Goal:** Liste virtualisée de résultats avec gestion des états loading / error / empty / success. Utilise `@shopify/flash-list` v2 (pattern existant dans `library.tsx`). Pas de pagination V1 : on affiche tous les `data.results` (limit=20 server-side suffisant).
+
+- [ ] **Step 4.1 : Implémenter `SearchResultsList`**
+
+```typescript
+/**
+ * SearchResultsList — FlashList virtualisée des résultats de recherche.
+ *
+ * États :
+ *   - isLoading=true → skeletons (3 cards)
+ *   - error !== null → ErrorState avec retry
+ *   - results.length === 0 && query !== "" → "Aucun résultat" + suggestion
+ *   - results.length > 0 → FlashList
+ */
+
+import React, { useCallback } from "react";
+import { View, Text, ActivityIndicator, StyleSheet } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import { SearchResultCard } from "./SearchResultCard";
+import type { GlobalSearchResultItem } from "@/services/api";
+
+interface SearchResultsListProps {
+  results: GlobalSearchResultItem[];
+  isLoading: boolean;
+  error: Error | null;
+  bottomPadding: number;
+  query: string;
+}
+
+export const SearchResultsList: React.FC<SearchResultsListProps> = ({
+  results,
+  isLoading,
+  error,
+  bottomPadding,
+  query,
+}) => {
+  const { colors } = useTheme();
+  const router = useRouter();
+
+  const handlePress = useCallback(
+    (item: GlobalSearchResultItem) => {
+      // Navigate vers analysis avec params highlight
+      const summaryId = item.summary_id ?? item.source_id;
+      const tab = item.source_metadata.tab ?? "synthesis";
+      router.push({
+        pathname: "/(tabs)/analysis/[id]",
+        params: {
+          id: String(summaryId),
+          q: query,
+          highlight: String(item.source_id),
+          tab,
+        },
+      } as any);
+    },
+    [router, query],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: GlobalSearchResultItem }) => (
+      <SearchResultCard item={item} onPress={() => handlePress(item)} query={query} />
+    ),
+    [handlePress, query],
+  );
+
+  const keyExtractor = useCallback(
+    (item: GlobalSearchResultItem) => `${item.source_type}-${item.source_id}`,
+    [],
+  );
+
+  if (isLoading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color={palette.gold} size="large" />
+        <Text style={[styles.loadingText, { color: colors.textTertiary }]}>
+          Recherche en cours…
+        </Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Ionicons name="cloud-offline-outline" size={42} color={colors.textTertiary} />
+        <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+          Recherche indisponible — vérifie ta connexion
+        </Text>
+      </View>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <View style={styles.center}>
+        <Ionicons name="search-outline" size={42} color={colors.textTertiary} />
+        <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+          Aucun résultat pour « {query} »
+        </Text>
+        <Text style={[styles.emptyHint, { color: colors.textTertiary }]}>
+          Essaie d'autres mots-clés ou élargis tes filtres
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlashList
+      data={results}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      contentContainerStyle={{
+        paddingHorizontal: sp.lg,
+        paddingTop: sp.md,
+        paddingBottom: bottomPadding,
+      }}
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: sp.xl,
+  },
+  loadingText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    marginTop: sp.md,
+  },
+  errorText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.base,
+    textAlign: "center",
+    marginTop: sp.md,
+  },
+  emptyText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.base,
+    textAlign: "center",
+    marginTop: sp.md,
+  },
+  emptyHint: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    textAlign: "center",
+    marginTop: sp.xs,
+  },
+});
+```
+
+- [ ] **Step 4.2 : Vérifier visuellement (états loading/error/empty)**
+
+Aucun test unitaire dédié — les états sont testés indirectement via `useSemanticSearch.test.ts` (Task 7).
+
+- [ ] **Step 4.3 : Commit**
+
+```bash
+git add mobile/src/components/search/SearchResultsList.tsx
+git commit -m "feat(mobile-search): add SearchResultsList with FlashList and 4 states"
+```
+
+---
+
+## Task 5 — Composant `SearchResultCard`
+
+**Files:**
+
+- Create: `mobile/src/components/search/SearchResultCard.tsx`
+- Create: `mobile/src/components/search/__tests__/SearchResultCard.test.tsx`
+
+**Goal:** Carte individuelle d'un résultat. Affiche un badge type (`SYNTHÈSE`, `FLASHCARD`, `QUIZ`, `CHAT`, `TRANSCRIPT`), le titre du summary, le `text_preview` avec mise en évidence visuelle (substring match), et le score. Tap → navigate via le parent.
+
+- [ ] **Step 5.1 : TDD — test**
+
+```typescript
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { SearchResultCard } from "../SearchResultCard";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import type { GlobalSearchResultItem } from "@/services/api";
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+const baseItem: GlobalSearchResultItem = {
+  source_type: "summary",
+  source_id: 1,
+  summary_id: 42,
+  score: 0.91,
+  text_preview: "La transition énergétique impose…",
+  source_metadata: { summary_title: "Crise énergétique EU", tab: "synthesis" },
+};
+
+describe("SearchResultCard", () => {
+  it("affiche le badge SYNTHÈSE pour source_type summary", () => {
+    const { getByText } = renderWithTheme(
+      <SearchResultCard item={baseItem} onPress={jest.fn()} query="transition" />,
+    );
+    expect(getByText(/synthèse/i)).toBeTruthy();
+  });
+
+  it("affiche le titre du summary", () => {
+    const { getByText } = renderWithTheme(
+      <SearchResultCard item={baseItem} onPress={jest.fn()} query="x" />,
+    );
+    expect(getByText(/crise énergétique/i)).toBeTruthy();
+  });
+
+  it("déclenche onPress au tap", () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderWithTheme(
+      <SearchResultCard item={baseItem} onPress={onPress} query="x" />,
+    );
+    fireEvent.press(getByLabelText(/résultat de recherche/i));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("affiche FLASHCARD pour source_type=flashcard", () => {
+    const item = { ...baseItem, source_type: "flashcard" as const };
+    const { getByText } = renderWithTheme(
+      <SearchResultCard item={item} onPress={jest.fn()} query="x" />,
+    );
+    expect(getByText(/flashcard/i)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 5.2 : Implémenter**
+
+```typescript
+/**
+ * SearchResultCard — Carte individuelle d'un résultat de recherche.
+ */
+
+import React, { useMemo } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import type { GlobalSearchResultItem } from "@/services/api";
+
+const TYPE_META: Record<
+  GlobalSearchResultItem["source_type"],
+  { label: string; color: string; icon: keyof typeof Ionicons.glyphMap }
+> = {
+  summary: { label: "SYNTHÈSE", color: palette.indigo, icon: "document-text-outline" },
+  flashcard: { label: "FLASHCARD", color: palette.green, icon: "albums-outline" },
+  quiz: { label: "QUIZ", color: palette.violet, icon: "help-circle-outline" },
+  chat: { label: "CHAT", color: palette.cyan, icon: "chatbubble-outline" },
+  transcript: { label: "TRANSCRIPT", color: palette.amber, icon: "mic-outline" },
+};
+
+interface SearchResultCardProps {
+  item: GlobalSearchResultItem;
+  onPress: () => void;
+  query: string;
+}
+
+export const SearchResultCard: React.FC<SearchResultCardProps> = ({ item, onPress, query }) => {
+  const { colors } = useTheme();
+  const meta = TYPE_META[item.source_type];
+
+  const previewParts = useMemo(() => {
+    const q = query.trim();
+    if (!q) return [{ text: item.text_preview, match: false }];
+    const regex = new RegExp(`(${q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "ig");
+    return item.text_preview.split(regex).map((part) => ({
+      text: part,
+      match: part.toLowerCase() === q.toLowerCase(),
+    }));
+  }, [item.text_preview, query]);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.card,
+        {
+          backgroundColor: colors.bgCard,
+          borderColor: colors.border,
+          opacity: pressed ? 0.85 : 1,
+        },
+      ]}
+      accessibilityLabel={`Résultat de recherche : ${meta.label} — ${item.source_metadata.summary_title ?? "Sans titre"}`}
+      accessibilityRole="button"
+    >
+      <View style={styles.headerRow}>
+        <View style={[styles.badge, { backgroundColor: meta.color + "20", borderColor: meta.color }]}>
+          <Ionicons name={meta.icon} size={12} color={meta.color} />
+          <Text style={[styles.badgeText, { color: meta.color }]}>{meta.label}</Text>
+        </View>
+        <Text style={[styles.score, { color: colors.textTertiary }]}>
+          {Math.round(item.score * 100)}%
+        </Text>
+      </View>
+
+      {item.source_metadata.summary_title && (
+        <Text style={[styles.title, { color: colors.textPrimary }]} numberOfLines={1}>
+          {item.source_metadata.summary_title}
+        </Text>
+      )}
+
+      <Text style={[styles.preview, { color: colors.textSecondary }]} numberOfLines={3}>
+        {previewParts.map((p, i) => (
+          <Text
+            key={i}
+            style={p.match ? { backgroundColor: palette.gold + "40", color: colors.textPrimary } : undefined}
+          >
+            {p.text}
+          </Text>
+        ))}
+      </Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    padding: sp.md,
+    marginBottom: sp.md,
+  },
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: sp.xs,
+  },
+  badge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: sp.sm,
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+  },
+  badgeText: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize["2xs"],
+    letterSpacing: 0.4,
+  },
+  score: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.xs,
+  },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+    marginBottom: sp.xs,
+  },
+  preview: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    lineHeight: 20,
+  },
+});
+```
+
+- [ ] **Step 5.3 : Tests verts**
+
+```bash
+cd mobile && npm run test -- search/SearchResultCard.test.tsx
+```
+
+- [ ] **Step 5.4 : Commit**
+
+```bash
+git add mobile/src/components/search/SearchResultCard.tsx mobile/src/components/search/__tests__/SearchResultCard.test.tsx
+git commit -m "feat(mobile-search): add SearchResultCard with type badges and query highlighting"
+```
+
+---
+
+## Task 6 — `SearchFiltersSheet` (BottomSheet filtres avancés)
+
+**Files:**
+
+- Create: `mobile/src/components/search/SearchFiltersSheet.tsx`
+
+**Goal:** BottomSheet pour les filtres avancés (source_types, plateforme, langue, favoris, période). V1 mobile : seulement les filtres essentiels (source_types pills + favorites toggle + platform youtube/tiktok). On reporte langue/catégorie/playlist V1.1 (yagni).
+
+- [ ] **Step 6.1 : Implémenter**
+
+Use `SimpleBottomSheet` interne (cohérence Expo Go) :
+
+```typescript
+/**
+ * SearchFiltersSheet — BottomSheet de filtres avancés.
+ *
+ * V1 mobile (medium tier) : 3 sections seulement
+ *   - Source types (pills multi-select)
+ *   - Plateforme (youtube/tiktok/all)
+ *   - Favoris uniquement (switch)
+ *
+ * V1.1 reporté : langue, catégorie, période, playlist.
+ */
+
+import React, { forwardRef, useCallback } from "react";
+import { View, Text, Pressable, Switch, StyleSheet, ScrollView } from "react-native";
+import { SimpleBottomSheet, type SimpleBottomSheetRef } from "../ui/SimpleBottomSheet";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import type { GlobalSearchRequest } from "@/services/api";
+
+const ALL_SOURCE_TYPES: Array<NonNullable<GlobalSearchRequest["source_types"]>[number]> = [
+  "summary",
+  "flashcard",
+  "quiz",
+  "chat",
+  "transcript",
+];
+const SOURCE_LABELS: Record<string, string> = {
+  summary: "Synthèses",
+  flashcard: "Flashcards",
+  quiz: "Quiz",
+  chat: "Chat",
+  transcript: "Transcripts",
+};
+
+interface SearchFiltersSheetProps {
+  filters: Partial<GlobalSearchRequest>;
+  onChange: (next: Partial<GlobalSearchRequest>) => void;
+  onClose: () => void;
+}
+
+export const SearchFiltersSheet = forwardRef<SimpleBottomSheetRef, SearchFiltersSheetProps>(
+  ({ filters, onChange, onClose }, ref) => {
+    const { colors } = useTheme();
+
+    const toggleSourceType = useCallback(
+      (t: NonNullable<GlobalSearchRequest["source_types"]>[number]) => {
+        const current = filters.source_types ?? ALL_SOURCE_TYPES;
+        const next = current.includes(t)
+          ? current.filter((x) => x !== t)
+          : [...current, t];
+        onChange({ ...filters, source_types: next.length > 0 ? next : undefined });
+      },
+      [filters, onChange],
+    );
+
+    const setPlatform = useCallback(
+      (p: GlobalSearchRequest["platform"] | undefined) => {
+        onChange({ ...filters, platform: p });
+      },
+      [filters, onChange],
+    );
+
+    const toggleFavorites = useCallback(
+      (v: boolean) => onChange({ ...filters, favorites_only: v }),
+      [filters, onChange],
+    );
+
+    return (
+      <SimpleBottomSheet
+        ref={ref}
+        snapPoint="60%"
+        backgroundStyle={{ backgroundColor: colors.bgPrimary }}
+        handleIndicatorStyle={{ backgroundColor: colors.borderLight }}
+        onClose={onClose}
+      >
+        <ScrollView contentContainerStyle={styles.content}>
+          <Text style={[styles.title, { color: colors.textPrimary }]}>Filtres</Text>
+
+          <Text style={[styles.section, { color: colors.textSecondary }]}>Type de contenu</Text>
+          <View style={styles.pillRow}>
+            {ALL_SOURCE_TYPES.map((t) => {
+              const active = (filters.source_types ?? ALL_SOURCE_TYPES).includes(t);
+              return (
+                <Pressable
+                  key={t}
+                  onPress={() => toggleSourceType(t)}
+                  style={[
+                    styles.pill,
+                    {
+                      backgroundColor: active ? palette.gold + "20" : colors.glassBg,
+                      borderColor: active ? palette.gold : colors.glassBorder,
+                    },
+                  ]}
+                  accessibilityRole="checkbox"
+                  accessibilityState={{ checked: active }}
+                  accessibilityLabel={SOURCE_LABELS[t]}
+                >
+                  <Text
+                    style={[
+                      styles.pillText,
+                      { color: active ? palette.gold : colors.textTertiary },
+                    ]}
+                  >
+                    {SOURCE_LABELS[t]}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={[styles.section, { color: colors.textSecondary }]}>Plateforme</Text>
+          <View style={styles.pillRow}>
+            {[
+              { v: undefined, label: "Toutes" },
+              { v: "youtube" as const, label: "YouTube" },
+              { v: "tiktok" as const, label: "TikTok" },
+            ].map((opt) => {
+              const active = filters.platform === opt.v;
+              return (
+                <Pressable
+                  key={opt.label}
+                  onPress={() => setPlatform(opt.v)}
+                  style={[
+                    styles.pill,
+                    {
+                      backgroundColor: active ? palette.indigo + "20" : colors.glassBg,
+                      borderColor: active ? palette.indigo : colors.glassBorder,
+                    },
+                  ]}
+                >
+                  <Text style={[styles.pillText, { color: active ? palette.indigo : colors.textTertiary }]}>
+                    {opt.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <View style={styles.row}>
+            <Text style={[styles.rowLabel, { color: colors.textPrimary }]}>Favoris uniquement</Text>
+            <Switch
+              value={filters.favorites_only ?? false}
+              onValueChange={toggleFavorites}
+              trackColor={{ false: colors.glassBg, true: palette.gold }}
+            />
+          </View>
+        </ScrollView>
+      </SimpleBottomSheet>
+    );
+  },
+);
+
+SearchFiltersSheet.displayName = "SearchFiltersSheet";
+
+const styles = StyleSheet.create({
+  content: { padding: sp.lg, gap: sp.md },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.lg,
+    marginBottom: sp.sm,
+  },
+  section: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.sm,
+    marginTop: sp.md,
+  },
+  pillRow: { flexDirection: "row", flexWrap: "wrap", gap: sp.sm },
+  pill: {
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.xs + 2,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+  },
+  pillText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.xs,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: sp.lg,
+  },
+  rowLabel: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.base,
+  },
+});
+```
+
+- [ ] **Step 6.2 : Brancher dans `search.tsx`**
+
+Ajouter un bouton "Filtres" sticky sous la SearchBar qui ouvre le sheet. Garder ça simple V1.
+
+- [ ] **Step 6.3 : Commit**
+
+```bash
+git add mobile/src/components/search/SearchFiltersSheet.tsx mobile/app/\(tabs\)/search.tsx
+git commit -m "feat(mobile-search): add SearchFiltersSheet with source_types, platform, favorites"
+```
+
+---
+
+## Task 7 — Hook `useSemanticSearch` (React Query + debounce 400ms)
+
+**Files:**
+
+- Create: `mobile/src/components/search/useSemanticSearch.ts`
+- Create: `mobile/src/components/search/__tests__/useSemanticSearch.test.ts`
+
+**Goal:** Hook qui debounce la query (400ms — plus tolérant que web 200ms à cause du clavier mobile + autocorrect), appelle `searchApi.globalSearch`, et retourne `{ data, isLoading, error }`. Skip si `query.trim().length < 2`.
+
+- [ ] **Step 7.1 : TDD — test**
+
+```typescript
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useSemanticSearch } from "../useSemanticSearch";
+import { searchApi } from "@/services/api";
+
+jest.mock("@/services/api", () => ({
+  searchApi: { globalSearch: jest.fn() },
+}));
+
+const mocked = searchApi.globalSearch as jest.MockedFunction<typeof searchApi.globalSearch>;
+
+const createWrapper = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useSemanticSearch", () => {
+  beforeEach(() => jest.clearAllMocks());
+  jest.useFakeTimers();
+
+  it("ne fetch pas si query trim < 2 caractères", () => {
+    renderHook(() => useSemanticSearch(" a ", {}), { wrapper: createWrapper() });
+    jest.advanceTimersByTime(500);
+    expect(mocked).not.toHaveBeenCalled();
+  });
+
+  it("debounce 400ms avant l'appel API", async () => {
+    mocked.mockResolvedValue({
+      query: "test",
+      total_results: 0,
+      results: [],
+      searched_at: "2026-05-03T10:00:00Z",
+    });
+    renderHook(() => useSemanticSearch("transition", {}), { wrapper: createWrapper() });
+    jest.advanceTimersByTime(300);
+    expect(mocked).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(150);
+    await waitFor(() => expect(mocked).toHaveBeenCalledTimes(1));
+  });
+
+  it("transmet les filtres à l'API", async () => {
+    mocked.mockResolvedValue({
+      query: "x",
+      total_results: 0,
+      results: [],
+      searched_at: "",
+    });
+    renderHook(
+      () => useSemanticSearch("query", { source_types: ["summary"], favorites_only: true }),
+      { wrapper: createWrapper() },
+    );
+    jest.advanceTimersByTime(500);
+    await waitFor(() =>
+      expect(mocked).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: "query",
+          source_types: ["summary"],
+          favorites_only: true,
+        }),
+      ),
+    );
+  });
+});
+```
+
+- [ ] **Step 7.2 : Implémenter**
+
+```typescript
+/**
+ * useSemanticSearch — Hook React Query pour /api/search/global.
+ *
+ * Debounce 400ms (plus tolérant que web 200ms : keyboard mobile + autocorrect).
+ * Skip si query.trim().length < 2.
+ * Cache 30s (staleTime) — recherches récentes restent fraîches.
+ */
+
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { searchApi } from "@/services/api";
+import type { GlobalSearchRequest, GlobalSearchResponse } from "@/services/api";
+
+const DEBOUNCE_MS = 400;
+const MIN_QUERY_LENGTH = 2;
+
+interface UseSemanticSearchResult {
+  data: GlobalSearchResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useSemanticSearch(
+  query: string,
+  filters: Partial<GlobalSearchRequest>,
+): UseSemanticSearchResult {
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const trimmed = debouncedQuery.trim();
+  const enabled = trimmed.length >= MIN_QUERY_LENGTH;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["search", "global", trimmed, filters],
+    queryFn: () =>
+      searchApi.globalSearch({
+        query: trimmed,
+        limit: 20,
+        ...filters,
+      }),
+    enabled,
+    staleTime: 30_000,
+    retry: 1,
+  });
+
+  return {
+    data: enabled ? data : undefined,
+    isLoading: enabled && isLoading,
+    error: (error as Error) ?? null,
+  };
+}
+```
+
+- [ ] **Step 7.3 : Tests verts**
+
+```bash
+cd mobile && npm run test -- search/useSemanticSearch.test.ts
+```
+
+- [ ] **Step 7.4 : Commit**
+
+```bash
+git add mobile/src/components/search/useSemanticSearch.ts mobile/src/components/search/__tests__/useSemanticSearch.test.ts
+git commit -m "feat(mobile-search): add useSemanticSearch hook with 400ms debounce"
+```
+
+---
+
+## Task 8 — Recent queries (`useRecentQueries` + `SearchEmptyState`)
+
+**Files:**
+
+- Create: `mobile/src/components/search/useRecentQueries.ts`
+- Create: `mobile/src/components/search/SearchEmptyState.tsx`
+
+**Goal:** Hook qui gère les recent queries — primary AsyncStorage cache (5 dernières localement) + sync API best-effort (10 dernières server-side). Empty state qui propose les queries récentes en chips cliquables.
+
+- [ ] **Step 8.1 : Implémenter `useRecentQueries`**
+
+```typescript
+/**
+ * useRecentQueries — Hook AsyncStorage + sync API (best-effort).
+ *
+ * Primary cache : AsyncStorage clé "deepsight_recent_queries" (5 max).
+ * Fallback API : `searchApi.getRecentQueries()` au mount si AsyncStorage vide.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { searchApi } from "@/services/api";
+
+const STORAGE_KEY = "deepsight_recent_queries";
+const MAX_LOCAL = 5;
+
+export function useRecentQueries() {
+  const [queries, setQueries] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Load on mount: AsyncStorage first, fallback to API
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored) as string[];
+          if (active) setQueries(parsed.slice(0, MAX_LOCAL));
+        } else {
+          // Fallback API
+          const res = await searchApi.getRecentQueries();
+          if (active) {
+            setQueries(res.queries.slice(0, MAX_LOCAL));
+            await AsyncStorage.setItem(
+              STORAGE_KEY,
+              JSON.stringify(res.queries.slice(0, MAX_LOCAL)),
+            );
+          }
+        }
+      } catch {
+        if (active) setQueries([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const push = useCallback(async (q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) return;
+    setQueries((prev) => {
+      const next = [trimmed, ...prev.filter((x) => x !== trimmed)].slice(
+        0,
+        MAX_LOCAL,
+      );
+      AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(async () => {
+    setQueries([]);
+    await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
+    await searchApi.clearRecentQueries().catch(() => {});
+  }, []);
+
+  return { queries, loading, push, clear };
+}
+```
+
+- [ ] **Step 8.2 : Implémenter `SearchEmptyState`**
+
+```typescript
+import React from "react";
+import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import { useRecentQueries } from "./useRecentQueries";
+
+interface SearchEmptyStateProps {
+  onSelectQuery: (q: string) => void;
+}
+
+export const SearchEmptyState: React.FC<SearchEmptyStateProps> = ({ onSelectQuery }) => {
+  const { colors } = useTheme();
+  const { queries, clear } = useRecentQueries();
+
+  return (
+    <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+      <Ionicons name="sparkles-outline" size={42} color={palette.gold} />
+      <Text style={[styles.title, { color: colors.textPrimary }]}>
+        Cherche ce que tu veux dans tes analyses
+      </Text>
+      <Text style={[styles.subtitle, { color: colors.textTertiary }]}>
+        Synthèses, flashcards, quiz, chats, transcripts — tout est indexé
+      </Text>
+
+      {queries.length > 0 && (
+        <>
+          <View style={styles.headerRow}>
+            <Text style={[styles.section, { color: colors.textSecondary }]}>Recherches récentes</Text>
+            <Pressable onPress={clear} hitSlop={8} accessibilityLabel="Effacer l'historique">
+              <Text style={[styles.clearText, { color: colors.textTertiary }]}>Effacer</Text>
+            </Pressable>
+          </View>
+          <View style={styles.chipsRow}>
+            {queries.map((q) => (
+              <Pressable
+                key={q}
+                onPress={() => onSelectQuery(q)}
+                style={[styles.chip, { backgroundColor: colors.glassBg, borderColor: colors.glassBorder }]}
+                accessibilityRole="button"
+                accessibilityLabel={`Relancer la recherche : ${q}`}
+              >
+                <Ionicons name="time-outline" size={14} color={colors.textTertiary} />
+                <Text style={[styles.chipText, { color: colors.textSecondary }]} numberOfLines={1}>
+                  {q}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scroll: { padding: sp.xl, alignItems: "center" },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.lg,
+    textAlign: "center",
+    marginTop: sp.md,
+  },
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    textAlign: "center",
+    marginTop: sp.xs,
+    maxWidth: 320,
+  },
+  headerRow: {
+    flexDirection: "row",
+    width: "100%",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: sp["2xl"],
+  },
+  section: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.sm,
+  },
+  clearText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.xs,
+  },
+  chipsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: sp.sm,
+    marginTop: sp.md,
+    width: "100%",
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.xs + 2,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    maxWidth: "48%",
+  },
+  chipText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+  },
+});
+```
+
+- [ ] **Step 8.3 : Brancher la persistance dans `search.tsx`**
+
+Dans le screen `search.tsx`, appeler `recentQueries.push(query)` quand une recherche est effectuée (debounce, 1 fois par query). Pattern :
+
+```typescript
+const recent = useRecentQueries();
+useEffect(() => {
+  if (data && data.results.length >= 0 && query.trim().length >= 2) {
+    recent.push(query);
+  }
+}, [data]);
+```
+
+- [ ] **Step 8.4 : Commit**
+
+```bash
+git add mobile/src/components/search/useRecentQueries.ts \
+        mobile/src/components/search/SearchEmptyState.tsx \
+        mobile/app/\(tabs\)/search.tsx
+git commit -m "feat(mobile-search): add recent queries with AsyncStorage cache and empty state"
+```
+
+---
+
+## Task 9 — Composant `HighlightedText` + `SemanticHighlighter` Provider
+
+**Files:**
+
+- Create: `mobile/src/components/highlight/SemanticHighlighter.tsx`
+- Create: `mobile/src/components/highlight/HighlightedText.tsx`
+- Create: `mobile/src/components/highlight/__tests__/HighlightedText.test.tsx`
+- Create: `mobile/src/components/highlight/index.ts`
+
+**Goal:** Provider React Context qui héberge la query intra-analyse + les matches. `HighlightedText` est un wrapper `<Text>` qui split le texte sur les matches et applique le surlignage jaune. **Tap sur match jaune = ouvrir `PassageActionSheet`** (Task 11) — pas de tooltip.
+
+- [ ] **Step 9.1 : Implémenter `SemanticHighlighter` (Context)**
+
+```typescript
+/**
+ * SemanticHighlighter — Context Provider pour la recherche intra-analyse.
+ *
+ * Hosts :
+ *   - query courante
+ *   - matches retournés par /api/search/within/{summary_id}
+ *   - currentMatchIndex (pour FAB navigation ↑↓)
+ *   - flag activeHighlightPassageId (passage cliqué = highlight appuyé temporairement)
+ *
+ * Consumers : `HighlightedText`, `HighlightNavigationBar`, `PassageActionSheet`.
+ */
+
+import React, { createContext, useContext, useState, useCallback, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { searchApi } from "@/services/api";
+import type { WithinMatchItem } from "@/services/api";
+
+interface SemanticHighlighterValue {
+  query: string;
+  setQuery: (q: string) => void;
+  matches: WithinMatchItem[];
+  currentMatchIndex: number;
+  setCurrentMatchIndex: (i: number) => void;
+  isLoading: boolean;
+  activePassageId: string | null;
+  setActivePassageId: (id: string | null) => void;
+}
+
+const Ctx = createContext<SemanticHighlighterValue | null>(null);
+
+interface SemanticHighlighterProviderProps {
+  children: React.ReactNode;
+  summaryId: number;
+  initialQuery?: string;
+  initialPassageId?: string | null;
+}
+
+export const SemanticHighlighterProvider: React.FC<SemanticHighlighterProviderProps> = ({
+  children,
+  summaryId,
+  initialQuery = "",
+  initialPassageId = null,
+}) => {
+  const [query, setQuery] = useState(initialQuery);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [activePassageId, setActivePassageId] = useState<string | null>(initialPassageId);
+
+  const enabled = query.trim().length >= 2;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["search", "within", summaryId, query.trim()],
+    queryFn: () => searchApi.withinSearch(summaryId, { query: query.trim() }),
+    enabled,
+    staleTime: 60_000,
+  });
+
+  const matches = useMemo(() => data?.matches ?? [], [data]);
+
+  const value = useMemo<SemanticHighlighterValue>(
+    () => ({
+      query,
+      setQuery,
+      matches,
+      currentMatchIndex,
+      setCurrentMatchIndex,
+      isLoading,
+      activePassageId,
+      setActivePassageId,
+    }),
+    [query, matches, currentMatchIndex, isLoading, activePassageId],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+};
+
+export function useSemanticHighlighter(): SemanticHighlighterValue | null {
+  return useContext(Ctx);
+}
+```
+
+- [ ] **Step 9.2 : TDD — test pour `HighlightedText`**
+
+```typescript
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { HighlightedText } from "../HighlightedText";
+import { SemanticHighlighterProvider } from "../SemanticHighlighter";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const wrap = (child: React.ReactNode) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <ThemeProvider>
+        <SemanticHighlighterProvider summaryId={1}>{child}</SemanticHighlighterProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("HighlightedText", () => {
+  it("rend le texte tel quel quand pas de matches", () => {
+    const { getByText } = render(wrap(<HighlightedText tab="synthesis">Hello world</HighlightedText>));
+    expect(getByText("Hello world")).toBeTruthy();
+  });
+
+  it("appelle onTapMatch quand un span surligné est tapé", () => {
+    // Test indirect — quand matches arrivent via React Query, le highlight est rendu.
+    // Ici on teste juste que le wrapper rend du texte sans crasher.
+    const { getByText } = render(wrap(<HighlightedText tab="synthesis">Texte de test</HighlightedText>));
+    expect(getByText(/texte/i)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 9.3 : Implémenter `HighlightedText`**
+
+Approche RN-spécifique : on ne peut pas injecter du HTML brut, on split le texte sur les matches et on rend des `<Text>` nestés. Pour V1 mobile, on simplifie en cherchant le texte exact des `m.text` dans le children string (matching simple).
+
+```typescript
+/**
+ * HighlightedText — Wrapper Text qui surligne les passages matchés.
+ *
+ * Approche V1 mobile : on prend les `WithinMatchItem` du provider et on cherche
+ * une présence du `text` (passage) dans le children. Si trouvé, on split et
+ * on rend la portion en jaune avec onPress → ouvre PassageActionSheet.
+ *
+ * Limitations connues V1 :
+ *   - Match exact uniquement (pas de fuzzy)
+ *   - 1 seul match par render — si plusieurs occurences du même text, seule la 1ère est highlightée
+ *   Trade-off acceptable mobile (medium tier).
+ */
+
+import React, { useCallback } from "react";
+import { Text, type TextProps } from "react-native";
+import { palette } from "@/theme/colors";
+import { useSemanticHighlighter } from "./SemanticHighlighter";
+import type { WithinMatchItem } from "@/services/api";
+
+interface HighlightedTextProps extends TextProps {
+  children: string;
+  tab: WithinMatchItem["tab"];
+  onTapMatch?: (match: WithinMatchItem) => void;
+}
+
+export const HighlightedText: React.FC<HighlightedTextProps> = ({
+  children,
+  tab,
+  onTapMatch,
+  style,
+  ...rest
+}) => {
+  const ctx = useSemanticHighlighter();
+
+  const handleTap = useCallback(
+    (m: WithinMatchItem) => {
+      ctx?.setActivePassageId(m.passage_id);
+      onTapMatch?.(m);
+    },
+    [ctx, onTapMatch],
+  );
+
+  if (!ctx || ctx.matches.length === 0) {
+    return (
+      <Text style={style} {...rest}>
+        {children}
+      </Text>
+    );
+  }
+
+  // Filtrer par tab
+  const tabMatches = ctx.matches.filter((m) => m.tab === tab);
+  if (tabMatches.length === 0) {
+    return (
+      <Text style={style} {...rest}>
+        {children}
+      </Text>
+    );
+  }
+
+  // Construire les segments en cherchant chaque `m.text` dans children
+  // Approche naïve : on split sur le 1er match trouvé. V1.1 : multi-match overlap detection.
+  let remaining = children;
+  const segments: Array<{ text: string; match: WithinMatchItem | null }> = [];
+
+  for (const m of tabMatches) {
+    if (!m.text) continue;
+    const idx = remaining.indexOf(m.text);
+    if (idx === -1) continue;
+    if (idx > 0) segments.push({ text: remaining.slice(0, idx), match: null });
+    segments.push({ text: m.text, match: m });
+    remaining = remaining.slice(idx + m.text.length);
+  }
+  if (remaining) segments.push({ text: remaining, match: null });
+
+  if (segments.length === 0) {
+    return (
+      <Text style={style} {...rest}>
+        {children}
+      </Text>
+    );
+  }
+
+  return (
+    <Text style={style} {...rest}>
+      {segments.map((seg, i) =>
+        seg.match ? (
+          <Text
+            key={`m-${i}-${seg.match.passage_id}`}
+            onPress={() => handleTap(seg.match!)}
+            style={{
+              backgroundColor:
+                ctx.activePassageId === seg.match.passage_id
+                  ? palette.gold + "60"
+                  : palette.gold + "35",
+              color: palette.gold,
+            }}
+            // hitSlop n'est pas supporté sur Text inline — on s'appuie sur la taille typo + padding visuel via background
+            accessibilityRole="button"
+            accessibilityLabel={`Passage correspondant : ${seg.match.text.slice(0, 60)}`}
+          >
+            {seg.text}
+          </Text>
+        ) : (
+          <Text key={`p-${i}`}>{seg.text}</Text>
+        ),
+      )}
+    </Text>
+  );
+};
+```
+
+- [ ] **Step 9.4 : Index file**
+
+Create: `mobile/src/components/highlight/index.ts`
+
+```typescript
+export { HighlightedText } from "./HighlightedText";
+export {
+  SemanticHighlighterProvider,
+  useSemanticHighlighter,
+} from "./SemanticHighlighter";
+export { PassageActionSheet } from "./PassageActionSheet";
+export { HighlightNavigationBar } from "./HighlightNavigationBar";
+export { useHighlightNav } from "./useHighlightNav";
+```
+
+- [ ] **Step 9.5 : Tests verts**
+
+```bash
+cd mobile && npm run test -- highlight/HighlightedText.test.tsx
+```
+
+- [ ] **Step 9.6 : Commit**
+
+```bash
+git add mobile/src/components/highlight/
+git commit -m "feat(mobile-search): add SemanticHighlighter provider and HighlightedText component"
+```
+
+---
+
+## Task 10 — Intégration `HighlightedText` dans `AnalysisContentDisplay`
+
+**Files:**
+
+- Modify: `mobile/src/components/analysis/AnalysisContentDisplay.tsx`
+- Modify: `mobile/app/(tabs)/analysis/[id].tsx` — wrap avec `SemanticHighlighterProvider`
+
+**Goal:** Le `AnalysisContentDisplay` (qui affiche la synthèse texte) doit délier ses `<Text>` paragraphes en `<HighlightedText tab="synthesis">` ou `<HighlightedText tab="digest">` selon le contexte. Quand le provider fournit des matches, ils sont surlignés ; sinon comportement inchangé.
+
+- [ ] **Step 10.1 : Lire `AnalysisContentDisplay.tsx` pour repérer les `<Text>` paragraphes principaux**
+
+```bash
+grep -n "<Text\|<Markdown" mobile/src/components/analysis/AnalysisContentDisplay.tsx | head -30
+```
+
+Identifier les paragraphes "long-form" (synthesis/digest) — typiquement dans un composant Markdown rendu ou dans des `<Text>` répétés via `.map()` sur les sections.
+
+- [ ] **Step 10.2 : Stratégie minimum invasive**
+
+Pour V1, on ne touche **PAS** au Markdown render (`react-native-markdown-display`) — trop complexe pour intercepter les `<Text>` enfants. À la place, on highlight uniquement les **titres de section** + le **subtitle/intro paragraph** au-dessus du markdown (si exposés en clair). Le tab Synthèse markdown lui-même ne sera pas surligné en V1 mobile.
+
+**Compromis V1 mobile assumé** : Le surlignage en intra-analyse mobile fonctionne pour :
+
+- Les flashcards (Q + A) → tab Étude
+- Les quiz (question) → tab Étude
+- Les chats (turn user/agent) → tab Hub
+- Les sections du structured_index (titres + summary courts) → tab Résumé header
+
+Le markdown long-form du tab Résumé ne sera highlighté qu'en V1.1 (nécessite hook custom dans markdown renderer).
+
+- [ ] **Step 10.3 : Wrapper le composant avec le Provider**
+
+Dans `mobile/app/(tabs)/analysis/[id].tsx`, ajouter dans les params Expo Router :
+
+```typescript
+const {
+  id,
+  backTo,
+  initialTab,
+  q,
+  highlight,
+  tab: incomingTab,
+} = useLocalSearchParams<{
+  id: string;
+  backTo?: string;
+  initialTab?: string;
+  q?: string;
+  highlight?: string;
+  tab?: string;
+}>();
+```
+
+Et wrapper le contenu :
+
+```typescript
+import { SemanticHighlighterProvider } from "@/components/highlight";
+
+// ... dans le return :
+<SemanticHighlighterProvider
+  summaryId={Number(effectiveSummaryIdStr) || 0}
+  initialQuery={q ?? ""}
+  initialPassageId={highlight ?? null}
+>
+  {/* ... rest of analysis screen ... */}
+</SemanticHighlighterProvider>
+```
+
+- [ ] **Step 10.4 : Auto-switch vers le tab incoming**
+
+Si `incomingTab` arrive en param et est différent du tab actif, déclencher `setActiveTab(tabIndexMap[incomingTab])`. Mapping naturel :
+
+- `synthesis` / `digest` → tab 0 (Résumé)
+- `flashcards` / `quiz` → tab Étude (pas direct sur cette page mais sur Study tab — ouverture cross-tab via router.push)
+- `chat` → tab Hub avec param summaryId
+- `transcript` → tab 0 (Résumé) — pas de tab dédié transcript
+
+- [ ] **Step 10.5 : Highlight le titre des sections du structured_index**
+
+Le `AnalysisContentDisplay` (à inspecter) rend probablement un index avec les sections. Pour V1, on remplace ces titres par `<HighlightedText tab="synthesis">{section.title}</HighlightedText>` quand le `SemanticHighlighter` est actif.
+
+- [ ] **Step 10.6 : Commit**
+
+```bash
+git add mobile/app/\(tabs\)/analysis/\[id\].tsx mobile/src/components/analysis/AnalysisContentDisplay.tsx
+git commit -m "feat(mobile-search): wire SemanticHighlighterProvider into analysis screen"
+```
+
+---
+
+## Task 11 — `PassageActionSheet` BottomSheet (3 actions)
+
+**Files:**
+
+- Create: `mobile/src/components/highlight/PassageActionSheet.tsx`
+- Create: `mobile/src/components/highlight/__tests__/PassageActionSheet.test.tsx`
+
+**Goal:** BottomSheet qui s'ouvre au tap sur un passage surligné (via `setActivePassageId` dans le provider). 3 actions :
+
+1. **Demander à l'IA** → navigate vers `/(tabs)/hub?summaryId=X&prefillQuery=Explique-moi : <passage>`
+2. **Sauter au timecode** (si `metadata.start_ts` présent dans le match)
+3. **Voir dans Synthèse / Flashcard / Quiz / Chat** (selon `match.tab`)
+
+Pas de tooltip IA mobile (cf. spec §5.3).
+
+- [ ] **Step 11.1 : TDD — test**
+
+```typescript
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { PassageActionSheet } from "../PassageActionSheet";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import type { WithinMatchItem } from "@/services/api";
+
+const baseMatch: WithinMatchItem = {
+  source_type: "summary",
+  source_id: 1,
+  summary_id: 42,
+  text: "passage texte",
+  text_html: "<mark>passage</mark> texte",
+  tab: "synthesis",
+  score: 0.9,
+  passage_id: "p-1",
+  metadata: {},
+};
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe("PassageActionSheet", () => {
+  it("affiche les 3 actions principales", () => {
+    const { getByText } = renderWithTheme(
+      <PassageActionSheet
+        match={baseMatch}
+        query="x"
+        isOpen
+        onClose={jest.fn()}
+        summaryId={42}
+      />,
+    );
+    expect(getByText(/demander à l'ia/i)).toBeTruthy();
+    expect(getByText(/voir dans/i)).toBeTruthy();
+  });
+
+  it("masque 'Sauter timecode' si pas de start_ts", () => {
+    const { queryByText } = renderWithTheme(
+      <PassageActionSheet
+        match={baseMatch}
+        query="x"
+        isOpen
+        onClose={jest.fn()}
+        summaryId={42}
+      />,
+    );
+    expect(queryByText(/sauter au timecode/i)).toBeNull();
+  });
+
+  it("affiche 'Sauter timecode' si start_ts présent", () => {
+    const m = { ...baseMatch, metadata: { start_ts: 222 } };
+    const { getByText } = renderWithTheme(
+      <PassageActionSheet match={m} query="x" isOpen onClose={jest.fn()} summaryId={42} />,
+    );
+    expect(getByText(/sauter au timecode/i)).toBeTruthy();
+  });
+
+  it("ferme via onClose au tap sur backdrop", () => {
+    const onClose = jest.fn();
+    renderWithTheme(
+      <PassageActionSheet match={baseMatch} query="x" isOpen={false} onClose={onClose} summaryId={42} />,
+    );
+    // isOpen=false → close immediate sera déclenchée par useEffect
+    expect(true).toBe(true); // smoke
+  });
+});
+```
+
+- [ ] **Step 11.2 : Implémenter**
+
+```typescript
+/**
+ * PassageActionSheet — BottomSheet d'actions sur un passage surligné mobile.
+ *
+ * 3 actions tap-friendly (pas de tooltip IA mobile, cf. spec §5.3).
+ */
+
+import React, { useEffect, useRef, useCallback } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { SimpleBottomSheet, type SimpleBottomSheetRef } from "../ui/SimpleBottomSheet";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import type { WithinMatchItem } from "@/services/api";
+
+interface PassageActionSheetProps {
+  match: WithinMatchItem | null;
+  query: string;
+  summaryId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const TAB_LABELS_FR: Record<WithinMatchItem["tab"], string> = {
+  synthesis: "Synthèse",
+  digest: "Synthèse",
+  flashcards: "Flashcards",
+  quiz: "Quiz",
+  chat: "Chat",
+  transcript: "Transcript",
+};
+
+export const PassageActionSheet: React.FC<PassageActionSheetProps> = ({
+  match,
+  query,
+  summaryId,
+  isOpen,
+  onClose,
+}) => {
+  const { colors } = useTheme();
+  const router = useRouter();
+  const sheetRef = useRef<SimpleBottomSheetRef>(null);
+
+  useEffect(() => {
+    if (isOpen && match) {
+      sheetRef.current?.snapToIndex(0);
+    } else {
+      sheetRef.current?.close();
+    }
+  }, [isOpen, match]);
+
+  const handleAskAI = useCallback(() => {
+    if (!match) return;
+    router.push({
+      pathname: "/(tabs)/hub",
+      params: {
+        summaryId: String(summaryId),
+        prefillQuery: `Explique-moi ce passage : ${match.text}`,
+        initialMode: "chat",
+      },
+    } as any);
+    onClose();
+  }, [match, router, summaryId, onClose]);
+
+  const handleSeekTimecode = useCallback(() => {
+    if (!match || !match.metadata.start_ts) return;
+    // V1 mobile : on déclenche via custom event ou setState parent
+    // Le fallback est de simplement fermer le sheet ; le seek est délégué à
+    // l'AudioSummaryPlayer/VideoPlayer parent qui devra écouter `activePassageId`.
+    onClose();
+  }, [match, onClose]);
+
+  const handleViewInTab = useCallback(() => {
+    if (!match) return;
+    if (match.tab === "chat") {
+      router.push({
+        pathname: "/(tabs)/hub",
+        params: { summaryId: String(summaryId), initialMode: "chat" },
+      } as any);
+    } else if (match.tab === "flashcards" || match.tab === "quiz") {
+      router.push({
+        pathname: "/(tabs)/study",
+        params: { summaryId: String(summaryId) },
+      } as any);
+    } else {
+      // synthesis / digest / transcript = tab Résumé (déjà actif)
+      // on ferme juste le sheet
+    }
+    onClose();
+  }, [match, router, summaryId, onClose]);
+
+  if (!match) return null;
+  const hasTimecode = typeof match.metadata.start_ts === "number";
+  const tabLabel = TAB_LABELS_FR[match.tab];
+
+  return (
+    <SimpleBottomSheet
+      ref={sheetRef}
+      snapPoint="38%"
+      backgroundStyle={{ backgroundColor: colors.bgPrimary }}
+      handleIndicatorStyle={{ backgroundColor: colors.borderLight }}
+      onClose={onClose}
+    >
+      <View style={[styles.content, { backgroundColor: colors.bgPrimary }]}>
+        <Text style={[styles.preview, { color: colors.textTertiary }]} numberOfLines={3}>
+          “{match.text}”
+        </Text>
+
+        <Pressable
+          style={[styles.action, { backgroundColor: palette.gold + "15", borderColor: palette.gold }]}
+          onPress={handleAskAI}
+          accessibilityLabel="Demander à l'IA d'expliquer ce passage"
+          accessibilityRole="button"
+        >
+          <Ionicons name="sparkles-outline" size={20} color={palette.gold} />
+          <Text style={[styles.actionText, { color: palette.gold }]}>Demander à l'IA</Text>
+        </Pressable>
+
+        {hasTimecode && (
+          <Pressable
+            style={[styles.action, { backgroundColor: colors.glassBg, borderColor: colors.glassBorder }]}
+            onPress={handleSeekTimecode}
+            accessibilityLabel="Sauter au timecode"
+            accessibilityRole="button"
+          >
+            <Ionicons name="play-circle-outline" size={20} color={colors.textPrimary} />
+            <Text style={[styles.actionText, { color: colors.textPrimary }]}>
+              Sauter au timecode {Math.floor((match.metadata.start_ts as number) / 60)}:
+              {String(Math.floor((match.metadata.start_ts as number) % 60)).padStart(2, "0")}
+            </Text>
+          </Pressable>
+        )}
+
+        <Pressable
+          style={[styles.action, { backgroundColor: colors.glassBg, borderColor: colors.glassBorder }]}
+          onPress={handleViewInTab}
+          accessibilityLabel={`Voir dans ${tabLabel}`}
+          accessibilityRole="button"
+        >
+          <Ionicons name="arrow-forward-circle-outline" size={20} color={colors.textPrimary} />
+          <Text style={[styles.actionText, { color: colors.textPrimary }]}>
+            Voir dans {tabLabel}
+          </Text>
+        </Pressable>
+      </View>
+    </SimpleBottomSheet>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: { padding: sp.lg, gap: sp.md },
+  preview: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    fontStyle: "italic",
+    lineHeight: 20,
+    marginBottom: sp.sm,
+  },
+  action: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.md,
+    paddingHorizontal: sp.lg,
+    paddingVertical: sp.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+  },
+  actionText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.base,
+    flex: 1,
+  },
+});
+```
+
+- [ ] **Step 11.3 : Tests verts**
+
+```bash
+cd mobile && npm run test -- highlight/PassageActionSheet.test.tsx
+```
+
+- [ ] **Step 11.4 : Commit**
+
+```bash
+git add mobile/src/components/highlight/PassageActionSheet.tsx \
+        mobile/src/components/highlight/__tests__/PassageActionSheet.test.tsx
+git commit -m "feat(mobile-search): add PassageActionSheet with 3 tap-friendly actions"
+```
+
+---
+
+## Task 12 — `HighlightNavigationBar` flottant (FAB ↑↓ + compteur)
+
+**Files:**
+
+- Create: `mobile/src/components/highlight/HighlightNavigationBar.tsx`
+- Create: `mobile/src/components/highlight/useHighlightNav.ts`
+- Create: `mobile/src/components/highlight/__tests__/useHighlightNav.test.ts`
+
+**Goal:** Bouton flottant en bas-droite (FAB-style, `position: absolute`) qui affiche `[3/12 ↑ ↓ ✕]` et permet de naviguer entre les matches. Tap sur ↑/↓ change le `currentMatchIndex` du provider et déclenche un scroll auto + flash CSS sur le match concerné. Tap sur ✕ ferme la recherche intra-analyse (clear query).
+
+- [ ] **Step 12.1 : Hook `useHighlightNav`**
+
+```typescript
+import { useCallback } from "react";
+import { useSemanticHighlighter } from "./SemanticHighlighter";
+
+export function useHighlightNav() {
+  const ctx = useSemanticHighlighter();
+
+  const next = useCallback(() => {
+    if (!ctx || ctx.matches.length === 0) return;
+    const i = (ctx.currentMatchIndex + 1) % ctx.matches.length;
+    ctx.setCurrentMatchIndex(i);
+    ctx.setActivePassageId(ctx.matches[i].passage_id);
+  }, [ctx]);
+
+  const prev = useCallback(() => {
+    if (!ctx || ctx.matches.length === 0) return;
+    const i =
+      (ctx.currentMatchIndex - 1 + ctx.matches.length) % ctx.matches.length;
+    ctx.setCurrentMatchIndex(i);
+    ctx.setActivePassageId(ctx.matches[i].passage_id);
+  }, [ctx]);
+
+  const close = useCallback(() => {
+    if (!ctx) return;
+    ctx.setQuery("");
+    ctx.setCurrentMatchIndex(0);
+    ctx.setActivePassageId(null);
+  }, [ctx]);
+
+  return {
+    total: ctx?.matches.length ?? 0,
+    current: ctx ? ctx.currentMatchIndex + 1 : 0,
+    matchesEmpty: !ctx || ctx.matches.length === 0,
+    next,
+    prev,
+    close,
+    currentMatch: ctx && ctx.matches[ctx.currentMatchIndex],
+  };
+}
+```
+
+- [ ] **Step 12.2 : Test du hook**
+
+```typescript
+import { renderHook, act } from "@testing-library/react-native";
+import React from "react";
+import { useHighlightNav } from "../useHighlightNav";
+import { SemanticHighlighterProvider } from "../SemanticHighlighter";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const wrap = (ui: React.ReactNode) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <SemanticHighlighterProvider summaryId={1}>{ui}</SemanticHighlighterProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("useHighlightNav", () => {
+  it("retourne total=0 sans matches", () => {
+    const { result } = renderHook(() => useHighlightNav(), {
+      wrapper: ({ children }) => wrap(children),
+    });
+    expect(result.current.total).toBe(0);
+    expect(result.current.matchesEmpty).toBe(true);
+  });
+
+  it("next/prev sont des no-op sans matches", () => {
+    const { result } = renderHook(() => useHighlightNav(), {
+      wrapper: ({ children }) => wrap(children),
+    });
+    act(() => result.current.next());
+    expect(result.current.current).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 12.3 : Composant `HighlightNavigationBar`**
+
+```typescript
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import { useHighlightNav } from "./useHighlightNav";
+
+interface Props {
+  bottomOffset?: number;
+}
+
+export const HighlightNavigationBar: React.FC<Props> = ({ bottomOffset = 80 }) => {
+  const { colors } = useTheme();
+  const { total, current, matchesEmpty, next, prev, close } = useHighlightNav();
+
+  if (matchesEmpty) return null;
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(180)}
+      exiting={FadeOut.duration(140)}
+      style={[
+        styles.bar,
+        { bottom: bottomOffset, backgroundColor: colors.bgElevated, borderColor: palette.gold + "40" },
+      ]}
+    >
+      <Text style={[styles.counter, { color: colors.textPrimary }]}>
+        {current}/{total}
+      </Text>
+      <Pressable
+        onPress={prev}
+        style={styles.btn}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityLabel="Match précédent"
+      >
+        <Ionicons name="chevron-up" size={22} color={palette.gold} />
+      </Pressable>
+      <Pressable
+        onPress={next}
+        style={styles.btn}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityLabel="Match suivant"
+      >
+        <Ionicons name="chevron-down" size={22} color={palette.gold} />
+      </Pressable>
+      <Pressable
+        onPress={close}
+        style={styles.btn}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityLabel="Fermer la recherche intra-analyse"
+      >
+        <Ionicons name="close" size={20} color={colors.textTertiary} />
+      </Pressable>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  bar: {
+    position: "absolute",
+    right: sp.lg,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.sm,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    elevation: 6,
+    shadowColor: "#000",
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+  },
+  counter: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
+    minWidth: 36,
+    textAlign: "center",
+  },
+  btn: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+```
+
+- [ ] **Step 12.4 : Brancher dans `analysis/[id].tsx`**
+
+À l'intérieur du `SemanticHighlighterProvider`, ajouter en bas de la page :
+
+```typescript
+<HighlightNavigationBar bottomOffset={tabBarFootprint + 20} />
+```
+
+- [ ] **Step 12.5 : Commit**
+
+```bash
+git add mobile/src/components/highlight/HighlightNavigationBar.tsx \
+        mobile/src/components/highlight/useHighlightNav.ts \
+        mobile/src/components/highlight/__tests__/useHighlightNav.test.ts \
+        mobile/app/\(tabs\)/analysis/\[id\].tsx
+git commit -m "feat(mobile-search): add floating HighlightNavigationBar with up/down/close"
+```
+
+---
+
+## Task 13 — Bouton loupe dans le header de `analysis/[id].tsx` + intra-search SearchBar
+
+**Files:**
+
+- Modify: `mobile/app/(tabs)/analysis/[id].tsx`
+
+**Goal:** Ajouter un bouton loupe à droite du `BackHeader`. Tap → toggle une `SearchBar` floating sticky en haut de la page (sous le header). Tape une query → set la query du provider via `setQuery` → `SemanticHighlighter` fetch les matches → highlights apparaissent dans tous les `<HighlightedText>` de la page → `HighlightNavigationBar` apparaît en bas-droite. `Esc` (Android back button) ferme la SearchBar et clear la query.
+
+- [ ] **Step 13.1 : State local pour la search bar visibility**
+
+Dans `AnalysisDetailScreen` :
+
+```typescript
+const [searchBarVisible, setSearchBarVisible] = useState(Boolean(q));
+```
+
+(initial = true si `q` arrive en param de navigation depuis le tab Search.)
+
+- [ ] **Step 13.2 : Modifier `BackHeader`**
+
+```typescript
+const BackHeader = (
+  <View style={[styles.header, { paddingTop: insets.top + sp.sm }]}>
+    <Pressable onPress={handleBack} style={styles.iconButton} accessibilityLabel="Retour">
+      <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+    </Pressable>
+    <View style={{ flex: 1 }} />
+    <Pressable
+      onPress={() => setSearchBarVisible((v) => !v)}
+      style={styles.iconButton}
+      accessibilityLabel={searchBarVisible ? "Fermer la recherche" : "Rechercher dans cette analyse"}
+      accessibilityRole="button"
+      hitSlop={8}
+    >
+      <Ionicons
+        name={searchBarVisible ? "close" : "search"}
+        size={24}
+        color={colors.textPrimary}
+      />
+    </Pressable>
+  </View>
+);
+```
+
+- [ ] **Step 13.3 : Wire la SearchBar au Provider**
+
+Créer un sub-composant `IntraAnalysisSearchInput` :
+
+```typescript
+const IntraAnalysisSearchInput: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+  const ctx = useSemanticHighlighter();
+  const [localValue, setLocalValue] = useState(ctx?.query ?? "");
+
+  useEffect(() => {
+    const t = setTimeout(() => ctx?.setQuery(localValue), 300);
+    return () => clearTimeout(t);
+  }, [localValue, ctx]);
+
+  return (
+    <View style={{ paddingHorizontal: sp.lg, paddingVertical: sp.sm }}>
+      <SearchBar
+        value={localValue}
+        onChangeText={setLocalValue}
+        autoFocus
+        placeholder="Rechercher dans cette analyse…"
+      />
+    </View>
+  );
+};
+```
+
+Et l'afficher quand `searchBarVisible` :
+
+```typescript
+{searchBarVisible && <IntraAnalysisSearchInput onClose={() => setSearchBarVisible(false)} />}
+```
+
+(Importer `SearchBar` depuis `@/components/search/SearchBar`.)
+
+- [ ] **Step 13.4 : `PassageActionSheet` ouvert quand `activePassageId` change**
+
+Ajouter dans `AnalysisDetailScreen` :
+
+```typescript
+const ctx = useSemanticHighlighter();
+const [actionSheetMatch, setActionSheetMatch] =
+  useState<WithinMatchItem | null>(null);
+
+useEffect(() => {
+  if (!ctx?.activePassageId) return;
+  const m = ctx.matches.find((x) => x.passage_id === ctx.activePassageId);
+  if (m) setActionSheetMatch(m);
+}, [ctx?.activePassageId, ctx?.matches]);
+```
+
+Wait — le hook `useSemanticHighlighter` doit être appelé DANS le scope du provider. Il faut donc déplacer cette logique dans un sub-composant rendu enfant du provider, ou ajouter un useEffect séparé via `<HighlightActionSheetController />`.
+
+Solution propre : créer un composant `<HighlightActionSheetController summaryId={...} />` rendu DANS le provider, qui écoute `activePassageId` et ouvre le sheet.
+
+```typescript
+const HighlightActionSheetController: React.FC<{ summaryId: number; query: string }> = ({ summaryId, query }) => {
+  const ctx = useSemanticHighlighter();
+  const [m, setM] = useState<WithinMatchItem | null>(null);
+
+  useEffect(() => {
+    if (!ctx?.activePassageId) {
+      setM(null);
+      return;
+    }
+    const found = ctx.matches.find((x) => x.passage_id === ctx.activePassageId);
+    setM(found ?? null);
+  }, [ctx?.activePassageId, ctx?.matches]);
+
+  return (
+    <PassageActionSheet
+      match={m}
+      query={query}
+      summaryId={summaryId}
+      isOpen={!!m}
+      onClose={() => {
+        ctx?.setActivePassageId(null);
+        setM(null);
+      }}
+    />
+  );
+};
+```
+
+- [ ] **Step 13.5 : Commit**
+
+```bash
+git add mobile/app/\(tabs\)/analysis/\[id\].tsx
+git commit -m "feat(mobile-search): add header search button and intra-analysis SearchBar with action sheet"
+```
+
+---
+
+## Task 14 — Plan privileges mirror (`semanticSearchTooltip`) + feature flag check
+
+**Files:**
+
+- Modify: `mobile/src/config/planPrivileges.ts`
+- Create: `mobile/src/services/featureFlags.ts`
+
+**Goal:** Mirror du flag backend `semantic_search_tooltip` dans le `PlanFeatures` mobile (cohérence cross-platform — même si non consommé en mobile V1, c'est un upsell potentiel V1.1 quand on ajoutera le tooltip pop-over). Aussi, ajouter un client `featureFlags` qui fetch `/api/features` pour cacher le tab Search si `FEATURE_SEMANTIC_SEARCH_V1=false` côté backend.
+
+- [ ] **Step 14.1 : Modifier `planPrivileges.ts`**
+
+Ajouter dans l'interface `PlanFeatures` (ligne 132-165) :
+
+```typescript
+export interface PlanFeatures {
+  // ... existant ...
+  semanticSearchTooltip: boolean; // Tooltip IA sur passage match (web only V1, mobile V1.1)
+}
+```
+
+Et dans les 3 plans (free / pro / expert) :
+
+```typescript
+free: {
+  // ... existant ...
+  semanticSearchTooltip: false,
+},
+pro: {
+  // ... existant ...
+  semanticSearchTooltip: true,
+},
+expert: {
+  // ... existant ...
+  semanticSearchTooltip: true,
+},
+```
+
+- [ ] **Step 14.2 : Créer `featureFlags.ts`**
+
+```typescript
+/**
+ * featureFlags — Wrapper léger autour de GET /api/features pour gating UI.
+ *
+ * Cache 5 min (le flag change rarement). Fallback `true` (optimistic) si erreur.
+ */
+
+import { request } from "./api";
+
+interface FeatureFlagsResponse {
+  semantic_search_v1?: boolean;
+  // (autres flags listés au besoin)
+}
+
+let cache: { value: FeatureFlagsResponse; expiresAt: number } | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export async function getFeatureFlags(): Promise<FeatureFlagsResponse> {
+  const now = Date.now();
+  if (cache && cache.expiresAt > now) return cache.value;
+  try {
+    // request est exporté ailleurs ou on utilise fetch direct
+    const res = await fetch(
+      `${require("../constants/config").API_BASE_URL}/api/features`,
+    );
+    if (!res.ok) throw new Error("flags fetch failed");
+    const value = (await res.json()) as FeatureFlagsResponse;
+    cache = { value, expiresAt: now + CACHE_TTL_MS };
+    return value;
+  } catch {
+    return { semantic_search_v1: true }; // optimistic — UI visible par défaut
+  }
+}
+
+export async function isSemanticSearchV1Enabled(): Promise<boolean> {
+  const flags = await getFeatureFlags();
+  return flags.semantic_search_v1 ?? true;
+}
+```
+
+- [ ] **Step 14.3 : Hook `useSemanticSearchEnabled`**
+
+```typescript
+// mobile/src/hooks/useSemanticSearchEnabled.ts
+import { useEffect, useState } from "react";
+import { isSemanticSearchV1Enabled } from "../services/featureFlags";
+
+export function useSemanticSearchEnabled(): boolean {
+  const [enabled, setEnabled] = useState(true); // optimistic
+  useEffect(() => {
+    let active = true;
+    isSemanticSearchV1Enabled().then((v) => {
+      if (active) setEnabled(v);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+  return enabled;
+}
+```
+
+- [ ] **Step 14.4 : Hide tab si flag OFF**
+
+Dans `mobile/src/components/navigation/CustomTabBar.tsx`, lire le flag et filtrer la route `search` du `visibleRoutes` :
+
+```typescript
+import { useSemanticSearchEnabled } from "@/hooks/useSemanticSearchEnabled";
+// ... dans CustomTabBar
+const searchEnabled = useSemanticSearchEnabled();
+const visibleRoutes = useMemo(
+  () =>
+    (state.routes as Array<{ key: string; name: string }>).filter(
+      (route) =>
+        route.name in TAB_META && (route.name !== "search" || searchEnabled),
+    ),
+  [state.routes, searchEnabled],
+);
+```
+
+- [ ] **Step 14.5 : Commit**
+
+```bash
+git add mobile/src/config/planPrivileges.ts \
+        mobile/src/services/featureFlags.ts \
+        mobile/src/hooks/useSemanticSearchEnabled.ts \
+        mobile/src/components/navigation/CustomTabBar.tsx
+git commit -m "feat(mobile-search): add semanticSearchTooltip plan flag mirror and feature flag gating"
+```
+
+---
+
+## Task 15 — Tests Jest sur composants critiques + 1 flow Detox (optionnel)
+
+**Files:**
+
+- Tous les `__tests__/*.test.tsx` créés en Tasks 1, 3, 5, 7, 9, 11, 12
+- Optionnel : `mobile/e2e/semantic-search.e2e.ts` (Detox)
+
+**Goal:** S'assurer que la suite Jest mobile reste verte (178+ tests existants doivent passer) et ajouter un flow Detox haut niveau (search global → tap result → highlight visible → tap match → action sheet ouverte). Le Detox flow est nice-to-have V1 — peut être reporté V1.1 si infra Detox pas prête.
+
+- [ ] **Step 15.1 : Lancer toute la suite Jest**
+
+```bash
+cd mobile && npm run test
+```
+
+Attendu : 178 + nouveaux tests = ~190+ tous verts.
+
+- [ ] **Step 15.2 : Si Detox configuré, écrire le flow E2E**
+
+Vérifier d'abord :
+
+```bash
+cd mobile && cat detox.config.js 2>/dev/null
+```
+
+Si Detox absent → SKIP ce step (V1.1 follow-up).
+
+Si Detox présent → créer `mobile/e2e/semantic-search.e2e.ts` :
+
+```typescript
+import { device, element, by, expect as detoxExpect } from "detox";
+
+describe("Semantic Search V1", () => {
+  beforeAll(async () => {
+    await device.launchApp({ permissions: { notifications: "YES" } });
+  });
+
+  it("search → tap result → highlight visible → tap match → action sheet", async () => {
+    // 1. Login (à adapter selon fixtures Detox du projet)
+    await element(by.id("login-email")).typeText("test@test.com");
+    await element(by.id("login-password")).typeText("password");
+    await element(by.id("login-submit")).tap();
+
+    // 2. Aller au tab Search
+    await element(by.label("Rechercher")).tap();
+
+    // 3. Taper une query
+    await element(by.label("Champ de recherche sémantique")).typeText(
+      "transition",
+    );
+    await waitFor(element(by.label(/Résultat de recherche/i)).atIndex(0))
+      .toBeVisible()
+      .withTimeout(8000);
+
+    // 4. Tap sur le 1er résultat
+    await element(by.label(/Résultat de recherche/i))
+      .atIndex(0)
+      .tap();
+
+    // 5. Vérifier qu'on est dans l'analyse, et qu'un passage surligné est visible
+    await detoxExpect(
+      element(by.label(/Passage correspondant/i)),
+    ).toBeVisible();
+
+    // 6. Tap sur le passage surligné
+    await element(by.label(/Passage correspondant/i))
+      .atIndex(0)
+      .tap();
+
+    // 7. ActionSheet ouverte
+    await detoxExpect(element(by.text(/Demander à l'IA/i))).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 15.3 : Commit**
+
+```bash
+git add mobile/e2e/semantic-search.e2e.ts || true
+git commit -m "test(mobile-search): add Detox E2E flow for semantic search V1" --allow-empty
+```
+
+(Allow-empty si Detox absent.)
+
+---
+
+## Task 16 — EAS preview build + test manuel iOS/Android
+
+**Files:**
+
+- Aucun (commande infra)
+
+**Goal:** Lancer un EAS Build preview pour vérifier le rendu sur device réel (iOS + Android). Pas un release prod — le release sera fait dans la phase d'orchestration finale du projet semantic-search-v1.
+
+- [ ] **Step 16.1 : Lancer le build preview**
+
+```bash
+cd mobile && eas build --profile preview --platform all
+```
+
+Attendre les builds (15-25min iOS + Android).
+
+- [ ] **Step 16.2 : Test manuel sur device**
+
+Checklist :
+
+- [ ] Tab Search visible avec icône loupe entre Library et Hub
+- [ ] Tap dans la SearchBar → clavier remonte sans masquer la barre (KeyboardAvoidingView OK)
+- [ ] Taper "transition" (ou autre query qui matche tes analyses) → résultats apparaissent en < 1.5s
+- [ ] Tap sur un résultat → analyse s'ouvre avec passages surlignés en jaune
+- [ ] FAB ↑↓ visible en bas-droite avec compteur "3/12"
+- [ ] Tap sur ↑/↓ → highlight focus change (passage devient jaune appuyé)
+- [ ] Tap sur un passage surligné → BottomSheet "Demander à l'IA / Voir dans X" s'ouvre
+- [ ] Tap "Demander à l'IA" → navigate vers Hub avec input pré-rempli
+- [ ] Bouton loupe dans header analyse → toggle search bar intra-analyse
+- [ ] Empty state avec recent queries fonctionne après quelques recherches
+
+- [ ] **Step 16.3 : Documenter les bugs trouvés**
+
+Si bugs critiques : créer des tâches dans Asana projet `DeepSight Mobile` et fix avant merge.
+Si polish issues : créer un follow-up V1.1.
+
+- [ ] **Step 16.4 : Push final + créer la PR**
+
+```bash
+git push origin feat/search-mobile-phase3
+gh pr create --base main --title "feat(mobile): Semantic Search V1 — Phase 3 mobile (search tab + intra-analyse + PassageActionSheet)" --body "$(cat <<'EOF'
+## Summary
+
+Phase 3 mobile de Semantic Search V1 (cf. spec docs/superpowers/specs/2026-05-03-semantic-search-design.md §5).
+
+- New tab `Search` entre Library et Hub
+- `SearchBar` + `SearchResultsList` (FlashList virtualisée) + `SearchResultCard` avec badges typés
+- `SearchFiltersSheet` BottomSheet (source_types, plateforme, favoris)
+- Intra-analyse via bouton loupe dans le header de `analysis/[id].tsx`
+- `HighlightedText` + `SemanticHighlighter` Provider
+- `PassageActionSheet` avec 3 actions tap-friendly (Demander à l'IA, Sauter timecode, Voir dans tab)
+- `HighlightNavigationBar` flottant FAB ↑↓ avec compteur
+- AsyncStorage cache des 5 dernières queries + sync API best-effort
+- Mirror plan flag `semanticSearchTooltip` (réservé V1.1 — pas consommé V1)
+- Feature flag gating via `/api/features` (tab caché si `FEATURE_SEMANTIC_SEARCH_V1=false`)
+
+## Test plan
+
+- [x] Jest suite verte (~190 tests)
+- [ ] Manual smoke test iOS preview build via EAS
+- [ ] Manual smoke test Android preview build via EAS
+- [ ] Detox flow E2E (optionnel V1.1 si infra non prête)
+
+## Out of scope
+
+- Activation feature flag prod (manuelle, dernière étape orchestration)
+- EAS update OTA prod (réservé phase release globale)
+- Tooltip IA mobile (tier medium = pas de tooltip — V1.1+)
+- Highlights dans le markdown long-form du tab Résumé (V1.1 — nécessite hook custom react-native-markdown-display)
+EOF
+)"
+```
+
+---
+
+## Definition of Done — Phase 3 Mobile
+
+- [ ] Branche `feat/search-mobile-phase3` mergée dans `main` via PR
+- [ ] Tab Search visible et fonctionnel sur iOS + Android (EAS preview build)
+- [ ] Recherche globale debounce 400ms → résultats < 1.5s sur 1000 passages user
+- [ ] Recherche intra-analyse fonctionne via bouton loupe header
+- [ ] `PassageActionSheet` 3 actions tap-friendly opérationnel
+- [ ] `HighlightNavigationBar` FAB navigation entre matches OK
+- [ ] AsyncStorage cache des 5 dernières queries persistant + reset à clear
+- [ ] Plan flag `semanticSearchTooltip` mirror backend (cross-platform consistency)
+- [ ] Feature flag `FEATURE_SEMANTIC_SEARCH_V1` côté backend cache le tab si OFF
+- [ ] Tous les tests Jest verts (Jest 178 + nouveaux ~12 = ~190)
+- [ ] Pas de régression sur les autres tabs (Library / Study / Hub / Profile / Subscription)
+- [ ] Pas de nouvelle erreur TypeScript hors les 19 pré-existantes documentées
+- [ ] Accessibilité validée : tous les `<Text>` highlightés et `<Pressable>` ont `accessibilityLabel` + `accessibilityRole`
+- [ ] Commit messages ASCII propres, prefix `feat(mobile-search):` cohérent
+- [ ] PR description liée à la spec et aux phases adjacentes (Phases 2 web et 4 extension)
+
+---
+
+## Notes mobile-spécifiques
+
+- **Pas de Cmd+F mobile** — le bouton loupe dans le header est l'entrée principale de la recherche intra-analyse. Pas de raccourci clavier.
+- **Pas de tooltip IA mobile** — tap sur highlight ouvre directement le `PassageActionSheet`. Le flag `semanticSearchTooltip` reste mirror du backend pour cohérence cross-platform et upsell V1.1 (modal "Le tooltip IA est sur web uniquement V1").
+- **Tap-friendly** : `hitSlop` n'est pas utilisable sur `<Text>` inline (`onPress` sur `<Text>` n'expose pas hitSlop). On compense par background visuel (jaune pâle 35% → jaune appuyé 60% au tap).
+- **KeyboardAvoidingView** : essentiel autour de la SearchBar — le clavier mobile masque la barre sinon (cf. risque H + Mitigation ligne 724 du spec).
+- **Reanimated 4** : utiliser `FadeIn`/`FadeOut` sur le `HighlightNavigationBar` (pas `Animated` legacy de React Native).
+- **Style cohérence** : design system mobile dark-first, palette `gold` pour les highlights (`palette.gold = "#C8903A"`), accents `indigo/violet/cyan` pour les badges typés (cf. `mobile/src/theme/colors.ts`).
+- **Tier medium** : simplifications acceptables vs web tier full — pas de filtres avancés langue/catégorie/playlist V1, pas de tooltip IA, markdown long-form non highlighté V1 (titres de section + flashcards/quiz/chat suffisent V1).
+
+---
+
+## Risques & rollback
+
+| Risque                                                          | Mitigation                                                                                                           |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Backend FEATURE_SEMANTIC_SEARCH_V1 OFF → tab visible quand même | `useSemanticSearchEnabled` hook caché optimistic mais filtre route dans CustomTabBar — vérifier que le filter marche |
+| Highlight casse le rendu Markdown du tab Résumé                 | V1 ne touche PAS au Markdown render. Highlights uniquement sur titres de section, flashcards/quiz/chat               |
+| AsyncStorage corruption                                         | Try/catch silencieux — fallback queries vide                                                                         |
+| Mistral API timeout intra-analyse                               | React Query retry: 1 + le user voit le state error UI                                                                |
+| BottomSheet `SimpleBottomSheet` vs `@gorhom/bottom-sheet`       | On privilégie `SimpleBottomSheet` interne (Expo Go compatible — pattern existant `TutorBottomSheet`)                 |
+| EAS Build preview échoue                                        | Tester d'abord `npx expo start` en local — fix avant build cloud                                                     |
+| Tests Jest cassent à cause de mock React Query manquant         | Wrapper `QueryClientProvider` documenté dans Tasks 7 et 9                                                            |
+
+**Rollback strategy** : si bug critique en prod après merge, set backend `FEATURE_SEMANTIC_SEARCH_V1=false` (SSH Hetzner + `docker restart repo-backend-1`) → le tab Search disparaît automatiquement côté mobile via le hook `useSemanticSearchEnabled`. Pas de besoin de hot-fix mobile.
+
+---
+
+_Plan rédigé le 2026-05-03 par Claude Opus 4.7 (1M context) suite au brief Phase 3 mobile de Maxime, focus Section 5 de `docs/superpowers/specs/2026-05-03-semantic-search-design.md`._

--- a/docs/superpowers/plans/2026-05-03-semantic-search-v1-phase4-extension.md
+++ b/docs/superpowers/plans/2026-05-03-semantic-search-v1-phase4-extension.md
@@ -1,0 +1,1982 @@
+# Semantic Search V1 — Phase 4 Extension Chrome Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter une fonctionnalité Quick Search légère dans l'extension Chrome (sidepanel `HomeView`) qui consomme `POST /api/search/global` (Phase 1 backend déjà mergé via PR #292) et offre un footer "Voir tous les résultats sur deepsightsynthesis.com" pour rebasculer vers le web tier (full feature).
+
+**Architecture:** Light tier — UN seul composant `QuickSearch` collapse/expand placé dans `HomeView.tsx` au-dessus de `RecentsList`. Pas d'intra-analyse search, pas de tooltip IA, pas de filtres avancés (la spec impose la sobriété pour respecter l'espace contraint du sidepanel). Cache `chrome.storage.local` pour les 5 dernières queries du user. Click sur résultat → ouvre l'analyse correspondante via le pattern existant (sidepanel reste ouvert, route `summary/{id}` dans un nouvel onglet web). Footer → `chrome.tabs.create` vers `WEBAPP_URL/search?q=...`.
+
+**Tech Stack:** TypeScript strict + React 18 + Webpack 5 + Manifest V3, Jest + jsdom + Testing Library (pattern existant). Le service worker `background.ts` gère les API calls via le pattern `apiRequest` (CSP MV3 oblige). Storage = `chrome.storage.local` uniquement (pas de localStorage côté extension).
+
+**Spec source:** `docs/superpowers/specs/2026-05-03-semantic-search-design.md` — focus Section 6 (Extension Chrome).
+
+**Phase 1 backend dependencies (déjà disponibles en prod via PR #292) :**
+
+- `POST /api/search/global` — body `{ query, limit, source_types?, platform?, lang?, category?, date_from?, date_to?, favorites_only?, playlist_id? }` — auth required, JWT déjà manipulé par `apiRequest` dans `background.ts`
+- `GET /api/search/recent-queries` → `{ queries: list[str] }` (10 dernières queries du user)
+- `DELETE /api/search/recent-queries` → 204
+
+Réponse `/global` :
+
+```json
+{
+  "query": "string",
+  "total_results": 42,
+  "results": [
+    {
+      "source_type": "summary" | "flashcard" | "quiz" | "chat" | "transcript",
+      "source_id": 123,
+      "summary_id": 456,
+      "score": 0.87,
+      "text_preview": "…la transition énergétique impose…",
+      "source_metadata": {
+        "summary_title": "…",
+        "summary_thumbnail": "…",
+        "video_id": "abc",
+        "channel": "…",
+        "tab": "synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript"
+      }
+    }
+  ],
+  "searched_at": "2026-05-03T..."
+}
+```
+
+---
+
+## File Structure
+
+### Files créés
+
+- `extension/src/types/search.ts` — TypeScript types pour les responses search (mirror du backend Pydantic)
+- `extension/src/sidepanel/components/QuickSearch.tsx` — composant racine (input + collapse/expand + results)
+- `extension/src/sidepanel/components/QuickSearchResultsList.tsx` — liste compacte de résultats
+- `extension/src/sidepanel/components/QuickSearchResultItem.tsx` — 1 ligne par résultat avec badge type compact
+- `extension/src/sidepanel/hooks/useQuickSearch.ts` — hook avec debounce 400ms + cache local
+- `extension/src/utils/searchCache.ts` — helpers `chrome.storage.local` pour les 5 dernières queries
+- `extension/__tests__/sidepanel/components/QuickSearch.test.tsx`
+- `extension/__tests__/sidepanel/components/QuickSearchResultsList.test.tsx`
+- `extension/__tests__/sidepanel/components/QuickSearchResultItem.test.tsx`
+- `extension/__tests__/sidepanel/hooks/useQuickSearch.test.tsx`
+- `extension/__tests__/utils/searchCache.test.ts`
+- `extension/__tests__/background/search-global.test.ts`
+
+### Files modifiés
+
+- `extension/src/types/index.ts` — ajout `SEARCH_GLOBAL`, `GET_RECENT_QUERIES` dans `MessageAction`
+- `extension/src/background.ts` — handler `searchGlobal()` + `getRecentQueries()` (route via `apiRequest`)
+- `extension/src/sidepanel/views/HomeView.tsx` — insère `<QuickSearch />` au-dessus du label "Récent"
+- `extension/__tests__/sidepanel/views/HomeView.test.tsx` — assert que QuickSearch render avant RecentsList
+
+### Hors scope explicit
+
+- Intra-analyse search (`POST /api/search/within/{id}`) → absent extension light tier
+- Tooltip IA (`POST /api/search/explain-passage`) → absent extension
+- Filtres avancés (platform/lang/date_from/favorites_only) → web tier only
+- Sync cross-device des recent queries → out of scope V1 (chaque plateforme a son cache local)
+
+---
+
+## Conventions globales pour TOUTES les tasks
+
+- Branche worktree dédiée : `feat/search-extension-phase4`
+- Commits ASCII propres (pas d'emojis), prefix `feat(extension):` / `test(extension):` / `chore(extension):`
+- Tests Jest + jsdom + Testing Library — pattern existant (cf. `__tests__/sidepanel/components/RecentsList.test.tsx`)
+- Pas de `localStorage`, uniquement `chrome.storage.local` (CSP MV3)
+- API calls TOUJOURS via `chrome.runtime.sendMessage` vers `background.ts` (sidepanel ne peut pas fetch directement à cause de CSP MV3 + le pattern existant `apiRequest` gère le refresh JWT 401)
+- TypeScript strict, zéro `any` — utiliser les types de `extension/src/types/search.ts`
+- Styling : reuse classes CSS existantes du sidepanel (`v3-*`, ds-\*) sinon inline styles cohérents avec `RecentsList` (fontSize 13, padding 8/16, opacity 0.5/0.6)
+- Le sidepanel fait ~360px de large — la liste 1 ligne par résultat est non-négociable
+
+---
+
+## Task 1: Extension API client — `searchGlobal` + `getRecentQueries` dans background.ts
+
+**Files:**
+
+- Modify: `extension/src/types/index.ts` (ajout actions)
+- Create: `extension/src/types/search.ts`
+- Modify: `extension/src/background.ts` (ajout 2 fonctions API + 2 cases switch)
+- Test: `extension/__tests__/background/search-global.test.ts`
+
+- [ ] **Step 1: Créer le fichier types `extension/src/types/search.ts`**
+
+```typescript
+// Types pour les endpoints de recherche sémantique V1 (Phase 1 backend PR #292)
+
+export type SearchSourceType =
+  | "summary"
+  | "flashcard"
+  | "quiz"
+  | "chat"
+  | "transcript";
+
+export interface SearchSourceMetadata {
+  summary_title?: string;
+  summary_thumbnail?: string;
+  video_id?: string;
+  channel?: string;
+  tab?: "synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript";
+  start_ts?: number;
+  end_ts?: number;
+  anchor?: string;
+  flashcard_id?: number;
+  quiz_question_id?: number;
+}
+
+export interface SearchResult {
+  source_type: SearchSourceType;
+  source_id: number;
+  summary_id: number | null;
+  score: number;
+  text_preview: string;
+  source_metadata: SearchSourceMetadata;
+}
+
+export interface GlobalSearchResponse {
+  query: string;
+  total_results: number;
+  results: SearchResult[];
+  searched_at: string;
+}
+
+export interface RecentQueriesResponse {
+  queries: string[];
+}
+
+export interface GlobalSearchOptions {
+  query: string;
+  limit?: number;
+  source_types?: SearchSourceType[];
+}
+```
+
+- [ ] **Step 2: Étendre `MessageAction` dans `extension/src/types/index.ts`**
+
+Trouver la ligne 210 du fichier (la fin du type union `MessageAction`), juste avant `;`. Ajouter 2 actions :
+
+```typescript
+  // Recherche sémantique V1 (Phase 4 extension)
+  | "SEARCH_GLOBAL"
+  | "GET_RECENT_QUERIES"
+```
+
+Puis dans `MessageResponse` (ligne ~223) ajouter les fields optionnels :
+
+```typescript
+export interface MessageResponse {
+  success?: boolean;
+  authenticated?: boolean;
+  user?: User;
+  status?: TaskStatus;
+  summary?: Summary;
+  plan?: PlanInfo;
+  result?: unknown;
+  error?: string;
+  share_url?: string;
+  state?: VoiceButtonState;
+  // Phase 4 search
+  searchResults?: GlobalSearchResponse;
+  recentQueries?: string[];
+}
+```
+
+Et au top du fichier (après le bloc d'imports/types existants) :
+
+```typescript
+import type { GlobalSearchResponse } from "./search";
+```
+
+- [ ] **Step 3: Écrire le test échouant `__tests__/background/search-global.test.ts`**
+
+```typescript
+/**
+ * Tests — SEARCH_GLOBAL action handler
+ * Source : src/background.ts (handleMessage switch case)
+ */
+
+import { resetChromeMocks, seedLocalStorage } from "../setup/chrome-api-mock";
+
+const mockFetch = jest.fn();
+(global as unknown as Record<string, unknown>).fetch = mockFetch;
+
+let handleMessage: (message: {
+  action: string;
+  data?: Record<string, unknown>;
+}) => Promise<unknown>;
+
+beforeAll(() => {
+  const onMessageAddListener = chrome.runtime.onMessage
+    .addListener as jest.Mock;
+  onMessageAddListener.mockClear();
+  require("../../src/background");
+  const registeredCallback = onMessageAddListener.mock.calls[0]?.[0];
+  if (registeredCallback) {
+    handleMessage = async (message) => {
+      return new Promise((resolve) => {
+        registeredCallback(message, {}, resolve);
+      });
+    };
+  }
+});
+
+beforeEach(() => {
+  resetChromeMocks();
+  mockFetch.mockReset();
+  seedLocalStorage({ accessToken: "test-token" });
+});
+
+describe("SEARCH_GLOBAL", () => {
+  it("calls /search/global with the right body and forwards the response", async () => {
+    const fakeResults = {
+      query: "transition énergétique",
+      total_results: 2,
+      results: [
+        {
+          source_type: "summary",
+          source_id: 12,
+          summary_id: 12,
+          score: 0.91,
+          text_preview: "…la transition énergétique impose…",
+          source_metadata: { summary_title: "Crise EU", video_id: "abc" },
+        },
+        {
+          source_type: "flashcard",
+          source_id: 34,
+          summary_id: 12,
+          score: 0.87,
+          text_preview: "Q: Quels objectifs pour la transition…",
+          source_metadata: { summary_title: "Crise EU" },
+        },
+      ],
+      searched_at: "2026-05-03T10:00:00Z",
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(fakeResults),
+    });
+
+    const response = (await handleMessage({
+      action: "SEARCH_GLOBAL",
+      data: { query: "transition énergétique", limit: 10 },
+    })) as { success: boolean; searchResults: typeof fakeResults };
+
+    expect(response.success).toBe(true);
+    expect(response.searchResults).toEqual(fakeResults);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/search/global"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ query: "transition énergétique", limit: 10 }),
+      }),
+    );
+  });
+
+  it("returns error when not authenticated", async () => {
+    seedLocalStorage({}); // no accessToken
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ detail: "Not authenticated" }),
+    });
+
+    const response = (await handleMessage({
+      action: "SEARCH_GLOBAL",
+      data: { query: "test" },
+    })) as { success: boolean; error?: string };
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBeDefined();
+  });
+});
+
+describe("GET_RECENT_QUERIES", () => {
+  it("calls /search/recent-queries and returns the queries array", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ queries: ["énergie", "europe", "ia mistral"] }),
+    });
+
+    const response = (await handleMessage({
+      action: "GET_RECENT_QUERIES",
+    })) as { success: boolean; recentQueries: string[] };
+
+    expect(response.success).toBe(true);
+    expect(response.recentQueries).toEqual(["énergie", "europe", "ia mistral"]);
+  });
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cd extension && npm test -- search-global.test`
+Expected: FAIL with "Unknown action" (le case n'existe pas encore dans le switch)
+
+- [ ] **Step 5: Implémenter `searchGlobal` + `getRecentQueries` dans `background.ts`**
+
+Insérer après la fonction `quickChat` (vers ligne 413), avant la section `// ── Chat API ──` :
+
+```typescript
+// ── Search API (Phase 4 extension) ──
+
+import type {
+  GlobalSearchOptions,
+  GlobalSearchResponse,
+  RecentQueriesResponse,
+} from "./types/search";
+
+async function searchGlobal(
+  options: GlobalSearchOptions,
+): Promise<GlobalSearchResponse> {
+  // limit max 10 côté extension (vs 30 web/mobile) — espace contraint sidepanel.
+  const body: Record<string, unknown> = {
+    query: options.query,
+    limit: options.limit ?? 10,
+  };
+  if (options.source_types && options.source_types.length > 0) {
+    body.source_types = options.source_types;
+  }
+  return apiRequest<GlobalSearchResponse>("/search/global", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function getRecentQueries(): Promise<RecentQueriesResponse> {
+  return apiRequest<RecentQueriesResponse>("/search/recent-queries");
+}
+```
+
+⚠️ Le `import type` doit être déplacé en haut du fichier avec les autres imports (TypeScript strict refuse les imports en milieu de fichier).
+
+Puis ajouter 2 cases dans `handleExtensionMessage` switch (vers ligne 1063, après `case "GET_PLAN"`):
+
+```typescript
+    case "SEARCH_GLOBAL": {
+      const opts = message.data as GlobalSearchOptions;
+      try {
+        const searchResults = await searchGlobal(opts);
+        return { success: true, searchResults };
+      } catch (e) {
+        return { success: false, error: (e as Error).message };
+      }
+    }
+
+    case "GET_RECENT_QUERIES": {
+      try {
+        const result = await getRecentQueries();
+        return { success: true, recentQueries: result.queries };
+      } catch (e) {
+        return { success: false, error: (e as Error).message };
+      }
+    }
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd extension && npm test -- search-global.test`
+Expected: PASS (3 tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add extension/src/types/search.ts extension/src/types/index.ts extension/src/background.ts extension/__tests__/background/search-global.test.ts
+git commit -m "feat(extension): add SEARCH_GLOBAL and GET_RECENT_QUERIES actions in background"
+```
+
+---
+
+## Task 2: Cache local des 5 dernières queries (`searchCache.ts`)
+
+**Files:**
+
+- Create: `extension/src/utils/searchCache.ts`
+- Test: `extension/__tests__/utils/searchCache.test.ts`
+
+- [ ] **Step 1: Écrire le test échouant**
+
+```typescript
+/**
+ * Tests — searchCache helpers
+ * Source : src/utils/searchCache.ts
+ */
+
+import { resetChromeMocks } from "../setup/chrome-api-mock";
+import {
+  getCachedQueries,
+  pushCachedQuery,
+  clearCachedQueries,
+} from "../../src/utils/searchCache";
+
+describe("searchCache", () => {
+  beforeEach(() => {
+    resetChromeMocks();
+  });
+
+  it("returns empty array when no queries cached yet", async () => {
+    const queries = await getCachedQueries();
+    expect(queries).toEqual([]);
+  });
+
+  it("pushes a new query at the head and persists it", async () => {
+    await pushCachedQuery("transition énergétique");
+    const queries = await getCachedQueries();
+    expect(queries).toEqual(["transition énergétique"]);
+  });
+
+  it("keeps only the 5 most recent queries (LRU cap)", async () => {
+    for (let i = 1; i <= 7; i++) {
+      await pushCachedQuery(`query ${i}`);
+    }
+    const queries = await getCachedQueries();
+    expect(queries).toHaveLength(5);
+    // Most recent first
+    expect(queries[0]).toBe("query 7");
+    expect(queries[4]).toBe("query 3");
+  });
+
+  it("dedupes : pushing an existing query moves it to the head", async () => {
+    await pushCachedQuery("a");
+    await pushCachedQuery("b");
+    await pushCachedQuery("c");
+    await pushCachedQuery("a"); // already present → moved to head
+    const queries = await getCachedQueries();
+    expect(queries).toEqual(["a", "c", "b"]);
+  });
+
+  it("trims and ignores empty queries", async () => {
+    await pushCachedQuery("   ");
+    await pushCachedQuery("");
+    const queries = await getCachedQueries();
+    expect(queries).toEqual([]);
+  });
+
+  it("clearCachedQueries empties the cache", async () => {
+    await pushCachedQuery("x");
+    await clearCachedQueries();
+    const queries = await getCachedQueries();
+    expect(queries).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd extension && npm test -- searchCache.test`
+Expected: FAIL with "Cannot find module '../../src/utils/searchCache'"
+
+- [ ] **Step 3: Implémenter `extension/src/utils/searchCache.ts`**
+
+```typescript
+/**
+ * searchCache — Cache local des 5 dernières queries de recherche.
+ *
+ * Stocké dans `chrome.storage.local` clé `recent_queries` (cf. spec § 6.3).
+ * Pas de sync cross-device en V1 (cf. spec « Pas de sync cross-device pour V1 »).
+ */
+
+import Browser from "./browser-polyfill";
+
+const STORAGE_KEY = "recent_queries";
+const MAX_QUERIES = 5;
+
+export async function getCachedQueries(): Promise<string[]> {
+  try {
+    const data = (await Browser.storage.local.get(STORAGE_KEY)) as {
+      [STORAGE_KEY]?: string[];
+    };
+    const queries = data[STORAGE_KEY];
+    return Array.isArray(queries) ? queries.slice(0, MAX_QUERIES) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function pushCachedQuery(query: string): Promise<void> {
+  const trimmed = query.trim();
+  if (!trimmed) return;
+  const existing = await getCachedQueries();
+  const deduped = existing.filter((q) => q !== trimmed);
+  const next = [trimmed, ...deduped].slice(0, MAX_QUERIES);
+  try {
+    await Browser.storage.local.set({ [STORAGE_KEY]: next });
+  } catch {
+    // Storage quota or permission error — fail silently
+  }
+}
+
+export async function clearCachedQueries(): Promise<void> {
+  try {
+    await Browser.storage.local.remove(STORAGE_KEY);
+  } catch {
+    // Ignore errors on clear
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd extension && npm test -- searchCache.test`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/utils/searchCache.ts extension/__tests__/utils/searchCache.test.ts
+git commit -m "feat(extension): add searchCache helpers for chrome.storage.local LRU"
+```
+
+---
+
+## Task 3: Hook `useQuickSearch` (debounce 400ms + cache)
+
+**Files:**
+
+- Create: `extension/src/sidepanel/hooks/useQuickSearch.ts`
+- Test: `extension/__tests__/sidepanel/hooks/useQuickSearch.test.tsx`
+
+- [ ] **Step 1: Écrire le test échouant**
+
+```typescript
+/**
+ * Tests — useQuickSearch hook
+ * Source : src/sidepanel/hooks/useQuickSearch.ts
+ */
+
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { resetChromeMocks } from "../../setup/chrome-api-mock";
+import { useQuickSearch } from "../../../src/sidepanel/hooks/useQuickSearch";
+
+// Test harness — minimal React component that exposes the hook state.
+function Harness({ query }: { query: string }) {
+  const { results, loading, error } = useQuickSearch(query);
+  return (
+    <div>
+      <span data-testid="loading">{loading ? "true" : "false"}</span>
+      <span data-testid="error">{error || ""}</span>
+      <span data-testid="count">{results.length}</span>
+      {results.map((r, i) => (
+        <span key={i} data-testid={`result-${i}`}>
+          {r.source_type}:{r.source_id}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+describe("useQuickSearch", () => {
+  beforeEach(() => {
+    resetChromeMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns empty results when query is shorter than 2 chars", async () => {
+    render(<Harness query="a" />);
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(screen.getByTestId("loading")).toHaveTextContent("false");
+  });
+
+  it("debounces 400ms before sending the search request", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    sendMessage.mockResolvedValue({
+      success: true,
+      searchResults: {
+        query: "test",
+        total_results: 0,
+        results: [],
+        searched_at: "2026-05-03T00:00:00Z",
+      },
+    });
+
+    render(<Harness query="test" />);
+
+    // Avant 400ms — aucun call
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(399);
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(2);
+    });
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "SEARCH_GLOBAL",
+          data: { query: "test", limit: 10 },
+        }),
+      );
+    });
+  });
+
+  it("populates results when sendMessage succeeds", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    sendMessage.mockResolvedValue({
+      success: true,
+      searchResults: {
+        query: "ai",
+        total_results: 1,
+        results: [
+          {
+            source_type: "summary",
+            source_id: 7,
+            summary_id: 7,
+            score: 0.9,
+            text_preview: "…",
+            source_metadata: {},
+          },
+        ],
+        searched_at: "2026-05-03T00:00:00Z",
+      },
+    });
+
+    render(<Harness query="ai" />);
+    act(() => {
+      jest.advanceTimersByTime(401);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("count")).toHaveTextContent("1");
+      expect(screen.getByTestId("result-0")).toHaveTextContent("summary:7");
+    });
+  });
+
+  it("surfaces error when sendMessage fails", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    sendMessage.mockResolvedValue({
+      success: false,
+      error: "Network error",
+    });
+
+    render(<Harness query="test" />);
+    act(() => {
+      jest.advanceTimersByTime(401);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error")).toHaveTextContent("Network error");
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd extension && npm test -- useQuickSearch.test`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Implémenter `extension/src/sidepanel/hooks/useQuickSearch.ts`**
+
+```typescript
+/**
+ * useQuickSearch — Hook React qui appelle SEARCH_GLOBAL avec debounce 400ms.
+ *
+ * Spec : extension light tier (max 10 résultats, debounce 400ms cf. spec § 6.2).
+ * Pas de cache mémoire intra-session — l'extension est censée être légère ;
+ * un re-render avec la même query fait un nouveau call (acceptable car le
+ * backend cache 24h en Redis).
+ */
+
+import { useEffect, useState } from "react";
+import Browser from "../../utils/browser-polyfill";
+import type { MessageResponse } from "../../types";
+import type { GlobalSearchResponse, SearchResult } from "../../types/search";
+
+const DEBOUNCE_MS = 400;
+const MIN_QUERY_LENGTH = 2;
+
+interface QuickSearchState {
+  results: SearchResult[];
+  loading: boolean;
+  error: string | null;
+  totalResults: number;
+}
+
+export function useQuickSearch(query: string): QuickSearchState {
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [totalResults, setTotalResults] = useState(0);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setResults([]);
+      setLoading(false);
+      setError(null);
+      setTotalResults(0);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const timer = setTimeout(async () => {
+      try {
+        const response = await Browser.runtime.sendMessage<
+          unknown,
+          MessageResponse
+        >({
+          action: "SEARCH_GLOBAL",
+          data: { query: trimmed, limit: 10 },
+        });
+
+        if (cancelled) return;
+
+        if (response.success && response.searchResults) {
+          const payload = response.searchResults as GlobalSearchResponse;
+          setResults(payload.results);
+          setTotalResults(payload.total_results);
+          setError(null);
+        } else {
+          setResults([]);
+          setTotalResults(0);
+          setError(response.error || "Recherche impossible");
+        }
+      } catch (e) {
+        if (cancelled) return;
+        setResults([]);
+        setTotalResults(0);
+        setError((e as Error).message || "Recherche impossible");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
+
+  return { results, loading, error, totalResults };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd extension && npm test -- useQuickSearch.test`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/sidepanel/hooks/useQuickSearch.ts extension/__tests__/sidepanel/hooks/useQuickSearch.test.tsx
+git commit -m "feat(extension): add useQuickSearch hook with 400ms debounce"
+```
+
+---
+
+## Task 4: Composant `QuickSearchResultItem` (1 ligne par résultat)
+
+**Files:**
+
+- Create: `extension/src/sidepanel/components/QuickSearchResultItem.tsx`
+- Test: `extension/__tests__/sidepanel/components/QuickSearchResultItem.test.tsx`
+
+- [ ] **Step 1: Écrire le test échouant**
+
+```typescript
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QuickSearchResultItem } from "../../../src/sidepanel/components/QuickSearchResultItem";
+import type { SearchResult } from "../../../src/types/search";
+
+describe("QuickSearchResultItem", () => {
+  const baseResult: SearchResult = {
+    source_type: "summary",
+    source_id: 12,
+    summary_id: 12,
+    score: 0.91,
+    text_preview: "…la transition énergétique impose une refonte du mix électrique européen…",
+    source_metadata: {
+      summary_title: "Crise énergétique EU",
+      summary_thumbnail: "https://example.com/thumb.jpg",
+      video_id: "abc",
+    },
+  };
+
+  it("renders the summary title", () => {
+    render(<QuickSearchResultItem result={baseResult} onSelect={() => {}} />);
+    expect(screen.getByText("Crise énergétique EU")).toBeInTheDocument();
+  });
+
+  it("renders the source type badge", () => {
+    render(<QuickSearchResultItem result={baseResult} onSelect={() => {}} />);
+    // Badge text matches the source type, case-insensitive
+    expect(screen.getByText(/synth/i)).toBeInTheDocument();
+  });
+
+  it("renders different badge for flashcard", () => {
+    const flashcardResult: SearchResult = {
+      ...baseResult,
+      source_type: "flashcard",
+      source_metadata: { ...baseResult.source_metadata, summary_title: "Ex" },
+    };
+    render(
+      <QuickSearchResultItem
+        result={flashcardResult}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText(/flashcard/i)).toBeInTheDocument();
+  });
+
+  it("calls onSelect with the result when clicked", () => {
+    const onSelect = jest.fn();
+    render(<QuickSearchResultItem result={baseResult} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText("Crise énergétique EU"));
+    expect(onSelect).toHaveBeenCalledWith(baseResult);
+  });
+
+  it("falls back to text_preview if no summary_title", () => {
+    const noTitle: SearchResult = {
+      ...baseResult,
+      source_metadata: {},
+    };
+    render(<QuickSearchResultItem result={noTitle} onSelect={() => {}} />);
+    expect(
+      screen.getByText(/la transition énergétique impose/i),
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd extension && npm test -- QuickSearchResultItem.test`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Implémenter `extension/src/sidepanel/components/QuickSearchResultItem.tsx`**
+
+```typescript
+import React from "react";
+import type { SearchResult, SearchSourceType } from "../../types/search";
+
+interface Props {
+  result: SearchResult;
+  onSelect: (result: SearchResult) => void;
+}
+
+const BADGE_LABELS: Record<SearchSourceType, string> = {
+  summary: "Synthèse",
+  flashcard: "Flashcard",
+  quiz: "Quiz",
+  chat: "Chat",
+  transcript: "Transcript",
+};
+
+const BADGE_COLORS: Record<SearchSourceType, string> = {
+  summary: "rgba(99, 102, 241, 0.25)", // indigo
+  flashcard: "rgba(139, 92, 246, 0.25)", // violet
+  quiz: "rgba(6, 182, 212, 0.25)", // cyan
+  chat: "rgba(59, 130, 246, 0.25)", // bleu
+  transcript: "rgba(255, 255, 255, 0.1)", // gris
+};
+
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 1).trimEnd() + "…";
+}
+
+export function QuickSearchResultItem({
+  result,
+  onSelect,
+}: Props): JSX.Element {
+  const title =
+    result.source_metadata?.summary_title?.trim() ||
+    truncate(result.text_preview, 60);
+
+  const badgeLabel = BADGE_LABELS[result.source_type];
+  const badgeColor = BADGE_COLORS[result.source_type];
+
+  return (
+    <li
+      onClick={() => onSelect(result)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(result);
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      style={{
+        padding: "8px 16px",
+        cursor: "pointer",
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+        borderBottom: "1px solid rgba(255,255,255,0.05)",
+        fontSize: 13,
+      }}
+    >
+      <span
+        style={{
+          flexShrink: 0,
+          fontSize: 10,
+          padding: "2px 6px",
+          borderRadius: 4,
+          background: badgeColor,
+          textTransform: "uppercase",
+          letterSpacing: 0.4,
+          fontWeight: 600,
+        }}
+      >
+        {badgeLabel}
+      </span>
+      <span
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          flex: 1,
+        }}
+        title={title}
+      >
+        {title}
+      </span>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd extension && npm test -- QuickSearchResultItem.test`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/sidepanel/components/QuickSearchResultItem.tsx extension/__tests__/sidepanel/components/QuickSearchResultItem.test.tsx
+git commit -m "feat(extension): add QuickSearchResultItem with type badge"
+```
+
+---
+
+## Task 5: Composant `QuickSearchResultsList` (liste compacte + footer)
+
+**Files:**
+
+- Create: `extension/src/sidepanel/components/QuickSearchResultsList.tsx`
+- Test: `extension/__tests__/sidepanel/components/QuickSearchResultsList.test.tsx`
+
+- [ ] **Step 1: Écrire le test échouant**
+
+```typescript
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { resetChromeMocks } from "../../setup/chrome-api-mock";
+import { QuickSearchResultsList } from "../../../src/sidepanel/components/QuickSearchResultsList";
+import type { SearchResult } from "../../../src/types/search";
+
+describe("QuickSearchResultsList", () => {
+  beforeEach(() => {
+    resetChromeMocks();
+  });
+
+  const mockResults: SearchResult[] = [
+    {
+      source_type: "summary",
+      source_id: 1,
+      summary_id: 1,
+      score: 0.92,
+      text_preview: "Crise énergétique européenne",
+      source_metadata: { summary_title: "Crise EU", video_id: "v1" },
+    },
+    {
+      source_type: "flashcard",
+      source_id: 2,
+      summary_id: 1,
+      score: 0.87,
+      text_preview: "Q: Quels objectifs pour la transition…",
+      source_metadata: { summary_title: "Crise EU", video_id: "v1" },
+    },
+  ];
+
+  it("renders a loading state when loading is true", () => {
+    render(
+      <QuickSearchResultsList
+        results={[]}
+        loading={true}
+        error={null}
+        query="test"
+        totalResults={0}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText(/recherche/i)).toBeInTheDocument();
+  });
+
+  it("renders an error state when error is set", () => {
+    render(
+      <QuickSearchResultsList
+        results={[]}
+        loading={false}
+        error="Network down"
+        query="test"
+        totalResults={0}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText(/network down/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when no results", () => {
+    render(
+      <QuickSearchResultsList
+        results={[]}
+        loading={false}
+        error={null}
+        query="zzz"
+        totalResults={0}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText(/aucun résultat/i)).toBeInTheDocument();
+  });
+
+  it("renders all results when populated", () => {
+    render(
+      <QuickSearchResultsList
+        results={mockResults}
+        loading={false}
+        error={null}
+        query="test"
+        totalResults={2}
+        onSelect={() => {}}
+      />,
+    );
+    // Both items should be present (Crise EU appears in both)
+    expect(screen.getAllByText("Crise EU")).toHaveLength(2);
+  });
+
+  it("forwards onSelect when a result item is clicked", () => {
+    const onSelect = jest.fn();
+    render(
+      <QuickSearchResultsList
+        results={mockResults}
+        loading={false}
+        error={null}
+        query="test"
+        totalResults={2}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.click(screen.getAllByText("Crise EU")[0]);
+    expect(onSelect).toHaveBeenCalledWith(mockResults[0]);
+  });
+
+  it("renders footer with total_results that opens web app on click", () => {
+    const tabsCreate = chrome.tabs.create as jest.Mock;
+    render(
+      <QuickSearchResultsList
+        results={mockResults}
+        loading={false}
+        error={null}
+        query="énergie"
+        totalResults={42}
+        onSelect={() => {}}
+      />,
+    );
+    const footer = screen.getByText(/voir tous les résultats/i);
+    expect(footer).toBeInTheDocument();
+    fireEvent.click(footer);
+    expect(tabsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining("/search?q="),
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd extension && npm test -- QuickSearchResultsList.test`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Implémenter `extension/src/sidepanel/components/QuickSearchResultsList.tsx`**
+
+```typescript
+import React from "react";
+import Browser from "../../utils/browser-polyfill";
+import { WEBAPP_URL } from "../../utils/config";
+import { QuickSearchResultItem } from "./QuickSearchResultItem";
+import type { SearchResult } from "../../types/search";
+
+interface Props {
+  results: SearchResult[];
+  loading: boolean;
+  error: string | null;
+  query: string;
+  totalResults: number;
+  onSelect: (result: SearchResult) => void;
+}
+
+export function QuickSearchResultsList({
+  results,
+  loading,
+  error,
+  query,
+  totalResults,
+  onSelect,
+}: Props): JSX.Element {
+  const openWebSearch = () => {
+    const url = `${WEBAPP_URL}/search?q=${encodeURIComponent(query)}`;
+    Browser.tabs.create({ url });
+  };
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          padding: 16,
+          opacity: 0.6,
+          fontSize: 13,
+          textAlign: "center",
+        }}
+        role="status"
+        aria-live="polite"
+      >
+        Recherche en cours…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        style={{
+          padding: 16,
+          color: "#fca5a5",
+          fontSize: 13,
+        }}
+        role="alert"
+      >
+        {error}
+      </div>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <div
+        style={{
+          padding: 16,
+          opacity: 0.6,
+          fontSize: 13,
+        }}
+      >
+        Aucun résultat pour « {query} »
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {results.map((r) => (
+          <QuickSearchResultItem
+            key={`${r.source_type}-${r.source_id}`}
+            result={r}
+            onSelect={onSelect}
+          />
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={openWebSearch}
+        style={{
+          width: "100%",
+          padding: "10px 16px",
+          background: "transparent",
+          border: "none",
+          borderTop: "1px solid rgba(255,255,255,0.05)",
+          color: "rgba(99, 102, 241, 0.95)",
+          fontSize: 12,
+          cursor: "pointer",
+          textAlign: "left",
+        }}
+        aria-label={`Voir les ${totalResults} résultats sur deepsightsynthesis.com`}
+      >
+        Voir tous les résultats ({totalResults}) sur deepsightsynthesis.com →
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd extension && npm test -- QuickSearchResultsList.test`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/sidepanel/components/QuickSearchResultsList.tsx extension/__tests__/sidepanel/components/QuickSearchResultsList.test.tsx
+git commit -m "feat(extension): add QuickSearchResultsList with web footer link"
+```
+
+---
+
+## Task 6: Composant racine `QuickSearch` (input + collapse/expand + cache)
+
+**Files:**
+
+- Create: `extension/src/sidepanel/components/QuickSearch.tsx`
+- Test: `extension/__tests__/sidepanel/components/QuickSearch.test.tsx`
+
+- [ ] **Step 1: Écrire le test échouant**
+
+```typescript
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { resetChromeMocks } from "../../setup/chrome-api-mock";
+import { QuickSearch } from "../../../src/sidepanel/components/QuickSearch";
+
+describe("QuickSearch", () => {
+  beforeEach(() => {
+    resetChromeMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders the collapsed input with the placeholder", () => {
+    render(<QuickSearch onSelectResult={() => {}} />);
+    expect(
+      screen.getByPlaceholderText(/rechercher mes analyses/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show results panel until user types", () => {
+    render(<QuickSearch onSelectResult={() => {}} />);
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("expands and shows loading after typing 2+ chars", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    sendMessage.mockResolvedValue({
+      success: true,
+      searchResults: {
+        query: "ai",
+        total_results: 0,
+        results: [],
+        searched_at: "2026-05-03T00:00:00Z",
+      },
+    });
+
+    render(<QuickSearch onSelectResult={() => {}} />);
+    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+
+    fireEvent.change(input, { target: { value: "ai" } });
+
+    // Loading visible immediately (debounce starts but loading state is set)
+    expect(screen.getByText(/recherche/i)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(401);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/aucun résultat/i)).toBeInTheDocument();
+    });
+  });
+
+  it("does not call SEARCH_GLOBAL for queries shorter than 2 chars", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    sendMessage.mockResolvedValue({ success: true, searchResults: { query: "", total_results: 0, results: [], searched_at: "" } });
+
+    render(<QuickSearch onSelectResult={() => {}} />);
+    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+
+    fireEvent.change(input, { target: { value: "a" } });
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "SEARCH_GLOBAL" }),
+    );
+  });
+
+  it("collapses (clears results) when input is emptied", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    sendMessage.mockResolvedValue({
+      success: true,
+      searchResults: {
+        query: "ai",
+        total_results: 0,
+        results: [],
+        searched_at: "",
+      },
+    });
+
+    render(<QuickSearch onSelectResult={() => {}} />);
+    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+
+    fireEvent.change(input, { target: { value: "ai" } });
+    act(() => {
+      jest.advanceTimersByTime(401);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/aucun résultat/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(screen.queryByText(/aucun résultat/i)).toBeNull();
+  });
+
+  it("calls onSelectResult when a result item is clicked", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    const fakeResult = {
+      source_type: "summary",
+      source_id: 5,
+      summary_id: 5,
+      score: 0.9,
+      text_preview: "test preview",
+      source_metadata: { summary_title: "Test" },
+    };
+    sendMessage.mockResolvedValue({
+      success: true,
+      searchResults: {
+        query: "test",
+        total_results: 1,
+        results: [fakeResult],
+        searched_at: "",
+      },
+    });
+
+    const onSelect = jest.fn();
+    render(<QuickSearch onSelectResult={onSelect} />);
+    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+
+    fireEvent.change(input, { target: { value: "test" } });
+    act(() => {
+      jest.advanceTimersByTime(401);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Test")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Test"));
+    expect(onSelect).toHaveBeenCalledWith(fakeResult);
+  });
+
+  it("persists the query into chrome.storage.local cache after a successful search", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    sendMessage.mockResolvedValue({
+      success: true,
+      searchResults: {
+        query: "energie",
+        total_results: 0,
+        results: [],
+        searched_at: "",
+      },
+    });
+    const setSpy = chrome.storage.local.set as jest.Mock;
+
+    render(<QuickSearch onSelectResult={() => {}} />);
+    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+
+    fireEvent.change(input, { target: { value: "energie" } });
+    act(() => {
+      jest.advanceTimersByTime(401);
+    });
+
+    await waitFor(() => {
+      expect(setSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recent_queries: expect.arrayContaining(["energie"]),
+        }),
+      );
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd extension && npm test -- QuickSearch.test`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Implémenter `extension/src/sidepanel/components/QuickSearch.tsx`**
+
+```typescript
+import React, { useState, useEffect } from "react";
+import { useQuickSearch } from "../hooks/useQuickSearch";
+import { QuickSearchResultsList } from "./QuickSearchResultsList";
+import { pushCachedQuery } from "../../utils/searchCache";
+import type { SearchResult } from "../../types/search";
+
+interface Props {
+  onSelectResult: (result: SearchResult) => void;
+}
+
+export function QuickSearch({ onSelectResult }: Props): JSX.Element {
+  const [query, setQuery] = useState("");
+  const { results, loading, error, totalResults } = useQuickSearch(query);
+
+  const trimmed = query.trim();
+  const isExpanded = trimmed.length >= 2;
+
+  // Persist query in chrome.storage.local cache once we have a non-empty
+  // backend response (success path). We don't cache on error/loading to avoid
+  // spamming the cache with half-typed queries.
+  useEffect(() => {
+    if (!loading && !error && trimmed.length >= 2) {
+      void pushCachedQuery(trimmed);
+    }
+  }, [loading, error, trimmed]);
+
+  const handleClear = () => {
+    setQuery("");
+  };
+
+  return (
+    <div style={{ padding: "8px 16px" }}>
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: 10,
+            fontSize: 14,
+            opacity: 0.6,
+            pointerEvents: "none",
+          }}
+        >
+          🔍
+        </span>
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
+          placeholder="Rechercher mes analyses…"
+          aria-label="Rechercher dans mes analyses"
+          spellCheck={false}
+          autoComplete="off"
+          style={{
+            width: "100%",
+            padding: "8px 32px 8px 32px",
+            background: "rgba(255,255,255,0.05)",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: 6,
+            color: "inherit",
+            fontSize: 13,
+            outline: "none",
+          }}
+        />
+        {query.length > 0 && (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="Effacer la recherche"
+            style={{
+              position: "absolute",
+              right: 6,
+              background: "transparent",
+              border: "none",
+              color: "rgba(255,255,255,0.6)",
+              cursor: "pointer",
+              fontSize: 14,
+              padding: 4,
+            }}
+          >
+            ✕
+          </button>
+        )}
+      </div>
+      {isExpanded && (
+        <div
+          style={{
+            marginTop: 8,
+            background: "rgba(255,255,255,0.02)",
+            border: "1px solid rgba(255,255,255,0.05)",
+            borderRadius: 6,
+            overflow: "hidden",
+            maxHeight: 360,
+            overflowY: "auto",
+          }}
+        >
+          <QuickSearchResultsList
+            results={results}
+            loading={loading}
+            error={error}
+            query={trimmed}
+            totalResults={totalResults}
+            onSelect={onSelectResult}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd extension && npm test -- QuickSearch.test`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/sidepanel/components/QuickSearch.tsx extension/__tests__/sidepanel/components/QuickSearch.test.tsx
+git commit -m "feat(extension): add QuickSearch root component with collapse/expand"
+```
+
+---
+
+## Task 7: Click sur résultat → ouvre l'analyse
+
+**Files:**
+
+- Modify: `extension/src/sidepanel/views/HomeView.tsx`
+- Test: `extension/__tests__/sidepanel/views/HomeView.test.tsx` (extension)
+
+**Décision design** : Vu que `HomeView` reçoit déjà `onSelectRecent: (recent: RecentAnalysis) => void` (qui pousse vers une analyse complète), on adopte le même pattern : `onSelectResult` ouvre l'analyse dans un nouvel onglet web (cohérent avec le footer "voir tous sur deepsightsynthesis.com" et avec le pattern existant "v3-recent-item" dans `MainView.tsx:778-782` qui fait déjà `target="_blank"`).
+
+L'extension light tier ne dispose PAS d'`AnalysisView` autonome dans le sidepanel pour rendre une analyse arbitraire (cf. spec § 6.2 « Tap sur résultat → ouvre l'analyse dans `AnalysisView` du sidepanel »). En réalité l'extension n'a aucun composant qui sait afficher une analyse depuis un `summary_id` arbitraire (l'`AnalysisView.tsx` actuel pilote l'analyse de la vidéo du tab actif). On suit donc la convention `MainView` recents : ouvrir `${WEBAPP_URL}/summary/{summaryId}` dans un nouvel onglet.
+
+- [ ] **Step 1: Étendre le test `HomeView.test.tsx`**
+
+Ajouter un nouveau bloc `describe` à la fin du fichier existant `extension/__tests__/sidepanel/views/HomeView.test.tsx` :
+
+```typescript
+describe("HomeView — QuickSearch integration", () => {
+  it("renders the QuickSearch input above the Recents label", () => {
+    render(
+      <HomeView
+        user={mockUser}
+        recents={mockRecents}
+        currentTab={{ url: null, platform: null, tabId: null }}
+        onAnalyze={() => {}}
+        onSelectRecent={() => {}}
+        onUpgrade={() => {}}
+      />,
+    );
+    const searchInput = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    const recentsLabel = screen.getByText(/^récent$/i);
+    // QuickSearch DOIT apparaître AVANT le label "Récent" dans le DOM
+    expect(
+      searchInput.compareDocumentPosition(recentsLabel) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("opens summary URL in a new tab when a result is clicked", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    sendMessage.mockResolvedValue({
+      success: true,
+      searchResults: {
+        query: "test",
+        total_results: 1,
+        results: [
+          {
+            source_type: "summary",
+            source_id: 99,
+            summary_id: 99,
+            score: 0.95,
+            text_preview: "Mock preview",
+            source_metadata: { summary_title: "Mock Title" },
+          },
+        ],
+        searched_at: "",
+      },
+    });
+    const tabsCreate = chrome.tabs.create as jest.Mock;
+
+    render(
+      <HomeView
+        user={mockUser}
+        recents={mockRecents}
+        currentTab={{ url: null, platform: null, tabId: null }}
+        onAnalyze={() => {}}
+        onSelectRecent={() => {}}
+        onUpgrade={() => {}}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    fireEvent.change(input, { target: { value: "test" } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Mock Title")).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+
+    fireEvent.click(screen.getByText("Mock Title"));
+    expect(tabsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ url: expect.stringContaining("/summary/99") }),
+    );
+  });
+});
+```
+
+⚠️ Au top du fichier, ajouter `fireEvent` et `waitFor` à l'import existant :
+
+```typescript
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd extension && npm test -- HomeView.test`
+Expected: FAIL ("Unable to find an element with placeholder rechercher mes analyses")
+
+- [ ] **Step 3: Modifier `HomeView.tsx` — insérer QuickSearch**
+
+Le fichier source actuel (`extension/src/sidepanel/views/HomeView.tsx`, 73 lignes). Modifier comme suit :
+
+```typescript
+import React from "react";
+import { RecentsList, RecentAnalysis } from "../components/RecentsList";
+import { VideoDetectedCard } from "../components/VideoDetectedCard";
+import { UrlInputCard } from "../components/UrlInputCard";
+import { PlanBadge } from "../components/PlanBadge";
+import { QuickSearch } from "../components/QuickSearch";
+import { CurrentTabInfo } from "../hooks/useCurrentTab";
+import Browser from "../../utils/browser-polyfill";
+import { WEBAPP_URL } from "../../utils/config";
+import type { SearchResult } from "../../types/search";
+
+interface User {
+  plan: "free" | "etudiant" | "starter" | "pro" | "equipe";
+  creditsLeft: number;
+}
+
+export interface HomeViewProps {
+  user: User;
+  recents: RecentAnalysis[];
+  currentTab: CurrentTabInfo;
+  videoMeta?: { title: string; thumbnail: string };
+  onAnalyze: (url: string) => void;
+  onSelectRecent: (recent: RecentAnalysis) => void;
+  onUpgrade: () => void;
+}
+
+export function HomeView({
+  user,
+  recents,
+  currentTab,
+  videoMeta,
+  onAnalyze,
+  onSelectRecent,
+  onUpgrade,
+}: HomeViewProps): JSX.Element {
+  const isOnVideo =
+    currentTab.platform !== null &&
+    currentTab.url !== null &&
+    videoMeta !== undefined;
+
+  const handleSelectSearchResult = (result: SearchResult) => {
+    // Phase 4 spec § 6.2 — extension light tier : on ouvre l'analyse
+    // directement dans l'app web (pas d'AnalysisView autonome côté extension).
+    if (result.summary_id !== null && result.summary_id !== undefined) {
+      Browser.tabs.create({
+        url: `${WEBAPP_URL}/summary/${result.summary_id}`,
+      });
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <PlanBadge
+        plan={user.plan}
+        creditsLeft={user.creditsLeft}
+        onUpgrade={onUpgrade}
+      />
+
+      {isOnVideo && videoMeta && currentTab.url && currentTab.platform ? (
+        <VideoDetectedCard
+          title={videoMeta.title}
+          thumbnail={videoMeta.thumbnail}
+          platform={currentTab.platform}
+          onAnalyze={() => onAnalyze(currentTab.url!)}
+        />
+      ) : (
+        <UrlInputCard onSubmit={onAnalyze} />
+      )}
+
+      {/* Phase 4 — Quick Search (light tier) */}
+      <QuickSearch onSelectResult={handleSelectSearchResult} />
+
+      <div
+        style={{
+          padding: "8px 16px",
+          fontSize: 11,
+          opacity: 0.5,
+          textTransform: "uppercase",
+          letterSpacing: 1,
+        }}
+      >
+        Récent
+      </div>
+      <div style={{ flex: 1, overflowY: "auto" }}>
+        <RecentsList recents={recents} onSelect={onSelectRecent} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd extension && npm test -- HomeView.test`
+Expected: PASS (les 5 tests existants + 2 nouveaux = 7 total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/sidepanel/views/HomeView.tsx extension/__tests__/sidepanel/views/HomeView.test.tsx
+git commit -m "feat(extension): integrate QuickSearch above RecentsList in HomeView"
+```
+
+---
+
+## Task 8: Vérification typecheck + tests full suite
+
+**Files:** aucune modification — vérification globale.
+
+- [ ] **Step 1: Run TypeScript typecheck (zéro erreur attendue)**
+
+Run: `cd extension && npm run typecheck`
+Expected: 0 erreurs TypeScript. Si erreur sur `MessageResponse` → vérifier que `searchResults?` et `recentQueries?` sont bien typés.
+
+- [ ] **Step 2: Run full Jest suite**
+
+Run: `cd extension && npm test`
+Expected: tous les tests verts, incluant les ~40+ nouveaux tests Phase 4.
+
+Si un test pré-existant (`MainView.test.tsx`, `App.test.tsx`, etc.) casse → diagnostiquer ; ne pas masquer.
+
+- [ ] **Step 3: Commit du typecheck si nettoyage nécessaire (sinon skip)**
+
+Si l'étape 1 ou 2 a nécessité des fixes mineurs (ex : import manquant, type narrowing), commit :
+
+```bash
+git add -p
+git commit -m "chore(extension): fix typecheck for Phase 4 search integration"
+```
+
+---
+
+## Task 9: Build extension + ZIP pour Chrome Web Store
+
+**Files:**
+
+- Run: `npm run build`
+- Output: `extension/dist/` updated
+- Output: `~/Documents/deepsight-extension-search-v1.zip` (à uploader sur Chrome Web Store par Maxime)
+
+- [ ] **Step 1: Build production**
+
+Run: `cd extension && npm run build`
+Expected:
+
+- Output `dist/` updated
+- 0 erreurs Webpack
+- Vérifier que `dist/sidepanel.js` contient bien le nouveau bundle (taille ~+10-15 KB)
+
+- [ ] **Step 2: Vérifier le manifest.json**
+
+Run: `cat extension/dist/manifest.json | head -30`
+Expected:
+
+- Pas de nouvelles permissions requises (search/global utilise `host_permissions: api.deepsightsynthesis.com` déjà présent)
+- `manifest_version: 3` toujours OK
+
+⚠️ Si une nouvelle permission s'avérait nécessaire (ne devrait pas — on réutilise `apiRequest` existant), il faudrait l'ajouter dans le source manifest et soumettre Maxime à un re-review Chrome Web Store. Dans le scope V1, ce ne devrait pas arriver.
+
+- [ ] **Step 3: Test manuel local — chrome://extensions**
+
+Sequence (à exécuter par Maxime ou un sub-agent avec Chrome):
+
+1. Ouvrir `chrome://extensions/`
+2. Mode développeur activé
+3. "Charger l'extension non empaquetée" → sélectionner `C:/Users/33667/DeepSight-Main/extension/dist/`
+4. Recharger l'extension si déjà loaded (icône reload sur la card)
+5. Ouvrir le sidepanel (clic icône action ou raccourci natif Chrome)
+6. Vérifier :
+   - Input "🔍 Rechercher mes analyses…" présent au-dessus de la liste Recents
+   - Taper 2+ caractères → debounce 400ms → liste de résultats apparaît
+   - Click sur un résultat → nouvel onglet web `/summary/{id}` s'ouvre
+   - Footer "Voir tous les résultats sur deepsightsynthesis.com →" → click ouvre `/search?q=...`
+   - Vider l'input → la liste se collapse
+7. Vérifier `chrome.storage.local` (DevTools sidepanel → Application → Storage) :
+   - `recent_queries: [...]` (max 5 éléments) après 2-3 recherches
+8. Test offline / API down : couper le réseau, recommencer une recherche → message d'erreur affiché, pas de crash
+
+⚠️ Si le test révèle un bug fonctionnel, ne pas commit le ZIP — fix d'abord, re-build, retest.
+
+- [ ] **Step 4: Créer le ZIP pour Chrome Web Store**
+
+Sur Windows (PowerShell) :
+
+```powershell
+cd C:\Users\33667\DeepSight-Main\extension
+Compress-Archive -Path dist\* -DestinationPath ~\Documents\deepsight-extension-search-v1.zip -Force
+```
+
+Sur bash :
+
+```bash
+cd /c/Users/33667/DeepSight-Main/extension
+rm -f ~/Documents/deepsight-extension-search-v1.zip
+(cd dist && zip -r ~/Documents/deepsight-extension-search-v1.zip .)
+```
+
+Expected: fichier ZIP ~1-3 MB selon assets.
+
+- [ ] **Step 5: Commit dist/ rebuild + report**
+
+```bash
+git add extension/dist/
+git commit -m "chore(extension): rebuild dist for Phase 4 QuickSearch + zip ready for Chrome Web Store"
+```
+
+⚠️ **Ne pas push --force**, ne pas auto-soumettre Chrome Web Store. Le ZIP ~/Documents/deepsight-extension-search-v1.zip est l'artefact final que Maxime upload manuellement sur le Developer Dashboard (cf. Vault note `audit-kimi-deepsight-2026-04-29` — pattern récurrent du projet).
+
+---
+
+## Task 10: Préparer la PR
+
+**Files:**
+
+- Branche : `feat/search-extension-phase4`
+- Base : `main`
+- Test plan dans la description PR
+
+- [ ] **Step 1: Sanity check — git status propre**
+
+Run: `git status -sb`
+Expected: branch ahead of origin, working tree clean
+
+- [ ] **Step 2: Push la branche**
+
+```bash
+git push -u origin feat/search-extension-phase4
+```
+
+- [ ] **Step 3: Créer la PR via gh CLI**
+
+```bash
+gh pr create --base main --head feat/search-extension-phase4 \
+  --title "feat(extension): semantic search V1 — phase 4 (QuickSearch sidepanel)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Ajoute `QuickSearch` (light tier) dans le sidepanel `HomeView` au-dessus de `RecentsList`.
+- Consomme `POST /api/search/global?limit=10` (Phase 1 backend déjà mergé via PR #292).
+- Footer "Voir tous les résultats sur deepsightsynthesis.com" qui ouvre `/search?q=...` dans un nouvel onglet web.
+- Cache `chrome.storage.local` des 5 dernières queries (LRU dedup).
+- Pas d'intra-analyse search ni de tooltip IA — espace contraint sidepanel (cf. spec § 6).
+
+## Architecture
+
+| Couche | Composant | Responsabilité |
+|---|---|---|
+| Background | `searchGlobal()` + `getRecentQueries()` | API client, refresh JWT 401 via `apiRequest` existant |
+| Hook | `useQuickSearch(query)` | Debounce 400ms, gère loading/error/results state |
+| UI | `QuickSearch` | Input + collapse/expand + persist cache |
+| UI | `QuickSearchResultsList` | États loading/error/empty + footer web |
+| UI | `QuickSearchResultItem` | 1 ligne par résultat avec badge type compact |
+| Storage | `searchCache.ts` | LRU 5 queries, `chrome.storage.local` clé `recent_queries` |
+
+## Test plan
+
+- [ ] `cd extension && npm test` — tous les tests Jest verts (~40 nouveaux)
+- [ ] `cd extension && npm run typecheck` — 0 erreurs TS
+- [ ] `npm run build` — webpack build OK
+- [ ] Test manuel chrome://extensions :
+  - [ ] Input visible au-dessus de "Récent"
+  - [ ] Debounce 400ms fonctionne (pas d'API call avant)
+  - [ ] Click résultat → nouvel onglet `/summary/{id}`
+  - [ ] Footer → nouvel onglet `/search?q=...`
+  - [ ] `chrome.storage.local.recent_queries` populé
+  - [ ] Erreur réseau gracieuse (pas de crash)
+
+## Spec source
+
+`docs/superpowers/specs/2026-05-03-semantic-search-design.md` — Section 6.
+
+## Plan d'exécution
+
+`docs/superpowers/plans/2026-05-03-semantic-search-v1-phase4-extension.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Linker la PR au sub-agent runner / hub Asana**
+
+Pas de modif code. Juste copier l'URL PR dans le projet Asana **DeepSight Extension Chrome** (`1214026081649153`).
+
+---
+
+## Self-Review Checklist (à exécuter en fin de plan)
+
+**1. Spec coverage** :
+
+- ✅ Composant unique `QuickSearch.tsx` placé dans `HomeView.tsx` au-dessus de `RecentsList` → Task 7
+- ✅ Input "🔍 Rechercher mes analyses…" → Task 6
+- ✅ Expand inline avec liste résultats simplifiée → Tasks 5+6
+- ✅ Pas d'intra-analyse search → confirmé dans "Hors scope explicit"
+- ✅ Pas de tooltip IA → confirmé dans "Hors scope explicit"
+- ✅ Pas de filtres avancés → liste flat compacte par défaut (`source_types` accepté en param mais jamais utilisé côté UI V1)
+- ✅ Footer "Voir tous les résultats sur deepsightsynthesis.com →" via `chrome.tabs.create` → Task 5
+- ✅ Cache `chrome.storage.local` 5 dernières queries → Task 2
+- ✅ `POST /api/search/global` avec `limit=10` (extension space) → Task 1 (ligne `body.limit ?? 10`)
+- ✅ `GET /api/search/recent-queries` exposé pour future use (suggestions) → Task 1
+- ✅ Pas d'`/within` ni `/explain-passage` → confirmé "Hors scope explicit"
+- ✅ Test manuel Chrome → Task 9
+- ✅ Build extension + ZIP → Task 9
+
+**2. Placeholder scan** : Aucun "TBD/TODO/implement later" trouvé. Toutes les sections de code sont concrètes et copy-pasteables.
+
+**3. Type consistency** :
+
+- `SearchResult.summary_id: number | null` cohérent entre Task 1 (types/search.ts) + Task 4 (rendu) + Task 7 (handler)
+- `SearchSourceType` réutilisé partout (pas de string libre)
+- `MessageResponse.searchResults?: GlobalSearchResponse` cohérent entre background.ts + useQuickSearch
+- `pushCachedQuery(query: string): Promise<void>` même signature partout
+
+**4. Conventions extension respectées** :
+
+- ✅ Manifest V3 — `chrome.storage.local` only (Task 2)
+- ✅ Service worker → API calls → CSP-safe (Task 1)
+- ✅ Espace ≤360px → 1 ligne par résultat (Task 4)
+- ✅ Limit=10 résultats (vs 30 web/mobile)
+- ✅ Auth via JWT existant + `apiRequest` qui handle refresh (Task 1)
+
+---
+
+_Plan rédigé le 2026-05-03 par Claude Opus 4.7. Phase 4 du sprint Semantic Search V1 — light tier extension Chrome. Phase 1 backend déjà déployée prod via PR #292. Phases 2 (web) et 3 (mobile) à mener en parallèle dans des sprints séparés._


### PR DESCRIPTION
## Summary

3 plans d'implémentation détaillés pour les phases frontend de Semantic Search V1, écrits par 3 sub-agents Opus 4.7 en parallèle. Phase 1 backend déjà mergée (#292) + déployée prod.

### Phase 2 — Web Frontend (`phase2-web.md`)
- **21 tasks**, ~5-7h dev solo (~3-4h en parallèle)
- Sidebar tab `/search` + `SearchPage` + `SemanticHighlighter` + `ExplainTooltip` + Cmd+F intercept
- ⚠️ Findings : `SidebarNav.tsx` orphelin (vrai = `Sidebar.tsx`), pas de route `/analysis/[id]` (utilise `/hub?summaryId=...`), pas de `@floating-ui/react` (fallback Framer Motion + DOMRect)

### Phase 3 — Mobile Expo (`phase3-mobile.md`)
- **16 tasks**, ~3 jours dev
- Tab Search + `PassageActionSheet` BottomSheet + nav FAB ↑/↓ + intra-analysis (analysis/[id])
- ⚠️ Findings : utilise `SimpleBottomSheet` interne (Expo Go compat) pas `@gorhom/bottom-sheet` direct, highlight markdown long-form reporté V1.1 (V1 = structured_index + flashcards + quiz + chat only)

### Phase 4 — Extension Chrome (`phase4-extension.md`)
- **10 tasks**, ~6-8h dev (light tier)
- `QuickSearch` dans `HomeView` sidepanel + footer "Voir tous sur web"
- ⚠️ Findings : pas de `searchApi` côté extension → tout via `chrome.runtime.sendMessage` vers `background.ts`, click résultat ouvre `WEBAPP_URL/summary/{id}` dans nouvel onglet (pas in-sidepanel — divergence pragmatique vs spec)

## Tous les plans sont autonomes

Chaque plan suit le pattern writing-plans : Goal/Architecture/Tech Stack header + File Structure + tasks bite-sized TDD avec snippets production-ready. Prêts à être exécutés via subagent-driven-development quand tu seras prêt.

## Test plan

- [ ] Review chaque plan
- [ ] Confirmer route `/hub?summaryId=...` (vs `/analysis/[id]`) pour Phase 2
- [ ] Décision floating-ui vs Framer Motion fallback (Phase 2)
- [ ] Décision sur l'ouverture de l'analyse depuis extension (sidepanel vs nouvel onglet web)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — 3 sub-agents Opus 4.7 parallèles