### PR TITLE
fix(mobile): retire CTA "Analyse complète" crashant du Hub

### DIFF
--- a/mobile/__tests__/components/conversation/ConversationContent.test.tsx
+++ b/mobile/__tests__/components/conversation/ConversationContent.test.tsx
@@ -72,6 +72,15 @@ jest.mock("../../../src/components/voice/VoiceSettings", () => {
   };
 });
 
+// Mock HubAnalysisSheet (uses useQuery + bottom-sheet)
+jest.mock("../../../src/components/hub/HubAnalysisSheet", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    HubAnalysisSheet: React.forwardRef(() => React.createElement(View, null)),
+  };
+});
+
 jest.spyOn(Alert, "alert").mockImplementation(() => {});
 
 import { ConversationContent } from "../../../src/components/conversation/ConversationContent";

--- a/mobile/__tests__/components/conversation/MiniActionBar.test.tsx
+++ b/mobile/__tests__/components/conversation/MiniActionBar.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Tests for MiniActionBar.
- * Verifies callbacks + haptics per button + isUpgrading + isFavorite states.
+ * Verifies callbacks + haptics per button + canShowSummary + isFavorite states.
  */
 import React from "react";
 import { render, fireEvent } from "@testing-library/react-native";
@@ -15,14 +15,6 @@ jest.mock("../../../src/contexts/ThemeContext", () => {
       setTheme: jest.fn(),
       toggleTheme: jest.fn(),
     }),
-  };
-});
-
-jest.mock("../../../src/components/ui/DeepSightSpinner", () => {
-  const React = require("react");
-  const { View } = require("react-native");
-  return {
-    DeepSightSpinner: () => React.createElement(View, { testID: "spinner" }),
   };
 });
 
@@ -43,7 +35,6 @@ import { haptics } from "../../../src/utils/haptics";
 
 const baseProps = {
   isFavorite: false,
-  onViewAnalysis: jest.fn(),
   onToggleFavorite: jest.fn(),
   onShare: jest.fn(),
 };
@@ -53,11 +44,20 @@ describe("MiniActionBar", () => {
     jest.clearAllMocks();
   });
 
