### PR TITLE
fix(debate): repair test_pipeline_persists_video_b_as_perspective_position_0

### DIFF
--- a/backend/tests/test_debate_adaptive.py
+++ b/backend/tests/test_debate_adaptive.py
@@ -530,6 +530,18 @@ async def test_pipeline_persists_video_b_as_perspective_position_0(
     monkeypatch.setattr(debate_router, "_call_mistral", mock_mistral)
     monkeypatch.setattr(debate_router, "_call_magistral", mock_magistral)
     monkeypatch.setattr(debate_router, "_call_perplexity", mock_perplexity)
+    # Sprint v2 (PR #311) : auto-search ne passe plus par
+    # debate_router._search_opposing_video, mais par
+    # debate.matching.search_opposing_video_legacy_compat (importé
+    # dynamiquement dans _run_debate_pipeline). On mocke la nouvelle voie.
+    import debate.matching as debate_matching
+
+    monkeypatch.setattr(
+        debate_matching,
+        "search_opposing_video_legacy_compat",
+        mock_search_opposing,
+    )
+    # Conservé pour les chemins legacy qui pourraient encore l'invoquer.
     monkeypatch.setattr(
         debate_router, "_search_opposing_video", mock_search_opposing
     )


### PR DESCRIPTION
## Root cause

PR #311 (Wave 2 A — multi-criteria matching) replaced `router._search_opposing_video` with `matching.search_opposing_video_legacy_compat` in `_run_debate_pipeline` (router.py:775, dynamic `from debate.matching import …`). PR #312 (Wave 2 B — adaptive 1-N + Magistral) shipped `test_pipeline_persists_video_b_as_perspective_position_0` still mocking the **old** symbol (`debate_router._search_opposing_video`).

In CI/dev (no Brave key), `_search_perspective_video` short-circuits to `None` (`matching.py:714`). The pipeline takes the "auto-search failed → analyse partielle" branch (router.py:807) and **returns before** reaching the Magistral comparison step at line 917 — so `call_log` never sees a `('magistral', …)` entry and the assertion `"Expected at least one Magistral call in comparison step"` fails.

## Fix

Test-only. Also patch `debate.matching.search_opposing_video_legacy_compat` (the symbol the pipeline now imports dynamically) with the same `mock_search_opposing` returning `vidB_found`. Kept the legacy `debate_router._search_opposing_video` patch for any other call sites.

No production code touched. Magistral wiring in `_run_debate_pipeline` is intact and correct.

## Verification

```
PYTHONPATH=src python -m pytest tests/test_debate_adaptive.py::test_pipeline_persists_video_b_as_perspective_position_0 -xvs
# 1 passed in 2.93s

PYTHONPATH=src python -m pytest tests/test_debate_adaptive.py tests/test_debate_matching.py tests/test_debate_voice_context.py tests/test_debate_voice_router.py tests/test_debate_voice_tools.py tests/test_voice_debate_v2.py -v
# 137 passed in 12.72s
```

## Impact

- Backend prod : **unchanged** — only `backend/tests/test_debate_adaptive.py` modified.
- Risk : None. Safe to admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)