### PR TITLE
feat(debate-voice): N-perspectives + relation types — Wave 2 C

### DIFF
--- a/backend/src/voice/debate_context.py
+++ b/backend/src/voice/debate_context.py
@@ -1,8 +1,13 @@
 """
-Debate Voice Context — Assembleur de contexte pour l'agent vocal Modérateur de débat.
+Debate Voice Context — Assembleur de contexte pour l'agent vocal Modérateur de débat (v2).
 
-Agrège les données d'une DebateAnalysis (2 vidéos, thèses, arguments, convergences,
-divergences, fact-check, synthèse) et optionnellement les transcripts des 2 vidéos,
+v2 — N perspectives (1 vidéo A + 1 à N vidéos B avec relation_type ∈ {opposite, complement, nuance}).
+Backward-compat : pour les debates pré-v2 (table `debate_perspectives` absente ou vide), on
+synthétise une perspective implicite position=0 relation='opposite' depuis les colonnes
+`debate_analyses.video_b_*` historiques. Cf. spec §8.
+
+Agrège les données d'une DebateAnalysis (1 vidéo A + N perspectives, thèses, arguments,
+convergences, divergences, fact-check, synthèse) et optionnellement les transcripts,
 puis formate le tout pour injection dans le system prompt ElevenLabs.
 """
 
@@ -13,6 +18,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Optional
 
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.database import DebateAnalysis
@@ -21,30 +27,53 @@ logger = logging.getLogger(__name__)
 
 
 # Budgets (en caractères) pour le format vocal. L'agent débat reçoit plus
-# que l'agent "explorer" car il doit jongler avec 2 vidéos.
+# que l'agent "explorer" car il doit jongler avec plusieurs vidéos.
 MAX_CONTEXT_DEBATE_VOICE = 16_000
 
-# Sous-budgets (somme ≈ MAX_CONTEXT_DEBATE_VOICE)
+# Sous-budgets — partagés entre la vidéo A et l'ensemble des perspectives B.
 BUDGET_HEADER = 400
 BUDGET_THESES = 1_600
-BUDGET_ARGUMENTS_PER_VIDEO = 2_500
+BUDGET_ARGUMENTS_VIDEO_A = 2_500
+BUDGET_ARGUMENTS_PERSPECTIVES_TOTAL = 2_500  # Splitté entre les N perspectives
 BUDGET_CONVERGENCE = 1_000
 BUDGET_DIVERGENCE = 2_000
 BUDGET_FACT_CHECK = 2_000
 BUDGET_SUMMARY = 2_000
-BUDGET_TRANSCRIPT_PER_VIDEO = 1_500  # Dégradé — on préfère digest + thèses
+BUDGET_TRANSCRIPT_VIDEO_A = 1_500
+BUDGET_TRANSCRIPT_PERSPECTIVES_TOTAL = 1_500  # Splitté entre les N perspectives
 
 
-def _safe_json_list(value: Optional[str]) -> list:
-    """Parse un champ JSON texte, retourne [] si invalide."""
+# Relation type ↔ libellés FR/EN
+RELATION_LABELS = {
+    "fr": {
+        "opposite": "opposition",
+        "complement": "complément",
+        "nuance": "nuance",
+    },
+    "en": {
+        "opposite": "opposition",
+        "complement": "complement",
+        "nuance": "nuance",
+    },
+}
+
+
+def _safe_json_list(value) -> list:
+    """Parse un champ JSON (texte ou déjà list/dict), retourne [] si invalide."""
     if not value:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        for key in ("claims", "items", "list"):
+            if key in value and isinstance(value[key], list):
+                return value[key]
         return []
     try:
         parsed = json.loads(value)
         if isinstance(parsed, list):
             return parsed
         if isinstance(parsed, dict):
-            # Certains debates encapsulent dans {"claims": [...]}
             for key in ("claims", "items", "list"):
                 if key in parsed and isinstance(parsed[key], list):
                     return parsed[key]
@@ -53,16 +82,50 @@ def _safe_json_list(value: Optional[str]) -> list:
         return []
 
 
-def _truncate(text: str, max_chars: int, suffix: str = " [...]") -> str:
+def _truncate(text_value: str, max_chars: int, suffix: str = " [...]") -> str:
     """Tronque proprement un texte à max_chars, avec suffixe de troncature."""
-    if not text:
+    if not text_value:
         return ""
-    if len(text) <= max_chars:
-        return text
+    if len(text_value) <= max_chars:
+        return text_value
     cut = max_chars - len(suffix)
     if cut < 1:
-        return text[:max_chars]
-    return text[:cut].rstrip() + suffix
+        return text_value[:max_chars]
+    return text_value[:cut].rstrip() + suffix
+
+
+def _normalize_relation(value: Optional[str]) -> str:
+    """Normalise relation_type vers une des 3 valeurs canoniques."""
+    if not value:
+        return "opposite"
+    v = str(value).strip().lower()
+    if v in ("opposite", "opposition", "oppose"):
+        return "opposite"
+    if v in ("complement", "complementary", "complément", "complementaire"):
+        return "complement"
+    if v in ("nuance", "nuanced", "nuancé"):
+        return "nuance"
+    return "opposite"
+
+
+def _compute_dominant_relation(perspectives: list["PerspectiveCtx"]) -> str:
+    """
+    Détermine la relation_type dominante. Priorité en cas d'égalité :
+    opposite > complement > nuance (cf. spec §2.1).
+    """
+    if not perspectives:
+        return "opposite"
+    counts: dict[str, int] = {"opposite": 0, "complement": 0, "nuance": 0}
+    for p in perspectives:
+        rel = _normalize_relation(p.relation_type)
+        counts[rel] = counts.get(rel, 0) + 1
+    # Tri par count décroissant + ordre de priorité comme tie-breaker
+    priority_order = ["opposite", "complement", "nuance"]
+    sorted_relations = sorted(
+        priority_order,
+        key=lambda r: (-counts[r], priority_order.index(r)),
+    )
+    return sorted_relations[0]
 
 
 @dataclass
@@ -76,12 +139,20 @@ class _Labels:
         return "SUJET DU DÉBAT" if self.fr else "DEBATE TOPIC"
 
     @property
+    def topic_perspectives(self) -> str:
+        return "SUJET" if self.fr else "TOPIC"
+
+    @property
     def video_a(self) -> str:
         return "VIDÉO A" if self.fr else "VIDEO A"
 
     @property
-    def video_b(self) -> str:
-        return "VIDÉO B" if self.fr else "VIDEO B"
+    def perspectives_section(self) -> str:
+        return "PERSPECTIVES" if self.fr else "PERSPECTIVES"
+
+    @property
+    def perspective_singular(self) -> str:
+        return "Perspective" if self.fr else "Perspective"
 
     @property
     def title(self) -> str:
@@ -90,6 +161,10 @@ class _Labels:
     @property
     def channel(self) -> str:
         return "Chaîne" if self.fr else "Channel"
+
+    @property
+    def relation(self) -> str:
+        return "Relation" if self.fr else "Relation"
 
     @property
     def theses(self) -> str:
@@ -120,12 +195,16 @@ class _Labels:
         return "SYNTHÈSE DU DÉBAT" if self.fr else "DEBATE SUMMARY"
 
     @property
+    def summary_perspectives(self) -> str:
+        return "SYNTHÈSE GLOBALE" if self.fr else "GLOBAL SUMMARY"
+
+    @property
     def transcript_a(self) -> str:
         return "TRANSCRIPT VIDÉO A" if self.fr else "VIDEO A TRANSCRIPT"
 
     @property
-    def transcript_b(self) -> str:
-        return "TRANSCRIPT VIDÉO B" if self.fr else "VIDEO B TRANSCRIPT"
+    def transcript_perspective(self) -> str:
+        return "TRANSCRIPT" if self.fr else "TRANSCRIPT"
 
     @property
     def strong(self) -> str:
@@ -138,6 +217,10 @@ class _Labels:
     @property
     def weak(self) -> str:
         return "faible" if self.fr else "weak"
+
+    @property
+    def dominant_label(self) -> str:
+        return "Relation dominante" if self.fr else "Dominant relation"
 
 
 def _format_arguments(args: list[dict], max_chars: int, L: _Labels) -> str:
@@ -168,15 +251,40 @@ def _format_arguments(args: list[dict], max_chars: int, L: _Labels) -> str:
     return _truncate("\n".join(parts), max_chars)
 
 
+def _format_relation_human(relation_type: str, lang: str) -> str:
+    """Renvoie le label humain de la relation pour vocalisation."""
+    fr = lang != "en"
+    labels = RELATION_LABELS["fr" if fr else "en"]
+    return labels.get(_normalize_relation(relation_type), relation_type or "?")
+
+
+@dataclass
+class PerspectiveCtx:
+    """Une perspective (vidéo B-i) dans un débat v2."""
+
+    position: int = 0
+    relation_type: str = "opposite"
+    perspective_id: int = -1  # -1 = perspective virtuelle (fallback v1)
+    video_id: str = ""
+    video_title: str = ""
+    video_channel: str = ""
+    platform: str = "youtube"
+    thesis: str = ""
+    arguments: list[dict] = field(default_factory=list)
+    transcript: str = ""
+    audience_level: str = "unknown"
+    channel_quality_score: float = 0.0
+
+
 @dataclass
 class DebateRichContext:
-    """Contexte débat assemblé, prêt à être formaté pour ElevenLabs."""
+    """Contexte débat assemblé v2, prêt à être formaté pour ElevenLabs."""
 
     debate_id: int
     topic: str = ""
     lang: str = "fr"
 
-    # Vidéo A
+    # Vidéo A (l'ancrage)
     video_a_id: str = ""
     video_a_title: str = ""
     video_a_channel: str = ""
@@ -185,64 +293,176 @@ class DebateRichContext:
     arguments_a: list[dict] = field(default_factory=list)
     transcript_a: str = ""
 
-    # Vidéo B
-    video_b_id: str = ""
-    video_b_title: str = ""
-    video_b_channel: str = ""
-    platform_b: str = "youtube"
-    thesis_b: str = ""
-    arguments_b: list[dict] = field(default_factory=list)
-    transcript_b: str = ""
+    # Vidéo B(s) en v2 — N perspectives (≥1, max 3)
+    perspectives: list[PerspectiveCtx] = field(default_factory=list)
 
-    # Analyse comparative
+    # Relation dominante (calculée à la construction)
+    relation_type_dominant: str = "opposite"
+
+    # Analyse comparative (globale)
     convergence_points: list = field(default_factory=list)
     divergence_points: list[dict] = field(default_factory=list)
     fact_check: list[dict] = field(default_factory=list)
     debate_summary: str = ""
 
