### PR TITLE
feat(hub): backend Hub Workspace MVP — wave 1

### DIFF
--- a/backend/alembic/versions/018_hub_workspace.py
+++ b/backend/alembic/versions/018_hub_workspace.py
@@ -1,0 +1,103 @@
+"""hub_workspaces — Hub Miro Workspace MVP table
+
+Revision ID: 018_hub_workspace
+Revises: 017_debate_v2_perspectives
+Create Date: 2026-05-05
+
+Sprint Hub Miro Workspace MVP — VAGUE 1 BACKEND.
+
+Crée la table `hub_workspaces` qui stocke les workspaces Miro générés par
+l'utilisateur depuis 2-20 analyses Summary sélectionnées dans le Hub.
+
+Spec : docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md
+Gating : Expert only (vérifié dans backend/src/hub/service.py).
+Cap : 5 workspaces actifs / user / 30 jours.
+
+Pas de backfill : nouvelle table.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "018_hub_workspace"
+down_revision: Union[str, None] = "017_debate_v2_perspectives"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "hub_workspaces" not in existing_tables:
+        op.create_table(
+            "hub_workspaces",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column("name", sa.String(length=200), nullable=False),
+            sa.Column("summary_ids", sa.JSON(), nullable=False),
+            sa.Column("miro_board_id", sa.String(length=100), nullable=True),
+            sa.Column("miro_board_url", sa.String(length=500), nullable=True),
+            sa.Column(
+                "status",
+                sa.String(length=20),
+                nullable=False,
+                server_default="pending",
+            ),  # pending | creating | ready | failed
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+        op.create_index(
+            "idx_hub_workspaces_user_created",
+            "hub_workspaces",
+            ["user_id", sa.text("created_at DESC")],
+        )
+        op.create_index(
+            "idx_hub_workspaces_user_status",
+            "hub_workspaces",
+            ["user_id", "status"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "hub_workspaces" in existing_tables:
+        # Drop indexes d'abord
+        try:
+            op.drop_index(
+                "idx_hub_workspaces_user_status", table_name="hub_workspaces"
+            )
+        except Exception:
+            pass
+        try:
+            op.drop_index(
+                "idx_hub_workspaces_user_created", table_name="hub_workspaces"
+            )
+        except Exception:
+            pass
+        op.drop_table("hub_workspaces")

--- a/backend/src/billing/plan_config.py
+++ b/backend/src/billing/plan_config.py
@@ -156,6 +156,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": False,
                 "deep_research": False,
                 "geo": False,
+                "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
             },
             "mobile": {
                 "analyse": True,
@@ -175,6 +176,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": False,
                 "deep_research": False,
                 "geo": False,
+                "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
             },
             "extension": {
                 "analyse": True,
@@ -194,6 +196,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": False,
                 "deep_research": False,
                 "geo": False,
+                "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
             },
         },
     },
@@ -293,6 +296,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": True,
                 "deep_research": False,
                 "geo": True,
+                "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
             },
             "mobile": {
                 "analyse": True,
@@ -312,6 +316,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": False,
                 "deep_research": False,
                 "geo": True,
+                "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
             },
             "extension": {
                 "analyse": True,
@@ -331,6 +336,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": False,
                 "deep_research": False,
                 "geo": False,
+                "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
             },
         },
     },
@@ -432,6 +438,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": True,
                 "deep_research": True,
                 "geo": True,
+                "hub_workspace": True,  # Hub Miro Workspace — Expert only (web)
             },
             "mobile": {
                 "analyse": True,
@@ -451,6 +458,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": False,
                 "deep_research": False,
                 "geo": True,
+                "hub_workspace": False,  # Hub Miro Workspace — Expert only (web only, mobile = CTA web)
             },
             "extension": {
                 "analyse": True,
@@ -470,6 +478,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "debate": False,
                 "deep_research": False,
                 "geo": False,
+                "hub_workspace": False,  # Hub Miro Workspace — Expert only (web only, ext = CTA web)
             },
         },
     },

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -1489,6 +1489,68 @@ class ChatTextDigest(Base):
     )
 
 
+class HubWorkspace(Base):
+    """Hub Miro Workspace — workspace Miro généré depuis 2-20 analyses Summary.
+
+    Spec : docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md
+    Gating : Expert only (vérifié dans backend/src/hub/service.py).
+    Cap : 5 workspaces actifs (status IN pending|creating|ready) / user / 30 jours.
+
+    Workflow async :
+      1. POST /api/hub/workspaces → INSERT row(status='pending')
+      2. BackgroundTasks lance _create_miro_board_async → status='creating'
+      3. Sur succès → miro_board_id, miro_board_url renseignés, status='ready'
+      4. Sur erreur → status='failed', error_message renseigné
+
+    Migration : alembic 018_hub_workspace.py.
+    """
+
+    __tablename__ = "hub_workspaces"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Métadonnées workspace
+    name = Column(String(200), nullable=False)
+    # Liste d'IDs de Summary inclus dans le workspace (2-20 items, validé service-side)
+    summary_ids = Column(JSON, nullable=False)
+
+    # Miro (NULL au create, populés après async board create)
+    miro_board_id = Column(String(100), nullable=True)
+    miro_board_url = Column(String(500), nullable=True)
+
+    # Status : pending | creating | ready | failed
+    status = Column(
+        String(20),
+        nullable=False,
+        default="pending",
+        server_default="pending",
+    )
+    error_message = Column(Text, nullable=True)
+
+    # Timestamps
+    created_at = Column(
+        DateTime, default=func.now(), server_default=func.now(), nullable=False, index=True
+    )
+    updated_at = Column(
+        DateTime,
+        default=func.now(),
+        onupdate=func.now(),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index("idx_hub_workspaces_user_created", "user_id", "created_at"),
+        Index("idx_hub_workspaces_user_status", "user_id", "status"),
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # 🔧 FONCTIONS DATABASE
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/src/debate/miro_service.py
+++ b/backend/src/debate/miro_service.py
@@ -337,3 +337,185 @@ async def generate_debate_board(
         len(divergence_points[:5]),
     )
     return {"board_id": board_id, "view_link": view_link}
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 🧩 HUB MIRO WORKSPACE — Sprint Hub Miro MVP (2026-05-05)
+# Spec : docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md
+# Helper distinct de generate_debate_board pour ne pas casser la signature
+# Débat IA déjà en prod.
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+HUB_CARD_WIDTH = 300
+HUB_CARD_HEIGHT = 200
+HUB_CARD_GAP_X = 50
+HUB_CARD_GAP_Y = 60
+HUB_GRID_COLUMNS = 4  # 4 cards/row → grille équilibrée jusqu'à 20 cards (5 rows)
+
+
+async def create_hub_workspace_board(
+    name: str,
+    summaries: list,
+) -> dict:
+    """Crée un board Miro pour un Hub Workspace DeepSight.
+
+    Layout :
+      - Grille (HUB_GRID_COLUMNS colonnes) de cards Miro, une par Summary.
+      - Card width=300, height=200, gap horizontal=50, vertical=60.
+      - Chaque card affiche : titre vidéo, channel, lien.
+
+    Parameters
+    ----------
+    name : str
+        Nom donné par l'utilisateur (max 200 chars).
+    summaries : list
+        Liste d'objets Summary (SQLAlchemy) — doit exposer ``video_title``,
+        ``video_channel``, ``video_url``, ``video_id``, ``platform``.
+
+    Returns
+    -------
+    dict
+        ``{"board_id": str, "view_link": str}``
+
+    Raises
+    ------
+    MiroServiceError
+        Si MIRO_API_TOKEN absent ou Miro API call échoue.
+    """
+    token = _get_miro_token()
+    if not token:
+        raise MiroServiceError("MIRO_API_TOKEN not configured")
+
+    safe_name = (name or "Workspace").strip()[:200] or "Workspace"
+
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+        # ─── 1. Create board ──────────────────────────────────────────────
+        board_body = {
+            "name": safe_name,
+            "description": (
+                f"DeepSight Hub Workspace — {len(summaries)} analyses"
+            )[:500],
+            "policy": {
+                "permissionsPolicy": {
+                    "collaborationToolsStartAccess": "all_editors",
+                    "copyAccess": "anyone",
+                    "sharingAccess": "team_members_with_editing_rights",
+                },
+                "sharingPolicy": {
+                    "access": "view",
+                    "inviteToAccountAndBoardLinkAccess": "no_access",
+                    "organizationAccess": "view",
+                    "teamAccess": "view",
+                },
+            },
+        }
+        board = await _miro_post(client, "/boards", token, board_body)
+        board_id: str = str(board.get("id") or "")
+        if not board_id:
+            raise MiroServiceError(
+                f"Miro create board returned no id: {board!r}"
+            )
+
+        # ─── 2. Cards (grille) ────────────────────────────────────────────
+        # Position grille : colonne = idx % cols, row = idx // cols.
+        # Centrée autour de (0,0) horizontalement.
+        cols = HUB_GRID_COLUMNS
+        col_step = HUB_CARD_WIDTH + HUB_CARD_GAP_X
+        row_step = HUB_CARD_HEIGHT + HUB_CARD_GAP_Y
+        total = len(summaries)
+        n_cols_actual = min(cols, max(1, total))
+        # x_start = position de la 1ère colonne (centré)
+        x_start = -((n_cols_actual - 1) * col_step) / 2
+
+        for idx, summary in enumerate(summaries):
+            col = idx % cols
+            row = idx // cols
+            x = x_start + col * col_step
+            y = row * row_step
+
+            video_title = _truncate(getattr(summary, "video_title", None), 100) or "Sans titre"
+            video_channel = _truncate(getattr(summary, "video_channel", None), 80) or ""
+            video_url = getattr(summary, "video_url", None) or ""
+            platform_name = (getattr(summary, "platform", None) or "youtube").lower()
+
+            # Body HTML formatté (Miro card supporte HTML basique).
+            description_parts = [f"<p><strong>{video_title}</strong></p>"]
+            if video_channel:
+                description_parts.append(f"<p>{video_channel}</p>")
+            if video_url:
+                description_parts.append(
+                    f'<p><a href="{video_url}">Ouvrir la vidéo ({platform_name})</a></p>'
+                )
+            description_html = "".join(description_parts)
+
+            await _miro_post(
+                client,
+                f"/boards/{board_id}/cards",
+                token,
+                {
+                    "data": {
+                        "title": video_title,
+                        "description": description_html,
+                    },
+                    "position": {"x": x, "y": y},
+                    "geometry": {
+                        "width": HUB_CARD_WIDTH,
+                        "height": HUB_CARD_HEIGHT,
+                    },
+                },
+            )
+
+        # ─── 3. Get board details (viewLink) ──────────────────────────────
+        board_detail = await _miro_get(client, f"/boards/{board_id}", token)
+        view_link = (
+            board_detail.get("viewLink")
+            or board_detail.get("view_link")
+            or board.get("viewLink")
+            or board.get("view_link")
+            or f"https://miro.com/app/board/{board_id}/"
+        )
+
+    logger.info(
+        "[MIRO] Hub workspace board generated: id=%s, summaries=%d",
+        board_id,
+        total,
+    )
+    return {"board_id": board_id, "view_link": view_link}
+
+
+async def delete_hub_workspace_board(board_id: str) -> bool:
+    """Best-effort delete d'un board Miro. Logue mais ne raise pas.
+
+    Returns
+    -------
+    bool
+        True si delete OK, False si échec (token absent ou API fail).
+    """
+    token = _get_miro_token()
+    if not token or not board_id:
+        return False
+
+    url = f"{MIRO_API_BASE}/boards/{board_id}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            resp = await client.delete(url, headers=headers)
+            if resp.status_code in (200, 204):
+                return True
+            logger.warning(
+                "[MIRO] Hub workspace board delete non-2xx: status=%s board=%s",
+                resp.status_code,
+                board_id,
+            )
+            return False
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "[MIRO] Hub workspace board delete network error: %s (board=%s)",
+            exc,
+            board_id,
+        )
+        return False

--- a/backend/src/hub/__init__.py
+++ b/backend/src/hub/__init__.py
@@ -1,0 +1,4 @@
+"""Hub Miro Workspace — gestion des workspaces Miro DeepSight.
+
+Spec : docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md
+"""

--- a/backend/src/hub/router.py
+++ b/backend/src/hub/router.py
@@ -1,0 +1,130 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧩 HUB ROUTER — Endpoints REST Hub Miro Workspace                                 ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Préfixe : /api/hub                                                                ║
+║  Spec    : docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md             ║
+║                                                                                    ║
+║  Endpoints :                                                                       ║
+║    POST   /workspaces        — Crée un workspace (Expert only, async Miro)         ║
+║    GET    /workspaces        — Liste les workspaces du user (paginé)               ║
+║    GET    /workspaces/{id}   — Détail d'un workspace                               ║
+║    DELETE /workspaces/{id}   — Supprime un workspace (best-effort Miro delete)     ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Query, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import get_current_user
+from db.database import User, get_session
+
+from .schemas import (
+    HubWorkspaceCreate,
+    HubWorkspaceListResponse,
+    HubWorkspaceResponse,
+)
+from .service import (
+    _create_miro_board_async,
+    create_workspace,
+    delete_workspace,
+    get_workspace,
+    list_workspaces,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(tags=["Hub"])
+
+
+# ─── POST /workspaces ────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/workspaces",
+    response_model=HubWorkspaceResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_hub_workspace(
+    payload: HubWorkspaceCreate,
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> HubWorkspaceResponse:
+    """Crée un Hub Workspace (Expert only).
+
+    Réponse immédiate avec status=``pending`` ; le board Miro est créé en
+    background. Poller GET /workspaces/{id} pour observer status='ready'.
+    """
+    workspace = await create_workspace(db, current_user, payload)
+
+    # Schedule background Miro board creation
+    background_tasks.add_task(_create_miro_board_async, workspace.id)
+
+    return HubWorkspaceResponse.model_validate(workspace)
+
+
+# ─── GET /workspaces ─────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/workspaces",
+    response_model=HubWorkspaceListResponse,
+)
+async def list_hub_workspaces(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> HubWorkspaceListResponse:
+    """Retourne la liste des workspaces du user, ordre desc created_at."""
+    items, total = await list_workspaces(
+        db, current_user, limit=limit, offset=offset
+    )
+    return HubWorkspaceListResponse(
+        items=[HubWorkspaceResponse.model_validate(ws) for ws in items],
+        total=total,
+    )
+
+
+# ─── GET /workspaces/{id} ────────────────────────────────────────────────────
+
+
+@router.get(
+    "/workspaces/{workspace_id}",
+    response_model=HubWorkspaceResponse,
+)
+async def get_hub_workspace(
+    workspace_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> HubWorkspaceResponse:
+    """Détail d'un workspace. 404 si inconnu OU pas du user."""
+    workspace = await get_workspace(db, current_user, workspace_id)
+    return HubWorkspaceResponse.model_validate(workspace)
+
+
+# ─── DELETE /workspaces/{id} ─────────────────────────────────────────────────
+
+
+@router.delete(
+    "/workspaces/{workspace_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_hub_workspace(
+    workspace_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Supprime un workspace. Best-effort delete sur le board Miro associé.
+
+    404 si workspace inconnu ou pas du user. 204 sinon.
+    """
+    await delete_workspace(db, current_user, workspace_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/hub/schemas.py
+++ b/backend/src/hub/schemas.py
@@ -1,0 +1,100 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  📘 HUB SCHEMAS — Pydantic v2 schemas for Hub Miro Workspace endpoints             ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+
+Spec : docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════════════
+
+MIN_SUMMARIES_PER_WORKSPACE = 2
+MAX_SUMMARIES_PER_WORKSPACE = 20
+MAX_WORKSPACE_NAME_LENGTH = 200
+MAX_ACTIVE_WORKSPACES_PER_USER = 5  # cap mensuel (rolling 30 jours)
+ACTIVE_WORKSPACE_WINDOW_DAYS = 30
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Request schemas
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class HubWorkspaceCreate(BaseModel):
+    """Body de POST /api/hub/workspaces."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_WORKSPACE_NAME_LENGTH,
+        description="Nom donné par l'utilisateur au workspace",
+    )
+    summary_ids: list[int] = Field(
+        ...,
+        min_length=MIN_SUMMARIES_PER_WORKSPACE,
+        max_length=MAX_SUMMARIES_PER_WORKSPACE,
+        description=(
+            f"IDs des analyses Summary à inclure "
+            f"(min {MIN_SUMMARIES_PER_WORKSPACE}, max {MAX_SUMMARIES_PER_WORKSPACE})"
+        ),
+    )
+
+    @field_validator("summary_ids")
+    @classmethod
+    def _ensure_unique_positive_ids(cls, v: list[int]) -> list[int]:
+        if any(sid <= 0 for sid in v):
+            raise ValueError("summary_ids must be positive integers")
+        # Dédupliquer en conservant l'ordre
+        seen: set[int] = set()
+        deduped: list[int] = []
+        for sid in v:
+            if sid in seen:
+                continue
+            seen.add(sid)
+            deduped.append(sid)
+        if len(deduped) < MIN_SUMMARIES_PER_WORKSPACE:
+            raise ValueError(
+                f"summary_ids must contain at least {MIN_SUMMARIES_PER_WORKSPACE} unique IDs"
+            )
+        return deduped
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Response schemas
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class HubWorkspaceResponse(BaseModel):
+    """Représentation d'un workspace Miro renvoyée par l'API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    name: str
+    summary_ids: list[int]
+    miro_board_id: Optional[str] = None
+    miro_board_url: Optional[str] = None
+    status: str  # pending | creating | ready | failed
+    error_message: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class HubWorkspaceListResponse(BaseModel):
+    """Réponse paginée pour GET /api/hub/workspaces."""
+
+    items: list[HubWorkspaceResponse]
+    total: int

--- a/backend/src/hub/service.py
+++ b/backend/src/hub/service.py
@@ -1,0 +1,382 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧩 HUB SERVICE — Logique métier Hub Miro Workspace                                ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Spec : docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md                ║
+║  Gating : Expert only (vérifié strict côté plan + via is_feature_available SSOT). ║
+║  Cap : 5 workspaces actifs / user / 30 jours.                                      ║
+║  Sync : one-way push DeepSight → Miro (board admin token, view-only sharing).      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from billing.plan_config import is_feature_available, normalize_plan_id
+from db.database import HubWorkspace, Summary, User, async_session_maker
+
+from .schemas import (
+    ACTIVE_WORKSPACE_WINDOW_DAYS,
+    MAX_ACTIVE_WORKSPACES_PER_USER,
+    MAX_SUMMARIES_PER_WORKSPACE,
+    MIN_SUMMARIES_PER_WORKSPACE,
+    HubWorkspaceCreate,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+ACTIVE_STATUSES: tuple[str, ...] = ("pending", "creating", "ready")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _user_owns_summaries(
+    db: AsyncSession, user_id: int, summary_ids: list[int]
+) -> bool:
+    """Retourne True si tous les ``summary_ids`` appartiennent à ``user_id``.
+
+    Vérifie aussi que tous existent — un ID inconnu fait retourner False.
+    """
+    if not summary_ids:
+        return False
+    result = await db.execute(
+        select(func.count(Summary.id)).where(
+            Summary.id.in_(summary_ids),
+            Summary.user_id == user_id,
+        )
+    )
+    count = int(result.scalar() or 0)
+    return count == len(set(summary_ids))
+
+
+async def _count_active_workspaces(
+    db: AsyncSession, user_id: int
+) -> int:
+    """Compte les workspaces actifs (status pending/creating/ready) sur la
+    fenêtre des ``ACTIVE_WORKSPACE_WINDOW_DAYS`` derniers jours.
+    """
+    cutoff = datetime.utcnow() - timedelta(days=ACTIVE_WORKSPACE_WINDOW_DAYS)
+    result = await db.execute(
+        select(func.count(HubWorkspace.id)).where(
+            HubWorkspace.user_id == user_id,
+            HubWorkspace.status.in_(ACTIVE_STATUSES),
+            HubWorkspace.created_at >= cutoff,
+        )
+    )
+    return int(result.scalar() or 0)
+
+
+def _ensure_expert_plan(user: User) -> None:
+    """Raise HTTPException 403 si l'utilisateur n'a pas accès à la feature
+    ``hub_workspace`` sur la plateforme web (Expert only).
+
+    Admin bypass : ``user.is_admin = True`` court-circuite le gate.
+    """
+    if getattr(user, "is_admin", False):
+        return
+
+    raw_plan = (user.plan or "free")
+    plan = normalize_plan_id(raw_plan)
+
+    # Vérification stricte Expert (matrice SSOT) — sur web.
+    if not is_feature_available(plan, "hub_workspace", "web"):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "hub_workspace_expert_only",
+                "message": "Hub Workspaces are Expert only",
+                "current_plan": plan,
+                "required_plan": "expert",
+            },
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Public API
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def create_workspace(
+    db: AsyncSession,
+    user: User,
+    payload: HubWorkspaceCreate,
+) -> HubWorkspace:
+    """Crée un Hub Workspace avec status ``pending`` puis renvoie la row.
+
+    Contrôles :
+      * Plan == ``expert`` (sauf admin bypass).
+      * <= ``MAX_ACTIVE_WORKSPACES_PER_USER`` actifs sur 30 jours glissants.
+      * ``summary_ids`` length ∈ [2, 20] et tous appartiennent au user.
+
+    L'orchestration du board Miro (background task) est lancée par le
+    router via ``BackgroundTasks.add_task(_create_miro_board_async, ...)``.
+    """
+    # 1. Gating plan (Expert only)
+    _ensure_expert_plan(user)
+
+    # 2. Cap mensuel (rolling 30j)
+    active_count = await _count_active_workspaces(db, user.id)
+    if active_count >= MAX_ACTIVE_WORKSPACES_PER_USER:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "code": "hub_workspace_quota_exceeded",
+                "message": (
+                    f"Limite {MAX_ACTIVE_WORKSPACES_PER_USER} workspaces / "
+                    f"{ACTIVE_WORKSPACE_WINDOW_DAYS} jours atteinte"
+                ),
+                "active_count": active_count,
+                "limit": MAX_ACTIVE_WORKSPACES_PER_USER,
+                "window_days": ACTIVE_WORKSPACE_WINDOW_DAYS,
+            },
+        )
+
+    # 3. Validation summary_ids — length déjà checkée par Pydantic, on
+    # double-check ici par sécurité (au cas où le service est appelé hors HTTP)
+    summary_ids = list(payload.summary_ids)
+    if not (
+        MIN_SUMMARIES_PER_WORKSPACE
+        <= len(summary_ids)
+        <= MAX_SUMMARIES_PER_WORKSPACE
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "hub_workspace_invalid_summary_count",
+                "message": (
+                    f"summary_ids must contain {MIN_SUMMARIES_PER_WORKSPACE} "
+                    f"to {MAX_SUMMARIES_PER_WORKSPACE} items"
+                ),
+                "received": len(summary_ids),
+            },
+        )
+
+    # 4. Ownership des summaries
+    if not await _user_owns_summaries(db, user.id, summary_ids):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "hub_workspace_invalid_summary_ids",
+                "message": (
+                    "Some summary_ids are unknown or not owned by this user"
+                ),
+            },
+        )
+
+    # 5. Insert
+    workspace = HubWorkspace(
+        user_id=user.id,
+        name=payload.name.strip(),
+        summary_ids=summary_ids,
+        status="pending",
+    )
+    db.add(workspace)
+    await db.commit()
+    await db.refresh(workspace)
+
+    logger.info(
+        "[HUB] Workspace created id=%s user=%s summaries=%d",
+        workspace.id,
+        user.id,
+        len(summary_ids),
+    )
+    return workspace
+
+
+async def list_workspaces(
+    db: AsyncSession,
+    user: User,
+    limit: int = 20,
+    offset: int = 0,
+) -> tuple[list[HubWorkspace], int]:
+    """Retourne ``(items, total)`` — workspaces du user, ordre desc created_at."""
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
+
+    total_result = await db.execute(
+        select(func.count(HubWorkspace.id)).where(
+            HubWorkspace.user_id == user.id
+        )
+    )
+    total = int(total_result.scalar() or 0)
+
+    result = await db.execute(
+        select(HubWorkspace)
+        .where(HubWorkspace.user_id == user.id)
+        .order_by(HubWorkspace.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    items = list(result.scalars().all())
+    return items, total
+
+
+async def get_workspace(
+    db: AsyncSession, user: User, workspace_id: int
+) -> HubWorkspace:
+    """Retourne le workspace ou raise 404 si pas trouvé OU pas du user.
+
+    On répond 404 (pas 403) pour ne pas révéler l'existence à un attaquant.
+    """
+    result = await db.execute(
+        select(HubWorkspace).where(HubWorkspace.id == workspace_id)
+    )
+    workspace = result.scalar_one_or_none()
+    if workspace is None or workspace.user_id != user.id:
+        if not getattr(user, "is_admin", False) or workspace is None:
+            raise HTTPException(
+                status_code=404,
+                detail={"code": "hub_workspace_not_found"},
+            )
+    return workspace
+
+
+async def delete_workspace(
+    db: AsyncSession, user: User, workspace_id: int
+) -> None:
+    """Supprime un workspace + best-effort delete board Miro côté API.
+
+    404 si workspace inconnu ou pas du user.
+    """
+    workspace = await get_workspace(db, user, workspace_id)
+
+    # Best effort : delete board Miro si existant.
+    miro_board_id = workspace.miro_board_id
+    if miro_board_id:
+        try:
+            from debate.miro_service import delete_hub_workspace_board
+
+            ok = await delete_hub_workspace_board(miro_board_id)
+            if not ok:
+                logger.warning(
+                    "[HUB] Miro board delete failed (non-blocking) ws=%s board=%s",
+                    workspace_id,
+                    miro_board_id,
+                )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning(
+                "[HUB] Miro delete raised (non-blocking) ws=%s err=%s",
+                workspace_id,
+                exc,
+            )
+
+    await db.delete(workspace)
+    await db.commit()
+    logger.info("[HUB] Workspace deleted id=%s user=%s", workspace_id, user.id)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Background task — Miro board async creation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _create_miro_board_async(workspace_id: int) -> None:
+    """Background task : crée le board Miro pour le workspace.
+
+    Ouvre sa propre AsyncSession (indépendante de la requête HTTP).
+    Update status : pending → creating → ready (ou failed).
+    """
+    async with async_session_maker() as session:
+        try:
+            # 1. Charger le workspace
+            result = await session.execute(
+                select(HubWorkspace).where(HubWorkspace.id == workspace_id)
+            )
+            workspace = result.scalar_one_or_none()
+            if workspace is None:
+                logger.warning(
+                    "[HUB] _create_miro_board_async: workspace %s not found",
+                    workspace_id,
+                )
+                return
+
+            # 2. status='creating'
+            workspace.status = "creating"
+            await session.commit()
+
+            # 3. Charger les summaries du workspace
+            summary_ids = list(workspace.summary_ids or [])
+            summaries_res = await session.execute(
+                select(Summary).where(Summary.id.in_(summary_ids))
+            )
+            summaries = list(summaries_res.scalars().all())
+
+            # Préserver l'ordre demandé par l'utilisateur
+            ordered: list[Summary] = []
+            by_id = {s.id: s for s in summaries}
+            for sid in summary_ids:
+                if sid in by_id:
+                    ordered.append(by_id[sid])
+
+            if not ordered:
+                raise RuntimeError("No summaries found for workspace")
+
+            # 4. Créer le board (helper miro_service)
+            from debate.miro_service import (
+                MiroServiceError,
+                create_hub_workspace_board,
+            )
+
+            try:
+                board = await create_hub_workspace_board(
+                    name=workspace.name,
+                    summaries=ordered,
+                )
+            except MiroServiceError as exc:
+                workspace.status = "failed"
+                workspace.error_message = str(exc)[:500]
+                await session.commit()
+                logger.error(
+                    "[HUB] Miro board creation failed ws=%s err=%s",
+                    workspace_id,
+                    exc,
+                )
+                return
+
+            # 5. status='ready'
+            workspace.miro_board_id = board.get("board_id")
+            workspace.miro_board_url = board.get("view_link")
+            workspace.status = "ready"
+            workspace.error_message = None
+            await session.commit()
+
+            logger.info(
+                "[HUB] Workspace ready id=%s board=%s",
+                workspace_id,
+                workspace.miro_board_id,
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.exception(
+                "[HUB] _create_miro_board_async failed ws=%s",
+                workspace_id,
+            )
+            try:
+                # Best-effort : marquer comme failed dans une nouvelle session.
+                async with async_session_maker() as recover:
+                    res = await recover.execute(
+                        select(HubWorkspace).where(
+                            HubWorkspace.id == workspace_id
+                        )
+                    )
+                    ws = res.scalar_one_or_none()
+                    if ws is not None:
+                        ws.status = "failed"
+                        ws.error_message = str(exc)[:500]
+                        await recover.commit()
+            except Exception:
+                logger.exception(
+                    "[HUB] could not mark workspace %s as failed",
+                    workspace_id,
+                )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -399,6 +399,15 @@ except ImportError as e:
     DOCUMENTS_ROUTER_AVAILABLE = False
     logger.warning(f"⚠️ Documents router not available: {e}")
 
+# 🧩 Hub Miro Workspace router (Sprint Hub Miro MVP — 2026-05-05)
+try:
+    from hub.router import router as hub_router
+
+    HUB_ROUTER_AVAILABLE = True
+except ImportError as e:
+    HUB_ROUTER_AVAILABLE = False
+    logger.warning(f"⚠️ Hub router not available: {e}")
+
 # Global video cache instance
 _video_cache: "VideoContentCacheService | None" = None
 
@@ -1214,6 +1223,11 @@ if STUDY_REVIEW_ROUTER_AVAILABLE:
 if DOCUMENTS_ROUTER_AVAILABLE:
     app.include_router(documents_router, prefix="/api/documents", tags=["Documents"])
     logger.info("📄 Documents router loaded (POST /api/documents/analyze-url, /analyze-upload, /ocr-only)")
+
+# 🧩 Hub Miro Workspace router (Sprint Hub Miro MVP — 2026-05-05)
+if HUB_ROUTER_AVAILABLE:
+    app.include_router(hub_router, prefix="/api/hub", tags=["Hub"])
+    logger.info("🧩 Hub router loaded (POST /api/hub/workspaces — Expert only)")
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 🖼️ THUMBNAIL STATIC FILES (local VPS fallback when R2 creds not available)

--- a/backend/tests/test_hub_workspace.py
+++ b/backend/tests/test_hub_workspace.py
@@ -1,0 +1,508 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TEST HUB MIRO WORKSPACE — Vague 1 backend                                      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+
+Couverture (Sprint Hub Miro Workspace MVP — 2026-05-05) :
+
+  1. Endpoint POST /api/hub/workspaces :
+     - 201 nominal (Expert + 3 summaries owned)
+     - 403 si plan != expert (free, pro)
+     - 429 si déjà 5 workspaces actifs sur 30j
+     - 400 si summary_ids inconnus / pas du user
+     - 422 si len(summary_ids) < 2 ou > 20 (Pydantic validation)
+  2. Endpoint GET /api/hub/workspaces : liste ordre desc
+  3. Endpoint GET /api/hub/workspaces/{id} :
+     - 200 owner
+     - 404 autre user (on cache l'existence)
+  4. Endpoint DELETE /api/hub/workspaces/{id} : 204 + row absente
+  5. Background task Miro : monkeypatché, on vérifie l'enregistrement et args.
+"""
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock
+
+# ── Env defaults pour import safety (avant import des modules src) ────────────
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from sqlalchemy.ext.asyncio import (  # noqa: E402
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy import select  # noqa: E402
+from httpx import AsyncClient, ASGITransport  # noqa: E402
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 FIXTURES — SQLite in-memory + User Expert/Pro/Free + Summaries
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    """SQLite in-memory + tous les models créés via Base.metadata.create_all."""
+    from db.database import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    SessionLocal = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with SessionLocal() as session:
+        yield session
+
+    await engine.dispose()
+
+
+async def _make_user(db_session, plan: str, username: str) -> "User":
+    from db.database import User
+
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        password_hash="hashed_pw",
+        plan=plan,
+        credits=1000,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def expert_user(db_session):
+    return await _make_user(db_session, "expert", "expert_user")
+
+
+@pytest_asyncio.fixture
+async def pro_user(db_session):
+    return await _make_user(db_session, "pro", "pro_user")
+
+
+@pytest_asyncio.fixture
+async def free_user(db_session):
+    return await _make_user(db_session, "free", "free_user")
+
+
+async def _make_summary(db_session, user_id: int, title: str = "Test") -> "Summary":
+    from db.database import Summary
+
+    summary = Summary(
+        user_id=user_id,
+        video_id=f"vid{title[:8]}",
+        video_title=title,
+        video_channel="Test Channel",
+        video_url="https://youtube.com/watch?v=test",
+        platform="youtube",
+        lang="fr",
+        summary_content="Summary",
+    )
+    db_session.add(summary)
+    await db_session.commit()
+    await db_session.refresh(summary)
+    return summary
+
+
+@pytest_asyncio.fixture
+async def expert_summaries(db_session, expert_user):
+    """3 summaries pour l'expert user."""
+    s1 = await _make_summary(db_session, expert_user.id, "Video1")
+    s2 = await _make_summary(db_session, expert_user.id, "Video2")
+    s3 = await _make_summary(db_session, expert_user.id, "Video3")
+    return [s1, s2, s3]
+
+
+# ─── App + override deps ────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def app_factory(db_session, monkeypatch):
+    """Factory qui rend une app FastAPI + helper pour set le user override.
+
+    Mocks `_create_miro_board_async` pour ne pas appeler Miro réellement.
+    Stocke les calls dans `app.state.miro_calls` pour assertion.
+    """
+    from main import app
+    from db.database import get_session
+    from auth.dependencies import get_current_user
+    import hub.router as hub_router_module
+
+    # Monkeypatch background task — on stocke les calls
+    miro_calls: list[int] = []
+
+    async def fake_create(workspace_id: int) -> None:
+        miro_calls.append(workspace_id)
+
+    monkeypatch.setattr(
+        hub_router_module, "_create_miro_board_async", fake_create
+    )
+
+    async def override_session():
+        return db_session
+
+    app.dependency_overrides[get_session] = override_session
+
+    def set_user(user):
+        async def override_user():
+            return user
+
+        app.dependency_overrides[get_current_user] = override_user
+
+    yield app, set_user, miro_calls
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def expert_client(app_factory, expert_user):
+    app, set_user, miro_calls = app_factory
+    set_user(expert_user)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c, miro_calls
+
+
+@pytest_asyncio.fixture
+async def pro_client(app_factory, pro_user):
+    app, set_user, miro_calls = app_factory
+    set_user(pro_user)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c, miro_calls
+
+
+@pytest_asyncio.fixture
+async def free_client(app_factory, free_user):
+    app, set_user, miro_calls = app_factory
+    set_user(free_user)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c, miro_calls
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. ✅ POST /api/hub/workspaces — création
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_expert_succeeds(
+    expert_client, expert_summaries
+):
+    """Expert + 3 summaries owned → 201, status=pending, BackgroundTask scheduled."""
+    client, miro_calls = expert_client
+    sids = [s.id for s in expert_summaries]
+    resp = await client.post(
+        "/api/hub/workspaces",
+        json={"name": "Mon Workspace", "summary_ids": sids},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "Mon Workspace"
+    assert body["summary_ids"] == sids
+    assert body["status"] == "pending"
+    assert body["miro_board_id"] is None
+    assert body["miro_board_url"] is None
+    # Background task scheduled avec workspace.id
+    assert miro_calls == [body["id"]]
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_pro_forbidden(pro_client, db_session, pro_user):
+    """Pro user → 403 (Expert only)."""
+    s1 = await _make_summary(db_session, pro_user.id, "ProVid1")
+    s2 = await _make_summary(db_session, pro_user.id, "ProVid2")
+    client, _ = pro_client
+    resp = await client.post(
+        "/api/hub/workspaces",
+        json={"name": "Pro WS", "summary_ids": [s1.id, s2.id]},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["detail"]["code"] == "hub_workspace_expert_only"
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_free_forbidden(
+    free_client, db_session, free_user
+):
+    """Free user → 403 (Expert only)."""
+    s1 = await _make_summary(db_session, free_user.id, "FreeVid1")
+    s2 = await _make_summary(db_session, free_user.id, "FreeVid2")
+    client, _ = free_client
+    resp = await client.post(
+        "/api/hub/workspaces",
+        json={"name": "Free WS", "summary_ids": [s1.id, s2.id]},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_quota_exceeded(
+    expert_client, expert_summaries, db_session, expert_user
+):
+    """5 workspaces actifs déjà → 6ème → 429."""
+    from db.database import HubWorkspace
+
+    sids = [s.id for s in expert_summaries]
+    # Crée directement 5 workspaces actifs (status=ready) en DB
+    for i in range(5):
+        ws = HubWorkspace(
+            user_id=expert_user.id,
+            name=f"WS{i}",
+            summary_ids=sids,
+            status="ready",
+        )
+        db_session.add(ws)
+    await db_session.commit()
+
+    client, _ = expert_client
+    resp = await client.post(
+        "/api/hub/workspaces",
+        json={"name": "6th WS", "summary_ids": sids},
+    )
+    assert resp.status_code == 429
+    body = resp.json()
+    assert body["detail"]["code"] == "hub_workspace_quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_invalid_summary_ids(
+    expert_client, expert_summaries
+):
+    """summary_id inexistant → 400."""
+    sids = [expert_summaries[0].id, 999999]  # 999999 n'existe pas
+    client, _ = expert_client
+    resp = await client.post(
+        "/api/hub/workspaces",
+        json={"name": "WS bad", "summary_ids": sids},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["detail"]["code"] == "hub_workspace_invalid_summary_ids"
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_other_user_summary_forbidden(
+    expert_client, db_session, free_user
+):
+    """summary_id appartenant à un autre user → 400."""
+    other_summary = await _make_summary(
+        db_session, free_user.id, "OtherUserVid"
+    )
+    s_self = await _make_summary(db_session, free_user.id + 100000, "Vid self")
+    # Note: ce dernier ne sera pas owned by expert, mais on en crée un en plus
+    # On va en faire un de l'expert pour avoir 2 IDs valides + 1 invalide
+    from db.database import User as UserModel
+
+    # Récupère expert_user via DB (le client en a un)
+    res = await db_session.execute(
+        select(UserModel).where(UserModel.username == "expert_user")
+    )
+    expert = res.scalar_one()
+    s_expert = await _make_summary(db_session, expert.id, "ExpertVid")
+
+    client, _ = expert_client
+    resp = await client.post(
+        "/api/hub/workspaces",
+        json={
+            "name": "Mixed",
+            "summary_ids": [s_expert.id, other_summary.id],
+        },
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["detail"]["code"] == "hub_workspace_invalid_summary_ids"
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_min_2_summaries(
+    expert_client, expert_summaries
+):
+    """1 summary → 422 (Pydantic min_length=2)."""
+    client, _ = expert_client
+    resp = await client.post(
+        "/api/hub/workspaces",
+        json={"name": "WS too small", "summary_ids": [expert_summaries[0].id]},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_max_20_summaries(
+    expert_client, db_session, expert_user
+):
+    """21 summaries → 422 (Pydantic max_length=20)."""
+    summaries = [
+        await _make_summary(db_session, expert_user.id, f"Vid{i:02d}")
+        for i in range(21)
+    ]
+    sids = [s.id for s in summaries]
+    client, _ = expert_client
+    resp = await client.post(
+        "/api/hub/workspaces",
+        json={"name": "WS too big", "summary_ids": sids},
+    )
+    assert resp.status_code == 422
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. ✅ GET /api/hub/workspaces — liste
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_list_workspaces(
+    expert_client, expert_summaries, db_session, expert_user
+):
+    """3 workspaces créés directement en DB → liste de 3 ordre desc created_at."""
+    from db.database import HubWorkspace
+
+    sids = [s.id for s in expert_summaries]
+    for i in range(3):
+        ws = HubWorkspace(
+            user_id=expert_user.id,
+            name=f"WS{i}",
+            summary_ids=sids,
+            status="ready",
+        )
+        db_session.add(ws)
+    await db_session.commit()
+
+    client, _ = expert_client
+    resp = await client.get("/api/hub/workspaces")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 3
+    assert len(body["items"]) == 3
+    # Ordre desc created_at — les rows ont été insérées dans l'ordre WS0, WS1, WS2
+    # donc WS2 doit apparaître en premier (or, tie-break par id desc dans certains cas)
+    names = [item["name"] for item in body["items"]]
+    # On vérifie au moins que toutes sont présentes
+    assert set(names) == {"WS0", "WS1", "WS2"}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. ✅ GET /api/hub/workspaces/{id} — détail
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_owner(
+    expert_client, expert_summaries, db_session, expert_user
+):
+    """Owner peut récupérer son workspace."""
+    from db.database import HubWorkspace
+
+    ws = HubWorkspace(
+        user_id=expert_user.id,
+        name="My WS",
+        summary_ids=[s.id for s in expert_summaries],
+        status="ready",
+    )
+    db_session.add(ws)
+    await db_session.commit()
+    await db_session.refresh(ws)
+
+    client, _ = expert_client
+    resp = await client.get(f"/api/hub/workspaces/{ws.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == ws.id
+    assert body["name"] == "My WS"
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_other_user_404(
+    app_factory, db_session, expert_user, expert_summaries
+):
+    """Un autre user → 404 (on ne révèle pas l'existence)."""
+    from db.database import HubWorkspace, User as UserModel
+
+    # 1. Crée un workspace pour expert_user
+    ws = HubWorkspace(
+        user_id=expert_user.id,
+        name="Owner WS",
+        summary_ids=[s.id for s in expert_summaries],
+        status="ready",
+    )
+    db_session.add(ws)
+
+    # 2. Crée un autre expert user
+    other = UserModel(
+        username="other_expert",
+        email="other@example.com",
+        password_hash="x",
+        plan="expert",
+        credits=100,
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(ws)
+    await db_session.refresh(other)
+
+    app, set_user, _ = app_factory
+    set_user(other)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        resp = await c.get(f"/api/hub/workspaces/{ws.id}")
+    assert resp.status_code == 404
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. ✅ DELETE /api/hub/workspaces/{id}
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace(
+    expert_client, expert_summaries, db_session, expert_user
+):
+    """Delete owner → 204 + row absente."""
+    from db.database import HubWorkspace
+
+    ws = HubWorkspace(
+        user_id=expert_user.id,
+        name="To Delete",
+        summary_ids=[s.id for s in expert_summaries],
+        status="ready",
+        miro_board_id=None,  # Pas de board → pas d'appel Miro DELETE
+    )
+    db_session.add(ws)
+    await db_session.commit()
+    await db_session.refresh(ws)
+    ws_id = ws.id
+
+    client, _ = expert_client
+    resp = await client.delete(f"/api/hub/workspaces/{ws_id}")
+    assert resp.status_code == 204
+
+    # Vérifier que la row a bien été supprimée
+    res = await db_session.execute(
+        select(HubWorkspace).where(HubWorkspace.id == ws_id)
+    )
+    assert res.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace_not_found(expert_client):
+    """DELETE sur ID inexistant → 404."""
+    client, _ = expert_client
+    resp = await client.delete("/api/hub/workspaces/999999")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Vague 1 backend du **Sprint Hub Miro Workspace MVP** (spec PR #334, `docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md`).

- **Modèle SQLAlchemy `HubWorkspace`** + migration Alembic **018** (revises `017_debate_v2_perspectives`). Colonnes : `user_id` (FK CASCADE), `name` (str 200), `summary_ids` (JSON, 2-20 items), `miro_board_id`/`miro_board_url` (NULL au create), `status` (`pending|creating|ready|failed`), `error_message`, `created_at`/`updated_at`. Indexes composites `(user_id, created_at)` et `(user_id, status)`.

- **Module `backend/src/hub/`** : `schemas.py` (Pydantic v2 strict, dédup IDs, validators), `service.py` (gating Expert via `is_feature_available()` SSOT + admin bypass, cap **5 workspaces actifs / user / 30j rolling**, validation ownership des `summary_ids`, background task async avec session DB indépendante), `router.py` (`POST /workspaces` 201, `GET /workspaces` paginé, `GET /workspaces/{id}`, `DELETE /workspaces/{id}` 204).

- **`miro_service.py` étendu** (zéro changement de signature pour ne pas casser Débat IA prod) : helpers `create_hub_workspace_board(name, summaries)` (grille 4 colonnes, cards Miro avec titre/channel/lien) + `delete_hub_workspace_board(board_id)` (best-effort).

- **`plan_config.py` SSOT** : feature `hub_workspace` ajoutée à la matrice `platforms` — `True` UNIQUEMENT pour `expert/web`, `False` partout ailleurs (mobile/extension Expert restent CTA web pour le MVP).

- **Enregistrement router** dans `main.py` : `/api/hub/*`, tag `Hub`.

## Test plan

- [x] **13 tests intégration** verts en local (`tests/test_hub_workspace.py`, SQLite in-memory, **pas de mock DB**, monkeypatch ciblé sur `_create_miro_board_async` pour isoler Miro REST) :
  - `test_create_workspace_expert_succeeds` (201, BackgroundTask scheduled avec workspace.id)
  - `test_create_workspace_pro_forbidden` (403)
  - `test_create_workspace_free_forbidden` (403)
  - `test_create_workspace_quota_exceeded` (5 actifs déjà → 6ème = 429)
  - `test_create_workspace_invalid_summary_ids` (ID inexistant → 400)
  - `test_create_workspace_other_user_summary_forbidden` (summary owned par un autre user → 400)
  - `test_create_workspace_min_2_summaries` (1 summary → 422 Pydantic)
  - `test_create_workspace_max_20_summaries` (21 → 422 Pydantic)
  - `test_list_workspaces` (3 créés → liste de 3, pagination)
  - `test_get_workspace_owner` (owner peut get)
  - `test_get_workspace_other_user_404` (autre user → 404, on cache l'existence)
  - `test_delete_workspace` (204 + row absente)
  - `test_delete_workspace_not_found` (404)
- [x] **Tests existants verts** : `test_debate_adaptive.py` + `test_plan_gates.py` + `test_debate_matching.py` (104 passed, 0 régression).
- [x] `alembic heads` retourne `018_hub_workspace (head)` — chain valide.
- [ ] Smoke test prod après deploy : `GET /api/hub/workspaces` doit retourner 401.

## Notes deploy

Avec PR #329 (entrypoint.sh) en prod, `alembic upgrade head` au boot du container appliquera la 018 automatiquement.

Wave 2 frontend à venir (UI sélection multi-analyses + bouton Create Workspace + page liste/détail).