### PR TITLE
feat(brave): Optimize Brave Search API costs (-50 to -60% target)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ backend/*.pyc
 backend/.env
 backend/venv/
 backend/.venv/
+backend/data/
+backend/*.db
+backend/**/*.db
 
 # ─── Mobile ───
 mobile/node_modules/

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -718,6 +718,16 @@ MISTRAL_AGENT_ENABLED = True  # Set False to force Brave-only pipeline
 # Brave reste TOUJOURS en last-resort (n'est pas affecté par ce flag).
 MISTRAL_AGENT_PRIMARY = False
 
+# Phase 2 cost optimisation (mai 2026) — bascule du Deep Research vidéo
+# (5 queries × 8 résultats Brave = ~40 appels par analyse) vers l'Agent Mistral
+# natif (1 seul appel via web_search). Économie estimée : ~15-25% du budget
+# Brave Search ($102/mois → ~$76/mois). Default OFF tant que le benchmark
+# qualité Agent vs Brave Deep Research n'est pas validé. Brave reste fallback
+# automatique en cas d'échec/circuit-breaker Agent.
+DEEP_RESEARCH_USE_MISTRAL_AGENT = (
+    os.getenv("DEEP_RESEARCH_USE_MISTRAL_AGENT", "false").lower() == "true"
+)
+
 # Modèle de modération contenu
 MISTRAL_MODERATION_MODEL = "mistral-moderation-latest"
 

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -91,7 +91,7 @@ class _DeepSightSettings(BaseSettings):
     # Pricing v0 LEGACY — conservees pour grandfathering / mapping webhooks
     STRIPE_PRICE_PLUS_TEST: str = ""
     STRIPE_PRICE_PLUS_LIVE: str = ""
-    STRIPE_PRICE_PRO_TEST: str = ""    # ⚠ ancien Pro 9.99 € (legacy), pas le nouveau Pro 8.99 €
+    STRIPE_PRICE_PRO_TEST: str = ""  # ⚠ ancien Pro 9.99 € (legacy), pas le nouveau Pro 8.99 €
     STRIPE_PRICE_PRO_LIVE: str = ""
 
     # Pricing v2 — 4 plans actifs (Pro 8.99 / Expert 19.99) × 2 cycles (8 vars)
@@ -724,9 +724,7 @@ MISTRAL_AGENT_PRIMARY = False
 # Brave Search ($102/mois → ~$76/mois). Default OFF tant que le benchmark
 # qualité Agent vs Brave Deep Research n'est pas validé. Brave reste fallback
 # automatique en cas d'échec/circuit-breaker Agent.
-DEEP_RESEARCH_USE_MISTRAL_AGENT = (
-    os.getenv("DEEP_RESEARCH_USE_MISTRAL_AGENT", "false").lower() == "true"
-)
+DEEP_RESEARCH_USE_MISTRAL_AGENT = os.getenv("DEEP_RESEARCH_USE_MISTRAL_AGENT", "false").lower() == "true"
 
 # Modèle de modération contenu
 MISTRAL_MODERATION_MODEL = "mistral-moderation-latest"
@@ -750,23 +748,15 @@ MISTRAL_MODERATION_MODEL = "mistral-moderation-latest"
 # sur 10 vidéos avec marqueurs visibles. Toggle = .env MAGISTRAL_EPISTEMIC_ENABLED=true
 # =============================================================================
 
-MAGISTRAL_EPISTEMIC_ENABLED: bool = (
-    os.getenv("MAGISTRAL_EPISTEMIC_ENABLED", "false").lower() == "true"
-)
-MAGISTRAL_EPISTEMIC_MODEL: str = os.getenv(
-    "MAGISTRAL_EPISTEMIC_MODEL", "magistral-medium-2509"
-)
+MAGISTRAL_EPISTEMIC_ENABLED: bool = os.getenv("MAGISTRAL_EPISTEMIC_ENABLED", "false").lower() == "true"
+MAGISTRAL_EPISTEMIC_MODEL: str = os.getenv("MAGISTRAL_EPISTEMIC_MODEL", "magistral-medium-2509")
 MAGISTRAL_EPISTEMIC_TIERS: list = [
-    t.strip().lower()
-    for t in os.getenv("MAGISTRAL_EPISTEMIC_TIERS", "expert").split(",")
-    if t.strip()
+    t.strip().lower() for t in os.getenv("MAGISTRAL_EPISTEMIC_TIERS", "expert").split(",") if t.strip()
 ]
 
 
 # 🔍 Semantic Search V1 (extended : summary + flashcard + quiz + chat)
