### PR TITLE
feat(debate-ui): integrate Wave 4 G onboarding components

### DIFF
--- a/frontend/src/components/AnalysisHub/SynthesisTab.tsx
+++ b/frontend/src/components/AnalysisHub/SynthesisTab.tsx
@@ -32,6 +32,7 @@ import { CitationExport } from "../CitationExport";
 import { StudyToolsModal } from "../StudyToolsModal";
 import { KeywordsModal } from "../KeywordsModal";
 import { AnalysisActionBar } from "../analysis/AnalysisActionBar";
+import { DebateContextualCTA } from "../debate";
 import { videoApi, shareApi } from "../../services/api";
 import { sanitizeTitle } from "../../utils/sanitize";
 import type { Summary, EnrichedConcept } from "../../services/api";
@@ -288,6 +289,24 @@ export const SynthesisTab: React.FC<SynthesisTabProps> = ({
               conceptsCount={concepts.length}
               showUpgradeCTA={user?.plan === "free" || user?.plan === "student"}
               compact={false}
+            />
+          </div>
+        )}
+
+        {/* CTA Débat IA — confronter cette vidéo à une perspective opposée.
+            Wave 4 G du sprint Débat IA v2. */}
+        {(selectedSummary.video_url || selectedSummary.video_id) && (
+          <div className="mt-6 not-prose">
+            <DebateContextualCTA
+              videoUrl={
+                selectedSummary.video_url ||
+                `https://www.youtube.com/watch?v=${selectedSummary.video_id}`
+              }
+              userPlan={
+                (user?.plan === "pro" || user?.plan === "expert"
+                  ? user.plan
+                  : "free") as "free" | "pro" | "expert"
+              }
             />
           </div>
         )}

--- a/frontend/src/components/debate/index.ts
+++ b/frontend/src/components/debate/index.ts
@@ -7,3 +7,10 @@ export { DebateCreateForm } from "./DebateCreateForm";
 export { DebateSummaryCard } from "./DebateSummaryCard";
 export { DebateChat } from "./DebateChat";
 export { DebateHistoryCard } from "./DebateHistoryCard";
+export {
+  DebateOnboardingTour,
+  useResetDebateOnboarding,
+} from "./DebateOnboardingTour";
+export { DebateExamples } from "./DebateExamples";
+export type { Example as DebateExample } from "./DebateExamples";
+export { DebateContextualCTA } from "./DebateContextualCTA";

