### PR TITLE
feat(hub): hubApi client + useHubWorkspacesStore Zustand

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3395,6 +3395,70 @@ export const keywordImageApi = {
   },
 };
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🧩 HUB WORKSPACE API — Miro Workspaces (Expert only, 5/30j cap)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export type HubWorkspaceStatus = "pending" | "creating" | "ready" | "failed";
+
+export interface HubWorkspace {
+  id: number;
+  name: string;
+  summary_ids: number[];
+  miro_board_id: string | null;
+  miro_board_url: string | null;
+  status: HubWorkspaceStatus;
+  error_message: string | null;
+  created_at: string; // ISO
+  updated_at: string; // ISO
+}
+
+export interface HubWorkspaceCreatePayload {
+  name: string;
+  summary_ids: number[]; // 2..20 items
+}
+
+export interface HubWorkspaceListResponse {
+  items: HubWorkspace[];
+  total: number;
+}
+
+export const hubApi = {
+  async createWorkspace(
+    payload: HubWorkspaceCreatePayload,
+  ): Promise<HubWorkspace> {
+    return request<HubWorkspace>("/api/hub/workspaces", {
+      method: "POST",
+      body: { name: payload.name, summary_ids: payload.summary_ids },
+    });
+  },
+
+  async listWorkspaces(params?: {
+    limit?: number;
+    offset?: number;
+  }): Promise<HubWorkspaceListResponse> {
+    const queryParams = new URLSearchParams();
+    if (typeof params?.limit === "number")
+      queryParams.set("limit", String(params.limit));
+    if (typeof params?.offset === "number")
+      queryParams.set("offset", String(params.offset));
+    const query = queryParams.toString();
+    return request<HubWorkspaceListResponse>(
+      `/api/hub/workspaces${query ? `?${query}` : ""}`,
+    );
+  },
+
+  async getWorkspace(id: number): Promise<HubWorkspace> {
+    return request<HubWorkspace>(`/api/hub/workspaces/${id}`);
+  },
+
+  async deleteWorkspace(id: number): Promise<void> {
+    await request<Record<string, never>>(`/api/hub/workspaces/${id}`, {
+      method: "DELETE",
+    });
+  },
+};
+
 // Export par défaut
 export default {
   auth: authApi,
@@ -3422,4 +3486,5 @@ export default {
   gamification: gamificationApi,
   keywordImage: keywordImageApi,
   geo: geoApi,
+  hub: hubApi,
 };

--- a/frontend/src/store/__tests__/useHubWorkspacesStore.test.ts
+++ b/frontend/src/store/__tests__/useHubWorkspacesStore.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests Vitest pour useHubWorkspacesStore.
+ * Mocks hubApi via vi.mock — pas de fetch réel.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// IMPORTANT: vi.mock doit être hoisté avant l'import du store.
+// On mocke ../../services/api en gardant ApiError concret pour les instanceof checks.
+vi.mock("../../services/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../services/api")>(
+      "../../services/api",
+    );
+  return {
+    ...actual,
+    hubApi: {
+      createWorkspace: vi.fn(),
+      listWorkspaces: vi.fn(),
+      getWorkspace: vi.fn(),
+      deleteWorkspace: vi.fn(),
+    },
+  };
+});
+
+import { hubApi, ApiError, type HubWorkspace } from "../../services/api";
+import { useHubWorkspacesStore } from "../useHubWorkspacesStore";
+
+const mockedHubApi = hubApi as unknown as {
+  createWorkspace: ReturnType<typeof vi.fn>;
+  listWorkspaces: ReturnType<typeof vi.fn>;
+  getWorkspace: ReturnType<typeof vi.fn>;
+  deleteWorkspace: ReturnType<typeof vi.fn>;
+};
+
+function makeWorkspace(overrides: Partial<HubWorkspace> = {}): HubWorkspace {
+  return {
+    id: 1,
+    name: "Test Workspace",
+    summary_ids: [10, 20],
+    miro_board_id: null,
+    miro_board_url: null,
+    status: "pending",
+    error_message: null,
+    created_at: "2026-05-05T12:00:00Z",
+    updated_at: "2026-05-05T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("useHubWorkspacesStore", () => {
+  beforeEach(() => {
+    useHubWorkspacesStore.getState().reset();
+    vi.clearAllMocks();
+  });
+
+  it("fetchWorkspaces success — populates workspaces + total", async () => {
+    const items = [
+      makeWorkspace({ id: 1, name: "WS A" }),
+      makeWorkspace({ id: 2, name: "WS B" }),
+    ];
+    mockedHubApi.listWorkspaces.mockResolvedValueOnce({ items, total: 2 });
+
+    await useHubWorkspacesStore.getState().fetchWorkspaces({ limit: 20 });
+
+    const s = useHubWorkspacesStore.getState();
+    expect(s.workspaces).toHaveLength(2);
+    expect(s.workspaces[0].name).toBe("WS A");
+    expect(s.total).toBe(2);
+    expect(s.isLoadingList).toBe(false);
+    expect(s.listError).toBeNull();
+    expect(mockedHubApi.listWorkspaces).toHaveBeenCalledWith({ limit: 20 });
+  });
+
+  it("fetchWorkspaces error — sets listError + isLoadingList=false", async () => {
+    mockedHubApi.listWorkspaces.mockRejectedValueOnce(
+      new ApiError("Internal", 500),
+    );
+
+    await useHubWorkspacesStore.getState().fetchWorkspaces();
+
+    const s = useHubWorkspacesStore.getState();
+    expect(s.workspaces).toEqual([]);
+    expect(s.isLoadingList).toBe(false);
+    expect(s.listError).not.toBeNull();
+    expect(s.listError?.status).toBe(500);
+  });
+
+  it("createWorkspace success — pushes new workspace at the head", async () => {
+    // Préparer la liste existante
+    useHubWorkspacesStore.setState({
+      workspaces: [makeWorkspace({ id: 1, name: "Existing" })],
+      total: 1,
+    });
+
+    const created = makeWorkspace({ id: 99, name: "Brand new" });
+    mockedHubApi.createWorkspace.mockResolvedValueOnce(created);
+
+    const result = await useHubWorkspacesStore
+      .getState()
+      .createWorkspace({ name: "Brand new", summary_ids: [10, 20] });
+
+    expect(result.id).toBe(99);
+    const s = useHubWorkspacesStore.getState();
+    expect(s.workspaces[0].id).toBe(99);
+    expect(s.workspaces).toHaveLength(2);
+    expect(s.total).toBe(2);
+    expect(s.isCreating).toBe(false);
+    expect(s.createError).toBeNull();
+  });
+
+  it("createWorkspace gating error 403 — friendly Expert message + re-throw", async () => {
+    mockedHubApi.createWorkspace.mockRejectedValueOnce(
+      new ApiError("Expert plan required", 403),
+    );
+
+    await expect(
+      useHubWorkspacesStore
+        .getState()
+        .createWorkspace({ name: "X", summary_ids: [1, 2] }),
+    ).rejects.toBeInstanceOf(ApiError);
+
+    const s = useHubWorkspacesStore.getState();
+    expect(s.createError).not.toBeNull();
+    expect(s.createError?.status).toBe(403);
+    expect(s.createError?.isGatingError).toBe(true);
+    expect(s.createError?.isQuotaError).toBe(false);
+    expect(s.createError?.message.toLowerCase()).toContain("expert");
+    expect(s.isCreating).toBe(false);
+  });
+
+  it("createWorkspace quota error 429 — friendly Limite 5 message", async () => {
+    mockedHubApi.createWorkspace.mockRejectedValueOnce(
+      new ApiError("Quota exceeded", 429),
+    );
+
+    await expect(
+      useHubWorkspacesStore
+        .getState()
+        .createWorkspace({ name: "X", summary_ids: [1, 2] }),
+    ).rejects.toBeInstanceOf(ApiError);
+
+    const s = useHubWorkspacesStore.getState();
+    expect(s.createError).not.toBeNull();
+    expect(s.createError?.status).toBe(429);
+    expect(s.createError?.isQuotaError).toBe(true);
+    expect(s.createError?.isGatingError).toBe(false);
+    expect(s.createError?.message).toContain("Limite 5");
+    expect(s.isCreating).toBe(false);
+  });
+
+  it("deleteWorkspace optimistic remove — workspace disparait avant settle", async () => {
+    useHubWorkspacesStore.setState({
+      workspaces: [
+        makeWorkspace({ id: 1, name: "Keep" }),
+        makeWorkspace({ id: 2, name: "Delete me" }),
+        makeWorkspace({ id: 3, name: "Keep too" }),
+      ],
+      total: 3,
+    });
+
+    // Resolve avec un délai pour observer l'état optimistic
+    let resolveDelete: () => void = () => {};
+    mockedHubApi.deleteWorkspace.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+    );
+
+    const deletePromise = useHubWorkspacesStore.getState().deleteWorkspace(2);
+
+    // Vérifier le retrait optimistic AVANT que la promise serveur ne resolve
+    const sMid = useHubWorkspacesStore.getState();
+    expect(sMid.workspaces.find((w) => w.id === 2)).toBeUndefined();
+    expect(sMid.workspaces).toHaveLength(2);
+    expect(sMid.total).toBe(2);
+
+    // Maintenant resolve la promise serveur
+    resolveDelete();
+    await deletePromise;
+
+    const sFinal = useHubWorkspacesStore.getState();
+    expect(sFinal.workspaces).toHaveLength(2);
+    expect(sFinal.workspaces.map((w) => w.id)).toEqual([1, 3]);
+    expect(sFinal.total).toBe(2);
+  });
+});

