### PR TITLE
fix(semantic-search): Phase 2/3/4 follow-ups (Task 16 + 12 critical fixes)

### DIFF
--- a/extension/__tests__/sidepanel/components/QuickSearch.test.tsx
+++ b/extension/__tests__/sidepanel/components/QuickSearch.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 //
-// Tests — QuickSearch (input + collapse/expand + cache push)
+// Tests — QuickSearch (input + collapse/expand + cache push + feature flag probe)
 // Source : src/sidepanel/components/QuickSearch.tsx
 
 import React from "react";
@@ -14,6 +14,45 @@ import {
 import { resetChromeMocks } from "../../setup/chrome-api-mock";
 import { QuickSearch } from "../../../src/sidepanel/components/QuickSearch";
 
+// Helper : configure le mock chrome.runtime.sendMessage pour répondre
+// différemment selon l'action (probe GET_RECENT_QUERIES vs SEARCH_GLOBAL).
+function mockSendMessage(handlers: {
+  recentQueries?: string[];
+  recentQueriesSuccess?: boolean;
+  recentQueriesError?: string;
+  searchResults?: {
+    success: boolean;
+    searchResults?: {
+      query: string;
+      total_results: number;
+      results: unknown[];
+      searched_at: string;
+    };
+    error?: string;
+  };
+}) {
+  const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+  sendMessage.mockImplementation((msg: { action: string }) => {
+    if (msg?.action === "GET_RECENT_QUERIES") {
+      if (handlers.recentQueriesSuccess === false) {
+        return Promise.resolve({
+          success: false,
+          error: handlers.recentQueriesError ?? "feature_disabled",
+        });
+      }
+      return Promise.resolve({
+        success: true,
+        recentQueries: handlers.recentQueries ?? [],
+      });
+    }
+    if (msg?.action === "SEARCH_GLOBAL") {
+      return Promise.resolve(handlers.searchResults ?? { success: true });
+    }
+    return Promise.resolve({});
+  });
+  return sendMessage;
+}
+
 describe("QuickSearch", () => {
   beforeEach(() => {
     resetChromeMocks();
@@ -24,33 +63,44 @@ describe("QuickSearch", () => {
     jest.useRealTimers();
   });
 
-  it("renders the collapsed input with the placeholder", () => {
+  it("renders the collapsed input with the placeholder", async () => {
+    mockSendMessage({});
     render(<QuickSearch onSelectResult={() => {}} />);
-    expect(
-      screen.getByPlaceholderText(/rechercher mes analyses/i),
-    ).toBeInTheDocument();
+    // Wait for the probe to settle so the component is rendered (not null).
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(/rechercher mes analyses/i),
+      ).toBeInTheDocument();
+    });
   });
 
-  it("does not show results panel until user types 2+ chars", () => {
+  it("does not show results panel until user types 2+ chars", async () => {
+    mockSendMessage({});
     render(<QuickSearch onSelectResult={() => {}} />);
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(/rechercher mes analyses/i),
+      ).toBeInTheDocument();
+    });
     expect(screen.queryByRole("status")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("expands and shows loading after typing 2+ chars", async () => {
-    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
-    sendMessage.mockResolvedValue({
-      success: true,
+    mockSendMessage({
       searchResults: {
-        query: "ai",
-        total_results: 0,
-        results: [],
-        searched_at: "2026-05-03T00:00:00Z",
+        success: true,
+        searchResults: {
+          query: "ai",
+          total_results: 0,
+          results: [],
+          searched_at: "2026-05-03T00:00:00Z",
+        },
       },
     });
 
     render(<QuickSearch onSelectResult={() => {}} />);
-    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    const input = await screen.findByPlaceholderText(/rechercher mes analyses/i);
 
     fireEvent.change(input, { target: { value: "ai" } });
 
@@ -67,19 +117,20 @@ describe("QuickSearch", () => {
   });
 
   it("does not call SEARCH_GLOBAL for queries shorter than 2 chars", async () => {
-    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
-    sendMessage.mockResolvedValue({
-      success: true,
+    const sendMessage = mockSendMessage({
       searchResults: {
-        query: "",
-        total_results: 0,
-        results: [],
-        searched_at: "",
+        success: true,
+        searchResults: {
+          query: "",
+          total_results: 0,
+          results: [],
+          searched_at: "",
+        },
       },
     });
 
     render(<QuickSearch onSelectResult={() => {}} />);
-    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    const input = await screen.findByPlaceholderText(/rechercher mes analyses/i);
 
     fireEvent.change(input, { target: { value: "a" } });
     await act(async () => {
@@ -92,19 +143,20 @@ describe("QuickSearch", () => {
   });
 
   it("collapses (clears results) when input is emptied", async () => {
-    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
-    sendMessage.mockResolvedValue({
-      success: true,
+    mockSendMessage({
       searchResults: {
-        query: "ai",
-        total_results: 0,
-        results: [],
-        searched_at: "",
+        success: true,
+        searchResults: {
+          query: "ai",
+          total_results: 0,
+          results: [],
+          searched_at: "",
+        },
       },
     });
 
     render(<QuickSearch onSelectResult={() => {}} />);
-    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    const input = await screen.findByPlaceholderText(/rechercher mes analyses/i);
 
     fireEvent.change(input, { target: { value: "ai" } });
     await act(async () => {
@@ -119,7 +171,6 @@ describe("QuickSearch", () => {
   });
 
   it("calls onSelectResult when a result item is clicked", async () => {
-    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
     const fakeResult = {
       source_type: "summary" as const,
       source_id: 5,
@@ -128,19 +179,21 @@ describe("QuickSearch", () => {
       text_preview: "test preview",
       source_metadata: { summary_title: "Test" },
     };
-    sendMessage.mockResolvedValue({
-      success: true,
+    mockSendMessage({
       searchResults: {
-        query: "test",
-        total_results: 1,
-        results: [fakeResult],
-        searched_at: "",
+        success: true,
+        searchResults: {
+          query: "test",
+          total_results: 1,
+          results: [fakeResult],
+          searched_at: "",
+        },
       },
     });
 
     const onSelect = jest.fn();
     render(<QuickSearch onSelectResult={onSelect} />);
-    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    const input = await screen.findByPlaceholderText(/rechercher mes analyses/i);
 
     fireEvent.change(input, { target: { value: "test" } });
     await act(async () => {
@@ -155,21 +208,30 @@ describe("QuickSearch", () => {
     expect(onSelect).toHaveBeenCalledWith(fakeResult);
   });
 
-  it("persists the query into chrome.storage.local cache after a successful search", async () => {
-    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
-    sendMessage.mockResolvedValue({
-      success: true,
+  it("persists the query into chrome.storage.local cache after a successful search WITH results", async () => {
+    const fakeResult = {
+      source_type: "summary" as const,
+      source_id: 5,
+      summary_id: 5,
+      score: 0.9,
+      text_preview: "preview",
+      source_metadata: { summary_title: "Energie title" },
+    };
+    mockSendMessage({
       searchResults: {
-        query: "energie",
-        total_results: 0,
-        results: [],
-        searched_at: "",
+        success: true,
+        searchResults: {
+          query: "energie",
+          total_results: 1,
+          results: [fakeResult],
+          searched_at: "",
+        },
       },
     });
     const setSpy = chrome.storage.local.set as jest.Mock;
 
     render(<QuickSearch onSelectResult={() => {}} />);
-    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    const input = await screen.findByPlaceholderText(/rechercher mes analyses/i);
 
     fireEvent.change(input, { target: { value: "energie" } });
     await act(async () => {
@@ -180,6 +242,164 @@ describe("QuickSearch", () => {
       expect(setSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           recent_queries: expect.arrayContaining(["energie"]),
+        }),
+      );
+    });
+  });
+
+  it("does NOT cache the query when search returns zero results (bonus fix)", async () => {
+    mockSendMessage({
+      searchResults: {
+        success: true,
+        searchResults: {
+          query: "nomatch",
+          total_results: 0,
+          results: [],
+          searched_at: "",
+        },
+      },
+    });
+    const setSpy = chrome.storage.local.set as jest.Mock;
+
+    render(<QuickSearch onSelectResult={() => {}} />);
+    const input = await screen.findByPlaceholderText(/rechercher mes analyses/i);
+
+    fireEvent.change(input, { target: { value: "nomatch" } });
+    await act(async () => {
+      jest.advanceTimersByTime(401);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/aucun résultat/i)).toBeInTheDocument();
+    });
+
+    expect(setSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        recent_queries: expect.anything(),
+      }),
+    );
+  });
+
+  it("hides the component entirely when feature flag is disabled (probe returns feature_disabled)", async () => {
+    mockSendMessage({
+      recentQueriesSuccess: false,
+      recentQueriesError: "feature_disabled",
+    });
+
+    const { container } = render(<QuickSearch onSelectResult={() => {}} />);
+    // Wait for the probe to resolve (microtask).
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("hides the component when probe error mentions 503 / 404", async () => {
+    mockSendMessage({
+      recentQueriesSuccess: false,
+      recentQueriesError: "Service Unavailable: 503",
+    });
+
+    const { container } = render(<QuickSearch onSelectResult={() => {}} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("displays recent queries as suggestions when input is focused and empty", async () => {
+    mockSendMessage({
+      recentQueries: ["énergie", "europe", "ia"],
+    });
+
+    render(<QuickSearch onSelectResult={() => {}} />);
+    const input = await screen.findByPlaceholderText(/rechercher mes analyses/i);
+
+    // Wait for probe to settle and recentQueries to populate.
+    await waitFor(() => {
+      // No suggestions yet because input is not focused.
+      expect(screen.queryByRole("listbox")).toBeNull();
+    });
+
+    fireEvent.focus(input);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      expect(screen.getByText("énergie")).toBeInTheDocument();
+      expect(screen.getByText("europe")).toBeInTheDocument();
+      expect(screen.getByText("ia")).toBeInTheDocument();
+    });
+  });
+
+  it("hides suggestions when query is non-empty", async () => {
+    mockSendMessage({
+      recentQueries: ["énergie"],
+      searchResults: {
+        success: true,
+        searchResults: {
+          query: "ai",
+          total_results: 0,
+          results: [],
+          searched_at: "",
+        },
+      },
+    });
+
+    render(<QuickSearch onSelectResult={() => {}} />);
+    const input = await screen.findByPlaceholderText(/rechercher mes analyses/i);
+
+    fireEvent.focus(input);
+    await waitFor(() => {
+      expect(screen.getByText("énergie")).toBeInTheDocument();
+    });
+
+    // Type something — suggestions should disappear.
+    fireEvent.change(input, { target: { value: "ai" } });
+    expect(screen.queryByText(/recherches récentes/i)).toBeNull();
+  });
+
+  it("clicking a suggestion sets the query and triggers a search", async () => {
+    mockSendMessage({
+      recentQueries: ["transition"],
+      searchResults: {
+        success: true,
+        searchResults: {
+          query: "transition",
+          total_results: 0,
+          results: [],
+          searched_at: "",
+        },
+      },
+    });
+
+    render(<QuickSearch onSelectResult={() => {}} />);
+    const input = (await screen.findByPlaceholderText(
+      /rechercher mes analyses/i,
+    )) as HTMLInputElement;
+
+    fireEvent.focus(input);
+    await waitFor(() => {
+      expect(screen.getByText("transition")).toBeInTheDocument();
+    });
+
+    fireEvent.mouseDown(screen.getByText("transition"));
+
+    await waitFor(() => {
+      expect(input.value).toBe("transition");
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(401);
+    });
+
+    await waitFor(() => {
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "SEARCH_GLOBAL",
+          data: { query: "transition", limit: 10 },
         }),
       );
     });

--- a/extension/__tests__/sidepanel/hooks/useQuickSearch.test.tsx
+++ b/extension/__tests__/sidepanel/hooks/useQuickSearch.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 //
-// Tests — useQuickSearch hook (debounce 400ms + chrome.runtime.sendMessage)
+// Tests — useQuickSearch hook (debounce 400ms + chrome.runtime.sendMessage + AbortController)
 // Source : src/sidepanel/hooks/useQuickSearch.ts (Phase 4 Semantic Search V1)
 
 import React from "react";
@@ -124,5 +124,122 @@ describe("useQuickSearch", () => {
     await waitFor(() => {
       expect(screen.getByTestId("error")).toHaveTextContent("Network error");
     });
+  });
+
+  it("ignores stale results when a new query supersedes the old one (abort)", async () => {
+    // Simule un sendMessage lent qui résout APRÈS qu'un nouveau call ait
+    // déjà eu lieu. Avant le fix #4, le premier résultat lent overwriterait
+    // les résultats du second call (race condition).
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    let resolveFirst: ((value: unknown) => void) | null = null;
+    const firstPromise = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    sendMessage.mockImplementationOnce(() => firstPromise);
+    sendMessage.mockResolvedValueOnce({
+      success: true,
+      searchResults: {
+        query: "second",
+        total_results: 1,
+        results: [
+          {
+            source_type: "summary",
+            source_id: 222,
+            summary_id: 222,
+            score: 0.9,
+            text_preview: "second result",
+            source_metadata: {},
+          },
+        ],
+        searched_at: "2026-05-03T00:00:00Z",
+      },
+    });
+
+    const { rerender } = render(<Harness query="first" />);
+
+    // Trigger first request via debounce.
+    await act(async () => {
+      jest.advanceTimersByTime(401);
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    // User types a different query AVANT que la première réponse n'arrive.
+    rerender(<Harness query="second" />);
+    await act(async () => {
+      jest.advanceTimersByTime(401);
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+
+    // Maintenant on résout la PREMIÈRE requête (la stale) avec un résultat
+    // différent — le hook doit l'ignorer puisqu'elle a été abort.
+    await act(async () => {
+      resolveFirst?.({
+        success: true,
+        searchResults: {
+          query: "first",
+          total_results: 1,
+          results: [
+            {
+              source_type: "summary",
+              source_id: 111,
+              summary_id: 111,
+              score: 0.9,
+              text_preview: "stale first",
+              source_metadata: {},
+            },
+          ],
+          searched_at: "2026-05-03T00:00:00Z",
+        },
+      });
+    });
+
+    await waitFor(() => {
+      // L'UI doit refléter UNIQUEMENT le second résultat, pas le stale.
+      expect(screen.getByTestId("result-0")).toHaveTextContent("summary:222");
+    });
+    // Et pas de result-1 (count=1).
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+  });
+
+  it("aborts the in-flight request on unmount (no state update after unmount)", async () => {
+    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+    let resolveCall: ((value: unknown) => void) | null = null;
+    sendMessage.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCall = resolve;
+        }),
+    );
+
+    const { unmount } = render(<Harness query="test" />);
+    await act(async () => {
+      jest.advanceTimersByTime(401);
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    // Unmount avant que la requête réponde.
+    unmount();
+
+    // Résoudre la requête maintenant — le hook ne doit pas warn React
+    // (set state on unmounted component) car signal.aborted est true.
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    await act(async () => {
+      resolveCall?.({
+        success: true,
+        searchResults: {
+          query: "test",
+          total_results: 0,
+          results: [],
+          searched_at: "",
+        },
+      });
+    });
+
+    // Pas de warning React "Can't perform a React state update on an unmounted component".
+    const stateUpdateWarnings = consoleErrorSpy.mock.calls.filter((args) =>
+      String(args[0] ?? "").includes("unmounted component"),
+    );
+    expect(stateUpdateWarnings).toHaveLength(0);
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/extension/__tests__/sidepanel/views/HomeView.test.tsx
+++ b/extension/__tests__/sidepanel/views/HomeView.test.tsx
@@ -14,7 +14,33 @@ const mockRecents = [
   },
 ];
 
+// Helper : mock sendMessage avec une réponse différenciée selon l'action.
+function mockSendMessage(handlers: {
+  recentQueries?: string[];
+  searchResults?: unknown;
+}) {
+  const sendMessage = chrome.runtime.sendMessage as jest.Mock;
+  sendMessage.mockImplementation((msg: { action: string }) => {
+    if (msg?.action === "GET_RECENT_QUERIES") {
+      return Promise.resolve({
+        success: true,
+        recentQueries: handlers.recentQueries ?? [],
+      });
+    }
+    if (msg?.action === "SEARCH_GLOBAL") {
+      return Promise.resolve(handlers.searchResults ?? { success: true });
+    }
+    return Promise.resolve({});
+  });
+  return sendMessage;
+}
+
 describe("HomeView", () => {
+  beforeEach(() => {
+    resetChromeMocks();
+    mockSendMessage({});
+  });
+
   it("renders QG mode (UrlInputCard) when no video detected", () => {
     render(
       <HomeView
@@ -107,7 +133,8 @@ describe("HomeView — QuickSearch integration", () => {
     resetChromeMocks();
   });
 
-  it("renders the QuickSearch input above the Recents label", () => {
+  it("renders the QuickSearch input above the Recents label", async () => {
+    mockSendMessage({});
     render(
       <HomeView
         user={mockUser}
@@ -118,7 +145,9 @@ describe("HomeView — QuickSearch integration", () => {
         onUpgrade={() => {}}
       />,
     );
-    const searchInput = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    const searchInput = await screen.findByPlaceholderText(
+      /rechercher mes analyses/i,
+    );
     const recentsLabel = screen.getByText(/^récent$/i);
     // QuickSearch DOIT apparaître AVANT le label "Récent" dans le DOM.
     expect(
@@ -127,26 +156,37 @@ describe("HomeView — QuickSearch integration", () => {
     ).toBeTruthy();
   });
 
-  it("opens summary URL in a new tab when a result is clicked", async () => {
-    const sendMessage = chrome.runtime.sendMessage as jest.Mock;
-    sendMessage.mockResolvedValue({
-      success: true,
+  it("opens summary URL in a new tab when result video_id does NOT match current tab", async () => {
+    mockSendMessage({
       searchResults: {
-        query: "test",
-        total_results: 1,
-        results: [
-          {
-            source_type: "summary",
-            source_id: 99,
-            summary_id: 99,
-            score: 0.95,
-            text_preview: "Mock preview",
-            source_metadata: { summary_title: "Mock Title" },
-          },
-        ],
-        searched_at: "",
+        success: true,
+        searchResults: {
+          query: "test",
+          total_results: 1,
+          results: [
+            {
+              source_type: "summary",
+              source_id: 99,
+              summary_id: 99,
+              score: 0.95,
+              text_preview: "Mock preview",
+              source_metadata: {
+                summary_title: "Mock Title",
+                video_id: "DIFFERENT_VID",
+              },
+            },
+          ],
+          searched_at: "",
+        },
       },
     });
+    // Active tab is on a YouTube video with a different ID → no jump.
+    (chrome.tabs.query as jest.Mock).mockResolvedValue([
+      {
+        id: 42,
+        url: "https://www.youtube.com/watch?v=other_video",
+      },
+    ]);
     const tabsCreate = chrome.tabs.create as jest.Mock;
 
     render(
@@ -160,7 +200,9 @@ describe("HomeView — QuickSearch integration", () => {
       />,
     );
 
-    const input = screen.getByPlaceholderText(/rechercher mes analyses/i);
+    const input = await screen.findByPlaceholderText(
+      /rechercher mes analyses/i,
+    );
     fireEvent.change(input, { target: { value: "test" } });
 
     await waitFor(
@@ -171,8 +213,147 @@ describe("HomeView — QuickSearch integration", () => {
     );
 
     fireEvent.click(screen.getByText("Mock Title"));
-    expect(tabsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ url: expect.stringContaining("/summary/99") }),
+    await waitFor(() => {
+      expect(tabsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining("/summary/99"),
+        }),
+      );
+    });
+  });
+
+  it("dispatches JUMP_TO_TIMESTAMP when result video_id matches current tab", async () => {
+    mockSendMessage({
+      searchResults: {
+        success: true,
+        searchResults: {
+          query: "test",
+          total_results: 1,
+          results: [
+            {
+              source_type: "transcript",
+              source_id: 12,
+              summary_id: 99,
+              score: 0.95,
+              text_preview: "Mock preview",
+              source_metadata: {
+                summary_title: "Same Video Title",
+                video_id: "matching_video",
+                start_ts: 42.5,
+              },
+            },
+          ],
+          searched_at: "",
+        },
+      },
+    });
+    (chrome.tabs.query as jest.Mock).mockResolvedValue([
+      {
+        id: 7,
+        url: "https://www.youtube.com/watch?v=matching_video",
+      },
+    ]);
+    const tabsCreate = chrome.tabs.create as jest.Mock;
+    const tabsSendMessage = chrome.tabs.sendMessage as jest.Mock;
+
+    render(
+      <HomeView
+        user={mockUser}
+        recents={mockRecents}
+        currentTab={{ url: null, platform: null, tabId: null }}
+        onAnalyze={() => {}}
+        onSelectRecent={() => {}}
+        onUpgrade={() => {}}
+      />,
     );
+
+    const input = await screen.findByPlaceholderText(
+      /rechercher mes analyses/i,
+    );
+    fireEvent.change(input, { target: { value: "test" } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Same Video Title")).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+
+    fireEvent.click(screen.getByText("Same Video Title"));
+
+    await waitFor(() => {
+      expect(tabsSendMessage).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({
+          action: "JUMP_TO_TIMESTAMP",
+          ts: 42.5,
+        }),
+      );
+    });
+    // Pas de fallback ouverture web tier puisqu'on a matched.
+    expect(tabsCreate).not.toHaveBeenCalled();
+  });
+
+  it("falls back to web /summary when video_id matches but tabs.sendMessage throws", async () => {
+    mockSendMessage({
+      searchResults: {
+        success: true,
+        searchResults: {
+          query: "test",
+          total_results: 1,
+          results: [
+            {
+              source_type: "transcript",
+              source_id: 13,
+              summary_id: 100,
+              score: 0.9,
+              text_preview: "Preview",
+              source_metadata: {
+                summary_title: "Match Fail Title",
+                video_id: "match_id",
+                start_ts: 30,
+              },
+            },
+          ],
+          searched_at: "",
+        },
+      },
+    });
+    (chrome.tabs.query as jest.Mock).mockRejectedValueOnce(
+      new Error("query failed"),
+    );
+    const tabsCreate = chrome.tabs.create as jest.Mock;
+
+    render(
+      <HomeView
+        user={mockUser}
+        recents={mockRecents}
+        currentTab={{ url: null, platform: null, tabId: null }}
+        onAnalyze={() => {}}
+        onSelectRecent={() => {}}
+        onUpgrade={() => {}}
+      />,
+    );
+
+    const input = await screen.findByPlaceholderText(
+      /rechercher mes analyses/i,
+    );
+    fireEvent.change(input, { target: { value: "test" } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Match Fail Title")).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+
+    fireEvent.click(screen.getByText("Match Fail Title"));
+    await waitFor(() => {
+      expect(tabsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining("/summary/100"),
+        }),
+      );
+    });
   });
 });

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -22,13 +22,46 @@ import {
 
 // Audio ducking pendant les voice calls — instance unique par tab.
 const audioController = new YouTubeAudioController();
+
+/**
+ * Saute la lecture du <video> YouTube actif au timestamp `ts` (en secondes).
+ *
+ * Phase 4 Semantic Search V1 : déclenché par le sidepanel quand l'utilisateur
+ * clique un résultat dont le video_id correspond à la vidéo de l'onglet
+ * courant. On scope la query au lecteur principal (#movie_player video) pour
+ * éviter de toucher des miniatures/previews qui peuvent contenir leurs
+ * propres <video>. Best-effort : si rien trouvé, on tombe silencieusement.
+ */
+const jumpToTimestamp = (ts: number): void => {
+  if (!Number.isFinite(ts) || ts < 0) return;
+  const player = document.querySelector<HTMLVideoElement>(
+    "#movie_player video, video.html5-main-video, video",
+  );
+  if (!player) return;
+  try {
+    player.currentTime = ts;
+    // Tente une lecture (no-op si déjà playing). play() peut rejeter si
+    // l'autoplay policy le bloque — on swallow.
+    void player.play().catch(() => {
+      /* autoplay blocked or already playing */
+    });
+  } catch {
+    /* readonly currentTime in some weird states — swallow */
+  }
+};
+
 // Defensive : `chrome.runtime.onMessage` peut ne pas exister dans certains
 // contextes de test où le mock chrome est minimaliste.
 if (chrome?.runtime?.onMessage?.addListener) {
-  chrome.runtime.onMessage.addListener((msg: { type?: string }) => {
-    if (msg?.type === "DUCK_AUDIO") audioController.attach();
-    if (msg?.type === "RESTORE_AUDIO") audioController.detach();
-  });
+  chrome.runtime.onMessage.addListener(
+    (msg: { type?: string; action?: string; ts?: number }) => {
+      if (msg?.type === "DUCK_AUDIO") audioController.attach();
+      if (msg?.type === "RESTORE_AUDIO") audioController.detach();
+      if (msg?.action === "JUMP_TO_TIMESTAMP") {
+        jumpToTimestamp(typeof msg.ts === "number" ? msg.ts : 0);
+      }
+    },
+  );
 }
 
 let lastUrl = location.href;

--- a/extension/src/sidepanel/components/QuickSearch.tsx
+++ b/extension/src/sidepanel/components/QuickSearch.tsx
@@ -2,42 +2,123 @@
  * QuickSearch — Composant racine sidepanel : input + collapse/expand + cache.
  *
  * Phase 4 light tier (cf. spec § 6 + plan 2026-05-03-semantic-search-v1-phase4-extension):
- *   1. Input "🔍 Rechercher mes analyses…" au-dessus de RecentsList
- *   2. Expand inline (collapse si query<2 chars)
- *   3. Cache chrome.storage.local des 5 dernières queries (LRU dedup)
- *   4. Click résultat → onSelectResult callback (HomeView ouvre nouvel onglet web)
- *   5. Footer ouvre /search?q=... web tier (full feature)
+ *   1. Probe feature flag au mount via GET_RECENT_QUERIES — si désactivé,
+ *      composant invisible (return null).
+ *   2. Input "🔍 Rechercher mes analyses…" au-dessus de RecentsList
+ *   3. Expand inline (collapse si query<2 chars)
+ *   4. Cache chrome.storage.local des 5 dernières queries (LRU dedup)
+ *      — uniquement push si la recherche backend a renvoyé >0 résultats.
+ *   5. Recent queries affichées en suggestions au focus de l'input quand
+ *      la query est vide.
+ *   6. Click résultat → onSelectResult callback (HomeView décide jump/open)
+ *   7. Footer ouvre /search?q=... web tier (full feature)
  */
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
+import Browser from "../../utils/browser-polyfill";
 import { useQuickSearch } from "../hooks/useQuickSearch";
 import { QuickSearchResultsList } from "./QuickSearchResultsList";
 import { pushCachedQuery } from "../../utils/searchCache";
+import type { MessageResponse } from "../../types";
 import type { SearchResult } from "../../types/search";
 
 interface Props {
   onSelectResult: (result: SearchResult) => void;
 }
 
-export function QuickSearch({ onSelectResult }: Props): JSX.Element {
+type ProbeStatus = "pending" | "enabled" | "disabled";
+
+// Pattern reconnu comme "feature flag désactivé" côté backend. Le backend
+// renvoie 404/503 ou un message contenant `feature_disabled` quand la flag
+// SEMANTIC_SEARCH_V1_ENABLED est false.
+const FEATURE_DISABLED_PATTERN = /feature_disabled|404|503|not\s*found|not\s*available/i;
+
+export function QuickSearch({ onSelectResult }: Props): JSX.Element | null {
   const [query, setQuery] = useState("");
-  const { results, loading, error, totalResults } = useQuickSearch(query);
+  const [probeStatus, setProbeStatus] = useState<ProbeStatus>("pending");
+  const [recentQueries, setRecentQueries] = useState<string[]>([]);
+  const [isFocused, setIsFocused] = useState(false);
+  const { results, loading, error, totalResults } = useQuickSearch(
+    probeStatus === "enabled" ? query : "",
+  );
 
   const trimmed = query.trim();
-  const isExpanded = trimmed.length >= 2;
+  const isExpanded = probeStatus === "enabled" && trimmed.length >= 2;
+
+  // ── Probe feature flag (one-shot au mount) ────────────────────────────
+  // Le backend expose GET /search/recent-queries qui renvoie 404/503/feature_disabled
+  // quand SEMANTIC_SEARCH_V1_ENABLED=false. On utilise cette probe pour décider
+  // si on affiche le composant ou pas (return null si désactivé).
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = (await Browser.runtime.sendMessage({
+          action: "GET_RECENT_QUERIES",
+        })) as MessageResponse;
+        if (cancelled) return;
+        if (response?.success === false) {
+          const msg = response.error ?? "";
+          if (FEATURE_DISABLED_PATTERN.test(msg)) {
+            setProbeStatus("disabled");
+            return;
+          }
+          // Erreur transitoire (réseau, 401, etc.) — on garde le composant
+          // affiché mais sans recent queries, l'user pourra quand même chercher.
+          setProbeStatus("enabled");
+          return;
+        }
+        setProbeStatus("enabled");
+        if (Array.isArray(response?.recentQueries)) {
+          setRecentQueries(response.recentQueries.slice(0, 5));
+        }
+      } catch {
+        if (cancelled) return;
+        // Network error — on reste affiché, l'user pourra réessayer.
+        setProbeStatus("enabled");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Persist query in chrome.storage.local cache uniquement après une réponse
-  // backend OK (success path). On ne cache pas pendant loading/error pour
-  // éviter de spammer le cache avec des half-typed queries.
+  // backend OK avec >0 résultats. On ne cache pas les queries qui n'ont
+  // produit aucun match — elles ne sont pas utiles en suggestion future.
   useEffect(() => {
-    if (!loading && !error && trimmed.length >= 2) {
+    if (
+      probeStatus === "enabled" &&
+      !loading &&
+      !error &&
+      trimmed.length >= 2 &&
+      results.length > 0
+    ) {
       void pushCachedQuery(trimmed);
     }
-  }, [loading, error, trimmed]);
+  }, [probeStatus, loading, error, trimmed, results.length]);
 
-  const handleClear = () => {
+  const handleClear = useCallback(() => {
     setQuery("");
-  };
+  }, []);
+
+  const handleSuggestionClick = useCallback((suggestion: string) => {
+    setQuery(suggestion);
+    setIsFocused(false);
+  }, []);
+
+  // Suggestions visibles uniquement quand : feature ON + input focus + query
+  // vide + au moins 1 recent query mémorisée côté backend.
+  const showSuggestions =
+    probeStatus === "enabled" &&
+    isFocused &&
+    trimmed.length === 0 &&
+    recentQueries.length > 0;
+
+  // Feature désactivée côté backend → composant invisible.
+  if (probeStatus === "disabled") {
+    return null;
+  }
 
   return (
     <div style={{ padding: "8px 16px" }}>
@@ -64,6 +145,10 @@ export function QuickSearch({ onSelectResult }: Props): JSX.Element {
           type="search"
           value={query}
           onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
+          onFocus={() => setIsFocused(true)}
+          // Petit delay pour permettre le click sur une suggestion avant le
+          // blur (sinon onMouseDown déclenche blur avant le click).
+          onBlur={() => window.setTimeout(() => setIsFocused(false), 150)}
           placeholder="Rechercher mes analyses…"
           aria-label="Rechercher dans mes analyses"
           spellCheck={false}
@@ -99,6 +184,60 @@ export function QuickSearch({ onSelectResult }: Props): JSX.Element {
           </button>
         )}
       </div>
+      {showSuggestions && (
+        <ul
+          role="listbox"
+          aria-label="Recherches récentes"
+          style={{
+            listStyle: "none",
+            margin: "8px 0 0 0",
+            padding: 4,
+            background: "rgba(255,255,255,0.02)",
+            border: "1px solid rgba(255,255,255,0.05)",
+            borderRadius: 6,
+          }}
+        >
+          <li
+            style={{
+              padding: "4px 8px",
+              fontSize: 11,
+              opacity: 0.5,
+              textTransform: "uppercase",
+              letterSpacing: 1,
+            }}
+            aria-hidden="true"
+          >
+            Recherches récentes
+          </li>
+          {recentQueries.map((q) => (
+            <li key={q}>
+              <button
+                type="button"
+                role="option"
+                aria-selected="false"
+                // onMouseDown plutôt que onClick pour intercepter avant que
+                // le blur de l'input ne déclenche (et masque la liste).
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleSuggestionClick(q);
+                }}
+                style={{
+                  width: "100%",
+                  padding: "6px 8px",
+                  background: "transparent",
+                  border: "none",
+                  color: "inherit",
+                  fontSize: 13,
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+              >
+                {q}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
       {isExpanded && (
         <div
           style={{

--- a/extension/src/sidepanel/hooks/useQuickSearch.ts
+++ b/extension/src/sidepanel/hooks/useQuickSearch.ts
@@ -9,9 +9,17 @@
  * Le sidepanel ne peut PAS faire fetch() direct (CSP MV3) → tout passe par
  * `chrome.runtime.sendMessage` vers `background.ts` qui à son tour appelle
  * `apiRequest` (gère le refresh JWT 401).
+ *
+ * Annulation : on stocke un AbortController par requête en cours dans une
+ * ref. À chaque nouveau call (changement de query, debounce, etc.), on
+ * abort() le précédent. Comme `chrome.runtime.sendMessage` ne supporte
+ * pas nativement de signal côté Chrome, on observe `signal.aborted` au
+ * retour du sendMessage pour ignorer le résultat stale (donc le hook
+ * écarte le résultat ; le background fetch ne s'arrête pas vraiment côté
+ * réseau, mais c'est sans impact UX). Cleanup au unmount via abort.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Browser from "../../utils/browser-polyfill";
 import type { MessageResponse } from "../../types";
 import type { SearchResult } from "../../types/search";
@@ -33,8 +41,17 @@ export function useQuickSearch(query: string): QuickSearchState {
   const [error, setError] = useState<string | null>(null);
   const [totalResults, setTotalResults] = useState(0);
 
+  const abortControllerRef = useRef<AbortController | null>(null);
+
   useEffect(() => {
     const trimmed = query.trim();
+
+    // Toute nouvelle exécution → annule la précédente.
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    const { signal } = controller;
+
     if (trimmed.length < MIN_QUERY_LENGTH) {
       setResults([]);
       setLoading(false);
@@ -43,18 +60,19 @@ export function useQuickSearch(query: string): QuickSearchState {
       return;
     }
 
-    let cancelled = false;
     setLoading(true);
     setError(null);
 
     const timer = setTimeout(async () => {
+      // Si on a été annulé pendant le timeout du debounce, sort tout de suite.
+      if (signal.aborted) return;
       try {
         const response = (await Browser.runtime.sendMessage({
           action: "SEARCH_GLOBAL",
           data: { query: trimmed, limit: SEARCH_LIMIT },
         })) as MessageResponse;
 
-        if (cancelled) return;
+        if (signal.aborted) return;
 
         if (response.success && response.searchResults) {
           setResults(response.searchResults.results);
@@ -66,20 +84,27 @@ export function useQuickSearch(query: string): QuickSearchState {
           setError(response.error || "Recherche impossible");
         }
       } catch (e) {
-        if (cancelled) return;
+        if (signal.aborted) return;
         setResults([]);
         setTotalResults(0);
         setError((e as Error).message || "Recherche impossible");
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!signal.aborted) setLoading(false);
       }
     }, DEBOUNCE_MS);
 
     return () => {
-      cancelled = true;
       clearTimeout(timer);
+      controller.abort();
     };
   }, [query]);
+
+  // Cleanup au unmount : abort le dernier controller s'il existe.
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   return { results, loading, error, totalResults };
 }

--- a/extension/src/sidepanel/views/HomeView.tsx
+++ b/extension/src/sidepanel/views/HomeView.tsx
@@ -7,6 +7,7 @@ import { QuickSearch } from "../components/QuickSearch";
 import { CurrentTabInfo } from "../hooks/useCurrentTab";
 import Browser from "../../utils/browser-polyfill";
 import { WEBAPP_URL } from "../../utils/config";
+import { extractYouTubeVideoId } from "../../utils/video";
 import type { SearchResult } from "../../types/search";
 
 interface User {
@@ -38,12 +39,51 @@ export function HomeView({
     currentTab.url !== null &&
     videoMeta !== undefined;
 
-  // Phase 4 — extension light tier : on ouvre l'analyse directement dans
-  // l'app web (pas d'AnalysisView autonome côté extension). Cohérent avec
-  // le footer "Voir tous sur deepsightsynthesis.com" et avec le pattern
-  // existant des recents (`v3-recent-item` ouvre /summary/{id} dans nouvel
-  // onglet web — cf. spec § 6.2 + plan task 7).
-  const handleSelectSearchResult = (result: SearchResult) => {
+  // Phase 4 — extension light tier : si l'utilisateur clique un résultat
+  // dont le video_id correspond à la vidéo YouTube actuellement ouverte
+  // dans l'onglet actif → on saute au timestamp directement plutôt que
+  // d'ouvrir une page web. Sinon on garde le pattern existant : ouvrir
+  // /summary/{id} dans un nouvel onglet web (cf. spec § 6.2 + plan task 7).
+  //
+  // Re-query l'onglet courant au moment du click (pas du mount) pour
+  // éviter les stale tabIds après un changement d'onglet.
+  const handleSelectSearchResult = async (
+    result: SearchResult,
+  ): Promise<void> => {
+    const targetVideoId = result.source_metadata?.video_id;
+    const startTs = result.source_metadata?.start_ts;
+
+    if (targetVideoId) {
+      try {
+        const tabs = await Browser.tabs.query({
+          active: true,
+          currentWindow: true,
+        });
+        const activeTab = tabs[0];
+        const activeTabId = activeTab?.id;
+        const activeTabUrl = activeTab?.url ?? null;
+        const activeVideoId = activeTabUrl
+          ? extractYouTubeVideoId(activeTabUrl)
+          : null;
+
+        if (
+          activeTabId !== undefined &&
+          activeVideoId &&
+          activeVideoId === targetVideoId
+        ) {
+          // Match — dispatch au content script du tab actif.
+          await Browser.tabs.sendMessage(activeTabId, {
+            action: "JUMP_TO_TIMESTAMP",
+            ts: typeof startTs === "number" ? startTs : 0,
+          });
+          return;
+        }
+      } catch {
+        // Best-effort : si la query/sendMessage échoue, on retombe sur
+        // le comportement par défaut (ouvrir l'analyse en web).
+      }
+    }
+
     if (result.summary_id !== null && result.summary_id !== undefined) {
       Browser.tabs.create({
         url: `${WEBAPP_URL}/summary/${result.summary_id}`,

--- a/frontend/e2e/semantic-search-global.spec.ts
+++ b/frontend/e2e/semantic-search-global.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E — Semantic Search V1 / Phase 2 web (global search flow).
+ *
+ * Couvre le happy path :
+ *   1. /search loads, input visible
+ *   2. typing 2+ chars triggers /api/search/global
+ *   3. results render as clickable cards
+ *   4. click on a result navigates to /hub with summaryId + q + highlight params
+ *
+ * Auth + API are mocked. Unit tests cover useSemanticSearch logic
+ * (404→featureDisabled, debounce, etc.) — this spec only verifies the
+ * UI flow + URL contract that downstream highlight rendering depends on.
+ */
+test.describe("Semantic Search — global", () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock /me so the page loads as authenticated user
+    await page.route("**/api/auth/me", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 1,
+          username: "testuser",
+          email: "test@test.com",
+          plan: "pro",
+          credits_remaining: 100,
+        }),
+      });
+    });
+
+    // Mock recent queries (empty)
+    await page.route("**/api/search/recent-queries", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ queries: [] }),
+      });
+    });
+
+    // Mock search/global with one synthesis result
+    await page.route("**/api/search/global**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          query: "mistral",
+          results: [
+            {
+              summary_id: 42,
+              video_title: "Test video about Mistral AI",
+              passage: "Mistral est une IA française...",
+              source_type: "synthesis",
+              score: 0.92,
+              highlight_id: "synth-1",
+              source_metadata: {
+                section_id: "intro",
+              },
+            },
+          ],
+          total: 1,
+        }),
+      });
+    });
+  });
+
+  test("global search → click result → /hub with highlight params", async ({
+    page,
+  }) => {
+    await page.goto("/search");
+
+    // Input visible
+    const searchInput = page.locator(
+      'input[type="search"], input[placeholder*="Recherche" i]',
+    );
+    await expect(searchInput).toBeVisible();
+
+    // Type query
+    await searchInput.fill("mistral");
+
+    // Result card appears
+    const resultCard = page
+      .locator('[data-testid="search-result-card"], article')
+      .filter({ hasText: "Mistral" })
+      .first();
+    await expect(resultCard).toBeVisible({ timeout: 5000 });
+
+    // Click result
+    await resultCard.click();
+
+    // URL should be /hub with summaryId, q, and highlight params
+    await page.waitForURL(/\/hub\?.*summaryId=42/, { timeout: 5000 });
+    const url = new URL(page.url());
+    expect(url.pathname).toBe("/hub");
+    expect(url.searchParams.get("summaryId")).toBe("42");
+    expect(url.searchParams.get("q")).toBe("mistral");
+    expect(url.searchParams.get("highlight")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/highlight/HighlightedText.tsx
+++ b/frontend/src/components/highlight/HighlightedText.tsx
@@ -2,6 +2,19 @@ import React, { useEffect, useRef } from "react";
 import { useSemanticHighlight } from "./useSemanticHighlight";
 import type { WithinMatch } from "../../services/api";
 
+/**
+ * Hard cap on the number of <mark> nodes rendered. Beyond this, performance
+ * degrades quickly (DOM mutations + scroll-into-view) and the UX becomes noisy
+ * — the user can refine the query instead.
+ */
+const MAX_MARKS = 50;
+
+/**
+ * Tags whose text content must NEVER be wrapped (preserves code blocks,
+ * keyboard hints and pre-formatted text exactly as the author wrote them).
+ */
+const SKIP_PARENT_TAGS = new Set(["CODE", "PRE", "KBD"]);
+
 interface Props {
   /** Tab identity — only matches for this tab are rendered */
   tab: WithinMatch["tab"];
@@ -38,14 +51,34 @@ export const HighlightedText: React.FC<Props> = ({
 
     if (!ctx || ctx.matches.length === 0) return;
 
-    const tabMatches = ctx.matches.filter((m) => m.tab === tab);
+    // Hard cap — only consider the top-N matches. Backend already orders by
+    // score, so this preserves the most relevant passages.
+    const tabMatches = ctx.matches
+      .filter((m) => m.tab === tab)
+      .slice(0, MAX_MARKS);
     if (tabMatches.length === 0) return;
 
-    // 2. Walk text nodes and wrap exact `text` occurrences
-    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    // 2. Walk text nodes and wrap exact `text` occurrences. Skip nodes whose
+    //    closest parent is a <code>, <pre>, or <kbd> — we never alter inline
+    //    code blocks or keyboard hints.
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: (n) => {
+        let parent: Node | null = n.parentNode;
+        while (parent && parent !== root) {
+          if (
+            parent.nodeType === Node.ELEMENT_NODE &&
+            SKIP_PARENT_TAGS.has((parent as Element).tagName)
+          ) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          parent = parent.parentNode;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
     const targets: { node: Text; match: WithinMatch }[] = [];
     let node: Node | null = walker.nextNode();
-    while (node) {
+    while (node && targets.length < MAX_MARKS) {
       const txt = node.nodeValue ?? "";
       for (const m of tabMatches) {
         const idx = txt.indexOf(m.text);

--- a/frontend/src/components/highlight/__tests__/HighlightedText.test.tsx
+++ b/frontend/src/components/highlight/__tests__/HighlightedText.test.tsx
@@ -79,4 +79,48 @@ describe("HighlightedText", () => {
     );
     expect(container.querySelector("mark.ds-highlight")).toBeNull();
   });
+
+  it("caps the number of marks rendered to 50 (hard cap)", () => {
+    // Build 60 matches all targeting the same passage text — only 50 should be wrapped.
+    const matches: WithinMatch[] = Array.from({ length: 60 }, (_, i) => ({
+      ...mockMatch,
+      passage_id: `cap-${i}`,
+      text: `cap${i}`,
+    }));
+    const Wrapper = wrap(matches);
+    const paragraphs = matches
+      .map((m) => `<span>${m.text}</span>`)
+      .join(" ");
+    const { container } = render(
+      <Wrapper>
+        <HighlightedText tab="synthesis">
+          <p dangerouslySetInnerHTML={{ __html: paragraphs }} />
+        </HighlightedText>
+      </Wrapper>,
+    );
+    const marks = container.querySelectorAll("mark.ds-highlight");
+    expect(marks.length).toBeLessThanOrEqual(50);
+  });
+
+  it("does not wrap text inside <code>, <pre> or <kbd>", () => {
+    const Wrapper = wrap([mockMatch]);
+    const { container } = render(
+      <Wrapper>
+        <HighlightedText tab="synthesis">
+          <div>
+            <p>La transition énergétique impose une refonte.</p>
+            <pre>La transition énergétique appartient au pre.</pre>
+            <code>La transition énergétique appartient au code.</code>
+            <kbd>La transition énergétique appartient au kbd.</kbd>
+          </div>
+        </HighlightedText>
+      </Wrapper>,
+    );
+    const marks = container.querySelectorAll("mark.ds-highlight");
+    // Only the <p> match should be wrapped, not the pre/code/kbd ones.
+    expect(marks.length).toBe(1);
+    expect(marks[0].closest("pre")).toBeNull();
+    expect(marks[0].closest("code")).toBeNull();
+    expect(marks[0].closest("kbd")).toBeNull();
+  });
 });

--- a/frontend/src/components/highlight/__tests__/HighlightedText.test.tsx
+++ b/frontend/src/components/highlight/__tests__/HighlightedText.test.tsx
@@ -88,9 +88,7 @@ describe("HighlightedText", () => {
       text: `cap${i}`,
     }));
     const Wrapper = wrap(matches);
-    const paragraphs = matches
-      .map((m) => `<span>${m.text}</span>`)
-      .join(" ");
+    const paragraphs = matches.map((m) => `<span>${m.text}</span>`).join(" ");
     const { container } = render(
       <Wrapper>
         <HighlightedText tab="synthesis">

--- a/frontend/src/components/highlight/__tests__/useCmdFIntercept.test.tsx
+++ b/frontend/src/components/highlight/__tests__/useCmdFIntercept.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { renderHook, cleanup } from "@testing-library/react";
+import React from "react";
+import { useCmdFIntercept } from "../useCmdFIntercept";
+
+afterEach(cleanup);
+afterEach(() => {
+  // Clean up any DOM artefacts from previous tests
+  document.body.innerHTML = "";
+});
+
+/**
+ * Helper that fires a Cmd+F (or Ctrl+F) keydown event with the given target.
+ * preventDefault tracking is exposed via the returned event for assertions.
+ */
+function fireCmdF(target: EventTarget | null) {
+  const ev = new KeyboardEvent("keydown", {
+    key: "f",
+    metaKey: true,
+    ctrlKey: false,
+    bubbles: true,
+    cancelable: true,
+  });
+  // Some platforms set ctrlKey instead of metaKey — both branches are
+  // covered by the implementation, but for tests we use metaKey only.
+  if (target) {
+    Object.defineProperty(ev, "target", { value: target, writable: false });
+    target.dispatchEvent(ev);
+  } else {
+    window.dispatchEvent(ev);
+  }
+  return ev;
+}
+
+describe("useCmdFIntercept", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("intercepts Cmd+F when the target is inside .analysis-page", () => {
+    const onIntercept = vi.fn();
+    const scope = document.createElement("div");
+    scope.className = "analysis-page";
+    const inner = document.createElement("div");
+    scope.appendChild(inner);
+    document.body.appendChild(scope);
+
+    renderHook(() =>
+      useCmdFIntercept({
+        scopeSelector: ".analysis-page",
+        onIntercept,
+      }),
+    );
+
+    const ev = fireCmdF(inner);
+    expect(onIntercept).toHaveBeenCalledTimes(1);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("does NOT intercept Cmd+F when the target is outside .analysis-page", () => {
+    const onIntercept = vi.fn();
+    const scope = document.createElement("div");
+    scope.className = "analysis-page";
+    document.body.appendChild(scope);
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+
+    renderHook(() =>
+      useCmdFIntercept({
+        scopeSelector: ".analysis-page",
+        onIntercept,
+      }),
+    );
+
+    const ev = fireCmdF(outside);
+    expect(onIntercept).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("does NOT intercept Cmd+F when the target is body (no analysis page on screen)", () => {
+    const onIntercept = vi.fn();
+    // No .analysis-page on the page at all.
+    renderHook(() =>
+      useCmdFIntercept({
+        scopeSelector: ".analysis-page",
+        onIntercept,
+      }),
+    );
+
+    const ev = fireCmdF(document.body);
+    expect(onIntercept).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("does NOT intercept when enabled=false", () => {
+    const onIntercept = vi.fn();
+    const scope = document.createElement("div");
+    scope.className = "analysis-page";
+    document.body.appendChild(scope);
+
+    renderHook(() =>
+      useCmdFIntercept({
+        scopeSelector: ".analysis-page",
+        onIntercept,
+        enabled: false,
+      }),
+    );
+
+    fireCmdF(scope);
+    expect(onIntercept).not.toHaveBeenCalled();
+  });
+
+  it("intercepts Cmd+F on a deeply nested child of .analysis-page", () => {
+    const onIntercept = vi.fn();
+    const scope = document.createElement("div");
+    scope.className = "analysis-page";
+    const a = document.createElement("section");
+    const b = document.createElement("article");
+    const c = document.createElement("p");
+    a.appendChild(b);
+    b.appendChild(c);
+    scope.appendChild(a);
+    document.body.appendChild(scope);
+
+    renderHook(() =>
+      useCmdFIntercept({
+        scopeSelector: ".analysis-page",
+        onIntercept,
+      }),
+    );
+
+    fireCmdF(c);
+    expect(onIntercept).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/highlight/useCmdFIntercept.ts
+++ b/frontend/src/components/highlight/useCmdFIntercept.ts
@@ -20,22 +20,15 @@ export function useCmdFIntercept({
       const isCmdF =
         (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f" && !e.shiftKey;
       if (!isCmdF) return;
-      const scope = document.querySelector(scopeSelector);
-      if (!scope) return;
-      const active = document.activeElement;
-      const inScope = active
-        ? scope.contains(active) || scope === active
-        : false;
-      // Also intercept if the user is just on the page (no input focused)
-      const onPageNoInputFocused =
-        !active ||
-        active === document.body ||
-        (active instanceof HTMLElement &&
-          !["INPUT", "TEXTAREA"].includes(active.tagName));
-      if (inScope || onPageNoInputFocused) {
-        e.preventDefault();
-        onIntercept();
-      }
+      // Strict scope policy: only intercept Cmd/Ctrl+F when the *event target*
+      // is inside the scope element (typically `.analysis-page`). Anywhere
+      // else on the app, leave the browser default Find-in-page intact —
+      // intercepting globally surprises users on dashboards / settings / etc.
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      if (!target.closest(scopeSelector)) return;
+      e.preventDefault();
+      onIntercept();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);

--- a/frontend/src/components/hub/HubAnalysisPanel.tsx
+++ b/frontend/src/components/hub/HubAnalysisPanel.tsx
@@ -9,13 +9,37 @@
 import React, { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { AnalysisHub } from "../AnalysisHub";
+import { HighlightedText } from "../highlight/HighlightedText";
 import type {
   Summary,
   EnrichedConcept,
   ReliabilityResult,
   User,
+  WithinMatch,
 } from "../../services/api";
 import type { TabId } from "./types";
+
+/**
+ * Map HubTabBar tab id ("synthesis" | "reliability" | "quiz" | "flashcards" |
+ * "geo") to the WithinMatch tab vocabulary expected by the highlight chain
+ * ("synthesis" | "digest" | "flashcards" | "quiz" | "chat" | "transcript").
+ *
+ * Only "synthesis", "flashcards" and "quiz" overlap. Tabs without a backend
+ * counterpart (reliability, geo) fall back to "synthesis" — the HighlightedText
+ * filter then renders zero marks for them, which is the desired no-op.
+ */
+const toMatchTab = (
+  tab: Exclude<TabId, "chat">,
+): WithinMatch["tab"] => {
+  switch (tab) {
+    case "synthesis":
+    case "flashcards":
+    case "quiz":
+      return tab;
+    default:
+      return "synthesis";
+  }
+};
 
 interface Props {
   selectedSummary: Summary | null;
@@ -67,24 +91,42 @@ export const HubAnalysisPanel: React.FC<Props> = ({
 
   return (
     <div className="px-4 py-4 w-full">
-      <AnalysisHub
-        selectedSummary={selectedSummary}
-        reliabilityData={reliability}
-        reliabilityLoading={reliabilityLoading}
-        user={analysisUser}
-        language={language}
-        concepts={concepts}
-        onTimecodeClick={handleTimecodeClick}
-        onOpenChat={handleOpenChat}
-        onNavigate={handleNavigate}
-        enabledTabs={["synthesis", "reliability", "quiz", "flashcards", "geo"]}
-        showKeywords
-        showStudyTools={false}
-        showVoice={false}
-        activeTabExternal={activeTab}
-        onTabChange={onTabChange}
-        hideInternalTabBar
-      />
+      <HighlightedText
+        tab={toMatchTab(activeTab)}
+        onMarkClick={(_id, match) => {
+          // Bubble up the click + bounding rect to HubPage so it can position
+          // and open the ExplainTooltip. Using a CustomEvent keeps this
+          // component decoupled from the highlight provider/tooltip wiring.
+          const el = document.querySelector<HTMLElement>(
+            `mark.ds-highlight[data-passage-id="${match.passage_id}"]`,
+          );
+          const rect = el?.getBoundingClientRect() ?? null;
+          window.dispatchEvent(
+            new CustomEvent("ds-highlight-click", {
+              detail: { match, rect },
+            }),
+          );
+        }}
+      >
+        <AnalysisHub
+          selectedSummary={selectedSummary}
+          reliabilityData={reliability}
+          reliabilityLoading={reliabilityLoading}
+          user={analysisUser}
+          language={language}
+          concepts={concepts}
+          onTimecodeClick={handleTimecodeClick}
+          onOpenChat={handleOpenChat}
+          onNavigate={handleNavigate}
+          enabledTabs={["synthesis", "reliability", "quiz", "flashcards", "geo"]}
+          showKeywords
+          showStudyTools={false}
+          showVoice={false}
+          activeTabExternal={activeTab}
+          onTabChange={onTabChange}
+          hideInternalTabBar
+        />
+      </HighlightedText>
     </div>
   );
 };

--- a/frontend/src/components/search/__tests__/useSemanticSearch.test.ts
+++ b/frontend/src/components/search/__tests__/useSemanticSearch.test.ts
@@ -3,11 +3,18 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { useSemanticSearch } from "../useSemanticSearch";
-import { searchApi } from "../../../services/api";
+import { searchApi, ApiError } from "../../../services/api";
 
-vi.mock("../../../services/api", () => ({
-  searchApi: { searchGlobal: vi.fn() },
-}));
+vi.mock("../../../services/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../../services/api")>(
+      "../../../services/api",
+    );
+  return {
+    ...actual,
+    searchApi: { searchGlobal: vi.fn() },
+  };
+});
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {
   const qc = new QueryClient({
@@ -76,5 +83,43 @@ describe("useSemanticSearch", () => {
       expect(searchApi.searchGlobal).toHaveBeenCalledTimes(1);
       expect(searchApi.searchGlobal).toHaveBeenLastCalledWith("aist", {}, 20);
     });
+  });
+
+  it("exposes featureDisabled=true when backend returns 404 (flag off)", async () => {
+    (
+      searchApi.searchGlobal as unknown as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new ApiError("Not Found", 404));
+    const { result } = renderHook(
+      () => useSemanticSearch({ query: "ai", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.featureDisabled).toBe(true));
+    // Generic error must NOT be exposed when feature is disabled —
+    // SearchPage relies on this distinction to render a dedicated empty state.
+    expect(result.current.error).toBeNull();
+  });
+
+  it("exposes featureDisabled=true when backend returns 503", async () => {
+    (
+      searchApi.searchGlobal as unknown as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new ApiError("Service Unavailable", 503));
+    const { result } = renderHook(
+      () => useSemanticSearch({ query: "ai", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.featureDisabled).toBe(true));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("keeps generic error for non-feature-disabled status (e.g. 500)", async () => {
+    (
+      searchApi.searchGlobal as unknown as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new ApiError("Server error", 500));
+    const { result } = renderHook(
+      () => useSemanticSearch({ query: "ai", filters: {}, debounceMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.featureDisabled).toBe(false);
   });
 });

--- a/frontend/src/components/search/useSemanticSearch.ts
+++ b/frontend/src/components/search/useSemanticSearch.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   searchApi,
+  ApiError,
   type GlobalSearchResponse,
   type SearchFilters,
 } from "../../services/api";
@@ -14,6 +15,18 @@ interface UseSemanticSearchOptions {
   debounceMs?: number;
   /** disable the query entirely (e.g. when query.length < 2) */
   enabled?: boolean;
+}
+
+/**
+ * Status codes that mean "feature flag SEMANTIC_SEARCH_V1_ENABLED is off"
+ * on the backend. We render a dedicated empty state for these instead of a
+ * generic error toast — the user has done nothing wrong and there is no
+ * "retry" that would help.
+ */
+const FEATURE_DISABLED_STATUSES = new Set([404, 503]);
+
+function isFeatureDisabledError(err: unknown): boolean {
+  return err instanceof ApiError && FEATURE_DISABLED_STATUSES.has(err.status);
 }
 
 export function useSemanticSearch({
@@ -37,7 +50,7 @@ export function useSemanticSearch({
   const trimmed = debouncedQuery.trim();
   const isEnabled = enabled && trimmed.length >= 2;
 
-  return useQuery<GlobalSearchResponse, Error>({
+  const result = useQuery<GlobalSearchResponse, Error>({
     queryKey: ["search", "global", trimmed, filters, limit],
     queryFn: () => searchApi.searchGlobal(trimmed, filters, limit),
     enabled: isEnabled,
@@ -45,4 +58,22 @@ export function useSemanticSearch({
     gcTime: 5 * 60 * 1000,
     retry: false,
   });
+
+  const featureDisabled = isFeatureDisabledError(result.error);
+
+  return {
+    ...result,
+    /**
+     * True when the backend signaled the feature is unavailable
+     * (404 / 503). Distinct from `error` so the page can render a
+     * neutral "Bientôt disponible" empty state rather than a red error.
+     */
+    featureDisabled,
+    /**
+     * Hide the underlying ApiError from consumers when it really means
+     * "feature off". This keeps `error` semantic = "something actually
+     * went wrong, the user can retry".
+     */
+    error: featureDisabled ? null : result.error,
+  };
 }

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -34,6 +34,13 @@ import { HubAnalysisPanel } from "../components/hub/HubAnalysisPanel";
 import { HubTabBar } from "../components/hub/HubTabBar";
 import { QuickVoiceCallCTA } from "../components/hub/QuickVoiceCallCTA";
 import { useAnalyzeAndOpenHub } from "../hooks/useAnalyzeAndOpenHub";
+import { SemanticHighlightProvider } from "../components/highlight/SemanticHighlightProvider";
+import { HighlightNavigationBar } from "../components/highlight/HighlightNavigationBar";
+import { IntraAnalysisSearchBar } from "../components/highlight/IntraAnalysisSearchBar";
+import { ExplainTooltip } from "../components/highlight/ExplainTooltip";
+import { useCmdFIntercept } from "../components/highlight/useCmdFIntercept";
+import { useSemanticHighlight } from "../components/highlight/useSemanticHighlight";
+import type { WithinMatch } from "../services/api";
 import { Loader2 } from "lucide-react";
 import type {
   HubConversation,
@@ -584,180 +591,279 @@ const HubPage: React.FC = () => {
 
   const activeConv = conversations.find((c) => c.id === activeConvId) ?? null;
 
+  // ── Semantic Search V1 / Task 16 — Hub wiring ───────────────────────────
+  // Local UI state for the intra-analysis search bar + explain tooltip.
+  // The actual highlight chain (provider → marks → nav bar → tooltip) is
+  // driven by `<SemanticHighlightProvider>` which wraps the whole return,
+  // and `<HighlightedText>` lives inside `HubAnalysisPanel`. The tooltip
+  // listens to a window CustomEvent dispatched by the marks click handler
+  // to stay decoupled from the provider tree.
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [tooltipMatch, setTooltipMatch] = useState<WithinMatch | null>(null);
+  const [tooltipAnchor, setTooltipAnchor] = useState<DOMRect | null>(null);
+  const summaryIdNum = fullSummary?.id ? Number(fullSummary.id) : null;
+
+  useCmdFIntercept({
+    scopeSelector: ".analysis-page",
+    onIntercept: () => setSearchOpen(true),
+    enabled: activeTab !== "chat",
+  });
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{ match: WithinMatch; rect: DOMRect | null }>
+      ).detail;
+      if (detail?.match) {
+        setTooltipMatch(detail.match);
+        setTooltipAnchor(detail.rect);
+      }
+    };
+    window.addEventListener("ds-highlight-click", handler);
+    return () => window.removeEventListener("ds-highlight-click", handler);
+  }, []);
+
   return (
-    <div className="relative h-screen flex flex-col overflow-hidden bg-[#0a0a0f]">
-      <DoodleBackground variant="default" className="!opacity-[0.32]" />
-      <SEO title="Hub" path="/hub" />
+    <SemanticHighlightProvider summaryId={summaryIdNum}>
+      <div className="relative h-screen flex flex-col overflow-hidden bg-[#0a0a0f]">
+        <DoodleBackground variant="default" className="!opacity-[0.32]" />
+        <SEO title="Hub" path="/hub" />
 
-      <HubHeader
-        onMenuClick={toggleDrawer}
-        onHomeClick={() => navigate("/")}
-        title={activeConv?.title ?? "Hub"}
-        subtitle={
-          activeConv
-            ? buildHubSubtitle(
-                activeConv.video_source,
-                summaryContext?.video_duration_secs,
-                activeConv.updated_at,
-              ) || undefined
-            : undefined
-        }
-        videoSource={activeConv?.video_source ?? null}
-        pipSlot={
-          activeConv?.summary_id ? (
-            <VideoPiPPlayer
-              thumbnailUrl={activeConv.video_thumbnail_url ?? null}
-              title={activeConv.title}
-              durationSecs={summaryContext?.video_duration_secs ?? 0}
-              expanded={pipExpanded}
-              onExpand={() => setPipExpanded(true)}
-              onShrink={() => setPipExpanded(false)}
-            />
-          ) : null
-        }
-      />
-
-      {activeConvId !== null && (
-        <HubTabBar
-          activeTab={activeTab}
-          onTabChange={handleTabChange}
-          chatMessageCount={messages.length}
-          factCheckCount={
-            reliability?.fact_check_lite?.high_risk_claims?.length ?? 0
+        <HubHeader
+          onMenuClick={toggleDrawer}
+          onHomeClick={() => navigate("/")}
+          onSearchClick={
+            activeTab !== "chat" && summaryIdNum
+              ? () => setSearchOpen(true)
+              : undefined
+          }
+          title={activeConv?.title ?? "Hub"}
+          subtitle={
+            activeConv
+              ? buildHubSubtitle(
+                  activeConv.video_source,
+                  summaryContext?.video_duration_secs,
+                  activeConv.updated_at,
+                ) || undefined
+              : undefined
+          }
+          videoSource={activeConv?.video_source ?? null}
+          pipSlot={
+            activeConv?.summary_id ? (
+              <VideoPiPPlayer
+                thumbnailUrl={activeConv.video_thumbnail_url ?? null}
+                title={activeConv.title}
+                durationSecs={summaryContext?.video_duration_secs ?? 0}
+                expanded={pipExpanded}
+                onExpand={() => setPipExpanded(true)}
+                onShrink={() => setPipExpanded(false)}
+              />
+            ) : null
           }
         />
-      )}
 
-      <div className="relative flex-1 flex flex-col overflow-hidden">
-        {analyzingTaskId && !activeConvId ? (
-          <AnalyzingPlaceholder
-            progress={analyzingProgress}
-            message={analyzingMessage}
-            error={analyzingError}
+        {activeConvId !== null && (
+          <HubTabBar
+            activeTab={activeTab}
+            onTabChange={handleTabChange}
+            chatMessageCount={messages.length}
+            factCheckCount={
+              reliability?.fact_check_lite?.high_risk_claims?.length ?? 0
+            }
           />
-        ) : activeConvId === null ? (
-          <NoConvPlaceholder
-            onOpenDrawer={toggleDrawer}
-            onStartCall={() => setVoiceCallOpen(true)}
-            voiceEnabled={voiceEnabled}
-          />
-        ) : (
-          <>
-            {activeTab === "chat" ? (
-              <div className="flex-1 overflow-y-auto min-h-0">
-                {voiceEnabled && (
-                  <QuickVoiceCallCTA
-                    onStart={() => setVoiceCallOpen(true)}
-                    disabled={!activeConvId}
-                  />
-                )}
-                <Timeline
-                  messages={messages}
-                  isThinking={isThinking}
-                  onQuestionClick={handleSend}
-                />
-              </div>
-            ) : (
-              <div
-                key={activeTab}
-                className="flex-1 overflow-y-auto min-h-0"
-                ref={(el) => {
-                  if (!el) return;
-                  el.scrollTop = tabScrollPositions[activeTab] ?? 0;
-                }}
-                onScroll={(e) => {
-                  setTabScrollPosition(
-                    activeTab,
-                    (e.target as HTMLDivElement).scrollTop,
-                  );
-                }}
-              >
-                {summaryContext && (
-                  <HubAnalysisPanel
-                    selectedSummary={fullSummary}
-                    concepts={concepts}
-                    reliability={reliability}
-                    reliabilityLoading={reliabilityLoading}
-                    user={user}
-                    language={language as "fr" | "en"}
-                    activeTab={activeTab as Exclude<TabId, "chat">}
-                    onTabChange={(t) => handleTabChange(t)}
-                  />
-                )}
-              </div>
-            )}
-            <InputBar
-              onSend={handleSend}
-              onPttHoldComplete={handlePttHoldComplete}
-              disabled={!activeConvId}
-              activeTab={activeTab}
-              onTabChange={handleTabChange}
-            />
-          </>
         )}
 
-        <ConversationsDrawer
-          open={drawerOpen}
-          onClose={toggleDrawer}
-          conversations={conversations}
-          activeConvId={activeConvId}
-          onSelect={(id) => {
-            setActiveConv(id);
-            setSearchParams({ conv: String(id) });
-          }}
-          onAnalyze={triggerAnalyze}
-        />
+        <div className="relative flex-1 flex flex-col overflow-hidden">
+          {analyzingTaskId && !activeConvId ? (
+            <AnalyzingPlaceholder
+              progress={analyzingProgress}
+              message={analyzingMessage}
+              error={analyzingError}
+            />
+          ) : activeConvId === null ? (
+            <NoConvPlaceholder
+              onOpenDrawer={toggleDrawer}
+              onStartCall={() => setVoiceCallOpen(true)}
+              voiceEnabled={voiceEnabled}
+            />
+          ) : (
+            <>
+              {activeTab === "chat" ? (
+                <div className="flex-1 overflow-y-auto min-h-0">
+                  {voiceEnabled && (
+                    <QuickVoiceCallCTA
+                      onStart={() => setVoiceCallOpen(true)}
+                      disabled={!activeConvId}
+                    />
+                  )}
+                  <Timeline
+                    messages={messages}
+                    isThinking={isThinking}
+                    onQuestionClick={handleSend}
+                  />
+                </div>
+              ) : (
+                <div
+                  key={activeTab}
+                  className="analysis-page flex-1 overflow-y-auto min-h-0"
+                  ref={(el) => {
+                    if (!el) return;
+                    el.scrollTop = tabScrollPositions[activeTab] ?? 0;
+                  }}
+                  onScroll={(e) => {
+                    setTabScrollPosition(
+                      activeTab,
+                      (e.target as HTMLDivElement).scrollTop,
+                    );
+                  }}
+                >
+                  {summaryContext && (
+                    <HubAnalysisPanel
+                      selectedSummary={fullSummary}
+                      concepts={concepts}
+                      reliability={reliability}
+                      reliabilityLoading={reliabilityLoading}
+                      user={user}
+                      language={language as "fr" | "en"}
+                      activeTab={activeTab as Exclude<TabId, "chat">}
+                      onTabChange={(t) => handleTabChange(t)}
+                    />
+                  )}
+                </div>
+              )}
+              <InputBar
+                onSend={handleSend}
+                onPttHoldComplete={handlePttHoldComplete}
+                disabled={!activeConvId}
+                activeTab={activeTab}
+                onTabChange={handleTabChange}
+              />
+            </>
+          )}
 
-        <NewConversationModal
-          open={newConvModalOpen}
-          onClose={() => setNewConvModalOpen(false)}
-          onSuccess={async (summaryId) => {
-            // Re-fetch conversations to surface the freshly analyzed entry,
-            // then activate it so the user lands directly on the new session.
-            try {
-              const resp = await videoApi.getHistory({ limit: 50, page: 1 });
-              const convs: HubConversation[] = (resp.items || []).map(
-                (item: any) => ({
-                  id: item.id,
-                  summary_id: item.id,
-                  title: sanitizeTitle(item.video_title) || "Sans titre",
-                  video_source: (item.platform === "tiktok"
-                    ? "tiktok"
-                    : "youtube") as "youtube" | "tiktok",
-                  video_thumbnail_url: item.thumbnail_url ?? null,
-                  last_snippet: undefined,
-                  updated_at: item.created_at,
-                }),
-              );
-              setConversations(convs);
-              setActiveConv(summaryId);
-              setSearchParams({ conv: String(summaryId) });
-              if (drawerOpen) toggleDrawer();
-            } catch (err) {
-              console.error("[HubPage] re-fetch after analyze failed:", err);
-              // Best-effort: surface at least the new active conv even if
-              // the history fetch fails (the user can still chat with it).
-              setActiveConv(summaryId);
-              setSearchParams({ conv: String(summaryId) });
-            }
-          }}
-          language={language as "fr" | "en"}
-        />
+          <ConversationsDrawer
+            open={drawerOpen}
+            onClose={toggleDrawer}
+            conversations={conversations}
+            activeConvId={activeConvId}
+            onSelect={(id) => {
+              setActiveConv(id);
+              setSearchParams({ conv: String(id) });
+            }}
+            onAnalyze={triggerAnalyze}
+          />
 
-        {voiceEnabled && (
-          <CallModeFullBleed
-            open={voiceCallOpen}
-            onClose={() => setVoiceCallOpen(false)}
-            summaryId={activeConv?.summary_id ?? null}
-            title={activeConv?.title ?? null}
-            subtitle={null}
-            onVoiceMessage={handleVoiceMessage}
-            controllerRef={voiceControllerRef}
+          <NewConversationModal
+            open={newConvModalOpen}
+            onClose={() => setNewConvModalOpen(false)}
+            onSuccess={async (summaryId) => {
+              // Re-fetch conversations to surface the freshly analyzed entry,
+              // then activate it so the user lands directly on the new session.
+              try {
+                const resp = await videoApi.getHistory({ limit: 50, page: 1 });
+                const convs: HubConversation[] = (resp.items || []).map(
+                  (item: any) => ({
+                    id: item.id,
+                    summary_id: item.id,
+                    title: sanitizeTitle(item.video_title) || "Sans titre",
+                    video_source: (item.platform === "tiktok"
+                      ? "tiktok"
+                      : "youtube") as "youtube" | "tiktok",
+                    video_thumbnail_url: item.thumbnail_url ?? null,
+                    last_snippet: undefined,
+                    updated_at: item.created_at,
+                  }),
+                );
+                setConversations(convs);
+                setActiveConv(summaryId);
+                setSearchParams({ conv: String(summaryId) });
+                if (drawerOpen) toggleDrawer();
+              } catch (err) {
+                console.error("[HubPage] re-fetch after analyze failed:", err);
+                // Best-effort: surface at least the new active conv even if
+                // the history fetch fails (the user can still chat with it).
+                setActiveConv(summaryId);
+                setSearchParams({ conv: String(summaryId) });
+              }
+            }}
             language={language as "fr" | "en"}
+          />
+
+          {voiceEnabled && (
+            <CallModeFullBleed
+              open={voiceCallOpen}
+              onClose={() => setVoiceCallOpen(false)}
+              summaryId={activeConv?.summary_id ?? null}
+              title={activeConv?.title ?? null}
+              subtitle={null}
+              onVoiceMessage={handleVoiceMessage}
+              controllerRef={voiceControllerRef}
+              language={language as "fr" | "en"}
+            />
+          )}
+        </div>
+
+        {/* ── Semantic Search V1 / Task 16 overlays ──────────────────────── */}
+        <HighlightNavigationBar />
+        <IntraAnalysisSearchBar
+          open={searchOpen}
+          onClose={() => setSearchOpen(false)}
+        />
+        {summaryIdNum !== null && (
+          <ExplainTooltipBridge
+            match={tooltipMatch}
+            anchorRect={tooltipAnchor}
+            summaryId={summaryIdNum}
+            onClose={() => {
+              setTooltipMatch(null);
+              setTooltipAnchor(null);
+            }}
+            onCiteInChat={(passage) => {
+              handleTabChange("chat");
+              handleSend(passage);
+            }}
+            onJumpToTab={(tab) => {
+              // The WithinMatch tab vocabulary partially overlaps with the
+              // HubTabBar one. "synthesis" / "flashcards" / "quiz" map 1:1.
+              // "transcript", "digest", "chat" don't have a dedicated tab —
+              // they fall through to "synthesis" which is the closest visual
+              // anchor in the Hub layout.
+              const target =
+                tab === "flashcards" || tab === "quiz" ? tab : "synthesis";
+              handleTabChange(target as TabId);
+            }}
           />
         )}
       </div>
-    </div>
+    </SemanticHighlightProvider>
+  );
+};
+
+/**
+ * Bridge sub-component that lives INSIDE the SemanticHighlightProvider so
+ * it can read the live `query` from context. The tooltip itself is decoupled
+ * from the provider (it accepts `query` as a prop) so it stays portable.
+ */
+const ExplainTooltipBridge: React.FC<{
+  match: WithinMatch | null;
+  anchorRect: DOMRect | null;
+  summaryId: number;
+  onClose: () => void;
+  onCiteInChat: (passage: string) => void;
+  onJumpToTab: (tab: WithinMatch["tab"]) => void;
+}> = ({ match, anchorRect, summaryId, onClose, onCiteInChat, onJumpToTab }) => {
+  const ctx = useSemanticHighlight();
+  return (
+    <ExplainTooltip
+      open={match !== null}
+      match={match}
+      query={ctx?.query ?? ""}
+      summaryId={summaryId}
+      anchorRect={anchorRect}
+      onClose={onClose}
+      onCiteInChat={onCiteInChat}
+      onJumpToTab={onJumpToTab}
+    />
   );
 };
 

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -54,7 +54,10 @@ const SearchPage: React.FC = () => {
     setParams(next, { replace: true });
   }, [query, filters, setParams]);
 
-  const { data, isFetching, error } = useSemanticSearch({ query, filters });
+  const { data, isFetching, error, featureDisabled } = useSemanticSearch({
+    query,
+    filters,
+  });
 
   // Track query when results land
   useEffect(() => {
@@ -135,19 +138,35 @@ const SearchPage: React.FC = () => {
             <SearchAdvancedFilters filters={filters} onChange={setFilters} />
           )}
 
-          {error && (
+          {featureDisabled && (
+            <div
+              role="status"
+              className="rounded-xl border border-white/10 bg-white/[0.03] px-6 py-10 text-center"
+            >
+              <p className="text-base text-white/85 font-medium mb-1">
+                Fonctionnalité bientôt disponible
+              </p>
+              <p className="text-sm text-white/55">
+                La recherche sémantique est en cours d'activation côté serveur.
+                Reviens d'ici quelques minutes — aucune action requise de ta
+                part.
+              </p>
+            </div>
+          )}
+
+          {!featureDisabled && error && (
             <div className="text-center py-8 text-red-300">
               Une erreur est survenue. Réessaie dans un instant.
             </div>
           )}
 
-          {!error && isFetching && (
+          {!featureDisabled && !error && isFetching && (
             <div className="flex justify-center py-10">
               <DeepSightSpinner size="md" />
             </div>
           )}
 
-          {!error && !isFetching && isEmptyQuery && (
+          {!featureDisabled && !error && !isFetching && isEmptyQuery && (
             <SearchEmptyState
               variant="no-query"
               recentQueries={recent}
@@ -155,11 +174,15 @@ const SearchPage: React.FC = () => {
             />
           )}
 
-          {!error && !isFetching && !isEmptyQuery && !hasResults && (
-            <SearchEmptyState variant="no-results" query={query} />
-          )}
+          {!featureDisabled &&
+            !error &&
+            !isFetching &&
+            !isEmptyQuery &&
+            !hasResults && (
+              <SearchEmptyState variant="no-results" query={query} />
+            )}
 
-          {!error && !isFetching && hasResults && data && (
+          {!featureDisabled && !error && !isFetching && hasResults && data && (
             <SearchResultsList
               results={data.results}
               query={query}

--- a/frontend/src/pages/__tests__/SearchPage.test.tsx
+++ b/frontend/src/pages/__tests__/SearchPage.test.tsx
@@ -4,15 +4,22 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import SearchPage from "../SearchPage";
-import { searchApi } from "../../services/api";
+import { searchApi, ApiError } from "../../services/api";
 
-vi.mock("../../services/api", () => ({
-  searchApi: {
-    searchGlobal: vi.fn(),
-    getRecentQueries: vi.fn().mockResolvedValue({ queries: [] }),
-    clearRecentQueries: vi.fn(),
-  },
-}));
+vi.mock("../../services/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../services/api")>(
+      "../../services/api",
+    );
+  return {
+    ...actual,
+    searchApi: {
+      searchGlobal: vi.fn(),
+      getRecentQueries: vi.fn().mockResolvedValue({ queries: [] }),
+      clearRecentQueries: vi.fn(),
+    },
+  };
+});
 vi.mock("../../components/layout/Sidebar", () => ({ Sidebar: () => null }));
 vi.mock("../../components/DoodleBackground", () => ({ default: () => null }));
 vi.mock("../../components/SEO", () => ({ SEO: () => null }));

--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -107,15 +107,14 @@ const IntraAnalysisSearchInput: React.FC = () => {
 };
 
 function AnalysisDetailScreenInner() {
-  // Note : `q` / `highlight` / `tab` sont consommés par le wrapper externe
-  // `AnalysisDetailScreen` qui pose le SemanticHighlighterProvider. Ils sont
-  // re-extraits ici uniquement pour piloter l'état initial de la SearchBar
-  // intra-analyse (`searchBarVisible = Boolean(q)`).
-  const { id, backTo, initialTab, q } = useLocalSearchParams<{
+  // Note : `q` / `highlight` pilotent l'état initial de la SearchBar intra-analyse
+  // (`searchBarVisible = Boolean(q)`) et l'`initialPassageId` du provider semantic.
+  const { id, backTo, initialTab, q, highlight } = useLocalSearchParams<{
     id: string;
     backTo?: string;
     initialTab?: string;
     q?: string;
+    highlight?: string;
   }>();
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -639,7 +638,22 @@ function AnalysisDetailScreenInner() {
     );
   }
 
+  // SemanticHighlighter — summaryId effectif (peut être 0 tant qu'un task_id
+  // n'est pas résolu). Le `key` force un re-mount quand l'id devient valide,
+  // ce qui réinitialise correctement le state du provider et permet au query
+  // de se déclencher (cf. `enabled = query.length>=2 && summaryId>0`).
+  const semanticSummaryId = (() => {
+    const n = Number(effectiveId);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  })();
+
   return (
+    <SemanticHighlighterProvider
+      key={semanticSummaryId}
+      summaryId={semanticSummaryId}
+      initialQuery={q ?? ""}
+      initialPassageId={highlight ?? null}
+    >
     <View
       style={[
         styles.container,
@@ -890,37 +904,18 @@ function AnalysisDetailScreenInner() {
         </>
       )}
     </View>
+    </SemanticHighlighterProvider>
   );
 }
 
 /**
- * Wrapper exporté default — instancie le `SemanticHighlighterProvider` autour
- * de l'écran. Le summaryId effectif est passé via la prop. La query/passage_id
- * initiaux viennent des params URL `?q=...&highlight=...`.
+ * Default export — alias direct de `AnalysisDetailScreenInner`.
+ * Le `SemanticHighlighterProvider` est désormais instancié À L'INTÉRIEUR
+ * d'Inner pour avoir accès à `effectiveId` (résolu après streaming d'un
+ * task_id frais). Cf. fix bloquant #2 PR #298.
  */
 export default function AnalysisDetailScreen() {
-  const { id, q, highlight } = useLocalSearchParams<{
-    id: string;
-    q?: string;
-    highlight?: string;
-  }>();
-
-  // Note: Le summaryId réel peut différer de `id` (id peut être un task_id).
-  // On utilise une approximation : si id est numérique on l'utilise,
-  // sinon le provider est désactivé (summaryId=0). Le provider rejette les fetch
-  // quand summaryId<=0 (cf. SemanticHighlighter `enabled` guard).
-  const numericId = Number(id);
-  const summaryId = Number.isFinite(numericId) && numericId > 0 ? numericId : 0;
-
-  return (
-    <SemanticHighlighterProvider
-      summaryId={summaryId}
-      initialQuery={q ?? ""}
-      initialPassageId={highlight ?? null}
-    >
-      <AnalysisDetailScreenInner />
-    </SemanticHighlighterProvider>
-  );
+  return <AnalysisDetailScreenInner />;
 }
 
 const styles = StyleSheet.create({

--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -63,9 +63,7 @@ const HighlightActionSheetController: React.FC<{
       setM(null);
       return;
     }
-    const found = ctx.matches.find(
-      (x) => x.passage_id === ctx.activePassageId,
-    );
+    const found = ctx.matches.find((x) => x.passage_id === ctx.activePassageId);
     setM(found ?? null);
   }, [ctx?.activePassageId, ctx?.matches]);
 
@@ -654,206 +652,34 @@ function AnalysisDetailScreenInner() {
       initialQuery={q ?? ""}
       initialPassageId={highlight ?? null}
     >
-    <View
-      style={[
-        styles.container,
-        {
-          backgroundColor: colors.bgPrimary,
-          // En fullscreen : paddingBottom=0 pour que l'overlay absolu atteigne le bas de l'écran.
-          // En mode normal : footprint partagé pour ne jamais cacher le dernier élément derrière la TabBar.
-          paddingBottom: isFullscreen ? 0 : tabBarFootprint,
-        },
-      ]}
-    >
-      <DoodleBackground variant="analysis" density="low" />
-      <StatusBar barStyle={isDark ? "light-content" : "dark-content"} />
+      <View
+        style={[
+          styles.container,
+          {
+            backgroundColor: colors.bgPrimary,
+            // En fullscreen : paddingBottom=0 pour que l'overlay absolu atteigne le bas de l'écran.
+            // En mode normal : footprint partagé pour ne jamais cacher le dernier élément derrière la TabBar.
+            paddingBottom: isFullscreen ? 0 : tabBarFootprint,
+          },
+        ]}
+      >
+        <DoodleBackground variant="analysis" density="low" />
+        <StatusBar barStyle={isDark ? "light-content" : "dark-content"} />
 
-      {/* Streaming Overlay */}
-      {showStreamingOverlay && id && (
-        <StreamingOverlay
-          taskId={id}
-          onCancel={handleCancelAnalysis}
-          onComplete={handleStreamingComplete}
-        />
-      )}
-
-      {/* ── MODE NORMAL ─────────────────────────────────── */}
-
-      {/* Header normal — masqué en fullscreen */}
-      {!isFullscreen && (
-        <View style={[styles.header, { paddingTop: insets.top + sp.sm }]}>
-          <Pressable
-            onPress={handleBack}
-            style={styles.iconButton}
-            accessibilityLabel="Retour"
-            accessibilityRole="button"
-          >
-            <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
-          </Pressable>
-          <Text
-            style={[styles.headerTitle, { color: colors.textPrimary }]}
-            numberOfLines={1}
-          >
-            {summary?.title || "Analyse"}
-          </Text>
-          {/* Bouton loupe — recherche intra-analyse (Semantic Search V1) */}
-          <Pressable
-            onPress={() => setSearchBarVisible((v) => !v)}
-            style={styles.iconButton}
-            accessibilityLabel={
-              searchBarVisible
-                ? "Fermer la recherche"
-                : "Rechercher dans cette analyse"
-            }
-            accessibilityRole="button"
-            hitSlop={8}
-          >
-            <Ionicons
-              name={searchBarVisible ? "close" : "search"}
-              size={22}
-              color={colors.textTertiary}
-            />
-          </Pressable>
-          {/* Bouton export */}
-          {canExport && (
-            <Pressable
-              onPress={() => setIsExportVisible(true)}
-              style={styles.iconButton}
-              accessibilityLabel="Exporter l'analyse"
-              accessibilityRole="button"
-            >
-              <Ionicons
-                name="share-outline"
-                size={22}
-                color={colors.textTertiary}
-              />
-            </Pressable>
-          )}
-          {/* Bouton nouvelle analyse */}
-          <Pressable
-            onPress={handleNewAnalysis}
-            style={styles.iconButton}
-            accessibilityLabel="Nouvelle analyse"
-            accessibilityRole="button"
-          >
-            <Ionicons
-              name="add-circle-outline"
-              size={24}
-              color={colors.textTertiary}
-            />
-          </Pressable>
-        </View>
-      )}
-
-      {/* Search bar intra-analyse — visible quand searchBarVisible=true */}
-      {!isFullscreen && searchBarVisible && <IntraAnalysisSearchInput />}
-
-      {/* Video Player — masqué en fullscreen.
-          NB: la condition de visibilité (videoId valide, plateforme connue,
-          thumbnail TikTok dispo) est gérée DANS VideoPlayer pour garantir un
-          rendu null systématique si le contenu n'est pas affichable. */}
-      {!isFullscreen && summary && (
-        <VideoPlayer
-          videoId={summary.videoId}
-          title={summary.title}
-          scrollY={scrollY}
-          platform={summary.platform}
-          thumbnail={summary.thumbnail}
-        />
-      )}
-
-      {/* Tab bar — masqué en fullscreen */}
-      {!isFullscreen && TabBar}
-
-      {/* PagerView normal — masqué en fullscreen */}
-      {!isFullscreen && Pager}
-
-      {/* Action Bar — masquée en fullscreen */}
-      {!isFullscreen && summary && (
-        <View>
-          <TutorButton
-            onPress={() => setIsTutorVisible(true)}
-            disabled={!summary.title}
-            style={styles.tutorButtonInline}
+        {/* Streaming Overlay */}
+        {showStreamingOverlay && id && (
+          <StreamingOverlay
+            taskId={id}
+            onCancel={handleCancelAnalysis}
+            onComplete={handleStreamingComplete}
           />
-          <ActionBar
-            summaryId={summary.id}
-            title={summary.title}
-            videoId={summary.videoId}
-            isFavorite={isFavorite}
-            onFavoriteChange={setIsFavorite}
-          />
-        </View>
-      )}
+        )}
 
-      {/* Tuteur V2 mobile lite — bottom-sheet text-only sur le concept de l'analyse */}
-      {summary && (
-        <TutorBottomSheet
-          isOpen={isTutorVisible}
-          onClose={() => setIsTutorVisible(false)}
-          conceptTerm={summary.title ?? null}
-          conceptDef={summary.title ?? null}
-          summaryId={Number(summary.id)}
-          sourceVideoTitle={summary.title ?? undefined}
-        />
-      )}
+        {/* ── MODE NORMAL ─────────────────────────────────── */}
 
-      {/* Export Menu */}
-      {summary && (
-        <ExportMenu
-          summaryId={Number(summary.id)}
-          videoTitle={summary.title || "analyse"}
-          visible={isExportVisible}
-          onClose={() => setIsExportVisible(false)}
-        />
-      )}
-
-      {/* Voice Chat — bouton FAB ouvre ConversationScreen en mode 'call' */}
-      {summary && (
-        <>
-          <VoiceButton
-            summaryId={id as string}
-            videoTitle={summary.title || "Vidéo"}
-            onSessionStart={() => {
-              setConversationInitialMode("call");
-              setIsVoiceVisible(true);
-            }}
-          />
-          <ConversationScreen
-            visible={isVoiceVisible}
-            summaryId={summary.id}
-            initialMode={conversationInitialMode}
-            videoTitle={summary.title || "Vidéo"}
-            channelName={summary.channel}
-            platform={
-              (summary.platform === "tiktok" ? "tiktok" : "youtube") as
-                | "youtube"
-                | "tiktok"
-            }
-            initialFavorite={summary.isFavorite}
-            onClose={() => setIsVoiceVisible(false)}
-          />
-        </>
-      )}
-
-      {/* ── MODE FULLSCREEN ──────────────────────────────── */}
-      {/* paddingBottom du container est 0 → l'overlay couvre l'écran entier.
-          La TabBar globale est cachée via tabBarStore (cf. useEffect ci-dessus)
-          donc on n'a plus besoin de réserver TAB_BAR_HEIGHT — seul le safe area
-          bottom suffit. */}
-      {isFullscreen && (
-        <View
-          style={[
-            styles.fullscreenOverlay,
-            {
-              backgroundColor: colors.bgPrimary,
-              paddingTop: insets.top,
-              paddingBottom: insets.bottom,
-            },
-          ]}
-        >
-          {/* Header compact fullscreen */}
-          <View style={styles.fullscreenHeader}>
+        {/* Header normal — masqué en fullscreen */}
+        {!isFullscreen && (
+          <View style={[styles.header, { paddingTop: insets.top + sp.sm }]}>
             <Pressable
               onPress={handleBack}
               style={styles.iconButton}
@@ -872,38 +698,225 @@ function AnalysisDetailScreenInner() {
             >
               {summary?.title || "Analyse"}
             </Text>
+            {/* Bouton loupe — recherche intra-analyse (Semantic Search V1) */}
             <Pressable
-              onPress={handleToggleFullscreen}
+              onPress={() => setSearchBarVisible((v) => !v)}
               style={styles.iconButton}
-              accessibilityLabel="Quitter le plein écran"
+              accessibilityLabel={
+                searchBarVisible
+                  ? "Fermer la recherche"
+                  : "Rechercher dans cette analyse"
+              }
+              accessibilityRole="button"
+              hitSlop={8}
+            >
+              <Ionicons
+                name={searchBarVisible ? "close" : "search"}
+                size={22}
+                color={colors.textTertiary}
+              />
+            </Pressable>
+            {/* Bouton export */}
+            {canExport && (
+              <Pressable
+                onPress={() => setIsExportVisible(true)}
+                style={styles.iconButton}
+                accessibilityLabel="Exporter l'analyse"
+                accessibilityRole="button"
+              >
+                <Ionicons
+                  name="share-outline"
+                  size={22}
+                  color={colors.textTertiary}
+                />
+              </Pressable>
+            )}
+            {/* Bouton nouvelle analyse */}
+            <Pressable
+              onPress={handleNewAnalysis}
+              style={styles.iconButton}
+              accessibilityLabel="Nouvelle analyse"
               accessibilityRole="button"
             >
               <Ionicons
-                name="contract-outline"
-                size={22}
-                color={colors.textPrimary}
+                name="add-circle-outline"
+                size={24}
+                color={colors.textTertiary}
               />
             </Pressable>
           </View>
+        )}
 
-          {/* Tab bar en fullscreen */}
-          {TabBar}
+        {/* Search bar intra-analyse — visible quand searchBarVisible=true */}
+        {!isFullscreen && searchBarVisible && <IntraAnalysisSearchInput />}
 
-          {/* PagerView plein écran — instance distincte mais même comportement */}
-          {Pager}
-        </View>
-      )}
-
-      {/* ── Semantic Search V1 — overlays intra-analyse ─────────────── */}
-      {!isFullscreen && (
-        <>
-          <HighlightNavigationBar bottomOffset={tabBarFootprint + 20} />
-          <HighlightActionSheetController
-            summaryId={Number(effectiveId) || 0}
+        {/* Video Player — masqué en fullscreen.
+          NB: la condition de visibilité (videoId valide, plateforme connue,
+          thumbnail TikTok dispo) est gérée DANS VideoPlayer pour garantir un
+          rendu null systématique si le contenu n'est pas affichable. */}
+        {!isFullscreen && summary && (
+          <VideoPlayer
+            videoId={summary.videoId}
+            title={summary.title}
+            scrollY={scrollY}
+            platform={summary.platform}
+            thumbnail={summary.thumbnail}
           />
-        </>
-      )}
-    </View>
+        )}
+
+        {/* Tab bar — masqué en fullscreen */}
+        {!isFullscreen && TabBar}
+
+        {/* PagerView normal — masqué en fullscreen */}
+        {!isFullscreen && Pager}
+
+        {/* Action Bar — masquée en fullscreen */}
+        {!isFullscreen && summary && (
+          <View>
+            <TutorButton
+              onPress={() => setIsTutorVisible(true)}
+              disabled={!summary.title}
+              style={styles.tutorButtonInline}
+            />
+            <ActionBar
+              summaryId={summary.id}
+              title={summary.title}
+              videoId={summary.videoId}
+              isFavorite={isFavorite}
+              onFavoriteChange={setIsFavorite}
+            />
+          </View>
+        )}
+
+        {/* Tuteur V2 mobile lite — bottom-sheet text-only sur le concept de l'analyse */}
+        {summary && (
+          <TutorBottomSheet
+            isOpen={isTutorVisible}
+            onClose={() => setIsTutorVisible(false)}
+            conceptTerm={summary.title ?? null}
+            conceptDef={summary.title ?? null}
+            summaryId={Number(summary.id)}
+            sourceVideoTitle={summary.title ?? undefined}
+          />
+        )}
+
+        {/* Export Menu */}
+        {summary && (
+          <ExportMenu
+            summaryId={Number(summary.id)}
+            videoTitle={summary.title || "analyse"}
+            visible={isExportVisible}
+            onClose={() => setIsExportVisible(false)}
+          />
+        )}
+
+        {/* Voice Chat — bouton FAB ouvre ConversationScreen en mode 'call' */}
+        {summary && (
+          <>
+            <VoiceButton
+              summaryId={id as string}
+              videoTitle={summary.title || "Vidéo"}
+              onSessionStart={() => {
+                setConversationInitialMode("call");
+                setIsVoiceVisible(true);
+              }}
+            />
+            <ConversationScreen
+              visible={isVoiceVisible}
+              summaryId={summary.id}
+              initialMode={conversationInitialMode}
+              videoTitle={summary.title || "Vidéo"}
+              channelName={summary.channel}
+              platform={
+                (summary.platform === "tiktok" ? "tiktok" : "youtube") as
+                  | "youtube"
+                  | "tiktok"
+              }
+              initialFavorite={summary.isFavorite}
+              onClose={() => setIsVoiceVisible(false)}
+            />
+          </>
+        )}
+
+        {/* ── MODE FULLSCREEN ──────────────────────────────── */}
+        {/* paddingBottom du container est 0 → l'overlay couvre l'écran entier.
+          La TabBar globale est cachée via tabBarStore (cf. useEffect ci-dessus)
+          donc on n'a plus besoin de réserver TAB_BAR_HEIGHT — seul le safe area
+          bottom suffit. */}
+        {isFullscreen && (
+          <View
+            style={[
+              styles.fullscreenOverlay,
+              {
+                backgroundColor: colors.bgPrimary,
+                paddingTop: insets.top,
+                paddingBottom: insets.bottom,
+              },
+            ]}
+          >
+            {/* Header compact fullscreen */}
+            <View style={styles.fullscreenHeader}>
+              <Pressable
+                onPress={handleBack}
+                style={styles.iconButton}
+                accessibilityLabel="Retour"
+                accessibilityRole="button"
+              >
+                <Ionicons
+                  name="arrow-back"
+                  size={24}
+                  color={colors.textPrimary}
+                />
+              </Pressable>
+              <Text
+                style={[styles.headerTitle, { color: colors.textPrimary }]}
+                numberOfLines={1}
+              >
+                {summary?.title || "Analyse"}
+              </Text>
+              <Pressable
+                onPress={handleToggleFullscreen}
+                style={styles.iconButton}
+                accessibilityLabel="Quitter le plein écran"
+                accessibilityRole="button"
+              >
+                <Ionicons
+                  name="contract-outline"
+                  size={22}
+                  color={colors.textPrimary}
+                />
+              </Pressable>
+            </View>
+
+            {/* Tab bar en fullscreen */}
+            {TabBar}
+
+            {/* PagerView plein écran — instance distincte mais même comportement */}
+            {Pager}
+          </View>
+        )}
+
+        {/* ── Semantic Search V1 — overlays intra-analyse ─────────────── */}
+        {!isFullscreen && (
+          <>
+            {/*
+            Stack vertical : la nav bar se positionne AU-DESSUS du `VoiceButton`
+            (rendu uniquement quand `summary` existe). Sinon (fallback pré-summary),
+            offset court près de la tab bar. Décision arbitrée 2026-05-04 :
+            VoiceButton à `tabBarFootprint + 88`, hauteur 64, gap stack 12 →
+            nav bar à `tabBarFootprint + 88 + 64 + 12 = tabBarFootprint + 164`.
+          */}
+            <HighlightNavigationBar
+              bottomOffset={
+                summary ? tabBarFootprint + 164 : tabBarFootprint + 20
+              }
+            />
+            <HighlightActionSheetController
+              summaryId={Number(effectiveId) || 0}
+            />
+          </>
+        )}
+      </View>
     </SemanticHighlighterProvider>
   );
 }

--- a/mobile/app/(tabs)/hub.tsx
+++ b/mobile/app/(tabs)/hub.tsx
@@ -51,6 +51,7 @@ export default function HubScreen() {
     summaryId?: string;
     videoUrl?: string;
     initialMode?: "chat" | "call";
+    prefillQuery?: string;
   }>();
   const router = useRouter();
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -60,6 +61,23 @@ export default function HubScreen() {
 
   const summaryId = params.summaryId ?? null;
   const initialMode = params.initialMode ?? "chat";
+  // prefillQuery : injecté par PassageActionSheet ("Demander à l'IA") ou
+  // tout autre deep-link. Capturé une seule fois au mount via useState pour
+  // éviter qu'un re-render le re-déclenche après que l'input ait été modifié
+  // par l'user. Le param URL est ensuite cleared via setParams.
+  const [pendingPrefill, setPendingPrefill] = useState<string | null>(
+    params.prefillQuery ?? null,
+  );
+  useEffect(() => {
+    if (params.prefillQuery && pendingPrefill !== params.prefillQuery) {
+      setPendingPrefill(params.prefillQuery);
+    }
+    // Clear le param URL une fois lu pour éviter re-trigger après navigation.
+    if (params.prefillQuery) {
+      router.setParams({ prefillQuery: undefined });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.prefillQuery]);
 
   // Charger l'historique pour le drawer ET pour fallback last-conv
   const { data: historyData } = useQuery({
@@ -140,6 +158,8 @@ export default function HubScreen() {
           platform={headerPlatform}
           initialFavorite={activeConv?.isFavorite ?? false}
           onMenuPress={() => setDrawerOpen(true)}
+          prefillQuery={pendingPrefill}
+          onPrefillConsumed={() => setPendingPrefill(null)}
         />
       ) : (
         <HubEmptyState

--- a/mobile/src/components/analysis/AnalysisContentDisplay.tsx
+++ b/mobile/src/components/analysis/AnalysisContentDisplay.tsx
@@ -33,6 +33,7 @@ import { sp, borderRadius as br } from "../../theme/spacing";
 import { fontFamily, fontSize, lineHeight } from "../../theme/typography";
 import { palette } from "../../theme/colors";
 import { AnalysisSkeleton } from "../ui/SkeletonLoader";
+import { HighlightedText } from "../highlight/HighlightedText";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -533,10 +534,18 @@ export const AnalysisContentDisplay: React.FC<AnalysisContentDisplayProps> = ({
           }
         }
 
+        // Cas par défaut : on wrap dans HighlightedText pour permettre
+        // au SemanticHighlighter de surligner les passages matchés (Task 10).
+        // Si le provider est absent (pas de SemanticHighlighterProvider parent)
+        // ou si pas de matches sur ce tab, HighlightedText rend le texte tel quel.
         return (
-          <Text key={node.key} style={[styles.text, { color: textColor }]}>
+          <HighlightedText
+            key={node.key}
+            tab="synthesis"
+            style={[styles.text, { color: textColor }]}
+          >
             {text}
-          </Text>
+          </HighlightedText>
         );
       },
     }),

--- a/mobile/src/components/conversation/ConversationContent.tsx
+++ b/mobile/src/components/conversation/ConversationContent.tsx
@@ -16,7 +16,7 @@
  * Spec : `docs/superpowers/specs/2026-05-04-mobile-hub-tab-unified-design.md` §4.2
  */
 
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   StyleSheet,
   KeyboardAvoidingView,
@@ -57,6 +57,14 @@ export interface ConversationContentProps {
   onMenuPress?: () => void;
   /** Modal mode : close button. Si null/absent : pas de close. */
   onClose?: () => void;
+  /**
+   * Texte à pré-remplir dans l'input au mount (ex: "Demander à l'IA"
+   * depuis PassageActionSheet de la search V1). Une fois consommé,
+   * `onPrefillConsumed` est appelé pour que le parent clear son état.
+   */
+  prefillQuery?: string | null;
+  /** Callback déclenché une fois `prefillQuery` injecté dans l'input. */
+  onPrefillConsumed?: () => void;
 }
 
 export const ConversationContent: React.FC<ConversationContentProps> = ({
@@ -69,12 +77,24 @@ export const ConversationContent: React.FC<ConversationContentProps> = ({
   initialFavorite = false,
   onMenuPress,
   onClose,
+  prefillQuery,
+  onPrefillConsumed,
 }) => {
   const settingsSheetRef = useRef<BottomSheet | null>(null);
   const summarySheetRef = useRef<BottomSheet | null>(null);
   const [addonVisible, setAddonVisible] = useState(false);
   const [inputText, setInputText] = useState("");
   const [isFavorite, setIsFavorite] = useState(initialFavorite);
+
+  // Inject prefillQuery into the input draft once on mount/change, then
+  // signal the parent so it can clear its URL param. Don't write again
+  // afterwards — the user is free to edit or send the draft.
+  useEffect(() => {
+    if (prefillQuery && prefillQuery.length > 0) {
+      setInputText(prefillQuery);
+      onPrefillConsumed?.();
+    }
+  }, [prefillQuery, onPrefillConsumed]);
 
   const conv = useConversation({
     summaryId,


### PR DESCRIPTION
## Summary

Consolidates 13 commits of follow-up fixes for Semantic Search V1 Phase 2/3/4 that were ready before but missed the merge of #297, #298, #307. Notably contains **Task 16 (Hub wiring)** — without which ~1000 lines of highlight code (Provider/HighlightedText/NavigationBar/SearchBar/Tooltip/useCmdFIntercept) on PR #307 are dead code never mounted.

### Web (PR #307 follow-ups)
- `feat: wire Task 16 Hub integration` — `<SemanticHighlightProvider>` wraps Hub return, `.analysis-page` class on non-chat wrapper, `useCmdFIntercept` opens search bar (chat tab keeps browser default), `HighlightNavigationBar` mount, `ExplainTooltipBridge` reads `ctx.query`, listens to `ds-highlight-click` CustomEvent, `onCiteInChat` switches to chat tab + sends, `onJumpToTab` maps WithinMatch tabs → HubTabBar tabs.
- `feat: wrap AnalysisHub with HighlightedText` (HubAnalysisPanel) — decoupled via window CustomEvent.
- `fix: distinguish featureDisabled (404/503) from generic error` — neutral "Bientôt disponible" empty state instead of red retry toast.
- `fix: restrict useCmdFIntercept to .analysis-page scope` — preserves browser default Cmd+F elsewhere.
- `feat: hard cap 50 marks + skip <code>/<pre>` in DOM walker — perf + correctness.
- `test: add semantic-search-global E2E spec` (Playwright, mocked auth+API).

### Mobile (PR #298 follow-ups)
- `fix: wrap AnalysisContentDisplay paragraphs with HighlightedText (Task 10)` — highlights now actually render in synthesis.
- `fix: refresh provider summaryId on task_id → resolvedSummaryId transition` — provider was permanently disabled on fresh task_id otherwise.
- `fix: wire prefillQuery from PassageActionSheet to Hub ConversationInput` — "Demander à l'IA" action now seeds the input draft.
- `fix: stack HighlightNavigationBar above VoiceButton (gap 12px)` — was non-conformantly under VoiceButton.

### Extension (PR #297 follow-ups)
- `fix: probe feature flag via /recent-queries on mount, hide if disabled` — composant invisible quand `SEMANTIC_SEARCH_V1_ENABLED=false`.
- `feat: jump to timestamp in YouTube player when video_id matches current tab` — `chrome.tabs.sendMessage(tabId, JUMP_TO_TIMESTAMP)`, revérifie tabId au click pour éviter stale.
- `fix: AbortController to cancel stale fetches in useQuickSearch` — fix race conditions sur typing rapide.

## Test plan

- [ ] Web : `/hub?summaryId=XXX&q=foo` opens with highlights wrapped, Cmd+F intercepts inside `.analysis-page`, click on `<mark>` opens ExplainTooltip
- [ ] Mobile : ouvrir analyse, search → click passage → ActionSheet "Demander à l'IA" → switch tab Hub avec input pré-rempli
- [ ] Extension : QuickSearch hidden si flag OFF backend (smoke local)
- [ ] CI : lint pré-existant rouge sur main (audit-kimi tech debt connue) — pas régressions ajoutées par ce PR

## Activation

Une fois mergé : flip `SEMANTIC_SEARCH_V1_ENABLED=true` sur Hetzner pour activer la chaîne complète.

🤖 Generated with [Claude Code](https://claude.com/claude-code)