### PR TITLE
fix(web): pricing annual toggle + Expert badge on account page

### DIFF
--- a/frontend/src/pages/MyAccount.tsx
+++ b/frontend/src/pages/MyAccount.tsx
@@ -366,6 +366,12 @@ export const MyAccount: React.FC = () => {
       bgColor: "bg-indigo-500/10",
       icon: "⭐",
     },
+    expert: {
+      label: "Expert",
+      color: "text-violet-400",
+      bgColor: "bg-violet-500/10",
+      icon: "👑",
+    },
   };
 
   const currentPlan = planConfig[normalizedPlan] || planConfig["free"];

--- a/frontend/src/pages/UpgradePage.tsx
+++ b/frontend/src/pages/UpgradePage.tsx
@@ -232,6 +232,7 @@ interface PlanCardProps {
   trialLoading: boolean;
   onStartTrial: () => void;
   allPlans: ApiBillingPlan[];
+  cycle: BillingCycle;
 }
 
 const PlanCard: React.FC<PlanCardProps> = ({
@@ -243,6 +244,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
   trialLoading,
   onStartTrial,
   allPlans,
+  cycle,
 }) => {
   const Icon = getPlanIcon(plan.id);
   const gradient = getPlanGradient(plan.id);
@@ -252,9 +254,22 @@ const PlanCard: React.FC<PlanCardProps> = ({
   const isFree = plan.price_monthly_cents === 0;
   const nameDisplay = lang === "fr" ? plan.name : plan.name_en;
 
-  const monthlyPrice = plan.price_monthly_cents;
-  const displayPrice = monthlyPrice;
+  const isYearly = cycle === "yearly";
+  const displayPrice = isFree
+    ? 0
+    : isYearly
+      ? (plan.price_yearly_cents ?? plan.price_monthly_cents)
+      : plan.price_monthly_cents;
   const priceDisplay = formatPriceFr(displayPrice);
+  const priceSuffix = isFree
+    ? ""
+    : isYearly
+      ? lang === "fr"
+        ? "/an"
+        : "/yr"
+      : lang === "fr"
+        ? "/mois"
+        : "/mo";
 
   // Find unlock plan names for features_locked
   const getUnlockPlanName = (unlockPlanId: string) => {
@@ -327,7 +342,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
             {priceDisplay}
           </span>
           <span className="text-text-tertiary text-xs sm:text-sm ml-1">
-            €/{lang === "fr" ? "mois" : "mo"}
+            €{priceSuffix}
           </span>
         </div>
 
@@ -1403,6 +1418,7 @@ export const UpgradePage: React.FC = () => {
                             trialLoading={trialLoading}
                             onStartTrial={handleStartTrial}
                             allPlans={plans}
+                            cycle={cycle}
                           />
                         </motion.div>
                       ))}


### PR DESCRIPTION
## Summary

Deux bugs UI repérés lors du test fonctionnel pré-démo (Claude in Chrome) sur https://deepsightsynthesis.com :

- **`/upgrade` — toggle Mensuel/Annuel** : la table de comparaison se mettait à jour, mais les Plan Cards en haut restaient figées sur les prix mensuels. Cause : prop `cycle` non passée à `<PlanCard>` ; le composant hardcodait `price_monthly_cents` et le suffixe `€/mois`.
- **`/account` — badge "Gratuit"** : pour un utilisateur Expert, `MyAccount.tsx` affichait "Gratuit" alors que `/upgrade` affichait correctement Expert comme plan actuel. Cause : dictionnaire `planConfig` incomplet (seulement `free` + `pro`), le fallback `|| planConfig["free"]` se déclenchait pour `expert`.

Les deux bugs viennent du même type de régression de la migration Pricing v2 (Alembic 012, avril 2026) : du code qui n'a pas été mis à jour pour le 3e tier.

## Test plan

- [x] `tsc --noEmit` passe sur les 2 fichiers modifiés (erreurs TS pré-existantes hors scope)
- [ ] Manuel : ouvrir `/upgrade`, cliquer "Annuel" → les 3 Cards affichent désormais 0 €, 89,90 €/an, 199,90 €/an (au lieu de 8,99 €/mois et 19,99 €/mois)
- [ ] Manuel : ouvrir `/account` avec un compte Expert → badge affiche "Expert 👑" (au lieu de "Gratuit 🆓")

## Notes

- Suggestion follow-up (hors scope) signalée par l'agent diagnostic : remplacer `planConfig` local par `myPlan` (déjà fetched côté backend, single source of truth `PLANS[plan_id]`) pour éviter ce genre de drift à l'avenir. Pas inclus dans cette PR pour rester laser-focalisé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)