### PR TITLE
spec(hub-miro): Hub Miro Workspace MVP — 1-pager pour arbitrage

### DIFF
--- a/docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md
+++ b/docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md
@@ -1,0 +1,58 @@
+# Hub Miro Workspace MVP — 2026-05-05
+
+## Pitch
+
+Étendre Miro (mergé prod via Débat IA, PR #318/#330) au Hub web `/hub` comme workspace agrégateur d'analyses. MVP **manuel et ciblé** : user sélectionne 3-N analyses, clique "Créer workspace", reçoit un board Miro mosaïque read-only embed dans le Hub. Mesure 2 semaines, élargir si signal vert.
+
+## Scope MVP
+
+- **Plateforme** : Web only (`HubPage.tsx`, route `/hub`). Mobile + Extension hors phase 1.
+- **Cluster** : **manuel**. Multi-select dans `ConversationsDrawer` + bouton "Créer workspace" (3-10 analyses).
+- **Board** : mosaïque thumbnails. 1 sticky par `Summary` (titre + thèse extraite de `content`), 3 colonnes, top-down par date.
+- **Sync** : one-way push DeepSight → Miro à création. Read-only.
+- **Persistance** : table `hub_workspace` (id, user_id, name, summary_ids[], miro_board_id, miro_view_link, created_at).
+- **Gating** : **Expert only**. Justifie tier 19,99 €, plafonne coût Miro. Limite 5 workspaces actifs/mois.
+- **Réutilisation** : `miro_service.py` + `generate_hub_workspace_board()` (mêmes helpers, même token admin). `DebateMiroEmbed` factorisé en `MiroBoardEmbed` générique.
+
+## Architecture
+
+```
+[Hub /hub]
+    │
+    ├── ConversationsDrawer ──(multi-select)──► [Créer workspace]
+    │                                                  │
+    │                                                  ▼
+    │                                  POST /api/hub/workspace
+    │                                                  │
+    │                                                  ▼
+    │                            miro_service.generate_hub_workspace_board
+    │                                                  │
+    └── HubWorkspaceEmbed ◄── GET /api/hub/workspace/{id}
+```
+
+## Coût Miro projeté
+
+**Hypothèses** : ~10 stickies/board, user Expert ≈ 2 workspaces/mois, plafond 5/mois.
+
+- **Bloquant Free Miro** : 3 editable boards/account. Pattern token admin actuel sature dès le 4ᵉ.
+- **Solution MVP** : compte DeepSight Miro en **Starter $8/mo** (boards illimités). Coût plancher ~$96/an.
+- **À 100 users Expert × 2 workspaces/mois = 200 boards/mois** : reste $8/mo (Starter flat). Rate limit 2000 req/min largement OK.
+- **Risque** : > 1000 users Expert → migrer vers OAuth user-level (phase 2).
+
+## Métriques 2 semaines
+
+1. **Activation** : % users Expert créant ≥1 workspace en 14j. Cible >15 %.
+2. **Repeat** : % "créateurs" en créant ≥2. Cible >40 %.
+3. **Embed open rate** : ouverture iframe (analytics). Cible >60 %.
+4. **External CTR** : clics "Ouvrir dans Miro" (signal valeur réelle).
+5. **Coût Miro réel** : surveiller boards/mois et rate limit.
+
+## Out-of-scope phase 1
+
+Auto-clustering sémantique (`TranscriptEmbedding`) ; bi-directionnel webhooks ; Mobile + Extension ; mind map cross-vidéos ; workspaces partagés entre users ; OAuth user-level.
+
+## Questions ouvertes
+
+- [ ] **Q1 — Gating tier** : Expert only (reco) **OU** Pro+Expert (élargit base test, dilue justif Expert) ?
+- [ ] **Q2 — Limite workspaces/mois** : 5 (reco prudent) **OU** 10 **OU** illimité avec soft warning ?
+- [ ] **Q3 — Naming UX** : "Workspace" (reco neutre) **OU** "Tableau" (collision Miro board) **OU** "Hub Board" (branding) ?


### PR DESCRIPTION
## Pitch

Étendre Miro (déjà mergé prod via PR #318/#330 pour Débat IA) au **Hub web `/hub`** comme workspace agrégateur d'analyses. **MVP manuel et ciblé**, pas d'auto-clustering. Mesure 2 semaines, élargir si signal vert.

Spec complet (≤500 mots) : [`docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md`](../blob/spec/hub-miro-workspace-mvp/docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md)

## Recommandations clés

| Décision | Reco | Rationale |
|----------|------|-----------|
| Cluster mechanism | **Manuel** | Multi-select dans `ConversationsDrawer`, control user max, friction tech zéro. Auto-clustering = phase 2 si signal. |
| Structure board | **Mosaïque thumbnails** | Réutilise `MiroBoardEmbed` pattern Débat IA. 1 sticky/Summary, 3 colonnes par date. Pas de mind map cross-vidéos (out-of-scope). |
| Sync direction | **One-way push** | Création unique, read-only. Bi-dir webhooks = phase 2. |
| Gating tier | **Expert only** | Justifie 19,99 €, plafonne coût Miro, ne dilue pas Pro 8,99 €. |
| Coût Miro | **~\$96/an plancher** | Compte DeepSight org → Miro Starter \$8/mo (boards illimités). À 100 users Expert × 2 workspaces/mois = 200 boards/mois, reste flat \$8/mo. |
| Risque rouge | **Free tier Miro = 3 boards** | Pattern token admin actuel saturait. Solution : passer Starter \$8/mo dès activation. |

## Questions ouvertes (à arbitrer)

Maxime, coche directement la PR :

- [ ] **Q1 — Gating tier** : Expert only (reco) **OU** Pro+Expert (élargit base test, mais dilue justif Expert) ?
- [ ] **Q2 — Limite workspaces actifs/mois** : 5 (reco prudent) **OU** 10 (plus généreux) **OU** illimité avec soft warning ?
- [ ] **Q3 — Naming UX** : "Workspace" (reco neutre) **OU** "Tableau" (collision conceptuelle avec Miro board) **OU** "Hub Board" (continuité branding) ?

## Métriques 2 semaines (validation MVP)

1. Activation rate users Expert (cible >15 %)
2. Repeat rate "créateurs" ≥2 workspaces (cible >40 %)
3. Embed iframe open rate (cible >60 %)
4. External "Ouvrir dans Miro" CTR (signal valeur réelle)
5. Coût Miro réel + saturation rate limit

## Out-of-scope phase 1

Auto-clustering sémantique, bi-dir webhooks, Mobile + Extension, mind map cross-vidéos, workspaces partagés, OAuth user-level Miro.

---

**PR laissée OPEN** : pas de code à merger. Maxime arbitre Q1/Q2/Q3 → on planifie l'implémentation derrière.

🤖 Generated with [Claude Code](https://claude.com/claude-code)