### PR TITLE
hotfix(hub): render <mark> highlights + portal nav bar + synthetic conv from summaryId

### DIFF
--- a/frontend/src/components/highlight/HighlightNavigationBar.tsx
+++ b/frontend/src/components/highlight/HighlightNavigationBar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
 import { ChevronUp, ChevronDown, X } from "lucide-react";
 import { useSemanticHighlight } from "./useSemanticHighlight";
 
@@ -31,13 +32,20 @@ export const HighlightNavigationBar: React.FC = () => {
   const total = ctx.matches.length;
   const current = ctx.currentIndex + 1;
 
-  return (
+  // Portal to <body> with `position: fixed` so the bar stays visible
+  // regardless of any ancestor with `overflow: hidden` / `h-screen` /
+  // flex stacking that would otherwise clip a `sticky` element. Bug
+  // observed in HubPage where the bar was rendered inside an
+  // `h-screen overflow-hidden flex flex-col` container and the sticky
+  // positioning resolved to y=623 (off-screen).
+  if (typeof document === "undefined") return null;
+  return createPortal(
     <nav
       role="navigation"
       aria-label="Résultats de recherche"
-      className="sticky top-[56px] z-40 mx-auto w-full max-w-3xl px-4"
+      className="fixed left-1/2 -translate-x-1/2 top-[64px] z-50 w-full max-w-3xl px-4 pointer-events-none"
     >
-      <div className="mt-2 flex items-center gap-2 px-3 py-2 rounded-lg bg-[#12121a]/95 border border-amber-500/30 backdrop-blur-xl shadow-lg">
+      <div className="pointer-events-auto flex items-center gap-2 px-3 py-2 rounded-lg bg-[#12121a]/95 border border-amber-500/30 backdrop-blur-xl shadow-lg">
         <span
           className="text-sm font-mono text-amber-300 tabular-nums"
           aria-live="polite"
@@ -75,6 +83,7 @@ export const HighlightNavigationBar: React.FC = () => {
           <X className="w-4 h-4" />
         </button>
       </div>
-    </nav>
+    </nav>,
+    document.body,
   );
 };

--- a/frontend/src/components/highlight/HighlightedText.tsx
+++ b/frontend/src/components/highlight/HighlightedText.tsx
@@ -15,6 +15,59 @@ const MAX_MARKS = 50;
  */
 const SKIP_PARENT_TAGS = new Set(["CODE", "PRE", "KBD"]);
 
+/**
+ * Stopwords ignored when falling back to query-word highlighting.
+ * Short connectives that would either match noise or already be in
+ * SKIP_PARENT_TAGS adjacency.
+ */
+const QUERY_STOPWORDS = new Set([
+  "le",
+  "la",
+  "les",
+  "un",
+  "une",
+  "des",
+  "du",
+  "de",
+  "et",
+  "ou",
+  "est",
+  "sont",
+  "dans",
+  "sur",
+  "avec",
+  "pour",
+  "par",
+  "que",
+  "qui",
+  "ce",
+  "ces",
+  "the",
+  "and",
+  "or",
+  "of",
+  "in",
+  "on",
+  "to",
+  "for",
+  "with",
+  "is",
+  "are",
+  "this",
+  "that",
+  "these",
+  "those",
+]);
+
+/** Extract significant query words (≥3 chars, not stopwords). */
+function significantQueryWords(q: string): string[] {
+  return q
+    .toLowerCase()
+    .split(/[\s,;:!?'"().]+/)
+    .map((w) => w.trim())
+    .filter((w) => w.length >= 3 && !QUERY_STOPWORDS.has(w));
+}
+
 interface Props {
   /** Tab identity — only matches for this tab are rendered */
   tab: WithinMatch["tab"];
@@ -76,26 +129,59 @@ export const HighlightedText: React.FC<Props> = ({
         return NodeFilter.FILTER_ACCEPT;
       },
     });
-    const targets: { node: Text; match: WithinMatch }[] = [];
+    // Significant query words are used as a fallback when the full passage
+    // text isn't found as a contiguous text node (which is the common case
+    // — markdown render fragments paragraphs into <strong>/<em>/<a> spans
+    // so `indexOf(match.text)` rarely matches a full sentence).
+    const queryWords = significantQueryWords(ctx.query);
+
+    type Target = { node: Text; match: WithinMatch; term: string };
+    const targets: Target[] = [];
     let node: Node | null = walker.nextNode();
     while (node && targets.length < MAX_MARKS) {
       const txt = node.nodeValue ?? "";
+      const txtLower = txt.toLowerCase();
+      let matched = false;
+
+      // 1) Try exact passage text first (ideal case — single text node)
       for (const m of tabMatches) {
-        const idx = txt.indexOf(m.text);
-        if (idx >= 0) {
-          targets.push({ node: node as Text, match: m });
+        if (txt.indexOf(m.text) >= 0) {
+          targets.push({ node: node as Text, match: m, term: m.text });
+          matched = true;
           break;
         }
       }
+
+      // 2) Fallback : look for any significant query word in this node.
+      //    Each occurrence becomes a separate <mark> associated with the
+      //    first match whose passage text contains the same word (so the
+      //    explain tooltip routes to a sensible passage).
+      if (!matched && queryWords.length > 0) {
+        for (const word of queryWords) {
+          const idx = txtLower.indexOf(word);
+          if (idx >= 0) {
+            const term = txt.slice(idx, idx + word.length);
+            const associatedMatch =
+              tabMatches.find((m) => m.text.toLowerCase().includes(word)) ??
+              tabMatches[0];
+            targets.push({ node: node as Text, match: associatedMatch, term });
+            break; // one mark per text node max in fallback mode
+          }
+        }
+      }
+
       node = walker.nextNode();
     }
 
-    targets.forEach(({ node: textNode, match }) => {
+    targets.forEach(({ node: textNode, match, term }) => {
       const txt = textNode.nodeValue ?? "";
-      const idx = txt.indexOf(match.text);
+      // Use lowercased index lookup so the fallback (query word) is
+      // case-insensitive but we preserve the original casing in the mark.
+      const idx = txt.toLowerCase().indexOf(term.toLowerCase());
       if (idx < 0) return;
+      const actualTerm = txt.slice(idx, idx + term.length);
       const before = txt.slice(0, idx);
-      const after = txt.slice(idx + match.text.length);
+      const after = txt.slice(idx + term.length);
       const parent = textNode.parentNode;
       if (!parent) return;
       const mark = document.createElement("mark");
@@ -105,7 +191,7 @@ export const HighlightedText: React.FC<Props> = ({
         "aria-label",
         `Passage correspondant : ${match.text.slice(0, 60)}`,
       );
-      mark.textContent = match.text;
+      mark.textContent = actualTerm;
       if (ctx.matches[ctx.currentIndex]?.passage_id === match.passage_id) {
         mark.classList.add("flash");
       }
@@ -144,7 +230,7 @@ export const HighlightedText: React.FC<Props> = ({
       root.addEventListener("click", handler);
       return () => root.removeEventListener("click", handler);
     }
-  }, [ctx?.matches, ctx?.currentIndex, tab, onMarkClick, ctx]);
+  }, [ctx?.matches, ctx?.currentIndex, ctx?.query, tab, onMarkClick, ctx]);
 
   return (
     <div ref={containerRef} data-highlight-tab={tab}>

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -326,15 +326,53 @@ const HubPage: React.FC = () => {
           }),
         );
         setConversations(convs);
-        // Auto-select if URL has ?conv=<id> or ?summary=<id>
+        // Auto-select if URL has ?conv=<id> or ?summary[Id]=<id>.
         const target =
           urlConvId !== null
             ? Number(urlConvId)
             : urlSummaryId !== null
               ? Number(urlSummaryId)
               : null;
-        if (target && convs.find((c) => c.id === target)) {
+        if (!target) return;
+        if (convs.find((c) => c.id === target)) {
           setActiveConv(target);
+          return;
+        }
+        // Conv not in user's history (legitimate case when arriving from
+        // /search on a summary that exists but has no chat conversation yet,
+        // or a shared analysis). Fetch the summary directly and synthesize
+        // a HubConversation entry so the analysis panel can render.
+        try {
+          const summary = await videoApi.getSummary(target);
+          if (cancelled || !summary) return;
+          const platform: "youtube" | "tiktok" =
+            (summary as { platform?: string }).platform === "tiktok"
+              ? "tiktok"
+              : "youtube";
+          const synthetic: HubConversation = {
+            id: target,
+            summary_id: target,
+            title:
+              sanitizeTitle(
+                (summary as { video_title?: string; title?: string })
+                  .video_title ?? (summary as { title?: string }).title,
+              ) || "Sans titre",
+            video_source: platform,
+            video_thumbnail_url:
+              (summary as { thumbnail_url?: string }).thumbnail_url ?? null,
+            last_snippet: undefined,
+            updated_at:
+              (summary as { created_at?: string; updated_at?: string })
+                .updated_at ?? (summary as { created_at?: string }).created_at,
+          };
+          setConversations([synthetic, ...convs]);
+          setActiveConv(target);
+        } catch (err) {
+          console.warn(
+            `[HubPage] could not resolve summaryId=${target} as a synthetic conversation:`,
+            err,
+          );
+          // Leave activeConvId null — empty-state will show.
         }
       } catch (err) {
         console.error("[HubPage] fetch conversations failed:", err);

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -170,8 +170,15 @@ const HubPage: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const urlConvId = searchParams.get("conv");
-  const urlSummaryId = searchParams.get("summary");
+  // Accepts both `?summaryId=` (canonical, used by SearchResultCard from
+  // Phase 2 web) and legacy `?summary=`. Falls through `urlConvId` when
+  // neither is present.
+  const urlSummaryId =
+    searchParams.get("summaryId") ?? searchParams.get("summary");
   const urlTab = searchParams.get("tab") as TabId | null;
+  // ?q= drives the SemanticHighlightProvider (synthesis highlights) when
+  // arriving from /search with a deeplink. Propagated via UrlQueryBridge.
+  const urlQ = searchParams.get("q");
 
   const { language } = useTranslation();
   const { user } = useAuth();
@@ -601,7 +608,13 @@ const HubPage: React.FC = () => {
   const [searchOpen, setSearchOpen] = useState(false);
   const [tooltipMatch, setTooltipMatch] = useState<WithinMatch | null>(null);
   const [tooltipAnchor, setTooltipAnchor] = useState<DOMRect | null>(null);
-  const summaryIdNum = fullSummary?.id ? Number(fullSummary.id) : null;
+  // Source of truth for "is an analysis attached to the active conv ?".
+  // Use `activeConv.summary_id` (resolved as soon as conversations load)
+  // rather than `fullSummary.id` (only resolved after the deep fetch),
+  // so the magnifier button + provider become available immediately.
+  const summaryIdNum = activeConv?.summary_id
+    ? Number(activeConv.summary_id)
+    : null;
 
   useCmdFIntercept({
     scopeSelector: ".analysis-page",
@@ -809,6 +822,7 @@ const HubPage: React.FC = () => {
           open={searchOpen}
           onClose={() => setSearchOpen(false)}
         />
+        {urlQ && summaryIdNum !== null && <UrlQueryBridge q={urlQ} />}
         {summaryIdNum !== null && (
           <ExplainTooltipBridge
             match={tooltipMatch}
@@ -865,6 +879,24 @@ const ExplainTooltipBridge: React.FC<{
       onJumpToTab={onJumpToTab}
     />
   );
+};
+
+/**
+ * Propagates the URL `?q=` deeplink param into the SemanticHighlightProvider
+ * once the provider mounts (and the conv/summary is resolved). Without this,
+ * arriving on `/hub?summaryId=119&q=mistral&highlight=...` from /search
+ * would never trigger the within-search fetch and no <mark> would render
+ * even though everything else is wired correctly.
+ */
+const UrlQueryBridge: React.FC<{ q: string }> = ({ q }) => {
+  const ctx = useSemanticHighlight();
+  useEffect(() => {
+    if (ctx && q && ctx.query !== q) {
+      ctx.setQuery(q);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q, ctx?.setQuery]);
+  return null;
 };
 
 export default HubPage;


### PR DESCRIPTION
## Summary

Smoke test on prod after PR #319 surfaced 3 distinct rendering bugs that left the Task 16 highlight chain technically wired but invisibly broken:

| # | Bug | Fix |
|---|-----|-----|
| 1 | `document.querySelectorAll('mark.ds-highlight').length === 0` even when provider counts 6 matches for "écosystème" | DOM walker now falls back to significant query words when the full passage text is fragmented across markdown spans |
| 2 | `HighlightNavigationBar` rendered at y=623, off-screen, due to ancestor `h-screen overflow-hidden` clipping `sticky` | `createPortal` to `document.body` + `position: fixed` |
| 3 | `/hub?summaryId=119` stuck on "Aucune conversation sélectionnée" when the summary isn't in the user's conv list | Fetch summary directly via `videoApi.getSummary(id)` and synthesize a `HubConversation` entry. Side effect: also unhides the magnifier button (transitively makes `summaryIdNum` resolvable). |

## Smoke test (prod after Vercel rebuild ~5min)

- [ ] `/search` → query → click → `/hub` charge l'analyse même si elle n'est pas dans la liste de convs
- [ ] `document.querySelectorAll('mark.ds-highlight').length > 0` quand la query matche du texte
- [ ] `HighlightNavigationBar` visible en haut centré (compteur 1/N)
- [ ] Bouton loupe visible dans HubHeader
- [ ] Cmd/Ctrl+F intercepté + barre custom

🤖 Generated with [Claude Code](https://claude.com/claude-code)