### PR TITLE
feat(debate-ui): onboarding components — Wave 4 G

### DIFF
--- a/frontend/src/components/debate/DebateContextualCTA.tsx
+++ b/frontend/src/components/debate/DebateContextualCTA.tsx
@@ -1,0 +1,90 @@
+/**
+ * CTA contextuel à placer dans la page d'analyse vidéo standard.
+ * Bouton "Voir les perspectives opposées" qui pré-remplit DebateCreateForm avec l'URL.
+ *
+ * Sprint Débat IA v2 — Wave 4 G.
+ * Spec : docs/superpowers/specs/2026-05-04-debate-ia-v2.md §10 (CTA contextuel post-analyse).
+ *
+ * Usage (depuis la page d'analyse vidéo) :
+ *   <DebateContextualCTA videoUrl={summary.video_url} userPlan={user.plan} />
+ */
+
+import { motion } from "framer-motion";
+import { useNavigate } from "react-router-dom";
+
+interface Props {
+  videoUrl: string;
+  userPlan: "free" | "pro" | "expert";
+  variant?: "card" | "compact";
+}
+
+export function DebateContextualCTA({
+  videoUrl,
+  userPlan,
+  variant = "card",
+}: Props) {
+  const navigate = useNavigate();
+  const isGated = userPlan === "free";
+
+  const handleClick = () => {
+    if (isGated) {
+      navigate("/upgrade?feature=debate");
+      return;
+    }
+    const params = new URLSearchParams({ url: videoUrl, mode: "auto" });
+    navigate(`/debate?${params.toString()}`);
+  };
+
+  if (variant === "compact") {
+    return (
+      <button
+        onClick={handleClick}
+        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium border border-violet-500/30 bg-violet-500/10 text-violet-300 hover:bg-violet-500/20 transition"
+      >
+        <span>⚔️</span>
+        <span>Voir les perspectives opposées</span>
+        {isGated && <span className="text-amber-400 ml-1">Pro</span>}
+      </button>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="rounded-2xl border border-violet-500/20 bg-gradient-to-br from-violet-500/5 to-transparent p-5"
+    >
+      <div className="flex items-start gap-4">
+        <div className="text-3xl">⚔️</div>
+        <div className="flex-1">
+          <h3 className="text-base font-semibold text-white mb-1">
+            Confronte cette vidéo à un autre point de vue
+          </h3>
+          <p className="text-sm text-white/60 mb-4 leading-relaxed">
+            DeepSight trouve automatiquement une vidéo qui défend la position
+            opposée — opposition, complément ou nuance. Idéal pour sortir de sa
+            bulle de filtres.
+          </p>
+          <button
+            onClick={handleClick}
+            disabled={false}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-violet-600 hover:bg-violet-500 text-white text-sm font-medium transition shadow-lg shadow-violet-500/30"
+          >
+            {isGated ? (
+              <>
+                <span>Débloquer avec Pro</span>
+                <span className="text-amber-300">↑</span>
+              </>
+            ) : (
+              <>
+                <span>Lancer un débat IA</span>
+                <span>→</span>
+              </>
+            )}
+            <span className="text-xs text-white/60 ml-1">(5 crédits)</span>
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/debate/DebateExamples.tsx
+++ b/frontend/src/components/debate/DebateExamples.tsx
@@ -1,0 +1,150 @@
+/**
+ * Section "Essayer un exemple" sur la page Débat IA.
+ * 3 exemples célèbres pré-générés, accessibles sans coût crédits (mode démo).
+ *
+ * Sprint Débat IA v2 — Wave 4 G.
+ * Spec : docs/superpowers/specs/2026-05-04-debate-ia-v2.md §10.
+ */
+
+import { motion } from "framer-motion";
+
+type Example = {
+  id: string;
+  topic: string;
+  thesis_a: string;
+  channel_a: string;
+  thesis_b: string;
+  channel_b: string;
+  relation: "opposite" | "complement" | "nuance";
+  emoji: string;
+};
+
+const EXAMPLES: Example[] = [
+  {
+    id: "demo-semaine-4j",
+    topic: "Semaine de 4 jours : révolution productive ou utopie économique ?",
+    thesis_a: "La semaine de 4 jours augmente la productivité et le bien-être.",
+    channel_a: "Hugo Décrypte",
+    thesis_b:
+      "Trop coûteuse pour les PME, elle accroît les inégalités sectorielles.",
+    channel_b: "Le Figaro Économie",
+    relation: "opposite",
+    emoji: "💼",
+  },
+  {
+    id: "demo-ia-emplois",
+    topic: "L'IA va-t-elle détruire ou créer des emplois ?",
+    thesis_a:
+      "L'IA automatise les tâches répétitives mais crée de nouveaux métiers à valeur ajoutée.",
+    channel_a: "Science4All",
+    thesis_b:
+      "Sans politiques de transition, 30% des emplois disparaîtront sans remplacement.",
+    channel_b: "Thinkerview",
+    relation: "nuance",
+    emoji: "🤖",
+  },
+  {
+    id: "demo-climat-action",
+    topic: "Action individuelle vs collective face au changement climatique",
+    thesis_a:
+      "Les gestes quotidiens (vélo, alim, tri) sont essentiels pour réduire l'empreinte carbone.",
+    channel_a: "Le Réveilleur",
+    thesis_b:
+      "Sans réformes politiques structurelles, l'action individuelle est marginale (2% de l'impact).",
+    channel_b: "Bon Pote",
+    relation: "complement",
+    emoji: "🌍",
+  },
+];
+
+const RELATION_LABELS = {
+  opposite: {
+    label: "Opposition",
+    color: "text-red-400 bg-red-500/10 border-red-500/30",
+  },
+  complement: {
+    label: "Complément",
+    color: "text-emerald-400 bg-emerald-500/10 border-emerald-500/30",
+  },
+  nuance: {
+    label: "Nuance",
+    color: "text-amber-400 bg-amber-500/10 border-amber-500/30",
+  },
+};
+
+interface Props {
+  onSelectExample: (example: Example) => void;
+}
+
+export function DebateExamples({ onSelectExample }: Props) {
+  return (
+    <section className="my-12">
+      <div className="text-center mb-6">
+        <h2 className="text-xl font-semibold text-white mb-2">
+          Essayer un exemple
+        </h2>
+        <p className="text-sm text-white/60 max-w-xl mx-auto">
+          Découvre la fonctionnalité Débat IA sans utiliser de crédits. 3 sujets
+          pré-analysés pour explorer les relations entre points de vue.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-5xl mx-auto">
+        {EXAMPLES.map((ex, i) => {
+          const relation = RELATION_LABELS[ex.relation];
+          return (
+            <motion.button
+              key={ex.id}
+              onClick={() => onSelectExample(ex)}
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.08, duration: 0.4 }}
+              whileHover={{ y: -4, transition: { duration: 0.2 } }}
+              className="group text-left rounded-2xl border border-white/10 bg-gradient-to-br from-white/[0.03] to-white/[0.01] p-5 hover:border-violet-500/40 hover:shadow-lg hover:shadow-violet-500/10 transition-all"
+            >
+              <div className="flex items-start justify-between mb-3">
+                <span className="text-3xl">{ex.emoji}</span>
+                <span
+                  className={`text-xs px-2 py-1 rounded-full border ${relation.color}`}
+                >
+                  {relation.label}
+                </span>
+              </div>
+              <h3 className="text-sm font-semibold text-white/90 mb-3 leading-tight line-clamp-2">
+                {ex.topic}
+              </h3>
+              <div className="space-y-2 text-xs">
+                <div className="flex items-start gap-2">
+                  <span className="text-violet-400 font-medium shrink-0">
+                    A · {ex.channel_a}
+                  </span>
+                </div>
+                <p className="text-white/60 line-clamp-2 leading-relaxed">
+                  {ex.thesis_a}
+                </p>
+                <div className="flex items-start gap-2 mt-3">
+                  <span className="text-cyan-400 font-medium shrink-0">
+                    B · {ex.channel_b}
+                  </span>
+                </div>
+                <p className="text-white/60 line-clamp-2 leading-relaxed">
+                  {ex.thesis_b}
+                </p>
+              </div>
+              <div className="mt-4 text-xs text-violet-400 group-hover:translate-x-1 transition-transform">
+                Explorer ce débat →
+              </div>
+            </motion.button>
+          );
+        })}
+      </div>
+
+      <p className="text-center text-xs text-white/40 mt-6">
+        Démo gratuite — l'analyse complète sur tes vidéos consomme 5 crédits (+
+        3 par perspective ajoutée).
+      </p>
+    </section>
+  );
+}
+
+export type { Example };

