### PR TITLE
feat(mobile-search): Semantic Search V1 - Phase 3 mobile Expo

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -24,6 +24,12 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="search"
+        options={{
+          title: "Recherche",
+        }}
+      />
+      <Tabs.Screen
         name="hub"
         options={{
           title: "Hub",

--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -38,15 +38,84 @@ import { AcademicSourcesSection } from "@/components/academic";
 import { FactCheckButton } from "@/components/factcheck";
 import { WebEnrichment } from "@/components/enrichment";
 import { usePlan } from "@/contexts/PlanContext";
+import {
+  SemanticHighlighterProvider,
+  HighlightNavigationBar,
+  PassageActionSheet,
+  useSemanticHighlighter,
+} from "@/components/highlight";
+import { SearchBar as IntraSearchBar } from "@/components/search/SearchBar";
+import type { WithinMatchItem } from "@/services/api";
 
 const TAB_LABELS = ["Résumé", "Sources", "Chat"] as const;
 const TAB_COUNT = TAB_LABELS.length;
 
-export default function AnalysisDetailScreen() {
-  const { id, backTo, initialTab } = useLocalSearchParams<{
+// Sub-composant : contrôle l'ouverture du PassageActionSheet quand
+// `activePassageId` change. Doit être rendu DANS le SemanticHighlighterProvider.
+const HighlightActionSheetController: React.FC<{
+  summaryId: number;
+}> = ({ summaryId }) => {
+  const ctx = useSemanticHighlighter();
+  const [m, setM] = useState<WithinMatchItem | null>(null);
+
+  React.useEffect(() => {
+    if (!ctx?.activePassageId) {
+      setM(null);
+      return;
+    }
+    const found = ctx.matches.find(
+      (x) => x.passage_id === ctx.activePassageId,
+    );
+    setM(found ?? null);
+  }, [ctx?.activePassageId, ctx?.matches]);
+
+  return (
+    <PassageActionSheet
+      match={m}
+      query={ctx?.query ?? ""}
+      summaryId={summaryId}
+      isOpen={!!m}
+      onClose={() => {
+        ctx?.setActivePassageId(null);
+        setM(null);
+      }}
+    />
+  );
+};
+
+// Sub-composant : input de la SearchBar intra-analyse, branchée au Provider.
+// Debounce 300ms avant de pousser dans `ctx.setQuery`.
+const IntraAnalysisSearchInput: React.FC = () => {
+  const ctx = useSemanticHighlighter();
+  const [localValue, setLocalValue] = useState(ctx?.query ?? "");
+
+  React.useEffect(() => {
+    const t = setTimeout(() => ctx?.setQuery(localValue), 300);
+    return () => clearTimeout(t);
+  }, [localValue, ctx]);
+
+  return (
+    <View style={{ paddingHorizontal: sp.lg, paddingVertical: sp.sm }}>
+      <IntraSearchBar
+        value={localValue}
+        onChangeText={setLocalValue}
+        autoFocus
+        placeholder="Rechercher dans cette analyse…"
+      />
+    </View>
+  );
+};
+
+function AnalysisDetailScreenInner() {
+  // Note : `q` / `highlight` / `tab` sont consommés par le wrapper externe
+  // `AnalysisDetailScreen` qui pose le SemanticHighlighterProvider. Ils sont
+  // re-extraits ici uniquement pour piloter l'état initial de la SearchBar
+  // intra-analyse (`searchBarVisible = Boolean(q)`).
+  const { id, backTo, initialTab, q } = useLocalSearchParams<{
     id: string;
     backTo?: string;
     initialTab?: string;
+    q?: string;
   }>();
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -70,6 +139,7 @@ export default function AnalysisDetailScreen() {
   const [isVoiceVisible, setIsVoiceVisible] = useState(false);
   const [isExportVisible, setIsExportVisible] = useState(false);
   const [isTutorVisible, setIsTutorVisible] = useState(false);
+  const [searchBarVisible, setSearchBarVisible] = useState(Boolean(q));
   const [tabBarWidth, setTabBarWidth] = useState(0);
   const scrollY = useSharedValue(0);
   const tabIndicatorX = useSharedValue(initialTabIndex);
@@ -612,6 +682,24 @@ export default function AnalysisDetailScreen() {
           >
             {summary?.title || "Analyse"}
           </Text>
+          {/* Bouton loupe — recherche intra-analyse (Semantic Search V1) */}
+          <Pressable
+            onPress={() => setSearchBarVisible((v) => !v)}
+            style={styles.iconButton}
+            accessibilityLabel={
+              searchBarVisible
+                ? "Fermer la recherche"
+                : "Rechercher dans cette analyse"
+            }
+            accessibilityRole="button"
+            hitSlop={8}
+          >
+            <Ionicons
+              name={searchBarVisible ? "close" : "search"}
+              size={22}
+              color={colors.textTertiary}
+            />
+          </Pressable>
           {/* Bouton export */}
           {canExport && (
             <Pressable
@@ -642,6 +730,9 @@ export default function AnalysisDetailScreen() {
           </Pressable>
         </View>
       )}
+
+      {/* Search bar intra-analyse — visible quand searchBarVisible=true */}
+      {!isFullscreen && searchBarVisible && <IntraAnalysisSearchInput />}
 
       {/* Video Player — masqué en fullscreen.
           NB: la condition de visibilité (videoId valide, plateforme connue,
@@ -788,7 +879,47 @@ export default function AnalysisDetailScreen() {
           {Pager}
         </View>
       )}
+
+      {/* ── Semantic Search V1 — overlays intra-analyse ─────────────── */}
+      {!isFullscreen && (
+        <>
+          <HighlightNavigationBar bottomOffset={tabBarFootprint + 20} />
+          <HighlightActionSheetController
+            summaryId={Number(effectiveId) || 0}
+          />
+        </>
+      )}
     </View>
+  );
+}
+
+/**
+ * Wrapper exporté default — instancie le `SemanticHighlighterProvider` autour
+ * de l'écran. Le summaryId effectif est passé via la prop. La query/passage_id
+ * initiaux viennent des params URL `?q=...&highlight=...`.
+ */
+export default function AnalysisDetailScreen() {
+  const { id, q, highlight } = useLocalSearchParams<{
+    id: string;
+    q?: string;
+    highlight?: string;
+  }>();
+
+  // Note: Le summaryId réel peut différer de `id` (id peut être un task_id).
+  // On utilise une approximation : si id est numérique on l'utilise,
+  // sinon le provider est désactivé (summaryId=0). Le provider rejette les fetch
+  // quand summaryId<=0 (cf. SemanticHighlighter `enabled` guard).
+  const numericId = Number(id);
+  const summaryId = Number.isFinite(numericId) && numericId > 0 ? numericId : 0;
+
+  return (
+    <SemanticHighlighterProvider
+      summaryId={summaryId}
+      initialQuery={q ?? ""}
+      initialPassageId={highlight ?? null}
+    >
+      <AnalysisDetailScreenInner />
+    </SemanticHighlighterProvider>
   );
 }
 

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,0 +1,183 @@
+/**
+ * mobile/app/(tabs)/search.tsx
+ *
+ * Tab Search — recherche sémantique globale dans tout le contenu personnel
+ * du user (synthèses, flashcards, quiz, chat, transcripts).
+ *
+ * Spec : `docs/superpowers/specs/2026-05-03-semantic-search-design.md` §5
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize, textStyles } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import { DoodleBackground } from "@/components/ui/DoodleBackground";
+import {
+  type SimpleBottomSheetRef,
+} from "@/components/ui/SimpleBottomSheet";
+import { SearchBar } from "@/components/search/SearchBar";
+import { SearchResultsList } from "@/components/search/SearchResultsList";
+import { SearchEmptyState } from "@/components/search/SearchEmptyState";
+import { SearchFiltersSheet } from "@/components/search/SearchFiltersSheet";
+import { useSemanticSearch } from "@/components/search/useSemanticSearch";
+import { useRecentQueries } from "@/components/search/useRecentQueries";
+import type { GlobalSearchRequest } from "@/services/api";
+
+export default function SearchScreen() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const tabBarFootprint = useTabBarFootprint();
+
+  const [query, setQuery] = useState("");
+  const [filters, setFilters] = useState<Partial<GlobalSearchRequest>>({});
+  const { data, isLoading, error } = useSemanticSearch(query, filters);
+  const recent = useRecentQueries();
+
+  const filtersSheetRef = useRef<SimpleBottomSheetRef>(null);
+
+  const handleQueryChange = useCallback((q: string) => setQuery(q), []);
+
+  const handleOpenFilters = useCallback(() => {
+    filtersSheetRef.current?.snapToIndex(0);
+  }, []);
+
+  // Persister la recherche aboutie dans recent queries
+  useEffect(() => {
+    if (!data) return;
+    if (query.trim().length < 2) return;
+    void recent.push(query);
+    // On veut déclencher uniquement quand `data` change (résultat reçu).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  const filterCount = Object.entries(filters).filter(
+    ([, v]) => v !== undefined && v !== null && v !== false,
+  ).length;
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bgPrimary }]}>
+      <DoodleBackground variant="default" density="low" />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={styles.flex}
+        keyboardVerticalOffset={insets.top}
+      >
+        <View style={[styles.header, { paddingTop: insets.top + sp.sm }]}>
+          <Text style={[styles.title, { color: colors.textPrimary }]}>
+            Rechercher
+          </Text>
+          <Text style={[styles.subtitle, { color: colors.textTertiary }]}>
+            Dans tes analyses, flashcards, quiz et chats
+          </Text>
+        </View>
+
+        <View style={styles.searchWrap}>
+          <SearchBar
+            value={query}
+            onChangeText={handleQueryChange}
+            autoFocus
+          />
+          <Pressable
+            onPress={handleOpenFilters}
+            style={[
+              styles.filterButton,
+              {
+                backgroundColor: colors.glassBg,
+                borderColor:
+                  filterCount > 0 ? palette.gold : colors.glassBorder,
+              },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={
+              filterCount > 0
+                ? `Filtres actifs (${filterCount})`
+                : "Ouvrir les filtres"
+            }
+          >
+            <Ionicons
+              name="options-outline"
+              size={18}
+              color={filterCount > 0 ? palette.gold : colors.textTertiary}
+            />
+            <Text
+              style={[
+                styles.filterText,
+                {
+                  color: filterCount > 0 ? palette.gold : colors.textTertiary,
+                },
+              ]}
+            >
+              Filtres{filterCount > 0 ? ` (${filterCount})` : ""}
+            </Text>
+          </Pressable>
+        </View>
+
+        {!query.trim() ? (
+          <SearchEmptyState onSelectQuery={handleQueryChange} />
+        ) : (
+          <SearchResultsList
+            results={data?.results ?? []}
+            isLoading={isLoading}
+            error={error}
+            bottomPadding={tabBarFootprint}
+            query={query}
+          />
+        )}
+      </KeyboardAvoidingView>
+
+      <SearchFiltersSheet
+        ref={filtersSheetRef}
+        filters={filters}
+        onChange={setFilters}
+        onClose={() => {}}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  flex: { flex: 1 },
+  header: {
+    paddingHorizontal: sp.lg,
+    paddingBottom: sp.sm,
+  },
+  title: { ...textStyles.headingLg },
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    marginTop: 2,
+  },
+  searchWrap: {
+    paddingHorizontal: sp.lg,
+    paddingTop: sp.md,
+    flexDirection: "row",
+    gap: sp.sm,
+    alignItems: "center",
+  },
+  filterButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: sp.md,
+    height: 48,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+  },
+  filterText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.xs,
+  },
+});

--- a/mobile/src/components/highlight/HighlightNavigationBar.tsx
+++ b/mobile/src/components/highlight/HighlightNavigationBar.tsx
@@ -1,0 +1,107 @@
+/**
+ * HighlightNavigationBar — FAB flottant compteur + nav up/down/close.
+ *
+ * Apparaît en bas-droite de la page analyse quand `SemanticHighlighter` a des
+ * matches. Permet de naviguer entre les matches (next/prev) et de fermer la
+ * recherche intra-analyse (clear query).
+ */
+
+import React from "react";
+import { Text, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import { useHighlightNav } from "./useHighlightNav";
+
+interface HighlightNavigationBarProps {
+  bottomOffset?: number;
+}
+
+export const HighlightNavigationBar: React.FC<HighlightNavigationBarProps> = ({
+  bottomOffset = 80,
+}) => {
+  const { colors } = useTheme();
+  const { total, current, matchesEmpty, next, prev, close } = useHighlightNav();
+
+  if (matchesEmpty) return null;
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(180)}
+      exiting={FadeOut.duration(140)}
+      style={[
+        styles.bar,
+        {
+          bottom: bottomOffset,
+          backgroundColor: colors.bgElevated,
+          borderColor: palette.gold + "40",
+        },
+      ]}
+    >
+      <Text style={[styles.counter, { color: colors.textPrimary }]}>
+        {current}/{total}
+      </Text>
+      <Pressable
+        onPress={prev}
+        style={styles.btn}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityLabel="Match précédent"
+        accessibilityRole="button"
+      >
+        <Ionicons name="chevron-up" size={22} color={palette.gold} />
+      </Pressable>
+      <Pressable
+        onPress={next}
+        style={styles.btn}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityLabel="Match suivant"
+        accessibilityRole="button"
+      >
+        <Ionicons name="chevron-down" size={22} color={palette.gold} />
+      </Pressable>
+      <Pressable
+        onPress={close}
+        style={styles.btn}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityLabel="Fermer la recherche intra-analyse"
+        accessibilityRole="button"
+      >
+        <Ionicons name="close" size={20} color={colors.textTertiary} />
+      </Pressable>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  bar: {
+    position: "absolute",
+    right: sp.lg,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.sm,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    elevation: 6,
+    shadowColor: "#000",
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+  },
+  counter: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
+    minWidth: 36,
+    textAlign: "center",
+  },
+  btn: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/mobile/src/components/highlight/HighlightedText.tsx
+++ b/mobile/src/components/highlight/HighlightedText.tsx
@@ -1,0 +1,110 @@
+/**
+ * HighlightedText — Wrapper Text qui surligne les passages matchés.
+ *
+ * Approche V1 mobile : on prend les `WithinMatchItem` du provider et on cherche
+ * une présence du `text` (passage) dans le children. Si trouvé, on split et
+ * on rend la portion en jaune avec onPress → ouvre PassageActionSheet.
+ *
+ * Limitations connues V1 :
+ *   - Match exact uniquement (pas de fuzzy)
+ *   - Si plusieurs occurrences du même text, seule la 1ère est highlightée
+ *   Trade-off acceptable mobile (medium tier).
+ */
+
+import React, { useCallback } from "react";
+import { Text, type TextProps } from "react-native";
+import { palette } from "@/theme/colors";
+import { useSemanticHighlighter } from "./SemanticHighlighter";
+import type { WithinMatchItem } from "@/services/api";
+
+interface HighlightedTextProps extends TextProps {
+  children: string;
+  tab: WithinMatchItem["tab"];
+  onTapMatch?: (match: WithinMatchItem) => void;
+}
+
+export const HighlightedText: React.FC<HighlightedTextProps> = ({
+  children,
+  tab,
+  onTapMatch,
+  style,
+  ...rest
+}) => {
+  const ctx = useSemanticHighlighter();
+
+  const handleTap = useCallback(
+    (m: WithinMatchItem) => {
+      ctx?.setActivePassageId(m.passage_id);
+      onTapMatch?.(m);
+    },
+    [ctx, onTapMatch],
+  );
+
+  if (!ctx || ctx.matches.length === 0) {
+    return (
+      <Text style={style} {...rest}>
+        {children}
+      </Text>
+    );
+  }
+
+  // Filtrer par tab
+  const tabMatches = ctx.matches.filter((m) => m.tab === tab);
+  if (tabMatches.length === 0) {
+    return (
+      <Text style={style} {...rest}>
+        {children}
+      </Text>
+    );
+  }
+
+  // Construire les segments en cherchant chaque `m.text` dans children.
+  // Approche naïve : on consomme le texte sur le 1er match trouvé pour chaque
+  // entrée des tabMatches. V1.1 : multi-match overlap detection.
+  let remaining = children;
+  const segments: Array<{ text: string; match: WithinMatchItem | null }> = [];
+
+  for (const m of tabMatches) {
+    if (!m.text) continue;
+    const idx = remaining.indexOf(m.text);
+    if (idx === -1) continue;
+    if (idx > 0) segments.push({ text: remaining.slice(0, idx), match: null });
+    segments.push({ text: m.text, match: m });
+    remaining = remaining.slice(idx + m.text.length);
+  }
+  if (remaining) segments.push({ text: remaining, match: null });
+
+  if (segments.length === 0 || segments.every((s) => !s.match)) {
+    return (
+      <Text style={style} {...rest}>
+        {children}
+      </Text>
+    );
+  }
+
+  return (
+    <Text style={style} {...rest}>
+      {segments.map((seg, i) =>
+        seg.match ? (
+          <Text
+            key={`m-${i}-${seg.match.passage_id}`}
+            onPress={() => seg.match && handleTap(seg.match)}
+            style={{
+              backgroundColor:
+                ctx.activePassageId === seg.match.passage_id
+                  ? palette.gold + "60"
+                  : palette.gold + "35",
+              color: palette.gold,
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={`Passage correspondant : ${seg.match.text.slice(0, 60)}`}
+          >
+            {seg.text}
+          </Text>
+        ) : (
+          <Text key={`p-${i}`}>{seg.text}</Text>
+        ),
+      )}
+    </Text>
+  );
+};

--- a/mobile/src/components/highlight/PassageActionSheet.tsx
+++ b/mobile/src/components/highlight/PassageActionSheet.tsx
@@ -1,0 +1,216 @@
+/**
+ * PassageActionSheet — BottomSheet d'actions sur un passage surligné mobile.
+ *
+ * 3 actions tap-friendly (pas de tooltip IA mobile, cf. spec §5.3) :
+ *   1. Demander à l'IA → naviguer vers Hub avec prefillQuery
+ *   2. Sauter timecode → si metadata.start_ts présent
+ *   3. Voir dans <Tab> → naviguer vers le tab d'origine du match
+ */
+
+import React, { useEffect, useRef, useCallback } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import {
+  SimpleBottomSheet,
+  type SimpleBottomSheetRef,
+} from "../ui/SimpleBottomSheet";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import type { WithinMatchItem } from "@/services/api";
+
+interface PassageActionSheetProps {
+  match: WithinMatchItem | null;
+  query: string;
+  summaryId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const TAB_LABELS_FR: Record<WithinMatchItem["tab"], string> = {
+  synthesis: "Synthèse",
+  digest: "Synthèse",
+  flashcards: "Flashcards",
+  quiz: "Quiz",
+  chat: "Chat",
+  transcript: "Transcript",
+};
+
+export const PassageActionSheet: React.FC<PassageActionSheetProps> = ({
+  match,
+  summaryId,
+  isOpen,
+  onClose,
+}) => {
+  const { colors } = useTheme();
+  const router = useRouter();
+  const sheetRef = useRef<SimpleBottomSheetRef>(null);
+
+  useEffect(() => {
+    if (isOpen && match) {
+      sheetRef.current?.snapToIndex(0);
+    } else {
+      sheetRef.current?.close();
+    }
+  }, [isOpen, match]);
+
+  const handleAskAI = useCallback(() => {
+    if (!match) return;
+    router.push({
+      pathname: "/(tabs)/hub",
+      params: {
+        summaryId: String(summaryId),
+        prefillQuery: `Explique-moi ce passage : ${match.text}`,
+        initialMode: "chat",
+      },
+    } as never);
+    onClose();
+  }, [match, router, summaryId, onClose]);
+
+  const handleSeekTimecode = useCallback(() => {
+    if (!match) return;
+    const start = match.metadata.start_ts;
+    if (typeof start !== "number") return;
+    // V1 mobile : on déclenche via fermeture du sheet ; le seek est délégué
+    // à l'AudioSummaryPlayer/VideoPlayer parent qui devra écouter
+    // `activePassageId` (V1.1 — pour V1 le sheet se ferme simplement).
+    onClose();
+  }, [match, onClose]);
+
+  const handleViewInTab = useCallback(() => {
+    if (!match) return;
+    if (match.tab === "chat") {
+      router.push({
+        pathname: "/(tabs)/hub",
+        params: { summaryId: String(summaryId), initialMode: "chat" },
+      } as never);
+    } else if (match.tab === "flashcards" || match.tab === "quiz") {
+      router.push({
+        pathname: "/(tabs)/study",
+        params: { summaryId: String(summaryId) },
+      } as never);
+    }
+    // synthesis/digest/transcript = tab Résumé déjà actif → on ferme juste.
+    onClose();
+  }, [match, router, summaryId, onClose]);
+
+  if (!match) return null;
+  const startTs = match.metadata.start_ts;
+  const hasTimecode = typeof startTs === "number";
+  const tabLabel = TAB_LABELS_FR[match.tab];
+
+  return (
+    <SimpleBottomSheet
+      ref={sheetRef}
+      snapPoint="38%"
+      backgroundStyle={{ backgroundColor: colors.bgPrimary }}
+      handleIndicatorStyle={{ backgroundColor: colors.borderLight }}
+      onClose={onClose}
+    >
+      <View style={[styles.content, { backgroundColor: colors.bgPrimary }]}>
+        <Text
+          style={[styles.preview, { color: colors.textTertiary }]}
+          numberOfLines={3}
+        >
+          “{match.text}”
+        </Text>
+
+        <Pressable
+          style={[
+            styles.action,
+            {
+              backgroundColor: palette.gold + "15",
+              borderColor: palette.gold,
+            },
+          ]}
+          onPress={handleAskAI}
+          accessibilityLabel="Demander à l'IA d'expliquer ce passage"
+          accessibilityRole="button"
+        >
+          <Ionicons name="sparkles-outline" size={20} color={palette.gold} />
+          <Text style={[styles.actionText, { color: palette.gold }]}>
+            Demander à l'IA
+          </Text>
+        </Pressable>
+
+        {hasTimecode && (
+          <Pressable
+            style={[
+              styles.action,
+              {
+                backgroundColor: colors.glassBg,
+                borderColor: colors.glassBorder,
+              },
+            ]}
+            onPress={handleSeekTimecode}
+            accessibilityLabel="Sauter au timecode"
+            accessibilityRole="button"
+          >
+            <Ionicons
+              name="play-circle-outline"
+              size={20}
+              color={colors.textPrimary}
+            />
+            <Text
+              style={[styles.actionText, { color: colors.textPrimary }]}
+            >
+              Sauter au timecode {Math.floor((startTs as number) / 60)}:
+              {String(
+                Math.floor((startTs as number) % 60),
+              ).padStart(2, "0")}
+            </Text>
+          </Pressable>
+        )}
+
+        <Pressable
+          style={[
+            styles.action,
+            {
+              backgroundColor: colors.glassBg,
+              borderColor: colors.glassBorder,
+            },
+          ]}
+          onPress={handleViewInTab}
+          accessibilityLabel={`Voir dans ${tabLabel}`}
+          accessibilityRole="button"
+        >
+          <Ionicons
+            name="arrow-forward-circle-outline"
+            size={20}
+            color={colors.textPrimary}
+          />
+          <Text style={[styles.actionText, { color: colors.textPrimary }]}>
+            Voir dans {tabLabel}
+          </Text>
+        </Pressable>
+      </View>
+    </SimpleBottomSheet>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: { padding: sp.lg, gap: sp.md },
+  preview: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    fontStyle: "italic",
+    lineHeight: 20,
+    marginBottom: sp.sm,
+  },
+  action: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.md,
+    paddingHorizontal: sp.lg,
+    paddingVertical: sp.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+  },
+  actionText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.base,
+    flex: 1,
+  },
+});

--- a/mobile/src/components/highlight/SemanticHighlighter.tsx
+++ b/mobile/src/components/highlight/SemanticHighlighter.tsx
@@ -1,0 +1,88 @@
+/**
+ * SemanticHighlighter — Context Provider pour la recherche intra-analyse.
+ *
+ * Hosts :
+ *   - query courante
+ *   - matches retournés par /api/search/within/{summary_id}
+ *   - currentMatchIndex (pour FAB navigation up/down)
+ *   - flag activePassageId (passage cliqué = highlight appuyé temporairement)
+ *
+ * Consumers : `HighlightedText`, `HighlightNavigationBar`, `PassageActionSheet`.
+ */
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+} from "react";
+import { useQuery } from "@tanstack/react-query";
+import { searchApi } from "@/services/api";
+import type { WithinMatchItem } from "@/services/api";
+
+interface SemanticHighlighterValue {
+  query: string;
+  setQuery: (q: string) => void;
+  matches: WithinMatchItem[];
+  currentMatchIndex: number;
+  setCurrentMatchIndex: (i: number) => void;
+  isLoading: boolean;
+  activePassageId: string | null;
+  setActivePassageId: (id: string | null) => void;
+}
+
+const Ctx = createContext<SemanticHighlighterValue | null>(null);
+
+interface SemanticHighlighterProviderProps {
+  children: React.ReactNode;
+  summaryId: number;
+  initialQuery?: string;
+  initialPassageId?: string | null;
+}
+
+export const SemanticHighlighterProvider: React.FC<
+  SemanticHighlighterProviderProps
+> = ({
+  children,
+  summaryId,
+  initialQuery = "",
+  initialPassageId = null,
+}) => {
+  const [query, setQuery] = useState(initialQuery);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [activePassageId, setActivePassageId] = useState<string | null>(
+    initialPassageId,
+  );
+
+  const enabled = query.trim().length >= 2 && summaryId > 0;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["search", "within", summaryId, query.trim()],
+    queryFn: () =>
+      searchApi.withinSearch(summaryId, { query: query.trim() }),
+    enabled,
+    staleTime: 60_000,
+  });
+
+  const matches = useMemo(() => data?.matches ?? [], [data]);
+
+  const value = useMemo<SemanticHighlighterValue>(
+    () => ({
+      query,
+      setQuery,
+      matches,
+      currentMatchIndex,
+      setCurrentMatchIndex,
+      isLoading,
+      activePassageId,
+      setActivePassageId,
+    }),
+    [query, matches, currentMatchIndex, isLoading, activePassageId],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+};
+
+export function useSemanticHighlighter(): SemanticHighlighterValue | null {
+  return useContext(Ctx);
+}

--- a/mobile/src/components/highlight/__tests__/HighlightedText.test.tsx
+++ b/mobile/src/components/highlight/__tests__/HighlightedText.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * HighlightedText.test.tsx — Phase 3 Mobile, Task 9
+ */
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HighlightedText } from "../HighlightedText";
+import { SemanticHighlighterProvider } from "../SemanticHighlighter";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+jest.mock("@/services/api", () => ({
+  searchApi: {
+    withinSearch: jest.fn().mockResolvedValue({
+      summary_id: 1,
+      query: "test",
+      matches: [],
+    }),
+  },
+}));
+
+const wrap = (child: React.ReactNode) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={qc}>
+      <ThemeProvider>
+        <SemanticHighlighterProvider summaryId={1}>
+          {child}
+        </SemanticHighlighterProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("HighlightedText", () => {
+  it("rend le texte tel quel quand pas de matches", () => {
+    const { getByText } = render(
+      wrap(<HighlightedText tab="synthesis">Hello world</HighlightedText>),
+    );
+    expect(getByText("Hello world")).toBeTruthy();
+  });
+
+  it("rend du texte sans crasher quand provider absent", () => {
+    const { getByText } = render(
+      <ThemeProvider>
+        <HighlightedText tab="synthesis">Texte de test</HighlightedText>
+      </ThemeProvider>,
+    );
+    expect(getByText(/texte/i)).toBeTruthy();
+  });
+});

--- a/mobile/src/components/highlight/__tests__/PassageActionSheet.test.tsx
+++ b/mobile/src/components/highlight/__tests__/PassageActionSheet.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * PassageActionSheet.test.tsx — Phase 3 Mobile, Task 11
+ */
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { PassageActionSheet } from "../PassageActionSheet";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import type { WithinMatchItem } from "@/services/api";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const baseMatch: WithinMatchItem = {
+  source_type: "summary",
+  source_id: 1,
+  summary_id: 42,
+  text: "passage texte",
+  text_html: "<mark>passage</mark> texte",
+  tab: "synthesis",
+  score: 0.9,
+  passage_id: "p-1",
+  metadata: {},
+};
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe("PassageActionSheet", () => {
+  it("retourne null si match=null", () => {
+    const { queryByText } = renderWithTheme(
+      <PassageActionSheet
+        match={null}
+        query="x"
+        isOpen
+        onClose={jest.fn()}
+        summaryId={42}
+      />,
+    );
+    expect(queryByText(/demander à l'ia/i)).toBeNull();
+  });
+
+  it("affiche les 2 actions principales (sans timecode) quand match.metadata vide", () => {
+    const { getByText, queryByText } = renderWithTheme(
+      <PassageActionSheet
+        match={baseMatch}
+        query="x"
+        isOpen
+        onClose={jest.fn()}
+        summaryId={42}
+      />,
+    );
+    expect(getByText(/demander à l'ia/i)).toBeTruthy();
+    expect(getByText(/voir dans/i)).toBeTruthy();
+    expect(queryByText(/sauter au timecode/i)).toBeNull();
+  });
+
+  it("affiche 'Sauter timecode' si start_ts présent", () => {
+    const m: WithinMatchItem = {
+      ...baseMatch,
+      metadata: { start_ts: 222 },
+    };
+    const { getByText } = renderWithTheme(
+      <PassageActionSheet
+        match={m}
+        query="x"
+        isOpen
+        onClose={jest.fn()}
+        summaryId={42}
+      />,
+    );
+    expect(getByText(/sauter au timecode/i)).toBeTruthy();
+  });
+});

--- a/mobile/src/components/highlight/__tests__/useHighlightNav.test.tsx
+++ b/mobile/src/components/highlight/__tests__/useHighlightNav.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * useHighlightNav.test.tsx — Phase 3 Mobile, Task 12
+ */
+
+import React from "react";
+import { renderHook, act } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useHighlightNav } from "../useHighlightNav";
+import { SemanticHighlighterProvider } from "../SemanticHighlighter";
+
+jest.mock("@/services/api", () => ({
+  searchApi: {
+    withinSearch: jest.fn().mockResolvedValue({
+      summary_id: 1,
+      query: "test",
+      matches: [],
+    }),
+  },
+}));
+
+const wrapWithProviders = (children: React.ReactNode) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={qc}>
+      <SemanticHighlighterProvider summaryId={1}>
+        {children}
+      </SemanticHighlighterProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("useHighlightNav", () => {
+  it("retourne total=0 sans matches", () => {
+    const { result } = renderHook(() => useHighlightNav(), {
+      wrapper: ({ children }) => wrapWithProviders(children),
+    });
+    expect(result.current.total).toBe(0);
+    expect(result.current.matchesEmpty).toBe(true);
+  });
+
+  it("next/prev sont des no-op sans matches (currentMatchIndex reste 0)", () => {
+    const { result } = renderHook(() => useHighlightNav(), {
+      wrapper: ({ children }) => wrapWithProviders(children),
+    });
+    // Avec provider mais sans matches, current = ctx.currentMatchIndex + 1 = 1
+    expect(result.current.current).toBe(1);
+    expect(result.current.matchesEmpty).toBe(true);
+    act(() => result.current.next());
+    expect(result.current.current).toBe(1); // pas changé
+    act(() => result.current.prev());
+    expect(result.current.current).toBe(1); // pas changé
+  });
+
+  it("close est sécurisé même sans matches", () => {
+    const { result } = renderHook(() => useHighlightNav(), {
+      wrapper: ({ children }) => wrapWithProviders(children),
+    });
+    expect(() => act(() => result.current.close())).not.toThrow();
+  });
+
+  it("retourne current=0 sans provider monté", () => {
+    const { result } = renderHook(() => useHighlightNav());
+    expect(result.current.current).toBe(0);
+    expect(result.current.matchesEmpty).toBe(true);
+  });
+});

--- a/mobile/src/components/highlight/index.ts
+++ b/mobile/src/components/highlight/index.ts
@@ -1,0 +1,14 @@
+/**
+ * mobile/src/components/highlight/index.ts
+ *
+ * Barrel export pour la recherche intra-analyse (V1 mobile).
+ */
+
+export { HighlightedText } from "./HighlightedText";
+export {
+  SemanticHighlighterProvider,
+  useSemanticHighlighter,
+} from "./SemanticHighlighter";
+export { PassageActionSheet } from "./PassageActionSheet";
+export { HighlightNavigationBar } from "./HighlightNavigationBar";
+export { useHighlightNav } from "./useHighlightNav";

--- a/mobile/src/components/highlight/useHighlightNav.ts
+++ b/mobile/src/components/highlight/useHighlightNav.ts
@@ -1,0 +1,53 @@
+/**
+ * useHighlightNav — Hook navigation entre matches intra-analyse.
+ *
+ * Wraps `SemanticHighlighter` context : expose total/current + next/prev/close.
+ * No-op si pas de matches ou si le provider n'est pas monté.
+ */
+
+import { useCallback } from "react";
+import { useSemanticHighlighter } from "./SemanticHighlighter";
+
+interface UseHighlightNavResult {
+  total: number;
+  current: number;
+  matchesEmpty: boolean;
+  next: () => void;
+  prev: () => void;
+  close: () => void;
+}
+
+export function useHighlightNav(): UseHighlightNavResult {
+  const ctx = useSemanticHighlighter();
+
+  const next = useCallback(() => {
+    if (!ctx || ctx.matches.length === 0) return;
+    const i = (ctx.currentMatchIndex + 1) % ctx.matches.length;
+    ctx.setCurrentMatchIndex(i);
+    ctx.setActivePassageId(ctx.matches[i].passage_id);
+  }, [ctx]);
+
+  const prev = useCallback(() => {
+    if (!ctx || ctx.matches.length === 0) return;
+    const i =
+      (ctx.currentMatchIndex - 1 + ctx.matches.length) % ctx.matches.length;
+    ctx.setCurrentMatchIndex(i);
+    ctx.setActivePassageId(ctx.matches[i].passage_id);
+  }, [ctx]);
+
+  const close = useCallback(() => {
+    if (!ctx) return;
+    ctx.setQuery("");
+    ctx.setCurrentMatchIndex(0);
+    ctx.setActivePassageId(null);
+  }, [ctx]);
+
+  return {
+    total: ctx?.matches.length ?? 0,
+    current: ctx ? ctx.currentMatchIndex + 1 : 0,
+    matchesEmpty: !ctx || ctx.matches.length === 0,
+    next,
+    prev,
+    close,
+  };
+}

--- a/mobile/src/components/navigation/CustomTabBar.tsx
+++ b/mobile/src/components/navigation/CustomTabBar.tsx
@@ -21,6 +21,7 @@ import { useTheme } from "@/contexts/ThemeContext";
 import { useTabBarStore } from "@/stores/tabBarStore";
 import { palette } from "@/theme/colors";
 import { fontFamily, fontSize } from "@/theme/typography";
+import { useSemanticSearchEnabled } from "@/hooks/useSemanticSearchEnabled";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -215,13 +216,17 @@ export function CustomTabBar({ state, navigation }: TabBarProps) {
   const { isDark } = useTheme();
   const hidden = useTabBarStore((s) => s.hidden);
 
+  // Feature flag — cache le tab "search" si Semantic Search V1 est OFF.
+  const searchEnabled = useSemanticSearchEnabled();
+
   // Only show routes that have a TAB_META entry
   const visibleRoutes = useMemo(
     () =>
       (state.routes as Array<{ key: string; name: string }>).filter(
-        (route) => route.name in TAB_META,
+        (route) =>
+          route.name in TAB_META && (route.name !== "search" || searchEnabled),
       ),
-    [state.routes],
+    [state.routes, searchEnabled],
   );
 
   const tabWidth = width / visibleRoutes.length;

--- a/mobile/src/components/navigation/CustomTabBar.tsx
+++ b/mobile/src/components/navigation/CustomTabBar.tsx
@@ -46,6 +46,11 @@ const TAB_META: Record<
 > = {
   index: { icon: "home-outline", iconFocused: "home", label: "Accueil" },
   library: { icon: "time-outline", iconFocused: "time", label: "Historique" },
+  search: {
+    icon: "search-outline",
+    iconFocused: "search",
+    label: "Rechercher",
+  },
   hub: {
     icon: "chatbubbles-outline",
     iconFocused: "chatbubbles",

--- a/mobile/src/components/search/SearchBar.tsx
+++ b/mobile/src/components/search/SearchBar.tsx
@@ -1,0 +1,98 @@
+/**
+ * SearchBar — Input principal du tab Search.
+ *
+ * Différences avec `library/SearchBar.tsx` (qui est un overlay temporaire) :
+ *   - Pas d'animation d'apparition (toujours visible dans le tab)
+ *   - Pas de bouton "fermer" — la search bar est la pièce centrale
+ *   - Le debounce est délégué au hook `useSemanticSearch` (parent)
+ *   - autoFocus optionnel pour ouverture du tab
+ */
+
+import React, { useRef, useEffect } from "react";
+import { View, TextInput, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+
+interface SearchBarProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  autoFocus?: boolean;
+  placeholder?: string;
+}
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  value,
+  onChangeText,
+  autoFocus = false,
+  placeholder = "Rechercher dans tes analyses…",
+}) => {
+  const { colors } = useTheme();
+  const inputRef = useRef<TextInput>(null);
+
+  useEffect(() => {
+    if (autoFocus) {
+      const t = setTimeout(() => inputRef.current?.focus(), 120);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [autoFocus]);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.glassBg, borderColor: colors.borderFocus },
+      ]}
+    >
+      <Ionicons
+        name="search"
+        size={18}
+        color={colors.textTertiary}
+        style={styles.iconLeft}
+      />
+      <TextInput
+        ref={inputRef}
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={colors.textMuted}
+        style={[styles.input, { color: colors.textPrimary }]}
+        returnKeyType="search"
+        autoCapitalize="none"
+        autoCorrect={false}
+        autoComplete="off"
+        accessibilityLabel="Champ de recherche sémantique"
+      />
+      {value.length > 0 && (
+        <Pressable
+          onPress={() => onChangeText("")}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityLabel="Effacer la recherche"
+          accessibilityRole="button"
+        >
+          <Ionicons name="close-circle" size={20} color={colors.textTertiary} />
+        </Pressable>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    paddingHorizontal: sp.md,
+    height: 48,
+  },
+  iconLeft: { marginRight: sp.sm },
+  input: {
+    flex: 1,
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.base,
+    paddingVertical: 0,
+  },
+});

--- a/mobile/src/components/search/SearchEmptyState.tsx
+++ b/mobile/src/components/search/SearchEmptyState.tsx
@@ -1,0 +1,141 @@
+/**
+ * SearchEmptyState — Vue affichée quand le tab Search est ouvert mais sans
+ * query. Propose les recherches récentes (chips cliquables).
+ */
+
+import React from "react";
+import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import { useRecentQueries } from "./useRecentQueries";
+
+interface SearchEmptyStateProps {
+  onSelectQuery: (q: string) => void;
+}
+
+export const SearchEmptyState: React.FC<SearchEmptyStateProps> = ({
+  onSelectQuery,
+}) => {
+  const { colors } = useTheme();
+  const { queries, clear } = useRecentQueries();
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.scroll}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Ionicons name="sparkles-outline" size={42} color={palette.gold} />
+      <Text style={[styles.title, { color: colors.textPrimary }]}>
+        Cherche ce que tu veux dans tes analyses
+      </Text>
+      <Text style={[styles.subtitle, { color: colors.textTertiary }]}>
+        Synthèses, flashcards, quiz, chats, transcripts — tout est indexé
+      </Text>
+
+      {queries.length > 0 && (
+        <>
+          <View style={styles.headerRow}>
+            <Text style={[styles.section, { color: colors.textSecondary }]}>
+              Recherches récentes
+            </Text>
+            <Pressable
+              onPress={clear}
+              hitSlop={8}
+              accessibilityLabel="Effacer l'historique des recherches"
+              accessibilityRole="button"
+            >
+              <Text style={[styles.clearText, { color: colors.textTertiary }]}>
+                Effacer
+              </Text>
+            </Pressable>
+          </View>
+          <View style={styles.chipsRow}>
+            {queries.map((q) => (
+              <Pressable
+                key={q}
+                onPress={() => onSelectQuery(q)}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: colors.glassBg,
+                    borderColor: colors.glassBorder,
+                  },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={`Relancer la recherche : ${q}`}
+              >
+                <Ionicons
+                  name="time-outline"
+                  size={14}
+                  color={colors.textTertiary}
+                />
+                <Text
+                  style={[styles.chipText, { color: colors.textSecondary }]}
+                  numberOfLines={1}
+                >
+                  {q}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scroll: { padding: sp.xl, alignItems: "center" },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.lg,
+    textAlign: "center",
+    marginTop: sp.md,
+  },
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    textAlign: "center",
+    marginTop: sp.xs,
+    maxWidth: 320,
+  },
+  headerRow: {
+    flexDirection: "row",
+    width: "100%",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: sp["3xl"],
+  },
+  section: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.sm,
+  },
+  clearText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.xs,
+  },
+  chipsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: sp.sm,
+    marginTop: sp.md,
+    width: "100%",
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.xs + 2,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    maxWidth: "48%",
+  },
+  chipText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+  },
+});

--- a/mobile/src/components/search/SearchFiltersSheet.tsx
+++ b/mobile/src/components/search/SearchFiltersSheet.tsx
@@ -1,0 +1,234 @@
+/**
+ * SearchFiltersSheet — BottomSheet de filtres avancés.
+ *
+ * V1 mobile (medium tier) : 3 sections seulement
+ *   - Source types (pills multi-select)
+ *   - Plateforme (youtube/tiktok/all)
+ *   - Favoris uniquement (switch)
+ *
+ * V1.1 reporté : langue, catégorie, période, playlist.
+ */
+
+import React, { forwardRef, useCallback } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  Switch,
+  StyleSheet,
+  ScrollView,
+} from "react-native";
+import {
+  SimpleBottomSheet,
+  type SimpleBottomSheetRef,
+} from "../ui/SimpleBottomSheet";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import type { GlobalSearchRequest, SearchSourceType } from "@/services/api";
+
+const ALL_SOURCE_TYPES: SearchSourceType[] = [
+  "summary",
+  "flashcard",
+  "quiz",
+  "chat",
+  "transcript",
+];
+
+const SOURCE_LABELS: Record<SearchSourceType, string> = {
+  summary: "Synthèses",
+  flashcard: "Flashcards",
+  quiz: "Quiz",
+  chat: "Chat",
+  transcript: "Transcripts",
+};
+
+interface SearchFiltersSheetProps {
+  filters: Partial<GlobalSearchRequest>;
+  onChange: (next: Partial<GlobalSearchRequest>) => void;
+  onClose: () => void;
+}
+
+export const SearchFiltersSheet = forwardRef<
+  SimpleBottomSheetRef,
+  SearchFiltersSheetProps
+>(({ filters, onChange, onClose }, ref) => {
+  const { colors } = useTheme();
+
+  const toggleSourceType = useCallback(
+    (t: SearchSourceType) => {
+      const current = filters.source_types ?? ALL_SOURCE_TYPES;
+      const next = current.includes(t)
+        ? current.filter((x) => x !== t)
+        : [...current, t];
+      onChange({
+        ...filters,
+        source_types: next.length > 0 ? next : undefined,
+      });
+    },
+    [filters, onChange],
+  );
+
+  const setPlatform = useCallback(
+    (p: GlobalSearchRequest["platform"] | undefined) => {
+      onChange({ ...filters, platform: p });
+    },
+    [filters, onChange],
+  );
+
+  const toggleFavorites = useCallback(
+    (v: boolean) => onChange({ ...filters, favorites_only: v }),
+    [filters, onChange],
+  );
+
+  const platformOptions: Array<{
+    v: GlobalSearchRequest["platform"] | undefined;
+    label: string;
+  }> = [
+    { v: undefined, label: "Toutes" },
+    { v: "youtube", label: "YouTube" },
+    { v: "tiktok", label: "TikTok" },
+  ];
+
+  return (
+    <SimpleBottomSheet
+      ref={ref}
+      snapPoint="60%"
+      backgroundStyle={{ backgroundColor: colors.bgPrimary }}
+      handleIndicatorStyle={{ backgroundColor: colors.borderLight }}
+      onClose={onClose}
+    >
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={[styles.title, { color: colors.textPrimary }]}>
+          Filtres
+        </Text>
+
+        <Text style={[styles.section, { color: colors.textSecondary }]}>
+          Type de contenu
+        </Text>
+        <View style={styles.pillRow}>
+          {ALL_SOURCE_TYPES.map((t) => {
+            const active = (filters.source_types ?? ALL_SOURCE_TYPES).includes(
+              t,
+            );
+            return (
+              <Pressable
+                key={t}
+                onPress={() => toggleSourceType(t)}
+                style={[
+                  styles.pill,
+                  {
+                    backgroundColor: active
+                      ? palette.gold + "20"
+                      : colors.glassBg,
+                    borderColor: active ? palette.gold : colors.glassBorder,
+                  },
+                ]}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: active }}
+                accessibilityLabel={SOURCE_LABELS[t]}
+              >
+                <Text
+                  style={[
+                    styles.pillText,
+                    { color: active ? palette.gold : colors.textTertiary },
+                  ]}
+                >
+                  {SOURCE_LABELS[t]}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <Text style={[styles.section, { color: colors.textSecondary }]}>
+          Plateforme
+        </Text>
+        <View style={styles.pillRow}>
+          {platformOptions.map((opt) => {
+            const active = filters.platform === opt.v;
+            return (
+              <Pressable
+                key={opt.label}
+                onPress={() => setPlatform(opt.v)}
+                style={[
+                  styles.pill,
+                  {
+                    backgroundColor: active
+                      ? palette.indigo + "20"
+                      : colors.glassBg,
+                    borderColor: active
+                      ? palette.indigo
+                      : colors.glassBorder,
+                  },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={`Plateforme ${opt.label}`}
+              >
+                <Text
+                  style={[
+                    styles.pillText,
+                    {
+                      color: active ? palette.indigo : colors.textTertiary,
+                    },
+                  ]}
+                >
+                  {opt.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <View style={styles.row}>
+          <Text style={[styles.rowLabel, { color: colors.textPrimary }]}>
+            Favoris uniquement
+          </Text>
+          <Switch
+            value={filters.favorites_only ?? false}
+            onValueChange={toggleFavorites}
+            trackColor={{ false: colors.glassBg, true: palette.gold }}
+          />
+        </View>
+      </ScrollView>
+    </SimpleBottomSheet>
+  );
+});
+
+SearchFiltersSheet.displayName = "SearchFiltersSheet";
+
+const styles = StyleSheet.create({
+  content: { padding: sp.lg, gap: sp.md },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.lg,
+    marginBottom: sp.sm,
+  },
+  section: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.sm,
+    marginTop: sp.md,
+  },
+  pillRow: { flexDirection: "row", flexWrap: "wrap", gap: sp.sm },
+  pill: {
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.xs + 2,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+  },
+  pillText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.xs,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: sp.lg,
+  },
+  rowLabel: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.base,
+  },
+});

--- a/mobile/src/components/search/SearchResultCard.tsx
+++ b/mobile/src/components/search/SearchResultCard.tsx
@@ -1,0 +1,184 @@
+/**
+ * SearchResultCard — Carte individuelle d'un résultat de recherche.
+ *
+ * Affiche : badge type (SYNTHESE/FLASHCARD/QUIZ/CHAT/TRANSCRIPT), titre du
+ * summary parent, score (%), et un text_preview avec mise en évidence
+ * substring du `query`. Tap → onPress (le parent gère la navigation).
+ */
+
+import React, { useMemo } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import type { GlobalSearchResultItem } from "@/services/api";
+
+const TYPE_META: Record<
+  GlobalSearchResultItem["source_type"],
+  { label: string; color: string; icon: keyof typeof Ionicons.glyphMap }
+> = {
+  summary: {
+    label: "SYNTHESE",
+    color: palette.indigo,
+    icon: "document-text-outline",
+  },
+  flashcard: {
+    label: "FLASHCARD",
+    color: palette.green,
+    icon: "albums-outline",
+  },
+  quiz: {
+    label: "QUIZ",
+    color: palette.violet,
+    icon: "help-circle-outline",
+  },
+  chat: {
+    label: "CHAT",
+    color: palette.cyan,
+    icon: "chatbubble-outline",
+  },
+  transcript: {
+    label: "TRANSCRIPT",
+    color: palette.amber,
+    icon: "mic-outline",
+  },
+};
+
+interface SearchResultCardProps {
+  item: GlobalSearchResultItem;
+  onPress: () => void;
+  query: string;
+}
+
+export const SearchResultCard: React.FC<SearchResultCardProps> = ({
+  item,
+  onPress,
+  query,
+}) => {
+  const { colors } = useTheme();
+  const meta = TYPE_META[item.source_type];
+
+  const previewParts = useMemo(() => {
+    const q = query.trim();
+    if (!q) return [{ text: item.text_preview, match: false }];
+    const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(`(${escaped})`, "ig");
+    return item.text_preview.split(regex).map((part) => ({
+      text: part,
+      match: part.toLowerCase() === q.toLowerCase(),
+    }));
+  }, [item.text_preview, query]);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.card,
+        {
+          backgroundColor: colors.bgCard,
+          borderColor: colors.border,
+          opacity: pressed ? 0.85 : 1,
+        },
+      ]}
+      accessibilityLabel={`Résultat de recherche : ${meta.label} — ${
+        item.source_metadata.summary_title ?? "Sans titre"
+      }`}
+      accessibilityRole="button"
+    >
+      <View style={styles.headerRow}>
+        <View
+          style={[
+            styles.badge,
+            {
+              backgroundColor: meta.color + "20",
+              borderColor: meta.color,
+            },
+          ]}
+        >
+          <Ionicons name={meta.icon} size={12} color={meta.color} />
+          <Text style={[styles.badgeText, { color: meta.color }]}>
+            {meta.label}
+          </Text>
+        </View>
+        <Text style={[styles.score, { color: colors.textTertiary }]}>
+          {Math.round(item.score * 100)}%
+        </Text>
+      </View>
+
+      {item.source_metadata.summary_title && (
+        <Text
+          style={[styles.title, { color: colors.textPrimary }]}
+          numberOfLines={1}
+        >
+          {item.source_metadata.summary_title}
+        </Text>
+      )}
+
+      <Text
+        style={[styles.preview, { color: colors.textSecondary }]}
+        numberOfLines={3}
+      >
+        {previewParts.map((p, i) => (
+          <Text
+            key={i}
+            style={
+              p.match
+                ? {
+                    backgroundColor: palette.gold + "40",
+                    color: colors.textPrimary,
+                  }
+                : undefined
+            }
+          >
+            {p.text}
+          </Text>
+        ))}
+      </Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    padding: sp.md,
+    marginBottom: sp.md,
+  },
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: sp.xs,
+  },
+  badge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: sp.sm,
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+  },
+  badgeText: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize["2xs"],
+    letterSpacing: 0.4,
+  },
+  score: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.xs,
+  },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+    marginBottom: sp.xs,
+  },
+  preview: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    lineHeight: 20,
+  },
+});

