### PR TITLE
feat(search): Semantic Search V1 — Phase 2 web frontend (SearchPage + SemanticHighlight + ExplainTooltip)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -310,6 +310,7 @@ const PlaylistDetailPage = lazyWithRetry(
   () => import("./pages/PlaylistDetailPage"),
 );
 const History = lazyWithRetry(() => import("./pages/History"));
+const SearchPage = lazyWithRetry(() => import("./pages/SearchPage"));
 const UpgradePage = lazyWithRetry(() => import("./pages/UpgradePage"));
 const Settings = lazyWithRetry(() => import("./pages/Settings"));
 const MyAccount = lazyWithRetry(() => import("./pages/MyAccount"));
@@ -344,8 +345,9 @@ const PREFETCH_MAP: Record<string, string[]> = {
     "/voice-call",
     "/study",
     "/about",
+    "/search",
   ],
-  "/history": ["/dashboard", "/analytics"],
+  "/history": ["/dashboard", "/analytics", "/search"],
   "/settings": ["/account"],
   "/debate": ["/dashboard", "/history"],
   "/upgrade": ["/dashboard", "/payment/success"],
@@ -367,6 +369,7 @@ const PAGE_LOADERS: Record<string, () => Promise<any>> = {
   "/hub": () => import("./pages/HubPage"),
   "/study": () => import("./pages/StudyHubPage"),
   "/about": () => import("./pages/AboutPage"),
+  "/search": () => import("./pages/SearchPage"),
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -823,6 +826,22 @@ const AppRoutes = () => {
                                 fallback={<PageSkeleton variant="full" />}
                               >
                                 <History />
+                              </Suspense>
+                            </RouteErrorBoundary>
+                          }
+                        />
+
+                        <Route
+                          path="/search"
+                          element={
+                            <RouteErrorBoundary
+                              variant="full"
+                              componentName="SearchPage"
+                            >
+                              <Suspense
+                                fallback={<PageSkeleton variant="full" />}
+                              >
+                                <SearchPage />
                               </Suspense>
                             </RouteErrorBoundary>
                           }

--- a/frontend/src/components/highlight/ExplainTooltip.tsx
+++ b/frontend/src/components/highlight/ExplainTooltip.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { motion, AnimatePresence } from "framer-motion";
+import { Sparkles, MessageSquare, ExternalLink, X } from "lucide-react";
+import { searchApi, type WithinMatch } from "../../services/api";
+import { useAuth } from "../../hooks/useAuth";
+import { PLAN_FEATURES, normalizePlanId } from "../../config/planPrivileges";
+import { ExplainUpsellModal } from "./ExplainUpsellModal";
+
+interface Props {
+  open: boolean;
+  match: WithinMatch | null;
+  query: string;
+  summaryId: number;
+  /** Anchor element rectangle (from getBoundingClientRect) for positioning */
+  anchorRect: DOMRect | null;
+  onClose: () => void;
+  onCiteInChat: (passage: string) => void;
+  onSeekTimecode?: (seconds: number) => void;
+  onJumpToTab?: (tab: WithinMatch["tab"]) => void;
+}
+
+export const ExplainTooltip: React.FC<Props> = ({
+  open,
+  match,
+  query,
+  summaryId,
+  anchorRect,
+  onClose,
+  onCiteInChat,
+  onJumpToTab,
+}) => {
+  const { user } = useAuth();
+  const plan = normalizePlanId(user?.plan);
+  const tooltipAllowed = PLAN_FEATURES[plan].semanticSearchTooltip;
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [upsellOpen, setUpsellOpen] = useState(false);
+
+  // Close on outside click / Esc
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (tooltipRef.current && !tooltipRef.current.contains(e.target as Node))
+        onClose();
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onEsc);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onEsc);
+    };
+  }, [open, onClose]);
+
+  // Open upsell instead of fetching for free users
+  useEffect(() => {
+    if (open && match && !tooltipAllowed) setUpsellOpen(true);
+  }, [open, match, tooltipAllowed]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["explain-passage", summaryId, match?.passage_id, query],
+    queryFn: () => {
+      if (!match) return Promise.reject(new Error("no match"));
+      return searchApi.explainPassage(
+        summaryId,
+        match.text,
+        query,
+        match.source_type,
+      );
+    },
+    enabled: open && !!match && tooltipAllowed,
+    staleTime: 60 * 60 * 1000, // 1h cache
+    gcTime: 60 * 60 * 1000,
+    retry: false,
+  });
+
+  if (!open || !match) {
+    return upsellOpen && match ? (
+      <ExplainUpsellModal
+        open
+        passageText={(match as WithinMatch).text}
+        onClose={() => {
+          setUpsellOpen(false);
+          onClose();
+        }}
+      />
+    ) : null;
+  }
+
+  if (!tooltipAllowed) {
+    return (
+      <ExplainUpsellModal
+        open={upsellOpen}
+        passageText={match.text}
+        onClose={() => {
+          setUpsellOpen(false);
+          onClose();
+        }}
+      />
+    );
+  }
+
+  // Position : prefer above anchor, fallback below
+  const margin = 8;
+  const tooltipMaxWidth = 360;
+  const top = anchorRect
+    ? anchorRect.top - margin - 220 < 0
+      ? anchorRect.bottom + margin
+      : anchorRect.top - margin - 220
+    : 100;
+  const left = anchorRect
+    ? Math.max(
+        8,
+        Math.min(window.innerWidth - tooltipMaxWidth - 8, anchorRect.left),
+      )
+    : 100;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        ref={tooltipRef}
+        role="tooltip"
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 6 }}
+        transition={{ duration: 0.15 }}
+        style={{ top, left, maxWidth: tooltipMaxWidth }}
+        className="fixed z-[55] rounded-xl bg-[#12121a] border border-white/15 shadow-2xl backdrop-blur-xl p-3 w-[min(90vw,360px)]"
+      >
+        <div className="flex items-start justify-between mb-2">
+          <span className="inline-flex items-center gap-1 text-[11px] font-medium text-indigo-300">
+            <Sparkles className="w-3 h-3" />
+            IA · Pourquoi ce passage matche
+          </span>
+          <button
+            onClick={onClose}
+            aria-label="Fermer"
+            className="p-0.5 rounded hover:bg-white/5"
+          >
+            <X className="w-3.5 h-3.5 text-white/55" />
+          </button>
+        </div>
+
+        {isLoading && (
+          <div className="space-y-1.5">
+            <div className="h-2.5 bg-white/10 rounded animate-pulse w-full" />
+            <div className="h-2.5 bg-white/10 rounded animate-pulse w-4/5" />
+          </div>
+        )}
+
+        {error && (
+          <p className="text-xs text-red-300">
+            Impossible de générer l'explication.
+          </p>
+        )}
+
+        {data && (
+          <p className="text-sm text-white/85 leading-relaxed">
+            {data.explanation}
+          </p>
+        )}
+
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          <button
+            type="button"
+            onClick={() => {
+              onCiteInChat(`Explique-moi ce passage : ${match.text}`);
+              onClose();
+            }}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-xs text-white/85 hover:bg-white/10"
+          >
+            <MessageSquare className="w-3 h-3" /> Citer dans chat
+          </button>
+          {onJumpToTab && match.tab !== "synthesis" && (
+            <button
+              type="button"
+              onClick={() => {
+                onJumpToTab(match.tab);
+                onClose();
+              }}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-xs text-white/85 hover:bg-white/10"
+            >
+              <ExternalLink className="w-3 h-3" />
+              Voir dans {match.tab}
+            </button>
+          )}
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/frontend/src/components/highlight/ExplainUpsellModal.tsx
+++ b/frontend/src/components/highlight/ExplainUpsellModal.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Sparkles, X } from "lucide-react";
+
+interface Props {
+  open: boolean;
+  passageText: string;
+  onClose: () => void;
+}
+
+export const ExplainUpsellModal: React.FC<Props> = ({
+  open,
+  passageText,
+  onClose,
+}) => {
+  const navigate = useNavigate();
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="explain-upsell-title"
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl bg-[#12121a] border border-white/10 shadow-2xl p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-3">
+          <h2
+            id="explain-upsell-title"
+            className="text-base font-semibold text-white flex items-center gap-2"
+          >
+            <Sparkles className="w-4 h-4 text-indigo-400" />
+            Comprendre ce passage avec l'IA
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Fermer"
+            className="p-1 rounded-md hover:bg-white/5"
+          >
+            <X className="w-4 h-4 text-white/55" />
+          </button>
+        </div>
+        <p className="text-sm text-white/65 mb-3">
+          Le tooltip IA est inclus avec Pro et Expert.
+        </p>
+        <p className="text-sm text-white/85 italic mb-4 line-clamp-3">
+          « {passageText} »
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/upgrade")}
+          className="w-full px-4 py-2.5 rounded-lg bg-gradient-to-r from-indigo-500 to-violet-500 text-white font-medium hover:opacity-95"
+        >
+          Essai gratuit 7 jours →
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/highlight/HighlightNavigationBar.tsx
+++ b/frontend/src/components/highlight/HighlightNavigationBar.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from "react";
+import { ChevronUp, ChevronDown, X } from "lucide-react";
+import { useSemanticHighlight } from "./useSemanticHighlight";
+
+export const HighlightNavigationBar: React.FC = () => {
+  const ctx = useSemanticHighlight();
+
+  // Keyboard shortcuts F3 / Shift+F3 for next/prev (browser standard)
+  useEffect(() => {
+    if (!ctx || ctx.matches.length === 0) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "F3") {
+        e.preventDefault();
+        if (e.shiftKey) {
+          ctx.prev();
+        } else {
+          ctx.next();
+        }
+      }
+      if (e.key === "Escape" && ctx.query) {
+        e.preventDefault();
+        ctx.close();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [ctx]);
+
+  if (!ctx || ctx.matches.length === 0) return null;
+
+  const total = ctx.matches.length;
+  const current = ctx.currentIndex + 1;
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Résultats de recherche"
+      className="sticky top-[56px] z-40 mx-auto w-full max-w-3xl px-4"
+    >
+      <div className="mt-2 flex items-center gap-2 px-3 py-2 rounded-lg bg-[#12121a]/95 border border-amber-500/30 backdrop-blur-xl shadow-lg">
+        <span
+          className="text-sm font-mono text-amber-300 tabular-nums"
+          aria-live="polite"
+        >
+          {current}/{total}
+        </span>
+        <span className="flex-1 truncate text-xs text-white/55">
+          « {ctx.query} »
+        </span>
+        <button
+          type="button"
+          onClick={ctx.prev}
+          aria-label="Match précédent"
+          aria-keyshortcuts="Shift+F3"
+          className="p-1.5 rounded-md text-white/65 hover:bg-white/5 hover:text-white"
+        >
+          <ChevronUp className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={ctx.next}
+          aria-label="Match suivant"
+          aria-keyshortcuts="F3"
+          className="p-1.5 rounded-md text-white/65 hover:bg-white/5 hover:text-white"
+        >
+          <ChevronDown className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={ctx.close}
+          aria-label="Fermer la recherche"
+          aria-keyshortcuts="Escape"
+          className="p-1.5 rounded-md text-white/65 hover:bg-white/5 hover:text-white"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </nav>
+  );
+};

--- a/frontend/src/components/highlight/HighlightedText.tsx
+++ b/frontend/src/components/highlight/HighlightedText.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useRef } from "react";
+import { useSemanticHighlight } from "./useSemanticHighlight";
+import type { WithinMatch } from "../../services/api";
+
+interface Props {
+  /** Tab identity — only matches for this tab are rendered */
+  tab: WithinMatch["tab"];
+  /** Click handler (passage_id) — typically opens ExplainTooltip */
+  onMarkClick?: (passageId: string, passage: WithinMatch) => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Wrapper that traverses children DOM after render and wraps text spans
+ * matching `match.text` with <mark className="ds-highlight">.
+ * Idempotent: clears previous marks on every effect run.
+ */
+export const HighlightedText: React.FC<Props> = ({
+  tab,
+  onMarkClick,
+  children,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const ctx = useSemanticHighlight();
+
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+
+    // 1. Strip previous marks (unwrap)
+    root.querySelectorAll("mark.ds-highlight").forEach((m) => {
+      const parent = m.parentNode;
+      if (!parent) return;
+      while (m.firstChild) parent.insertBefore(m.firstChild, m);
+      parent.removeChild(m);
+      parent.normalize();
+    });
+
+    if (!ctx || ctx.matches.length === 0) return;
+
+    const tabMatches = ctx.matches.filter((m) => m.tab === tab);
+    if (tabMatches.length === 0) return;
+
+    // 2. Walk text nodes and wrap exact `text` occurrences
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const targets: { node: Text; match: WithinMatch }[] = [];
+    let node: Node | null = walker.nextNode();
+    while (node) {
+      const txt = node.nodeValue ?? "";
+      for (const m of tabMatches) {
+        const idx = txt.indexOf(m.text);
+        if (idx >= 0) {
+          targets.push({ node: node as Text, match: m });
+          break;
+        }
+      }
+      node = walker.nextNode();
+    }
+
+    targets.forEach(({ node: textNode, match }) => {
+      const txt = textNode.nodeValue ?? "";
+      const idx = txt.indexOf(match.text);
+      if (idx < 0) return;
+      const before = txt.slice(0, idx);
+      const after = txt.slice(idx + match.text.length);
+      const parent = textNode.parentNode;
+      if (!parent) return;
+      const mark = document.createElement("mark");
+      mark.className = "ds-highlight";
+      mark.dataset.passageId = match.passage_id;
+      mark.setAttribute(
+        "aria-label",
+        `Passage correspondant : ${match.text.slice(0, 60)}`,
+      );
+      mark.textContent = match.text;
+      if (ctx.matches[ctx.currentIndex]?.passage_id === match.passage_id) {
+        mark.classList.add("flash");
+      }
+      const fragment = document.createDocumentFragment();
+      if (before) fragment.appendChild(document.createTextNode(before));
+      fragment.appendChild(mark);
+      if (after) fragment.appendChild(document.createTextNode(after));
+      parent.replaceChild(fragment, textNode);
+    });
+
+    // 3. Auto-scroll to current
+    if (
+      ctx.currentIndex >= 0 &&
+      tabMatches.includes(ctx.matches[ctx.currentIndex])
+    ) {
+      const target = root.querySelector<HTMLElement>(
+        `mark.ds-highlight[data-passage-id="${ctx.matches[ctx.currentIndex].passage_id}"]`,
+      );
+      if (target && typeof target.scrollIntoView === "function") {
+        target.scrollIntoView({ block: "center", behavior: "smooth" });
+      }
+    }
+
+    // 4. Wire click handlers
+    if (onMarkClick) {
+      const handler = (e: Event) => {
+        const target = (e.target as HTMLElement).closest<HTMLElement>(
+          "mark.ds-highlight",
+        );
+        if (!target) return;
+        const id = target.dataset.passageId;
+        if (!id) return;
+        const match = ctx.matches.find((m) => m.passage_id === id);
+        if (match) onMarkClick(id, match);
+      };
+      root.addEventListener("click", handler);
+      return () => root.removeEventListener("click", handler);
+    }
+  }, [ctx?.matches, ctx?.currentIndex, tab, onMarkClick, ctx]);
+
+  return (
+    <div ref={containerRef} data-highlight-tab={tab}>
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/components/highlight/IntraAnalysisSearchBar.tsx
+++ b/frontend/src/components/highlight/IntraAnalysisSearchBar.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef } from "react";
+import { Search, X } from "lucide-react";
+import { useSemanticHighlight } from "./useSemanticHighlight";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const IntraAnalysisSearchBar: React.FC<Props> = ({ open, onClose }) => {
+  const ctx = useSemanticHighlight();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [open]);
+
+  if (!open || !ctx) return null;
+
+  return (
+    <div
+      role="search"
+      aria-label="Recherche dans l'analyse"
+      className="fixed inset-x-0 top-3 z-50 mx-auto w-full max-w-xl px-4"
+    >
+      <div className="flex items-center gap-2 px-3 py-2 rounded-xl bg-[#12121a]/95 border border-white/15 backdrop-blur-xl shadow-2xl">
+        <Search className="w-4 h-4 text-white/55" aria-hidden />
+        <input
+          ref={inputRef}
+          type="search"
+          value={ctx.query}
+          onChange={(e) => ctx.setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              ctx.close();
+              onClose();
+            }
+            if (e.key === "Enter") {
+              e.preventDefault();
+              if (e.shiftKey) {
+                ctx.prev();
+              } else {
+                ctx.next();
+              }
+            }
+          }}
+          placeholder="Rechercher dans l'analyse…"
+          aria-label="Rechercher dans l'analyse"
+          className="flex-1 bg-transparent text-white placeholder-white/35 outline-none text-sm"
+        />
+        {ctx.loading && (
+          <span className="text-[11px] font-mono text-white/45">…</span>
+        )}
+        {!ctx.loading && ctx.matches.length > 0 && (
+          <span className="text-[11px] font-mono text-amber-300 tabular-nums">
+            {ctx.currentIndex + 1}/{ctx.matches.length}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            ctx.close();
+            onClose();
+          }}
+          aria-label="Fermer"
+          className="p-1.5 rounded-md text-white/55 hover:bg-white/5 hover:text-white"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/highlight/SemanticHighlightContext.ts
+++ b/frontend/src/components/highlight/SemanticHighlightContext.ts
@@ -1,0 +1,27 @@
+import { createContext } from "react";
+import type { WithinMatch } from "../../services/api";
+
+export interface SemanticHighlightState {
+  /** Active query — empty string when search bar closed */
+  query: string;
+  /** Loading state for /api/search/within */
+  loading: boolean;
+  /** Matches across all tabs */
+  matches: WithinMatch[];
+  /** Index in `matches` of the currently focused match (-1 if none) */
+  currentIndex: number;
+  /** Tab to switch to when current match is selected */
+  activeTab: WithinMatch["tab"] | null;
+  /** Open a search session */
+  setQuery: (q: string) => void;
+  /** Close the search session (clears matches) */
+  close: () => void;
+  /** Navigate next/prev match (wraps) */
+  next: () => void;
+  prev: () => void;
+  /** Jump to a specific passage_id (e.g. from search result deeplink) */
+  focus: (passageId: string) => void;
+}
+
+export const SemanticHighlightContext =
+  createContext<SemanticHighlightState | null>(null);

--- a/frontend/src/components/highlight/SemanticHighlightProvider.tsx
+++ b/frontend/src/components/highlight/SemanticHighlightProvider.tsx
@@ -1,0 +1,126 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { searchApi, type WithinMatch } from "../../services/api";
+import {
+  SemanticHighlightContext,
+  type SemanticHighlightState,
+} from "./SemanticHighlightContext";
+
+interface Props {
+  summaryId: number | null;
+  children: React.ReactNode;
+}
+
+export const SemanticHighlightProvider: React.FC<Props> = ({
+  summaryId,
+  children,
+}) => {
+  const [query, setQueryRaw] = useState("");
+  const [matches, setMatches] = useState<WithinMatch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+  const debounceRef = useRef<number | undefined>(undefined);
+
+  const fetchMatches = useCallback(
+    async (q: string) => {
+      if (!summaryId || q.trim().length < 2) {
+        setMatches([]);
+        setCurrentIndex(-1);
+        return;
+      }
+      setLoading(true);
+      try {
+        const res = await searchApi.searchWithin(summaryId, q.trim());
+        setMatches(res.matches);
+        setCurrentIndex(res.matches.length > 0 ? 0 : -1);
+      } catch {
+        setMatches([]);
+        setCurrentIndex(-1);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [summaryId],
+  );
+
+  const setQuery = useCallback(
+    (q: string) => {
+      setQueryRaw(q);
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = window.setTimeout(() => fetchMatches(q), 200);
+    },
+    [fetchMatches],
+  );
+
+  const close = useCallback(() => {
+    setQueryRaw("");
+    setMatches([]);
+    setCurrentIndex(-1);
+  }, []);
+
+  const next = useCallback(() => {
+    if (matches.length === 0) return;
+    setCurrentIndex((i) => (i + 1) % matches.length);
+  }, [matches.length]);
+
+  const prev = useCallback(() => {
+    if (matches.length === 0) return;
+    setCurrentIndex((i) => (i <= 0 ? matches.length - 1 : i - 1));
+  }, [matches.length]);
+
+  const focus = useCallback(
+    (passageId: string) => {
+      const idx = matches.findIndex((m) => m.passage_id === passageId);
+      if (idx >= 0) setCurrentIndex(idx);
+    },
+    [matches],
+  );
+
+  // Cleanup
+  useEffect(
+    () => () => {
+      window.clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
+  const activeTab = matches[currentIndex]?.tab ?? null;
+
+  const state: SemanticHighlightState = useMemo(
+    () => ({
+      query,
+      loading,
+      matches,
+      currentIndex,
+      activeTab,
+      setQuery,
+      close,
+      next,
+      prev,
+      focus,
+    }),
+    [
+      query,
+      loading,
+      matches,
+      currentIndex,
+      activeTab,
+      setQuery,
+      close,
+      next,
+      prev,
+      focus,
+    ],
+  );
+
+  return (
+    <SemanticHighlightContext.Provider value={state}>
+      {children}
+    </SemanticHighlightContext.Provider>
+  );
+};

--- a/frontend/src/components/highlight/__tests__/ExplainTooltip.test.tsx
+++ b/frontend/src/components/highlight/__tests__/ExplainTooltip.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { ExplainTooltip } from "../ExplainTooltip";
+import { searchApi } from "../../../services/api";
+import type { WithinMatch } from "../../../services/api";
+
+vi.mock("../../../services/api", () => ({
+  searchApi: { explainPassage: vi.fn() },
+}));
+
+// Auth mock — we'll override per-test
+const useAuthMock = vi.fn();
+vi.mock("../../../hooks/useAuth", () => ({ useAuth: () => useAuthMock() }));
+
+afterEach(cleanup);
+
+const mockMatch: WithinMatch = {
+  source_type: "summary",
+  source_id: 1,
+  text: "transition énergétique",
+  text_html: "transition énergétique",
+  start_offset: 0,
+  end_offset: 22,
+  tab: "synthesis",
+  score: 0.91,
+  passage_id: "p1",
+};
+
+function renderTooltip(
+  props: Partial<React.ComponentProps<typeof ExplainTooltip>> = {},
+) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ExplainTooltip
+          open
+          match={mockMatch}
+          query="transition"
+          summaryId={42}
+          anchorRect={null}
+          onClose={() => {}}
+          onCiteInChat={() => {}}
+          {...props}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExplainTooltip", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls explainPassage and renders explanation for Pro", async () => {
+    useAuthMock.mockReturnValue({ user: { plan: "pro" } });
+    (
+      searchApi.explainPassage as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      explanation: "Mentionne directement la transition énergétique.",
+      cached: false,
+      model_used: "mistral-small-latest",
+    });
+    renderTooltip();
+    await waitFor(() =>
+      expect(screen.getByText(/mentionne directement/i)).toBeInTheDocument(),
+    );
+    expect(searchApi.explainPassage).toHaveBeenCalledWith(
+      42,
+      "transition énergétique",
+      "transition",
+      "summary",
+    );
+  });
+
+  it("does NOT call explainPassage and shows upsell for free", async () => {
+    useAuthMock.mockReturnValue({ user: { plan: "free" } });
+    (
+      searchApi.explainPassage as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      explanation: "should-not-render",
+      cached: false,
+      model_used: "x",
+    });
+    renderTooltip();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Comprendre ce passage avec l'IA/i),
+      ).toBeInTheDocument(),
+    );
+    expect(searchApi.explainPassage).not.toHaveBeenCalled();
+  });
+
+  it("close button triggers onClose", async () => {
+    useAuthMock.mockReturnValue({ user: { plan: "pro" } });
+    (
+      searchApi.explainPassage as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      explanation: "x",
+      cached: true,
+      model_used: "mistral-small-latest",
+    });
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderTooltip({ onClose });
+    await waitFor(() => screen.getByText("x"));
+    await user.click(screen.getByLabelText(/fermer/i));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/highlight/__tests__/HighlightNavigationBar.test.tsx
+++ b/frontend/src/components/highlight/__tests__/HighlightNavigationBar.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { HighlightNavigationBar } from "../HighlightNavigationBar";
+import { SemanticHighlightContext } from "../SemanticHighlightContext";
+import type { WithinMatch } from "../../../services/api";
+
+afterEach(cleanup);
+
+const mockMatch = (id: string): WithinMatch => ({
+  source_type: "summary",
+  source_id: 1,
+  text: "x",
+  text_html: "x",
+  start_offset: 0,
+  end_offset: 1,
+  tab: "synthesis",
+  score: 0.9,
+  passage_id: id,
+});
+
+function withState(
+  matches: WithinMatch[],
+  idx = 0,
+  fns: Partial<{ next: () => void; prev: () => void; close: () => void }> = {},
+) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <SemanticHighlightContext.Provider
+      value={{
+        query: "ai",
+        loading: false,
+        matches,
+        currentIndex: idx,
+        activeTab: "synthesis",
+        setQuery: () => {},
+        close: fns.close ?? (() => {}),
+        next: fns.next ?? (() => {}),
+        prev: fns.prev ?? (() => {}),
+        focus: () => {},
+      }}
+    >
+      {children}
+    </SemanticHighlightContext.Provider>
+  );
+}
+
+describe("HighlightNavigationBar", () => {
+  it("returns null when no matches", () => {
+    const Wrap = withState([]);
+    const { container } = render(
+      <Wrap>
+        <HighlightNavigationBar />
+      </Wrap>,
+    );
+    expect(container.querySelector("nav")).toBeNull();
+  });
+
+  it("displays counter '1/2'", () => {
+    const Wrap = withState([mockMatch("a"), mockMatch("b")], 0);
+    render(
+      <Wrap>
+        <HighlightNavigationBar />
+      </Wrap>,
+    );
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+  });
+
+  it("calls next/prev/close when buttons clicked", async () => {
+    const user = userEvent.setup();
+    const next = vi.fn();
+    const prev = vi.fn();
+    const close = vi.fn();
+    const Wrap = withState([mockMatch("a"), mockMatch("b")], 0, {
+      next,
+      prev,
+      close,
+    });
+    render(
+      <Wrap>
+        <HighlightNavigationBar />
+      </Wrap>,
+    );
+    await user.click(screen.getByLabelText(/match suivant/i));
+    await user.click(screen.getByLabelText(/match précédent/i));
+    await user.click(screen.getByLabelText(/fermer la recherche/i));
+    expect(next).toHaveBeenCalled();
+    expect(prev).toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/highlight/__tests__/HighlightedText.test.tsx
+++ b/frontend/src/components/highlight/__tests__/HighlightedText.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import React from "react";
+import { HighlightedText } from "../HighlightedText";
+import { SemanticHighlightContext } from "../SemanticHighlightContext";
+import type { WithinMatch } from "../../../services/api";
+
+afterEach(cleanup);
+
+const mockMatch: WithinMatch = {
+  source_type: "summary",
+  source_id: 1,
+  text: "transition énergétique",
+  text_html: "transition énergétique",
+  start_offset: 0,
+  end_offset: 22,
+  tab: "synthesis",
+  score: 0.91,
+  passage_id: "p1",
+};
+
+const wrap =
+  (matches: WithinMatch[], idx = 0) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <SemanticHighlightContext.Provider
+      value={{
+        query: "transition",
+        loading: false,
+        matches,
+        currentIndex: idx,
+        activeTab: "synthesis",
+        setQuery: () => {},
+        close: () => {},
+        next: () => {},
+        prev: () => {},
+        focus: () => {},
+      }}
+    >
+      {children}
+    </SemanticHighlightContext.Provider>
+  );
+
+describe("HighlightedText", () => {
+  it("wraps a matching text span in <mark>", () => {
+    const Wrapper = wrap([mockMatch]);
+    const { container } = render(
+      <Wrapper>
+        <HighlightedText tab="synthesis">
+          <p>La transition énergétique impose une refonte.</p>
+        </HighlightedText>
+      </Wrapper>,
+    );
+    const mark = container.querySelector("mark.ds-highlight");
+    expect(mark).not.toBeNull();
+    expect(mark?.textContent).toBe("transition énergétique");
+    expect(mark?.getAttribute("data-passage-id")).toBe("p1");
+  });
+
+  it("does not wrap when no matches", () => {
+    const Wrapper = wrap([]);
+    const { container } = render(
+      <Wrapper>
+        <HighlightedText tab="synthesis">
+          <p>La transition énergétique.</p>
+        </HighlightedText>
+      </Wrapper>,
+    );
+    expect(container.querySelector("mark.ds-highlight")).toBeNull();
+  });
+
+  it("only wraps for matching tab", () => {
+    const Wrapper = wrap([mockMatch]);
+    const { container } = render(
+      <Wrapper>
+        <HighlightedText tab="quiz">
+          <p>La transition énergétique.</p>
+        </HighlightedText>
+      </Wrapper>,
+    );
+    expect(container.querySelector("mark.ds-highlight")).toBeNull();
+  });
+});

--- a/frontend/src/components/highlight/useCmdFIntercept.ts
+++ b/frontend/src/components/highlight/useCmdFIntercept.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+
+interface Options {
+  /** CSS selector that must contain the active focus / mouse target for interception */
+  scopeSelector: string;
+  /** Called when Cmd/Ctrl+F is pressed inside scope */
+  onIntercept: () => void;
+  /** Disable the listener (e.g. user is in a textarea) */
+  enabled?: boolean;
+}
+
+export function useCmdFIntercept({
+  scopeSelector,
+  onIntercept,
+  enabled = true,
+}: Options) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      const isCmdF =
+        (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f" && !e.shiftKey;
+      if (!isCmdF) return;
+      const scope = document.querySelector(scopeSelector);
+      if (!scope) return;
+      const active = document.activeElement;
+      const inScope = active
+        ? scope.contains(active) || scope === active
+        : false;
+      // Also intercept if the user is just on the page (no input focused)
+      const onPageNoInputFocused =
+        !active ||
+        active === document.body ||
+        (active instanceof HTMLElement &&
+          !["INPUT", "TEXTAREA"].includes(active.tagName));
+      if (inScope || onPageNoInputFocused) {
+        e.preventDefault();
+        onIntercept();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [scopeSelector, onIntercept, enabled]);
+}

--- a/frontend/src/components/highlight/useSemanticHighlight.ts
+++ b/frontend/src/components/highlight/useSemanticHighlight.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import {
+  SemanticHighlightContext,
+  type SemanticHighlightState,
+} from "./SemanticHighlightContext";
+
+/** Returns the highlight state, or null if not within a provider. */
+export function useSemanticHighlight(): SemanticHighlightState | null {
+  return useContext(SemanticHighlightContext);
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard,
   History,
+  Search,
   Swords,
   Settings,
   CreditCard,
@@ -442,6 +443,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
               to="/history"
               icon={History}
               label={t.nav.history}
+              collapsed={collapsed}
+            />
+            <NavItem
+              to="/search"
+              icon={Search}
+              label={language === "fr" ? "Recherche" : "Search"}
               collapsed={collapsed}
             />
             <NavItem

--- a/frontend/src/components/search/SearchAdvancedFilters.tsx
+++ b/frontend/src/components/search/SearchAdvancedFilters.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import type { SearchFilters } from "../../services/api";
+
+interface Props {
+  filters: SearchFilters;
+  onChange: (next: SearchFilters) => void;
+}
+
+export const SearchAdvancedFilters: React.FC<Props> = ({
+  filters,
+  onChange,
+}) => {
+  return (
+    <div className="w-full max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-3 p-4 rounded-xl bg-white/5 border border-white/10 backdrop-blur-xl">
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-white/65">Plateforme</span>
+        <select
+          value={filters.platform ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              platform: (e.target.value ||
+                undefined) as SearchFilters["platform"],
+            })
+          }
+          className="bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+        >
+          <option value="">Toutes</option>
+          <option value="youtube">YouTube</option>
+          <option value="tiktok">TikTok</option>
+          <option value="text">Texte</option>
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-white/65">Langue</span>
+        <select
+          value={filters.lang ?? ""}
+          onChange={(e) =>
+            onChange({ ...filters, lang: e.target.value || undefined })
+          }
+          className="bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+        >
+          <option value="">Toutes</option>
+          <option value="fr">Français</option>
+          <option value="en">English</option>
+          <option value="es">Español</option>
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-white/65">Catégorie</span>
+        <input
+          type="text"
+          value={filters.category ?? ""}
+          onChange={(e) =>
+            onChange({ ...filters, category: e.target.value || undefined })
+          }
+          placeholder="ex: science, politique…"
+          className="bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+        />
+      </label>
+
+      <div className="flex flex-col gap-1 text-sm">
+        <span className="text-white/65">Période</span>
+        <div className="flex gap-2">
+          <input
+            type="date"
+            value={filters.date_from ?? ""}
+            onChange={(e) =>
+              onChange({ ...filters, date_from: e.target.value || undefined })
+            }
+            className="flex-1 bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+          />
+          <input
+            type="date"
+            value={filters.date_to ?? ""}
+            onChange={(e) =>
+              onChange({ ...filters, date_to: e.target.value || undefined })
+            }
+            className="flex-1 bg-[#12121a] border border-white/10 rounded-md px-2 py-1.5 text-white"
+          />
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={!!filters.favorites_only}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              favorites_only: e.target.checked || undefined,
+            })
+          }
+        />
+        <span className="text-white/85">Favoris uniquement</span>
+      </label>
+    </div>
+  );
+};