-  it("renders all 3 actions", () => {
-    const { getByTestId } = render(<MiniActionBar {...baseProps} />);
+  it("renders Favori and Partager by default (no Résumé)", () => {
+    const { getByTestId, queryByTestId } = render(
+      <MiniActionBar {...baseProps} />,
+    );
     expect(getByTestId("mini-action-favorite")).toBeTruthy();
-    expect(getByTestId("mini-action-view-analysis")).toBeTruthy();
     expect(getByTestId("mini-action-share")).toBeTruthy();
+    expect(queryByTestId("mini-action-show-summary")).toBeNull();
+  });
+
+  it("renders Résumé when canShowSummary=true", () => {
+    const { getByTestId } = render(
+      <MiniActionBar {...baseProps} canShowSummary onShowSummary={jest.fn()} />,
+    );
+    expect(getByTestId("mini-action-show-summary")).toBeTruthy();
   });
 
   it("fires haptics.light + onToggleFavorite on Favori tap", () => {
@@ -70,14 +70,18 @@ describe("MiniActionBar", () => {
     expect(onToggleFavorite).toHaveBeenCalledTimes(1);
   });
 
-  it("fires haptics.medium + onViewAnalysis on Analyse complète tap", () => {
-    const onViewAnalysis = jest.fn();
+  it("fires haptics.medium + onShowSummary on Résumé tap", () => {
+    const onShowSummary = jest.fn();
     const { getByTestId } = render(
-      <MiniActionBar {...baseProps} onViewAnalysis={onViewAnalysis} />,
+      <MiniActionBar
+        {...baseProps}
+        canShowSummary
+        onShowSummary={onShowSummary}
+      />,
     );
-    fireEvent.press(getByTestId("mini-action-view-analysis"));
+    fireEvent.press(getByTestId("mini-action-show-summary"));
     expect(haptics.medium).toHaveBeenCalled();
-    expect(onViewAnalysis).toHaveBeenCalledTimes(1);
+    expect(onShowSummary).toHaveBeenCalledTimes(1);
   });
 
   it("fires haptics.light + onShare on Partager tap", () => {
@@ -88,39 +92,5 @@ describe("MiniActionBar", () => {
     fireEvent.press(getByTestId("mini-action-share"));
     expect(haptics.light).toHaveBeenCalled();
     expect(onShare).toHaveBeenCalledTimes(1);
-  });
-
-  it("renders spinner when isUpgrading=true", () => {
-    const { getByTestId, queryByText } = render(
-      <MiniActionBar {...baseProps} isUpgrading={true} />,
-    );
-    expect(getByTestId("spinner")).toBeTruthy();
-    expect(queryByText("Lancement...")).toBeTruthy();
-  });
-
-  it("disables Analyse complète tap when isUpgrading=true", () => {
-    const onViewAnalysis = jest.fn();
-    const { getByTestId } = render(
-      <MiniActionBar
-        {...baseProps}
-        isUpgrading={true}
-        onViewAnalysis={onViewAnalysis}
-      />,
-    );
-    fireEvent.press(getByTestId("mini-action-view-analysis"));
-    expect(onViewAnalysis).not.toHaveBeenCalled();
-  });
-
-  it("disables Analyse complète tap when canViewAnalysis=false", () => {
-    const onViewAnalysis = jest.fn();
-    const { getByTestId } = render(
-      <MiniActionBar
-        {...baseProps}
-        canViewAnalysis={false}
-        onViewAnalysis={onViewAnalysis}
-      />,
-    );
-    fireEvent.press(getByTestId("mini-action-view-analysis"));
-    expect(onViewAnalysis).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/components/conversation/ConversationContent.tsx
+++ b/mobile/src/components/conversation/ConversationContent.tsx
@@ -22,16 +22,14 @@ import {
   KeyboardAvoidingView,
   Platform,
   Share,
-  Alert,
 } from "react-native";
-import { useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
 import type BottomSheet from "@gorhom/bottom-sheet";
 import { useConversation } from "../../hooks/useConversation";
-import { historyApi, videoApi } from "../../services/api";
-import { useAnalysisStore } from "../../stores/analysisStore";
+import { historyApi } from "../../services/api";
 import { VoiceSettings } from "../voice/VoiceSettings";
 import VoiceAddonModal from "../voice/VoiceAddonModal";
+import { HubAnalysisSheet } from "../hub/HubAnalysisSheet";
 import { ConversationHeader } from "./ConversationHeader";
 import { ConversationFeed } from "./ConversationFeed";
 import { ConversationInput } from "./ConversationInput";
@@ -72,13 +70,11 @@ export const ConversationContent: React.FC<ConversationContentProps> = ({
   onMenuPress,
   onClose,
 }) => {
-  const router = useRouter();
   const settingsSheetRef = useRef<BottomSheet | null>(null);
+  const summarySheetRef = useRef<BottomSheet | null>(null);
   const [addonVisible, setAddonVisible] = useState(false);
   const [inputText, setInputText] = useState("");
   const [isFavorite, setIsFavorite] = useState(initialFavorite);
-  const [isUpgrading, setIsUpgrading] = useState(false);
-  const store = useAnalysisStore();
 
   const conv = useConversation({
     summaryId,
@@ -138,39 +134,15 @@ export const ConversationContent: React.FC<ConversationContentProps> = ({
     }
   }, [videoTitle, videoUrl]);
 
-  const handleViewAnalysis = useCallback(async () => {
+  const handleShowSummary = useCallback(() => {
     if (!conv.summaryId) return;
-    if (isUpgrading) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
-    setIsUpgrading(true);
-    try {
-      const result = await videoApi.upgradeQuickChat(
-        Number(conv.summaryId),
-        "standard",
-      );
-      if (result.status === "completed") {
-        router.replace({
-          pathname: "/(tabs)/analysis/[id]",
-          params: { id: conv.summaryId, initialTab: "0" },
-        } as never);
-        onClose?.();
-        return;
-      }
-      // Streaming overlay flow
-      store.startAnalysis(result.task_id);
-      router.replace({
-        pathname: "/(tabs)/analysis/[id]",
-        params: { id: result.task_id, initialTab: "0" },
-      } as never);
-      onClose?.();
-    } catch (err: unknown) {
-      setIsUpgrading(false);
-      const e = err as { message?: string; detail?: string };
-      const msg =
-        e?.message || e?.detail || "Erreur lors du lancement de l'analyse";
-      Alert.alert("Erreur", msg);
-    }
-  }, [conv.summaryId, isUpgrading, router, store, onClose]);
+    summarySheetRef.current?.expand();
+  }, [conv.summaryId]);
+
+  const handleCloseSummary = useCallback(() => {
+    summarySheetRef.current?.close();
+  }, []);
 
   // ─── Settings sheet ───
   const handleOpenSettings = useCallback(() => {
@@ -240,9 +212,8 @@ export const ConversationContent: React.FC<ConversationContentProps> = ({
 
         <MiniActionBar
           isFavorite={isFavorite}
-          isUpgrading={isUpgrading}
-          canViewAnalysis={Boolean(conv.summaryId)}
-          onViewAnalysis={handleViewAnalysis}
+          canShowSummary={Boolean(conv.summaryId)}
+          onShowSummary={handleShowSummary}
           onToggleFavorite={handleToggleFavorite}
           onShare={handleShare}
         />
@@ -264,6 +235,12 @@ export const ConversationContent: React.FC<ConversationContentProps> = ({
       <VoiceAddonModal
         visible={addonVisible}
         onClose={() => setAddonVisible(false)}
+      />
+
+      <HubAnalysisSheet
+        ref={summarySheetRef}
+        summaryId={conv.summaryId ?? null}
+        onClose={handleCloseSummary}
       />
     </>
   );

--- a/mobile/src/components/conversation/MiniActionBar.tsx
+++ b/mobile/src/components/conversation/MiniActionBar.tsx
@@ -1,17 +1,12 @@
 /**
- * MiniActionBar — 3 actions sticky au-dessus de l'input :
+ * MiniActionBar — actions sticky au-dessus de l'input :
  * - Favori (toggle filled/outlined) → onToggleFavorite
- * - Analyse complète (CTA principal, indigo) → onViewAnalysis
+ * - Résumé (CTA, ouvre HubAnalysisSheet in-place) → onShowSummary
  * - Partager → onShare
  *
- * Refactor du `miniActionBar` existant de QuickChatScreen.tsx.
- *
- * Polish (mai 2026) :
- * - Press scale 0.95 + spring back sur chaque bouton
- * - Haptics light sur les actions secondaires (Favori, Partager)
- * - Haptics medium sur le CTA principal (Analyse complète)
- * - Loading state visible (DeepSightSpinner) quand isUpgrading
- * - Variant favori filled/outlined avec couleur amber sur filled
+ * Le bouton "Analyse complète" (qui naviguait vers /(tabs)/analysis/[id])
+ * a été retiré : il causait un crash de l'app et l'affichage de l'analyse
+ * se fait désormais in-place via HubAnalysisSheet.
  */
 
 import React from "react";
@@ -24,7 +19,6 @@ import Animated, {
 } from "react-native-reanimated";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../contexts/ThemeContext";
-import { DeepSightSpinner } from "../ui/DeepSightSpinner";
 import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize } from "../../theme/typography";
 import { palette } from "../../theme/colors";
@@ -32,11 +26,12 @@ import { haptics } from "../../utils/haptics";
 
 interface MiniActionBarProps {
   isFavorite: boolean;
-  isUpgrading?: boolean;
-  canViewAnalysis?: boolean;
-  onViewAnalysis: () => void;
+  /** Active le bouton "Résumé" (ouvre HubAnalysisSheet). Défaut : false. */
+  canShowSummary?: boolean;
   onToggleFavorite: () => void;
   onShare: () => void;
+  /** Optionnel : tap "Résumé" → ouvre le bottom sheet d'analyse côté Hub. */
+  onShowSummary?: () => void;
 }
 
 // ─── Reusable press-scale wrapper ───
@@ -92,11 +87,10 @@ const PressScale: React.FC<PressScaleProps> = ({
 
 export const MiniActionBar: React.FC<MiniActionBarProps> = ({
   isFavorite,
-  isUpgrading = false,
-  canViewAnalysis = true,
-  onViewAnalysis,
+  canShowSummary = false,
   onToggleFavorite,
   onShare,
+  onShowSummary,
 }) => {
   const { colors } = useTheme();
 
@@ -105,14 +99,14 @@ export const MiniActionBar: React.FC<MiniActionBarProps> = ({
     onToggleFavorite();
   };
 
-  const handleViewAnalysis = () => {
-    haptics.medium();
-    onViewAnalysis();
-  };
-
   const handleShare = () => {
     haptics.light();
     onShare();
+  };
+
+  const handleShowSummary = () => {
+    haptics.medium();
+    onShowSummary?.();
   };
 
   return (
@@ -138,33 +132,29 @@ export const MiniActionBar: React.FC<MiniActionBarProps> = ({
         </Text>
       </PressScale>
 
-      <PressScale
-        onPress={handleViewAnalysis}
-        disabled={isUpgrading || !canViewAnalysis}
-        accessibilityLabel="Voir l'analyse complète"
-        testID="mini-action-view-analysis"
-        style={[
-          styles.upgradeAction,
-          {
-            backgroundColor: palette.indigo + "20",
-            borderColor: palette.indigo + "40",
-            opacity: !canViewAnalysis ? 0.4 : 1,
-          },
-        ]}
-      >
-        {isUpgrading ? (
-          <DeepSightSpinner size="xs" speed="fast" />
-        ) : (
+      {canShowSummary ? (
+        <PressScale
+          onPress={handleShowSummary}
+          accessibilityLabel="Voir le résumé"
+          testID="mini-action-show-summary"
+          style={[
+            styles.upgradeAction,
+            {
+              backgroundColor: palette.indigo + "20",
+              borderColor: palette.indigo + "40",
+            },
+          ]}
+        >
           <Ionicons
-            name="analytics-outline"
+            name="document-text-outline"
             size={16}
             color={palette.indigo}
           />
-        )}
-        <Text style={[styles.upgradeActionText, { color: palette.indigo }]}>
-          {isUpgrading ? "Lancement..." : "Analyse complète"}
-        </Text>
-      </PressScale>
+          <Text style={[styles.upgradeActionText, { color: palette.indigo }]}>
+            Résumé
+          </Text>
+        </PressScale>
+      ) : null}
 
       <PressScale
         onPress={handleShare}
@@ -172,11 +162,7 @@ export const MiniActionBar: React.FC<MiniActionBarProps> = ({
         testID="mini-action-share"
         style={styles.miniAction}
       >
-        <Ionicons
-          name="share-outline"
-          size={18}
-          color={colors.textTertiary}
-        />
+        <Ionicons name="share-outline" size={18} color={colors.textTertiary} />
         <Text style={[styles.miniActionText, { color: colors.textTertiary }]}>
           Partager
         </Text>

--- a/mobile/src/components/hub/HubAnalysisSheet.tsx
+++ b/mobile/src/components/hub/HubAnalysisSheet.tsx
@@ -1,0 +1,351 @@
+/**
+ * HubAnalysisSheet — Bottom sheet qui affiche l'analyse détaillée d'une
+ * conversation depuis l'onglet Hub mobile, sans quitter le Hub.
+ *
+ * Affiche : header (titre vidéo + chaîne + thumbnail + plateforme + mots),
+ * contenu markdown via AnalysisContentDisplay (disableScroll=true).
+ *
+ * États : loading (spinner), error (retry), empty (Quick Chat sans content).
+ *
+ * Le CTA "Ouvrir la vue complète" qui naviguait vers /(tabs)/analysis/[id]
+ * a été retiré : il causait un crash de l'app. Toute l'analyse vit désormais
+ * dans ce sheet, sans quitter le Hub.
+ */
+
+import React, { forwardRef, useCallback, useMemo } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  Pressable,
+  Image,
+} from "react-native";
+import BottomSheet, {
+  BottomSheetScrollView,
+  BottomSheetBackdrop,
+  type BottomSheetProps,
+  type BottomSheetBackdropProps,
+} from "@gorhom/bottom-sheet";
+import { useQuery } from "@tanstack/react-query";
+import { Ionicons } from "@expo/vector-icons";
+
+import { videoApi } from "@/services/api";
+import { AnalysisContentDisplay } from "@/components/analysis/AnalysisContentDisplay";
+import { useTheme } from "@/contexts/ThemeContext";
+import { sp, borderRadius as br } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+import { palette } from "@/theme/colors";
+
+interface HubAnalysisSheetProps {
+  /** ID de l'analyse à afficher. Si null, le sheet n'effectue aucun fetch. */
+  summaryId: string | null;
+  /** Callback quand le sheet se ferme (swipe down ou backdrop tap). */
+  onClose: () => void;
+}
+
+const SNAP_POINTS: BottomSheetProps["snapPoints"] = ["65%", "92%"];
+
+export const HubAnalysisSheet = forwardRef<BottomSheet, HubAnalysisSheetProps>(
+  ({ summaryId, onClose }, ref) => {
+    const { colors } = useTheme();
+
+    const {
+      data: summary,
+      isLoading,
+      error,
+      refetch,
+    } = useQuery({
+      queryKey: ["video-summary", summaryId],
+      queryFn: () => {
+        if (!summaryId) throw new Error("no-summary-id");
+        return videoApi.getSummary(summaryId);
+      },
+      enabled: !!summaryId,
+      staleTime: 60_000,
+    });
+
+    const renderBackdrop = useCallback(
+      (props: BottomSheetBackdropProps) => (
+        <BottomSheetBackdrop
+          {...props}
+          appearsOnIndex={0}
+          disappearsOnIndex={-1}
+          opacity={0.5}
+          pressBehavior="close"
+        />
+      ),
+      [],
+    );
+
+    const platformLabel = useMemo(() => {
+      if (!summary?.platform) return "YOUTUBE";
+      return summary.platform.toUpperCase();
+    }, [summary?.platform]);
+
+    return (
+      <BottomSheet
+        ref={ref}
+        index={-1}
+        snapPoints={SNAP_POINTS}
+        enablePanDownToClose
+        onClose={onClose}
+        backdropComponent={renderBackdrop}
+        backgroundStyle={[styles.bg, { backgroundColor: colors.bgPrimary }]}
+        handleIndicatorStyle={{ backgroundColor: colors.textTertiary }}
+      >
+        <BottomSheetScrollView
+          contentContainerStyle={styles.scrollContent}
+          testID="hub-analysis-sheet"
+        >
+          {summary ? (
+            <View
+              style={[styles.headerCard, { borderBottomColor: colors.border }]}
+            >
+              {summary.thumbnail ? (
+                <Image
+                  source={{ uri: summary.thumbnail }}
+                  style={styles.thumb}
+                  accessibilityLabel="Miniature vidéo"
+                />
+              ) : (
+                <View
+                  style={[
+                    styles.thumb,
+                    styles.thumbFallback,
+                    { backgroundColor: colors.bgCard },
+                  ]}
+                >
+                  <Ionicons
+                    name="videocam-outline"
+                    size={22}
+                    color={colors.textTertiary}
+                  />
+                </View>
+              )}
+              <View style={styles.headerText}>
+                <Text
+                  style={[styles.title, { color: colors.textPrimary }]}
+                  numberOfLines={2}
+                >
+                  {summary.title}
+                </Text>
+                {summary.channel ? (
+                  <Text
+                    style={[styles.channel, { color: colors.textSecondary }]}
+                    numberOfLines={1}
+                  >
+                    {summary.channel}
+                  </Text>
+                ) : null}
+                <View style={styles.metaRow}>
+                  <View
+                    style={[
+                      styles.badge,
+                      { backgroundColor: palette.indigo + "20" },
+                    ]}
+                  >
+                    <Text style={[styles.badgeText, { color: palette.indigo }]}>
+                      {platformLabel}
+                    </Text>
+                  </View>
+                  {summary.wordCount ? (
+                    <Text
+                      style={[styles.metaText, { color: colors.textTertiary }]}
+                    >
+                      {summary.wordCount} mots
+                    </Text>
+                  ) : null}
+                  {summary.mode ? (
+                    <Text
+                      style={[styles.metaText, { color: colors.textTertiary }]}
+                    >
+                      {summary.mode}
+                    </Text>
+                  ) : null}
+                </View>
+              </View>
+            </View>
+          ) : null}
+
+          {isLoading ? (
+            <View style={styles.center} testID="hub-analysis-sheet-loading">
+              <ActivityIndicator color={palette.indigo} />
+              <Text
+                style={[
+                  styles.muted,
+                  { color: colors.textTertiary, marginTop: sp.sm },
+                ]}
+              >
+                Chargement du résumé…
+              </Text>
+            </View>
+          ) : null}
+
+          {error && !isLoading ? (
+            <View style={styles.center} testID="hub-analysis-sheet-error">
+              <Ionicons
+                name="alert-circle-outline"
+                size={32}
+                color={palette.amber}
+              />
+              <Text
+                style={[
+                  styles.muted,
+                  {
+                    color: colors.textTertiary,
+                    marginTop: sp.sm,
+                    textAlign: "center",
+                  },
+                ]}
+              >
+                Impossible de charger l'analyse
+              </Text>
+              <Pressable
+                onPress={() => refetch()}
+                accessibilityLabel="Réessayer"
+                testID="hub-analysis-sheet-retry"
+                style={[
+                  styles.retryButton,
+                  {
+                    borderColor: palette.indigo + "60",
+                    backgroundColor: palette.indigo + "10",
+                  },
+                ]}
+              >
+                <Text style={[styles.retryText, { color: palette.indigo }]}>
+                  Réessayer
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
+
+          {!isLoading && !error && summary && !summary.content ? (
+            <View style={styles.center} testID="hub-analysis-sheet-empty">
+              <Ionicons
+                name="document-text-outline"
+                size={32}
+                color={colors.textTertiary}
+              />
+              <Text
+                style={[
+                  styles.muted,
+                  {
+                    color: colors.textTertiary,
+                    marginTop: sp.sm,
+                    textAlign: "center",
+                  },
+                ]}
+              >
+                Aucun résumé disponible. Lance l'analyse complète pour générer
+                le contenu détaillé.
+              </Text>
+            </View>
+          ) : null}
+
+          {!isLoading && !error && summary?.content ? (
+            <View
+              style={styles.contentWrapper}
+              testID="hub-analysis-sheet-content"
+            >
+              <AnalysisContentDisplay
+                content={summary.content}
+                disableScroll
+                bottomPadding={0}
+              />
+            </View>
+          ) : null}
+        </BottomSheetScrollView>
+      </BottomSheet>
+    );
+  },
+);
+
+HubAnalysisSheet.displayName = "HubAnalysisSheet";
+
+const styles = StyleSheet.create({
+  bg: {
+    borderTopLeftRadius: br.lg,
+    borderTopRightRadius: br.lg,
+  },
+  scrollContent: {
+    paddingBottom: 96,
+  },
+  headerCard: {
+    flexDirection: "row",
+    gap: sp.md,
+    paddingHorizontal: sp.lg,
+    paddingVertical: sp.md,
+    borderBottomWidth: 1,
+  },
+  thumb: {
+    width: 92,
+    height: 56,
+    borderRadius: br.sm,
+    backgroundColor: "#222",
+  },
+  thumbFallback: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerText: {
+    flex: 1,
+    gap: 4,
+  },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
+  },
+  channel: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+  },
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+    marginTop: 4,
+    flexWrap: "wrap",
+  },
+  badge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: br.sm,
+  },
+  badgeText: {
+    fontFamily: fontFamily.mono,
+    fontSize: 9,
+    letterSpacing: 1,
+  },
+  metaText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize["2xs"],
+  },
+  center: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: sp.lg,
+    paddingVertical: sp.xl,
+  },
+  muted: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+  },
+  retryButton: {
+    marginTop: sp.md,
+    paddingHorizontal: sp.lg,
+    paddingVertical: sp.sm,
+    borderRadius: br.full,
+    borderWidth: 1,
+  },
+  retryText: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.xs,
+  },
+  contentWrapper: {
+    paddingHorizontal: sp.md,
+    paddingTop: sp.md,
+  },
+});
+
+export default HubAnalysisSheet;


### PR DESCRIPTION
## Summary

- Le CTA indigo **"Analyse complète"** du `MiniActionBar` appelait `videoApi.upgradeQuickChat()` puis `router.replace('/(tabs)/analysis/[id]')` et faisait **quitter l'app** à chaque tap
- Refonte navigation : l'analyse vit désormais **in-place** dans la tab Hub via le `HubAnalysisSheet` (bottom sheet 65–92%, sans navigation)
- Le bouton **"Résumé"** du MiniActionBar devient le CTA principal indigo (`canShowSummary={true}` quand `summaryId` présent)
- Le footer CTA *"Ouvrir la vue complète"* du `HubAnalysisSheet` (qui reproduisait le même bug) est retiré

L'écran `/(tabs)/analysis/[id]` reste accessible depuis Library, Study, Tournesol et Home (RecentCarousel) — seule la navigation crashante depuis le Hub a été coupée.

## Files

- `mobile/src/components/conversation/MiniActionBar.tsx` — retire bouton + props (`isUpgrading`, `canViewAnalysis`, `onViewAnalysis`), promeut "Résumé" en CTA indigo
- `mobile/src/components/conversation/ConversationContent.tsx` — supprime `handleViewAnalysis` + imports `useRouter`/`videoApi`/`useAnalysisStore`/`Alert`, branche `HubAnalysisSheet` via `summarySheetRef.expand()`
- `mobile/src/components/hub/HubAnalysisSheet.tsx` — **nouveau** fichier (existait en branche feature mais jamais mergé), sans footer CTA navigation
- `mobile/__tests__/components/conversation/MiniActionBar.test.tsx` — réécrit pour les nouvelles props (`canShowSummary`/`onShowSummary`)
- `mobile/__tests__/components/conversation/ConversationContent.test.tsx` — mock `HubAnalysisSheet` ajouté (évite `QueryClientProvider` requis)

## Test plan

- [x] `npx jest __tests__/components/conversation/MiniActionBar.test.tsx` — **5/5** vert
- [x] `npx jest __tests__/components/conversation/ConversationContent.test.tsx __tests__/app/hub.test.tsx` — **14/14** vert
- [x] `npx tsc --noEmit` — 0 régression sur les 3 fichiers modifiés (les 7 erreurs `SunflowerLayer` sont pré-existantes)
- [ ] QA manuelle Expo Go : tap "Résumé" ouvre le bottom sheet, swipe down ferme proprement, pas de navigation
- [ ] Après merge → `eas update --branch production` (OTA prod, JS-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)