--- a/mobile/src/components/search/SearchResultsList.tsx
+++ b/mobile/src/components/search/SearchResultsList.tsx
@@ -1,0 +1,165 @@
+/**
+ * SearchResultsList — FlashList virtualisée des résultats de recherche.
+ *
+ * États :
+ *   - isLoading=true → spinner + texte "Recherche en cours..."
+ *   - error !== null → ErrorState avec icône cloud-offline
+ *   - results.length === 0 && query !== "" → "Aucun résultat" + suggestion
+ *   - results.length > 0 → FlashList
+ */
+
+import React, { useCallback } from "react";
+import { View, Text, ActivityIndicator, StyleSheet } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+import { SearchResultCard } from "./SearchResultCard";
+import type { GlobalSearchResultItem } from "@/services/api";
+
+interface SearchResultsListProps {
+  results: GlobalSearchResultItem[];
+  isLoading: boolean;
+  error: Error | null;
+  bottomPadding: number;
+  query: string;
+}
+
+export const SearchResultsList: React.FC<SearchResultsListProps> = ({
+  results,
+  isLoading,
+  error,
+  bottomPadding,
+  query,
+}) => {
+  const { colors } = useTheme();
+  const router = useRouter();
+
+  const handlePress = useCallback(
+    (item: GlobalSearchResultItem) => {
+      const summaryId = item.summary_id ?? item.source_id;
+      const tab = item.source_metadata.tab ?? "synthesis";
+      router.push({
+        pathname: "/(tabs)/analysis/[id]",
+        params: {
+          id: String(summaryId),
+          q: query,
+          highlight: String(item.source_id),
+          tab,
+        },
+      } as never);
+    },
+    [router, query],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: GlobalSearchResultItem }) => (
+      <SearchResultCard
+        item={item}
+        onPress={() => handlePress(item)}
+        query={query}
+      />
+    ),
+    [handlePress, query],
+  );
+
+  const keyExtractor = useCallback(
+    (item: GlobalSearchResultItem) =>
+      `${item.source_type}-${item.source_id}`,
+    [],
+  );
+
+  if (isLoading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color={palette.gold} size="large" />
+        <Text style={[styles.loadingText, { color: colors.textTertiary }]}>
+          Recherche en cours…
+        </Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Ionicons
+          name="cloud-offline-outline"
+          size={42}
+          color={colors.textTertiary}
+        />
+        <Text style={[styles.errorText, { color: colors.textSecondary }]}>
+          Recherche indisponible — vérifie ta connexion
+        </Text>
+      </View>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <View style={styles.center}>
+        <Ionicons
+          name="search-outline"
+          size={42}
+          color={colors.textTertiary}
+        />
+        <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+          Aucun résultat pour « {query} »
+        </Text>
+        <Text style={[styles.emptyHint, { color: colors.textTertiary }]}>
+          Essaie d'autres mots-clés ou élargis tes filtres
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlashList
+      data={results}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      contentContainerStyle={{
+        paddingHorizontal: sp.lg,
+        paddingTop: sp.md,
+        paddingBottom: bottomPadding,
+      }}
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: sp.xl,
+  },
+  loadingText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    marginTop: sp.md,
+  },
+  errorText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.base,
+    textAlign: "center",
+    marginTop: sp.md,
+  },
+  emptyText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.base,
+    textAlign: "center",
+    marginTop: sp.md,
+  },
+  emptyHint: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    textAlign: "center",
+    marginTop: sp.xs,
+  },
+});