--- a/frontend/src/store/useHubWorkspacesStore.ts
+++ b/frontend/src/store/useHubWorkspacesStore.ts
@@ -1,0 +1,259 @@
+/**
+ * ╔════════════════════════════════════════════════════════════════════════════════════╗
+ * ║  🧩 useHubWorkspacesStore — Zustand store for Hub Miro Workspaces                  ║
+ * ╠════════════════════════════════════════════════════════════════════════════════════╣
+ * ║  Spec : Sprint Hub Miro Workspace MVP — Wave 2a Agent B                            ║
+ * ║  Backend : PR #335 (commit 17bf81ae) — endpoints /api/hub/workspaces               ║
+ * ║                                                                                    ║
+ * ║  Distinct du store `useHubStore` existant (conversations / messages / tabs).        ║
+ * ║  Pas de persist — workspaces fetched fresh à chaque mount.                          ║
+ * ║                                                                                    ║
+ * ║  Erreurs API : on conserve le `status` dans le state via les codes friendly        ║
+ * ║  pour que l'UI puisse distinguer 401 / 403 / 404 / 429 / 400 via le message ou     ║
+ * ║  via les flags `isQuotaError` / `isGatingError` dérivés en lecture.                 ║
+ * ╚════════════════════════════════════════════════════════════════════════════════════╝
+ */
+
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import {
+  hubApi,
+  ApiError,
+  type HubWorkspace,
+  type HubWorkspaceCreatePayload,
+} from "../services/api";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🪪 Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface HubWorkspaceErrorState {
+  status: number; // 0 si network error / non-ApiError
+  message: string;
+  /** True si quota cap 5/30j atteint (HTTP 429). */
+  isQuotaError: boolean;
+  /** True si l'utilisateur n'est pas Expert (HTTP 403). */
+  isGatingError: boolean;
+}
+
+interface HubWorkspacesState {
+  // ─── List ────────────────────────────────────────────────────────────────
+  workspaces: HubWorkspace[];
+  total: number;
+  isLoadingList: boolean;
+  listError: HubWorkspaceErrorState | null;
+
+  // ─── Current ─────────────────────────────────────────────────────────────
+  currentWorkspace: HubWorkspace | null;
+  isLoadingCurrent: boolean;
+
+  // ─── Mutations ───────────────────────────────────────────────────────────
+  isCreating: boolean;
+  createError: HubWorkspaceErrorState | null;
+
+  // ─── Actions ─────────────────────────────────────────────────────────────
+  fetchWorkspaces: (params?: {
+    limit?: number;
+    offset?: number;
+  }) => Promise<void>;
+  fetchWorkspace: (id: number) => Promise<void>;
+  createWorkspace: (
+    payload: HubWorkspaceCreatePayload,
+  ) => Promise<HubWorkspace>;
+  deleteWorkspace: (id: number) => Promise<void>;
+  clearErrors: () => void;
+  reset: () => void;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🛠️ Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function toErrorState(err: unknown, fallback: string): HubWorkspaceErrorState {
+  if (err instanceof ApiError) {
+    let friendly = err.message || fallback;
+    const isQuota = err.status === 429;
+    const isGating = err.status === 403;
+    if (isQuota) {
+      friendly =
+        "Limite 5 workspaces atteinte sur les 30 derniers jours. " +
+        "Supprimez un workspace existant pour en créer un nouveau.";
+    } else if (isGating) {
+      friendly =
+        "Cette fonctionnalité est réservée au plan Expert. " +
+        "Mettez à niveau votre abonnement pour créer des workspaces Hub.";
+    }
+    return {
+      status: err.status,
+      message: friendly,
+      isQuotaError: isQuota,
+      isGatingError: isGating,
+    };
+  }
+  const message = err instanceof Error ? err.message : fallback;
+  return {
+    status: 0,
+    message,
+    isQuotaError: false,
+    isGatingError: false,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🌱 Initial state
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const INITIAL: Pick<
+  HubWorkspacesState,
+  | "workspaces"
+  | "total"
+  | "isLoadingList"
+  | "listError"
+  | "currentWorkspace"
+  | "isLoadingCurrent"
+  | "isCreating"
+  | "createError"
+> = {
+  workspaces: [],
+  total: 0,
+  isLoadingList: false,
+  listError: null,
+  currentWorkspace: null,
+  isLoadingCurrent: false,
+  isCreating: false,
+  createError: null,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🏪 Store
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const useHubWorkspacesStore = create<HubWorkspacesState>()(
+  immer((set, get) => ({
+    ...INITIAL,
+
+    // ─── fetchWorkspaces ─────────────────────────────────────────────────
+    fetchWorkspaces: async (params) => {
+      set((s) => {
+        s.isLoadingList = true;
+        s.listError = null;
+      });
+      try {
+        const res = await hubApi.listWorkspaces(params);
+        set((s) => {
+          s.workspaces = res.items;
+          s.total = res.total;
+          s.isLoadingList = false;
+        });
+      } catch (err) {
+        set((s) => {
+          s.listError = toErrorState(
+            err,
+            "Impossible de charger les workspaces.",
+          );
+          s.isLoadingList = false;
+        });
+      }
+    },
+
+    // ─── fetchWorkspace ──────────────────────────────────────────────────
+    fetchWorkspace: async (id) => {
+      set((s) => {
+        s.isLoadingCurrent = true;
+      });
+      try {
+        const ws = await hubApi.getWorkspace(id);
+        set((s) => {
+          s.currentWorkspace = ws;
+          s.isLoadingCurrent = false;
+        });
+      } catch (err) {
+        set((s) => {
+          s.listError = toErrorState(
+            err,
+            "Impossible de charger ce workspace.",
+          );
+          s.isLoadingCurrent = false;
+        });
+      }
+    },
+
+    // ─── createWorkspace ─────────────────────────────────────────────────
+    createWorkspace: async (payload) => {
+      set((s) => {
+        s.isCreating = true;
+        s.createError = null;
+      });
+      try {
+        const ws = await hubApi.createWorkspace(payload);
+        set((s) => {
+          // Push en tête de liste pour reflet immédiat dans l'UI
+          s.workspaces.unshift(ws);
+          s.total = s.total + 1;
+          s.isCreating = false;
+        });
+        return ws;
+      } catch (err) {
+        set((s) => {
+          s.createError = toErrorState(
+            err,
+            "Impossible de créer le workspace.",
+          );
+          s.isCreating = false;
+        });
+        // Re-throw pour que l'UI (modal, toast, redirect) puisse aussi gérer
+        throw err;
+      }
+    },
+
+    // ─── deleteWorkspace ─────────────────────────────────────────────────
+    deleteWorkspace: async (id) => {
+      // Optimistic remove — snapshot avant suppression pour rollback éventuel
+      const snapshot = get().workspaces;
+      const previousTotal = get().total;
+      set((s) => {
+        s.workspaces = s.workspaces.filter((w) => w.id !== id);
+        s.total = Math.max(0, s.total - 1);
+      });
+      try {
+        await hubApi.deleteWorkspace(id);
+      } catch (err) {
+        // Rollback optimistic + reload depuis serveur pour réconcilier
+        set((s) => {
+          s.workspaces = snapshot;
+          s.total = previousTotal;
+          s.listError = toErrorState(
+            err,
+            "Impossible de supprimer ce workspace.",
+          );
+        });
+        // Re-fetch pour s'assurer de la source de vérité
+        try {
+          const res = await hubApi.listWorkspaces();
+          set((s) => {
+            s.workspaces = res.items;
+            s.total = res.total;
+          });
+        } catch {
+          // Si même la liste re-fetch échoue, on garde le snapshot rollback
+        }
+        throw err;
+      }
+    },
+
+    // ─── clearErrors ─────────────────────────────────────────────────────
+    clearErrors: () => {
+      set((s) => {
+        s.listError = null;
+        s.createError = null;
+      });
+    },
+
+    // ─── reset ───────────────────────────────────────────────────────────
+    reset: () => {
+      set((s) => {
+        Object.assign(s, INITIAL);
+      });
+    },
+  })),
+);


### PR DESCRIPTION
## Summary

Wave 2a Agent B — câble client frontend sur endpoints PR #335.

- `frontend/src/services/api.ts` : ajout namespace `hubApi` + 4 types TS alignés avec Pydantic backend (`backend/src/hub/schemas.py`).
- `frontend/src/store/useHubWorkspacesStore.ts` : nouveau store Zustand+Immer dédié, **séparé** du `hubStore` existant (conversations/messages). Pas de persist — fresh fetch à chaque mount.
- Erreurs friendly via `toErrorState` : 403 → message gating Expert, 429 → message "Limite 5 atteinte sur 30 derniers jours". Flags `isQuotaError` / `isGatingError` exposés au state pour l'UI.
- Optimistic `deleteWorkspace` avec rollback + reload sur échec.
- 6 tests Vitest verts (success, error, create push head, gating 403, quota 429, optimistic delete).

Aucun touch sur `frontend/src/components/` ni `frontend/src/pages/` (Wave 2b plus tard) ni sur `hubStore.ts` existant.

## Test plan

- [x] Typecheck filtré sur `useHubWorkspaces|hubApi` : aucune nouvelle erreur sur les ajouts (les erreurs `Concept[]` / `generateAudioSummary` sont pré-existantes hors scope)
- [x] Vitest `src/store/__tests__/useHubWorkspacesStore` : 6/6 passent
- [ ] Vercel deploy preview vert
- [ ] Tests Wave 2b (composants UI) à venir dans une PR séparée

🤖 Generated with [Claude Code](https://claude.com/claude-code)