### PR TITLE
hotfix(hub): wire ?summaryId + ?q deeplink params into Task 16 highlight chain

### DIFF
--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -170,8 +170,15 @@ const HubPage: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const urlConvId = searchParams.get("conv");
-  const urlSummaryId = searchParams.get("summary");
+  // Accepts both `?summaryId=` (canonical, used by SearchResultCard from
+  // Phase 2 web) and legacy `?summary=`. Falls through `urlConvId` when
+  // neither is present.
+  const urlSummaryId =
+    searchParams.get("summaryId") ?? searchParams.get("summary");
   const urlTab = searchParams.get("tab") as TabId | null;
+  // ?q= drives the SemanticHighlightProvider (synthesis highlights) when
+  // arriving from /search with a deeplink. Propagated via UrlQueryBridge.
+  const urlQ = searchParams.get("q");
 
   const { language } = useTranslation();
   const { user } = useAuth();
@@ -601,7 +608,13 @@ const HubPage: React.FC = () => {
   const [searchOpen, setSearchOpen] = useState(false);
   const [tooltipMatch, setTooltipMatch] = useState<WithinMatch | null>(null);
   const [tooltipAnchor, setTooltipAnchor] = useState<DOMRect | null>(null);
-  const summaryIdNum = fullSummary?.id ? Number(fullSummary.id) : null;
+  // Source of truth for "is an analysis attached to the active conv ?".
+  // Use `activeConv.summary_id` (resolved as soon as conversations load)
+  // rather than `fullSummary.id` (only resolved after the deep fetch),
+  // so the magnifier button + provider become available immediately.
+  const summaryIdNum = activeConv?.summary_id
+    ? Number(activeConv.summary_id)
+    : null;
 
   useCmdFIntercept({
     scopeSelector: ".analysis-page",
@@ -809,6 +822,7 @@ const HubPage: React.FC = () => {
           open={searchOpen}
           onClose={() => setSearchOpen(false)}
         />
+        {urlQ && summaryIdNum !== null && <UrlQueryBridge q={urlQ} />}
         {summaryIdNum !== null && (
           <ExplainTooltipBridge
             match={tooltipMatch}
@@ -865,6 +879,24 @@ const ExplainTooltipBridge: React.FC<{
       onJumpToTab={onJumpToTab}
     />
   );
+};
+
+/**
+ * Propagates the URL `?q=` deeplink param into the SemanticHighlightProvider
+ * once the provider mounts (and the conv/summary is resolved). Without this,
+ * arriving on `/hub?summaryId=119&q=mistral&highlight=...` from /search
+ * would never trigger the within-search fetch and no <mark> would render
+ * even though everything else is wired correctly.
+ */
+const UrlQueryBridge: React.FC<{ q: string }> = ({ q }) => {
+  const ctx = useSemanticHighlight();
+  useEffect(() => {
+    if (ctx && q && ctx.query !== q) {
+      ctx.setQuery(q);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q, ctx?.setQuery]);
+  return null;
 };
 
 export default HubPage;


### PR DESCRIPTION
## Summary

After PR #315 unblocked /hub from crashing (\`useState\` import), the smoke test on prod surfaced 3 remaining issues that all stem from URL deeplink wiring not being plugged into the Task 16 highlight chain:

| # | Bug | Fix |
|---|-----|-----|
| 1 | \`/hub?summaryId=119\` ignored → "Aucune conversation sélectionnée" | Accept \`summaryId\` in addition to legacy \`summary\` query param |
| 2 | \`?q=mistral\` not propagated → 0 \`<mark>\` rendered | New \`UrlQueryBridge\` sub-component pushes URL \`?q=\` into the provider via \`ctx.setQuery()\` |
| 3 | Magnifier button hidden in HubHeader | Source \`summaryIdNum\` from \`activeConv.summary_id\` (resolved early) instead of \`fullSummary.id\` (resolved late) |

## Test plan

- [ ] Open \`/search\` → query → click result → URL becomes \`/hub?summaryId=...&q=...&highlight=...&tab=...\`
- [ ] /hub renders the analysis (no "Aucune conversation sélectionnée" empty state)
- [ ] DevTools: \`document.querySelectorAll('mark.ds-highlight').length > 0\` once synthesis loads
- [ ] Magnifier button visible in HubHeader (right of title, before PiP)
- [ ] Cmd/Ctrl+F opens IntraAnalysisSearchBar (no browser native Find)

🤖 Generated with [Claude Code](https://claude.com/claude-code)