### PR TITLE
fix(debate): align frontend DebateStatusResponse type with backend schema

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3100,8 +3100,14 @@ export interface DebateStatusResponse {
   debate_id: number;
   status: string;
   progress_message: string;
+  video_a_id?: string;
+  video_b_id?: string;
   video_a_title?: string;
   video_b_title?: string;
+  video_a_channel?: string;
+  video_b_channel?: string;
+  video_a_thumbnail?: string;
+  video_b_thumbnail?: string;
 }
 
 export interface DebateChatMessage {


### PR DESCRIPTION
## Summary

Fixes Bug #4 from the Débat IA v2 sprint tracking: 12 TypeScript errors in `DebatePage.tsx` polling effect (`Property 'video_a_id' does not exist on type 'DebateStatusResponse'`) plus a runtime UX bug where video thumbnails/IDs/channels never populated during `searching`/`analyzing_b` polling phases.

## Investigation result

Backend was **already correct**: commit `b994835f` (already on `main`) added `video_a_id`, `video_b_id`, `video_a_channel`, `video_b_channel`, `video_a_thumbnail`, `video_b_thumbnail` to both `DebateStatusResponse` Pydantic schema and the `GET /api/debate/status/{debate_id}` endpoint that returns them from the SQLAlchemy `Debate` row.

The desync was purely in `frontend/src/services/api.ts` — the TS interface only declared `video_a_title` and `video_b_title`, so the spread-conditional state update at `DebatePage.tsx:551-573` (added after the backend was widened) never type-checked and the runtime mutation was effectively dropped.

## Change

Added the 6 missing optional fields to the frontend `DebateStatusResponse` interface so it mirrors the Pydantic schema. No backend change needed.

## Test plan

- [x] Backend tests still green: `pytest tests/test_debate*.py -v --deselect ...test_pipeline_persists_video_b_as_perspective_position_0` → 106 passed, 1 deselected (pre-existing)
- [ ] After deploy, the live debate card on `/debate` should populate thumbnails/channels/IDs incrementally during `searching` → `analyzing_b` instead of waiting for `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)