-SEMANTIC_SEARCH_V1_ENABLED: bool = (
-    os.getenv("SEMANTIC_SEARCH_V1_ENABLED", "false").lower() == "true"
-)
+SEMANTIC_SEARCH_V1_ENABLED: bool = os.getenv("SEMANTIC_SEARCH_V1_ENABLED", "false").lower() == "true"
 
 # Modération — Phase 2 migration Mistral-First
 # log_only : calcule + log les scores mais laisse passer (calibration)

--- a/backend/src/videos/brave_search.py
+++ b/backend/src/videos/brave_search.py
@@ -10,12 +10,24 @@
 ╚════════════════════════════════════════════════════════════════════════════════════╝
 """
 
+import hashlib
+import logging
 import re
 from typing import Optional, List, Dict, Tuple
 from dataclasses import dataclass
 
+from core.cache import cache_service
 from core.config import get_brave_key
 from core.http_client import shared_http_client
+
+logger = logging.getLogger(__name__)
+
+# ── Cache TTLs (cost optimisation) ───────────────────────────────────────────
+# Fact-check : 72h — sujets d'actualité, on évite de servir trop ancien.
+# Deep research : 30j — recherche externe peu volatile, gros gain de cache.
+_FACTCHECK_CACHE_TTL = 72 * 3600
+_DEEP_RESEARCH_CACHE_TTL = 30 * 86400
+_CACHE_VERSION = "v1"  # Bump pour invalider tout le cache d'un coup si besoin
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -32,6 +44,69 @@ class BraveSearchResult:
     sources: List[Dict[str, str]]  # [{title, url, snippet}]
     query: str
     error: Optional[str] = None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 💾 CACHE HELPERS (cost optimisation)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _content_digest(video_title: str, video_channel: str, transcript: str) -> str:
+    """Hash stable du contenu vidéo (fallback si video_id absent)."""
+    payload = f"{video_title}|{video_channel}|{transcript[:1500]}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+def _factcheck_cache_key(
+    video_id: Optional[str], video_title: str, video_channel: str, transcript: str, lang: str
+) -> str:
+    identity = f"id:{video_id}" if video_id else f"h:{_content_digest(video_title, video_channel, transcript)}"
+    return f"brave:factcheck:{_CACHE_VERSION}:{lang}:{identity}"
+
+
+def _deep_research_cache_key(
+    video_id: Optional[str], video_title: str, video_channel: str, transcript: str, lang: str
+) -> str:
+    identity = f"id:{video_id}" if video_id else f"h:{_content_digest(video_title, video_channel, transcript)}"
+    return f"brave:deepresearch:{_CACHE_VERSION}:{lang}:{identity}"
+
+
+async def _increment_brave_request_counter() -> None:
+    """Compteur quotidien d'appels HTTP réels à Brave Search (best-effort, jamais bloquant).
+
+    Permet de mesurer l'impact des optimisations cache sur la facture Brave
+    sans avoir à attendre la facture mensuelle. Lecture via admin/stats.
+    """
+    try:
+        from datetime import datetime, timezone
+
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        key = f"brave:requests:daily:{date}"
+        current = await cache_service.get(key)
+        if not isinstance(current, int):
+            current = 0
+        # 35j de rétention pour avoir un mois glissant + marge
+        await cache_service.set(key, current + 1, ttl=35 * 86400)
+    except Exception as exc:
+        logger.debug("brave counter increment skipped: %s", exc)
+
+
+def _serialize_factcheck_payload(
+    context_text: Optional[str], sources: List[Dict[str, str]]
+) -> Dict[str, object]:
+    return {"context_text": context_text, "sources": sources}
+
+
+def _deserialize_factcheck_payload(
+    payload: Dict[str, object],
+) -> Tuple[Optional[str], List[Dict[str, str]]]:
+    context_text = payload.get("context_text") if isinstance(payload, dict) else None
+    sources = payload.get("sources") if isinstance(payload, dict) else None
+    if not isinstance(sources, list):
+        sources = []
+    if context_text is not None and not isinstance(context_text, str):
+        context_text = None
+    return context_text, sources
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -108,6 +183,9 @@ async def _call_brave_api(query: str, count: int = 5) -> BraveSearchResult:
     if len(query) > 400:
         query = query[:397] + "..."
 
+    # Compteur quotidien — mesure l'impact des optimisations cache
+    await _increment_brave_request_counter()
+
     try:
         async with shared_http_client() as client:
             response = await client.get(
@@ -183,7 +261,11 @@ async def _call_brave_api(query: str, count: int = 5) -> BraveSearchResult:
 
 
 async def get_brave_factcheck_context(
-    video_title: str, video_channel: str, transcript: str, lang: str = "fr"
+    video_title: str,
+    video_channel: str,
+    transcript: str,
+    lang: str = "fr",
+    video_id: Optional[str] = None,
 ) -> Tuple[Optional[str], List[Dict[str, str]]]:
     """
     Exécute 2-3 recherches Brave pour fact-checker le contenu vidéo.
