### PR TITLE
chore(hetzner): auto-run alembic upgrade head via entrypoint

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Container entrypoint — runs alembic migrations before handing off to uvicorn.
+#
+# WHY: Without this, Base.metadata.create_all() in main.py materialized tables
+# at uvicorn startup, then `alembic upgrade head` failed with DuplicateTable on
+# subsequent rebuilds — forcing manual `alembic stamp <rev>` per migration
+# (cf. sprints Débat IA v1/v2, Pricing v2, Semantic Search). With this script,
+# alembic runs FIRST, owns the schema cleanly, and create_all() becomes no-op.
+#
+# Failure mode: if alembic upgrade fails (e.g. divergent state), the container
+# still starts so the API stays up — admin must run `alembic stamp head` or
+# fix the migration manually. Health check + auto-rollback in deploy-backend.yml
+# protects against runtime regressions.
+set -e
+
+echo "[entrypoint] Running alembic upgrade head from /app..."
+cd /app
+if alembic upgrade head; then
+    echo "[entrypoint] alembic upgrade head: OK"
+else
+    echo "[entrypoint] WARNING: alembic upgrade failed (exit $?)."
+    echo "[entrypoint] Likely cause: Base.metadata.create_all() pre-created tables on a previous boot."
+    echo "[entrypoint] Container will start anyway. Run 'docker exec repo-backend-1 alembic stamp head' to resync."
+fi
+
+echo "[entrypoint] Handing off to uvicorn from /app/src..."
+cd /app/src
+exec "$@"

--- a/deploy/hetzner/Dockerfile
+++ b/deploy/hetzner/Dockerfile
@@ -41,12 +41,23 @@ COPY static/ ./static/
 COPY alembic.ini ./alembic.ini
 COPY alembic/ ./alembic/
 
+# Container entrypoint — runs alembic upgrade head before uvicorn so migrations
+# apply automatically on every container start. Replaces the manual
+# `docker exec repo-backend-1 alembic upgrade head` step that every recent
+# sprint had to do (Débat IA v2, Pricing v2, Semantic Search). Health check +
+# auto-rollback in deploy-backend.yml protect against bad migrations.
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
 WORKDIR /app/src
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=30s \
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=60s \
     CMD curl -f http://localhost:8080/health || exit 1
+
+# Entrypoint runs alembic upgrade head, then exec's CMD (uvicorn).
+ENTRYPOINT ["/app/entrypoint.sh"]
 
 # 4 workers pour 8 vCPU (I/O bound async → 1 worker / 2 vCPU)
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", \


### PR DESCRIPTION
## Summary

Élimine le tech-debt récurrent où chaque sprint avec migration alembic demandait un \`docker exec repo-backend-1 alembic upgrade head\` manuel post-deploy (Débat IA v1, Débat IA v2, Pricing v2, Semantic Search…).

## Bug racine

\`Base.metadata.create_all()\` appelé au boot uvicorn matérialise les nouvelles tables côté SQLAlchemy. Puis \`alembic upgrade head\` sur l'image rebuilt fail sur DuplicateTable, forçant :
- \`alembic stamp <rev>\` manuel pour chaque migration
- ALTER manuels pour les colonnes ajoutées

## Fix

\`entrypoint.sh\` lance \`alembic upgrade head\` **avant** uvicorn.
- Tables créées proprement par alembic
- \`create_all()\` devient no-op (tables existent déjà)
- Plus de stamp manuel

## Safety net

Si alembic plante (état divergent inattendu), le container démarre quand même (l'API reste up, l'admin peut faire un \`alembic stamp head\` à la main). Le health check + l'auto-rollback de \`.github/workflows/deploy-backend.yml\` restaurent automatiquement l'image \`deepsight-backend:previous\` si le smoke test \`/health\` fail.

## Changes

- \`backend/entrypoint.sh\` : nouveau script
- \`deploy/hetzner/Dockerfile\` : \`COPY entrypoint.sh\` + \`chmod +x\` + \`ENTRYPOINT [\"/app/entrypoint.sh\"]\`
- \`HEALTHCHECK start-period\` 30s → 60s (alembic peut prendre quelques secondes au 1er boot)

## Test plan

- [x] \`sh -n backend/entrypoint.sh\` → OK syntax
- [x] Sur un état actuel prod, \`alembic upgrade head\` est no-op (current revision = head 017_debate_v2_perspectives stampé manuellement)
- [ ] Au merge, deploy-backend.yml rebuild + recreate. Si l'entrypoint plante, smoke test fail → auto-rollback.
- [ ] Au prochain sprint avec migration : pas besoin de \`alembic stamp\` manuel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)