### PR TITLE
feat(debate): multi-criteria perspective matching — Wave 2 A

### DIFF
--- a/backend/alembic/versions/016_debate_v2_video_b_candidates_cache.py
+++ b/backend/alembic/versions/016_debate_v2_video_b_candidates_cache.py
@@ -1,0 +1,78 @@
+"""debate v2 — video_b_candidates cache table (cache only, perspectives table is in 017)
+
+Revision ID: 016_debate_v2_video_b_candidates_cache
+Revises: 015_add_search_index_tables
+Create Date: 2026-05-04
+
+Sub-agent A scope (Wave 2 / Débat IA v2):
+
+  Crée UNIQUEMENT la table de cache `debate_video_b_candidates` (TTL 7 jours).
+  Cette table sert au pipeline `_search_perspective_video` du module
+  `debate.matching` pour cacher le top-5 des candidats trouvés par
+  (topic, relation_type, lang, duration_bucket).
+
+  La table `debate_perspectives` ainsi que les nouvelles colonnes sur
+  `debate_analyses` (`relation_type_dominant`, `miro_board_url`,
+  `miro_board_id`) sont déléguées à la migration 017 (Sub-agent B / PR
+  adaptative). Voir spec docs/superpowers/specs/2026-05-04-debate-ia-v2.md §4.
+
+Idempotence : on garde des CREATE INDEX/TABLE non guardés volontairement —
+si la table existe déjà alembic remontera l'erreur, ce qui est le comportement
+souhaité (signal d'incohérence d'historique).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "016_debate_v2_video_b_candidates_cache"
+down_revision: Union[str, None] = "015_add_search_index_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create debate_video_b_candidates cache table + indexes."""
+    op.create_table(
+        "debate_video_b_candidates",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("cache_key", sa.String(64), nullable=False),  # sha256 hex
+        sa.Column("topic_normalized", sa.String(255), nullable=True),
+        sa.Column("relation_type", sa.String(20), nullable=False),
+        sa.Column("lang", sa.String(5), nullable=False),
+        sa.Column("duration_bucket", sa.String(10), nullable=False),
+        sa.Column("candidates_json", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("cache_key", name="uq_debate_video_b_candidates_key"),
+    )
+    op.create_index(
+        "idx_debate_video_b_candidates_key",
+        "debate_video_b_candidates",
+        ["cache_key"],
+    )
+    op.create_index(
+        "idx_debate_video_b_candidates_expires",
+        "debate_video_b_candidates",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop indexes + table."""
+    op.drop_index(
+        "idx_debate_video_b_candidates_expires",
+        table_name="debate_video_b_candidates",
+    )
+    op.drop_index(
+        "idx_debate_video_b_candidates_key",
+        table_name="debate_video_b_candidates",
+    )
+    op.drop_table("debate_video_b_candidates")

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -1061,6 +1061,31 @@ class DebateChatMessage(Base):
     __table_args__ = (Index("idx_debate_chat_messages_debate", "debate_id"),)
 
 
+class DebateVideoBCandidatesCache(Base):
+    """Cache 7j des candidats matching B (top-5) pour un (topic, relation, lang, bucket).
+
+    Sprint Débat IA v2 — alembic 016 (cache table only — perspectives table arrives in 017).
+    Cf. docs/superpowers/specs/2026-05-04-debate-ia-v2.md §4.3 / §4.4.
+    """
+
+    __tablename__ = "debate_video_b_candidates"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    cache_key = Column(String(64), unique=True, nullable=False, index=True)  # sha256 hex
+    topic_normalized = Column(String(255))  # debug uniquement
+    relation_type = Column(String(20), nullable=False)  # 'opposite' | 'complement' | 'nuance'
+    lang = Column(String(5), nullable=False)
+    duration_bucket = Column(String(10), nullable=False)  # 'short' | 'medium' | 'long'
+    candidates_json = Column(Text, nullable=False)  # JSON list of top-5 PerspectiveCandidate
+    created_at = Column(DateTime, default=func.now(), nullable=False)
+    expires_at = Column(DateTime, nullable=False, index=True)
+
+    __table_args__ = (
+        Index("idx_debate_video_b_candidates_key", "cache_key"),
+        Index("idx_debate_video_b_candidates_expires", "expires_at"),
+    )
+
+
 class SharedAnalysis(Base):
     """Table des analyses partagées (liens publics)"""
 

--- a/backend/src/debate/matching.py
+++ b/backend/src/debate/matching.py
@@ -1,0 +1,933 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎯 DEBATE MATCHING v2 — Multi-criteria perspective video search                  ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Refonte du legacy `_search_opposing_video` (router.py:280-359) en pipeline       ║
+║  multi-critères paramétré par `relation_type` ∈ {opposite, complement, nuance}.  ║
+║                                                                                    ║
+║  Pipeline :                                                                        ║
+║  1. Cache lookup (debate_video_b_candidates, hash topic+relation+filters, 7j)     ║
+║  2. Mistral génère 2 search queries adaptées à relation_type                      ║
+║  3. Brave Search YouTube (count=15) pour chaque query                             ║
+║  4. Filtrage dur (excluded ids, durée tier-aware short→short, langue)            ║
+║  5. Scoring composite multi-critères :                                            ║
+║       0.30 duration + 0.20 channel_quality + 0.15 freshness                       ║
+║       + 0.20 audience + 0.15 query_relevance                                      ║
+║     duration_match_score == 0  ⇒  rejet immédiat (-inf)                           ║
+║  6. Diversity rule for 'nuance' : prefer audience opposite to existing            ║
+║  7. Pick top-1, persist top-5 in cache, return                                    ║
+║                                                                                    ║
+║  Spec : docs/superpowers/specs/2026-05-04-debate-ia-v2.md  §4.1 / §4.4 / §5      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📋 TYPES & CONSTANTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+RelationType = Literal["opposite", "complement", "nuance"]
+AudienceLevel = Literal["vulgarisation", "expert", "unknown"]
+DurationBucket = Literal["short", "medium", "long"]
+
+CACHE_TTL_SECONDS: int = 7 * 24 * 3600  # 7 days
+
+# ── Scoring weights (cf. spec §4.1) ───────────────────────────────────────────
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "duration_match": 0.30,
+    "channel_quality": 0.20,
+    "freshness": 0.15,
+    "audience": 0.20,
+    "query_relevance": 0.15,
+}
+
+# ── Channel heuristics ────────────────────────────────────────────────────────
+TRASH_CHANNEL_PATTERNS: List[str] = [
+    r"clickbait",
+    r"top \d+ shocking",
+    r"\bfake\b",
+    r"truth.*exposed",
+    r"compilation \d{4}",
+    r"reupload",
+]
+
+EDU_CHANNEL_BONUS: List[str] = [
+    "ScienceEtonnante",
+    "Heu?reka",
+    "Mr Phi",
+    "DirtyBiology",
+    "Crash Course",
+    "Kurzgesagt",
+    "Veritasium",
+    "3Blue1Brown",
+    "PBS Eons",
+    "Numberphile",
+    "Computerphile",
+]
+
+# ── Channel-quality threshold below which candidate is dropped ────────────────
+TRASH_QUALITY_FLOOR: float = 0.2
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 DATACLASSES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class PerspectiveFilters:
+    """Filtres + signaux à transmettre au pipeline matching.
+
+    `excluded_video_ids` couvre la vidéo A et toute perspective déjà persistée.
+    `excluded_audience_levels` est utilisé par la règle de diversité (relation
+    `nuance` → on évite l'audience déjà couverte côté A si renseignée).
+    """
+
+    video_a_id: str
+    video_a_title: str = ""
+    video_a_channel: str = ""
+    video_a_duration_seconds: int = 0
+    excluded_video_ids: set = field(default_factory=set)
+    excluded_audience_levels: set = field(default_factory=set)
+    user_plan: str = "free"
+
+
+@dataclass
+class PerspectiveCandidate:
+    """Candidat scoré renvoyé par le pipeline matching."""
+
+    video_id: str
+    platform: str
+    title: str
+    channel: str
+    thumbnail: str
+    duration_seconds: int
+    published_at: Optional[str]
+    audience_level: AudienceLevel
+    channel_quality_score: float
+    raw_query: str
+    score: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🪪 TIER MAPPING (format-aware, 3 buckets ≠ Duration Router 6 tiers)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def tier_from_duration(duration_seconds: int) -> DurationBucket:
+    """Retourne le bucket strict de matching ('short'|'medium'|'long').
+
+    Justification du mapping 3-tiers : pour le matching on veut éviter qu'une
+    vidéo de 8 min soit comparée à une de 2 h. 3 buckets suffisent (cf. spec §3.3).
+    """
+    if not duration_seconds or duration_seconds <= 0:
+        # Pas d'info → on traite comme 'medium' pour ne pas tout rejeter
+        return "medium"
+    if duration_seconds < 60:
+        return "short"
+    if duration_seconds < 1200:  # 20 min
+        return "medium"
+    return "long"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📊 SCORING HELPERS — un par dimension
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _apply_duration_filter(
+    candidate_duration: int, target_duration: int
+) -> float:
+    """Score 0..1 strict format-aware.
+
+    Matching parfait (même bucket)  → 1.0
+    Bucket différent                → 0.0  (rejet immédiat en aval)
+    """
+    target_bucket = tier_from_duration(target_duration)
+    candidate_bucket = tier_from_duration(candidate_duration)
+    return 1.0 if candidate_bucket == target_bucket else 0.0
+
+
+def _apply_channel_quality_filter(
+    channel_name: str, channel_context: Optional[Dict[str, Any]]
+) -> float:
+    """Score 0..1. Combine bonus éducatif, blacklist, signaux ch_ctx (cf. §3.4)."""
+    name = (channel_name or "").lower()
+    score = 0.5  # baseline neutre
+
+    for trash in TRASH_CHANNEL_PATTERNS:
+        if re.search(trash, name, re.I):
+            score -= 0.4
+
+    for edu in EDU_CHANNEL_BONUS:
+        if edu.lower() in name:
+            score += 0.3
+            break  # un seul bonus pour ne pas exploser le score
+
+    if channel_context:
+        try:
+            chapters_pct = float(channel_context.get("has_chapters_pct", 0) or 0)
+            avg_dur = float(
+                channel_context.get("avg_video_duration_seconds", 0) or 0
+            )
+        except (TypeError, ValueError):
+            chapters_pct, avg_dur = 0.0, 0.0
+        if chapters_pct > 0.6:
+            score += 0.1
+        if avg_dur > 600:
+            score += 0.05
+
+    return max(0.0, min(1.0, score))
+
+
+def _apply_freshness_weight(published_at: Optional[str]) -> float:
+    """Pondéré ±12 mois mais pas strict. Vieille vidéo OK si très pertinente."""
+    if not published_at:
+        return 0.5
+    try:
+        cleaned = published_at.replace("Z", "+00:00")
+        d = datetime.fromisoformat(cleaned)
+        if d.tzinfo is None:
+            d = d.replace(tzinfo=timezone.utc)
+    except (ValueError, AttributeError):
+        return 0.5
+
+    months_old = (datetime.now(timezone.utc) - d).days / 30.0
+    if months_old < 0:
+        # Future-dated metadata bug → treat as fresh
+        return 1.0
+    if months_old < 12:
+        return 1.0
+    if months_old < 24:
+        return 0.7
+    if months_old < 60:
+        return 0.4
+    return 0.2  # >5 ans : badge "Vidéo de YYYY" affiché côté UI
+
+
+def _detect_audience(
+    candidate: Dict[str, Any], channel_context: Optional[Dict[str, Any]]
+) -> AudienceLevel:
+    """Retourne 'vulgarisation' | 'expert' | 'unknown' (heuristique titre+ch_ctx)."""
+    title_lower = (candidate.get("title") or "").lower()
+
+    vulgar_markers = (
+        "explained",
+        "expliqué",
+        "intro",
+        "beginner",
+        "débutant",
+        "for dummies",
+        "pour les nuls",
+    )
+    expert_markers = (
+        "paper",
+        "research",
+        "deep dive",
+        "advanced",
+        "phd",
+        "thèse",
+        "conference",
+        "preprint",
+        "lecture",
+    )
+
+    if any(t in title_lower for t in vulgar_markers):
+        return "vulgarisation"
+    if any(t in title_lower for t in expert_markers):
+        return "expert"
+
+    if channel_context:
+        try:
+            avg_dur = float(
+                channel_context.get("avg_video_duration_seconds", 0) or 0
+            )
+        except (TypeError, ValueError):
+            avg_dur = 0.0
+        if avg_dur > 1800:  # >30 min en moyenne → tendance expert
+            return "expert"
+
+    return "unknown"
+
+
+def _apply_audience_filter(
+    candidate_audience: AudienceLevel,
+    relation_type: RelationType,
+    excluded_audience_levels: Optional[set] = None,
+) -> float:
+    """Retourne un score 0..1 selon la règle :
+
+    - 'opposite' : strict, aucune préférence (neutre 0.5)
+    - 'complement' : neutre 0.6 (légère préférence pour des angles différents)
+    - 'nuance' : diversifier — bonus si l'audience candidate diffère de celles
+      déjà présentes dans `excluded_audience_levels` (ex: A=vulgar → bonus expert).
+    """
+    excluded = excluded_audience_levels or set()
+
+    if relation_type == "nuance":
+        # Bonus diversité quand on apporte un angle audience différent
+        if candidate_audience != "unknown" and candidate_audience not in excluded:
+            return 1.0
+        if candidate_audience == "unknown":
+            return 0.4
+        return 0.5  # déjà couvert → pas pénalisé mais pas bonus
+
+    if relation_type == "complement":
+        # Légère préférence pour des angles non encore couverts
+        if candidate_audience != "unknown" and candidate_audience not in excluded:
+            return 0.75
+        return 0.6
+
+    # opposite : pas de préférence d'audience particulière
+    return 0.5
+
+
+def _query_relevance_score(rank_in_results: int, total: int) -> float:
+    """Score 0..1 basé sur la position du candidat dans Brave search rank.
+
+    Plus le résultat apparaît tôt dans la liste, plus le score est élevé.
+    Décroissance douce : pos 0 → 1.0, pos 5 → ~0.66, pos 10 → ~0.45.
+    """
+    if total <= 0 or rank_in_results < 0:
+        return 0.5
+    # Decay exponentiel léger
+    return float(math.exp(-rank_in_results / 8.0))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧮 SCORE COMPOSITE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def score_candidate(
+    candidate: Dict[str, Any],
+    filters: PerspectiveFilters,
+    relation_type: RelationType,
+    rank_in_results: int = 0,
+    total_results: int = 1,
+    channel_context: Optional[Dict[str, Any]] = None,
+    weights: Optional[Dict[str, float]] = None,
+) -> float:
+    """Compute a composite score for a candidate dict.
+
+    `candidate` shape (post-Brave normalization) :
+        {video_id, title, channel, duration_seconds, published_at, thumbnail}
+
+    Returns:
+        composite score ∈ [0..1] OR -inf if duration_match == 0 (rejet).
+    """
+    w = weights or DEFAULT_WEIGHTS
+
+    duration_score = _apply_duration_filter(
+        candidate.get("duration_seconds") or 0,
+        filters.video_a_duration_seconds,
+    )
+    if duration_score == 0:
+        return float("-inf")  # rejet immédiat (cf. spec §4.1)
+
+    channel_quality = _apply_channel_quality_filter(
+        candidate.get("channel") or "", channel_context
+    )
+    freshness = _apply_freshness_weight(candidate.get("published_at"))
+    audience = _detect_audience(candidate, channel_context)
+    audience_score = _apply_audience_filter(
+        audience, relation_type, filters.excluded_audience_levels
+    )
+    relevance = _query_relevance_score(rank_in_results, total_results)
+
+    composite = (
+        duration_score * w["duration_match"]
+        + channel_quality * w["channel_quality"]
+        + freshness * w["freshness"]
+        + audience_score * w["audience"]
+        + relevance * w["query_relevance"]
+    )
+    return float(max(0.0, min(1.0, composite)))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔎 QUERY GENERATION (Mistral, adapted to relation_type)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+_RELATION_INSTRUCTIONS: Dict[str, str] = {
+    "opposite": (
+        "Tu cherches une vidéo qui CONTREDIT, CRITIQUE ou OPPOSE la thèse. "
+        "Mots-clés antagonistes : critique, problème, limite, contre, debunked, myth, "
+        "issue, vs, fake, overrated."
+    ),
+    "complement": (
+        "Tu cherches une vidéo qui COMPLÈTE, ENRICHIT ou ÉTEND la thèse sous un autre angle. "
+        "Mots-clés : approfondir, perspective, autre, complément, étude de cas, case study, "
+        "deep dive, exploration, behind the scenes, insider."
+    ),
+    "nuance": (
+        "Tu cherches une vidéo qui APPORTE DE LA NUANCE — ni totalement pour ni contre, "
+        "mais conditionnelle ou contextuelle. Mots-clés : nuance, dépend, contexte, "
+        "limites de, when does X work, conditions, exceptions, depends on, edge cases."
+    ),
+}
+
+
+async def _generate_queries_for_relation(
+    topic: str,
+    thesis_a: str,
+    relation_type: RelationType,
+    title_to_avoid: str,
+    lang: str,
+    model: str,
+    call_mistral_fn,
+    extract_json_fn,
+) -> List[str]:
+    """Mistral génère 2 queries YouTube adaptées au type de relation.
+
+    `call_mistral_fn` et `extract_json_fn` sont injectés pour faciliter le test
+    (au lieu d'importer en dur depuis router.py et créer un cycle).
+    """
+    instruction = _RELATION_INSTRUCTIONS.get(
+        relation_type, _RELATION_INSTRUCTIONS["opposite"]
+    )
+    lang_inst = (
+        "Formule en français." if lang == "fr" else "Write in English."
+    )
+    sys_prompt = (
+        "Tu es expert en recherche YouTube. Génère DEUX requêtes (5-10 mots chacune) "
+        f"susceptibles de retourner une vidéo qui {instruction} "
+        f"NE REPRODUIS PAS le titre original. {lang_inst} "
+        'Réponds UNIQUEMENT en JSON : {"query_primary": "...", "query_alternative": "..."}'
+    )
+    user_prompt = (
+        f"Sujet : {topic}\nThèse : {thesis_a}\nTitre à éviter : {title_to_avoid or '(inconnu)'}"
+    )
+
+    raw = await call_mistral_fn(
+        [
+            {"role": "system", "content": sys_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        model=model,
+        temperature=0.6,
+        json_mode=True,
+    )
+    if not raw:
+        return []
+
+    parsed = extract_json_fn(raw) or {}
+    queries: List[str] = []
+    if isinstance(parsed, dict):
+        for key in ("query_primary", "query_alternative"):
+            q = parsed.get(key)
+            if isinstance(q, str) and q.strip():
+                queries.append(q.strip().strip('"').strip("'")[:100])
+    return queries
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 💾 CACHE — debate_video_b_candidates (TTL 7 days)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def compute_candidates_cache_key(
+    topic: str, relation_type: RelationType, lang: str, duration_a: int
+) -> str:
+    """Déterministe sha256 hex (cf. spec §3.5).
+
+    Bucket `short|medium|long` au lieu de la durée brute → plus de hits cache.
+    """
+    bucket = tier_from_duration(duration_a)
+    raw = f"v2|{(topic or '').lower().strip()[:200]}|{relation_type}|{lang}|{bucket}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+async def _get_cached_candidates(
+    cache_key: str, db: AsyncSession
+) -> Optional[List[Dict[str, Any]]]:
+    """Lit la table debate_video_b_candidates (PG L2). Retourne None si miss/expiré."""
+    try:
+        # Import lazy pour éviter un cycle si database.py n'est pas encore prêt
+        from db.database import DebateVideoBCandidatesCache
+    except ImportError:
+        logger.debug(
+            "[DEBATE-MATCH] DebateVideoBCandidatesCache model not available — skip cache"
+        )
+        return None
+
+    try:
+        result = await db.execute(
+            select(DebateVideoBCandidatesCache).where(
+                DebateVideoBCandidatesCache.cache_key == cache_key
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        # TTL check (côté app, pas de scheduler purge encore)
+        expires_at = row.expires_at
+        if expires_at is not None:
+            now = datetime.now(timezone.utc)
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            if expires_at <= now:
+                return None
+        try:
+            data = json.loads(row.candidates_json) if row.candidates_json else None
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(data, list):
+            return None
+        return data
+    except Exception as exc:  # noqa: BLE001 — best-effort cache layer
+        logger.warning("[DEBATE-MATCH] Cache lookup failed: %s", str(exc)[:200])
+        return None
+
+
+async def _put_cached_candidates(
+    cache_key: str,
+    candidates: List[Dict[str, Any]],
+    relation_type: RelationType,
+    lang: str,
+    duration_bucket: DurationBucket,
+    topic_normalized: str,
+    db: AsyncSession,
+    ttl_seconds: int = CACHE_TTL_SECONDS,
+) -> None:
+    """Upsert (cache_key) sur la table debate_video_b_candidates."""
+    try:
+        from db.database import DebateVideoBCandidatesCache
+    except ImportError:
+        logger.debug(
+            "[DEBATE-MATCH] DebateVideoBCandidatesCache model unavailable — skip cache write"
+        )
+        return
+
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    try:
+        # Try update first (cheap path), then insert
+        result = await db.execute(
+            select(DebateVideoBCandidatesCache).where(
+                DebateVideoBCandidatesCache.cache_key == cache_key
+            )
+        )
+        existing = result.scalar_one_or_none()
+        candidates_json = json.dumps(candidates, ensure_ascii=False)
+        if existing:
+            existing.candidates_json = candidates_json
+            existing.expires_at = expires_at
+            existing.relation_type = relation_type
+            existing.lang = lang
+            existing.duration_bucket = duration_bucket
+            existing.topic_normalized = topic_normalized[:255]
+        else:
+            db.add(
+                DebateVideoBCandidatesCache(
+                    cache_key=cache_key,
+                    relation_type=relation_type,
+                    lang=lang,
+                    duration_bucket=duration_bucket,
+                    candidates_json=candidates_json,
+                    topic_normalized=topic_normalized[:255],
+                    created_at=now,
+                    expires_at=expires_at,
+                )
+            )
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[DEBATE-MATCH] Cache write failed: %s", str(exc)[:200])
+        try:
+            await db.rollback()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 BRAVE NORMALIZATION — extract video_id, clean title, etc.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_YT_PATTERN = re.compile(r"youtube\.com/watch\?v=([a-zA-Z0-9_-]{11})")
+
+
+def _normalize_brave_result(
+    result: Dict[str, Any], query: str
+) -> Optional[Dict[str, Any]]:
+    """Convertit un result Brave en dict candidate normalisé.
+
+    Returns None si pas un YouTube URL exploitable.
+    """
+    url = result.get("url") or ""
+    match = _YT_PATTERN.search(url)
+    if not match:
+        return None
+
+    video_id = match.group(1)
+    raw_title = result.get("title") or ""
+    try:
+        fixed_title = raw_title.encode("latin-1").decode("utf-8")
+    except (UnicodeDecodeError, UnicodeEncodeError):
+        fixed_title = raw_title
+    if fixed_title.endswith(" - YouTube"):
+        fixed_title = fixed_title[: -len(" - YouTube")].strip()
+
+    description = (result.get("description") or "").strip()
+    # Brave parfois met la chaîne dans description ou meta_url.hostname-like
+    channel = result.get("channel") or ""
+    if not channel and description:
+        # Best-effort : la description Brave commence souvent par "ChannelName · ..."
+        # On laisse vide si pas trouvable, le scoring tolère.
+        pass
+
+    duration_seconds = 0
+    raw_duration = result.get("duration_seconds") or result.get("duration") or 0
+    try:
+        duration_seconds = int(raw_duration) if raw_duration else 0
+    except (TypeError, ValueError):
+        duration_seconds = 0
+
+    return {
+        "video_id": video_id,
+        "platform": "youtube",
+        "title": fixed_title,
+        "channel": channel,
+        "thumbnail": result.get("thumbnail") or "",
+        "duration_seconds": duration_seconds,
+        "published_at": result.get("published_at") or result.get("page_age"),
+        "url": url,
+        "raw_query": query,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 PUBLIC ENTRY — _search_perspective_video
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _search_perspective_video(
+    topic: str,
+    thesis_a: str,
+    relation: RelationType,
+    filters: PerspectiveFilters,
+    lang: str = "fr",
+    *,
+    db: Optional[AsyncSession] = None,
+    model: str = "mistral-small-2603",
+    call_mistral_fn=None,
+    extract_json_fn=None,
+    brave_search_fn=None,
+    channel_context_fn=None,
+    weights: Optional[Dict[str, float]] = None,
+) -> Optional[PerspectiveCandidate]:
+    """Pipeline matching multi-critères pour trouver la perspective B.
+
+    Args:
+        topic: sujet détecté côté A.
+        thesis_a: thèse défendue par A.
+        relation: 'opposite' | 'complement' | 'nuance'.
+        filters: PerspectiveFilters (durée A, excluded ids, plan, etc.).
+        lang: 'fr' | 'en'.
+        db: AsyncSession pour le cache (peut être None → cache désactivé).
+        model: Mistral model id pour la query gen (default small).
+        call_mistral_fn / extract_json_fn / brave_search_fn / channel_context_fn:
+            injections pour faciliter les tests. Si None, fallbacks production
+            via debate.router._call_mistral / _extract_json / _brave_youtube_search
+            et services.channel_content_cache.get_or_fetch_channel_context.
+
+    Returns:
+        Top-1 PerspectiveCandidate ou None si aucun candidat acceptable trouvé.
+    """
+    # ── Lazy injection des fallbacks production ───────────────────────────────
+    if call_mistral_fn is None or extract_json_fn is None:
+        from debate.router import (  # type: ignore
+            _call_mistral as _prod_call_mistral,
+            _extract_json as _prod_extract_json,
+        )
+
+        call_mistral_fn = call_mistral_fn or _prod_call_mistral
+        extract_json_fn = extract_json_fn or _prod_extract_json
+
+    if brave_search_fn is None:
+        from debate.router import _brave_youtube_search as _prod_brave  # type: ignore
+
+        brave_search_fn = _prod_brave
+
+    if channel_context_fn is None:
+        try:
+            from services.channel_content_cache import (  # type: ignore
+                get_or_fetch_channel_context as _prod_chan_ctx,
+            )
+
+            channel_context_fn = _prod_chan_ctx
+        except ImportError:
+            channel_context_fn = None  # graceful: scoring tolère ch_ctx None
+
+    duration_bucket = tier_from_duration(filters.video_a_duration_seconds)
+
+    # ── 0) Cache lookup ───────────────────────────────────────────────────────
+    cache_key = compute_candidates_cache_key(
+        topic, relation, lang, filters.video_a_duration_seconds
+    )
+    if db is not None:
+        cached = await _get_cached_candidates(cache_key, db)
+        if cached:
+            for cand in cached:
+                if cand.get("video_id") not in filters.excluded_video_ids:
+                    logger.info(
+                        "[DEBATE-MATCH] cache_hit relation=%s key=%s",
+                        relation,
+                        cache_key[:16],
+                    )
+                    try:
+                        return PerspectiveCandidate(**{
+                            k: v for k, v in cand.items()
+                            if k in PerspectiveCandidate.__dataclass_fields__
+                        })
+                    except TypeError:
+                        # Schema drift → fallthrough to live search
+                        break
+
+    # ── 1) Brave key gating ───────────────────────────────────────────────────
+    try:
+        from core.config import get_brave_key  # type: ignore
+
+        brave_key = get_brave_key()
+    except Exception:  # noqa: BLE001
+        brave_key = ""
+
+    if not brave_key:
+        logger.warning("[DEBATE-MATCH] No Brave key — cannot search perspective")
+        return None
+
+    # ── 2) Generate queries ──────────────────────────────────────────────────
+    queries = await _generate_queries_for_relation(
+        topic=topic,
+        thesis_a=thesis_a,
+        relation_type=relation,
+        title_to_avoid=filters.video_a_title,
+        lang=lang,
+        model=model,
+        call_mistral_fn=call_mistral_fn,
+        extract_json_fn=extract_json_fn,
+    )
+    if not queries:
+        logger.warning(
+            "[DEBATE-MATCH] No queries generated relation=%s topic=%r",
+            relation,
+            (topic or "")[:80],
+        )
+        return None
+
+    # ── 3) Brave Search → flat raw list ──────────────────────────────────────
+    raw_results: List[Tuple[Dict[str, Any], str]] = []
+    for q in queries:
+        try:
+            results = await brave_search_fn(q, brave_key, count=15)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[DEBATE-MATCH] Brave failed q=%r: %s", q[:80], str(exc)[:200]
+            )
+            continue
+        for r in results or []:
+            raw_results.append((r, q))
+
+    if not raw_results:
+        logger.warning(
+            "[DEBATE-MATCH] Brave returned 0 results across %d queries", len(queries)
+        )
+        return None
+
+    # ── 4) Normalize + hard filters (excluded ids, dedupe by video_id) ────────
+    seen_ids: set = set()
+    normalized: List[Dict[str, Any]] = []
+    for idx, (r, q) in enumerate(raw_results):
+        cand = _normalize_brave_result(r, q)
+        if not cand:
+            continue
+        vid = cand["video_id"]
+        if vid in filters.excluded_video_ids or vid in seen_ids:
+            continue
+        seen_ids.add(vid)
+        cand["__rank"] = idx
+        normalized.append(cand)
+
+    if not normalized:
+        logger.warning(
+            "[DEBATE-MATCH] No candidate left after dedup/exclusions (excluded=%d)",
+            len(filters.excluded_video_ids),
+        )
+        return None
+
+    # ── 5) Enrich with channel context (cap 8 to limit fan-out) ──────────────
+    enriched: List[PerspectiveCandidate] = []
+    total_norm = len(normalized)
+    cap = min(8, total_norm)
+    for cand in normalized[:cap]:
+        ch_ctx: Optional[Dict[str, Any]] = None
+        ch_id = cand.get("channel") or ""
+        if channel_context_fn and ch_id:
+            try:
+                ch_ctx = await channel_context_fn("youtube", ch_id)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "[DEBATE-MATCH] channel_context_fn failed channel=%r: %s",
+                    ch_id[:60],
+                    str(exc)[:200],
+                )
+                ch_ctx = None
+
+        ch_quality = _apply_channel_quality_filter(cand.get("channel") or "", ch_ctx)
+        if ch_quality < TRASH_QUALITY_FLOOR:
+            continue  # trash channel filter
+
+        composite = score_candidate(
+            cand,
+            filters,
+            relation,
+            rank_in_results=cand.get("__rank", 0),
+            total_results=total_norm,
+            channel_context=ch_ctx,
+            weights=weights,
+        )
+        if composite == float("-inf"):
+            continue  # duration mismatch hard reject
+
+        audience = _detect_audience(cand, ch_ctx)
+        enriched.append(
+            PerspectiveCandidate(
+                video_id=cand["video_id"],
+                platform="youtube",
+                title=(cand.get("title") or "")[:500],
+                channel=(cand.get("channel") or "")[:255],
+                thumbnail=cand.get("thumbnail") or "",
+                duration_seconds=cand.get("duration_seconds") or 0,
+                published_at=cand.get("published_at"),
+                audience_level=audience,
+                channel_quality_score=ch_quality,
+                raw_query=cand.get("raw_query") or "",
+                score=composite,
+            )
+        )
+
+    if not enriched:
+        logger.warning(
+            "[DEBATE-MATCH] All candidates rejected post-scoring (norm=%d)", total_norm
+        )
+        return None
+
+    enriched.sort(key=lambda x: x.score, reverse=True)
+    chosen = enriched[0]
+
+    # ── 6) Persist top-5 in cache (best-effort) ──────────────────────────────
+    if db is not None:
+        top5 = [c.to_dict() for c in enriched[:5]]
+        await _put_cached_candidates(
+            cache_key,
+            top5,
+            relation_type=relation,
+            lang=lang,
+            duration_bucket=duration_bucket,
+            topic_normalized=(topic or "")[:200],
+            db=db,
+        )
+
+    logger.info(
+        "[DEBATE-MATCH] picked relation=%s vid=%s score=%.3f channel=%r audience=%s",
+        relation,
+        chosen.video_id,
+        chosen.score,
+        chosen.channel[:60],
+        chosen.audience_level,
+    )
+    return chosen
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔁 BACKWARD-COMPAT WRAPPER — pour `mode=auto` legacy
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def search_opposing_video_legacy_compat(
+    topic: str,
+    thesis_a: str,
+    video_a_id: str,
+    video_a_title: Optional[str] = None,
+    video_a_channel: Optional[str] = None,
+    lang: str = "fr",
+    model: str = "mistral-small-2603",
+    *,
+    video_a_duration_seconds: int = 0,
+    user_plan: str = "free",
+    db: Optional[AsyncSession] = None,
+) -> Optional[Dict[str, str]]:
+    """Wrapper drop-in pour remplacer l'ancien `_search_opposing_video`.
+
+    Conserve la signature de retour `{url, title, channel}` afin que le code
+    appelant (router.py:_run_debate_pipeline) ne casse pas.
+    """
+    filters = PerspectiveFilters(
+        video_a_id=video_a_id,
+        video_a_title=video_a_title or "",
+        video_a_channel=video_a_channel or "",
+        video_a_duration_seconds=video_a_duration_seconds,
+        excluded_video_ids={video_a_id},
+        excluded_audience_levels=set(),
+        user_plan=user_plan,
+    )
+    chosen = await _search_perspective_video(
+        topic=topic,
+        thesis_a=thesis_a,
+        relation="opposite",
+        filters=filters,
+        lang=lang,
+        db=db,
+        model=model,
+    )
+    if not chosen:
+        return None
+    return {
+        "url": f"https://www.youtube.com/watch?v={chosen.video_id}",
+        "title": chosen.title,
+        "channel": chosen.channel,
+    }
+
+
+__all__ = [
+    "RelationType",
+    "AudienceLevel",
+    "DurationBucket",
+    "DEFAULT_WEIGHTS",
+    "TRASH_CHANNEL_PATTERNS",
+    "EDU_CHANNEL_BONUS",
+    "TRASH_QUALITY_FLOOR",
+    "PerspectiveFilters",
+    "PerspectiveCandidate",
+    "tier_from_duration",
+    "score_candidate",
+    "compute_candidates_cache_key",
+    "_apply_duration_filter",
+    "_apply_channel_quality_filter",
+    "_apply_freshness_weight",
+    "_detect_audience",
+    "_apply_audience_filter",
+    "_query_relevance_score",
+    "_generate_queries_for_relation",
+    "_search_perspective_video",
+    "search_opposing_video_legacy_compat",
+]

--- a/backend/src/debate/router.py
+++ b/backend/src/debate/router.py
@@ -487,7 +487,14 @@ async def _run_debate_pipeline(
                 debate.status = "searching"
                 await session.commit()
 
-                opposing = await _search_opposing_video(
+                # Sprint Débat IA v2 — multi-criteria matching via debate.matching.
+                # Le legacy `_search_opposing_video` est remplacé par
+                # `search_opposing_video_legacy_compat` (drop-in qui appelle
+                # `_search_perspective_video(..., relation='opposite', ...)` sous
+                # le capot, conserve le shape de retour {url, title, channel}).
+                from debate.matching import search_opposing_video_legacy_compat
+
+                opposing = await search_opposing_video_legacy_compat(
                     topic=detected_topic,
                     thesis_a=thesis_a,
                     video_a_id=video_a_id,
@@ -495,6 +502,8 @@ async def _run_debate_pipeline(
                     video_a_channel=debate.video_a_channel,
                     lang=lang,
                     model=model,
+                    user_plan=user_plan,
+                    db=session,
                 )
                 if opposing and opposing.get("url"):
                     try:

--- a/backend/tests/test_debate_matching.py
+++ b/backend/tests/test_debate_matching.py
@@ -1,0 +1,1111 @@
+"""
+Tests unitaires + E2E mocked + alembic round-trip pour le module debate.matching.
+
+Sprint Débat IA v2 — Wave 2 A finalisation (PR #311).
+
+Couvre :
+- score_candidate : combinaisons de filtres (durée, channel, audience, freshness, relevance)
+- _apply_duration_filter : format-aware short/medium/long, rejet si bucket différent
+- _apply_channel_quality_filter : trash patterns, edu bonus, signaux ch_ctx
+- _apply_audience_filter : 'opposite'/'complement'/'nuance' avec règles distinctes
+- _apply_freshness_weight : pondération ±12 mois
+- _generate_queries_for_relation : queries adaptées au type de relation
+- _search_perspective_video : E2E mocké (cache hit/miss, no match)
+- alembic 016 upgrade/downgrade round-trip sur SQLite
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, inspect
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 📦 Imports du module sous test
+# ─────────────────────────────────────────────────────────────────────────────
+from debate.matching import (
+    DEFAULT_WEIGHTS,
+    PerspectiveCandidate,
+    PerspectiveFilters,
+    _apply_audience_filter,
+    _apply_channel_quality_filter,
+    _apply_duration_filter,
+    _apply_freshness_weight,
+    _detect_audience,
+    _generate_queries_for_relation,
+    _normalize_brave_result,
+    _query_relevance_score,
+    _search_perspective_video,
+    compute_candidates_cache_key,
+    score_candidate,
+    tier_from_duration,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🪪 1. tier_from_duration
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestTierFromDuration:
+    def test_zero_or_negative_returns_medium(self):
+        assert tier_from_duration(0) == "medium"
+        assert tier_from_duration(-10) == "medium"
+
+    def test_short_threshold(self):
+        assert tier_from_duration(30) == "short"
+        assert tier_from_duration(59) == "short"
+
+    def test_medium_threshold(self):
+        assert tier_from_duration(60) == "medium"
+        assert tier_from_duration(600) == "medium"
+        assert tier_from_duration(1199) == "medium"
+
+    def test_long_threshold(self):
+        assert tier_from_duration(1200) == "long"
+        assert tier_from_duration(3600) == "long"
+        assert tier_from_duration(7200) == "long"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ⏱️ 2. _apply_duration_filter (format-aware, rejet si bucket mismatch)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestApplyDurationFilter:
+    def test_same_bucket_short_score_one(self):
+        # 30s vs 45s : both short
+        assert _apply_duration_filter(30, 45) == 1.0
+
+    def test_same_bucket_medium_score_one(self):
+        # 5min vs 10min : both medium
+        assert _apply_duration_filter(300, 600) == 1.0
+
+    def test_same_bucket_long_score_one(self):
+        # 30min vs 1h : both long
+        assert _apply_duration_filter(1800, 3600) == 1.0
+
+    def test_short_vs_long_score_zero(self):
+        # 30s candidate vs 1h target : different buckets
+        assert _apply_duration_filter(30, 3600) == 0.0
+
+    def test_short_vs_medium_score_zero(self):
+        # 30s vs 5min
+        assert _apply_duration_filter(30, 300) == 0.0
+
+    def test_medium_vs_long_score_zero(self):
+        # 5min vs 30min
+        assert _apply_duration_filter(300, 1800) == 0.0
+
+    def test_zero_target_treated_as_medium(self):
+        # Target 0 → bucket medium ; medium candidate scores 1
+        assert _apply_duration_filter(600, 0) == 1.0
+        # short candidate vs unknown medium target → 0
+        assert _apply_duration_filter(30, 0) == 0.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📺 3. _apply_channel_quality_filter
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestApplyChannelQualityFilter:
+    def test_neutral_baseline(self):
+        score = _apply_channel_quality_filter("Random Channel", None)
+        assert 0.45 <= score <= 0.55  # ≈ baseline 0.5
+
+    def test_trash_pattern_clickbait_reduced(self):
+        score = _apply_channel_quality_filter("Best Clickbait Channel 2025", None)
+        # baseline 0.5 - 0.4 (clickbait) = 0.1
+        assert score < 0.2
+
+    def test_trash_pattern_top_n_shocking(self):
+        score = _apply_channel_quality_filter("Top 10 Shocking Truths", None)
+        assert score < 0.2
+
+    def test_trash_pattern_compilation_year(self):
+        # "compilation 2024" matches the regex
+        score = _apply_channel_quality_filter("Best Compilation 2024", None)
+        assert score < 0.2
+
+    def test_edu_channel_bonus(self):
+        # ScienceEtonnante is in EDU_CHANNEL_BONUS
+        score = _apply_channel_quality_filter("ScienceEtonnante", None)
+        # baseline 0.5 + 0.3 = 0.8
+        assert score >= 0.75
+
+    def test_kurzgesagt_bonus(self):
+        score = _apply_channel_quality_filter("Kurzgesagt – In a Nutshell", None)
+        assert score >= 0.75
+
+    def test_only_one_edu_bonus_applied(self):
+        # Multiple edu names should still produce only one bonus (not stacked)
+        # Using a name that contains both 'kurzgesagt' and 'veritasium'
+        score = _apply_channel_quality_filter("Kurzgesagt Veritasium", None)
+        # 0.5 + 0.3 (one bonus) = 0.8, capped well below 1.1
+        assert score <= 0.85
+
+    def test_channel_context_chapters_bonus(self):
+        ctx = {"has_chapters_pct": 0.8, "avg_video_duration_seconds": 800}
+        score = _apply_channel_quality_filter("Some Channel", ctx)
+        # baseline 0.5 + 0.1 (chapters) + 0.05 (avg_dur) = 0.65
+        assert score >= 0.6
+
+    def test_channel_context_ignored_when_invalid(self):
+        ctx = {"has_chapters_pct": "not-a-number", "avg_video_duration_seconds": None}
+        score = _apply_channel_quality_filter("Some Channel", ctx)
+        # Should fall back to neutral 0.5
+        assert 0.45 <= score <= 0.55
+
+    def test_score_clamped_zero_to_one(self):
+        # Multiple trash patterns should still floor at 0
+        score = _apply_channel_quality_filter("Clickbait Reupload Fake", None)
+        assert score >= 0.0
+        assert score <= 1.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📅 4. _apply_freshness_weight (pondéré ±12 mois)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestApplyFreshnessWeight:
+    def test_none_returns_neutral(self):
+        assert _apply_freshness_weight(None) == 0.5
+
+    def test_invalid_string_returns_neutral(self):
+        assert _apply_freshness_weight("not-a-date") == 0.5
+
+    def test_recent_video_under_12_months(self):
+        recent = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        assert _apply_freshness_weight(recent) == 1.0
+
+    def test_iso_with_z_suffix(self):
+        recent = (
+            datetime.now(timezone.utc) - timedelta(days=15)
+        ).isoformat().replace("+00:00", "Z")
+        assert _apply_freshness_weight(recent) == 1.0
+
+    def test_video_18_months_old(self):
+        old = (datetime.now(timezone.utc) - timedelta(days=18 * 30)).isoformat()
+        # 18 months : > 12 but < 24 → 0.7
+        assert _apply_freshness_weight(old) == 0.7
+
+    def test_video_3_years_old(self):
+        old = (datetime.now(timezone.utc) - timedelta(days=3 * 365)).isoformat()
+        # 36 months : > 24 but < 60 → 0.4
+        assert _apply_freshness_weight(old) == 0.4
+
+    def test_video_6_years_old(self):
+        old = (datetime.now(timezone.utc) - timedelta(days=6 * 365)).isoformat()
+        # 72 months : > 60 → 0.2
+        assert _apply_freshness_weight(old) == 0.2
+
+    def test_future_dated_treated_as_fresh(self):
+        future = (datetime.now(timezone.utc) + timedelta(days=10)).isoformat()
+        assert _apply_freshness_weight(future) == 1.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 👥 5. _detect_audience + _apply_audience_filter
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDetectAudience:
+    def test_vulgar_marker_french(self):
+        cand = {"title": "La physique quantique pour les nuls"}
+        assert _detect_audience(cand, None) == "vulgarisation"
+
+    def test_vulgar_marker_english(self):
+        cand = {"title": "Quantum physics explained for beginners"}
+        assert _detect_audience(cand, None) == "vulgarisation"
+
+    def test_expert_marker(self):
+        cand = {"title": "Deep dive into quantum field theory PhD lecture"}
+        assert _detect_audience(cand, None) == "expert"
+
+    def test_expert_paper(self):
+        cand = {"title": "Recent paper on string theory research"}
+        assert _detect_audience(cand, None) == "expert"
+
+    def test_unknown_default(self):
+        cand = {"title": "Some random video about physics"}
+        assert _detect_audience(cand, None) == "unknown"
+
+    def test_channel_context_long_avg_dur_expert(self):
+        cand = {"title": "Some random video"}
+        ctx = {"avg_video_duration_seconds": 2400}  # > 1800 = expert
+        assert _detect_audience(cand, ctx) == "expert"
+
+    def test_channel_context_short_avg_dur_unknown(self):
+        cand = {"title": "Some random video"}
+        ctx = {"avg_video_duration_seconds": 600}
+        assert _detect_audience(cand, ctx) == "unknown"
+
+
+class TestApplyAudienceFilter:
+    def test_opposite_neutral_score(self):
+        # 'opposite' : aucune préférence
+        assert _apply_audience_filter("vulgarisation", "opposite", set()) == 0.5
+        assert _apply_audience_filter("expert", "opposite", set()) == 0.5
+        assert _apply_audience_filter("unknown", "opposite", set()) == 0.5
+
+    def test_complement_prefers_uncovered(self):
+        # 'complement' : légère pref pour audience pas encore couverte
+        assert _apply_audience_filter(
+            "expert", "complement", {"vulgarisation"}
+        ) == 0.75
+        # déjà couvert → neutre
+        assert _apply_audience_filter(
+            "vulgarisation", "complement", {"vulgarisation"}
+        ) == 0.6
+
+    def test_complement_unknown_baseline(self):
+        assert _apply_audience_filter("unknown", "complement", set()) == 0.6
+
+    def test_nuance_bonus_diversity(self):
+        # 'nuance' : bonus si audience candidate diffère des excluded
+        assert _apply_audience_filter("expert", "nuance", {"vulgarisation"}) == 1.0
+
+    def test_nuance_unknown_low(self):
+        assert _apply_audience_filter("unknown", "nuance", set()) == 0.4
+
+    def test_nuance_already_covered_neutral(self):
+        # candidate audience déjà dans excluded → 0.5
+        assert _apply_audience_filter(
+            "vulgarisation", "nuance", {"vulgarisation"}
+        ) == 0.5
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎯 6. _query_relevance_score
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestQueryRelevanceScore:
+    def test_first_position(self):
+        assert _query_relevance_score(0, 10) == pytest.approx(1.0, abs=0.01)
+
+    def test_decay(self):
+        # exp(-5/8) ≈ 0.535 / exp(-10/8) ≈ 0.286
+        s_5 = _query_relevance_score(5, 15)
+        s_10 = _query_relevance_score(10, 15)
+        assert s_5 > s_10
+        assert 0.5 < s_5 < 0.7
+        assert 0.2 < s_10 < 0.4
+
+    def test_zero_total(self):
+        # safety fallback
+        assert _query_relevance_score(0, 0) == 0.5
+
+    def test_negative_rank(self):
+        assert _query_relevance_score(-1, 10) == 0.5
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧮 7. score_candidate (composite)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestScoreCandidate:
+    def _make_filters(self, target_dur=600, excluded_audience=None):
+        return PerspectiveFilters(
+            video_a_id="vidA",
+            video_a_title="Title A",
+            video_a_channel="Channel A",
+            video_a_duration_seconds=target_dur,
+            excluded_video_ids={"vidA"},
+            excluded_audience_levels=excluded_audience or set(),
+            user_plan="pro",
+        )
+
+    def test_duration_mismatch_returns_neg_inf(self):
+        # candidate short, target medium → bucket mismatch → -inf
+        cand = {"duration_seconds": 30, "title": "X", "channel": "C"}
+        filters = self._make_filters(target_dur=600)  # medium
+        score = score_candidate(cand, filters, "opposite")
+        assert score == float("-inf")
+
+    def test_score_in_unit_range(self):
+        cand = {
+            "duration_seconds": 600,  # medium
+            "title": "Quantum physics explained",
+            "channel": "ScienceEtonnante",
+            "published_at": (
+                datetime.now(timezone.utc) - timedelta(days=30)
+            ).isoformat(),
+        }
+        filters = self._make_filters(target_dur=600)
+        score = score_candidate(cand, filters, "opposite")
+        assert 0.0 <= score <= 1.0
+
+    def test_high_score_optimal_candidate(self):
+        # All factors maxed
+        cand = {
+            "duration_seconds": 600,
+            "title": "Quantum physics explained for beginners",
+            "channel": "Veritasium",
+            "published_at": (
+                datetime.now(timezone.utc) - timedelta(days=30)
+            ).isoformat(),
+        }
+        filters = self._make_filters(target_dur=600, excluded_audience={"expert"})
+        # nuance + audience vulgarisation (different from excluded expert) → bonus
+        score = score_candidate(
+            cand, filters, "nuance", rank_in_results=0, total_results=10
+        )
+        # duration 1.0 * 0.30 + ch 0.8 * 0.20 + fresh 1.0 * 0.15 + audience 1.0 * 0.20 + relevance 1.0 * 0.15
+        # = 0.30 + 0.16 + 0.15 + 0.20 + 0.15 = 0.96
+        assert score > 0.85
+
+    def test_low_score_trash_channel(self):
+        cand = {
+            "duration_seconds": 600,
+            "title": "Some random video",
+            "channel": "Top 10 Shocking Reveal",
+            "published_at": "2018-05-01T00:00:00+00:00",
+        }
+        filters = self._make_filters(target_dur=600)
+        score = score_candidate(cand, filters, "opposite")
+        # trash channel → low ch_quality, old → low freshness
+        # but score should still be in [0, 1] range or clamped
+        assert 0.0 <= score <= 0.6
+
+    def test_custom_weights(self):
+        cand = {
+            "duration_seconds": 600,
+            "title": "Random",
+            "channel": "Random Channel",
+            "published_at": (
+                datetime.now(timezone.utc) - timedelta(days=15)
+            ).isoformat(),
+        }
+        filters = self._make_filters(target_dur=600)
+        # Custom weights putting all weight on duration
+        custom = {
+            "duration_match": 1.0,
+            "channel_quality": 0.0,
+            "freshness": 0.0,
+            "audience": 0.0,
+            "query_relevance": 0.0,
+        }
+        score = score_candidate(
+            cand, filters, "opposite", weights=custom
+        )
+        # duration 1.0 * 1.0 = 1.0
+        assert score == 1.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 8. _normalize_brave_result
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestNormalizeBraveResult:
+    def test_valid_youtube_url(self):
+        result = {
+            "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "title": "Rick Astley - Never Gonna Give You Up - YouTube",
+            "thumbnail": "https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg",
+            "duration_seconds": 213,
+        }
+        cand = _normalize_brave_result(result, "test query")
+        assert cand is not None
+        assert cand["video_id"] == "dQw4w9WgXcQ"
+        assert cand["platform"] == "youtube"
+        assert "YouTube" not in cand["title"]  # suffix stripped
+        assert cand["duration_seconds"] == 213
+        assert cand["raw_query"] == "test query"
+
+    def test_non_youtube_url_returns_none(self):
+        result = {"url": "https://example.com/page", "title": "Random"}
+        assert _normalize_brave_result(result, "q") is None
+
+    def test_invalid_duration_falls_back_to_zero(self):
+        result = {
+            "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "title": "Test",
+            "duration_seconds": "not-a-number",
+        }
+        cand = _normalize_brave_result(result, "q")
+        assert cand is not None
+        assert cand["duration_seconds"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔑 9. compute_candidates_cache_key
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCacheKey:
+    def test_deterministic(self):
+        k1 = compute_candidates_cache_key("Climate change", "opposite", "fr", 600)
+        k2 = compute_candidates_cache_key("Climate change", "opposite", "fr", 600)
+        assert k1 == k2
+
+    def test_different_relations_yield_different_keys(self):
+        k1 = compute_candidates_cache_key("X", "opposite", "fr", 600)
+        k2 = compute_candidates_cache_key("X", "complement", "fr", 600)
+        assert k1 != k2
+
+    def test_bucket_collapse(self):
+        # 5min and 10min are both 'medium' → same key
+        k1 = compute_candidates_cache_key("X", "opposite", "fr", 300)
+        k2 = compute_candidates_cache_key("X", "opposite", "fr", 600)
+        assert k1 == k2
+
+    def test_different_lang_yields_different_keys(self):
+        k1 = compute_candidates_cache_key("X", "opposite", "fr", 600)
+        k2 = compute_candidates_cache_key("X", "opposite", "en", 600)
+        assert k1 != k2
+
+    def test_topic_normalized_lowercase(self):
+        k1 = compute_candidates_cache_key("Climate Change", "opposite", "fr", 600)
+        k2 = compute_candidates_cache_key("climate change", "opposite", "fr", 600)
+        assert k1 == k2
+
+    def test_sha256_hex_format(self):
+        k = compute_candidates_cache_key("X", "opposite", "fr", 600)
+        assert len(k) == 64
+        assert all(c in "0123456789abcdef" for c in k)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎬 10. _generate_queries_for_relation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGenerateQueriesForRelation:
+    @pytest.mark.asyncio
+    async def test_opposite_invokes_mistral_with_critical_keywords(self):
+        captured_messages = []
+
+        async def fake_mistral(messages, model, temperature, json_mode):
+            captured_messages.extend(messages)
+            return json.dumps({
+                "query_primary": "climate change myth debunked",
+                "query_alternative": "climate change critique",
+            })
+
+        def fake_extract_json(raw):
+            return json.loads(raw)
+
+        queries = await _generate_queries_for_relation(
+            topic="Climate change",
+            thesis_a="Humans cause climate change",
+            relation_type="opposite",
+            title_to_avoid="Climate Change Truth",
+            lang="en",
+            model="mistral-small-2603",
+            call_mistral_fn=fake_mistral,
+            extract_json_fn=fake_extract_json,
+        )
+
+        assert len(queries) == 2
+        assert "myth debunked" in queries[0]
+        # Vérifier que le system prompt contient les mots-clés "opposite"
+        sys_msg = next(m for m in captured_messages if m["role"] == "system")
+        assert "CONTREDIT" in sys_msg["content"] or "OPPOSE" in sys_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_complement_uses_complement_instructions(self):
+        captured_messages = []
+
+        async def fake_mistral(messages, model, temperature, json_mode):
+            captured_messages.extend(messages)
+            return json.dumps({
+                "query_primary": "deep dive case study",
+                "query_alternative": "behind the scenes insider",
+            })
+
+        queries = await _generate_queries_for_relation(
+            topic="X",
+            thesis_a="Y",
+            relation_type="complement",
+            title_to_avoid="Z",
+            lang="fr",
+            model="m",
+            call_mistral_fn=fake_mistral,
+            extract_json_fn=lambda r: json.loads(r),
+        )
+        sys_msg = next(m for m in captured_messages if m["role"] == "system")
+        assert "COMPLÈTE" in sys_msg["content"] or "ÉTEND" in sys_msg["content"]
+        assert len(queries) == 2
+
+    @pytest.mark.asyncio
+    async def test_nuance_uses_nuance_instructions(self):
+        captured_messages = []
+
+        async def fake_mistral(messages, model, temperature, json_mode):
+            captured_messages.extend(messages)
+            return json.dumps({
+                "query_primary": "depends on context",
+                "query_alternative": "edge cases when does X work",
+            })
+
+        queries = await _generate_queries_for_relation(
+            topic="X",
+            thesis_a="Y",
+            relation_type="nuance",
+            title_to_avoid="Z",
+            lang="fr",
+            model="m",
+            call_mistral_fn=fake_mistral,
+            extract_json_fn=lambda r: json.loads(r),
+        )
+        sys_msg = next(m for m in captured_messages if m["role"] == "system")
+        assert "NUANCE" in sys_msg["content"] or "conditionnelle" in sys_msg["content"]
+        assert len(queries) == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_mistral_response_returns_empty_list(self):
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return ""
+
+        queries = await _generate_queries_for_relation(
+            topic="X",
+            thesis_a="Y",
+            relation_type="opposite",
+            title_to_avoid="Z",
+            lang="fr",
+            model="m",
+            call_mistral_fn=fake_mistral,
+            extract_json_fn=lambda r: {},
+        )
+        assert queries == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_empty_list(self):
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return "{not valid json"
+
+        def fake_extract(raw):
+            return None  # extract_json_fn returns None on failure
+
+        queries = await _generate_queries_for_relation(
+            topic="X",
+            thesis_a="Y",
+            relation_type="opposite",
+            title_to_avoid="Z",
+            lang="fr",
+            model="m",
+            call_mistral_fn=fake_mistral,
+            extract_json_fn=fake_extract,
+        )
+        assert queries == []
+
+    @pytest.mark.asyncio
+    async def test_lang_fr_vs_en_different_instruction(self):
+        captured_fr = []
+        captured_en = []
+
+        async def fake_fr(messages, model, temperature, json_mode):
+            captured_fr.extend(messages)
+            return json.dumps({"query_primary": "a", "query_alternative": "b"})
+
+        async def fake_en(messages, model, temperature, json_mode):
+            captured_en.extend(messages)
+            return json.dumps({"query_primary": "a", "query_alternative": "b"})
+
+        await _generate_queries_for_relation(
+            topic="X", thesis_a="Y", relation_type="opposite",
+            title_to_avoid="", lang="fr", model="m",
+            call_mistral_fn=fake_fr, extract_json_fn=lambda r: json.loads(r),
+        )
+        await _generate_queries_for_relation(
+            topic="X", thesis_a="Y", relation_type="opposite",
+            title_to_avoid="", lang="en", model="m",
+            call_mistral_fn=fake_en, extract_json_fn=lambda r: json.loads(r),
+        )
+        sys_fr = next(m for m in captured_fr if m["role"] == "system")["content"]
+        sys_en = next(m for m in captured_en if m["role"] == "system")["content"]
+        assert "français" in sys_fr.lower() or "francais" in sys_fr.lower()
+        assert "english" in sys_en.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 11. _search_perspective_video — E2E mocked
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_filters(target_dur=600):
+    return PerspectiveFilters(
+        video_a_id="vidA",
+        video_a_title="Climate Change Truth",
+        video_a_channel="Channel A",
+        video_a_duration_seconds=target_dur,
+        excluded_video_ids={"vidA"},
+        excluded_audience_levels=set(),
+        user_plan="pro",
+    )
+
+
+def _make_brave_result(video_id="abc12345678", title="Test video", duration=600):
+    return {
+        "url": f"https://www.youtube.com/watch?v={video_id}",
+        "title": title,
+        "thumbnail": f"https://img.youtube.com/vi/{video_id}/mqdefault.jpg",
+        "duration_seconds": duration,
+        "channel": "Test Channel",
+        "published_at": (
+            datetime.now(timezone.utc) - timedelta(days=30)
+        ).isoformat(),
+    }
+
+
+class TestSearchPerspectiveVideoE2E:
+    @pytest.mark.asyncio
+    async def test_nominal_finds_candidate(self):
+        """Cas nominal — Brave retourne un résultat valide → top-1 sélectionné."""
+
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return json.dumps({
+                "query_primary": "climate myth",
+                "query_alternative": "climate critique",
+            })
+
+        async def fake_brave(query, key, count):
+            # Retourne un résultat YouTube valide pour chaque query
+            return [_make_brave_result(video_id="vidB1234567")]
+
+        with patch(
+            "debate.matching.get_brave_key", create=True, return_value="fake-key"
+        ) as _, patch(
+            "core.config.get_brave_key", return_value="fake-key"
+        ):
+            chosen = await _search_perspective_video(
+                topic="Climate change",
+                thesis_a="Humans cause climate change",
+                relation="opposite",
+                filters=_make_filters(target_dur=600),
+                lang="en",
+                db=None,  # disable cache
+                model="mistral-small",
+                call_mistral_fn=fake_mistral,
+                extract_json_fn=lambda r: json.loads(r),
+                brave_search_fn=fake_brave,
+                channel_context_fn=AsyncMock(return_value=None),
+            )
+
+        assert chosen is not None
+        assert chosen.video_id == "vidB1234567"
+        assert chosen.platform == "youtube"
+        assert chosen.score > 0.0
+
+    @pytest.mark.asyncio
+    async def test_no_brave_results_returns_none(self):
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return json.dumps({"query_primary": "q1", "query_alternative": "q2"})
+
+        async def fake_brave(query, key, count):
+            return []
+
+        with patch("core.config.get_brave_key", return_value="fake-key"):
+            chosen = await _search_perspective_video(
+                topic="X",
+                thesis_a="Y",
+                relation="opposite",
+                filters=_make_filters(target_dur=600),
+                lang="fr",
+                db=None,
+                call_mistral_fn=fake_mistral,
+                extract_json_fn=lambda r: json.loads(r),
+                brave_search_fn=fake_brave,
+                channel_context_fn=AsyncMock(return_value=None),
+            )
+
+        assert chosen is None
+
+    @pytest.mark.asyncio
+    async def test_no_brave_key_returns_none(self):
+        """Si pas de clé Brave configurée, retourne None proprement."""
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return json.dumps({"query_primary": "q1", "query_alternative": "q2"})
+
+        async def fake_brave(query, key, count):
+            return [_make_brave_result()]
+
+        with patch("core.config.get_brave_key", return_value=""):
+            chosen = await _search_perspective_video(
+                topic="X",
+                thesis_a="Y",
+                relation="opposite",
+                filters=_make_filters(target_dur=600),
+                lang="fr",
+                db=None,
+                call_mistral_fn=fake_mistral,
+                extract_json_fn=lambda r: json.loads(r),
+                brave_search_fn=fake_brave,
+                channel_context_fn=AsyncMock(return_value=None),
+            )
+
+        assert chosen is None
+
+    @pytest.mark.asyncio
+    async def test_no_queries_returns_none(self):
+        """Si Mistral renvoie 0 query, on n'appelle pas Brave et on retourne None."""
+        brave_called = []
+
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return ""
+
+        async def fake_brave(query, key, count):
+            brave_called.append(query)
+            return [_make_brave_result()]
+
+        with patch("core.config.get_brave_key", return_value="fake-key"):
+            chosen = await _search_perspective_video(
+                topic="X",
+                thesis_a="Y",
+                relation="opposite",
+                filters=_make_filters(target_dur=600),
+                lang="fr",
+                db=None,
+                call_mistral_fn=fake_mistral,
+                extract_json_fn=lambda r: None,
+                brave_search_fn=fake_brave,
+                channel_context_fn=AsyncMock(return_value=None),
+            )
+
+        assert chosen is None
+        assert brave_called == []
+
+    @pytest.mark.asyncio
+    async def test_excluded_ids_filtered(self):
+        """Les video_ids dans excluded_video_ids ne doivent pas être candidats."""
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return json.dumps({"query_primary": "q1", "query_alternative": "q2"})
+
+        async def fake_brave(query, key, count):
+            return [
+                _make_brave_result(video_id="excludedVid"),
+                _make_brave_result(video_id="okVideo1234"),
+            ]
+
+        filters = PerspectiveFilters(
+            video_a_id="vidA",
+            video_a_title="T",
+            video_a_channel="C",
+            video_a_duration_seconds=600,
+            excluded_video_ids={"vidA", "excludedVid"},
+            excluded_audience_levels=set(),
+            user_plan="pro",
+        )
+
+        with patch("core.config.get_brave_key", return_value="fake-key"):
+            chosen = await _search_perspective_video(
+                topic="X",
+                thesis_a="Y",
+                relation="opposite",
+                filters=filters,
+                lang="fr",
+                db=None,
+                call_mistral_fn=fake_mistral,
+                extract_json_fn=lambda r: json.loads(r),
+                brave_search_fn=fake_brave,
+                channel_context_fn=AsyncMock(return_value=None),
+            )
+
+        assert chosen is not None
+        assert chosen.video_id == "okVideo1234"
+
+    @pytest.mark.asyncio
+    async def test_duration_mismatch_rejected(self):
+        """Toutes les vidéos avec bucket différent doivent être rejetées."""
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return json.dumps({"query_primary": "q1", "query_alternative": "q2"})
+
+        async def fake_brave(query, key, count):
+            # All candidates are short (30s) but target is medium (600s)
+            return [
+                _make_brave_result(video_id="vidShort1A1", duration=30),
+                _make_brave_result(video_id="vidShort2B2", duration=20),
+            ]
+
+        with patch("core.config.get_brave_key", return_value="fake-key"):
+            chosen = await _search_perspective_video(
+                topic="X",
+                thesis_a="Y",
+                relation="opposite",
+                filters=_make_filters(target_dur=600),  # medium target
+                lang="fr",
+                db=None,
+                call_mistral_fn=fake_mistral,
+                extract_json_fn=lambda r: json.loads(r),
+                brave_search_fn=fake_brave,
+                channel_context_fn=AsyncMock(return_value=None),
+            )
+
+        # All candidates rejected → None
+        assert chosen is None
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_brave_call(self):
+        """Si le cache retourne des candidats, Brave n'est pas appelé."""
+        brave_calls = []
+        mistral_calls = []
+
+        async def fake_mistral(messages, model, temperature, json_mode):
+            mistral_calls.append(messages)
+            return json.dumps({"query_primary": "q1", "query_alternative": "q2"})
+
+        async def fake_brave(query, key, count):
+            brave_calls.append(query)
+            return [_make_brave_result()]
+
+        # Mock _get_cached_candidates to return a cached result
+        cached_data = [{
+            "video_id": "cachedVid12",
+            "platform": "youtube",
+            "title": "Cached video",
+            "channel": "Cached Channel",
+            "thumbnail": "thumb.jpg",
+            "duration_seconds": 600,
+            "published_at": None,
+            "audience_level": "unknown",
+            "channel_quality_score": 0.5,
+            "raw_query": "cached q",
+            "score": 0.85,
+        }]
+
+        mock_db = AsyncMock()
+
+        with patch(
+            "debate.matching._get_cached_candidates",
+            AsyncMock(return_value=cached_data),
+        ), patch("core.config.get_brave_key", return_value="fake-key"):
+            chosen = await _search_perspective_video(
+                topic="X",
+                thesis_a="Y",
+                relation="opposite",
+                filters=_make_filters(target_dur=600),
+                lang="fr",
+                db=mock_db,
+                call_mistral_fn=fake_mistral,
+                extract_json_fn=lambda r: json.loads(r),
+                brave_search_fn=fake_brave,
+                channel_context_fn=AsyncMock(return_value=None),
+            )
+
+        assert chosen is not None
+        assert chosen.video_id == "cachedVid12"
+        # Brave should NOT have been called when cache hit
+        assert brave_calls == []
+        assert mistral_calls == []
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_calls_brave_then_caches(self):
+        """Cache miss → Brave appelé → résultat persisté en cache."""
+        brave_calls = []
+        cache_writes = []
+
+        async def fake_mistral(messages, model, temperature, json_mode):
+            return json.dumps({"query_primary": "q1", "query_alternative": "q2"})
+
+        async def fake_brave(query, key, count):
+            brave_calls.append(query)
+            return [_make_brave_result(video_id="missVidB123")]
+
+        async def fake_put_cache(*args, **kwargs):
+            cache_writes.append((args, kwargs))
+
+        mock_db = AsyncMock()
+
+        with patch(
+            "debate.matching._get_cached_candidates", AsyncMock(return_value=None)
+        ), patch(
+            "debate.matching._put_cached_candidates", AsyncMock(side_effect=fake_put_cache)
+        ), patch("core.config.get_brave_key", return_value="fake-key"):
+            chosen = await _search_perspective_video(
+                topic="X",
+                thesis_a="Y",
+                relation="opposite",
+                filters=_make_filters(target_dur=600),
+                lang="fr",
+                db=mock_db,
+                call_mistral_fn=fake_mistral,
+                extract_json_fn=lambda r: json.loads(r),
+                brave_search_fn=fake_brave,
+                channel_context_fn=AsyncMock(return_value=None),
+            )
+
+        assert chosen is not None
+        assert chosen.video_id == "missVidB123"
+        # Brave was called
+        assert len(brave_calls) >= 1
+        # Cache write was triggered
+        assert len(cache_writes) == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🗄️ 12. Migration alembic 016 — round-trip SQLite
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+_MIGRATION_016_PATH = (
+    _BACKEND_DIR / "alembic" / "versions" / "016_debate_v2_video_b_candidates_cache.py"
+)
+
+
+def _load_migration_016():
+    """Charger le module migration 016 par chemin absolu."""
+    spec = importlib.util.spec_from_file_location("mig_016", _MIGRATION_016_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ensure_real_alembic_for_016():
+    """Pareil que test_migration_007 — replace shadowing alembic package."""
+    backend_str = str(_BACKEND_DIR)
+    backend_alt = backend_str.replace("\\", "/")
+    for key in list(sys.modules):
+        if key == "alembic" or key.startswith("alembic."):
+            mod = sys.modules[key]
+            f = (getattr(mod, "__file__", "") or "").replace("\\", "/")
+            spath = (
+                getattr(mod, "__spec__", None).origin
+                if getattr(mod, "__spec__", None)
+                else ""
+            ) or ""
+            spath = spath.replace("\\", "/")
+            if (
+                "site-packages" not in f
+                and ("/backend/alembic" in f or "/backend/alembic" in spath or f == "")
+            ):
+                del sys.modules[key]
+    sys.path[:] = [
+        p
+        for p in sys.path
+        if p.replace("\\", "/").rstrip("/") not in (backend_alt.rstrip("/"),)
+    ]
+    if os.getcwd().replace("\\", "/").rstrip("/") == backend_alt.rstrip("/"):
+        sys.path[:] = [p for p in sys.path if p not in ("", ".")]
+
+
+def _run_migration_016(db_url: str, direction: str) -> None:
+    _ensure_real_alembic_for_016()
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+    from alembic import op as _op_module
+
+    sync_engine = create_engine(db_url)
+    mig = _load_migration_016()
+
+    with sync_engine.begin() as connection:
+        ctx = MigrationContext.configure(connection)
+        op_proxy = Operations(ctx)
+        old_proxy = getattr(_op_module, "_proxy", None)
+        _op_module._proxy = op_proxy
+        try:
+            if direction == "upgrade":
+                mig.upgrade()
+            elif direction == "downgrade":
+                mig.downgrade()
+            else:
+                raise ValueError(direction)
+        finally:
+            _op_module._proxy = old_proxy
+
+    sync_engine.dispose()
+
+
+@pytest.fixture
+def fresh_sqlite_for_016():
+    tmpdir = tempfile.mkdtemp(prefix="ds_alembic_016_")
+    db_path = os.path.join(tmpdir, "test.db")
+    db_url = f"sqlite:///{db_path}"
+    yield db_url
+    try:
+        os.remove(db_path)
+        os.rmdir(tmpdir)
+    except OSError:
+        pass
+
+
+class TestMigration016:
+    def test_upgrade_creates_table_and_indexes(self, fresh_sqlite_for_016):
+        db_url = fresh_sqlite_for_016
+        _run_migration_016(db_url, "upgrade")
+
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+
+        # Table exists
+        assert "debate_video_b_candidates" in inspector.get_table_names()
+
+        # Required columns
+        columns = {c["name"]: c for c in inspector.get_columns("debate_video_b_candidates")}
+        assert "id" in columns
+        assert "cache_key" in columns
+        assert "topic_normalized" in columns
+        assert "relation_type" in columns
+        assert "lang" in columns
+        assert "duration_bucket" in columns
+        assert "candidates_json" in columns
+        assert "created_at" in columns
+        assert "expires_at" in columns
+
+        # Required NOT NULL constraints
+        assert columns["cache_key"]["nullable"] is False
+        assert columns["relation_type"]["nullable"] is False
+        assert columns["lang"]["nullable"] is False
+        assert columns["duration_bucket"]["nullable"] is False
+        assert columns["candidates_json"]["nullable"] is False
+        assert columns["expires_at"]["nullable"] is False
+
+        # topic_normalized is nullable
+        assert columns["topic_normalized"]["nullable"] is True
+
+        # Indexes
+        indexes = {ix["name"] for ix in inspector.get_indexes("debate_video_b_candidates")}
+        assert "idx_debate_video_b_candidates_key" in indexes
+        assert "idx_debate_video_b_candidates_expires" in indexes
+
+        # Unique constraint on cache_key
+        uniques = inspector.get_unique_constraints("debate_video_b_candidates")
+        unique_names = {u["name"] for u in uniques}
+        assert "uq_debate_video_b_candidates_key" in unique_names
+
+        engine.dispose()
+
+    def test_downgrade_drops_table(self, fresh_sqlite_for_016):
+        db_url = fresh_sqlite_for_016
+        _run_migration_016(db_url, "upgrade")
+        _run_migration_016(db_url, "downgrade")
+
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+        assert "debate_video_b_candidates" not in inspector.get_table_names()
+        engine.dispose()
+
+    def test_round_trip_idempotent(self, fresh_sqlite_for_016):
+        """Upgrade puis downgrade laisse la DB clean."""
+        db_url = fresh_sqlite_for_016
+
+        _run_migration_016(db_url, "upgrade")
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+        assert "debate_video_b_candidates" in inspector.get_table_names()
+        engine.dispose()
+
+        _run_migration_016(db_url, "downgrade")
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+        tables = inspector.get_table_names()
+        assert "debate_video_b_candidates" not in tables
+        engine.dispose()
+
+    def test_revision_metadata(self):
+        """Verify revision id and down_revision for chain integrity."""
+        mig = _load_migration_016()
+        assert mig.revision == "016_debate_v2_video_b_candidates_cache"
+        assert mig.down_revision == "015_add_search_index_tables"


### PR DESCRIPTION
## Status: DRAFT WIP — sub-agent timed out, finalisation au reset quota

## Done
- `backend/src/debate/matching.py` — 933 lignes (scoring multi-critères, format-aware duration, channel quality, audience, freshness)
- `backend/alembic/versions/016_debate_v2_video_b_candidates_cache.py` — 78 lignes (cache table TTL 7j)
- `backend/src/db/database.py` — modèle `DebateVideoBCandidatesCache`
- `backend/src/debate/router.py` — hook minimal vers le nouveau matching

## TODO post-reset
- [ ] Tests unitaires + e2e mocké (`backend/tests/test_debate_matching.py`)
- [ ] `alembic check` valide
- [ ] `pytest` passe
- [ ] Smoke test mode auto

## Coordination
- Migration 016 (cache table) **uniquement** — `debate_perspectives` est dans PR Wave 2 B (migration 017)
- Doit être merge AVANT PR Wave 2 B (chaîne 015 → 016 → 017)

## Spec
docs/superpowers/specs/2026-05-04-debate-ia-v2.md sections 4.1, 4.4, 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)