-    def format_for_voice(self, language: str = "fr", max_chars: int = MAX_CONTEXT_DEBATE_VOICE) -> str:
-        """Formate le contexte complet pour le system prompt vocal ElevenLabs."""
+    # ─────────────────────────────────────────────────────────────────────
+    # Backward-compat properties — exposent video_b_* à partir de la 1ère
+    # perspective. Les anciens tests qui lisaient ctx.video_b_title continuent
+    # de marcher tant qu'il y a au moins 1 perspective.
+    # ─────────────────────────────────────────────────────────────────────
+    @property
+    def video_b_id(self) -> str:
+        return self.perspectives[0].video_id if self.perspectives else ""
+
+    @property
+    def video_b_title(self) -> str:
+        return self.perspectives[0].video_title if self.perspectives else ""
+
+    @property
+    def video_b_channel(self) -> str:
+        return self.perspectives[0].video_channel if self.perspectives else ""
+
+    @property
+    def platform_b(self) -> str:
+        return self.perspectives[0].platform if self.perspectives else "youtube"
+
+    @property
+    def thesis_b(self) -> str:
+        return self.perspectives[0].thesis if self.perspectives else ""
+
+    @property
+    def arguments_b(self) -> list[dict]:
+        return self.perspectives[0].arguments if self.perspectives else []
+
+    @property
+    def transcript_b(self) -> str:
+        return self.perspectives[0].transcript if self.perspectives else ""
+
+    def format_for_voice(
+        self, language: str = "fr", max_chars: int = MAX_CONTEXT_DEBATE_VOICE
+    ) -> str:
+        """
+        Formate le contexte complet pour le system prompt vocal ElevenLabs (v2).
+
+        Header dynamique :
+        - Si 1 perspective ('opposite') : « Débat IA » classique (vidéo A vs vidéo B).
+        - Si plusieurs OU dominant != opposite : « N perspectives sur le sujet... »
+          avec mention explicite des relation_types présents.
+        """
         fr = language != "en"
         L = _Labels(fr)
+        n = len(self.perspectives)
 
         lines: list[str] = []
 
-        # Header — sujet + métadonnées des 2 vidéos
-        lines.append(f"## {L.topic} : {self.topic}")
-        lines.append("")
-        lines.append(f"### {L.video_a}")
-        lines.append(f"{L.title} : {self.video_a_title}")
-        lines.append(f"{L.channel} : {self.video_a_channel}")
-        lines.append("")
-        lines.append(f"### {L.video_b}")
-        lines.append(f"{L.title} : {self.video_b_title}")
-        lines.append(f"{L.channel} : {self.video_b_channel}")
-        lines.append("")
+        # ── Header — sujet + dominante ──────────────────────────────────
+        is_classic_debate = (
+            n == 1
+            and _normalize_relation(self.perspectives[0].relation_type) == "opposite"
+        )
 
-        # Thèses
+        if is_classic_debate:
+            # Format historique : Débat IA classique (compat lecture)
+            lines.append(f"## {L.topic} : {self.topic}")
+            lines.append("")
+            lines.append(f"### {L.video_a}")
+            lines.append(f"{L.title} : {self.video_a_title}")
+            lines.append(f"{L.channel} : {self.video_a_channel}")
+            lines.append("")
+            persp = self.perspectives[0]
+            lines.append("### VIDÉO B" if fr else "### VIDEO B")
+            lines.append(f"{L.title} : {persp.video_title}")
+            lines.append(f"{L.channel} : {persp.video_channel}")
+            lines.append("")
+        else:
+            # Format v2 multi-perspectives
+            if fr:
+                lines.append(f"## {L.topic_perspectives} : {self.topic}")
+                lines.append("")
+                lines.append(
+                    f"Le débat compte {n + 1} perspectives au total : "
+                    f"1 vidéo principale (vidéo A) + {n} perspective"
+                    f"{'s ajoutées' if n > 1 else ' ajoutée'}."
+                )
+                lines.append(
+                    f"{L.dominant_label} : "
+                    f"{_format_relation_human(self.relation_type_dominant, language)}."
+                )
+            else:
+                lines.append(f"## {L.topic_perspectives} : {self.topic}")
+                lines.append("")
+                lines.append(
+                    f"This debate has {n + 1} perspectives total: 1 main video "
+                    f"(video A) + {n} added perspective{'s' if n > 1 else ''}."
+                )
+                lines.append(
+                    f"{L.dominant_label}: "
+                    f"{_format_relation_human(self.relation_type_dominant, language)}."
+                )
+            lines.append("")
+            lines.append(f"### {L.video_a}")
+            lines.append(f"{L.title} : {self.video_a_title}")
+            lines.append(f"{L.channel} : {self.video_a_channel}")
+            lines.append("")
+            lines.append(f"### {L.perspectives_section}")
+            for p in self.perspectives:
+                rel_human = _format_relation_human(p.relation_type, language)
+                # Position 0-based en DB, on l'expose 1-based à l'agent.
+                idx = p.position + 1
+                lines.append(
+                    f"- **{L.perspective_singular} {idx}** "
+                    f"({L.relation} : {rel_human}) — "
+                    f"{L.title} : {p.video_title} · "
+                    f"{L.channel} : {p.video_channel}"
+                )
+            lines.append("")
+
+        # ── Thèses ──────────────────────────────────────────────────────
         lines.append(f"## {L.theses}")
-        lines.append(f"**{L.video_a} — {L.thesis}** : {_truncate(self.thesis_a, BUDGET_THESES // 2)}")
-        lines.append(f"**{L.video_b} — {L.thesis}** : {_truncate(self.thesis_b, BUDGET_THESES // 2)}")
+        thesis_a_truncated = _truncate(
+            self.thesis_a, BUDGET_THESES // (n + 1) if n > 0 else BUDGET_THESES // 2
+        )
+        lines.append(f"**{L.video_a} — {L.thesis}** : {thesis_a_truncated}")
+        for p in self.perspectives:
+            rel_human = _format_relation_human(p.relation_type, language)
+            label = (
+                f"{L.perspective_singular} {p.position + 1} ({rel_human})"
+                if not is_classic_debate
+                else ("Vidéo B" if fr else "Video B")
+            )
+            thesis_p = _truncate(
+                p.thesis, BUDGET_THESES // (n + 1) if n > 0 else BUDGET_THESES // 2
+            )
+            lines.append(f"**{label} — {L.thesis}** : {thesis_p}")
         lines.append("")
 
-        # Arguments A
+        # ── Arguments vidéo A ───────────────────────────────────────────
         lines.append(f"## {L.arguments} — {L.video_a}")
-        lines.append(_format_arguments(self.arguments_a, BUDGET_ARGUMENTS_PER_VIDEO, L))
+        lines.append(_format_arguments(self.arguments_a, BUDGET_ARGUMENTS_VIDEO_A, L))
         lines.append("")
 
-        # Arguments B
-        lines.append(f"## {L.arguments} — {L.video_b}")
-        lines.append(_format_arguments(self.arguments_b, BUDGET_ARGUMENTS_PER_VIDEO, L))
-        lines.append("")
+        # ── Arguments par perspective ──────────────────────────────────
+        per_persp_budget = max(
+            500, BUDGET_ARGUMENTS_PERSPECTIVES_TOTAL // max(1, n)
+        )
+        for p in self.perspectives:
+            if is_classic_debate:
+                title = "Vidéo B" if fr else "Video B"
+            else:
+                rel_human = _format_relation_human(p.relation_type, language)
+                title = f"{L.perspective_singular} {p.position + 1} ({rel_human})"
+            lines.append(f"## {L.arguments} — {title}")
+            lines.append(_format_arguments(p.arguments, per_persp_budget, L))
+            lines.append("")
 
-        # Convergences
+        # ── Convergences ────────────────────────────────────────────────
         if self.convergence_points:
             lines.append(f"## {L.convergence}")
             conv_text = "\n".join(f"- {str(p)}" for p in self.convergence_points[:10])
             lines.append(_truncate(conv_text, BUDGET_CONVERGENCE))
             lines.append("")
 
-        # Divergences
+        # ── Divergences ─────────────────────────────────────────────────
         if self.divergence_points:
             lines.append(f"## {L.divergence}")
             div_parts: list[str] = []
@@ -251,13 +471,21 @@ class DebateRichContext:
                     topic_d = d.get("topic", "?")
                     pos_a = d.get("position_a", "")
                     pos_b = d.get("position_b", "")
-                    div_parts.append(f"- **{topic_d}** — {L.video_a} : {pos_a} / {L.video_b} : {pos_b}")
+                    side_b_label = (
+                        ("Vidéo B" if fr else "Video B")
+                        if is_classic_debate
+                        else (L.perspective_singular + " B")
+                    )
+                    div_parts.append(
+                        f"- **{topic_d}** — {L.video_a} : {pos_a} / "
+                        f"{side_b_label} : {pos_b}"
+                    )
                 else:
                     div_parts.append(f"- {str(d)}")
             lines.append(_truncate("\n".join(div_parts), BUDGET_DIVERGENCE))
             lines.append("")
 
-        # Fact-check
+        # ── Fact-check ──────────────────────────────────────────────────
         if self.fact_check:
             lines.append(f"## {L.fact_check}")
             fc_parts: list[str] = []
@@ -266,33 +494,163 @@ class DebateRichContext:
                     claim = item.get("claim", "?")
                     verdict = item.get("verdict", "?")
                     explanation = item.get("explanation", "")
-                    fc_parts.append(f"- [{verdict.upper()}] {claim} — {explanation}")
+                    fc_parts.append(
+                        f"- [{verdict.upper()}] {claim} — {explanation}"
+                    )
             lines.append(_truncate("\n".join(fc_parts), BUDGET_FACT_CHECK))
             lines.append("")
 
-        # Synthèse
+        # ── Synthèse globale ────────────────────────────────────────────
         if self.debate_summary:
-            lines.append(f"## {L.summary}")
+            heading = L.summary if is_classic_debate else L.summary_perspectives
+            lines.append(f"## {heading}")
             lines.append(_truncate(self.debate_summary, BUDGET_SUMMARY))
             lines.append("")
 
-        # Transcripts (optionnels, injectés seulement si présents et budget restant)
-        if self.transcript_a or self.transcript_b:
-            used = sum(len(l) for l in lines)
+        # ── Transcripts (optionnels, budget restant) ────────────────────
+        if self.transcript_a or any(p.transcript for p in self.perspectives):
+            used = sum(len(line) for line in lines)
             remaining = max(0, max_chars - used - BUDGET_HEADER)
