### PR TITLE
fix(debate): wire + Complément / + Nuance buttons under DebateVSLayout

### DIFF
--- a/frontend/src/pages/DebatePage.tsx
+++ b/frontend/src/pages/DebatePage.tsx
@@ -896,6 +896,58 @@ export const DebatePage: React.FC = () => {
         {/* Completed sections with doodle dividers */}
         {selectedDebate.status === "completed" && (
           <>
+            {/* 🆕 Sprint Débat IA v2 — Add perspective buttons (cap 1+N à 3 perspectives totales) */}
+            <div className="flex flex-wrap gap-3 justify-center mb-6">
+              <button
+                type="button"
+                onClick={() => handleAddPerspective("complement")}
+                disabled={
+                  isAddingPerspective ||
+                  (selectedDebate.perspectives?.length ?? 0) >= 3
+                }
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 transition-colors text-sm font-medium text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isAddingPerspective ? (
+                  <DeepSightSpinnerSmall />
+                ) : (
+                  <Plus className="w-4 h-4" />
+                )}
+                + Complément
+              </button>
+              <button
+                type="button"
+                onClick={() => handleAddPerspective("nuance")}
+                disabled={
+                  isAddingPerspective ||
+                  (selectedDebate.perspectives?.length ?? 0) >= 3
+                }
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 transition-colors text-sm font-medium text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isAddingPerspective ? (
+                  <DeepSightSpinnerSmall />
+                ) : (
+                  <Lightbulb className="w-4 h-4" />
+                )}
+                + Nuance
+              </button>
+            </div>
+
+            {/* Add perspective error */}
+            {addPerspectiveError && (
+              <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="mb-6 p-3 rounded-xl bg-amber-500/10 border border-amber-500/20 backdrop-blur-xl max-w-2xl mx-auto"
+              >
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5" />
+                  <p className="text-xs text-amber-300/90">
+                    {addPerspectiveError}
+                  </p>
+                </div>
+              </motion.div>
+            )}
+
             {/* Doodle divider between VS and convergence/divergence */}
             <DoodleDivider variant="analysis" density="sparse" />
 


### PR DESCRIPTION
## Cause

Le sprint Débat IA v2 a introduit le handler `handleAddPerspective` (ligne ~690) et les states `isAddingPerspective` / `addPerspectiveError`, mais ces 4 éléments n'étaient **jamais référencés** dans le JSX de `DebatePage.tsx`. Conséquence : l'utilisateur ne pouvait PAS ajouter de perspective via l'UI une fois le débat créé.

## Fix

Câblage UI minimal : 2 boutons "+ Complément" / "+ Nuance" affichés sous `<DebateVSLayout>` dans `renderDetail()`, dans le bloc `selectedDebate.status === "completed"`.

- Cap 1+N à 3 perspectives totales : boutons disabled si `selectedDebate.perspectives.length >= 3`
- Loader inline `<DeepSightSpinnerSmall />` pendant `isAddingPerspective`
- Bloc erreur amber sous les boutons quand `addPerspectiveError` non null (style cohérent avec poll error existant ligne ~841)
- Style Tailwind glassmorphism dark (`bg-white/5`, `border-white/10`, `rounded-xl`)

## Scope

- 1 seul fichier modifié : `frontend/src/pages/DebatePage.tsx`
- 52 insertions, 0 deletion
- Aucune nouvelle erreur TypeScript (12 erreurs `DebateStatusResponse` lignes 551-573 pré-existantes hors scope)
- Pas de touch sur `DebateVSLayout`, schemas backend, tests

## Test plan

- [ ] Sur `/debate/<id>` avec un débat status=completed, vérifier que les 2 boutons apparaissent sous le VS Layout
- [ ] Cliquer "+ Complément" → loader, puis nouvelle perspective ajoutée
- [ ] Cliquer "+ Nuance" → loader, puis nouvelle perspective ajoutée
- [ ] Après 3 perspectives totales : boutons disabled
- [ ] Erreur réseau simulée → bloc amber affiché avec message