### PR TITLE
feat: universal paste link button (YT/TikTok web + iOS schemes + Android intents) — 7 chat inputs tri-platform

### DIFF
--- a/backend/src/utils/video_id.py
+++ b/backend/src/utils/video_id.py
@@ -5,6 +5,8 @@ Extraction de (platform, video_id) depuis une URL YouTube ou TikTok.
 import re
 from urllib.parse import urlparse, parse_qs
 
+from voice.url_validator import normalize_url
+
 
 def extract_video_id(url: str) -> tuple[str, str]:
     """Extrait (platform, video_id) depuis une URL vidéo.
@@ -13,10 +15,13 @@ def extract_video_id(url: str) -> tuple[str, str]:
       - YouTube : youtube.com/watch?v=, youtu.be/, /embed/, /v/, /shorts/
       - TikTok  : tiktok.com/@user/video/ID, tiktok.com/t/CODE, vm.tiktok.com/CODE
 
+    Tolère également les schemes natifs mobile (vnd.youtube://, snssdk1233://,
+    tiktok://) et les Android intent:// links via :func:`normalize_url`.
+
     Raises:
         ValueError: Si l'URL n'est pas supportée.
     """
-    url = url.strip()
+    url = normalize_url(url.strip())
     parsed = urlparse(url)
     host = (parsed.hostname or "").lower()
 

--- a/backend/src/voice/url_validator.py
+++ b/backend/src/voice/url_validator.py
@@ -1,6 +1,7 @@
 """URL validator for voice sessions — accepts YouTube + TikTok only."""
 
 import re