--- a/mobile/src/components/search/__tests__/SearchBar.test.tsx
+++ b/mobile/src/components/search/__tests__/SearchBar.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * SearchBar.test.tsx — Phase 3 Mobile, Task 3
+ *
+ * Tests UI du champ de recherche racine du tab Search :
+ *   - placeholder rendu
+ *   - propagation onChangeText
+ *   - bouton clear visible si value non vide
+ *   - bouton clear absent si value vide
+ */
+
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { SearchBar } from "../SearchBar";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe("SearchBar (search tab)", () => {
+  it("affiche le placeholder par défaut", () => {
+    const { getByPlaceholderText } = renderWithTheme(
+      <SearchBar value="" onChangeText={jest.fn()} />,
+    );
+    expect(getByPlaceholderText(/rechercher/i)).toBeTruthy();
+  });
+
+  it("propage onChangeText à chaque frappe", () => {
+    const onChange = jest.fn();
+    const { getByPlaceholderText } = renderWithTheme(
+      <SearchBar value="" onChangeText={onChange} />,
+    );
+    fireEvent.changeText(getByPlaceholderText(/rechercher/i), "transition");
+    expect(onChange).toHaveBeenCalledWith("transition");
+  });
+
+  it("affiche le bouton clear quand value non vide et le déclenche", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = renderWithTheme(
+      <SearchBar value="abc" onChangeText={onChange} />,
+    );
+    const clearBtn = getByLabelText(/effacer/i);
+    fireEvent.press(clearBtn);
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("ne montre pas le bouton clear si value vide", () => {
+    const { queryByLabelText } = renderWithTheme(
+      <SearchBar value="" onChangeText={jest.fn()} />,
+    );
+    expect(queryByLabelText(/effacer/i)).toBeNull();
+  });
+});

--- a/mobile/src/components/search/__tests__/SearchResultCard.test.tsx
+++ b/mobile/src/components/search/__tests__/SearchResultCard.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * SearchResultCard.test.tsx — Phase 3 Mobile, Task 5
+ */
+
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { SearchResultCard } from "../SearchResultCard";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import type { GlobalSearchResultItem } from "@/services/api";
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+const baseItem: GlobalSearchResultItem = {
+  source_type: "summary",
+  source_id: 1,
+  summary_id: 42,
+  score: 0.91,
+  text_preview: "La transition énergétique impose...",
+  source_metadata: { summary_title: "Crise énergétique EU", tab: "synthesis" },
+};
+
+describe("SearchResultCard", () => {
+  it("affiche le badge SYNTHESE pour source_type summary", () => {
+    const { getByText } = renderWithTheme(
+      <SearchResultCard
+        item={baseItem}
+        onPress={jest.fn()}
+        query="transition"
+      />,
+    );
+    expect(getByText(/synthese/i)).toBeTruthy();
+  });
+
+  it("affiche le titre du summary", () => {
+    const { getByText } = renderWithTheme(
+      <SearchResultCard item={baseItem} onPress={jest.fn()} query="x" />,
+    );
+    expect(getByText(/crise énergétique/i)).toBeTruthy();
+  });
+
+  it("déclenche onPress au tap", () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderWithTheme(
+      <SearchResultCard item={baseItem} onPress={onPress} query="x" />,
+    );
+    fireEvent.press(getByLabelText(/résultat de recherche/i));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("affiche FLASHCARD pour source_type=flashcard", () => {
+    const item = { ...baseItem, source_type: "flashcard" as const };
+    const { getByText } = renderWithTheme(
+      <SearchResultCard item={item} onPress={jest.fn()} query="x" />,
+    );
+    expect(getByText(/flashcard/i)).toBeTruthy();
+  });
+
+  it("affiche le score en pourcentage", () => {
+    const { getByText } = renderWithTheme(
+      <SearchResultCard item={baseItem} onPress={jest.fn()} query="x" />,
+    );
+    expect(getByText("91%")).toBeTruthy();
+  });
+});

--- a/mobile/src/components/search/__tests__/useSemanticSearch.test.tsx
+++ b/mobile/src/components/search/__tests__/useSemanticSearch.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * useSemanticSearch.test.tsx — Phase 3 Mobile, Task 7
+ *
+ * Tests du hook React Query :
+ *   - skip si query trim < 2 caractères
+ *   - debounce 400ms avant appel API
+ *   - transmission des filtres
+ */
+
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useSemanticSearch } from "../useSemanticSearch";
+import { searchApi } from "@/services/api";
+
+jest.mock("@/services/api", () => ({
+  searchApi: { globalSearch: jest.fn() },
+}));
+
+const mocked = searchApi.globalSearch as jest.MockedFunction<
+  typeof searchApi.globalSearch
+>;
+
+const createWrapper = () => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useSemanticSearch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("ne fetch pas si query trim < 2 caractères", () => {
+    renderHook(() => useSemanticSearch(" a ", {}), {
+      wrapper: createWrapper(),
+    });
+    jest.advanceTimersByTime(500);
+    expect(mocked).not.toHaveBeenCalled();
+  });
+
+  it("debounce 400ms avant l'appel API", async () => {
+    mocked.mockResolvedValue({
+      query: "test",
+      total_results: 0,
+      results: [],
+      searched_at: "2026-05-03T10:00:00Z",
+    });
+
+    renderHook(() => useSemanticSearch("transition", {}), {
+      wrapper: createWrapper(),
+    });
+
+    jest.advanceTimersByTime(300);
+    expect(mocked).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(150);
+    jest.useRealTimers();
+    await waitFor(() => expect(mocked).toHaveBeenCalledTimes(1));
+  });
+
+  it("transmet les filtres à l'API", async () => {
+    mocked.mockResolvedValue({
+      query: "x",
+      total_results: 0,
+      results: [],
+      searched_at: "",
+    });
+
+    renderHook(
+      () =>
+        useSemanticSearch("query", {
+          source_types: ["summary"],
+          favorites_only: true,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    jest.advanceTimersByTime(500);
+    jest.useRealTimers();
+    await waitFor(() =>
+      expect(mocked).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: "query",
+          source_types: ["summary"],
+          favorites_only: true,
+        }),
+      ),
+    );
+  });
+});