--- a/frontend/src/components/search/SearchEmptyState.tsx
+++ b/frontend/src/components/search/SearchEmptyState.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Search as SearchIcon, Inbox } from "lucide-react";
+
+interface Props {
+  variant: "no-query" | "no-results";
+  query?: string;
+  recentQueries?: string[];
+  onPickQuery?: (q: string) => void;
+}
+
+export const SearchEmptyState: React.FC<Props> = ({
+  variant,
+  query,
+  recentQueries = [],
+  onPickQuery,
+}) => {
+  if (variant === "no-query") {
+    return (
+      <div className="text-center py-16">
+        <SearchIcon
+          className="w-10 h-10 text-white/25 mx-auto mb-3"
+          aria-hidden
+        />
+        <p className="text-white/65 mb-1">
+          Cherche dans toutes tes analyses, flashcards, quiz et chats.
+        </p>
+        {recentQueries.length > 0 && (
+          <div className="mt-6">
+            <p className="text-xs text-white/40 mb-2">Recherches récentes</p>
+            <div className="flex flex-wrap gap-2 justify-center">
+              {recentQueries.map((q) => (
+                <button
+                  key={q}
+                  type="button"
+                  onClick={() => onPickQuery?.(q)}
+                  className="px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-sm text-white/70 hover:bg-white/10"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center py-16">
+      <Inbox className="w-10 h-10 text-white/25 mx-auto mb-3" aria-hidden />
+      <p className="text-white/85 mb-1">Aucun résultat pour « {query} »</p>
+      <p className="text-sm text-white/45">
+        Essaie une formulation différente ou retire un filtre.
+      </p>
+    </div>
+  );
+};

--- a/frontend/src/components/search/SearchFiltersBar.tsx
+++ b/frontend/src/components/search/SearchFiltersBar.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { SlidersHorizontal } from "lucide-react";
+import type { SearchSourceType, SearchFilters } from "../../services/api";
+
+const ALL_TYPES: SearchSourceType[] = [
+  "summary",
+  "flashcard",
+  "quiz",
+  "chat",
+  "transcript",
+];
+const TYPE_LABELS: Record<SearchSourceType, string> = {
+  summary: "Synthèse",
+  flashcard: "Flashcards",
+  quiz: "Quiz",
+  chat: "Chat",
+  transcript: "Transcripts",
+};
+
+interface Props {
+  filters: SearchFilters;
+  onChange: (next: SearchFilters) => void;
+  countsByType?: Partial<Record<SearchSourceType, number>>;
+  totalCount?: number;
+  onToggleAdvanced: () => void;
+  advancedOpen: boolean;
+}
+
+export const SearchFiltersBar: React.FC<Props> = ({
+  filters,
+  onChange,
+  countsByType = {},
+  totalCount,
+  onToggleAdvanced,
+  advancedOpen,
+}) => {
+  const active = filters.source_types ?? [];
+  const isAll = active.length === 0;
+
+  const toggleAll = () => onChange({ ...filters, source_types: undefined });
+  const toggleType = (t: SearchSourceType) => {
+    const set = new Set(active);
+    if (set.has(t)) {
+      set.delete(t);
+    } else {
+      set.add(t);
+    }
+    onChange({
+      ...filters,
+      source_types: set.size === 0 ? undefined : Array.from(set),
+    });
+  };
+
+  return (
+    <div className="w-full max-w-3xl mx-auto flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={toggleAll}
+        aria-pressed={isAll}
+        className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+          isAll
+            ? "bg-indigo-500/20 text-indigo-200 border border-indigo-500/40"
+            : "bg-white/5 text-white/65 border border-white/10 hover:bg-white/10"
+        }`}
+      >
+        Tout {totalCount !== undefined ? `(${totalCount})` : ""}
+      </button>
+      {ALL_TYPES.map((t) => {
+        const isActive = active.includes(t);
+        const n = countsByType[t];
+        return (
+          <button
+            key={t}
+            type="button"
+            onClick={() => toggleType(t)}
+            aria-pressed={isActive}
+            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              isActive
+                ? "bg-indigo-500/20 text-indigo-200 border border-indigo-500/40"
+                : "bg-white/5 text-white/65 border border-white/10 hover:bg-white/10"
+            }`}
+          >
+            {TYPE_LABELS[t]}
+            {typeof n === "number" ? ` ${n}` : ""}
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        onClick={onToggleAdvanced}
+        aria-expanded={advancedOpen}
+        className="ml-auto flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-sm text-white/70 hover:text-white hover:bg-white/10"
+      >
+        <SlidersHorizontal className="w-3.5 h-3.5" />
+        Filtres avancés
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/search/SearchInput.tsx
+++ b/frontend/src/components/search/SearchInput.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useRef } from "react";
+import { Search, X, Clock } from "lucide-react";
+import { useRecentQueries } from "./useRecentQueries";
+
+interface Props {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit?: (q: string) => void;
+  autoFocus?: boolean;
+  placeholder?: string;
+}
+
+export const SearchInput: React.FC<Props> = ({
+  value,
+  onChange,
+  onSubmit,
+  autoFocus = true,
+  placeholder = "Rechercher dans tes analyses…",
+}) => {
+  const [focused, setFocused] = useState(false);
+  const { queries: recent } = useRecentQueries();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const showSuggestions =
+    focused && value.trim().length === 0 && recent.length > 0;
+
+  return (
+    <div className="relative w-full max-w-3xl mx-auto">
+      <div className="relative">
+        <Search
+          className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-white/45 pointer-events-none"
+          aria-hidden
+        />
+        <input
+          ref={inputRef}
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setTimeout(() => setFocused(false), 150)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && onSubmit) onSubmit(value);
+          }}
+          autoFocus={autoFocus}
+          placeholder={placeholder}
+          aria-label={placeholder}
+          className="w-full pl-12 pr-12 py-4 rounded-xl bg-white/5 border border-white/10 backdrop-blur-xl text-white placeholder-white/35 outline-none focus:border-indigo-500/40 focus:bg-white/[0.07] transition-colors"
+        />
+        {value.length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              onChange("");
+              inputRef.current?.focus();
+            }}
+            aria-label="Effacer la recherche"
+            className="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 rounded-md text-white/45 hover:text-white hover:bg-white/5"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+      {showSuggestions && (
+        <ul
+          role="listbox"
+          aria-label="Recherches récentes"
+          className="absolute z-30 left-0 right-0 mt-2 rounded-xl bg-[#12121a] border border-white/10 shadow-2xl overflow-hidden"
+        >
+          {recent.map((q) => (
+            <li key={q}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={false}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onChange(q);
+                  onSubmit?.(q);
+                }}
+                className="w-full flex items-center gap-3 px-4 py-3 text-left text-sm text-white/85 hover:bg-white/5"
+              >
+                <Clock className="w-4 h-4 text-white/40" aria-hidden />
+                <span className="truncate">{q}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/search/SearchResultCard.tsx
+++ b/frontend/src/components/search/SearchResultCard.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { ChevronRight } from "lucide-react";
+import { SearchTypeBadge } from "./SearchTypeBadge";
+import type { GlobalSearchResult } from "../../services/api";
+
+interface Props {
+  result: GlobalSearchResult;
+  query: string;
+  onOpen: (r: GlobalSearchResult) => void;
+}
+
+/** Bold the query terms inside the preview text. */
+function highlight(preview: string, q: string): React.ReactNode {
+  if (!q.trim()) return preview;
+  const re = new RegExp(
+    `(${q.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+    "ig",
+  );
+  const parts = preview.split(re);
+  return parts.map((p, i) =>
+    re.test(p) ? (
+      <mark key={i} className="bg-amber-400/30 text-amber-100 rounded px-0.5">
+        {p}
+      </mark>
+    ) : (
+      <React.Fragment key={i}>{p}</React.Fragment>
+    ),
+  );
+}
+
+export const SearchResultCard: React.FC<Props> = ({
+  result,
+  query,
+  onOpen,
+}) => {
+  const meta = result.source_metadata;
+  const title = meta.summary_title ?? "Analyse sans titre";
+  const channel = meta.channel ?? "";
+  const thumb = meta.summary_thumbnail;
+  const score = (result.score * 100).toFixed(0);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(result)}
+      data-testid="search-result-card"
+      className="w-full text-left flex gap-3 p-3 rounded-xl bg-white/[0.03] border border-white/10 hover:bg-white/5 hover:border-white/20 transition-colors group"
+    >
+      {thumb && (
+        <img
+          src={thumb}
+          alt=""
+          loading="lazy"
+          className="w-24 h-16 sm:w-32 sm:h-20 rounded-md object-cover flex-shrink-0"
+        />
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1 flex-wrap">
+          <SearchTypeBadge type={result.source_type} />
+          <span className="text-[11px] font-mono text-white/40">
+            score {score}%
+          </span>
+        </div>
+        <h3 className="text-sm font-medium text-white truncate">{title}</h3>
+        {channel && <p className="text-xs text-white/45 truncate">{channel}</p>}
+        <p className="text-sm text-white/70 mt-1 line-clamp-2">
+          {highlight(result.text_preview, query)}
+        </p>
+      </div>
+      <ChevronRight className="self-center w-4 h-4 text-white/25 group-hover:text-white/65 flex-shrink-0" />
+    </button>
+  );
+};

--- a/frontend/src/components/search/SearchResultsList.tsx
+++ b/frontend/src/components/search/SearchResultsList.tsx
@@ -1,0 +1,62 @@
+import React, { useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { SearchResultCard } from "./SearchResultCard";
+import type { GlobalSearchResult } from "../../services/api";
+
+interface Props {
+  results: GlobalSearchResult[];
+  query: string;
+  onOpen: (r: GlobalSearchResult) => void;
+}
+
+export const SearchResultsList: React.FC<Props> = ({
+  results,
+  query,
+  onOpen,
+}) => {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: results.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 110,
+    overscan: 6,
+  });
+
+  return (
+    <div
+      ref={parentRef}
+      className="w-full max-w-3xl mx-auto overflow-y-auto"
+      style={{ maxHeight: "calc(100vh - 280px)" }}
+    >
+      <div
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          width: "100%",
+          position: "relative",
+        }}
+      >
+        {virtualizer.getVirtualItems().map((vi) => {
+          const r = results[vi.index];
+          return (
+            <div
+              key={`${r.source_type}-${r.source_id}`}
+              data-index={vi.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${vi.start}px)`,
+                paddingBottom: 8,
+              }}
+            >
+              <SearchResultCard result={r} query={query} onOpen={onOpen} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/search/SearchTypeBadge.tsx
+++ b/frontend/src/components/search/SearchTypeBadge.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import {
+  BookOpen,
+  Brain,
+  BookMarked,
+  MessageCircle,
+  FileText,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { SearchSourceType } from "../../services/api";
+
+interface BadgeConfig {
+  label: string;
+  icon: LucideIcon;
+  bg: string;
+  text: string;
+}
+
+const TYPE_CONFIG: Record<SearchSourceType, BadgeConfig> = {
+  summary: {
+    label: "Synthèse",
+    icon: BookOpen,
+    bg: "bg-blue-500/15",
+    text: "text-blue-300",
+  },
+  flashcard: {
+    label: "Flashcard",
+    icon: BookMarked,
+    bg: "bg-emerald-500/15",
+    text: "text-emerald-300",
+  },
+  quiz: {
+    label: "Quiz",
+    icon: Brain,
+    bg: "bg-amber-500/15",
+    text: "text-amber-300",
+  },
+  chat: {
+    label: "Chat",
+    icon: MessageCircle,
+    bg: "bg-indigo-500/15",
+    text: "text-indigo-300",
+  },
+  transcript: {
+    label: "Transcript",
+    icon: FileText,
+    bg: "bg-violet-500/15",
+    text: "text-violet-300",
+  },
+};
+
+export const SearchTypeBadge: React.FC<{ type: SearchSourceType }> = ({
+  type,
+}) => {
+  const cfg = TYPE_CONFIG[type];
+  const Icon = cfg.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${cfg.bg} ${cfg.text}`}
+    >
+      <Icon className="w-3 h-3" aria-hidden />
+      {cfg.label}
+    </span>
+  );
+};

--- a/frontend/src/components/search/__tests__/SearchFiltersBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchFiltersBar.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchFiltersBar } from "../SearchFiltersBar";
+
+afterEach(cleanup);
+
+describe("SearchFiltersBar", () => {
+  it("renders 'Tout' active by default when no source_types", () => {
+    render(
+      <SearchFiltersBar
+        filters={{}}
+        onChange={() => {}}
+        onToggleAdvanced={() => {}}
+        advancedOpen={false}
+      />,
+    );
+    const all = screen.getByRole("button", { name: /Tout/ });
+    expect(all).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("toggles a type pill on click", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SearchFiltersBar
+        filters={{}}
+        onChange={onChange}
+        onToggleAdvanced={() => {}}
+        advancedOpen={false}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Synthèse/ }));
+    expect(onChange).toHaveBeenCalledWith({ source_types: ["summary"] });
+  });
+
+  it("expands advanced filters when clicked", async () => {
+    const user = userEvent.setup();
+    const onToggleAdvanced = vi.fn();
+    render(
+      <SearchFiltersBar
+        filters={{}}
+        onChange={() => {}}
+        onToggleAdvanced={onToggleAdvanced}
+        advancedOpen={false}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Filtres avancés/ }));
+    expect(onToggleAdvanced).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/search/__tests__/SearchInput.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchInput.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchInput } from "../SearchInput";
+
+vi.mock("../useRecentQueries", () => ({
+  useRecentQueries: () => ({
+    queries: ["transition énergétique", "crise énergie"],
+    addQuery: vi.fn(),
+    clear: vi.fn(),
+  }),
+}));
+
+afterEach(cleanup);
+
+describe("SearchInput", () => {
+  it("renders placeholder", () => {
+    render(<SearchInput value="" onChange={() => {}} />);
+    expect(screen.getByPlaceholderText(/rechercher/i)).toBeInTheDocument();
+  });
+
+  it("calls onChange when typing", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SearchInput value="" onChange={onChange} autoFocus={false} />);
+    const input = screen.getByRole("searchbox");
+    await user.type(input, "ai");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("shows suggestions when focused with empty value", async () => {
+    const user = userEvent.setup();
+    render(<SearchInput value="" onChange={() => {}} autoFocus={false} />);
+    await user.click(screen.getByRole("searchbox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByText("transition énergétique")).toBeInTheDocument();
+  });
+
+  it("clears value when X button is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SearchInput value="hello" onChange={onChange} autoFocus={false} />);
+    await user.click(screen.getByLabelText(/effacer/i));
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("calls onSubmit when pressing Enter", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <SearchInput
+        value="hello"
+        onChange={() => {}}
+        onSubmit={onSubmit}
+        autoFocus={false}
+      />,
+    );
+    await user.click(screen.getByRole("searchbox"));
+    await user.keyboard("{Enter}");
+    expect(onSubmit).toHaveBeenCalledWith("hello");
+  });
+});

--- a/frontend/src/components/search/__tests__/SearchResultCard.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchResultCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchResultCard } from "../SearchResultCard";
+import type { GlobalSearchResult } from "../../../services/api";
+
+afterEach(cleanup);
+
+const mockResult: GlobalSearchResult = {
+  source_type: "summary",
+  source_id: 42,
+  summary_id: 42,
+  score: 0.91,
+  text_preview:
+    "La transition énergétique impose une refonte du mix électrique européen.",
+  source_metadata: {
+    summary_title: "Crise énergétique EU",
+    channel: "Le Monde",
+    summary_thumbnail: "https://img.example/thumb.jpg",
+    tab: "synthesis",
+  },
+};
+
+describe("SearchResultCard", () => {
+  it("renders title, channel and score", () => {
+    render(<SearchResultCard result={mockResult} query="" onOpen={() => {}} />);
+    expect(screen.getByText("Crise énergétique EU")).toBeInTheDocument();
+    expect(screen.getByText("Le Monde")).toBeInTheDocument();
+    expect(screen.getByText(/score 91%/)).toBeInTheDocument();
+  });
+
+  it("renders the type badge", () => {
+    render(<SearchResultCard result={mockResult} query="" onOpen={() => {}} />);
+    expect(screen.getByText("Synthèse")).toBeInTheDocument();
+  });
+
+  it("calls onOpen when clicked", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(
+      <SearchResultCard result={mockResult} query="énergie" onOpen={onOpen} />,
+    );
+    await user.click(screen.getByTestId("search-result-card"));
+    expect(onOpen).toHaveBeenCalledWith(mockResult);
+  });
+
+  it("highlights the query term in preview", () => {
+    render(
+      <SearchResultCard
+        result={mockResult}
+        query="transition"
+        onOpen={() => {}}
+      />,
+    );
+    const marks = document.querySelectorAll("mark");
+    expect(marks.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/search/__tests__/useSemanticSearch.test.ts
+++ b/frontend/src/components/search/__tests__/useSemanticSearch.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useSemanticSearch } from "../useSemanticSearch";
+import { searchApi } from "../../../services/api";
+
+vi.mock("../../../services/api", () => ({
+  searchApi: { searchGlobal: vi.fn() },
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return React.createElement(QueryClientProvider, { client: qc }, children);
+};
+
+describe("useSemanticSearch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not call API when query is empty", () => {
+    const { result } = renderHook(
+      () => useSemanticSearch({ query: "", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(searchApi.searchGlobal).not.toHaveBeenCalled();
+  });
+
+  it("does not call API when query has less than 2 chars", () => {
+    renderHook(
+      () => useSemanticSearch({ query: "a", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    expect(searchApi.searchGlobal).not.toHaveBeenCalled();
+  });
+
+  it("calls searchGlobal when query has >= 2 chars", async () => {
+    (
+      searchApi.searchGlobal as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      query: "ai",
+      total_results: 0,
+      results: [],
+      searched_at: "2026-05-03T12:00:00Z",
+    });
+    renderHook(
+      () => useSemanticSearch({ query: "ai", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() =>
+      expect(searchApi.searchGlobal).toHaveBeenCalledWith("ai", {}, 20),
+    );
+  });
+
+  it("debounces input changes", async () => {
+    (
+      searchApi.searchGlobal as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      query: "f",
+      total_results: 0,
+      results: [],
+      searched_at: "x",
+    });
+    const { rerender } = renderHook(
+      ({ q }: { q: string }) =>
+        useSemanticSearch({ query: q, filters: {}, debounceMs: 50 }),
+      { wrapper, initialProps: { q: "" } },
+    );
+    rerender({ q: "ai" });
+    rerender({ q: "ais" });
+    rerender({ q: "aist" });
+    await new Promise((r) => setTimeout(r, 150));
+    await waitFor(() => {
+      expect(searchApi.searchGlobal).toHaveBeenCalledTimes(1);
+      expect(searchApi.searchGlobal).toHaveBeenLastCalledWith("aist", {}, 20);
+    });
+  });
+});

--- a/frontend/src/components/search/useRecentQueries.ts
+++ b/frontend/src/components/search/useRecentQueries.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from "react";
+import { searchApi } from "../../services/api";
+
+const STORAGE_KEY = "deepsight_recent_queries";
+const MAX_LOCAL = 5;
+
+function readLocal(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr.filter((s) => typeof s === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeLocal(queries: string[]) {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(queries.slice(0, MAX_LOCAL)),
+    );
+  } catch {
+    /* quota / private mode — silent ignore */
+  }
+}
+
+export function useRecentQueries() {
+  const [queries, setQueries] = useState<string[]>(() => readLocal());
+
+  // Sync with server on mount (server has up to 10, merge with local)
+  useEffect(() => {
+    let cancelled = false;
+    searchApi
+      .getRecentQueries()
+      .then(({ queries: server }) => {
+        if (cancelled) return;
+        const merged = Array.from(new Set([...readLocal(), ...server])).slice(
+          0,
+          MAX_LOCAL,
+        );
+        setQueries(merged);
+        writeLocal(merged);
+      })
+      .catch(() => {
+        /* offline / 404 / 401 — keep local */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const addQuery = useCallback((q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) return;
+    setQueries((prev) => {
+      const next = [trimmed, ...prev.filter((x) => x !== trimmed)].slice(
+        0,
+        MAX_LOCAL,
+      );
+      writeLocal(next);
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(async () => {
+    setQueries([]);
+    writeLocal([]);
+    try {
+      await searchApi.clearRecentQueries();
+    } catch {
+      /* swallow */
+    }
+  }, []);
+
+  return { queries, addQuery, clear };
+}

--- a/frontend/src/components/search/useSemanticSearch.ts
+++ b/frontend/src/components/search/useSemanticSearch.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  searchApi,
+  type GlobalSearchResponse,
+  type SearchFilters,
+} from "../../services/api";
+
+interface UseSemanticSearchOptions {
+  query: string;
+  filters: SearchFilters;
+  limit?: number;
+  /** debounce ms — defaults to 300, pass 0 to disable for tests */
+  debounceMs?: number;
+  /** disable the query entirely (e.g. when query.length < 2) */
+  enabled?: boolean;
+}
+
+export function useSemanticSearch({
+  query,
+  filters,
+  limit = 20,
+  debounceMs = 300,
+  enabled = true,
+}: UseSemanticSearchOptions) {
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+
+  useEffect(() => {
+    if (debounceMs === 0) {
+      setDebouncedQuery(query);
+      return;
+    }
+    const t = setTimeout(() => setDebouncedQuery(query), debounceMs);
+    return () => clearTimeout(t);
+  }, [query, debounceMs]);
+
+  const trimmed = debouncedQuery.trim();
+  const isEnabled = enabled && trimmed.length >= 2;
+
+  return useQuery<GlobalSearchResponse, Error>({
+    queryKey: ["search", "global", trimmed, filters, limit],
+    queryFn: () => searchApi.searchGlobal(trimmed, filters, limit),
+    enabled: isEnabled,
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/frontend/src/components/sidebar/SidebarNav.tsx
+++ b/frontend/src/components/sidebar/SidebarNav.tsx
@@ -4,6 +4,7 @@ import {
   Swords,
   MessageCircle,
   History,
+  Search,
   Gem,
   Settings,
   Crown,
@@ -24,8 +25,9 @@ export const SidebarNav: React.FC<SidebarNavProps> = ({
   const navItems = [
     { path: "/dashboard", icon: Video, label: "Vidéo" },
     { path: "/debate", icon: Swords, label: "Débat IA" },
-    { path: "/hub", icon: MessageCircle, label: "Hub" },
     { path: "/history", icon: History, label: "Historique" },
+    { path: "/search", icon: Search, label: "Recherche" },
+    { path: "/hub", icon: MessageCircle, label: "Hub" },
     { path: "/upgrade", icon: Gem, label: "Upgrade" },
     { path: "/settings", icon: Settings, label: "Paramètres" },
   ];

--- a/frontend/src/config/planPrivileges.ts
+++ b/frontend/src/config/planPrivileges.ts
@@ -191,6 +191,7 @@ export interface PlanFeatures {
   debate: boolean;
   deepResearch: boolean;
   factcheck: boolean;
+  semanticSearchTooltip: boolean;
 }
 
 export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
@@ -210,6 +211,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     debate: false,
     deepResearch: false,
     factcheck: false,
+    semanticSearchTooltip: false,
   },
   pro: {
     flashcards: true,
@@ -227,6 +229,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     debate: true,
     deepResearch: false,
     factcheck: true,
+    semanticSearchTooltip: true,
   },
   expert: {
     flashcards: true,
@@ -244,6 +247,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     debate: true,
     deepResearch: true,
     factcheck: true,
+    semanticSearchTooltip: true,
   },
 };
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -46,6 +46,7 @@
     "dashboard": "Dashboard",
     "analysis": "Analysis",
     "history": "History",
+    "search": "Search",
     "playlists": "Playlists",
     "settings": "Settings",
     "subscription": "My plan",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -46,6 +46,7 @@
     "dashboard": "Tableau de bord",
     "analysis": "Analyse",
     "history": "Historique",
+    "search": "Recherche",
     "playlists": "Playlists",
     "settings": "Paramètres",
     "subscription": "Mon plan",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,8 @@ html {
   font-size: 18px;
 }
 
+@import "./styles/highlight.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Sidebar } from "../components/layout/Sidebar";
+import DoodleBackground from "../components/DoodleBackground";
+import { SEO } from "../components/SEO";
+import { DeepSightSpinner } from "../components/ui/DeepSightSpinner";
+import { SearchInput } from "../components/search/SearchInput";
+import { SearchFiltersBar } from "../components/search/SearchFiltersBar";
+import { SearchAdvancedFilters } from "../components/search/SearchAdvancedFilters";
+import { SearchResultsList } from "../components/search/SearchResultsList";
+import { SearchEmptyState } from "../components/search/SearchEmptyState";
+import { useSemanticSearch } from "../components/search/useSemanticSearch";
+import { useRecentQueries } from "../components/search/useRecentQueries";
+import type {
+  GlobalSearchResult,
+  SearchFilters,
+  SearchSourceType,
+} from "../services/api";
+import { analytics } from "../services/analytics";
+
+const SearchPage: React.FC = () => {
+  const [params, setParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { addQuery, queries: recent } = useRecentQueries();
+
+  const initialQuery = params.get("q") ?? "";
+  const [query, setQuery] = useState(initialQuery);
+  const initialTypes = useMemo<SearchSourceType[] | undefined>(() => {
+    const raw = params.get("types");
+    if (!raw) return undefined;
+    return raw.split(",").filter(Boolean) as SearchSourceType[];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const [filters, setFilters] = useState<SearchFilters>({
+    source_types: initialTypes,
+    platform: (params.get("platform") ||
+      undefined) as SearchFilters["platform"],
+    lang: params.get("lang") || undefined,
+    category: params.get("category") || undefined,
+    favorites_only: params.get("favs") === "1" || undefined,
+  });
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  // Sync state → URL
+  useEffect(() => {
+    const next = new URLSearchParams();
+    if (query) next.set("q", query);
+    if (filters.source_types?.length)
+      next.set("types", filters.source_types.join(","));
+    if (filters.platform) next.set("platform", filters.platform);
+    if (filters.lang) next.set("lang", filters.lang);
+    if (filters.category) next.set("category", filters.category);
+    if (filters.favorites_only) next.set("favs", "1");
+    setParams(next, { replace: true });
+  }, [query, filters, setParams]);
+
+  const { data, isFetching, error } = useSemanticSearch({ query, filters });
+
+  // Track query when results land
+  useEffect(() => {
+    if (data && query.trim().length >= 2) {
+      addQuery(query);
+      analytics.capture("search_query", {
+        query_length: query.length,
+        results_count: data.total_results,
+        has_filters: Object.keys(filters).some(
+          (k) => (filters as Record<string, unknown>)[k] !== undefined,
+        ),
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.searched_at]);
+
+  const countsByType = useMemo<
+    Partial<Record<SearchSourceType, number>>
+  >(() => {
+    if (!data) return {};
+    const counts: Partial<Record<SearchSourceType, number>> = {};
+    for (const r of data.results) {
+      counts[r.source_type] = (counts[r.source_type] ?? 0) + 1;
+    }
+    return counts;
+  }, [data]);
+
+  const handleOpen = (r: GlobalSearchResult) => {
+    analytics.capture("search_result_clicked", {
+      position: data?.results.indexOf(r) ?? -1,
+      source_type: r.source_type,
+      score: r.score,
+    });
+    const tab = r.source_metadata.tab ?? "synthesis";
+    const url = new URLSearchParams({
+      summaryId: String(r.summary_id),
+      q: query,
+      highlight: `${r.source_type}-${r.source_id}`,
+      tab,
+    });
+    navigate(`/hub?${url.toString()}`);
+  };
+
+  const isEmptyQuery = query.trim().length < 2;
+  const hasResults = !!data && data.results.length > 0;
+
+  return (
+    <div className="min-h-screen bg-bg-primary text-text-primary relative">
+      <SEO title="Recherche — Deep Sight" noindex />
+      <DoodleBackground />
+      <Sidebar />
+      <main
+        id="main-content"
+        className="lg:pl-[240px] pt-6 pb-12 px-4 sm:px-6 lg:px-8 relative z-10"
+      >
+        <div className="max-w-5xl mx-auto space-y-6">
+          <header>
+            <h1 className="text-2xl sm:text-3xl font-semibold text-white mb-1">
+              Recherche
+            </h1>
+            <p className="text-sm text-white/55">
+              Sémantique sur tes analyses, flashcards, quiz et chats.
+            </p>
+          </header>
+
+          <SearchInput value={query} onChange={setQuery} onSubmit={setQuery} />
+
+          <SearchFiltersBar
+            filters={filters}
+            onChange={setFilters}
+            countsByType={countsByType}
+            totalCount={data?.total_results}
+            onToggleAdvanced={() => setAdvancedOpen((v) => !v)}
+            advancedOpen={advancedOpen}
+          />
+
+          {advancedOpen && (
+            <SearchAdvancedFilters filters={filters} onChange={setFilters} />
+          )}
+
+          {error && (
+            <div className="text-center py-8 text-red-300">
+              Une erreur est survenue. Réessaie dans un instant.
+            </div>
+          )}
+
+          {!error && isFetching && (
+            <div className="flex justify-center py-10">
+              <DeepSightSpinner size="md" />
+            </div>
+          )}
+
+          {!error && !isFetching && isEmptyQuery && (
+            <SearchEmptyState
+              variant="no-query"
+              recentQueries={recent}
+              onPickQuery={(q) => setQuery(q)}
+            />
+          )}
+
+          {!error && !isFetching && !isEmptyQuery && !hasResults && (
+            <SearchEmptyState variant="no-results" query={query} />
+          )}
+
+          {!error && !isFetching && hasResults && data && (
+            <SearchResultsList
+              results={data.results}
+              query={query}
+              onOpen={handleOpen}
+            />
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default SearchPage;

--- a/frontend/src/pages/__tests__/SearchPage.test.tsx
+++ b/frontend/src/pages/__tests__/SearchPage.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SearchPage from "../SearchPage";
+import { searchApi } from "../../services/api";
+
+vi.mock("../../services/api", () => ({
+  searchApi: {
+    searchGlobal: vi.fn(),
+    getRecentQueries: vi.fn().mockResolvedValue({ queries: [] }),
+    clearRecentQueries: vi.fn(),
+  },
+}));
+vi.mock("../../components/layout/Sidebar", () => ({ Sidebar: () => null }));
+vi.mock("../../components/DoodleBackground", () => ({ default: () => null }));
+vi.mock("../../components/SEO", () => ({ SEO: () => null }));
+vi.mock("../../services/analytics", () => ({
+  analytics: { capture: vi.fn() },
+}));
+
+afterEach(cleanup);
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/search"]}>
+        <SearchPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SearchPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows the no-query empty state initially", () => {
+    renderPage();
+    expect(screen.getByText(/cherche dans toutes/i)).toBeInTheDocument();
+  });
+
+  it("calls searchGlobal when typing >= 2 chars", async () => {
+    (
+      searchApi.searchGlobal as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      query: "ai",
+      total_results: 0,
+      results: [],
+      searched_at: "2026-05-03T12:00:00Z",
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByRole("searchbox"), "ai");
+    await waitFor(() => expect(searchApi.searchGlobal).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2581,7 +2581,83 @@ export interface SemanticSearchResponse {
   searched_at: string;
 }
 
+// ─── Search V1 — Phase 2 (Global / Within / Explain) ──────────────────────────
+
+export type SearchSourceType =
+  | "summary"
+  | "flashcard"
+  | "quiz"
+  | "chat"
+  | "transcript";
+
+export interface SearchFilters {
+  source_types?: SearchSourceType[];
+  platform?: "youtube" | "tiktok" | "text";
+  lang?: string;
+  category?: string;
+  date_from?: string; // ISO date YYYY-MM-DD
+  date_to?: string;
+  favorites_only?: boolean;
+  playlist_id?: number;
+}
+
+export interface SearchResultMetadata {
+  summary_title?: string;
+  summary_thumbnail?: string;
+  video_id?: string;
+  channel?: string;
+  tab?: "synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript";
+  start_ts?: number;
+  end_ts?: number;
+  anchor?: string;
+  flashcard_id?: number;
+  quiz_question_id?: number;
+}
+
+export interface GlobalSearchResult {
+  source_type: SearchSourceType;
+  source_id: number;
+  summary_id: number;
+  score: number;
+  text_preview: string;
+  source_metadata: SearchResultMetadata;
+}
+
+export interface GlobalSearchResponse {
+  query: string;
+  total_results: number;
+  results: GlobalSearchResult[];
+  searched_at: string;
+}
+
+export interface WithinMatch {
+  source_type: SearchSourceType;
+  source_id: number;
+  text: string;
+  text_html: string;
+  start_offset: number;
+  end_offset: number;
+  tab: "synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript";
+  score: number;
+  passage_id: string;
+}
+
+export interface WithinSearchResponse {
+  matches: WithinMatch[];
+}
+
+export interface ExplainPassageResponse {
+  explanation: string;
+  cached: boolean;
+  model_used: string;
+}
+
+export interface RecentQueriesResponse {
+  queries: string[];
+}
+
 export const searchApi = {
+  // Legacy — keep for backward compat with /api/search/semantic transcript-only
   async semanticSearch(
     query: string,
     limit: number = 10,
@@ -2591,6 +2667,57 @@ export const searchApi = {
       method: "POST",
       body: { query, limit, category },
     });
+  },
+
+  // V1 Phase 2 — Global cross-source search
+  async searchGlobal(
+    query: string,
+    filters: SearchFilters = {},
+    limit: number = 20,
+  ): Promise<GlobalSearchResponse> {
+    return request("/api/search/global", {
+      method: "POST",
+      body: { query, limit, ...filters },
+    });
+  },
+
+  // V1 Phase 2 — Intra-analysis search
+  async searchWithin(
+    summaryId: number,
+    query: string,
+    sourceTypes?: SearchSourceType[],
+  ): Promise<WithinSearchResponse> {
+    return request(`/api/search/within/${summaryId}`, {
+      method: "POST",
+      body: { query, source_types: sourceTypes },
+    });
+  },
+
+  // V1 Phase 2 — Explain a passage (Pro/Expert only on backend)
+  async explainPassage(
+    summaryId: number,
+    passageText: string,
+    query: string,
+    sourceType: SearchSourceType,
+  ): Promise<ExplainPassageResponse> {
+    return request("/api/search/explain-passage", {
+      method: "POST",
+      body: {
+        summary_id: summaryId,
+        passage_text: passageText,
+        query,
+        source_type: sourceType,
+      },
+    });
+  },
+
+  // V1 Phase 2 — Recent queries (server-side persistence)
+  async getRecentQueries(): Promise<RecentQueriesResponse> {
+    return request("/api/search/recent-queries", { method: "GET" });
+  },
+
+  async clearRecentQueries(): Promise<void> {
+    await request("/api/search/recent-queries", { method: "DELETE" });
   },
 };
 

--- a/frontend/src/styles/highlight.css
+++ b/frontend/src/styles/highlight.css
@@ -1,0 +1,35 @@
+/* frontend/src/styles/highlight.css
+   Semantic Search V1 highlight visuals.
+   amber-400 = rgb(251 191 36) ; amber-300 = rgb(252 211 77) */
+
+.ds-highlight {
+  background: rgb(251 191 36 / 0.35);
+  color: rgb(252 211 77);
+  padding: 0 2px;
+  border-radius: 2px;
+  border-bottom: 2px solid rgb(251 191 36);
+  cursor: pointer;
+  transition: background 200ms ease;
+}
+.ds-highlight:hover {
+  background: rgb(251 191 36 / 0.55);
+}
+.ds-highlight.flash {
+  animation: ds-highlight-flash 800ms ease-in-out;
+}
+@keyframes ds-highlight-flash {
+  0%,
+  100% {
+    background: rgb(251 191 36 / 0.35);
+  }
+  50% {
+    background: rgb(251 191 36 / 0.85);
+  }
+}
+
+/* Honour reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ds-highlight.flash {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Implémente la **Phase 2 (web frontend Next.js)** de Semantic Search V1, basée sur le plan `docs/superpowers/plans/2026-05-03-semantic-search-v1-phase2-web.md` et le spec `docs/superpowers/specs/2026-05-03-semantic-search-design.md`.

Backend Phase 1 mergée en prod le 2026-05-03 via #292 (6 endpoints `/api/search/*`, 7 tables embeddings backfillées via `mistral-embed` 1024-dim).

## Changes (15 commits search-related)

**Recherche globale (`/search`)**
- `searchApi` : `searchGlobal`, `searchWithin`, `explainPassage`, `recentQueries`
- `useSemanticSearch` hook (debounce 300ms)
- `useRecentQueries` hook (localStorage + server sync)
- `SearchInput` autocomplete recent queries
- `SearchTypeBadge` + filter pills + advanced filters
- `SearchResultCard` + `EmptyState` + virtualized `SearchResultsList` (`@tanstack/react-virtual`)
- `SearchPage` avec URL state sync + click flow vers `/hub`
- Route `/search` + sidebar nav item + i18n
- Feature flag `semanticSearchTooltip` (free=off, pro/expert=on)

**Highlighting intra-analyse (Cmd+F intercept)**
- `highlight.css` (`.ds-highlight` + flash animation)
- `SemanticHighlightProvider` (debounced within fetch)
- `HighlightedText` DOM-walker injectant `<mark>` spans
- `HighlightNavigationBar` (counter + F3/Esc shortcuts)
- `IntraAnalysisSearchBar` + `useCmdFIntercept` hook
- `ExplainTooltip` (cache + free plan upsell modal — Pro+Expert only)

## Test plan

- [ ] CI : tests frontend passent
- [ ] CI : lint clean
- [ ] Smoke : page `/search` load, query → résultats virtualisés
- [ ] Smoke : Cmd+F dans une page analyse intercepté → highlights
- [ ] Smoke : recent queries autocomplete (input vide focus)
- [ ] Smoke : free user → ExplainTooltip → modal upsell
- [ ] Smoke : pro user → ExplainTooltip → contenu IA
- [ ] Filtres avancés : platform, lang, category, date range, favorites only

## Release plan

Cette PR fait partie d'un release Semantic Search V1 tri-plateforme :
- ✅ #292 — Phase 1 backend (mergé prod)
- ⏳ Cette PR — Phase 2 web
- ⏳ #298 — Phase 3 mobile (draft)
- ⏳ #297 — Phase 4 extension (open)
- ⏳ Phase 5 — activation env `SEMANTIC_SEARCH_V1_ENABLED=true` Hetzner après merge des 4