### PR TITLE
fix(debate): repair DebatePage runtime crash (page blanche /debate)

### DIFF
--- a/frontend/src/pages/DebatePage.tsx
+++ b/frontend/src/pages/DebatePage.tsx
@@ -752,6 +752,42 @@ export const DebatePage: React.FC = () => {
       selectedDebate.fact_check_results &&
       selectedDebate.fact_check_results.length > 0;
 
+    // Map DebateAnalysis → DebateVSLayout props.
+    // Backward-compat v1: if perspectives[] is empty but video_b_* is set, derive a single implicit perspective.
+    const vsVideoA = {
+      title: selectedDebate.video_a_title ?? "",
+      channel: selectedDebate.video_a_channel ?? "",
+      thumbnail: selectedDebate.video_a_thumbnail ?? "",
+      videoId: selectedDebate.video_a_id,
+      platform: selectedDebate.platform_a,
+      thesis: selectedDebate.thesis_a ?? "",
+      arguments: selectedDebate.arguments_a ?? [],
+    };
+    const vsPerspectives: DebatePerspective[] =
+      selectedDebate.perspectives && selectedDebate.perspectives.length > 0
+        ? selectedDebate.perspectives
+        : selectedDebate.video_b_id
+          ? [
+              {
+                id: -1,
+                position: 0,
+                video_id: selectedDebate.video_b_id,
+                platform: selectedDebate.platform_b ?? "youtube",
+                video_title: selectedDebate.video_b_title,
+                video_channel: selectedDebate.video_b_channel,
+                video_thumbnail: selectedDebate.video_b_thumbnail,
+                thesis: selectedDebate.thesis_b,
+                arguments: selectedDebate.arguments_b ?? [],
+                relation_type:
+                  selectedDebate.relation_type_dominant ?? "opposite",
+                channel_quality_score: 0,
+                audience_level: "unknown",
+                fact_check_results: null,
+                created_at: selectedDebate.created_at,
+              },
+            ]
+          : [];
+
     return (
       <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
         {/* Back button */}
@@ -851,7 +887,11 @@ export const DebatePage: React.FC = () => {
         )}
         {/* VS Layout */}
         <div className="mb-4" data-onboard="debate-vs-layout">
-          <DebateVSLayout debate={selectedDebate} />
+          <DebateVSLayout
+            videoA={vsVideoA}
+            perspectives={vsPerspectives}
+            isLoading={isInProgress && vsPerspectives.length === 0}
+          />
         </div>
         {/* Completed sections with doodle dividers */}
         {selectedDebate.status === "completed" && (


### PR DESCRIPTION
## Symptôme

Page blanche / crash runtime sur `/debate` quand un débat est ouvert.

## Cause

`frontend/src/pages/DebatePage.tsx:854` (sur `origin/main`) faisait :

```tsx
<DebateVSLayout debate={selectedDebate} />
```

…alors que `DebateVSLayoutProps` (Sprint v2, Wave 3 D) attend `videoA + perspectives + isLoading?`. Au render, `videoA` était `undefined` → crash dès le premier accès aux champs (`videoA.title` etc.). C'est un héritage du sprint v2 jamais recâblé après la refonte adaptative 1+N.

## Fix

Construit `vsVideoA` et `vsPerspectives` à partir de `selectedDebate` (type `DebateAnalysis`) dans `renderDetail`, et passe-les correctement à `<DebateVSLayout>`.

Backward-compat v1 : si `perspectives[]` est vide mais que `video_b_id` est défini, on dérive une perspective implicite depuis `video_b_*` (relation `relation_type_dominant ?? "opposite"`). Sinon on tombe en empty state (N=0).

Skeleton (`isLoading=true`) montré uniquement quand on est en cours ET qu'aucune perspective n'est encore connue.

## Test

- `tsc --noEmit` : zéro nouvelle erreur sur les modifs (les 12 erreurs `DebatePage.tsx` rapportées sont pré-existantes sur `DebateStatusResponse` lignes 551-573, hors scope — voir bug #4 du tracking).
- Reproduit en prod après merge via Vercel auto-deploy.

## Hors scope (à traiter séparément)

- Boutons « + Complément / + Nuance » jamais câblés dans le JSX (`handleAddPerspective` défini ligne ~690 mais jamais référencé).
- `DebateStatusResponse` Pydantic incomplet (manque `video_a_id` etc.) → erreurs TS lignes 548-573.
- Test `test_debate_adaptive.py::test_pipeline_persists_video_b_as_perspective_position_0` cassé sur main.