### PR TITLE
fix(mobile): rules of hooks violation in CustomTabBar (Rendered more hooks crash)

### DIFF
--- a/mobile/src/components/navigation/CustomTabBar.tsx
+++ b/mobile/src/components/navigation/CustomTabBar.tsx
@@ -86,7 +86,6 @@ function TabItem({
   isDark,
 }: TabItemProps) {
   const meta = TAB_META[routeName];
-  if (!meta) return null;
 
   // Shared value that drives all animations for this tab
   const progress = useSharedValue(isFocused ? 1 : 0);
@@ -152,6 +151,9 @@ function TabItem({
     transform: [{ scale: progress.value }],
   }));
 
+  // Early return APRÈS tous les hooks — Rules of Hooks.
+  if (!meta) return null;
+
   return (
     <Pressable
       onPress={onPress}
@@ -208,10 +210,6 @@ export function CustomTabBar({ state, navigation }: TabBarProps) {
   const { isDark } = useTheme();
   const hidden = useTabBarStore((s) => s.hidden);
 
-  // Hidden en mode fullscreen analyse — l'écran consommateur appelle
-  // setTabBarHidden(true) via useEffect, et false au démontage / sortie.
-  if (hidden) return null;
-
   // Only show routes that have a TAB_META entry
   const visibleRoutes = useMemo(
     () =>
@@ -257,6 +255,11 @@ export function CustomTabBar({ state, navigation }: TabBarProps) {
     },
     [navigation],
   );
+
+  // Hidden en mode fullscreen analyse — l'écran consommateur appelle
+  // setTabBarHidden(true) via useEffect, et false au démontage / sortie.
+  // Early return APRÈS tous les hooks pour respecter les Rules of Hooks.
+  if (hidden) return null;
 
   // Bottom padding: safe area on iOS (notch), small fixed on Android
   const bottomPadding = Platform.select({


### PR DESCRIPTION
## Summary

Hotfix du crash **"Rendered more hooks than during the previous render"** au lancement de l'app mobile, introduit par PR #283 (Hub tab unified).

## Cause

`CustomTabBar.tsx` (modifié par PR #283 pour ajouter le tab Hub) avait deux violations Rules of Hooks :

1. **`CustomTabBar`** — `if (hidden) return null;` placé AVANT 4 hooks (`useMemo` ×2, `useCallback` ×2). Quand `useTabBarStore.hidden` flippe `true→false` (sortie d'un écran fullscreen `analysis/[id]`), on passe de 4 hooks à 8 → React panique.
2. **`TabItem`** — `if (!meta) return null;` placé AVANT 7 hooks (`useSharedValue` ×2, `useEffect`, `useCallback` ×2, `useAnimatedStyle` ×4).

## Fix

Déplacer les early returns APRÈS tous les hooks dans les deux composants. Aucun changement de logique — réordonnancement de 8 lignes.

## Test plan

- [ ] OTA via `eas update --branch production` après merge
- [ ] Vérifier en TestFlight que l'app ne crash plus au launch
- [ ] Vérifier que la TabBar disparaît bien en mode fullscreen analyse
- [ ] Vérifier que la TabBar revient à la sortie

## Release

JS-only — déployable via OTA EAS Update, pas de rebuild natif requis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)