-            per_video_budget = max(0, min(BUDGET_TRANSCRIPT_PER_VIDEO, remaining // 2))
-            if per_video_budget > 200:
-                if self.transcript_a:
-                    lines.append(f"## {L.transcript_a}")
-                    lines.append(_truncate(self.transcript_a, per_video_budget))
-                    lines.append("")
-                if self.transcript_b:
-                    lines.append(f"## {L.transcript_b}")
-                    lines.append(_truncate(self.transcript_b, per_video_budget))
+            video_a_budget = max(0, min(BUDGET_TRANSCRIPT_VIDEO_A, remaining // 2))
+            persp_total_budget = max(
+                0, min(BUDGET_TRANSCRIPT_PERSPECTIVES_TOTAL, remaining - video_a_budget)
+            )
+            per_persp_transcript_budget = (
+                persp_total_budget // max(1, n) if n > 0 else 0
+            )
+
+            if video_a_budget > 200 and self.transcript_a:
+                lines.append(f"## {L.transcript_a}")
+                lines.append(_truncate(self.transcript_a, video_a_budget))
+                lines.append("")
+
+            if per_persp_transcript_budget > 200:
+                for p in self.perspectives:
+                    if not p.transcript:
+                        continue
+                    if is_classic_debate:
+                        title = "TRANSCRIPT VIDÉO B" if fr else "VIDEO B TRANSCRIPT"
+                    else:
+                        rel_human = _format_relation_human(
+                            p.relation_type, language
+                        )
+                        title = (
+                            f"{L.transcript_perspective} — "
+                            f"{L.perspective_singular} {p.position + 1} ({rel_human})"
+                        )
+                    lines.append(f"## {title}")
+                    lines.append(
+                        _truncate(p.transcript, per_persp_transcript_budget)
+                    )
                     lines.append("")
 
-        text = "\n".join(lines)
-        return _truncate(text, max_chars)
+        text_out = "\n".join(lines)
+        return _truncate(text_out, max_chars)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Loaders — perspectives v2 (raw SQL pour résilience à l'absence du model)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _load_perspectives_safe(
+    debate_id: int, db: AsyncSession
+) -> list[dict]:
+    """
+    Charge les perspectives v2 si la table `debate_perspectives` existe,
+    sinon retourne []. Le caller construit le fallback v1 depuis
+    `debate_analyses.video_b_*`.
+
+    Utilise du raw SQL (`text()`) pour ne PAS dépendre du modèle SQLAlchemy
+    `DebatePerspective` (créé par Sub-agent B). Ainsi cette PR mergeable
+    indépendamment.
+    """
+    try:
+        result = await db.execute(
+            text(
+                "SELECT id, position, video_id, platform, video_title, "
+                "video_channel, thesis, arguments_json, relation_type, "
+                "audience_level, channel_quality_score "
+                "FROM debate_perspectives "
+                "WHERE debate_id = :id "
+                "ORDER BY position ASC"
+            ),
+            {"id": debate_id},
+        )
+        rows = result.fetchall()
+        if not rows:
+            return []
+        perspectives: list[dict] = []
+        for row in rows:
+            try:
+                mapping = dict(row._mapping)
+            except AttributeError:
+                # Fallback pour les drivers qui retournent un tuple simple
+                mapping = {
+                    "id": row[0],
+                    "position": row[1],
+                    "video_id": row[2],
+                    "platform": row[3],
+                    "video_title": row[4],
+                    "video_channel": row[5],
+                    "thesis": row[6],
+                    "arguments_json": row[7],
+                    "relation_type": row[8],
+                    "audience_level": row[9] if len(row) > 9 else "unknown",
+                    "channel_quality_score": row[10] if len(row) > 10 else 0.0,
+                }
+            perspectives.append(mapping)
+        return perspectives
+    except Exception as exc:
+        # Table absente, ou colonnes manquantes, ou autre erreur SQL — fallback v1.
+        logger.info(
+            "debate_context: perspectives table unavailable, fallback v1 (debate_id=%s, exc=%s)",
+            debate_id,
+            type(exc).__name__,
+        )
+        return []
+
+
+def _build_perspective_from_v1(debate: DebateAnalysis) -> Optional[PerspectiveCtx]:
+    """
+    Construit une perspective implicite position=0 relation='opposite' depuis
+    les colonnes historiques `debate_analyses.video_b_*`.
+    Retourne None si pas de vidéo B (debate orphelin).
+    """
+    if not debate.video_b_id and not debate.video_b_title:
+        return None
+    return PerspectiveCtx(
+        position=0,
+        relation_type="opposite",
+        perspective_id=-1,
+        video_id=debate.video_b_id or "",
+        video_title=debate.video_b_title or "",
+        video_channel=debate.video_b_channel or "",
+        platform=debate.platform_b or "youtube",
+        thesis=debate.thesis_b or "",
+        arguments=_safe_json_list(debate.arguments_b),
+        transcript="",  # Sera rempli plus bas si include_transcripts
+        audience_level="unknown",
+        channel_quality_score=0.0,
+    )
+
+
+def _build_perspective_from_v2(row: dict) -> PerspectiveCtx:
+    """Construit une PerspectiveCtx depuis une row de debate_perspectives."""
+    return PerspectiveCtx(
+        position=int(row.get("position") or 0),
+        relation_type=_normalize_relation(row.get("relation_type")),
+        perspective_id=int(row.get("id") or -1),
+        video_id=row.get("video_id") or "",
+        video_title=row.get("video_title") or "",
+        video_channel=row.get("video_channel") or "",
+        platform=row.get("platform") or "youtube",
+        thesis=row.get("thesis") or "",
+        arguments=_safe_json_list(row.get("arguments_json")),
+        transcript="",
+        audience_level=row.get("audience_level") or "unknown",
+        channel_quality_score=float(row.get("channel_quality_score") or 0.0),
+    )
 
 
 async def _load_transcript_safely(video_id: str, db: AsyncSession) -> str:
@@ -305,7 +663,9 @@ async def _load_transcript_safely(video_id: str, db: AsyncSession) -> str:
         transcript = await _get_full_transcript_from_cache(video_id, db)
         return transcript or ""
     except Exception as exc:
-        logger.warning("debate_context: transcript load failed for %s: %s", video_id, exc)
+        logger.warning(
+            "debate_context: transcript load failed for %s: %s", video_id, exc
+        )
         return ""
 
 
@@ -315,13 +675,36 @@ async def build_debate_rich_context(
     include_transcripts: bool = True,
 ) -> DebateRichContext:
     """
-    Assemble le contexte vocal complet à partir d'une DebateAnalysis.
+    Assemble le contexte vocal complet (v2) à partir d'une DebateAnalysis.
+
+    Logique :
+    1. Tente de charger les `DebatePerspective` rows (raw SQL).
+    2. Si vide → fallback v1 : synthétise une perspective implicite depuis
+       `debate.video_b_*`.
+    3. Charge les transcripts (vidéo A + chaque perspective) en parallèle si
+       include_transcripts=True.
+    4. Calcule la `relation_type_dominant` (cf. spec §2.1).
 
     Args:
         debate: Ligne debate_analyses (statut completed attendu).
         db: Session DB async pour charger les transcripts depuis TranscriptCache.
-        include_transcripts: Si True, tente de charger les transcripts des 2 vidéos.
+        include_transcripts: Si True, tente de charger les transcripts.
     """
+    # ── 1. Chargement perspectives (v2 ou fallback v1) ─────────────────
+    raw_perspectives = await _load_perspectives_safe(debate.id, db)
+
+    if raw_perspectives:
+        perspectives = [_build_perspective_from_v2(row) for row in raw_perspectives]
+        version_used = "v2"
+    else:
+        fallback = _build_perspective_from_v1(debate)
+        perspectives = [fallback] if fallback is not None else []
+        version_used = "v1_fallback"
+
+    # ── 2. Calcul de la relation dominante ──────────────────────────────
+    relation_dominant = _compute_dominant_relation(perspectives)
+
+    # ── 3. Construction du contexte ─────────────────────────────────────
     ctx = DebateRichContext(
         debate_id=debate.id,
         topic=debate.detected_topic or "",
@@ -332,42 +715,43 @@ async def build_debate_rich_context(
         platform_a=debate.platform_a or "youtube",
         thesis_a=debate.thesis_a or "",
         arguments_a=_safe_json_list(debate.arguments_a),
-        video_b_id=debate.video_b_id or "",
-        video_b_title=debate.video_b_title or "",
-        video_b_channel=debate.video_b_channel or "",
-        platform_b=debate.platform_b or "youtube",
-        thesis_b=debate.thesis_b or "",
-        arguments_b=_safe_json_list(debate.arguments_b),
+        perspectives=perspectives,
+        relation_type_dominant=relation_dominant,
         convergence_points=_safe_json_list(debate.convergence_points),
         divergence_points=_safe_json_list(debate.divergence_points),
         fact_check=_safe_json_list(debate.fact_check_results),
         debate_summary=debate.debate_summary or "",
     )
 
+    # ── 4. Chargement des transcripts ───────────────────────────────────
     if include_transcripts:
-        # Chargement parallèle des 2 transcripts
         import asyncio
 
-        transcript_a, transcript_b = await asyncio.gather(
-            _load_transcript_safely(ctx.video_a_id, db),
-            _load_transcript_safely(ctx.video_b_id, db),
-            return_exceptions=False,
-        )
-        ctx.transcript_a = transcript_a
-        ctx.transcript_b = transcript_b
+        # Liste des coroutines à exécuter en parallèle :
+        # video A + chaque perspective avec un video_id
+        tasks: list = [_load_transcript_safely(ctx.video_a_id, db)]
+        for p in perspectives:
+            tasks.append(_load_transcript_safely(p.video_id, db))
+
+        results = await asyncio.gather(*tasks, return_exceptions=False)
+        ctx.transcript_a = results[0] if results else ""
+        for i, p in enumerate(perspectives, start=1):
+            if i < len(results):
+                p.transcript = results[i] or ""
 
     logger.info(
         "debate_context.built",
         extra={
             "debate_id": debate.id,
-            "topic": ctx.topic[:50],
+            "topic": (ctx.topic or "")[:50],
+            "version_used": version_used,
+            "n_perspectives": len(ctx.perspectives),
+            "relation_dominant": ctx.relation_type_dominant,
             "arguments_a_count": len(ctx.arguments_a),
-            "arguments_b_count": len(ctx.arguments_b),
             "convergence_count": len(ctx.convergence_points),
             "divergence_count": len(ctx.divergence_points),
             "fact_check_count": len(ctx.fact_check),
             "transcript_a_chars": len(ctx.transcript_a),
-            "transcript_b_chars": len(ctx.transcript_b),
         },
     )
 

--- a/backend/src/voice/debate_tools.py
+++ b/backend/src/voice/debate_tools.py
@@ -1,10 +1,19 @@
 """
-Debate Voice Agent Server Tools
-================================
-5 tools appelables par l'agent vocal ElevenLabs "Modérateur de débat" via webhook.
-Chaque fonction retourne un string formaté pour lecture vocale (max ~1500 mots).
+Debate Voice Agent Server Tools (v2)
+====================================
+Tools appelables par l'agent vocal ElevenLabs "Modérateur de débat" via webhook.
 
-Tous ces tools lisent DebateAnalysis (pas Summary). Ownership vérifié au niveau router.
+v2 — Adaptation N perspectives (1 vidéo A + 1 à 3 vidéos B avec relation_type ∈
+{opposite, complement, nuance}). Tools historiques (`get_debate_overview`,
+`get_video_thesis`, `get_argument_comparison`, `search_in_debate_transcript`,
+`get_debate_fact_check`) **conservés en compat**. Trois nouveaux tools v2 :
+
+- `list_perspectives(debate_id)` — toutes les perspectives + métadonnées synthétiques.
+- `compare(debate_id, perspective_a_id, perspective_b_id)` — comparaison ciblée.
+- `synthesize_relation(debate_id, relation_type)` — focus sur une relation type.
+
+Tous ces tools lisent DebateAnalysis (et `debate_perspectives` si présente).
+Ownership vérifié au niveau router.
 """
 
 from __future__ import annotations
@@ -16,7 +25,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from db.database import DebateAnalysis
-from voice.debate_context import _safe_json_list, _truncate
+from voice.debate_context import (
+    PerspectiveCtx,
+    _build_perspective_from_v1,
+    _build_perspective_from_v2,
+    _format_relation_human,
+    _load_perspectives_safe,
+    _normalize_relation,
+    _safe_json_list,
+    _truncate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,46 +44,142 @@ async def _load_debate(debate_id: int, db: AsyncSession) -> Optional[DebateAnaly
     return result.scalar_one_or_none()
 
 
+async def _load_perspectives_for_tool(
+    debate: DebateAnalysis, db: AsyncSession
+) -> list[PerspectiveCtx]:
+    """
+    Renvoie la liste des perspectives v2 OU le fallback v1 (1 perspective implicite).
+    Mutualisé entre tous les nouveaux tools v2.
+    """
+    raw = await _load_perspectives_safe(debate.id, db)
+    if raw:
+        return [_build_perspective_from_v2(r) for r in raw]
+    fallback = _build_perspective_from_v1(debate)
+    return [fallback] if fallback is not None else []
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tools historiques (compat ElevenLabs Studio config existante)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
 async def get_debate_overview(debate_id: int, db: AsyncSession) -> str:
-    """Résumé haute-vue : sujet, 2 thèses, synthèse."""
+    """
+    Résumé haute-vue : sujet, thèses (vidéo A + chaque perspective), synthèse.
+
+    v2 : si plusieurs perspectives, listes-les toutes avec leur relation_type.
+    """
     logger.info("debate_tool.overview", extra={"debate_id": debate_id})
     debate = await _load_debate(debate_id, db)
     if debate is None:
         return "Débat introuvable."
 
-    lines = [
-        f"Sujet du débat : {debate.detected_topic or '(non détecté)'}",
-        "",
-        f"Vidéo A — {debate.video_a_title or 'titre inconnu'} ({debate.video_a_channel or 'chaîne inconnue'})",
-        f"  Thèse : {_truncate(debate.thesis_a or '(non identifiée)', 400)}",
-        "",
-        f"Vidéo B — {debate.video_b_title or 'titre inconnu'} ({debate.video_b_channel or 'chaîne inconnue'})",
-        f"  Thèse : {_truncate(debate.thesis_b or '(non identifiée)', 400)}",
-        "",
-        f"Synthèse : {_truncate(debate.debate_summary or '(aucune synthèse disponible)', 600)}",
-    ]
+    perspectives = await _load_perspectives_for_tool(debate, db)
+    n = len(perspectives)
+    is_classic = (
+        n == 1 and _normalize_relation(perspectives[0].relation_type) == "opposite"
+    )
+    lang = debate.lang or "fr"
+
+    lines: list[str] = [f"Sujet du débat : {debate.detected_topic or '(non détecté)'}", ""]
+
+    lines.append(
+        f"Vidéo A — {debate.video_a_title or 'titre inconnu'} "
+        f"({debate.video_a_channel or 'chaîne inconnue'})"
+    )
+    lines.append(
+        f"  Thèse : {_truncate(debate.thesis_a or '(non identifiée)', 400)}"
+    )
+    lines.append("")
+
+    if is_classic:
+        # Format historique : compat avec test_get_debate_overview
+        p = perspectives[0]
+        lines.append(
+            f"Vidéo B — {p.video_title or 'titre inconnu'} "
+            f"({p.video_channel or 'chaîne inconnue'})"
+        )
+        lines.append(f"  Thèse : {_truncate(p.thesis or '(non identifiée)', 400)}")
+        lines.append("")
+    else:
+        lines.append(f"Le débat compte {n} perspective{'s' if n > 1 else ''} ajoutée{'s' if n > 1 else ''} :")
+        for p in perspectives:
+            rel_human = _format_relation_human(p.relation_type, lang)
+            lines.append(
+                f"- Perspective {p.position + 1} ({rel_human}) — "
+                f"{p.video_title or 'titre inconnu'} "
+                f"({p.video_channel or 'chaîne inconnue'})"
+            )
+            lines.append(
+                f"    Thèse : {_truncate(p.thesis or '(non identifiée)', 300)}"
+            )
+        lines.append("")
+
+    lines.append(
+        f"Synthèse : {_truncate(debate.debate_summary or '(aucune synthèse disponible)', 600)}"
+    )
     return "\n".join(lines)
 
 
 async def get_video_thesis(debate_id: int, side: str, db: AsyncSession) -> str:
-    """Thèse + arguments détaillés de la vidéo A ou B."""
+    """
+    Thèse + arguments détaillés de la vidéo A ou d'une perspective B.
+
+    side accepté : 'video_a', 'a', 'video_b', 'b' (= position 0),
+    'perspective_1' / 'perspective_2' / 'perspective_3' (1-based).
+    """
     logger.info("debate_tool.thesis", extra={"debate_id": debate_id, "side": side})
     side_norm = (side or "").strip().lower()
-    if side_norm not in ("video_a", "video_b", "a", "b"):
-        return "Paramètre 'side' invalide. Utiliser 'video_a' ou 'video_b'."
-    is_a = side_norm in ("video_a", "a")
 
     debate = await _load_debate(debate_id, db)
     if debate is None:
         return "Débat introuvable."
 
-    title = (debate.video_a_title if is_a else debate.video_b_title) or "titre inconnu"
-    channel = (debate.video_a_channel if is_a else debate.video_b_channel) or "chaîne inconnue"
-    thesis = (debate.thesis_a if is_a else debate.thesis_b) or "(non identifiée)"
-    arguments = _safe_json_list(debate.arguments_a if is_a else debate.arguments_b)
+    if side_norm in ("video_a", "a"):
+        title = debate.video_a_title or "titre inconnu"
+        channel = debate.video_a_channel or "chaîne inconnue"
+        thesis = debate.thesis_a or "(non identifiée)"
+        arguments = _safe_json_list(debate.arguments_a)
+        section_label = "Vidéo A"
+    elif side_norm in ("video_b", "b") or side_norm.startswith("perspective_"):
+        # Calcule l'index de perspective (0-based)
+        if side_norm in ("video_b", "b"):
+            target_idx = 0
+        else:
+            try:
+                # 'perspective_1' -> 0, 'perspective_2' -> 1, etc.
+                target_idx = int(side_norm.split("_", 1)[1]) - 1
+            except (ValueError, IndexError):
+                return (
+                    "Paramètre 'side' invalide. Utiliser 'video_a', 'video_b', "
+                    "'perspective_1', 'perspective_2' ou 'perspective_3'."
+                )
+
+        perspectives = await _load_perspectives_for_tool(debate, db)
+        if target_idx < 0 or target_idx >= len(perspectives):
+            return (
+                f"Perspective {target_idx + 1} introuvable "
+                f"(le débat compte {len(perspectives)} perspective(s))."
+            )
+        p = perspectives[target_idx]
+        title = p.video_title or "titre inconnu"
+        channel = p.video_channel or "chaîne inconnue"
+        thesis = p.thesis or "(non identifiée)"
+        arguments = p.arguments
+        rel_human = _format_relation_human(p.relation_type, debate.lang or "fr")
+        section_label = (
+            f"Perspective {target_idx + 1} ({rel_human})"
+            if target_idx > 0 or _normalize_relation(p.relation_type) != "opposite"
+            else "Vidéo B"
+        )
+    else:
+        return (
+            "Paramètre 'side' invalide. Utiliser 'video_a', 'video_b', "
+            "'perspective_1', 'perspective_2' ou 'perspective_3'."
+        )
 
     lines = [
-        f"## {'Vidéo A' if is_a else 'Vidéo B'} — {title}",
+        f"## {section_label} — {title}",
         f"Chaîne : {channel}",
         "",
         f"**Thèse défendue** : {thesis}",
@@ -92,7 +206,10 @@ async def get_video_thesis(debate_id: int, side: str, db: AsyncSession) -> str:
 
 async def get_argument_comparison(debate_id: int, topic: str, db: AsyncSession) -> str:
     """Compare les positions A vs B sur un sous-thème."""
-    logger.info("debate_tool.compare", extra={"debate_id": debate_id, "topic": (topic or "")[:60]})
+    logger.info(
+        "debate_tool.compare",
+        extra={"debate_id": debate_id, "topic": (topic or "")[:60]},
+    )
     debate = await _load_debate(debate_id, db)
     if debate is None:
         return "Débat introuvable."
@@ -100,7 +217,8 @@ async def get_argument_comparison(debate_id: int, topic: str, db: AsyncSession) 
     divergence = _safe_json_list(debate.divergence_points)
     convergence = _safe_json_list(debate.convergence_points)
     arguments_a = _safe_json_list(debate.arguments_a)
-    arguments_b = _safe_json_list(debate.arguments_b)
+    perspectives = await _load_perspectives_for_tool(debate, db)
+    arguments_b = perspectives[0].arguments if perspectives else []
 
     topic_norm = (topic or "").strip().lower()
 
@@ -111,7 +229,8 @@ async def get_argument_comparison(debate_id: int, topic: str, db: AsyncSession) 
             for d in divergence[:6]:
                 if isinstance(d, dict):
                     lines.append(
-                        f"- **{d.get('topic', '?')}** — A : {d.get('position_a', '')} / B : {d.get('position_b', '')}"
+                        f"- **{d.get('topic', '?')}** — A : {d.get('position_a', '')} / "
+                        f"B : {d.get('position_b', '')}"
                     )
                 else:
                     lines.append(f"- {d}")
@@ -125,8 +244,12 @@ async def get_argument_comparison(debate_id: int, topic: str, db: AsyncSession) 
     matching_divergences = [
         d for d in divergence if isinstance(d, dict) and topic_norm in (d.get("topic") or "").lower()
     ]
-    matching_args_a = [a for a in arguments_a if isinstance(a, dict) and topic_norm in (a.get("claim") or "").lower()]
-    matching_args_b = [a for a in arguments_b if isinstance(a, dict) and topic_norm in (a.get("claim") or "").lower()]
+    matching_args_a = [
+        a for a in arguments_a if isinstance(a, dict) and topic_norm in (a.get("claim") or "").lower()
+    ]
+    matching_args_b = [
+        a for a in arguments_b if isinstance(a, dict) and topic_norm in (a.get("claim") or "").lower()
+    ]
 
     if not (matching_divergences or matching_args_a or matching_args_b):
         return (
@@ -136,7 +259,10 @@ async def get_argument_comparison(debate_id: int, topic: str, db: AsyncSession) 
 
     lines = [f"## Comparaison sur : {topic}", ""]
     for d in matching_divergences:
-        lines.append(f"**{d.get('topic', '?')}** — A : {d.get('position_a', '')} / B : {d.get('position_b', '')}")
+        lines.append(
+            f"**{d.get('topic', '?')}** — A : {d.get('position_a', '')} / "
+            f"B : {d.get('position_b', '')}"
+        )
     if matching_args_a:
         lines.append("\n**Arguments vidéo A** :")
         for a in matching_args_a[:3]:
@@ -155,9 +281,10 @@ async def search_in_debate_transcript(
     side: str,
     db: AsyncSession,
 ) -> str:
-    """Recherche BM25 dans le transcript de la vidéo A, B, ou les deux."""
+    """Recherche BM25 dans le transcript de la vidéo A, B (1ère perspective), ou les deux."""
     logger.info(
-        "debate_tool.search_transcript", extra={"debate_id": debate_id, "query": (query or "")[:60], "side": side}
+        "debate_tool.search_transcript",
+        extra={"debate_id": debate_id, "query": (query or "")[:60], "side": side},
     )
     debate = await _load_debate(debate_id, db)
     if debate is None:
@@ -172,11 +299,14 @@ async def search_in_debate_transcript(
     from chat.context_builder import _get_full_transcript_from_cache
     from videos.smart_search import search_relevant_passages, format_passages_for_chat
 
+    perspectives = await _load_perspectives_for_tool(debate, db)
+    video_b_id = perspectives[0].video_id if perspectives else ""
+
     sides: list[tuple[str, str]] = []
     if side_norm in ("video_a", "a", "both"):
         sides.append(("Vidéo A", debate.video_a_id or ""))
     if side_norm in ("video_b", "b", "both"):
-        sides.append(("Vidéo B", debate.video_b_id or ""))
+        sides.append(("Vidéo B", video_b_id))
 
     parts: list[str] = []
     for label, video_id in sides:
@@ -186,7 +316,9 @@ async def search_in_debate_transcript(
         try:
             transcript = await _get_full_transcript_from_cache(video_id, db)
         except Exception as exc:
-            logger.warning("search_in_debate_transcript: %s load failed: %s", label, exc)
+            logger.warning(
+                "search_in_debate_transcript: %s load failed: %s", label, exc
+            )
             transcript = ""
         if not transcript:
             parts.append(f"### {label}\n(transcript indisponible)")
@@ -199,7 +331,9 @@ async def search_in_debate_transcript(
                 max_passages=3,
             )
         except Exception as exc:
-            logger.warning("search_in_debate_transcript: %s smart_search failed: %s", label, exc)
+            logger.warning(
+                "search_in_debate_transcript: %s smart_search failed: %s", label, exc
+            )
             passages = []
         if not passages:
             parts.append(f"### {label}\n(aucun passage pertinent trouvé)")
@@ -243,3 +377,318 @@ async def get_debate_fact_check(debate_id: int, db: AsyncSession) -> str:
             lines.append(f"   Source : {source}")
 
     return _truncate("\n".join(lines), 3000)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Nouveaux tools v2 — Multi-perspectives + relation_type
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def list_perspectives(debate_id: int, db: AsyncSession) -> str:
+    """
+    Liste les N perspectives du débat avec titres, chaînes, relation_types et thèses.
+    Utile à l'agent pour annoncer la structure du débat avant d'attaquer un point.
+
+    v2 : aware de la table debate_perspectives.
+    Fallback v1 : retourne 1 perspective implicite (relation 'opposite') depuis
+    debate_analyses.video_b_*.
+    """
+    logger.info("debate_tool.list_perspectives", extra={"debate_id": debate_id})
+    debate = await _load_debate(debate_id, db)
+    if debate is None:
+        return "Débat introuvable."
+
+    perspectives = await _load_perspectives_for_tool(debate, db)
+    if not perspectives:
+        return (
+            "Aucune perspective trouvée pour ce débat. "
+            "Le débat est peut-être encore en cours d'analyse."
+        )
+
+    lang = debate.lang or "fr"
+    lines: list[str] = [
+        f"## Perspectives du débat ({len(perspectives) + 1} au total)",
+        "",
+        f"**Vidéo A** — {debate.video_a_title or 'titre inconnu'} "
+        f"({debate.video_a_channel or 'chaîne inconnue'})",
+        f"  Thèse : {_truncate(debate.thesis_a or '(non identifiée)', 300)}",
+        "",
+    ]
+
+    for p in perspectives:
+        rel_human = _format_relation_human(p.relation_type, lang)
+        idx = p.position + 1
+        lines.append(
+            f"**Perspective {idx}** ({rel_human}) — "
+            f"{p.video_title or 'titre inconnu'} "
+            f"({p.video_channel or 'chaîne inconnue'})"
+        )
+        lines.append(
+            f"  Thèse : {_truncate(p.thesis or '(non identifiée)', 300)}"
+        )
+        if p.arguments:
+            args_summary = "; ".join(
+                a.get("claim", "?") if isinstance(a, dict) else str(a)
+                for a in p.arguments[:3]
+            )
+            lines.append(f"  Arguments principaux : {_truncate(args_summary, 250)}")
+        lines.append("")
+
+    return _truncate("\n".join(lines), 3500)
+
+
+async def compare(
+    debate_id: int,
+    perspective_a_id: int,
+    perspective_b_id: int,
+    db: AsyncSession,
+) -> str:
+    """
+    Compare deux perspectives ciblées par leur ID (côté DB) ou leur position 1-based.
+
+    Convention :
+    - perspective_a_id == 0 (ou -10) → la vidéo A (l'ancrage du débat).
+    - perspective_a_id > 0 → ID de DebatePerspective.id (v2) ou position 1-based si IDs inconnus.
+
+    Fallback v1 : si table debate_perspectives absente, on autorise uniquement
+    perspective_a_id ∈ {0, vidéo A} et perspective_b_id ∈ {1, vidéo B implicite}.
+    """
+    logger.info(
+        "debate_tool.compare",
+        extra={
+            "debate_id": debate_id,
+            "perspective_a_id": perspective_a_id,
+            "perspective_b_id": perspective_b_id,
+        },
+    )
+    debate = await _load_debate(debate_id, db)
+    if debate is None:
+        return "Débat introuvable."
+
+    perspectives = await _load_perspectives_for_tool(debate, db)
+
+    def _resolve_side(pid: int) -> Optional[tuple[str, str, str, list]]:
+        """
+        Résout pid en tuple (label, title, thesis, arguments).
+        - pid == 0 → vidéo A.
+        - pid > 0 :
+          - tente match sur perspective.perspective_id (= row id en DB v2)
+          - sinon match sur position 1-based (1 → perspectives[0], etc.)
+        """
+        if pid == 0:
+            return (
+                "Vidéo A",
+                debate.video_a_title or "titre inconnu",
+                debate.thesis_a or "(non identifiée)",
+                _safe_json_list(debate.arguments_a),
+            )
+        # v2 : essaie de matcher sur perspective_id (DB row id)
+        for p in perspectives:
+            if p.perspective_id == pid and p.perspective_id != -1:
+                rel_human = _format_relation_human(
+                    p.relation_type, debate.lang or "fr"
+                )
+                label = f"Perspective {p.position + 1} ({rel_human})"
+                return (label, p.video_title or "titre inconnu", p.thesis or "(non identifiée)", p.arguments)
+        # Fallback : interprète pid comme position 1-based
+        if 1 <= pid <= len(perspectives):
+            p = perspectives[pid - 1]
+            rel_human = _format_relation_human(p.relation_type, debate.lang or "fr")
+            label = f"Perspective {pid} ({rel_human})"
+            return (label, p.video_title or "titre inconnu", p.thesis or "(non identifiée)", p.arguments)
+        return None
+
+    side_a = _resolve_side(perspective_a_id)
+    side_b = _resolve_side(perspective_b_id)
+
+    if side_a is None:
+        return (
+            f"Perspective A introuvable (id={perspective_a_id}). "
+            "Utiliser 0 pour la vidéo A, ou l'id/position d'une perspective."
+        )
+    if side_b is None:
+        return (
+            f"Perspective B introuvable (id={perspective_b_id}). "
+            "Utiliser 0 pour la vidéo A, ou l'id/position d'une perspective."
+        )
+    if perspective_a_id == perspective_b_id:
+        return (
+            "Les deux perspectives à comparer sont identiques. "
+            "Choisir 2 perspectives différentes."
+        )
+
+    label_a, title_a, thesis_a, args_a = side_a
+    label_b, title_b, thesis_b, args_b = side_b
+
+    lines = [
+        f"## Comparaison : {label_a} ↔ {label_b}",
+        "",
+        f"### {label_a} — {title_a}",
+        f"  Thèse : {_truncate(thesis_a, 400)}",
+        "",
+        f"### {label_b} — {title_b}",
+        f"  Thèse : {_truncate(thesis_b, 400)}",
+        "",
+        f"### Arguments — {label_a}",
+    ]
+    if not args_a:
+        lines.append("(aucun argument extrait)")
+    else:
+        for i, arg in enumerate(args_a[:5], start=1):
+            if isinstance(arg, dict):
+                lines.append(f"{i}. {arg.get('claim', '?')}")
+            else:
+                lines.append(f"{i}. {str(arg)}")
+    lines.append("")
+    lines.append(f"### Arguments — {label_b}")
+    if not args_b:
+        lines.append("(aucun argument extrait)")
+    else:
+        for i, arg in enumerate(args_b[:5], start=1):
+            if isinstance(arg, dict):
+                lines.append(f"{i}. {arg.get('claim', '?')}")
+            else:
+                lines.append(f"{i}. {str(arg)}")
+
+    # Heuristique de convergence/divergence : recoupe avec la synthèse globale.
+    convergence = _safe_json_list(debate.convergence_points)
+    divergence = _safe_json_list(debate.divergence_points)
+    if convergence:
+        lines.append("")
+        lines.append("### Points de convergence (synthèse globale)")
+        for c in convergence[:5]:
+            lines.append(f"- {c}")
+    if divergence:
+        lines.append("")
+        lines.append("### Points de divergence (synthèse globale)")
+        for d in divergence[:5]:
+            if isinstance(d, dict):
+                lines.append(
+                    f"- **{d.get('topic', '?')}** — "
+                    f"{d.get('position_a', '')} / {d.get('position_b', '')}"
+                )
+            else:
+                lines.append(f"- {str(d)}")
+
+    return _truncate("\n".join(lines), 3500)
+
+
+async def synthesize_relation(
+    debate_id: int,
+    relation_type: str,
+    db: AsyncSession,
+) -> str:
+    """
+    Synthèse focalisée sur un relation_type :
+    - 'opposite' : contradictions, points de désaccord (utilise les divergences globales).
+    - 'complement' : enrichissements (perspectives qui élargissent l'angle de la vidéo A).
+    - 'nuance' : subtilités (perspectives qui modulent ou précisent les claims).
+
+    Pour chaque relation, on liste les perspectives concernées + leurs thèses + leurs
+    arguments-clés, et on rappelle les points pertinents de l'analyse globale.
+    """
+    logger.info(
+        "debate_tool.synthesize_relation",
+        extra={"debate_id": debate_id, "relation_type": relation_type},
+    )
+    debate = await _load_debate(debate_id, db)
+    if debate is None:
+        return "Débat introuvable."
+
+    rel_norm = _normalize_relation(relation_type)
+    if not relation_type or rel_norm not in ("opposite", "complement", "nuance"):
+        return (
+            "Paramètre 'relation_type' invalide. Utiliser 'opposite', 'complement' "
+            "ou 'nuance'."
+        )
+
+    perspectives = await _load_perspectives_for_tool(debate, db)
+    matching = [p for p in perspectives if _normalize_relation(p.relation_type) == rel_norm]
+
+    lang = debate.lang or "fr"
+    rel_human = _format_relation_human(rel_norm, lang)
+
+    lines: list[str] = [f"## Synthèse — relation : {rel_human}", ""]
+
+    if not matching:
+        lines.append(
+            f"Aucune perspective de type '{rel_human}' dans ce débat. "
+            f"Le débat compte {len(perspectives)} perspective(s) au total."
+        )
+        # On affiche tout de même les points globaux pertinents si opposite
+        if rel_norm == "opposite":
+            divergence = _safe_json_list(debate.divergence_points)
+            if divergence:
+                lines.append("")
+                lines.append("Points de divergence globaux trouvés malgré tout :")
+                for d in divergence[:5]:
+                    if isinstance(d, dict):
+                        lines.append(
+                            f"- **{d.get('topic', '?')}** — "
+                            f"A : {d.get('position_a', '')} / "
+                            f"B : {d.get('position_b', '')}"
+                        )
+                    else:
+                        lines.append(f"- {str(d)}")
+        return _truncate("\n".join(lines), 3000)
+
+    lines.append(
+        f"{len(matching)} perspective(s) sur {len(perspectives)} sont en relation "
+        f"« {rel_human} » avec la vidéo A :"
+    )
+    lines.append("")
+    for p in matching:
+        idx = p.position + 1
+        lines.append(
+            f"### Perspective {idx} — {p.video_title or 'titre inconnu'} "
+            f"({p.video_channel or 'chaîne inconnue'})"
+        )
+        lines.append(f"  Thèse : {_truncate(p.thesis or '(non identifiée)', 400)}")
+        if p.arguments:
+            lines.append("  Arguments principaux :")
+            for i, arg in enumerate(p.arguments[:4], start=1):
+                if isinstance(arg, dict):
+                    lines.append(f"    {i}. {arg.get('claim', '?')}")
+                else:
+                    lines.append(f"    {i}. {str(arg)}")
+        lines.append("")
+
+    # Synthèse globale spécifique au relation_type
+    if rel_norm == "opposite":
+        divergence = _safe_json_list(debate.divergence_points)
+        if divergence:
+            lines.append("### Contradictions principales (synthèse globale)")
+            for d in divergence[:6]:
+                if isinstance(d, dict):
+                    lines.append(
+                        f"- **{d.get('topic', '?')}** — "
+                        f"A : {d.get('position_a', '')} / "
+                        f"B : {d.get('position_b', '')}"
+                    )
+                else:
+                    lines.append(f"- {str(d)}")
+            lines.append("")
+    elif rel_norm == "complement":
+        convergence = _safe_json_list(debate.convergence_points)
+        if convergence:
+            lines.append("### Enrichissements partagés (convergences globales)")
+            for c in convergence[:6]:
+                lines.append(f"- {c}")
+            lines.append("")
+    elif rel_norm == "nuance":
+        # Pour les nuances, on ne pré-suppose pas un signal global ; on commente la dynamique.
+        lines.append(
+            "### Lecture nuancée"
+        )
+        lines.append(
+            "Ces perspectives modulent les claims principaux de la vidéo A — "
+            "ni en franche opposition, ni en simple complément, mais en précisant "
+            "des cas particuliers ou en contextualisant les généralisations."
+        )
+        lines.append("")
+
+    if debate.debate_summary:
+        lines.append("### Synthèse globale du débat")
+        lines.append(_truncate(debate.debate_summary, 800))
+
+    return _truncate("\n".join(lines), 3500)

--- a/backend/tests/test_voice_debate_v2.py
+++ b/backend/tests/test_voice_debate_v2.py
@@ -1,0 +1,847 @@
+"""
+Tests Wave 2 C — voice moderator v2 (N perspectives + relation_types).
+
+Ce fichier couvre les NOUVELLES fonctionnalités v2 du moderator vocal de débat :
+- `build_debate_rich_context` en mode v2 nominal (table debate_perspectives présente)
+- `build_debate_rich_context` en mode v1 fallback (table absente / vide)
+- Nouveaux tools v2 : `list_perspectives`, `compare`, `synthesize_relation`
+- Tools legacy toujours fonctionnels
+- Compat ElevenLabs : agent_type="debate_moderator" présent dans le registre
+
+Les tests historiques restent dans test_debate_voice_context.py et
+test_debate_voice_tools.py — ce fichier-ci ne les redouble pas.
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from voice.debate_context import (
+    DebateRichContext,
+    PerspectiveCtx,
+    _normalize_relation,
+    _compute_dominant_relation,
+    build_debate_rich_context,
+)
+from voice.debate_tools import (
+    list_perspectives,
+    compare,
+    synthesize_relation,
+    get_debate_overview,
+    get_video_thesis,
+    get_argument_comparison,
+    get_debate_fact_check,
+    search_in_debate_transcript,
+)
+from db.database import DebateAnalysis
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Factories
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_debate(**overrides) -> DebateAnalysis:
+    """DebateAnalysis ‘complète’ avec colonnes legacy video_b_*."""
+    defaults = dict(
+        id=42,
+        user_id=1,
+        video_a_id="vidA01",
+        platform_a="youtube",
+        video_a_title="Vidéo A — perspective principale",
+        video_a_channel="ChannelA",
+        thesis_a="Thèse A : la position centrale du débat",
+        arguments_a=json.dumps(
+            [
+                {"claim": "ClaimA1", "evidence": "evA1", "strength": "strong"},
+                {"claim": "ClaimA2", "evidence": "evA2", "strength": "moderate"},
+            ]
+        ),
+        video_b_id="vidB01",
+        platform_b="youtube",
+        video_b_title="Vidéo B — perspective opposée (legacy v1)",
+        video_b_channel="ChannelB",
+        thesis_b="Thèse B : opposition à la thèse A",
+        arguments_b=json.dumps(
+            [{"claim": "ClaimB1", "evidence": "evB1", "strength": "strong"}]
+        ),
+        detected_topic="Sujet du débat IA v2",
+        convergence_points=json.dumps(["Convergence Z"]),
+        divergence_points=json.dumps(
+            [{"topic": "Prix", "position_a": "trop cher", "position_b": "justifié"}]
+        ),
+        fact_check_results=json.dumps(
+            [{"claim": "Affirmation X", "verdict": "confirmed", "explanation": "OK"}]
+        ),
+        debate_summary="Synthèse globale du débat.",
+        status="completed",
+        mode="auto",
+        lang="fr",
+        created_at=datetime.utcnow(),
+    )
+    defaults.update(overrides)
+    return DebateAnalysis(**defaults)
+
+
+def _make_v2_perspective_row(**overrides) -> dict:
+    """
+    Mimique d'une row `debate_perspectives` (mapping renvoyé par
+    `_load_perspectives_safe` quand la table existe).
+    """
+    defaults = dict(
+        id=1001,
+        position=0,
+        video_id="vidB01",
+        platform="youtube",
+        video_title="Vidéo B opposée",
+        video_channel="ChannelB",
+        thesis="Thèse opposée à A",
+        arguments_json=json.dumps(
+            [{"claim": "ClaimOpp1", "evidence": "evOpp", "strength": "strong"}]
+        ),
+        relation_type="opposite",
+        audience_level="grand_public",
+        channel_quality_score=0.7,
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+def _three_perspectives_rows() -> list[dict]:
+    """Trois perspectives avec relation_types variés (opposite/complement/nuance)."""
+    return [
+        _make_v2_perspective_row(
+            id=1001,
+            position=0,
+            video_id="vidOpp",
+            video_title="Vidéo opposée",
+            video_channel="ChannelOpp",
+            thesis="Thèse en opposition franche",
+            relation_type="opposite",
+            arguments_json=json.dumps(
+                [{"claim": "OppClaim1", "evidence": "OppEv", "strength": "strong"}]
+            ),
+        ),
+        _make_v2_perspective_row(
+            id=1002,
+            position=1,
+            video_id="vidComp",
+            video_title="Vidéo complémentaire",
+            video_channel="ChannelComp",
+            thesis="Thèse qui complète la principale",
+            relation_type="complement",
+            arguments_json=json.dumps(
+                [{"claim": "CompClaim1", "evidence": "CompEv", "strength": "moderate"}]
+            ),
+        ),
+        _make_v2_perspective_row(
+            id=1003,
+            position=2,
+            video_id="vidNua",
+            video_title="Vidéo nuançante",
+            video_channel="ChannelNua",
+            thesis="Thèse qui nuance la principale",
+            relation_type="nuance",
+            arguments_json=json.dumps(
+                [{"claim": "NuaClaim1", "evidence": "NuaEv", "strength": "weak"}]
+            ),
+        ),
+    ]
+
+
+def _mock_db_select_debate(debate: DebateAnalysis | None) -> AsyncMock:
+    """Mock un AsyncSession dont `execute(select(...))` renvoie ce debate."""
+    db = AsyncMock(spec=AsyncSession)
+    select_result = MagicMock()
+    select_result.scalar_one_or_none.return_value = debate
+    db.execute = AsyncMock(return_value=select_result)
+    return db
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. build_debate_rich_context — cas v2 nominal (3 perspectives)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_build_context_v2_three_perspectives_populated():
+    """
+    Cas v2 nominal : la table `debate_perspectives` retourne 3 rows.
+    Le contexte doit refléter les 3 titres, relations et thèses.
+    """
+    db = AsyncMock(spec=AsyncSession)
+    debate = _make_debate()
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_context._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        ctx = await build_debate_rich_context(debate, db, include_transcripts=False)
+
+    assert isinstance(ctx, DebateRichContext)
+    assert len(ctx.perspectives) == 3
+
+    titles = [p.video_title for p in ctx.perspectives]
+    relations = [p.relation_type for p in ctx.perspectives]
+
+    assert "Vidéo opposée" in titles
+    assert "Vidéo complémentaire" in titles
+    assert "Vidéo nuançante" in titles
+    assert relations == ["opposite", "complement", "nuance"]
+
+    theses = [p.thesis for p in ctx.perspectives]
+    assert any("opposition franche" in t for t in theses)
+    assert any("complète" in t for t in theses)
+    assert any("nuance" in t for t in theses)
+
+    # Relation dominante : tie 1-1-1, priorité opposite > complement > nuance
+    assert ctx.relation_type_dominant == "opposite"
+
+    # video_a propagée
+    assert ctx.video_a_title == debate.video_a_title
+    assert ctx.thesis_a == debate.thesis_a
+
+
+@pytest.mark.asyncio
+async def test_build_context_v2_format_for_voice_includes_three_titles():
+    """Le contexte vocal formaté mentionne les 3 perspectives + leurs relations."""
+    db = AsyncMock(spec=AsyncSession)
+    debate = _make_debate()
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_context._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        ctx = await build_debate_rich_context(debate, db, include_transcripts=False)
+
+    formatted = ctx.format_for_voice(language="fr", max_chars=12_000)
+
+    assert "Vidéo opposée" in formatted
+    assert "Vidéo complémentaire" in formatted
+    assert "Vidéo nuançante" in formatted
+    # Relations humaines (FR)
+    assert "opposition" in formatted
+    assert "complément" in formatted
+    assert "nuance" in formatted
+    # Header v2 multi-perspectives
+    assert "perspectives" in formatted.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. build_debate_rich_context — cas v2 avec UNE seule perspective
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_build_context_v2_single_perspective_classic_debate_format():
+    """
+    Une seule perspective, relation 'opposite' → format ‘Débat IA classique’
+    (compat avec lecture historique).
+    """
+    db = AsyncMock(spec=AsyncSession)
+    debate = _make_debate()
+    rows = [
+        _make_v2_perspective_row(
+            id=2001,
+            position=0,
+            video_id="vidSolo",
+            video_title="Vidéo B unique",
+            video_channel="ChannelSolo",
+            thesis="Thèse opposée unique",
+            relation_type="opposite",
+        )
+    ]
+
+    with patch(
+        "voice.debate_context._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        ctx = await build_debate_rich_context(debate, db, include_transcripts=False)
+
+    assert len(ctx.perspectives) == 1
+    assert ctx.perspectives[0].video_title == "Vidéo B unique"
+    assert ctx.relation_type_dominant == "opposite"
+
+    formatted = ctx.format_for_voice(language="fr", max_chars=12_000)
+    # Format classique réutilisé
+    assert "VIDÉO A" in formatted
+    assert "VIDÉO B" in formatted
+    assert "Vidéo B unique" in formatted
+
+
+@pytest.mark.asyncio
+async def test_build_context_v2_single_complement_uses_perspectives_format():
+    """
+    Une seule perspective MAIS relation 'complement' → format multi-perspectives
+    (le header annonce explicitement la relation dominante).
+    """
+    db = AsyncMock(spec=AsyncSession)
+    debate = _make_debate()
+    rows = [
+        _make_v2_perspective_row(
+            id=2002,
+            position=0,
+            video_id="vidComp",
+            video_title="Vidéo complément",
+            video_channel="ChannelComp",
+            thesis="Thèse qui élargit",
+            relation_type="complement",
+        )
+    ]
+
+    with patch(
+        "voice.debate_context._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        ctx = await build_debate_rich_context(debate, db, include_transcripts=False)
+
+    assert len(ctx.perspectives) == 1
+    assert ctx.relation_type_dominant == "complement"
+    formatted = ctx.format_for_voice(language="fr", max_chars=12_000)
+    assert "complément" in formatted
+    assert "Relation dominante" in formatted
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. build_debate_rich_context — cas v1 fallback (table absente)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_build_context_v1_fallback_when_perspectives_table_absent():
+    """
+    Cas v1 fallback : la table `debate_perspectives` n'existe pas → exception SQL
+    avalée par `_load_perspectives_safe`, on synthétise une perspective implicite
+    position=0 relation='opposite' depuis `debate_analyses.video_b_*`.
+    """
+    db = AsyncMock(spec=AsyncSession)
+    debate = _make_debate()  # video_b_* présents
+
+    # Simule la table absente : SELECT raw sur debate_perspectives lève.
+    # `_load_perspectives_safe` capture l'exception et renvoie [].
+    db.execute = AsyncMock(side_effect=Exception("no such table: debate_perspectives"))
+
+    ctx = await build_debate_rich_context(debate, db, include_transcripts=False)
+
+    # 1 perspective implicite (fallback v1)
+    assert len(ctx.perspectives) == 1
+    p = ctx.perspectives[0]
+    assert p.perspective_id == -1  # Marqueur "perspective virtuelle"
+    assert p.position == 0
+    assert p.relation_type == "opposite"
+    assert p.video_id == "vidB01"
+    assert p.video_title == "Vidéo B — perspective opposée (legacy v1)"
+    assert p.video_channel == "ChannelB"
+    assert p.thesis == "Thèse B : opposition à la thèse A"
+    assert len(p.arguments) == 1
+    assert p.arguments[0]["claim"] == "ClaimB1"
+
+    # Relation dominante reflète la perspective
+    assert ctx.relation_type_dominant == "opposite"
+
+    # Compat properties exposent video_b_*
+    assert ctx.video_b_title == "Vidéo B — perspective opposée (legacy v1)"
+    assert ctx.thesis_b == "Thèse B : opposition à la thèse A"
+
+
+@pytest.mark.asyncio
+async def test_build_context_v1_fallback_format_for_voice():
+    """Le format vocal en fallback v1 reste lisible (mention 1 perspective)."""
+    db = AsyncMock(spec=AsyncSession)
+    debate = _make_debate()
+    db.execute = AsyncMock(side_effect=Exception("no such table: debate_perspectives"))
+
+    ctx = await build_debate_rich_context(debate, db, include_transcripts=False)
+    formatted = ctx.format_for_voice(language="fr", max_chars=10_000)
+
+    assert "Vidéo B — perspective opposée (legacy v1)" in formatted
+    assert "VIDÉO A" in formatted
+    assert "VIDÉO B" in formatted
+    # Compat lecture : 1 perspective + opposite → format classique
+    assert "Sujet du débat IA v2" in formatted
+
+
+@pytest.mark.asyncio
+async def test_build_context_no_video_b_graceful():
+    """
+    Cas debate orphelin : pas de video_b_id ET table debate_perspectives absente.
+    Le contexte se construit sans planter, avec 0 perspective.
+    """
+    db = AsyncMock(spec=AsyncSession)
+    debate = _make_debate(
+        video_b_id=None,
+        video_b_title=None,
+        video_b_channel=None,
+        thesis_b=None,
+        arguments_b=None,
+        platform_b=None,
+    )
+    db.execute = AsyncMock(side_effect=Exception("no such table: debate_perspectives"))
+
+    ctx = await build_debate_rich_context(debate, db, include_transcripts=False)
+
+    assert len(ctx.perspectives) == 0
+    assert ctx.video_a_title == debate.video_a_title
+    # format_for_voice ne plante pas, et ne mentionne pas un nombre négatif
+    formatted = ctx.format_for_voice(language="fr", max_chars=8_000)
+    assert "Sujet du débat IA v2" in formatted
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. Tools v2 — list_perspectives
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_list_perspectives_v2_three_titles_and_relations():
+    """list_perspectives renvoie titres + thèses + relations human des 3 perspectives."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await list_perspectives(42, db)
+
+    # Header
+    assert "Perspectives du débat" in out
+    # Vidéo A
+    assert "Vidéo A — perspective principale" in out
+    assert "Thèse A" in out
+    # Les 3 perspectives
+    assert "Vidéo opposée" in out
+    assert "Vidéo complémentaire" in out
+    assert "Vidéo nuançante" in out
+    # Relations human FR
+    assert "opposition" in out
+    assert "complément" in out
+    assert "nuance" in out
+    # Numérotation 1-based
+    assert "Perspective 1" in out
+    assert "Perspective 2" in out
+    assert "Perspective 3" in out
+
+
+@pytest.mark.asyncio
+async def test_list_perspectives_v1_fallback_one_implicit_perspective():
+    """En fallback v1, list_perspectives renvoie la perspective implicite (vidéo B)."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=[]),
+    ):
+        out = await list_perspectives(42, db)
+
+    assert "Vidéo A" in out
+    assert "Vidéo B — perspective opposée (legacy v1)" in out
+    assert "opposition" in out  # relation_type='opposite' implicite
+    assert "Perspective 1" in out
+
+
+@pytest.mark.asyncio
+async def test_list_perspectives_missing_debate_returns_message():
+    """Pas de débat trouvé → message d'erreur clair."""
+    db = _mock_db_select_debate(None)
+    out = await list_perspectives(999, db)
+    assert "introuvable" in out.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. Tools v2 — compare
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_compare_video_a_vs_first_perspective():
+    """compare(0, 1) = vidéo A vs 1ère perspective (position 1-based)."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await compare(42, 0, 1, db)
+
+    # En-tête
+    assert "Comparaison" in out
+    # Vidéo A
+    assert "Vidéo A" in out
+    assert "Thèse A" in out
+    assert "ClaimA1" in out
+    # Perspective 1 (opposite)
+    assert "Vidéo opposée" in out
+    assert "OppClaim1" in out
+    assert "opposition" in out
+
+
+@pytest.mark.asyncio
+async def test_compare_two_perspectives_by_position():
+    """compare(1, 2) compare perspective 1 et perspective 2 (positions 1-based)."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await compare(42, 1, 2, db)
+
+    assert "Vidéo opposée" in out
+    assert "Vidéo complémentaire" in out
+    # Pas de Vidéo A en focus principal (mais peut apparaître dans la synthèse globale)
+    assert "OppClaim1" in out
+    assert "CompClaim1" in out
+
+
+@pytest.mark.asyncio
+async def test_compare_resolves_perspective_by_db_id():
+    """compare(0, 1002) résout 1002 = perspective_id en DB → 2ème perspective."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await compare(42, 0, 1002, db)
+
+    # 1002 = id complement
+    assert "Vidéo complémentaire" in out
+    assert "complément" in out
+
+
+@pytest.mark.asyncio
+async def test_compare_invalid_perspective_id():
+    """ID inexistant → message d'erreur explicite."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await compare(42, 0, 9999, db)
+
+    assert "introuvable" in out.lower()
+
+
+@pytest.mark.asyncio
+async def test_compare_same_perspective_twice():
+    """Comparer une perspective avec elle-même → message clair."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await compare(42, 1, 1, db)
+
+    assert "identiques" in out.lower() or "différentes" in out.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. Tools v2 — synthesize_relation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_synthesize_relation_opposite_focuses_on_contradictions():
+    """relation='opposite' → focus contradictions, listing perspectives oppose."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await synthesize_relation(42, "opposite", db)
+
+    assert "opposition" in out.lower()
+    assert "Vidéo opposée" in out
+    assert "OppClaim1" in out
+    # Les non-opposite ne sont PAS le focus
+    assert "Vidéo complémentaire" not in out
+    assert "Vidéo nuançante" not in out
+    # Section divergences globales
+    assert "Prix" in out  # tirée des divergence_points
+
+
+@pytest.mark.asyncio
+async def test_synthesize_relation_complement_focuses_on_enrichissements():
+    """relation='complement' → focus enrichissements + convergences globales."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await synthesize_relation(42, "complement", db)
+
+    assert "complément" in out.lower()
+    assert "Vidéo complémentaire" in out
+    assert "CompClaim1" in out
+    # Section convergences globales (Convergence Z)
+    assert "Convergence Z" in out
+    # Pas de focus sur les autres
+    assert "Vidéo opposée" not in out
+    assert "Vidéo nuançante" not in out
+
+
+@pytest.mark.asyncio
+async def test_synthesize_relation_nuance_focuses_on_subtleties():
+    """relation='nuance' → focus subtilités + lecture nuancée."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await synthesize_relation(42, "nuance", db)
+
+    assert "nuance" in out.lower()
+    assert "Vidéo nuançante" in out
+    assert "NuaClaim1" in out
+    assert "nuancée" in out.lower() or "nuance" in out.lower()
+    # Pas de focus sur les autres
+    assert "Vidéo opposée" not in out
+    assert "Vidéo complémentaire" not in out
+
+
+@pytest.mark.asyncio
+async def test_synthesize_relation_empty_returns_invalid_message():
+    """relation vide → message clair listant les valeurs autorisées.
+
+    NB : `_normalize_relation` retourne 'opposite' par défaut sur toute valeur
+    inconnue, donc la garde du tool ne déclenche que sur chaîne vide / None.
+    """
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await synthesize_relation(42, "", db)
+
+    low = out.lower()
+    assert "invalide" in low
+
+
+@pytest.mark.asyncio
+async def test_synthesize_relation_no_matching_perspective():
+    """
+    Aucune perspective ne matche le relation demandé → message + fallback global
+    (pour 'opposite', on continue d'afficher les divergences globales).
+    """
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = [
+        _make_v2_perspective_row(
+            id=3001, position=0, relation_type="complement",
+            video_title="Seule complement",
+        )
+    ]
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await synthesize_relation(42, "opposite", db)
+
+    low = out.lower()
+    assert "aucune" in low
+    # Pour opposite, on continue avec les divergences globales
+    assert "Prix" in out
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. Tools legacy — toujours fonctionnels (smoke)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_legacy_get_debate_overview_still_works_v1_fallback():
+    """get_debate_overview reste fonctionnel en fallback v1."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=[]),
+    ):
+        out = await get_debate_overview(42, db)
+
+    assert "Sujet du débat IA v2" in out
+    assert "Vidéo A — perspective principale" in out
+    # Fallback v1 → 1 perspective opposée → format classique avec "Vidéo B"
+    assert "Vidéo B — perspective opposée (legacy v1)" in out
+
+
+@pytest.mark.asyncio
+async def test_legacy_get_video_thesis_video_a():
+    """get_video_thesis side='video_a' renvoie thèse + arguments de A."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    out = await get_video_thesis(42, "video_a", db)
+    assert "Vidéo A — perspective principale" in out
+    assert "Thèse A" in out
+    assert "ClaimA1" in out
+
+
+@pytest.mark.asyncio
+async def test_legacy_get_video_thesis_perspective_2_v2():
+    """
+    get_video_thesis side='perspective_2' (v2) renvoie thèse de la 2ème perspective.
+    Acceptance : Tools historique étendus pour pointer une perspective N.
+    """
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    rows = _three_perspectives_rows()
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=rows),
+    ):
+        out = await get_video_thesis(42, "perspective_2", db)
+
+    # 2ème perspective = "Vidéo complémentaire"
+    assert "Vidéo complémentaire" in out
+    assert "complète" in out
+
+
+@pytest.mark.asyncio
+async def test_legacy_get_argument_comparison_topic_match():
+    """get_argument_comparison sur un sous-thème connu retourne A vs B."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+
+    with patch(
+        "voice.debate_tools._load_perspectives_safe",
+        new=AsyncMock(return_value=[]),  # fallback v1
+    ):
+        out = await get_argument_comparison(42, "Prix", db)
+
+    assert "Prix" in out
+    assert "trop cher" in out
+    assert "justifié" in out
+
+
+@pytest.mark.asyncio
+async def test_legacy_get_debate_fact_check_v2_safe():
+    """get_debate_fact_check fonctionne indépendamment du nombre de perspectives."""
+    debate = _make_debate()
+    db = _mock_db_select_debate(debate)
+    out = await get_debate_fact_check(42, db)
+    low = out.lower()
+    assert "confirmed" in low or "confirmé" in low
+    assert "Affirmation X" in out
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 8. Compat ElevenLabs — agent_type "debate_moderator" présent
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_agent_type_debate_moderator_registered():
+    """
+    Compat ElevenLabs : l'agent debate_moderator doit être enregistré avec sa config.
+    Sub-agent C ne doit pas casser le binding agent_type.
+    """
+    from voice.agent_types import (
+        DEBATE_MODERATOR,
+        AGENT_REGISTRY,
+        get_agent_config,
+    )
+
+    # Direct binding
+    assert DEBATE_MODERATOR.agent_type == "debate_moderator"
+    # Registry lookup
+    assert "debate_moderator" in AGENT_REGISTRY
+    cfg = get_agent_config("debate_moderator")
+    assert cfg.agent_type == "debate_moderator"
+    assert cfg.requires_debate is True
+
+    # Tools historiques toujours déclarés (compat ElevenLabs Studio)
+    expected_legacy_tools = {
+        "get_debate_overview",
+        "get_video_thesis",
+        "get_argument_comparison",
+        "search_in_debate_transcript",
+        "get_debate_fact_check",
+    }
+    assert expected_legacy_tools.issubset(set(cfg.tools))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 9. Helpers internes — _normalize_relation et _compute_dominant_relation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_normalize_relation_canonical_values():
+    """_normalize_relation accepte plusieurs synonymes / casing.
+
+    NB : on évite les chaînes avec accents dans ce test pour rester portable
+    (encodage cp1252 sur Windows). La liste complète des synonymes accentués
+    est exercée indirectement via les autres tests v2 qui passent par DB.
+    """
+    assert _normalize_relation("opposite") == "opposite"
+    assert _normalize_relation("Opposition") == "opposite"
+    assert _normalize_relation("OPPOSE") == "opposite"
+    assert _normalize_relation("complement") == "complement"
+    assert _normalize_relation("Complementary") == "complement"
+    assert _normalize_relation("complementaire") == "complement"
+    assert _normalize_relation("nuance") == "nuance"
+    assert _normalize_relation("nuanced") == "nuance"
+    # Default / inconnu -> opposite
+    assert _normalize_relation(None) == "opposite"
+    assert _normalize_relation("") == "opposite"
+    assert _normalize_relation("foo") == "opposite"
+
+
+def test_compute_dominant_relation_priority_opposite():
+    """Tie 1-1-1 → priorité opposite > complement > nuance (cf. spec §2.1)."""
+    perspectives = [
+        PerspectiveCtx(position=0, relation_type="opposite"),
+        PerspectiveCtx(position=1, relation_type="complement"),
+        PerspectiveCtx(position=2, relation_type="nuance"),
+    ]
+    assert _compute_dominant_relation(perspectives) == "opposite"
+
+
+def test_compute_dominant_relation_majority_complement():
+    """2 complement + 1 nuance → complement gagne."""
+    perspectives = [
+        PerspectiveCtx(position=0, relation_type="complement"),
+        PerspectiveCtx(position=1, relation_type="complement"),
+        PerspectiveCtx(position=2, relation_type="nuance"),
+    ]
+    assert _compute_dominant_relation(perspectives) == "complement"
+
+
+def test_compute_dominant_relation_empty_default():
+    """Pas de perspective → default opposite."""
+    assert _compute_dominant_relation([]) == "opposite"


### PR DESCRIPTION
## Status: DRAFT WIP — sub-agent timed out, code substantiel mais pas de tests

## Done
- `backend/src/voice/debate_context.py` — +576 lignes : `build_debate_rich_context` charge `DebatePerspective` avec fallback v1 (try/except sur table existence + raw SQL `text()`)
- `backend/src/voice/debate_tools.py` — +525 lignes : nouveaux tools `list_perspectives`, `compare`, `synthesize_relation`. Legacy tools conservés. `agent_type="debate_moderator"` inchangé pour compat ElevenLabs config.
- System prompt rewording pour relations multiples (opposition/complément/nuance)

## TODO post-reset
- [ ] `backend/tests/test_voice_debate_v2.py`
- [ ] Smoke test ElevenLabs end-to-end avec un débat 1+2 perspectives
- [ ] Valider fallback v1 marche (DB sans `debate_perspectives` table)

## Coordination
- **Mergeable indépendamment** des PR A et B grâce au fallback v1 (raw SQL try/except)
- Au runtime : si table `debate_perspectives` absente → lecture `debate_analyses.video_b_*` en construisant 1 perspective implicite position=0 relation='opposite'

## Spec
docs/superpowers/specs/2026-05-04-debate-ia-v2.md section 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)