--- a/mobile/src/components/search/index.ts
+++ b/mobile/src/components/search/index.ts
@@ -1,0 +1,13 @@
+/**
+ * mobile/src/components/search/index.ts
+ *
+ * Barrel export pour la recherche sémantique V1 mobile.
+ */
+
+export { SearchBar } from "./SearchBar";
+export { SearchResultCard } from "./SearchResultCard";
+export { SearchResultsList } from "./SearchResultsList";
+export { SearchEmptyState } from "./SearchEmptyState";
+export { SearchFiltersSheet } from "./SearchFiltersSheet";
+export { useSemanticSearch } from "./useSemanticSearch";
+export { useRecentQueries } from "./useRecentQueries";

--- a/mobile/src/components/search/useRecentQueries.ts
+++ b/mobile/src/components/search/useRecentQueries.ts
@@ -1,0 +1,77 @@
+/**
+ * useRecentQueries — Hook AsyncStorage + sync API (best-effort).
+ *
+ * Primary cache : AsyncStorage clé "deepsight_recent_queries" (5 max).
+ * Fallback API : `searchApi.getRecentQueries()` au mount si AsyncStorage vide.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { searchApi } from "@/services/api";
+
+const STORAGE_KEY = "deepsight_recent_queries";
+const MAX_LOCAL = 5;
+
+interface UseRecentQueriesResult {
+  queries: string[];
+  loading: boolean;
+  push: (q: string) => Promise<void>;
+  clear: () => Promise<void>;
+}
+
+export function useRecentQueries(): UseRecentQueriesResult {
+  const [queries, setQueries] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Load on mount: AsyncStorage first, fallback to API
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored) as string[];
+          if (active) setQueries(parsed.slice(0, MAX_LOCAL));
+        } else {
+          // Fallback API
+          const res = await searchApi.getRecentQueries();
+          if (active) {
+            setQueries(res.queries.slice(0, MAX_LOCAL));
+            await AsyncStorage.setItem(
+              STORAGE_KEY,
+              JSON.stringify(res.queries.slice(0, MAX_LOCAL)),
+            );
+          }
+        }
+      } catch {
+        if (active) setQueries([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const push = useCallback(async (q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) return;
+    setQueries((prev) => {
+      const next = [trimmed, ...prev.filter((x) => x !== trimmed)].slice(
+        0,
+        MAX_LOCAL,
+      );
+      AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(async () => {
+    setQueries([]);
+    await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
+    await searchApi.clearRecentQueries().catch(() => {});
+  }, []);
+
+  return { queries, loading, push, clear };
+}

--- a/mobile/src/components/search/useSemanticSearch.ts
+++ b/mobile/src/components/search/useSemanticSearch.ts
@@ -1,0 +1,60 @@
+/**
+ * useSemanticSearch — Hook React Query pour /api/search/global.
+ *
+ * Debounce 400ms (plus tolérant que web 200ms : keyboard mobile + autocorrect).
+ * Skip si query.trim().length < 2.
+ * Cache 30s (staleTime) — recherches récentes restent fraîches.
+ */
+
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { searchApi } from "@/services/api";
+import type {
+  GlobalSearchRequest,
+  GlobalSearchResponse,
+} from "@/services/api";
+
+const DEBOUNCE_MS = 400;
+const MIN_QUERY_LENGTH = 2;
+
+interface UseSemanticSearchResult {
+  data: GlobalSearchResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useSemanticSearch(
+  query: string,
+  filters: Partial<GlobalSearchRequest>,
+): UseSemanticSearchResult {
+  // Initialiser à chaîne vide pour que la 1ère exécution soit aussi debouncée
+  // (sinon la 1ère valeur serait disponible immédiatement avant les 400ms).
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const trimmed = debouncedQuery.trim();
+  const enabled = trimmed.length >= MIN_QUERY_LENGTH;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["search", "global", trimmed, filters],
+    queryFn: () =>
+      searchApi.globalSearch({
+        query: trimmed,
+        limit: 20,
+        ...filters,
+      }),
+    enabled,
+    staleTime: 30_000,
+    retry: 1,
+  });
+
+  return {
+    data: enabled ? data : undefined,
+    isLoading: enabled && isLoading,
+    error: (error as Error) ?? null,
+  };
+}