--- a/frontend/src/components/debate/DebateOnboardingTour.tsx
+++ b/frontend/src/components/debate/DebateOnboardingTour.tsx
@@ -1,0 +1,154 @@
+/**
+ * Coachmark progressif au 1er lancement de la page Débat IA.
+ * 3 étapes, skippable, persistance localStorage.
+ *
+ * Sprint Débat IA v2 — Wave 4 G.
+ * Spec : docs/superpowers/specs/2026-05-04-debate-ia-v2.md §10.
+ */
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+const STORAGE_KEY = "debate_onboarding_completed_v2";
+
+type Step = {
+  selector: string;
+  title: string;
+  body: string;
+  placement: "top" | "bottom" | "left" | "right";
+};
+
+const STEPS: Step[] = [
+  {
+    selector: '[data-onboard="debate-input"]',
+    title: "1. Choisis une vidéo",
+    body: "Colle l'URL d'une vidéo YouTube ou TikTok. DeepSight extrait sa thèse et cherche une perspective opposée automatiquement.",
+    placement: "bottom",
+  },
+  {
+    selector: '[data-onboard="debate-vs-layout"]',
+    title: "2. Confronte les arguments",
+    body: "Visualise la vidéo A et la perspective B côte-à-côte. Convergences en vert, divergences en rouge, fact-check inline.",
+    placement: "top",
+  },
+  {
+    selector: '[data-onboard="add-perspective"]',
+    title: "3. Enrichis le débat",
+    body: "Ajoute une perspective complémentaire ou une nuance (3 crédits chacune, max 3 perspectives au total).",
+    placement: "top",
+  },
+];
+
+export function DebateOnboardingTour() {
+  const [stepIdx, setStepIdx] = useState(-1);
+  const [target, setTarget] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY) === "true") return;
+    const timer = setTimeout(() => setStepIdx(0), 800);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (stepIdx < 0 || stepIdx >= STEPS.length) {
+      setTarget(null);
+      return;
+    }
+    const el = document.querySelector(STEPS[stepIdx].selector);
+    if (el instanceof HTMLElement) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      setTimeout(() => setTarget(el.getBoundingClientRect()), 400);
+    } else {
+      setTarget(null);
+    }
+  }, [stepIdx]);
+
+  const finish = () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    setStepIdx(-1);
+  };
+
+  if (stepIdx < 0 || stepIdx >= STEPS.length) return null;
+
+  const step = STEPS[stepIdx];
+  const isLast = stepIdx === STEPS.length - 1;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        key="onboarding-overlay"
+        className="fixed inset-0 z-[100] pointer-events-none"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        {target && (
+          <div
+            className="absolute rounded-2xl ring-4 ring-violet-500/60 shadow-[0_0_60px_rgba(139,92,246,0.5)] pointer-events-none transition-all duration-300"
+            style={{
+              top: target.top - 8,
+              left: target.left - 8,
+              width: target.width + 16,
+              height: target.height + 16,
+            }}
+          />
+        )}
+
+        <div
+          className="absolute inset-0 bg-black/60 backdrop-blur-sm pointer-events-auto"
+          onClick={finish}
+        />
+
+        <motion.div
+          key={`step-${stepIdx}`}
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="absolute left-1/2 -translate-x-1/2 bottom-12 w-[min(520px,90vw)] pointer-events-auto"
+        >
+          <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-[#1a1428] to-[#0f0a1a] p-6 shadow-2xl">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-xs uppercase tracking-wider text-violet-400">
+                Étape {stepIdx + 1} / {STEPS.length}
+              </span>
+              <button
+                onClick={finish}
+                className="text-xs text-white/50 hover:text-white/80 transition"
+              >
+                Passer le tutoriel
+              </button>
+            </div>
+            <h3 className="text-lg font-semibold text-white mb-2">
+              {step.title}
+            </h3>
+            <p className="text-sm text-white/70 mb-5 leading-relaxed">
+              {step.body}
+            </p>
+            <div className="flex items-center justify-between">
+              <div className="flex gap-1.5">
+                {STEPS.map((_, i) => (
+                  <div
+                    key={i}
+                    className={`h-1.5 rounded-full transition-all ${
+                      i === stepIdx ? "w-8 bg-violet-500" : "w-1.5 bg-white/20"
+                    }`}
+                  />
+                ))}
+              </div>
+              <button
+                onClick={() => (isLast ? finish() : setStepIdx(stepIdx + 1))}
+                className="px-4 py-2 rounded-xl bg-violet-600 hover:bg-violet-500 text-white text-sm font-medium transition shadow-lg shadow-violet-500/30"
+              >
+                {isLast ? "Compris !" : "Suivant →"}
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+/** Hook utilitaire pour relancer le tour (ex: bouton "Voir le tutoriel" dans paramètres). */
+export function useResetDebateOnboarding() {
+  return () => localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
3 nouveaux composants standalone pour l'onboarding du Débat IA v2 :
- **DebateOnboardingTour** — coachmark 3 étapes au 1er lancement (skippable, localStorage)
- **DebateExamples** — 3 exemples pré-faits (semaine 4j, IA emplois, climat) pour démo gratuite
- **DebateContextualCTA** — bouton "Voir les perspectives opposées" pour page analyse standard

## Why standalone (sans modif DebatePage)
Wave 3 D PR #316 modifie aussi \`DebatePage.tsx\` (+54 lignes naming + boutons add-perspective). Pour éviter conflit Git majeur, cette PR ne touche **pas** à DebatePage. L'intégration des 3 composants dans la page sera faite en PR follow-up après merge Wave 3 D.

## Coordination
- Mergeable indépendamment des PRs Wave 3 (#316 / #317 / #318)
- Suit les design tokens DeepSight (violet #8b5cf6, dark mode, glassmorphism)
- Zéro dépendance externe (pas de react-joyride, custom Framer Motion)

## TODO follow-up post-merge
- [ ] Intégrer les 3 composants dans DebatePage.tsx
- [ ] Trouver la page d'analyse vidéo standard et y ajouter \`<DebateContextualCTA />\`
- [ ] Tests unitaires Vitest
- [ ] Le naming adaptatif "Débat IA" / "Perspectives IA" est déjà couvert par Wave 3 D

🤖 Generated with [Claude Code](https://claude.com/claude-code)