### PR TITLE
fix(mobile): Tournesol hooks + Hub Quick Call + audit triage

### DIFF
--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from "react";
 import { View, Text, Pressable, StatusBar, StyleSheet } from "react-native";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter, useFocusEffect } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -266,13 +266,17 @@ export default function AnalysisDetailScreen() {
     setIsFullscreen((prev) => !prev);
   }, []);
 
-  // Cacher la TabBar globale en mode fullscreen — restaurée au démontage.
-  // Ce store pilote `<CustomTabBar>` directement (cf. tabBarStore.ts).
+  // Cacher la TabBar globale en mode fullscreen — `useFocusEffect` garantit
+  // que la TabBar est réaffichée dès que l'écran perd le focus (back nav,
+  // tab switch, modal stack), pas seulement au démontage. Évite que la
+  // TabBar reste invisible si l'écran crash entre hide(true) et hide(false).
   const setTabBarHidden = useTabBarStore((s) => s.setTabBarHidden);
-  React.useEffect(() => {
-    setTabBarHidden(isFullscreen);
-    return () => setTabBarHidden(false);
-  }, [isFullscreen, setTabBarHidden]);
+  useFocusEffect(
+    React.useCallback(() => {
+      setTabBarHidden(isFullscreen);
+      return () => setTabBarHidden(false);
+    }, [isFullscreen, setTabBarHidden]),
+  );
 
   // Sync PagerView page after fullscreen toggle — the conditional rendering
   // (`!isFullscreen && Pager` vs `isFullscreen && Pager`) causes React to

--- a/mobile/app/(tabs)/hub.tsx
+++ b/mobile/app/(tabs)/hub.tsx
@@ -54,6 +54,9 @@ export default function HubScreen() {
   }>();
   const router = useRouter();
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // Quand l'user clique "Nouvelle", on désactive l'auto-resolve pour
+  // laisser HubEmptyState s'afficher (sinon le useEffect re-pousse la 1ère conv).
+  const [intentNewConv, setIntentNewConv] = useState(false);
 
   const summaryId = params.summaryId ?? null;
   const initialMode = params.initialMode ?? "chat";
@@ -75,18 +78,20 @@ export default function HubScreen() {
     [conversations, summaryId],
   );
 
