### PR TITLE
hotfix(hub): import useState — unbreaks /hub crash from PR #314

### DIFF
--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -8,7 +8,7 @@
  * Backend : timeline unifiée déjà en place (PR #203). Schema HubMessage
  * mappé depuis ChatMessage côté API (source/voice_session_id/time_in_call_secs).
  */
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { videoApi, chatApi, reliabilityApi } from "../services/api";
 import { useAuth } from "../hooks/useAuth";


### PR DESCRIPTION
## Summary

PR #314 wired Task 16 (Semantic Search Hub integration) into HubPage.tsx and added 3 useState calls (\`searchOpen\`, \`tooltipMatch\`, \`tooltipAnchor\`) but **missed adding \`useState\` to the React import line** which only had \`useCallback, useEffect, useRef\`.

Result: every /hub mount in prod throws \`ReferenceError: useState is not defined\`, ErrorBoundary catches it and renders the crash screen. Hub is unreachable.

## Diagnosis

Smoke test via Claude in Chrome on prod confirmed:
- /hub crashes with ErrorBoundary screen
- Console shows \`ReferenceError: useState is not defined\` from \`HubPage-BcFkE1kS.js:1:53388\`
- /search works, navigates to /hub correctly, but the Hub page itself fails to mount

## Fix

One-line import addition in \`frontend/src/pages/HubPage.tsx\`:
\`\`\`diff
- import React, { useCallback, useEffect, useRef } from "react";
+ import React, { useCallback, useEffect, useRef, useState } from "react";
\`\`\`

## Urgency

Production /hub is broken since PR #314 merged ~30min ago. Merging admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)