### PR TITLE
refactor(account): use myPlan from backend SSOT for tier display

### DIFF
--- a/frontend/src/pages/MyAccount.tsx
+++ b/frontend/src/pages/MyAccount.tsx
@@ -349,7 +349,9 @@ export const MyAccount: React.FC = () => {
     navigate("/");
   };
 
-  // Plan info - v5.0 (Free, Pro, Expert)
+  // Plan info — fallback Tailwind classes used ONLY before myPlan resolves.
+  // Once billingApi.getMyPlan("web") returns, render uses myPlan.plan_name /
+  // plan_icon / plan_color (hex) from the backend SSOT (PLANS[plan_id]).
   const planConfig: Record<
     string,
     { label: string; color: string; bgColor: string; icon: string }
@@ -469,7 +471,17 @@ export const MyAccount: React.FC = () => {
             <header className="mb-8">
               <div className="flex items-center gap-4">
                 <div
-                  className={`w-12 h-12 sm:w-16 sm:h-16 rounded-2xl ${currentPlan.bgColor} flex items-center justify-center ${currentPlan.color} text-xl sm:text-2xl font-bold shadow-lg`}
+                  className={`w-12 h-12 sm:w-16 sm:h-16 rounded-2xl flex items-center justify-center text-xl sm:text-2xl font-bold shadow-lg ${
+                    myPlan ? "" : `${currentPlan.bgColor} ${currentPlan.color}`
+                  }`}
+                  style={
+                    myPlan
+                      ? {
+                          backgroundColor: `${myPlan.plan_color}20`,
+                          color: myPlan.plan_color,
+                        }
+                      : undefined
+                  }
                 >
                   {user?.email?.charAt(0).toUpperCase() || "U"}
                 </div>
@@ -479,9 +491,23 @@ export const MyAccount: React.FC = () => {
                   </h1>
                   <p className="text-text-secondary text-sm flex items-center gap-2 mt-1">
                     <span
-                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${currentPlan.bgColor} ${currentPlan.color}`}
+                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                        myPlan
+                          ? ""
+                          : `${currentPlan.bgColor} ${currentPlan.color}`
+                      }`}
+                      style={
+                        myPlan
+                          ? {
+                              backgroundColor: `${myPlan.plan_color}20`,
+                              color: myPlan.plan_color,
+                            }
+                          : undefined
+                      }
                     >
-                      {currentPlan.icon} {currentPlan.label}
+                      {myPlan
+                        ? `${myPlan.plan_icon} ${myPlan.plan_name}`
+                        : `${currentPlan.icon} ${currentPlan.label}`}
                     </span>
                     <span className="text-text-tertiary">•</span>
                     <span>{user?.email}</span>
@@ -523,9 +549,18 @@ export const MyAccount: React.FC = () => {
                   iconColor={currentPlan.color}
                   label={tr("Abonnement", "Subscription")}
                   value={
-                    <span className={`font-semibold ${currentPlan.color}`}>
-                      {currentPlan.icon} {currentPlan.label}
-                    </span>
+                    myPlan ? (
+                      <span
+                        className="font-semibold"
+                        style={{ color: myPlan.plan_color }}
+                      >
+                        {myPlan.plan_icon} {myPlan.plan_name}
+                      </span>
+                    ) : (
+                      <span className={`font-semibold ${currentPlan.color}`}>
+                        {currentPlan.icon} {currentPlan.label}
+                      </span>
+                    )
                   }
                 />
                 {user?.credits !== undefined && (


### PR DESCRIPTION
## Summary

Follow-up de la PR #306. Élimine la duplication entre le dictionnaire local `planConfig` (Tailwind classes hardcodées par tier) et `myPlan` (déjà fetched depuis `billingApi.getMyPlan("web")`, calculé côté backend depuis `PLANS[plan_id]`).

Avant : `planConfig` était la source primaire pour le badge header, le tag pill et l'InfoRow Abonnement → si un tier sortait du dictionnaire (cas `expert` manquant qui a causé le bug fixé en #306), fallback silencieux sur `Gratuit`.

Après : `myPlan` est la source primaire (label, icône, couleur hex). `planConfig` reste comme fallback pendant la courte fenêtre de chargement avant que `getMyPlan` ne résolve.

## Pourquoi

Le bug #306 (Expert affiché Gratuit sur `/account`) venait précisément du fait qu'on devait maintenir à la main un dictionnaire local en sync avec les tiers backend. Si on ajoute un tier "team" demain, ce code se cassera de la même manière. Avec `myPlan` comme source, le tier name/icon/color suit automatiquement le backend.

## Pas dans cette PR (volontairement hors scope)

- `frontend/src/services/api.ts:50-59` : le type `User.plan` accepte encore les ids legacy v0/v1 (`plus`, `etudiant`, `starter`, `student`, `team`, `unlimited`) en plus de `free|pro|expert`. Ces aliases ne devraient plus jamais être renvoyés post-Alembic 012, donc la signature est inutilement large. À nettoyer en PR séparée — ce qui aurait fait sauter le compilateur sur le `Record<string, ...>` trop permissif de cette PR.

## Test plan

- [x] `tsc --noEmit` clean sur `MyAccount.tsx`
- [ ] Manuel : `/account` affiche "Expert 👑" en violet pour un compte Expert (data depuis `myPlan.plan_color`, hex `#a78bfa` ou équivalent backend)
- [ ] Manuel : pendant le chargement initial (< 200 ms), fallback `currentPlan` Tailwind affiche le bon tier (pas de flash "Gratuit")
- [ ] Manuel : sections déjà sur `myPlan` (Mon Abonnement L912+) restent identiques

🤖 Generated with [Claude Code](https://claude.com/claude-code)