--- a/frontend/src/pages/DebatePage.tsx
+++ b/frontend/src/pages/DebatePage.tsx
@@ -27,6 +27,9 @@ import {
   DebateStatusTracker,
   DebateSummaryCard,
   DebateChat,
+  DebateOnboardingTour,
+  DebateExamples,
+  type DebateExample,
 } from "../components/debate";
 import { debateApi, ApiError } from "../services/api";
 import type {
@@ -661,6 +664,18 @@ export const DebatePage: React.FC = () => {
     setSearchParams({ id: String(id) });
   };
 
+  // Wave 4 G — DebateExamples démo. Le backend ne sert pas les exemples
+  // pré-générés : on scroll vers le formulaire pour que l'utilisateur colle
+  // ses propres URLs, et on affiche le topic d'inspiration via un état temporaire.
+  const [exampleHint, setExampleHint] = useState<DebateExample | null>(null);
+  const handleExampleClick = useCallback((example: DebateExample) => {
+    setExampleHint(example);
+    const target = document.querySelector('[data-onboard="debate-input"]');
+    if (target instanceof HTMLElement) {
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, []);
+
   const handleBack = () => {
     stopPolling();
     setPollError(null);
@@ -835,7 +850,7 @@ export const DebatePage: React.FC = () => {
           </motion.div>
         )}
         {/* VS Layout */}
-        <div className="mb-4">
+        <div className="mb-4" data-onboard="debate-vs-layout">
           <DebateVSLayout debate={selectedDebate} />
         </div>
         {/* Completed sections with doodle dividers */}
@@ -954,9 +969,42 @@ export const DebatePage: React.FC = () => {
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.1 }}
         className="mb-4"
+        data-onboard="debate-input"
       >
+        {exampleHint && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mb-3 p-3 rounded-lg bg-violet-500/10 border border-violet-500/20 text-sm text-violet-300 backdrop-blur-xl flex items-start gap-2"
+          >
+            <Lightbulb className="w-4 h-4 flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p className="font-medium text-violet-200 mb-0.5">
+                {exampleHint.emoji} {exampleHint.topic}
+              </p>
+              <p className="text-xs text-violet-300/70">
+                Colle l'URL d'une vidéo qui parle de ce sujet pour lancer le
+                débat. DeepSight trouvera automatiquement la perspective
+                opposée.
+              </p>
+            </div>
+            <button
+              onClick={() => setExampleHint(null)}
+              className="text-xs text-violet-300/60 hover:text-violet-200"
+              aria-label="Fermer le rappel d'exemple"
+            >
+              ✕
+            </button>
+          </motion.div>
+        )}
         <DebateCreateForm onSubmit={handleCreateDebate} loading={loading} />
       </motion.div>
+
+      {/* Démo : 3 exemples pré-faits sans coût crédits — affichés uniquement
+          quand aucun débat passé n'existe pour ne pas alourdir l'historique. */}
+      {!historyLoading && !historyError && debatesList.length === 0 && (
+        <DebateExamples onSelectExample={handleExampleClick} />
+      )}
 
       {/* Doodle divider between form and history */}
       <DoodleDivider variant="analysis" density="sparse" />
@@ -1030,6 +1078,10 @@ export const DebatePage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-bg-primary relative text-white">
+      {/* Coachmark progressif au 1er lancement — Wave 4 G.
+          Persistance localStorage ; ne s'affiche qu'une fois par device. */}
+      <DebateOnboardingTour />
+
       {/* Doodle background */}
       <ErrorBoundary fallback={null}>
         <DoodleBackground variant="analysis" />


### PR DESCRIPTION
## Summary

Câble les 3 composants standalone livrés par PR #321 dans \`DebatePage\` et la page d'analyse vidéo standard (\`SynthesisTab\` du hub).

## Changes

### \`DebatePage.tsx\`
- \`<DebateOnboardingTour />\` monté en top-level (coachmark 3 étapes au 1er lancement, persisté localStorage)
- \`<DebateExamples />\` rendu dans le state vide (avant le formulaire). \`handleExampleClick\` scroll vers l'input + affiche un hint avec le topic de l'exemple sélectionné
- Attributs \`data-onboard\` ajoutés sur \`DebateCreateForm\` (debate-input) et \`DebateVSLayout\` (debate-vs-layout) pour cibler les coachmarks

### \`SynthesisTab.tsx\` (page analyse standard)
- \`<DebateContextualCTA />\` ajouté juste après \`AnalysisValueDisplay\`
- \`videoUrl\` construit depuis \`selectedSummary.video_url\` avec fallback YouTube via \`video_id\`
- \`userPlan\` normalisé sur \`free | pro | expert\`

### \`components/debate/index.ts\`
- Export des 3 nouveaux composants + type \`DebateExample\`

## Notes & follow-ups

- Le 3ᵉ selector \`data-onboard=\"add-perspective\"\` reste à câbler quand les boutons \"+ Complément\" / \"+ Nuance\" seront ajoutés au layout VS. Pour l'instant, l'étape 3 du tour s'affiche sans ring de highlight (graceful — le coachmark vérifie l'existence du DOM avant de surligner).
- \`DebateExamples\` ne lance pas d'analyse (le backend ne sert pas d'exemples pré-générés). À la place : scroll vers le formulaire + hint visuel avec le topic d'inspiration.

## Test plan
- [x] \`npm run typecheck\` : aucune nouvelle erreur introduite (toutes les erreurs listées étaient déjà présentes sur main — DebatePage:854 \`<DebateVSLayout debate=...>\` est de la dette pré-existante)
- [x] \`npm test\` sur composants debate : 0 régression (aucun test n'existe encore pour DebateOnboardingTour, DebateExamples, DebateContextualCTA)
- [ ] QA prod : vérifier coachmark s'affiche au 1er load, exemples scrollent vers form, CTA apparaît sur SynthesisTab

🤖 Generated with [Claude Code](https://claude.com/claude-code)