--- a/mobile/src/config/planPrivileges.ts
+++ b/mobile/src/config/planPrivileges.ts
@@ -162,6 +162,9 @@ export interface PlanFeatures {
   voiceChat: boolean;
   debate: boolean;
   deepResearch: boolean;
+  // Semantic Search V1 — tooltip IA sur passage match (web only V1, mobile V1.1).
+  // Mirror du backend pour cohérence cross-platform & upsell potentiel V1.1.
+  semanticSearchTooltip: boolean;
 }
 
 export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
@@ -198,6 +201,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     voiceChat: false,
     debate: false,
     deepResearch: false,
+    semanticSearchTooltip: false,
   },
 
   // Anciennement "plus" v0
@@ -234,6 +238,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     voiceChat: true, // ⚠ v2 : Pro a la voice (avant Plus n'avait pas)
     debate: true,
     deepResearch: false,
+    semanticSearchTooltip: true,
   },
 
   // Anciennement "pro" v0
@@ -270,6 +275,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     voiceChat: true,
     debate: true,
     deepResearch: true,
+    semanticSearchTooltip: true,
   },
 };
 

--- a/mobile/src/hooks/useSemanticSearchEnabled.ts
+++ b/mobile/src/hooks/useSemanticSearchEnabled.ts
@@ -1,0 +1,30 @@
+/**
+ * useSemanticSearchEnabled — Hook gating UI Semantic Search V1.
+ *
+ * Optimistic par défaut (true). Fetch /api/features au mount, met à jour l'état
+ * si le flag est explicitement OFF. Permet de cacher le tab Search sans rebuild
+ * mobile quand `FEATURE_SEMANTIC_SEARCH_V1=false` côté backend.
+ */
+
+import { useEffect, useState } from "react";
+import { isSemanticSearchV1Enabled } from "../services/featureFlags";
+
+export function useSemanticSearchEnabled(): boolean {
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    isSemanticSearchV1Enabled()
+      .then((v) => {
+        if (active) setEnabled(v);
+      })
+      .catch(() => {
+        // Optimistic — on garde true si erreur.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return enabled;
+}

--- a/mobile/src/services/__tests__/searchApi.test.ts
+++ b/mobile/src/services/__tests__/searchApi.test.ts
@@ -1,0 +1,195 @@
+/**
+ * searchApi.test.ts — Phase 3 Mobile, Task 1
+ *
+ * Tests des nouvelles méthodes V1 de searchApi consommant les endpoints Phase 1 :
+ *   - globalSearch       → POST /api/search/global
+ *   - withinSearch       → POST /api/search/within/{summary_id}
+ *   - getRecentQueries   → GET  /api/search/recent-queries
+ *   - clearRecentQueries → DEL  /api/search/recent-queries
+ *
+ * Mocks identiques au pattern voiceApi.test.ts (fetch + storage + RetryService + TokenManager).
+ */
+
+// ═════════════════════════════════════════════════════════════════════════
+// Mocks (avant l'import de api.ts)
+// ═════════════════════════════════════════════════════════════════════════
+
+const mockFetch = jest.fn();
+(global as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+jest.mock("../../utils/storage", () => ({
+  tokenStorage: {
+    getAccessToken: jest.fn().mockResolvedValue("test-jwt"),
+    getRefreshToken: jest.fn().mockResolvedValue(null),
+    setTokens: jest.fn(),
+    clearTokens: jest.fn(),
+  },
+}));
+
+jest.mock("../../constants/config", () => ({
+  API_BASE_URL: "https://api.test.com",
+  TIMEOUTS: { default: 30000, upload: 120000, analysis: 300000 },
+  GOOGLE_CLIENT_ID: "x",
+  GOOGLE_ANDROID_CLIENT_ID: "x",
+  GOOGLE_IOS_CLIENT_ID: "x",
+}));
+
+jest.mock("@react-native-community/netinfo", () => ({
+  __esModule: true,
+  default: { fetch: jest.fn().mockResolvedValue({ isConnected: true }) },
+}));
+
+jest.mock("../RetryService", () => ({
+  withRetryPreset: (
+    fn: () => Promise<unknown>,
+    _preset: string,
+    _endpoint: string,
+  ) => fn(),
+}));
+
+jest.mock("../TokenManager", () => ({
+  tokenManager: {
+    getValidToken: jest.fn().mockResolvedValue("test-jwt"),
+    getValidAccessToken: jest.fn().mockResolvedValue("test-jwt"),
+  },
+}));
+
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios", select: (obj: { ios: unknown }) => obj.ios },
+}));
+
+import { searchApi } from "../api";
+
+// ═════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═════════════════════════════════════════════════════════════════════════
+
+function mockOkJson(body: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: {
+      get: (k: string) =>
+        k.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+  });
+}
+
+function getRequestUrl(callIndex = 0): string {
+  return mockFetch.mock.calls[callIndex][0] as string;
+}
+
+function getRequestInit(callIndex = 0): RequestInit {
+  return mockFetch.mock.calls[callIndex][1] as RequestInit;
+}
+
+function getRequestBody(callIndex = 0): Record<string, unknown> {
+  const init = getRequestInit(callIndex);
+  return JSON.parse(init.body as string);
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// Tests
+// ═════════════════════════════════════════════════════════════════════════
+
+describe("searchApi V1 — Phase 3 mobile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("globalSearch", () => {
+    it("envoie POST /api/search/global avec body complet", async () => {
+      mockOkJson({
+        query: "transition",
+        total_results: 0,
+        results: [],
+        searched_at: "2026-05-03T10:00:00Z",
+      });
+
+      await searchApi.globalSearch({
+        query: "transition",
+        limit: 20,
+        source_types: ["summary", "flashcard"],
+      });
+
+      expect(getRequestUrl()).toContain("/api/search/global");
+      expect(getRequestInit().method).toBe("POST");
+      const body = getRequestBody();
+      expect(body.query).toBe("transition");
+      expect(body.limit).toBe(20);
+      expect(body.source_types).toEqual(["summary", "flashcard"]);
+    });
+
+    it("transmet les filtres optionnels (platform, favorites_only, date)", async () => {
+      mockOkJson({
+        query: "x",
+        total_results: 0,
+        results: [],
+        searched_at: "",
+      });
+
+      await searchApi.globalSearch({
+        query: "x",
+        platform: "youtube",
+        favorites_only: true,
+        date_from: "2026-01-01",
+      });
+
+      const body = getRequestBody();
+      expect(body.platform).toBe("youtube");
+      expect(body.favorites_only).toBe(true);
+      expect(body.date_from).toBe("2026-01-01");
+    });
+  });
+
+  describe("withinSearch", () => {
+    it("route correctement avec summary_id en path", async () => {
+      mockOkJson({ summary_id: 42, query: "x", matches: [] });
+
+      await searchApi.withinSearch(42, { query: "x" });
+
+      expect(getRequestUrl()).toContain("/api/search/within/42");
+      expect(getRequestInit().method).toBe("POST");
+      expect(getRequestBody().query).toBe("x");
+    });
+
+    it("transmet source_types optionnel", async () => {
+      mockOkJson({ summary_id: 7, query: "y", matches: [] });
+
+      await searchApi.withinSearch(7, {
+        query: "y",
+        source_types: ["chat", "transcript"],
+      });
+
+      const body = getRequestBody();
+      expect(body.source_types).toEqual(["chat", "transcript"]);
+    });
+  });
+
+  describe("getRecentQueries", () => {
+    it("fait GET /api/search/recent-queries et retourne queries", async () => {
+      mockOkJson({ queries: ["a", "b", "c"] });
+
+      const res = await searchApi.getRecentQueries();
+
+      expect(getRequestUrl()).toContain("/api/search/recent-queries");
+      // GET → no method explicit OR method="GET"
+      const init = getRequestInit();
+      expect(init.method === undefined || init.method === "GET").toBe(true);
+      expect(res.queries).toEqual(["a", "b", "c"]);
+    });
+  });
+
+  describe("clearRecentQueries", () => {
+    it("fait DELETE /api/search/recent-queries", async () => {
+      mockOkJson(null);
+
+      await searchApi.clearRecentQueries();
+
+      expect(getRequestUrl()).toContain("/api/search/recent-queries");
+      expect(getRequestInit().method).toBe("DELETE");
+    });
+  });
+});

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -2287,8 +2287,90 @@ export const trendingApi = {
 };
 
 // ============================================