-  // Auto-resolve : si pas de summaryId mais history non vide → push le 1er
+  // Auto-resolve : si pas de summaryId mais history non vide → push le 1er.
+  // Désactivé tant que l'user a explicitement demandé une nouvelle conv.
   useEffect(() => {
-    if (!summaryId && conversations.length > 0) {
+    if (!summaryId && !intentNewConv && conversations.length > 0) {
       router.setParams({
         summaryId: String(conversations[0].id),
         initialMode: "chat",
       });
     }
-  }, [summaryId, conversations, router]);
+  }, [summaryId, intentNewConv, conversations, router]);
 
   const handleSelectConv = useCallback(
     (id: string | number) => {
+      setIntentNewConv(false);
       router.setParams({ summaryId: String(id), initialMode: "chat" });
       setDrawerOpen(false);
     },
@@ -94,6 +99,7 @@ export default function HubScreen() {
   );
 
   const handleNewConv = useCallback(() => {
+    setIntentNewConv(true);
     // setParams(undefined) clear la query (Expo Router)
     router.setParams({ summaryId: undefined, initialMode: undefined });
     setDrawerOpen(false);
@@ -103,6 +109,7 @@ export default function HubScreen() {
     async (url: string) => {
       try {
         const result = await videoApi.quickChat(url);
+        setIntentNewConv(false);
         router.setParams({
           summaryId: String(result.summary_id),
           initialMode: "chat",

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -70,12 +70,12 @@ export default function HomeScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [tournesolRefreshKey, setTournesolRefreshKey] = useState(0);
-  const [quickChatUrl, setQuickChatUrl] = useState("");
-  const [quickChatLoading, setQuickChatLoading] = useState(false);
+  const [quickCallUrl, setQuickCallUrl] = useState("");
+  const [quickCallLoading, setQuickCallLoading] = useState(false);
 
-  // Quick Chat handler
-  const handleQuickChat = useCallback(async () => {
-    const url = quickChatUrl.trim();
+  // Quick Call handler — prépare la conv puis ouvre le hub en mode appel vocal
+  const handleQuickCall = useCallback(async () => {
+    const url = quickCallUrl.trim();
     if (!url) return;
     const isValid =
       url.includes("youtube.com") ||
@@ -87,26 +87,26 @@ export default function HomeScreen() {
     }
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     Keyboard.dismiss();
-    setQuickChatLoading(true);
+    setQuickCallLoading(true);
     try {
       const result = await videoApi.quickChat(url);
-      setQuickChatUrl("");
+      setQuickCallUrl("");
       router.push({
         pathname: "/(tabs)/hub",
         params: {
           summaryId: String(result.summary_id),
-          initialMode: "chat",
+          initialMode: "call",
         },
       } as any);
     } catch (err: any) {
       Alert.alert(
-        "Erreur Quick Chat",
-        err?.message || "Impossible de préparer le chat.",
+        "Erreur Quick Call",
+        err?.message || "Impossible de préparer l'appel.",
       );
     } finally {
-      setQuickChatLoading(false);
+      setQuickCallLoading(false);
     }
-  }, [quickChatUrl]);
+  }, [quickCallUrl]);
 
   // Animated tab indicator
   const indicatorX = useSharedValue(0);
@@ -386,7 +386,7 @@ export default function HomeScreen() {
         {/* Credit Bar */}
         <CreditBar />
 
-        {/* Quick Chat Block */}
+        {/* Quick Call Block */}
         <View
           style={[
             styles.quickChatBox,
@@ -394,28 +394,28 @@ export default function HomeScreen() {
           ]}
         >
           <View style={styles.quickChatHeader}>
-            <Ionicons name="flash" size={16} color={palette.amber} />
+            <Ionicons name="call" size={16} color={palette.indigo} />
             <Text
               style={[styles.quickChatTitle, { color: colors.textPrimary }]}
             >
-              Quick Chat
+              Quick Call
             </Text>
             <View
               style={[
                 styles.quickChatBadge,
-                { backgroundColor: palette.green + "20" },
+                { backgroundColor: palette.indigo + "20" },
               ]}
             >
               <Text
-                style={[styles.quickChatBadgeText, { color: palette.green }]}
+                style={[styles.quickChatBadgeText, { color: palette.indigo }]}
               >
-                0 crédit
+                Voice
               </Text>
             </View>
           </View>
           <Text style={[styles.quickChatDesc, { color: colors.textTertiary }]}>
-            Chatte directement avec une vidéo YouTube ou TikTok — sans analyse
-            complète
+            Lance un appel vocal direct avec une vidéo YouTube ou TikTok — pose
+            tes questions à l'oral
           </Text>
           <View style={styles.quickChatRow}>
             <TextInput
@@ -429,34 +429,35 @@ export default function HomeScreen() {
               ]}
               placeholder="https://youtube.com/... ou tiktok.com/..."
               placeholderTextColor={colors.textMuted}
-              value={quickChatUrl}
-              onChangeText={setQuickChatUrl}
+              value={quickCallUrl}
+              onChangeText={setQuickCallUrl}
               autoCapitalize="none"
               autoCorrect={false}
               keyboardType="url"
               returnKeyType="go"
-              onSubmitEditing={handleQuickChat}
-              editable={!quickChatLoading}
+              onSubmitEditing={handleQuickCall}
+              editable={!quickCallLoading}
             />
             <Pressable
               style={[
                 styles.quickChatBtn,
                 {
-                  backgroundColor: quickChatUrl.trim()
+                  backgroundColor: quickCallUrl.trim()
                     ? palette.indigo
                     : colors.bgSecondary,
                 },
               ]}
-              onPress={handleQuickChat}
-              disabled={quickChatLoading || !quickChatUrl.trim()}
+              onPress={handleQuickCall}
+              disabled={quickCallLoading || !quickCallUrl.trim()}
+              accessibilityLabel="Lancer un appel vocal"
             >
-              {quickChatLoading ? (
+              {quickCallLoading ? (
                 <DeepSightSpinner size="xs" speed="fast" />
               ) : (
                 <Ionicons
-                  name="chatbubble-ellipses"
+                  name="mic"
                   size={18}
-                  color={quickChatUrl.trim() ? "#fff" : colors.textMuted}
+                  color={quickCallUrl.trim() ? "#fff" : colors.textMuted}
                 />
               )}
             </Pressable>

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -99,7 +99,6 @@
     "@testing-library/react-native": "^12.9.0",
     "@types/jest": "^29.5.12",
     "@types/react": "~19.1.10",
-    "@types/react-native": "~0.73.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "babel-plugin-module-resolver": "^5.0.0",

--- a/mobile/src/components/tournesol/TournesolRecommendations.tsx
+++ b/mobile/src/components/tournesol/TournesolRecommendations.tsx
@@ -161,6 +161,108 @@ export function TournesolRecommendations({
     return colors.textTertiary;
   };
 
+  const renderCard = useCallback(
+    ({ item }: { item: TournesolResult }) => {
+      const videoId = item.entity.metadata.video_id;
+      const score = item.collective_rating.tournesol_score;
+      const thumbnail = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
+
+      return (
+        <Pressable
+          style={[
+            styles.card,
+            { backgroundColor: colors.bgElevated, borderColor: colors.border },
+          ]}
+          onPress={() => handleVideoPress(videoId)}
+          accessibilityLabel={`Analyser: ${item.entity.metadata.name}`}
+        >
+          {/* Thumbnail */}
+          <View style={styles.thumbnailContainer}>
+            <Image
+              source={{ uri: thumbnail }}
+              style={styles.thumbnail}
+              contentFit="cover"
+            />
+            {/* Score badge */}
+            <View
+              style={[
+                styles.scoreBadge,
+                {
+                  backgroundColor: getScoreColor(score) + "20",
+                  borderColor: getScoreColor(score) + "40",
+                },
+              ]}
+            >
+              <Text style={styles.sunflower}>{"\uD83C\uDF3B"}</Text>
+              <Text style={[styles.scoreText, { color: getScoreColor(score) }]}>
+                {score > 0 ? "+" : ""}
+                {Math.round(score)}
+              </Text>
+            </View>
+            {/* Duration */}
+            {item.entity.metadata.duration && (
+              <View style={styles.durationBadge}>
+                <Text style={styles.durationText}>
+                  {formatDuration(item.entity.metadata.duration)}
+                </Text>
+              </View>
+            )}
+          </View>
+
+          {/* Info */}
+          <View style={styles.cardInfo}>
+            <Text
+              style={[styles.cardTitle, { color: colors.textPrimary }]}
+              numberOfLines={2}
+            >
+              {item.entity.metadata.name}
+            </Text>
+            <Text
+              style={[styles.cardChannel, { color: colors.textTertiary }]}
+              numberOfLines={1}
+            >
+              {item.entity.metadata.uploader || "YouTube"}
+            </Text>
+            <View style={styles.cardStats}>
+              <Text style={[styles.cardStat, { color: colors.textMuted }]}>
+                {item.collective_rating.n_contributors}{" "}
+                {language === "fr" ? "votes" : "votes"}
+              </Text>
+            </View>
+          </View>
+
+          {/* Analyze CTA */}
+          <View
+            style={[
+              styles.analyzeCta,
+              { backgroundColor: palette.indigo + "15" },
+            ]}
+          >
+            <Ionicons name="sparkles" size={12} color={palette.indigo} />
+            <Text style={[styles.analyzeText, { color: palette.indigo }]}>
+              {language === "fr" ? "Analyser" : "Analyze"}
+            </Text>
+          </View>
+        </Pressable>
+      );
+    },
+    [
+      colors.bgElevated,
+      colors.border,
+      colors.textPrimary,
+      colors.textTertiary,
+      colors.textMuted,
+      handleVideoPress,
+      language,
+    ],
+  );
+
+  const keyExtractor = useCallback(
+    (item: TournesolResult) => item.entity.uid,
+    [],
+  );
+
+  // Early returns APRÈS tous les hooks — Rules of Hooks
   if (loading) {
     return (
       <View style={styles.loadingContainer}>
@@ -172,99 +274,6 @@ export function TournesolRecommendations({
   if (error || results.length === 0) {
     return null; // Silently hide if no data
   }
-
-  const renderCard = useCallback(
-    ({ item }: { item: TournesolResult }) => {
-    const videoId = item.entity.metadata.video_id;
-    const score = item.collective_rating.tournesol_score;
-    const thumbnail = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
-
-    return (
-      <Pressable
-        style={[
-          styles.card,
-          { backgroundColor: colors.bgElevated, borderColor: colors.border },
-        ]}
-        onPress={() => handleVideoPress(videoId)}
-        accessibilityLabel={`Analyser: ${item.entity.metadata.name}`}
-      >
-        {/* Thumbnail */}
-        <View style={styles.thumbnailContainer}>
-          <Image
-            source={{ uri: thumbnail }}
-            style={styles.thumbnail}
-            contentFit="cover"
-          />
-          {/* Score badge */}
-          <View
-            style={[
-              styles.scoreBadge,
-              {
-                backgroundColor: getScoreColor(score) + "20",
-                borderColor: getScoreColor(score) + "40",
-              },
-            ]}
-          >
-            <Text style={styles.sunflower}>{"\uD83C\uDF3B"}</Text>
-            <Text style={[styles.scoreText, { color: getScoreColor(score) }]}>
-              {score > 0 ? "+" : ""}
-              {Math.round(score)}
-            </Text>
-          </View>
-          {/* Duration */}
-          {item.entity.metadata.duration && (
-            <View style={styles.durationBadge}>
-              <Text style={styles.durationText}>
-                {formatDuration(item.entity.metadata.duration)}
-              </Text>
-            </View>
-          )}
-        </View>
-
-        {/* Info */}
-        <View style={styles.cardInfo}>
-          <Text
-            style={[styles.cardTitle, { color: colors.textPrimary }]}
-            numberOfLines={2}
-          >
-            {item.entity.metadata.name}
-          </Text>
-          <Text
-            style={[styles.cardChannel, { color: colors.textTertiary }]}
-            numberOfLines={1}
-          >
-            {item.entity.metadata.uploader || "YouTube"}
-          </Text>
-          <View style={styles.cardStats}>
-            <Text style={[styles.cardStat, { color: colors.textMuted }]}>
-              {item.collective_rating.n_contributors}{" "}
-              {language === "fr" ? "votes" : "votes"}
-            </Text>
-          </View>
-        </View>
-
-        {/* Analyze CTA */}
-        <View
-          style={[
-            styles.analyzeCta,
-            { backgroundColor: palette.indigo + "15" },
-          ]}
-        >
-          <Ionicons name="sparkles" size={12} color={palette.indigo} />
-          <Text style={[styles.analyzeText, { color: palette.indigo }]}>
-            {language === "fr" ? "Analyser" : "Analyze"}
-          </Text>
-        </View>
-      </Pressable>
-    );
-    },
-    [colors.bgElevated, colors.border, colors.textPrimary, colors.textTertiary, colors.textMuted, handleVideoPress, language],
-  );
-
-  const keyExtractor = useCallback(
-    (item: TournesolResult) => item.entity.uid,
-    [],
-  );
 
   return (
     <Animated.View

--- a/mobile/src/hooks/useAnalysis.ts
+++ b/mobile/src/hooks/useAnalysis.ts
@@ -6,6 +6,7 @@ import type { AnalysisOptionsV2 } from "../types/v2";
 export function useAnalysis() {
   const store = useAnalysisStore();
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isMountedRef = useRef(true);
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -37,6 +38,9 @@ export function useAnalysis() {
         pollingRef.current = setInterval(async () => {
           try {
             const data = await videoApi.getStatus(taskId);
+            // A request can resolve after the hook unmounts and the interval
+            // has been cleared — avoid mutating the store in that window.
+            if (!isMountedRef.current) return;
 
             if (data.status === "processing") {
               store.setProgress(data.progress || 0);
@@ -53,6 +57,7 @@ export function useAnalysis() {
               store.failAnalysis(data.error || "Analysis failed");
             }
           } catch {
+            if (!isMountedRef.current) return;
             stopPolling();
             store.failAnalysis("Connection lost");
           }
@@ -65,7 +70,11 @@ export function useAnalysis() {
   );
 
   useEffect(() => {
-    return () => stopPolling();
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      stopPolling();
+    };
   }, [stopPolling]);
 
   return {

--- a/mobile/src/stores/analysisStore.ts
+++ b/mobile/src/stores/analysisStore.ts
@@ -104,12 +104,17 @@ export const useAnalysisStore = create<AnalysisStore>()(
     {
       name: "analysis-store",
       storage: createJSONStorage(() => AsyncStorage),
+      version: 1,
       // Only persist user preferences and cached data, not transient analysis state
       partialize: (state) => ({
         options: state.options,
         recentSummaries: state.recentSummaries,
         favorites: state.favorites,
       }),
+      // First versioned schema. Bump `version` and branch on `from` when the
+      // shape of persisted fields changes, otherwise AsyncStorage will replay
+      // an incompatible payload at app start.
+      migrate: (persistedState, _from) => persistedState as AnalysisStore,
     },
   ),
 );


### PR DESCRIPTION
## Summary
- `0968f095` fix rules-of-hooks violation in `TournesolRecommendations`
- `8e1835b4` Hub "Nouvelle" pill + replace Quick Chat → Quick Call on home
- `b3fcc9d8` audit triage: `analysisStore` persist `version: 1` + migrate, `useAnalysis` `isMountedRef` polling guard, `analysis/[id]` switches TabBar hide to `useFocusEffect`, drops dead `@types/react-native ~0.73` devDep

Mobile-only — no backend / web / extension changes.

## Test plan
- [x] `npm run typecheck` clean (0 errors)
- [ ] Smoke test: lance Expo, ouvre une analyse, toggle fullscreen, back nav → TabBar revient
- [ ] Smoke test: lance une analyse, kill l'écran avant la fin → pas de warning console post-unmount
- [ ] Smoke test: persisted `analysisStore` se charge sans erreur après l'update

🤖 Generated with [Claude Code](https://claude.com/claude-code)