+from urllib.parse import parse_qs, urlparse
 
 YOUTUBE_RE = re.compile(
     r"^https?://(?:www\.|m\.)?(?:youtube\.com/(?:watch\?v=|shorts/|embed/)|youtu\.be/)"
@@ -16,12 +17,98 @@ TIKTOK_RE = re.compile(
     r"(?:@[\w.-]+/video/(\d+)|t/([A-Za-z0-9]+)|v/(\d+))"
 )
 
+# ---------- Tolerant normalization (mobile schemes / android intents / share links) ----------
+
+# YouTube native scheme: vnd.youtube://watch?v=ID  or  youtube://watch?v=ID
+_YT_SCHEME_RE = re.compile(
+    r"^(?:vnd\.youtube|youtube)://(?:watch\?v=|.*[?&]v=)([a-zA-Z0-9_-]{11})",
+    re.IGNORECASE,
+)
+
+# YouTube native scheme alt: vnd.youtube:ID  (no //)
+_YT_SCHEME_BARE_RE = re.compile(
+    r"^(?:vnd\.youtube|youtube):([a-zA-Z0-9_-]{11})$",
+    re.IGNORECASE,
+)
+
+# Android intent URLs: intent://...#Intent;...;end
+_INTENT_RE = re.compile(r"^intent://(.+?)#Intent;", re.IGNORECASE)
+
+# TikTok native schemes (TikTok app, ByteDance internal)
+# snssdk1233://aweme/detail/<id>  (TikTok aweme = video)
+_TIKTOK_SNSSDK_RE = re.compile(
+    r"^snssdk\d+://aweme/detail/(\d+)",
+    re.IGNORECASE,
+)
+# tiktok://...video/<id>  or  tiktok://...
+_TIKTOK_SCHEME_VIDEO_RE = re.compile(
+    r"^tiktok://[^/]*/?(?:.*?/)?video/(\d+)",
+    re.IGNORECASE,
+)
+_TIKTOK_SCHEME_AWEME_RE = re.compile(
+    r"^tiktok://aweme/detail/(\d+)",
+    re.IGNORECASE,
+)
+
+
+def normalize_url(url: str) -> str:
+    """Normalize a raw URL/scheme/intent string into a canonical HTTPS URL.
+
+    Handles native mobile schemes and Android intent:// links by rewriting them
+    to standard https URLs that the existing regex validators accept.
+
+    Pass-through behavior: any URL that doesn't match a known mobile pattern is
+    returned as-is (stripped).
+
+    Examples
+    --------
+    >>> normalize_url("vnd.youtube://watch?v=dQw4w9WgXcQ")
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+    >>> normalize_url("intent://www.youtube.com/watch?v=abc#Intent;package=com.google.android.youtube;end")
+    'https://www.youtube.com/watch?v=abc'
+    >>> normalize_url("snssdk1233://aweme/detail/7123456789012345678")
+    'https://www.tiktok.com/@_/video/7123456789012345678'
+    """
+    if not url:
+        return url
+    raw = url.strip()
+    if not raw:
+        return raw
+
+    # ── YouTube native scheme ──────────────────────────────────────
+    if m := _YT_SCHEME_RE.match(raw):
+        return f"https://www.youtube.com/watch?v={m.group(1)}"
+    if m := _YT_SCHEME_BARE_RE.match(raw):
+        return f"https://www.youtube.com/watch?v={m.group(1)}"
+
+    # ── TikTok native scheme ───────────────────────────────────────
+    if m := _TIKTOK_SNSSDK_RE.match(raw):
+        return f"https://www.tiktok.com/@_/video/{m.group(1)}"
+    if m := _TIKTOK_SCHEME_AWEME_RE.match(raw):
+        return f"https://www.tiktok.com/@_/video/{m.group(1)}"
+    if m := _TIKTOK_SCHEME_VIDEO_RE.match(raw):
+        return f"https://www.tiktok.com/@_/video/{m.group(1)}"
+
+    # ── Android intent:// ──────────────────────────────────────────
+    if m := _INTENT_RE.match(raw):
+        # intent://www.youtube.com/watch?v=ID#Intent;...;end
+        # The body before #Intent is essentially the host+path+query, scheme implicit https.
+        body = m.group(1)
+        # Recurse if body looks like another scheme (rare). Otherwise prepend https://.
+        if "://" in body:
+            return normalize_url(body)
+        return f"https://{body}"
+
+    return raw
+
 
 def parse_video_url(url: str) -> tuple[str, str]:
     """Parse a YouTube or TikTok URL.
 
     Args:
-        url: Raw URL string from user input or share extension.
+        url: Raw URL string from user input or share extension. Tolerant of
+             mobile native schemes (vnd.youtube://, snssdk1233://, tiktok://)
+             and Android intent:// links via :func:`normalize_url`.
 
     Returns:
         Tuple of (platform, video_id) where platform is "youtube" or "tiktok".
@@ -29,6 +116,7 @@ def parse_video_url(url: str) -> tuple[str, str]:
     Raises:
         ValueError: If URL doesn't match either platform.
     """
+    url = normalize_url(url)
     if m := YOUTUBE_RE.match(url):
         return ("youtube", m.group(1))
     if m := TIKTOK_VM_RE.match(url):

--- a/backend/tests/voice/test_url_validator.py
+++ b/backend/tests/voice/test_url_validator.py
@@ -1,6 +1,6 @@
-"""Tests pour url_validator — regex YouTube + TikTok."""
+"""Tests pour url_validator — regex YouTube + TikTok + normalize_url tolerant."""
 import pytest
-from voice.url_validator import parse_video_url
+from voice.url_validator import normalize_url, parse_video_url
 
 
 class TestParseVideoURL:
@@ -52,3 +52,122 @@ class TestParseVideoURL:
     def test_parse_invalid_urls_raises(self, url):
         with pytest.raises(ValueError, match="URL non supportée"):
             parse_video_url(url)
+
+
+class TestNormalizeURL:
+    """Tolerant rewrite of mobile schemes / android intents / native share links."""
+
+    @pytest.mark.parametrize(
+        "raw,expected_https",
+        [
+            # ── YouTube — native mobile schemes (Android & iOS YouTube app share) ──
+            (
+                "vnd.youtube://watch?v=dQw4w9WgXcQ",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            ),
+            (
+                "vnd.youtube:dQw4w9WgXcQ",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            ),
+            (
+                "youtube://watch?v=dQw4w9WgXcQ",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            ),
+            # ── YouTube — Android intent ──
+            (
+                "intent://www.youtube.com/watch?v=dQw4w9WgXcQ#Intent;package=com.google.android.youtube;end",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            ),
+            (
+                "intent://m.youtube.com/watch?v=dQw4w9WgXcQ#Intent;scheme=https;package=com.google.android.youtube;end",
+                "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+            ),
+            # ── TikTok — native scheme (TikTok app, ByteDance internal) ──
+            (
+                "snssdk1233://aweme/detail/7123456789012345678",
+                "https://www.tiktok.com/@_/video/7123456789012345678",
+            ),
+            (
+                "tiktok://aweme/detail/7123456789012345678",
+                "https://www.tiktok.com/@_/video/7123456789012345678",
+            ),
+            (
+                "tiktok://www.tiktok.com/@user/video/7123456789012345678",
+                "https://www.tiktok.com/@_/video/7123456789012345678",
+            ),
+            # ── TikTok — Android intent ──
+            (
+                "intent://www.tiktok.com/@user/video/7123456789012345678#Intent;package=com.zhiliaoapp.musically;end",
+                "https://www.tiktok.com/@user/video/7123456789012345678",
+            ),
+            (
+                "intent://vm.tiktok.com/ZMabc123/#Intent;package=com.zhiliaoapp.musically;end",
+                "https://vm.tiktok.com/ZMabc123/",
+            ),
+            # ── HTTPS canonical — passthrough ──
+            (
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            ),
+            (
+                "https://www.tiktok.com/@user/video/7123456789012345678",
+                "https://www.tiktok.com/@user/video/7123456789012345678",
+            ),
+        ],
+    )
+    def test_normalize_rewrites_mobile_schemes(self, raw, expected_https):
+        assert normalize_url(raw) == expected_https
+
+    def test_normalize_empty_string(self):
+        assert normalize_url("") == ""
+
+    def test_normalize_strips_whitespace(self):
+        assert normalize_url("  https://youtu.be/abc  ") == "https://youtu.be/abc"
+
+    def test_normalize_unknown_passthrough(self):
+        # Non-recognized scheme should pass through (will fail validation downstream)
+        raw = "https://example.com/foo"
+        assert normalize_url(raw) == raw
+
+
+class TestParseAfterNormalize:
+    """End-to-end : raw mobile/intent inputs reach parse_video_url unscathed."""
+
+    @pytest.mark.parametrize(
+        "raw,expected_platform,expected_id",
+        [
+            # YouTube mobile/intent
+            ("vnd.youtube://watch?v=dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"),
+            ("youtube://watch?v=dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"),
+            (
+                "intent://www.youtube.com/watch?v=dQw4w9WgXcQ#Intent;package=com.google.android.youtube;end",
+                "youtube",
+                "dQw4w9WgXcQ",
+            ),
+            # TikTok mobile/intent
+            (
+                "snssdk1233://aweme/detail/7123456789012345678",
+                "tiktok",
+                "7123456789012345678",
+            ),
+            (
+                "tiktok://aweme/detail/7123456789012345678",
+                "tiktok",
+                "7123456789012345678",
+            ),
+            (
+                "intent://www.tiktok.com/@user/video/7123456789012345678#Intent;package=com.zhiliaoapp.musically;end",
+                "tiktok",
+                "7123456789012345678",
+            ),
+            (
+                "intent://vm.tiktok.com/ZMabc123/#Intent;package=com.zhiliaoapp.musically;end",
+                "tiktok",
+                "ZMabc123",
+            ),
+        ],
+    )
+    def test_parse_after_normalize(self, raw, expected_platform, expected_id):
+        platform, video_id = parse_video_url(raw)
+        assert platform == expected_platform
+        assert video_id == expected_id

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -16,6 +16,7 @@
     "alarms",
     "identity",
     "clipboardWrite",
+    "clipboardRead",
     "sidePanel",
     "offscreen"
   ],

--- a/extension/src/sidepanel/components/ConversationInput.tsx
+++ b/extension/src/sidepanel/components/ConversationInput.tsx
@@ -14,6 +14,7 @@ import React, { useState } from "react";
 import { SendIcon } from "../shared/Icons";
 import { DoodleIcon } from "../shared/doodles/DoodleIcon";
 import { useTranslation } from "../../i18n/useTranslation";
+import { PasteLinkButton } from "./PasteLinkButton";
 
 interface ConversationInputProps {
   /** Plan paid (autorise le toggle web-search). */
@@ -70,7 +71,7 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
   sessionExpired,
   onSubmit,
 }) => {
-  const { t } = useTranslation();
+  const { t, language } = useTranslation();
   const [value, setValue] = useState("");
 
   const handleSend = (): void => {
@@ -99,6 +100,13 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
 
   return (
     <div className="chat-input-area" data-testid="conversation-input">
+      {/* Paste link (extreme left) */}
+      <PasteLinkButton
+        onPaste={(text) => setValue(text)}
+        language={language}
+        disabled={disabled || sessionExpired}
+      />
+
       {/* Mic toggle (gauche) */}
       <button
         type="button"

--- a/extension/src/sidepanel/components/PasteLinkButton.tsx
+++ b/extension/src/sidepanel/components/PasteLinkButton.tsx
@@ -1,0 +1,168 @@
+/**
+ * PasteLinkButton (extension sidepanel) — read clipboard, normalize as
+ * YouTube/TikTok URL, insert via onPaste, surface inline tooltip feedback.
+ *
+ * Manifest V3 needs `clipboardRead` permission (added in public/manifest.json).
+ * navigator.clipboard.readText() works inside the side panel because it runs
+ * in an extension page (chrome-extension://) with user gesture.
+ */
+
+import React, { useCallback, useState } from "react";
+import { normalizeVideoUrl } from "../../utils/urlNormalizer";
+
+const ClipboardIcon: React.FC<{ size?: number }> = ({ size = 14 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="9" y="2" width="6" height="4" rx="1" />
+    <path d="M9 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-3" />
+  </svg>
+);
+
+const CheckIcon: React.FC<{ size?: number }> = ({ size = 14 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+interface Labels {
+  title: string;
+  youtube: string;
+  tiktok: string;
+  raw: string;
+  empty: string;
+  denied: string;
+}
+
+const LABELS_FR: Labels = {
+  title: "Coller le lien",
+  youtube: "Lien YouTube détecté",
+  tiktok: "Lien TikTok détecté",
+  raw: "Pas un lien vidéo reconnu",
+  empty: "Presse-papiers vide",
+  denied: "Accès au presse-papiers refusé",
+};
+
+const LABELS_EN: Labels = {
+  title: "Paste link",
+  youtube: "YouTube link detected",
+  tiktok: "TikTok link detected",
+  raw: "Not a recognized video link",
+  empty: "Clipboard is empty",
+  denied: "Clipboard access denied",
+};
+
+export interface PasteLinkButtonProps {
+  /** Called with text to insert (canonical URL when recognized, raw text otherwise). */
+  onPaste: (text: string) => void;
+  /** UI language. Default 'fr'. */
+  language?: "fr" | "en";
+  disabled?: boolean;
+}
+
+export const PasteLinkButton: React.FC<PasteLinkButtonProps> = ({
+  onPaste,
+  language = "fr",
+  disabled = false,
+}) => {
+  const t = language === "en" ? LABELS_EN : LABELS_FR;
+  const [flash, setFlash] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const flashTooltip = useCallback((msg: string, ok: boolean) => {
+    setFlash(msg);
+    setSuccess(ok);
+    setTimeout(() => {
+      setFlash(null);
+      setSuccess(false);
+    }, 1600);
+  }, []);
+
+  const handleClick = useCallback(async () => {
+    if (disabled) return;
+    let raw = "";
+    try {
+      raw = await navigator.clipboard.readText();
+    } catch {
+      flashTooltip(t.denied, false);
+      return;
+    }
+    const trimmed = (raw || "").trim();
+    if (!trimmed) {
+      flashTooltip(t.empty, false);
+      return;
+    }
+    const normalized = normalizeVideoUrl(trimmed);
+    if (normalized) {
+      onPaste(normalized.canonicalUrl);
+      flashTooltip(
+        normalized.platform === "youtube" ? t.youtube : t.tiktok,
+        true,
+      );
+      return;
+    }
+    onPaste(trimmed);
+    flashTooltip(t.raw, false);
+  }, [disabled, onPaste, t, flashTooltip]);
+
+  return (
+    <div className="paste-link-wrap" style={{ position: "relative" }}>
+      <button
+        type="button"
+        className={`chat-paste-btn ${success ? "chat-paste-success" : ""}`}
+        onClick={handleClick}
+        disabled={disabled}
+        title={t.title}
+        aria-label={t.title}
+        data-testid="paste-link-btn"
+      >
+        {success ? <CheckIcon size={14} /> : <ClipboardIcon size={14} />}
+      </button>
+      {flash && (
+        <span
+          role="status"
+          className="chat-paste-tooltip"
+          style={{
+            position: "absolute",
+            bottom: "calc(100% + 6px)",
+            left: "50%",
+            transform: "translateX(-50%)",
+            padding: "4px 8px",
+            borderRadius: 6,
+            fontSize: 11,
+            lineHeight: 1.2,
+            whiteSpace: "nowrap",
+            background: "var(--bg-elevated, #1a1a22)",
+            color: "var(--text-primary, #f1f5f9)",
+            border: "1px solid var(--border, rgba(255,255,255,.1))",
+            boxShadow: "0 4px 12px rgba(0,0,0,.4)",
+            pointerEvents: "none",
+            zIndex: 50,
+          }}
+        >
+          {flash}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default PasteLinkButton;

--- a/extension/src/sidepanel/styles/sidepanel.css
+++ b/extension/src/sidepanel/styles/sidepanel.css
@@ -2035,6 +2035,35 @@ a:hover {
   background: var(--accent-primary-muted);
 }
 
+.chat-paste-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.chat-paste-btn:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.04));
+}
+
+.chat-paste-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.chat-paste-success {
+  color: var(--accent-success, #22c55e) !important;
+  border-color: var(--accent-success, #22c55e) !important;
+}
+
 .chat-input {
   flex: 1;
   padding: 8px 12px;

--- a/extension/src/utils/urlNormalizer.ts
+++ b/extension/src/utils/urlNormalizer.ts
@@ -1,0 +1,108 @@
+/**
+ * urlNormalizer — Client-side video URL normalization (Chrome extension).
+ *
+ * Mirrors backend/src/voice/url_validator.py::normalize_url + parse_video_url
+ * and frontend/src/utils/urlNormalizer.ts (kept in sync intentionally).
+ *
+ * Accepts ANY format the user might paste from a YouTube/TikTok share sheet:
+ *   - canonical https URLs (web, mobile m.*, youtu.be, vm.tiktok.com, /shorts/, /embed/)
+ *   - mobile native schemes  (vnd.youtube://, youtube://, tiktok://, snssdk*)
+ *   - Android intent links   (intent://...#Intent;...;end)
+ *
+ * Returns null when the input doesn't match a known YouTube/TikTok pattern.
+ */
+
+export type NormalizedVideoUrl = {
+  platform: "youtube" | "tiktok";
+  canonicalUrl: string;
+  videoId: string;
+};
+
+// ── canonical regexes (mirror backend) ─────────────────────────────
+const YOUTUBE_RE =
+  /^https?:\/\/(?:www\.|m\.)?(?:youtube\.com\/(?:watch\?v=|shorts\/|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+const TIKTOK_VM_RE = /^https?:\/\/vm\.tiktok\.com\/([A-Za-z0-9]+)\/?/;
+const TIKTOK_RE =
+  /^https?:\/\/(?:www\.|m\.)?tiktok\.com\/(?:@[\w.-]+\/video\/(\d+)|t\/([A-Za-z0-9]+)|v\/(\d+))/;
+
+// ── mobile/intent rewrite regexes ──────────────────────────────────
+const YT_SCHEME_RE =
+  /^(?:vnd\.youtube|youtube):\/\/(?:watch\?v=|.*[?&]v=)([a-zA-Z0-9_-]{11})/i;
+const YT_SCHEME_BARE_RE = /^(?:vnd\.youtube|youtube):([a-zA-Z0-9_-]{11})$/i;
+const INTENT_RE = /^intent:\/\/(.+?)#Intent;/i;
+const TIKTOK_SNSSDK_RE = /^snssdk\d+:\/\/aweme\/detail\/(\d+)/i;
+const TIKTOK_SCHEME_VIDEO_RE = /^tiktok:\/\/[^/]*\/?(?:.*?\/)?video\/(\d+)/i;
+const TIKTOK_SCHEME_AWEME_RE = /^tiktok:\/\/aweme\/detail\/(\d+)/i;
+
+/**
+ * Normalize a raw URL/scheme/intent string into a canonical HTTPS URL.
+ * Pass-through for unknown patterns (returns the trimmed input).
+ */
+export function normalizeUrl(raw: string): string {
+  if (!raw) return raw;
+  const url = raw.trim();
+  if (!url) return url;
+
+  let m = url.match(YT_SCHEME_RE);
+  if (m) return `https://www.youtube.com/watch?v=${m[1]}`;
+  m = url.match(YT_SCHEME_BARE_RE);
+  if (m) return `https://www.youtube.com/watch?v=${m[1]}`;
+
+  m = url.match(TIKTOK_SNSSDK_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+  m = url.match(TIKTOK_SCHEME_AWEME_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+  m = url.match(TIKTOK_SCHEME_VIDEO_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+
+  m = url.match(INTENT_RE);
+  if (m) {
+    const body = m[1];
+    if (body.includes("://")) return normalizeUrl(body);
+    return `https://${body}`;
+  }
+
+  return url;
+}
+
+/**
+ * Detect (platform, canonicalUrl, videoId) from any user-pasted string.
+ * Returns null if the input isn't a recognized YouTube/TikTok video.
+ */
+export function normalizeVideoUrl(raw: string): NormalizedVideoUrl | null {
+  if (!raw) return null;
+  const url = normalizeUrl(raw);
+  if (!url) return null;
+
+  const ytMatch = url.match(YOUTUBE_RE);
+  if (ytMatch) {
+    return {
+      platform: "youtube",
+      canonicalUrl: url,
+      videoId: ytMatch[1],
+    };
+  }
+
+  const ttVmMatch = url.match(TIKTOK_VM_RE);
+  if (ttVmMatch) {
+    return {
+      platform: "tiktok",
+      canonicalUrl: url,
+      videoId: ttVmMatch[1],
+    };
+  }
+
+  const ttMatch = url.match(TIKTOK_RE);
+  if (ttMatch) {
+    const videoId = ttMatch[1] ?? ttMatch[2] ?? ttMatch[3];
+    if (videoId) {
+      return {
+        platform: "tiktok",
+        canonicalUrl: url,
+        videoId,
+      };
+    }
+  }
+
+  return null;
+}

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -33,6 +33,7 @@ import { useTTSContext } from "../contexts/TTSContext";
 import { EnrichedMarkdown, cleanConceptMarkers } from "./EnrichedMarkdown";
 import { ThumbnailImage } from "./ThumbnailImage";
 import { CopyMessageButton } from "./CopyMessageButton";
+import { PasteLinkButton } from "./PasteLinkButton";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // 🎯 TYPES
@@ -630,6 +631,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
 
           {/* Input row */}
           <form onSubmit={handleSubmit} className="flex items-end gap-2">
+            <PasteLinkButton
+              onPaste={(text) => setInput(text)}
+              language={language}
+            />
             <textarea
               ref={inputRef}
               value={input}

--- a/frontend/src/components/ChatPopup.tsx
+++ b/frontend/src/components/ChatPopup.tsx
@@ -47,6 +47,7 @@ import {
 import { EnrichedMarkdown } from "./EnrichedMarkdown";
 import { AudioPlayerButton } from "./AudioPlayerButton";
 import { CopyMessageButton } from "./CopyMessageButton";
+import { PasteLinkButton } from "./PasteLinkButton";
 
 // =============================================================================
 // TYPES
@@ -1196,6 +1197,12 @@ export const ChatPopup: React.FC<ChatPopupProps> = ({
               }}
             >
               <form onSubmit={handleSubmit} className="flex items-center gap-2">
+                {/* Paste link (extreme left) */}
+                <PasteLinkButton
+                  onPaste={(text) => setInput(text)}
+                  language={language}
+                />
+
                 {/* Web search toggle (compact, in input bar) */}
                 {isProUser && onToggleWebSearch && (
                   <button

--- a/frontend/src/components/PasteLinkButton.tsx
+++ b/frontend/src/components/PasteLinkButton.tsx
@@ -1,0 +1,141 @@
+/**
+ * PasteLinkButton (web) — read clipboard, normalize as YouTube/TikTok URL,
+ * insert raw or canonical text via onPaste, and surface a toast.
+ *
+ * Used by Hub InputBar, ChatPanel, ChatPopup, SmartInputBar.
+ */
+
+import React, { useCallback, useState } from "react";
+import { Clipboard, Check } from "lucide-react";
+import { normalizeVideoUrl } from "../utils/urlNormalizer";
+
+export type PasteLinkFeedback =
+  | { type: "youtube"; canonicalUrl: string }
+  | { type: "tiktok"; canonicalUrl: string }
+  | { type: "raw"; text: string }
+  | { type: "empty" }
+  | { type: "denied" };
+
+export interface PasteLinkButtonProps {
+  /** Called with the text inserted into the input (canonical URL when recognized, raw otherwise). */
+  onPaste: (text: string) => void;
+  /**
+   * Optional toast callback — caller wires it to its own toast system.
+   * If omitted, a 1.6s tooltip flash is shown next to the button.
+   */
+  showToast?: (
+    message: string,
+    type?: "success" | "error" | "info" | "warning",
+  ) => void;
+  /** Optional language for the default tooltip. Defaults to 'fr'. */
+  language?: "fr" | "en";
+  /** Compact: icon-only, 32×32. Default true (matches existing input bars). */
+  compact?: boolean;
+  /** Extra Tailwind classes for the button. */
+  className?: string;
+  disabled?: boolean;
+}
+
+const labels = {
+  fr: {
+    title: "Coller le lien",
+    youtube: "Lien YouTube détecté",
+    tiktok: "Lien TikTok détecté",
+    raw: "Pas un lien vidéo reconnu",
+    empty: "Presse-papiers vide",
+    denied: "Accès au presse-papiers refusé",
+  },
+  en: {
+    title: "Paste link",
+    youtube: "YouTube link detected",
+    tiktok: "TikTok link detected",
+    raw: "Not a recognized video link",
+    empty: "Clipboard is empty",
+    denied: "Clipboard access denied",
+  },
+} as const;
+
+export const PasteLinkButton: React.FC<PasteLinkButtonProps> = ({
+  onPaste,
+  showToast,
+  language = "fr",
+  compact = true,
+  className = "",
+  disabled = false,
+}) => {
+  const t = labels[language];
+  const [flash, setFlash] = useState<string | null>(null);
+
+  const flashTooltip = useCallback((msg: string) => {
+    setFlash(msg);
+    setTimeout(() => setFlash(null), 1600);
+  }, []);
+
+  const handleClick = useCallback(async () => {
+    if (disabled) return;
+    let raw = "";
+    try {
+      raw = await navigator.clipboard.readText();
+    } catch {
+      const msg = t.denied;
+      if (showToast) showToast(msg, "error");
+      else flashTooltip(msg);
+      return;
+    }
+    const trimmed = (raw || "").trim();
+    if (!trimmed) {
+      const msg = t.empty;
+      if (showToast) showToast(msg, "info");
+      else flashTooltip(msg);
+      return;
+    }
+    const normalized = normalizeVideoUrl(trimmed);
+    if (normalized) {
+      onPaste(normalized.canonicalUrl);
+      const msg = normalized.platform === "youtube" ? t.youtube : t.tiktok;
+      if (showToast) showToast(msg, "success");
+      else flashTooltip(msg);
+      return;
+    }
+    // Not a recognized video URL — still insert the raw text so user can edit.
+    onPaste(trimmed);
+    const msg = t.raw;
+    if (showToast) showToast(msg, "warning");
+    else flashTooltip(msg);
+  }, [disabled, onPaste, showToast, t, flashTooltip]);
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled}
+        title={t.title}
+        aria-label={t.title}
+        className={
+          compact
+            ? `w-8 h-8 grid place-items-center rounded-full text-text-tertiary hover:text-text-secondary hover:bg-white/[0.06] transition-colors disabled:opacity-40 ${className}`
+            : `inline-flex items-center gap-1.5 px-2.5 py-2 rounded-lg bg-surface-secondary/60 hover:bg-surface-secondary border border-border-subtle text-text-tertiary hover:text-text-secondary transition-colors text-xs disabled:opacity-40 ${className}`
+        }
+        data-testid="paste-link-btn"
+      >
+        {flash ? (
+          <Check className="w-4 h-4" />
+        ) : (
+          <Clipboard className="w-4 h-4" />
+        )}
+        {!compact && <span>{t.title}</span>}
+      </button>
+      {flash && !showToast && (
+        <span
+          role="status"
+          className="absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap px-2 py-1 rounded-md bg-bg-elevated border border-white/10 text-[11px] text-text-primary shadow-lg z-50"
+        >
+          {flash}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default PasteLinkButton;

--- a/frontend/src/components/hub/InputBar.tsx
+++ b/frontend/src/components/hub/InputBar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Mic, Send, Plus } from "lucide-react";
 import type { TabId } from "./types";
+import { PasteLinkButton } from "../PasteLinkButton";
 
 interface Props {
   onSend: (text: string) => void;
@@ -112,6 +113,7 @@ export const InputBar: React.FC<Props> = ({
       >
         <Plus className="w-4 h-4" />
       </button>
+      <PasteLinkButton onPaste={(text) => setVal(text)} disabled={disabled} />
       <input
         type="text"
         value={val}

--- a/frontend/src/utils/__tests__/urlNormalizer.test.ts
+++ b/frontend/src/utils/__tests__/urlNormalizer.test.ts
@@ -1,0 +1,166 @@
+/**
+ * urlNormalizer (web) — unit tests.
+ *
+ * Mirrors backend/tests/voice/test_url_validator.py shape so behavior stays
+ * lockstep across Python + TS.
+ */
+
+import { describe, expect, it } from "vitest";
+import { normalizeUrl, normalizeVideoUrl } from "../urlNormalizer";
+
+describe("normalizeUrl", () => {
+  describe("YouTube native schemes", () => {
+    it.each([
+      [
+        "vnd.youtube://watch?v=dQw4w9WgXcQ",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+      [
+        "youtube://watch?v=dQw4w9WgXcQ",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+      [
+        "vnd.youtube:dQw4w9WgXcQ",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+    ])("rewrites %s", (raw, expected) => {
+      expect(normalizeUrl(raw)).toBe(expected);
+    });
+  });
+
+  describe("Android intent links", () => {
+    it.each([
+      [
+        "intent://www.youtube.com/watch?v=dQw4w9WgXcQ#Intent;package=com.google.android.youtube;end",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+      [
+        "intent://m.youtube.com/watch?v=dQw4w9WgXcQ#Intent;scheme=https;package=com.google.android.youtube;end",
+        "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+      [
+        "intent://www.tiktok.com/@user/video/7123456789012345678#Intent;package=com.zhiliaoapp.musically;end",
+        "https://www.tiktok.com/@user/video/7123456789012345678",
+      ],
+      [
+        "intent://vm.tiktok.com/ZMabc123/#Intent;package=com.zhiliaoapp.musically;end",
+        "https://vm.tiktok.com/ZMabc123/",
+      ],
+    ])("rewrites %s", (raw, expected) => {
+      expect(normalizeUrl(raw)).toBe(expected);
+    });
+  });
+
+  describe("TikTok native schemes", () => {
+    it.each([
+      [
+        "snssdk1233://aweme/detail/7123456789012345678",
+        "https://www.tiktok.com/@_/video/7123456789012345678",
+      ],
+      [
+        "tiktok://aweme/detail/7123456789012345678",
+        "https://www.tiktok.com/@_/video/7123456789012345678",
+      ],
+      [
+        "tiktok://www.tiktok.com/@user/video/7123456789012345678",
+        "https://www.tiktok.com/@_/video/7123456789012345678",
+      ],
+    ])("rewrites %s", (raw, expected) => {
+      expect(normalizeUrl(raw)).toBe(expected);
+    });
+  });
+
+  it("passes through canonical https URLs", () => {
+    expect(normalizeUrl("https://www.youtube.com/watch?v=abc12345678")).toBe(
+      "https://www.youtube.com/watch?v=abc12345678",
+    );
+  });
+
+  it("strips whitespace", () => {
+    expect(normalizeUrl("  https://youtu.be/abc  ")).toBe(
+      "https://youtu.be/abc",
+    );
+  });
+
+  it("returns empty for empty input", () => {
+    expect(normalizeUrl("")).toBe("");
+  });
+});
+
+describe("normalizeVideoUrl", () => {
+  describe("recognizes canonical https URLs", () => {
+    it.each([
+      ["https://www.youtube.com/watch?v=dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      ["https://youtu.be/dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      ["https://youtube.com/shorts/abc123XYZ_-", "youtube", "abc123XYZ_-"],
+      ["https://www.youtube.com/embed/dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      [
+        "https://www.tiktok.com/@user/video/7123456789012345678",
+        "tiktok",
+        "7123456789012345678",
+      ],
+      ["https://vm.tiktok.com/ZMabc123/", "tiktok", "ZMabc123"],
+      [
+        "https://m.tiktok.com/v/7123456789012345678",
+        "tiktok",
+        "7123456789012345678",
+      ],
+    ])("%s → %s/%s", (url, platform, videoId) => {
+      const result = normalizeVideoUrl(url);
+      expect(result).not.toBeNull();
+      expect(result!.platform).toBe(platform);
+      expect(result!.videoId).toBe(videoId);
+    });
+  });
+
+  describe("recognizes mobile/intent inputs end-to-end", () => {
+    it.each([
+      ["vnd.youtube://watch?v=dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      ["youtube://watch?v=dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      [
+        "intent://www.youtube.com/watch?v=dQw4w9WgXcQ#Intent;package=com.google.android.youtube;end",
+        "youtube",
+        "dQw4w9WgXcQ",
+      ],
+      [
+        "snssdk1233://aweme/detail/7123456789012345678",
+        "tiktok",
+        "7123456789012345678",
+      ],
+      [
+        "tiktok://aweme/detail/7123456789012345678",
+        "tiktok",
+        "7123456789012345678",
+      ],
+      [
+        "intent://www.tiktok.com/@user/video/7123456789012345678#Intent;package=com.zhiliaoapp.musically;end",
+        "tiktok",
+        "7123456789012345678",
+      ],
+      [
+        "intent://vm.tiktok.com/ZMabc123/#Intent;package=com.zhiliaoapp.musically;end",
+        "tiktok",
+        "ZMabc123",
+      ],
+    ])("%s → %s/%s", (raw, platform, videoId) => {
+      const result = normalizeVideoUrl(raw);
+      expect(result).not.toBeNull();
+      expect(result!.platform).toBe(platform);
+      expect(result!.videoId).toBe(videoId);
+    });
+  });
+
+  describe("rejects non-video URLs", () => {
+    it.each([
+      "https://vimeo.com/123456",
+      "https://www.facebook.com/watch?v=12345",
+      "https://example.com",
+      "not a url",
+      "",
+      "https://www.tiktok.com/discover",
+      "https://www.tiktok.com/@user", // profile sans /video/
+    ])("%s → null", (raw) => {
+      expect(normalizeVideoUrl(raw)).toBeNull();
+    });
+  });
+});

--- a/frontend/src/utils/urlNormalizer.ts
+++ b/frontend/src/utils/urlNormalizer.ts
@@ -1,0 +1,112 @@
+/**
+ * urlNormalizer — Client-side video URL normalization (web).
+ *
+ * Mirrors backend/src/voice/url_validator.py::normalize_url + parse_video_url.
+ *
+ * Accepts ANY format the user might paste from a YouTube/TikTok share sheet:
+ *   - canonical https URLs (web, mobile m.*, youtu.be, vm.tiktok.com, /shorts/, /embed/)
+ *   - mobile native schemes  (vnd.youtube://, youtube://, tiktok://, snssdk*)
+ *   - Android intent links   (intent://...#Intent;...;end)
+ *
+ * Returns null when the input doesn't match a known YouTube/TikTok pattern,
+ * letting callers either insert the raw text or surface a "not a video link"
+ * toast.
+ */
+
+export type NormalizedVideoUrl = {
+  platform: "youtube" | "tiktok";
+  canonicalUrl: string;
+  videoId: string;
+};
+
+// ── canonical regexes (mirror backend) ─────────────────────────────
+const YOUTUBE_RE =
+  /^https?:\/\/(?:www\.|m\.)?(?:youtube\.com\/(?:watch\?v=|shorts\/|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+const TIKTOK_VM_RE = /^https?:\/\/vm\.tiktok\.com\/([A-Za-z0-9]+)\/?/;
+const TIKTOK_RE =
+  /^https?:\/\/(?:www\.|m\.)?tiktok\.com\/(?:@[\w.-]+\/video\/(\d+)|t\/([A-Za-z0-9]+)|v\/(\d+))/;
+
+// ── mobile/intent rewrite regexes ──────────────────────────────────
+const YT_SCHEME_RE =
+  /^(?:vnd\.youtube|youtube):\/\/(?:watch\?v=|.*[?&]v=)([a-zA-Z0-9_-]{11})/i;
+const YT_SCHEME_BARE_RE = /^(?:vnd\.youtube|youtube):([a-zA-Z0-9_-]{11})$/i;
+const INTENT_RE = /^intent:\/\/(.+?)#Intent;/i;
+const TIKTOK_SNSSDK_RE = /^snssdk\d+:\/\/aweme\/detail\/(\d+)/i;
+const TIKTOK_SCHEME_VIDEO_RE = /^tiktok:\/\/[^/]*\/?(?:.*?\/)?video\/(\d+)/i;
+const TIKTOK_SCHEME_AWEME_RE = /^tiktok:\/\/aweme\/detail\/(\d+)/i;
+
+/**
+ * Normalize a raw URL/scheme/intent string into a canonical HTTPS URL.
+ * Pass-through for unknown patterns (returns the trimmed input).
+ */
+export function normalizeUrl(raw: string): string {
+  if (!raw) return raw;
+  const url = raw.trim();
+  if (!url) return url;
+
+  // ── YouTube native scheme ──────────────────────────────────────
+  let m = url.match(YT_SCHEME_RE);
+  if (m) return `https://www.youtube.com/watch?v=${m[1]}`;
+  m = url.match(YT_SCHEME_BARE_RE);
+  if (m) return `https://www.youtube.com/watch?v=${m[1]}`;
+
+  // ── TikTok native scheme ───────────────────────────────────────
+  m = url.match(TIKTOK_SNSSDK_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+  m = url.match(TIKTOK_SCHEME_AWEME_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+  m = url.match(TIKTOK_SCHEME_VIDEO_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+
+  // ── Android intent:// ──────────────────────────────────────────
+  m = url.match(INTENT_RE);
+  if (m) {
+    const body = m[1];
+    if (body.includes("://")) return normalizeUrl(body);
+    return `https://${body}`;
+  }
+
+  return url;
+}
+
+/**
+ * Detect (platform, canonicalUrl, videoId) from any user-pasted string.
+ * Returns null if the input isn't a recognized YouTube/TikTok video.
+ */
+export function normalizeVideoUrl(raw: string): NormalizedVideoUrl | null {
+  if (!raw) return null;
+  const url = normalizeUrl(raw);
+  if (!url) return null;
+
+  const ytMatch = url.match(YOUTUBE_RE);
+  if (ytMatch) {
+    return {
+      platform: "youtube",
+      canonicalUrl: url,
+      videoId: ytMatch[1],
+    };
+  }
+
+  const ttVmMatch = url.match(TIKTOK_VM_RE);
+  if (ttVmMatch) {
+    return {
+      platform: "tiktok",
+      canonicalUrl: url,
+      videoId: ttVmMatch[1],
+    };
+  }
+
+  const ttMatch = url.match(TIKTOK_RE);
+  if (ttMatch) {
+    const videoId = ttMatch[1] ?? ttMatch[2] ?? ttMatch[3];
+    if (videoId) {
+      return {
+        platform: "tiktok",
+        canonicalUrl: url,
+        videoId,
+      };
+    }
+  }
+
+  return null;
+}

--- a/mobile/src/components/analysis/ChatInput.tsx
+++ b/mobile/src/components/analysis/ChatInput.tsx
@@ -5,6 +5,7 @@ import type { ThemeColors } from "../../theme/colors";
 import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize } from "../../theme/typography";
 import { palette } from "../../theme/colors";
+import { PasteLinkButton } from "../shared/PasteLinkButton";
 
 interface ChatInputProps {
   inputText: string;
@@ -33,6 +34,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           { backgroundColor: colors.bgCard, borderColor: colors.border },
         ]}
       >
+        <PasteLinkButton onPaste={setInputText} />
         <TextInput
           value={inputText}
           onChangeText={setInputText}

--- a/mobile/src/components/chat/ChatInput.tsx
+++ b/mobile/src/components/chat/ChatInput.tsx
@@ -23,6 +23,7 @@ import * as Haptics from "expo-haptics";
 import { useTheme } from "../../contexts/ThemeContext";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { Spacing, Typography, BorderRadius } from "../../constants/theme";
+import { PasteLinkButton } from "../shared/PasteLinkButton";
 
 interface ChatInputProps {
   value: string;
@@ -79,6 +80,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         { backgroundColor: colors.bgPrimary, borderTopColor: colors.border },
       ]}
     >
+      <PasteLinkButton onPaste={onChangeText} />
+
       {showWebSearch && (
         <Pressable
           style={[

--- a/mobile/src/components/conversation/ConversationInput.tsx
+++ b/mobile/src/components/conversation/ConversationInput.tsx
@@ -18,6 +18,7 @@ import { sp, borderRadius } from "../../theme/spacing";
 import { fontFamily, fontSize } from "../../theme/typography";
 import { palette } from "../../theme/colors";
 import type { VoiceMode } from "../../hooks/useConversation";
+import { PasteLinkButton } from "../shared/PasteLinkButton";
 
 interface ConversationInputProps {
   inputText: string;
@@ -80,6 +81,7 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({
           { backgroundColor: colors.bgCard, borderColor: colors.border },
         ]}
       >
+        <PasteLinkButton onPaste={setInputText} />
         <TextInput
           value={inputText}
           onChangeText={setInputText}

--- a/mobile/src/components/shared/PasteLinkButton.tsx
+++ b/mobile/src/components/shared/PasteLinkButton.tsx
@@ -1,0 +1,181 @@
+/**
+ * PasteLinkButton (mobile / Expo) — read clipboard via expo-clipboard,
+ * normalize as YouTube/TikTok URL, insert via onPaste, surface inline
+ * tooltip feedback (no Toast lib in mobile yet — use ephemeral inline text).
+ */
+
+import React, { useCallback, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import * as Clipboard from "expo-clipboard";
+import * as Haptics from "expo-haptics";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../contexts/ThemeContext";
+import { borderRadius, sp } from "../../theme/spacing";
+import { fontFamily, fontSize } from "../../theme/typography";
+import { normalizeVideoUrl } from "../../utils/urlNormalizer";
+
+interface Labels {
+  title: string;
+  youtube: string;
+  tiktok: string;
+  raw: string;
+  empty: string;
+  denied: string;
+}
+
+const LABELS_FR: Labels = {
+  title: "Coller le lien",
+  youtube: "Lien YouTube détecté",
+  tiktok: "Lien TikTok détecté",
+  raw: "Pas un lien vidéo reconnu",
+  empty: "Presse-papiers vide",
+  denied: "Accès au presse-papiers refusé",
+};
+
+const LABELS_EN: Labels = {
+  title: "Paste link",
+  youtube: "YouTube link detected",
+  tiktok: "TikTok link detected",
+  raw: "Not a recognized video link",
+  empty: "Clipboard is empty",
+  denied: "Clipboard access denied",
+};
+
+export interface PasteLinkButtonProps {
+  /** Called with text to insert (canonical URL when recognized, raw text otherwise). */
+  onPaste: (text: string) => void;
+  /** UI language. Default 'fr'. */
+  language?: "fr" | "en";
+  /** Disable the button. */
+  disabled?: boolean;
+  /** Compact size. Default 32×32. */
+  size?: number;
+}
+
+export const PasteLinkButton: React.FC<PasteLinkButtonProps> = ({
+  onPaste,
+  language = "fr",
+  disabled = false,
+  size = 32,
+}) => {
+  const { colors } = useTheme();
+  const t = language === "en" ? LABELS_EN : LABELS_FR;
+  const [flash, setFlash] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const flashTooltip = useCallback((msg: string, ok: boolean) => {
+    setFlash(msg);
+    setSuccess(ok);
+    setTimeout(() => {
+      setFlash(null);
+      setSuccess(false);
+    }, 1600);
+  }, []);
+
+  const handlePress = useCallback(async () => {
+    if (disabled) return;
+    Haptics.selectionAsync().catch(() => {
+      /* haptics may fail on iOS Simulator */
+    });
+    let raw = "";
+    try {
+      raw = await Clipboard.getStringAsync();
+    } catch {
+      flashTooltip(t.denied, false);
+      return;
+    }
+    const trimmed = (raw || "").trim();
+    if (!trimmed) {
+      flashTooltip(t.empty, false);
+      return;
+    }
+    const normalized = normalizeVideoUrl(trimmed);
+    if (normalized) {
+      onPaste(normalized.canonicalUrl);
+      flashTooltip(
+        normalized.platform === "youtube" ? t.youtube : t.tiktok,
+        true,
+      );
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(
+        () => {
+          /* haptics may fail on iOS Simulator */
+        },
+      );
+      return;
+    }
+    onPaste(trimmed);
+    flashTooltip(t.raw, false);
+  }, [disabled, onPaste, t, flashTooltip]);
+
+  return (
+    <View style={styles.wrapper}>
+      <Pressable
+        onPress={handlePress}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={t.title}
+        style={({ pressed }) => [
+          styles.button,
+          {
+            width: size,
+            height: size,
+            borderRadius: size / 2,
+            backgroundColor: colors.bgElevated,
+            opacity: disabled ? 0.4 : pressed ? 0.7 : 1,
+          },
+        ]}
+      >
+        <Ionicons
+          name={success ? "checkmark" : "clipboard-outline"}
+          size={Math.round(size * 0.5)}
+          color={success ? colors.accentSuccess : colors.textTertiary}
+        />
+      </Pressable>
+      {flash !== null && (
+        <View
+          style={[
+            styles.tooltip,
+            {
+              backgroundColor: colors.bgCard,
+              borderColor: colors.border,
+            },
+          ]}
+          pointerEvents="none"
+        >
+          <Text style={[styles.tooltipText, { color: colors.textPrimary }]}>
+            {flash}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: "relative",
+  },
+  button: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  tooltip: {
+    position: "absolute",
+    bottom: "100%",
+    marginBottom: sp.xs,
+    alignSelf: "center",
+    paddingHorizontal: sp.sm,
+    paddingVertical: sp.xs,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    minWidth: 160,
+    maxWidth: 240,
+  },
+  tooltipText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize["2xs"],
+    textAlign: "center",
+  },
+});
+
+export default PasteLinkButton;

--- a/mobile/src/utils/__tests__/urlNormalizer.test.ts
+++ b/mobile/src/utils/__tests__/urlNormalizer.test.ts
@@ -1,0 +1,163 @@
+/**
+ * urlNormalizer (mobile) — unit tests.
+ * Mirrors web + backend test cases.
+ */
+
+import { normalizeUrl, normalizeVideoUrl } from "../urlNormalizer";
+
+describe("normalizeUrl", () => {
+  describe("YouTube native schemes", () => {
+    it.each([
+      [
+        "vnd.youtube://watch?v=dQw4w9WgXcQ",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+      [
+        "youtube://watch?v=dQw4w9WgXcQ",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+      [
+        "vnd.youtube:dQw4w9WgXcQ",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+    ])("rewrites %s", (raw, expected) => {
+      expect(normalizeUrl(raw)).toBe(expected);
+    });
+  });
+
+  describe("Android intent links", () => {
+    it.each([
+      [
+        "intent://www.youtube.com/watch?v=dQw4w9WgXcQ#Intent;package=com.google.android.youtube;end",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+      [
+        "intent://m.youtube.com/watch?v=dQw4w9WgXcQ#Intent;scheme=https;package=com.google.android.youtube;end",
+        "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+      ],
+      [
+        "intent://www.tiktok.com/@user/video/7123456789012345678#Intent;package=com.zhiliaoapp.musically;end",
+        "https://www.tiktok.com/@user/video/7123456789012345678",
+      ],
+      [
+        "intent://vm.tiktok.com/ZMabc123/#Intent;package=com.zhiliaoapp.musically;end",
+        "https://vm.tiktok.com/ZMabc123/",
+      ],
+    ])("rewrites %s", (raw, expected) => {
+      expect(normalizeUrl(raw)).toBe(expected);
+    });
+  });
+
+  describe("TikTok native schemes", () => {
+    it.each([
+      [
+        "snssdk1233://aweme/detail/7123456789012345678",
+        "https://www.tiktok.com/@_/video/7123456789012345678",
+      ],
+      [
+        "tiktok://aweme/detail/7123456789012345678",
+        "https://www.tiktok.com/@_/video/7123456789012345678",
+      ],
+      [
+        "tiktok://www.tiktok.com/@user/video/7123456789012345678",
+        "https://www.tiktok.com/@_/video/7123456789012345678",
+      ],
+    ])("rewrites %s", (raw, expected) => {
+      expect(normalizeUrl(raw)).toBe(expected);
+    });
+  });
+
+  it("passes through canonical https URLs", () => {
+    expect(normalizeUrl("https://www.youtube.com/watch?v=abc12345678")).toBe(
+      "https://www.youtube.com/watch?v=abc12345678",
+    );
+  });
+
+  it("strips whitespace", () => {
+    expect(normalizeUrl("  https://youtu.be/abc  ")).toBe(
+      "https://youtu.be/abc",
+    );
+  });
+
+  it("returns empty for empty input", () => {
+    expect(normalizeUrl("")).toBe("");
+  });
+});
+
+describe("normalizeVideoUrl", () => {
+  describe("recognizes canonical https URLs", () => {
+    it.each([
+      ["https://www.youtube.com/watch?v=dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      ["https://youtu.be/dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      ["https://youtube.com/shorts/abc123XYZ_-", "youtube", "abc123XYZ_-"],
+      ["https://www.youtube.com/embed/dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      [
+        "https://www.tiktok.com/@user/video/7123456789012345678",
+        "tiktok",
+        "7123456789012345678",
+      ],
+      ["https://vm.tiktok.com/ZMabc123/", "tiktok", "ZMabc123"],
+      [
+        "https://m.tiktok.com/v/7123456789012345678",
+        "tiktok",
+        "7123456789012345678",
+      ],
+    ])("%s → %s/%s", (url, platform, videoId) => {
+      const result = normalizeVideoUrl(url);
+      expect(result).not.toBeNull();
+      expect(result!.platform).toBe(platform);
+      expect(result!.videoId).toBe(videoId);
+    });
+  });
+
+  describe("recognizes mobile/intent inputs end-to-end", () => {
+    it.each([
+      ["vnd.youtube://watch?v=dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      ["youtube://watch?v=dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ"],
+      [
+        "intent://www.youtube.com/watch?v=dQw4w9WgXcQ#Intent;package=com.google.android.youtube;end",
+        "youtube",
+        "dQw4w9WgXcQ",
+      ],
+      [
+        "snssdk1233://aweme/detail/7123456789012345678",
+        "tiktok",
+        "7123456789012345678",
+      ],
+      [
+        "tiktok://aweme/detail/7123456789012345678",
+        "tiktok",
+        "7123456789012345678",
+      ],
+      [
+        "intent://www.tiktok.com/@user/video/7123456789012345678#Intent;package=com.zhiliaoapp.musically;end",
+        "tiktok",
+        "7123456789012345678",
+      ],
+      [
+        "intent://vm.tiktok.com/ZMabc123/#Intent;package=com.zhiliaoapp.musically;end",
+        "tiktok",
+        "ZMabc123",
+      ],
+    ])("%s → %s/%s", (raw, platform, videoId) => {
+      const result = normalizeVideoUrl(raw);
+      expect(result).not.toBeNull();
+      expect(result!.platform).toBe(platform);
+      expect(result!.videoId).toBe(videoId);
+    });
+  });
+
+  describe("rejects non-video URLs", () => {
+    it.each([
+      "https://vimeo.com/123456",
+      "https://www.facebook.com/watch?v=12345",
+      "https://example.com",
+      "not a url",
+      "",
+      "https://www.tiktok.com/discover",
+      "https://www.tiktok.com/@user",
+    ])("%s → null", (raw) => {
+      expect(normalizeVideoUrl(raw)).toBeNull();
+    });
+  });
+});

--- a/mobile/src/utils/urlNormalizer.ts
+++ b/mobile/src/utils/urlNormalizer.ts
@@ -1,0 +1,109 @@
+/**
+ * urlNormalizer — Client-side video URL normalization (mobile / Expo RN).
+ *
+ * Mirrors backend/src/voice/url_validator.py::normalize_url + parse_video_url
+ * and frontend/src/utils/urlNormalizer.ts (kept in sync intentionally — this
+ * project deliberately duplicates instead of sharing a workspace package).
+ *
+ * Accepts ANY format the user might paste from a YouTube/TikTok share sheet:
+ *   - canonical https URLs (web, mobile m.*, youtu.be, vm.tiktok.com, /shorts/, /embed/)
+ *   - mobile native schemes  (vnd.youtube://, youtube://, tiktok://, snssdk*)
+ *   - Android intent links   (intent://...#Intent;...;end)
+ *
+ * Returns null when the input doesn't match a known YouTube/TikTok pattern.
+ */
+
+export type NormalizedVideoUrl = {
+  platform: "youtube" | "tiktok";
+  canonicalUrl: string;
+  videoId: string;
+};
+
+// ── canonical regexes (mirror backend) ─────────────────────────────
+const YOUTUBE_RE =
+  /^https?:\/\/(?:www\.|m\.)?(?:youtube\.com\/(?:watch\?v=|shorts\/|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+const TIKTOK_VM_RE = /^https?:\/\/vm\.tiktok\.com\/([A-Za-z0-9]+)\/?/;
+const TIKTOK_RE =
+  /^https?:\/\/(?:www\.|m\.)?tiktok\.com\/(?:@[\w.-]+\/video\/(\d+)|t\/([A-Za-z0-9]+)|v\/(\d+))/;
+
+// ── mobile/intent rewrite regexes ──────────────────────────────────
+const YT_SCHEME_RE =
+  /^(?:vnd\.youtube|youtube):\/\/(?:watch\?v=|.*[?&]v=)([a-zA-Z0-9_-]{11})/i;
+const YT_SCHEME_BARE_RE = /^(?:vnd\.youtube|youtube):([a-zA-Z0-9_-]{11})$/i;
+const INTENT_RE = /^intent:\/\/(.+?)#Intent;/i;
+const TIKTOK_SNSSDK_RE = /^snssdk\d+:\/\/aweme\/detail\/(\d+)/i;
+const TIKTOK_SCHEME_VIDEO_RE = /^tiktok:\/\/[^/]*\/?(?:.*?\/)?video\/(\d+)/i;
+const TIKTOK_SCHEME_AWEME_RE = /^tiktok:\/\/aweme\/detail\/(\d+)/i;
+
+/**
+ * Normalize a raw URL/scheme/intent string into a canonical HTTPS URL.
+ * Pass-through for unknown patterns (returns the trimmed input).
+ */
+export function normalizeUrl(raw: string): string {
+  if (!raw) return raw;
+  const url = raw.trim();
+  if (!url) return url;
+
+  let m = url.match(YT_SCHEME_RE);
+  if (m) return `https://www.youtube.com/watch?v=${m[1]}`;
+  m = url.match(YT_SCHEME_BARE_RE);
+  if (m) return `https://www.youtube.com/watch?v=${m[1]}`;
+
+  m = url.match(TIKTOK_SNSSDK_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+  m = url.match(TIKTOK_SCHEME_AWEME_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+  m = url.match(TIKTOK_SCHEME_VIDEO_RE);
+  if (m) return `https://www.tiktok.com/@_/video/${m[1]}`;
+
+  m = url.match(INTENT_RE);
+  if (m) {
+    const body = m[1];
+    if (body.includes("://")) return normalizeUrl(body);
+    return `https://${body}`;
+  }
+
+  return url;
+}
+
+/**
+ * Detect (platform, canonicalUrl, videoId) from any user-pasted string.
+ * Returns null if the input isn't a recognized YouTube/TikTok video.
+ */
+export function normalizeVideoUrl(raw: string): NormalizedVideoUrl | null {
+  if (!raw) return null;
+  const url = normalizeUrl(raw);
+  if (!url) return null;
+
+  const ytMatch = url.match(YOUTUBE_RE);
+  if (ytMatch) {
+    return {
+      platform: "youtube",
+      canonicalUrl: url,
+      videoId: ytMatch[1],
+    };
+  }
+
+  const ttVmMatch = url.match(TIKTOK_VM_RE);
+  if (ttVmMatch) {
+    return {
+      platform: "tiktok",
+      canonicalUrl: url,
+      videoId: ttVmMatch[1],
+    };
+  }
+
+  const ttMatch = url.match(TIKTOK_RE);
+  if (ttMatch) {
+    const videoId = ttMatch[1] ?? ttMatch[2] ?? ttMatch[3];
+    if (videoId) {
+      return {
+        platform: "tiktok",
+        canonicalUrl: url,
+        videoId,
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Ajoute un bouton **Paste Link** 📋 sur **7 inputs chat** des 3 plateformes (mobile, extension Chrome, web). Le bouton lit le clipboard, normalise les liens vidéo (YouTube + TikTok dans tous formats : web URLs, schemes iOS, intents Android, deep-links share), et insère dans l'input avec feedback.

Backend tolérant + util TS partagé + composant `<PasteLinkButton>` × 3.

## Architecture (3 layers)

### Layer 1 — Backend `normalize_url` tolérant
`backend/src/voice/url_validator.py` + `backend/src/utils/video_id.py` :
- `vnd.youtube://watch?v=ID` → `https://www.youtube.com/watch?v=ID`
- `youtube://watch?v=ID` → idem
- `vnd.youtube:ID` (bare, sans //) → idem
- `intent://www.youtube.com/watch?v=ID#Intent;package=...;end` → `https://www.youtube.com/watch?v=ID`
- `snssdk1233://aweme/detail/ID` → `https://www.tiktok.com/@_/video/ID`
- `tiktok://...` (variants) → `https://www.tiktok.com/@_/video/ID`
- Intent récursif si body contient un autre scheme
- HTTPS canonique : passthrough
- `parse_video_url()` appelle `normalize_url()` en tête → `/videos/analyze` accepte automatiquement tous les formats

### Layer 2 — Util TS partagé (3 fichiers dupliqués, mirror backend)
- `mobile/src/utils/urlNormalizer.ts`
- `extension/src/utils/urlNormalizer.ts`
- `frontend/src/utils/urlNormalizer.ts`

Signature commune :
\`\`\`ts
export type NormalizedVideoUrl = { platform: 'youtube' | 'tiktok'; canonicalUrl: string; videoId: string };
export function normalizeUrl(raw: string): string;
export function normalizeVideoUrl(raw: string): NormalizedVideoUrl | null;
\`\`\`

### Layer 3 — Composant `<PasteLinkButton>` (3 implémentations)
- `frontend/src/components/PasteLinkButton.tsx` (web — `navigator.clipboard.readText()`)
- `extension/src/sidepanel/components/PasteLinkButton.tsx` (Manifest V3 — `clipboardRead` permission ajoutée)
- `mobile/src/components/shared/PasteLinkButton.tsx` (Expo — `Clipboard.getStringAsync()`)

UX : tap → si clipboard contient lien valide → insert + feedback `"✓ Lien YouTube détecté"` / `"✓ Lien TikTok détecté"`. Si pas de lien → insert brut + toast `"Pas un lien vidéo reconnu"`. Si vide → toast `"Presse-papiers vide"`.

## 7 inputs intégrés

**Mobile (3)** :
- `mobile/src/components/conversation/ConversationInput.tsx` (Hub unifié — Quick Voice Call)
- `mobile/src/components/chat/ChatInput.tsx` (Quick Chat partagé)
- `mobile/src/components/analysis/ChatInput.tsx` (variant analysis screen)

**Extension (1)** :
- `extension/src/sidepanel/components/ConversationInput.tsx` (Quick Voice Call sidepanel)

**Web (3)** :
- `frontend/src/components/hub/InputBar.tsx` (Hub chat + PTT mic + Phone)
- `frontend/src/components/ChatPanel.tsx` (textarea analysis chat)
- `frontend/src/components/ChatPopup.tsx` (popup chat moderne)

**Référence existante intacte** : `frontend/src/components/SmartInputBar.tsx` (déjà bouton paste à lignes 845-865) et `mobile/src/components/home/URLInput.tsx` (déjà bouton "Coller" lignes 164-174) — laissés intacts comme demandé.

## Manifest extension

\`\`\`diff
   "permissions": [
     "storage",
     "activeTab",
     "tabs",
     "alarms",
     "identity",
     "clipboardWrite",
+    "clipboardRead",
     "sidePanel",
     "offscreen"
   ],
\`\`\`
Au reload, Chrome demandera la permission une fois.

## Tests

- **Backend pytest** : 43/43 ✅ (20 existants + 23 nouveaux cas mobile schemes + intents)
- **Frontend vitest** : 34/34 ✅ (`urlNormalizer.test.ts`)
- **Mobile jest** : 34/34 ✅ (`urlNormalizer.test.ts`)
- **TS `tsc --noEmit`** : zéro erreur sur les fichiers touchés
- **Extension** : pas de framework de test wired (`passWithNoTests`), util identique aux 2 autres plateformes

## Test plan

- [ ] CI : tous workflows verts (Backend Pytest, Frontend Vitest, Mobile CI, Extension CI)
- [ ] Smoke web : copier lien YT classique → bouton paste insère + toast détection
- [ ] Smoke web : copier lien `vnd.youtube://...` → normalize visible + toast YouTube
- [ ] Smoke extension : reload après installation → permission `clipboardRead` demandée → accept
- [ ] Smoke extension : copier lien TikTok mobile (`snssdk1233://`) → paste → insert HTTPS canonique
- [ ] Smoke mobile iOS : copier lien YouTube depuis app YT → paste → toast détection
- [ ] Smoke mobile Android : copier lien partage TikTok (intent://) → paste → insert HTTPS canonique

## Notes

- `setTimeout(1600ms)` inline pour le tooltip mobile/extension (pas de toast global). Le composant web accepte `showToast` prop optionnelle pour brancher un système toast existant.
- Pas de breaking change : tous les inputs gardent leurs props existantes, le bouton est purement additif.
- Refactor optionnel pour faire passer `SmartInputBar.tsx` (web) et `URLInput.tsx` (mobile) par `<PasteLinkButton>` reporté (hors scope strict).