@@ -197,6 +279,19 @@ async def get_brave_factcheck_context(
     if not api_key:
         print("⏭️ [BRAVE] Skipped — no API key", flush=True)
         return None, []
+
+    # ── Cache lookup (TTL 72h) ───────────────────────────────────────────────
+    cache_key = _factcheck_cache_key(video_id, video_title, video_channel, transcript, lang)
+    try:
+        cached = await cache_service.get(cache_key)
+    except Exception as exc:
+        logger.warning("brave factcheck cache GET error: %s", exc)
+        cached = None
+    if cached is not None:
+        ctx, src = _deserialize_factcheck_payload(cached)
+        if ctx is not None:
+            print(f"💾 [BRAVE] Fact-check cache HIT ({len(src)} sources) — saved 2-3 API calls", flush=True)
+            return ctx, src
 
     # Générer les requêtes intelligentes
     queries = generate_factcheck_queries(
@@ -256,6 +351,17 @@ async def get_brave_factcheck_context(
     success_count = sum(1 for r in results if isinstance(r, BraveSearchResult) and r.success)
     print(f"✅ [BRAVE] {success_count}/{len(queries)} queries OK — {len(all_sources)} unique sources", flush=True)
 
+    # ── Cache store (TTL 72h, succès uniquement) ─────────────────────────────
+    if success_count > 0:
+        try:
+            await cache_service.set(
+                cache_key,
+                _serialize_factcheck_payload(context_text, all_sources),
+                ttl=_FACTCHECK_CACHE_TTL,
+            )
+        except Exception as exc:
+            logger.warning("brave factcheck cache SET error: %s", exc)
+
     return context_text, all_sources
 
 
@@ -309,13 +415,30 @@ def generate_deep_research_queries(
 
 
 async def get_brave_deep_research_context(
-    video_title: str, video_channel: str, transcript: str, lang: str = "fr"
+    video_title: str,
+    video_channel: str,
+    transcript: str,
+    lang: str = "fr",
+    video_id: Optional[str] = None,
 ) -> "Tuple[Optional[str], List[Dict[str, str]]]":
     """🔬 Deep Research: 5 requêtes × 8 résultats = ~40 sources."""
     api_key = get_brave_key()
     if not api_key:
         print("⏭️ [BRAVE DEEP] Skipped — no API key", flush=True)
         return None, []
+
+    # ── Cache lookup (TTL 30j) ───────────────────────────────────────────────
+    cache_key = _deep_research_cache_key(video_id, video_title, video_channel, transcript, lang)
+    try:
+        cached = await cache_service.get(cache_key)
+    except Exception as exc:
+        logger.warning("brave deep research cache GET error: %s", exc)
+        cached = None
+    if cached is not None:
+        ctx, src = _deserialize_factcheck_payload(cached)
+        if ctx is not None:
+            print(f"💾 [BRAVE DEEP] Cache HIT ({len(src)} sources) — saved ~40 API calls", flush=True)
+            return ctx, src
 
     queries = generate_deep_research_queries(
         video_title=video_title,
@@ -370,5 +493,16 @@ async def get_brave_deep_research_context(
 
     success_count = sum(1 for r in results if isinstance(r, BraveSearchResult) and r.success)
     print(f"✅ [BRAVE DEEP] {success_count}/{len(queries)} queries OK — {len(all_sources)} unique sources", flush=True)
+
+    # ── Cache store (TTL 30j, succès uniquement) ─────────────────────────────
+    if success_count > 0:
+        try:
+            await cache_service.set(
+                cache_key,
+                _serialize_factcheck_payload(context_text, all_sources),
+                ttl=_DEEP_RESEARCH_CACHE_TTL,
+            )
+        except Exception as exc:
+            logger.warning("brave deep research cache SET error: %s", exc)
 
     return context_text, all_sources

--- a/backend/src/videos/brave_search.py
+++ b/backend/src/videos/brave_search.py
@@ -91,9 +91,7 @@ async def _increment_brave_request_counter() -> None:
         logger.debug("brave counter increment skipped: %s", exc)
 
 
-def _serialize_factcheck_payload(
-    context_text: Optional[str], sources: List[Dict[str, str]]
-) -> Dict[str, object]:
+def _serialize_factcheck_payload(context_text: Optional[str], sources: List[Dict[str, str]]) -> Dict[str, object]:
     return {"context_text": context_text, "sources": sources}
 
 

--- a/backend/src/videos/deep_research_dispatcher.py
+++ b/backend/src/videos/deep_research_dispatcher.py
@@ -1,0 +1,97 @@
+"""
+Deep Research dispatcher — Phase 2 cost optimisation.
+
+Dispatch entre Mistral Agent (1 appel API natif avec web_search) et le pipeline
+Brave Search historique (5 queries × 8 résultats = ~40 appels Brave par analyse).
+
+Comportement :
+- Si DEEP_RESEARCH_USE_MISTRAL_AGENT=true ET Agent disponible → Agent en premier
+- Échec Agent (circuit breaker, timeout, erreur) → fallback Brave automatique
+- Si flag off (défaut) → Brave direct, comportement historique inchangé
+
+Garantit zéro régression : flag off par défaut, fallback Brave systématique.
+"""
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from core.config import DEEP_RESEARCH_USE_MISTRAL_AGENT, MISTRAL_AGENT_MODEL
+from core.mistral_agent import agent_web_search
+from videos.brave_search import get_brave_deep_research_context
+
+logger = logging.getLogger(__name__)
+
+
+def _format_agent_result_as_context(
+    content: str, sources: List[Dict[str, str]]
+) -> str:
+    """Formate la réponse Agent dans le même style que Brave Deep Research.
+
+    Le prompt downstream attend un préfixe explicite et les sources listées,
+    on conserve la même structure pour ne pas changer le comportement aval.
+    """
+    return (
+        "═══ 🤖🔬 MISTRAL AGENT DEEP RESEARCH ═══\n"
+        f"{len(sources)} sources collectées via recherche web Mistral.\n\n"
+        + content
+    )
+
+
+async def dispatch_deep_research_context(
+    video_title: str,
+    video_channel: str,
+    transcript: str,
+    lang: str = "fr",
+    video_id: Optional[str] = None,
+) -> Tuple[Optional[str], List[Dict[str, str]]]:
+    """Dispatcher deep research : Mistral Agent en primary (si flag), Brave en fallback.
+
+    Args:
+        video_title, video_channel, transcript, lang : contexte vidéo
+        video_id : utilisé pour la clé de cache Brave (Phase 1)
+
+    Returns:
+        Tuple (context_text, sources). (None, []) si tout échoue.
+    """
+    # Path A : Mistral Agent en premier si flag activé
+    if DEEP_RESEARCH_USE_MISTRAL_AGENT:
+        try:
+            query = f"Recherche approfondie sur : {video_title}"
+            context = (
+                f"Vidéo : « {video_title} » par {video_channel}.\n\n"
+                f"Extrait du transcript (3000 premiers caractères) :\n{transcript[:3000]}\n\n"
+                "Effectue une recherche web exhaustive : vérification des faits, entités "
+                "mentionnées, critiques et controverses, contexte, actualités récentes. "
+                "Cite tes sources."
+            )
+            agent_result = await agent_web_search(
+                query=query,
+                context=context,
+                purpose="deep_research",
+                lang=lang,
+                model=MISTRAL_AGENT_MODEL,
+                timeout=60.0,
+            )
+            if agent_result and agent_result.success and agent_result.content:
+                logger.info(
+                    "[DEEP RESEARCH] Mistral Agent OK: %d chars, %d sources, %dms",
+                    len(agent_result.content),
+                    len(agent_result.sources),
+                    agent_result.latency_ms,
+                )
+                return (
+                    _format_agent_result_as_context(agent_result.content, agent_result.sources),
+                    agent_result.sources,
+                )
+            logger.warning("[DEEP RESEARCH] Mistral Agent unavailable, falling back to Brave")
+        except Exception as exc:
+            logger.warning("[DEEP RESEARCH] Mistral Agent error: %s — falling back to Brave", exc)
+
+    # Path B : Brave Deep Research (default + fallback)
+    return await get_brave_deep_research_context(
+        video_title=video_title,
+        video_channel=video_channel,
+        transcript=transcript,
+        lang=lang,
+        video_id=video_id,
+    )

--- a/backend/src/videos/deep_research_dispatcher.py
+++ b/backend/src/videos/deep_research_dispatcher.py
@@ -22,9 +22,7 @@ from videos.brave_search import get_brave_deep_research_context
 logger = logging.getLogger(__name__)
 
 
-def _format_agent_result_as_context(
-    content: str, sources: List[Dict[str, str]]
-) -> str:
+def _format_agent_result_as_context(content: str, sources: List[Dict[str, str]]) -> str:
     """Formate la réponse Agent dans le même style que Brave Deep Research.
 
     Le prompt downstream attend un préfixe explicite et les sources listées,
@@ -32,8 +30,7 @@ def _format_agent_result_as_context(
     """
     return (
         "═══ 🤖🔬 MISTRAL AGENT DEEP RESEARCH ═══\n"
-        f"{len(sources)} sources collectées via recherche web Mistral.\n\n"
-        + content
+        f"{len(sources)} sources collectées via recherche web Mistral.\n\n" + content
     )
 
 

--- a/backend/src/videos/streaming.py
+++ b/backend/src/videos/streaming.py
@@ -62,15 +62,15 @@ except ImportError as e:
         return None, []
 
 
-# 🔬 Deep Research imports
+# 🔬 Deep Research imports — dispatcher Mistral Agent / Brave (Phase 2 cost optim)
 try:
-    from videos.brave_search import get_brave_deep_research_context
+    from videos.deep_research_dispatcher import dispatch_deep_research_context
 
     BRAVE_DEEP_RESEARCH_AVAILABLE = True
 except ImportError:
     BRAVE_DEEP_RESEARCH_AVAILABLE = False
 
-    async def get_brave_deep_research_context(*args, **kwargs):
+    async def dispatch_deep_research_context(*args, **kwargs):
         return None, []
 
 
@@ -636,7 +636,7 @@ async def analysis_stream_generator(
 
                 brave_text, brave_sources = None, []
                 if BRAVE_DEEP_RESEARCH_AVAILABLE:
-                    brave_text, brave_sources = await get_brave_deep_research_context(
+                    brave_text, brave_sources = await dispatch_deep_research_context(
                         video_title=metadata.get("title", ""),
                         video_channel=metadata.get("channel", ""),
                         transcript=transcript,

--- a/backend/src/videos/streaming.py
+++ b/backend/src/videos/streaming.py
@@ -13,6 +13,7 @@
 
 import json
 import asyncio
+import os
 import uuid
 import httpx
 from datetime import datetime
@@ -640,6 +641,7 @@ async def analysis_stream_generator(
                         video_channel=metadata.get("channel", ""),
                         transcript=transcript,
                         lang=lang,
+                        video_id=video_id,
                     )
 
                 if brave_text and brave_sources:
@@ -763,10 +765,15 @@ async def analysis_stream_generator(
                 print(f"⚠️ [WEB-ENRICH] Error (non-blocking): {e}", flush=True)
 
         # 🦁 Brave fact-check standard (si pas de deep research)
+        # Cost optimisation : BRAVE_FACTCHECK_KEYWORDS_DISABLED=true permet de
+        # couper le déclenchement par keywords (sur free users notamment) tout
+        # en gardant Brave actif pour les analyses Pro+ avec web_enrichment.
+        # Default False → zéro changement de comportement.
         brave_context = None
         if not deep_research and BRAVE_SEARCH_AVAILABLE:
             brave_should_run = should_enrich
-            if not brave_should_run:
+            keywords_disabled = os.getenv("BRAVE_FACTCHECK_KEYWORDS_DISABLED", "false").lower() == "true"
+            if not brave_should_run and not keywords_disabled:
                 fast_kw = [
                     "ai",
                     "gpt",
@@ -803,6 +810,7 @@ async def analysis_stream_generator(
                         video_channel=metadata.get("channel", ""),
                         transcript=transcript,
                         lang=lang,
+                        video_id=video_id,
                     )
 
                     if brave_text:


### PR DESCRIPTION
## Contexte

Facture Brave Search API du 1er mai 2026 (`9E3XELZX-0007`, **7ème facture mensuelle consécutive**) : **$102.07 / mois** pour ~34 023 requêtes (cycle facturation calendaire). À ce rythme : **$1 224 / an** sur Brave seul.

Audit du code (cf. commit messages) a identifié 6 points d'usage Brave dont 2 sans cache (`get_brave_factcheck_context` + `get_brave_deep_research_context`), responsables d'environ **55-60 %** de la consommation.

## Stratégie : 2 phases avec garantie zéro régression

### Phase 1 — Quick wins (actif immédiat, commit `bc9a5a6`)

1. **Cache Redis sur fact-check** vidéo
   - Key : `brave:factcheck:v1:{lang}:{video_id|sha256(content)}`
   - TTL **72h** (prudent pour sujets d'actualité IA / crypto / élections)
   - Stocke le tuple `(context_text, sources)` au format JSON
   - Cached uniquement sur succès (pas de poisoning sur erreur transitoire)

2. **Cache Redis sur deep research** vidéo
   - Key : `brave:deepresearch:v1:{lang}:{video_id|sha256(content)}`
   - TTL **30 jours** (recherche externe peu volatile)
   - 1 hit cache économise ~40 appels Brave

3. **Compteur quotidien** `brave:requests:daily:{YYYY-MM-DD}` (rétention 35j)
   - Incrémenté dans `_call_brave_api` avant chaque appel HTTP
   - Permet de mesurer l'impact des optimisations sans attendre la facture mensuelle
   - Best-effort, jamais bloquant

4. **Kill-switch ops** `BRAVE_FACTCHECK_KEYWORDS_DISABLED` (default `false`)
   - Si `true` : désactive le déclenchement par keywords (`ai`, `gpt`, `crypto`...)
   - Préserve le fact-check pour Pro+ via `web_enrichment` (`should_enrich`)
   - **Default `false` → zéro changement de comportement**

**Économie estimée Phase 1 : -35 à -45 % (≈ $36 / mois, ≈ $432 / an)**

### Phase 2 — Migration Deep Research vers Mistral Agent (gated, commit `fd6c334`)

5. **Feature flag** `DEEP_RESEARCH_USE_MISTRAL_AGENT` (default `false`)
   - Activable à chaud via env var, sans redeploy
   - Activation prod après benchmark qualité

6. **Dispatcher** `videos/deep_research_dispatcher.py`
   - Si flag `true` + Mistral Agent dispo → `agent_web_search(purpose="deep_research")` (1 seul appel API au lieu de 5×8 = 40 appels Brave)
   - Échec / circuit breaker / timeout Agent → **fallback Brave automatique**
   - Format de sortie identique à Brave (`context_text`, `sources`) → pipeline downstream inchangé

**Économie supplémentaire Phase 2 (après activation) : -15 à -25 % (≈ $15-25 / mois)**

### Cible cumulative

| Phase | Économie | Coût Brave estimé |
|---|---|---|
| Avant | — | $102 / mois |
| Après Phase 1 | -35 à -45 % | ~$56-66 / mois |
| Après Phase 2 (activée) | -50 à -60 % | **~$40-50 / mois** |

**Économie annuelle cible : ~$700-800 / an** (~700 €).

## Garanties zéro régression

- **Phase 1 strictement additive** : cache miss → pipeline original inchangé. Cache hit → même payload servi (clé dérivée du contenu). Erreurs cache (Redis down, etc.) → swallowed et fallback API direct.
- **Phase 2 default off** : `DEEP_RESEARCH_USE_MISTRAL_AGENT=false` → aucun appel Mistral Agent, comportement Brave 100% inchangé.
- **Kill-switch default off** : `BRAVE_FACTCHECK_KEYWORDS_DISABLED=false` → déclenchement par keywords toujours actif.
- **Fallback Brave systématique** dans le dispatcher Phase 2 si Mistral Agent échoue.

## Tests

**135 / 135 passent** sur les zones touchées par mes changements :
- `tests/test_video_analysis.py`
- `tests/voice/test_web_tools_cache.py`
- `tests/test_companion_agent.py`
- `tests/videos/`
- `tests/test_plan_gates.py`
- `tests/core/test_plan_limits.py`

⚠️ 4 tests pré-existants cassent sur `tests/voice/test_streaming_orchestrator*.py` et `test_streaming_prompts_v2.py` — **ils cassent identiquement sur `main`**, aucun lien avec ce PR (zéro référence à `brave` / `deep_research` dans ces fichiers).

## Procédure d'activation prod

### Étape 1 — Merge + déploiement (immédiat)

Phase 1 active automatiquement après merge. Pas de variable d'env à configurer côté Hetzner.

### Étape 2 — Suivi des économies (semaine 1-2)

Surveiller le compteur Redis :
```bash
ssh root@89.167.23.214 "docker exec repo-redis-1 redis-cli GET deepsight:brave:requests:daily:$(date +%Y-%m-%d)"
```
Cible : passage de ~1130 / jour à ~600-700 / jour après stabilisation du cache.

### Étape 3 — Benchmark Mistral Agent (semaine 2-3)

Avant d'activer Phase 2 :
1. Activer en staging : `DEEP_RESEARCH_USE_MISTRAL_AGENT=true`
2. Lancer 20 analyses Pro avec deep research
3. Comparer qualité Agent vs Brave (sources, exhaustivité, fact-check)
4. Si OK → activer en prod via `.env.production`

### Étape 4 — Rollback rapide si problème

```bash
ssh root@89.167.23.214 "docker exec repo-backend-1 sh -c 'unset DEEP_RESEARCH_USE_MISTRAL_AGENT'"
docker restart repo-backend-1
```

Ou éditer `/opt/deepsight/repo/.env.production` et supprimer la variable.

## Files changed

- `backend/src/videos/brave_search.py` — cache + counter (+138 lignes)
- `backend/src/videos/streaming.py` — call sites mis à jour, kill-switch (+10 lignes)
- `backend/src/videos/deep_research_dispatcher.py` — nouveau (97 lignes)
- `backend/src/core/config.py` — flag `DEEP_RESEARCH_USE_MISTRAL_AGENT` (+10 lignes)

## Test plan

- [x] Syntaxe Python sur tous les fichiers modifiés
- [x] Import test du module `brave_search` (génération clés cache, TTLs, helpers)
- [x] Suite de tests sur zones touchées : 135 / 135 ✅
- [ ] **À faire post-merge** : monitoring du compteur Redis pendant 7-14 jours
- [ ] **À faire post-merge** : benchmark qualité Mistral Agent vs Brave Deep Research avant activation Phase 2
- [ ] **À faire post-merge** : valider que la facture Brave de juin reflète l'économie estimée

## Liens

- Facture Brave `9E3XELZX-0007` du 1er mai 2026 — $102.07
- Variable d'env Hetzner concernée : `BRAVE_SEARCH_API_KEY` (`/opt/deepsight/repo/.env.production`)
- Mistral Agent référence : `backend/src/core/mistral_agent.py` (déjà existant, supporte `purpose="deep_research"`)

https://claude.ai/code/session_01UDGBr8BBzNEcm7tRZUFCaU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDGBr8BBzNEcm7tRZUFCaU)_