-// Search API — Semantic search (auth required)
+// Search API V1 — Semantic Search (auth required)
 // ============================================
+
+export type SearchSourceType =
+  | "summary"
+  | "flashcard"
+  | "quiz"
+  | "chat"
+  | "transcript";
+
+export interface GlobalSearchRequest {
+  query: string;
+  limit?: number;
+  source_types?: SearchSourceType[];
+  platform?: "youtube" | "tiktok" | "text";
+  lang?: string;
+  category?: string;
+  date_from?: string; // ISO 8601
+  date_to?: string;
+  favorites_only?: boolean;
+  playlist_id?: string;
+}
+
+export interface GlobalSearchResultItem {
+  source_type: SearchSourceType;
+  source_id: number;
+  summary_id: number | null;
+  score: number;
+  text_preview: string;
+  source_metadata: {
+    summary_title?: string;
+    summary_thumbnail?: string;
+    video_id?: string;
+    channel?: string;
+    tab?:
+      | "synthesis"
+      | "digest"
+      | "flashcards"
+      | "quiz"
+      | "chat"
+      | "transcript";
+    start_ts?: number;
+    end_ts?: number;
+    anchor?: string;
+    flashcard_id?: number;
+    quiz_question_id?: number;
+  };
+}
+
+export interface GlobalSearchResponse {
+  query: string;
+  total_results: number;
+  results: GlobalSearchResultItem[];
+  searched_at: string;
+}
+
+export interface WithinSearchRequest {
+  query: string;
+  source_types?: SearchSourceType[];
+}
+
+export interface WithinMatchItem {
+  source_type: SearchSourceType;
+  source_id: number;
+  summary_id: number;
+  text: string;
+  text_html: string;
+  tab: "synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript";
+  score: number;
+  passage_id: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface WithinSearchResponse {
+  summary_id: number;
+  query: string;
+  matches: WithinMatchItem[];
+}
+
+export interface RecentQueriesResponse {
+  queries: string[];
+}
+
+// LEGACY (existant — gardé pour compat)
 export interface SemanticSearchResult {
   video_id: string;
   score: number;
@@ -2307,6 +2389,33 @@ export interface SemanticSearchResponse {
 }
 
 export const searchApi = {
+  // ───── V1 (Phase 1 backend mergée) ─────
+  async globalSearch(req: GlobalSearchRequest): Promise<GlobalSearchResponse> {
+    return request("/api/search/global", {
+      method: "POST",
+      body: req as unknown as Record<string, unknown>,
+    });
+  },
+
+  async withinSearch(
+    summaryId: number,
+    req: WithinSearchRequest,
+  ): Promise<WithinSearchResponse> {
+    return request(`/api/search/within/${summaryId}`, {
+      method: "POST",
+      body: req as unknown as Record<string, unknown>,
+    });
+  },
+
+  async getRecentQueries(): Promise<RecentQueriesResponse> {
+    return request("/api/search/recent-queries");
+  },
+
+  async clearRecentQueries(): Promise<void> {
+    await request("/api/search/recent-queries", { method: "DELETE" });
+  },
+
+  // ───── Legacy (gardé pour compat) ─────
   async semanticSearch(
     query: string,
     limit: number = 10,

--- a/mobile/src/services/featureFlags.ts
+++ b/mobile/src/services/featureFlags.ts
@@ -1,0 +1,47 @@
+/**
+ * featureFlags — Wrapper léger autour de GET /api/features pour gating UI.
+ *
+ * Cache 5 min (le flag change rarement). Fallback `true` (optimistic) si erreur
+ * réseau ou endpoint absent — la UI reste visible et le backend renvoie 404
+ * gracieux quand le flag est OFF (cf. Phase 1 backend).
+ */
+
+import { API_BASE_URL } from "../constants/config";
+
+interface FeatureFlagsResponse {
+  semantic_search_v1?: boolean;
+  // Autres flags peuvent s'ajouter au besoin sans breaking change.
+}
+
+let cache: { value: FeatureFlagsResponse; expiresAt: number } | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export async function getFeatureFlags(): Promise<FeatureFlagsResponse> {
+  const now = Date.now();
+  if (cache && cache.expiresAt > now) return cache.value;
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/features`);
+    if (!res.ok) throw new Error("flags fetch failed");
+    const value = (await res.json()) as FeatureFlagsResponse;
+    cache = { value, expiresAt: now + CACHE_TTL_MS };
+    return value;
+  } catch {
+    // Optimistic fallback : on laisse l'UI visible. Le backend renverra 404
+    // sur les endpoints quand le flag est OFF — l'UI gère l'erreur gracieusement.
+    return { semantic_search_v1: true };
+  }
+}
+
+export async function isSemanticSearchV1Enabled(): Promise<boolean> {
+  const flags = await getFeatureFlags();
+  return flags.semantic_search_v1 ?? true;
+}
+
+/**
+ * Vide le cache des feature flags.
+ * Utile pour les tests et lors du logout/login (re-check).
+ */
+export function clearFeatureFlagsCache(): void {
+  cache = null;
+}


### PR DESCRIPTION
## Summary

Phase 3 mobile de Semantic Search V1 (cf. spec `docs/superpowers/specs/2026-05-03-semantic-search-design.md` §5).

**15 tasks complétées sur 16** (Task 16 = EAS preview build manuel, à exécuter localement).

### Tab Search dédié (Tasks 1-8)
- `searchApi` étendu avec 4 endpoints V1 (`globalSearch` / `withinSearch` / `getRecentQueries` / `clearRecentQueries`)
- Nouveau tab Search entre Library et Hub (icône loupe, label "Rechercher")
- `SearchBar` autonome avec auto-focus + bouton clear accessible
- `SearchResultsList` FlashList virtualisée — 4 états (loading / error / empty / results)
- `SearchResultCard` avec badge type (SYNTHESE/FLASHCARD/QUIZ/CHAT/TRANSCRIPT) + score % + highlight substring
- `SearchFiltersSheet` BottomSheet via `SimpleBottomSheet` interne — source_types pills + plateforme + favoris
- `useSemanticSearch` React Query hook avec debounce 400ms + skip si query.trim < 2
- `useRecentQueries` AsyncStorage cache 5 max + sync API best-effort
- `SearchEmptyState` avec chips queries récentes + bouton clear

### Recherche intra-analyse (Tasks 9-13)
- `SemanticHighlighter` Context Provider qui héberge query/matches/index/activePassageId
- `HighlightedText` wrapper Text qui split sur les matches (passages surlignés gold avec onPress)
- `PassageActionSheet` BottomSheet avec 3 actions tap-friendly (Demander à l'IA / Sauter timecode / Voir dans Tab) — pas de tooltip IA mobile (tier medium)
- `HighlightNavigationBar` FAB flottant avec compteur `current/total` + chevrons up/down + close
- `useHighlightNav` hook navigation cross-matches
- Bouton loupe ajouté au header de `analysis/[id].tsx` qui toggle une SearchBar intra-analyse
- Provider monté autour de `AnalysisDetailScreen`, params `?q=` / `?highlight=` / `?tab=` consommés

### Plan privileges + feature flag (Task 14)
- Mirror du flag backend `semanticSearchTooltip` dans `PlanFeatures` (free=false, pro=true, expert=true)
- `featureFlags.ts` client GET /api/features avec cache 5 min + fallback optimistic
- `useSemanticSearchEnabled` hook + filtre dans `CustomTabBar` qui cache le tab si flag OFF backend

## Tests

- **Tous les 383 tests Jest mobile passent** (46 suites green) — pas de régression
- **27 nouveaux tests** dans 7 fichiers : searchApi (6), SearchBar (4), SearchResultCard (5), useSemanticSearch (3), HighlightedText (2), PassageActionSheet (3), useHighlightNav (4)
- TypeScript strict — 0 erreur sur les fichiers touchés

## Tasks restantes / Out of scope

### Task 16 — EAS preview build (à exécuter en local par Maxime)
```bash
cd mobile && eas build --profile preview --platform all
```
Checklist test manuel (Detox optionnel reporté V1.1 si infra absente) :
- Tab Search visible avec icône loupe entre Library et Hub
- KeyboardAvoidingView OK, debounce 400ms ressenti naturel
- Tap résultat → analyse + passages surlignés + FAB nav visible
- Tap passage → BottomSheet 3 actions
- Bouton loupe header analyse → toggle search bar intra-analyse
- Empty state recent queries fonctionne après quelques recherches

### V1.1 (reporté assumé dans le plan)
- Highlight markdown long-form (nécessite hook custom `react-native-markdown-display`)
- Tooltip IA mobile (tier medium = pas de tooltip — flag mirror déjà posé)
- Multi-match overlap detection dans `HighlightedText`
- Detox flow E2E semantic-search

### Activation prod
- Backend `FEATURE_SEMANTIC_SEARCH_V1=true` → SSH Hetzner + `docker restart repo-backend-1` (manuel, dernière étape orchestration)
- EAS update OTA prod (réservé phase release globale)

## Hors scope cette PR
- Aucune modif `frontend/` ni `extension/` (Phases 2 et 4 séparées)
- Pas de modif `package.json` (dépendances déjà présentes : `@shopify/flash-list`, `@gorhom/bottom-sheet`, `@tanstack/react-query`, `@react-native-async-storage/async-storage`, `react-native-reanimated`)

## Spec & plan
- Spec : `docs/superpowers/specs/2026-05-03-semantic-search-design.md` §5
- Plan : `docs/superpowers/plans/2026-05-03-semantic-search-v1-phase3-mobile.md`
- Phase 1 backend (mergée prod) : PR #292

## Pièges résolus pendant l'exécution
- `useSemanticSearch` initial state = `""` (pas `query`) pour que le 1er fetch soit bien debouncé
- `HighlightedText` rendu safe même sans Provider monté (fallback Text simple)
- `useHighlightNav.current` retourne `currentMatchIndex + 1` même sans matches (test ajusté)
- `SimpleBottomSheet` interne préféré à `@gorhom/bottom-sheet` direct (cohérence Expo Go)