### PR TITLE
fix(mobile): unblock build + audit triage (cherry-picked from #320)

### DIFF
--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from "react";
 import { View, Text, Pressable, StatusBar, StyleSheet } from "react-native";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter, useFocusEffect } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTabBarFootprint } from "@/hooks/useTabBarFootprint";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -333,13 +333,17 @@ function AnalysisDetailScreenInner() {
     setIsFullscreen((prev) => !prev);
   }, []);
 
-  // Cacher la TabBar globale en mode fullscreen — restaurée au démontage.
-  // Ce store pilote `<CustomTabBar>` directement (cf. tabBarStore.ts).
+  // Cacher la TabBar globale en mode fullscreen — `useFocusEffect` garantit
+  // que la TabBar est réaffichée dès que l'écran perd le focus (back nav,
+  // tab switch, modal stack), pas seulement au démontage. Évite que la
+  // TabBar reste invisible si l'écran crash entre hide(true) et hide(false).
   const setTabBarHidden = useTabBarStore((s) => s.setTabBarHidden);
-  React.useEffect(() => {
-    setTabBarHidden(isFullscreen);
-    return () => setTabBarHidden(false);
-  }, [isFullscreen, setTabBarHidden]);
+  useFocusEffect(
+    React.useCallback(() => {
+      setTabBarHidden(isFullscreen);
+      return () => setTabBarHidden(false);
+    }, [isFullscreen, setTabBarHidden]),
+  );
 
   // Sync PagerView page after fullscreen toggle — the conditional rendering
   // (`!isFullscreen && Pager` vs `isFullscreen && Pager`) causes React to

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -97,7 +97,6 @@
     "@testing-library/react-native": "^12.9.0",
     "@types/jest": "^29.5.12",
     "@types/react": "~19.1.10",
-    "@types/react-native": "~0.73.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "babel-plugin-module-resolver": "^5.0.0",

--- a/mobile/src/hooks/useAnalysis.ts
+++ b/mobile/src/hooks/useAnalysis.ts
@@ -6,6 +6,7 @@ import type { AnalysisOptionsV2 } from "../types/v2";
 export function useAnalysis() {
   const store = useAnalysisStore();
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isMountedRef = useRef(true);
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -37,6 +38,9 @@ export function useAnalysis() {
         pollingRef.current = setInterval(async () => {
           try {
             const data = await videoApi.getStatus(taskId);
+            // A request can resolve after the hook unmounts and the interval
+            // has been cleared — avoid mutating the store in that window.
+            if (!isMountedRef.current) return;
 
             if (data.status === "processing") {
               store.setProgress(data.progress || 0);
@@ -53,6 +57,7 @@ export function useAnalysis() {
               store.failAnalysis(data.error || "Analysis failed");
             }
           } catch {
+            if (!isMountedRef.current) return;
             stopPolling();
             store.failAnalysis("Connection lost");
           }
@@ -65,7 +70,11 @@ export function useAnalysis() {
   );
 
   useEffect(() => {
-    return () => stopPolling();
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      stopPolling();
+    };
   }, [stopPolling]);
 
   return {

--- a/mobile/src/stores/analysisStore.ts
+++ b/mobile/src/stores/analysisStore.ts
@@ -104,12 +104,17 @@ export const useAnalysisStore = create<AnalysisStore>()(
     {
       name: "analysis-store",
       storage: createJSONStorage(() => AsyncStorage),
+      version: 1,
       // Only persist user preferences and cached data, not transient analysis state
       partialize: (state) => ({
         options: state.options,
         recentSummaries: state.recentSummaries,
         favorites: state.favorites,
       }),
+      // First versioned schema. Bump `version` and branch on `from` when the
+      // shape of persisted fields changes, otherwise AsyncStorage will replay
+      // an incompatible payload at app start.
+      migrate: (persistedState, _from) => persistedState as AnalysisStore,
     },
   ),
 );


### PR DESCRIPTION
## Summary
Cherry-picked `b3fcc9d8` from #320 onto a clean branch from `main`.

PR #320 carried 2 unrelated commits (`8e1835b4`, `0968f095`) plus pre-existing CI failures from divergent branch state. This PR ships the audit triage fixes only.

## Changes
- `analysisStore`: add `version: 1` + no-op migrate on the persist config so AsyncStorage replays stay compatible the next time the schema bumps
- `useAnalysis`: guard polling callback with `isMountedRef` to avoid mutating the store after unmount when a `getStatus` request resolves late
- `analysis/[id]`: use `useFocusEffect` (not `useEffect`) for the TabBar hide toggle so a screen losing focus always restores the bar
- `package.json`: drop dead devDep `@types/react-native ~0.73` (RN 0.74+ ships its own types via `react-native/types`)

## Test plan
- [x] `npm run typecheck` clean (0 errors locally)
- [ ] Smoke test: lance Expo, ouvre une analyse, toggle fullscreen, back nav → TabBar revient
- [ ] Smoke test: lance une analyse, kill l'écran avant la fin → pas de warning console post-unmount
- [ ] Smoke test: persisted `analysisStore` se charge sans erreur après l'update

🤖 Generated with [Claude Code](https://claude.com/claude-code)