### PR TITLE
feat(hub): multi-select Drawer + CreateWorkspaceModal

### DIFF
--- a/frontend/src/components/hub/ConversationsDrawer.tsx
+++ b/frontend/src/components/hub/ConversationsDrawer.tsx
@@ -1,7 +1,19 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useMemo, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, Search, Send, Sparkles } from "lucide-react";
+import {
+  X,
+  Search,
+  Send,
+  Sparkles,
+  CheckSquare,
+  Square,
+  Lock,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import type { HubConversation } from "./types";
+import { useAuthContext } from "../../contexts/AuthContext";
+import { useToast } from "../Toast";
+import { CreateWorkspaceModal } from "./CreateWorkspaceModal";
 
 interface Props {
   open: boolean;
@@ -24,6 +36,10 @@ const PLATFORM_ICON: Record<
   youtube: { src: "/platforms/youtube-icon-red.svg", alt: "YouTube" },
   tiktok: { src: "/platforms/tiktok-note-color.svg", alt: "TikTok" },
 };
+
+/** Cap dur côté UI : backend accepte 2..20. */
+const MAX_SELECTION = 20;
+const MIN_SELECTION = 2;
 
 const groupBy = (convs: HubConversation[]) => {
   const today: HubConversation[] = [];
@@ -67,8 +83,59 @@ export const ConversationsDrawer: React.FC<Props> = ({
   onSelect,
   onAnalyze,
 }) => {
+  const navigate = useNavigate();
+  const { user } = useAuthContext();
+  const { showToast, ToastComponent } = useToast();
+
   const [query, setQuery] = useState("");
   const [newUrl, setNewUrl] = useState("");
+
+  // ─── Multi-select state (Hub Workspace) ──────────────────────────────────
+  const [isSelectMode, setIsSelectMode] = useState(false);
+  const [selectedSummaryIds, setSelectedSummaryIds] = useState<Set<number>>(
+    () => new Set(),
+  );
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+
+  /** Plan Expert requis pour Hub Workspace (gating). */
+  const canUseHubWorkspace = user?.plan === "expert";
+
+  // Reset le mode select quand le drawer se ferme.
+  useEffect(() => {
+    if (!open) {
+      setIsSelectMode(false);
+      setSelectedSummaryIds(new Set());
+    }
+  }, [open]);
+
+  const exitSelectMode = useCallback(() => {
+    setIsSelectMode(false);
+    setSelectedSummaryIds(new Set());
+  }, []);
+
+  const toggleSelection = useCallback(
+    (summaryId: number | null) => {
+      // Conv free-form (pas de vidéo attachée) → ignoré (pas d'analyse à inclure).
+      if (summaryId === null) return;
+      setSelectedSummaryIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(summaryId)) {
+          next.delete(summaryId);
+        } else {
+          if (next.size >= MAX_SELECTION) {
+            showToast(
+              `Maximum ${MAX_SELECTION} analyses par workspace.`,
+              "warning",
+            );
+            return prev;
+          }
+          next.add(summaryId);
+        }
+        return next;
+      });
+    },
+    [showToast],
+  );
 
   const handleAnalyzeSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -82,14 +149,22 @@ export const ConversationsDrawer: React.FC<Props> = ({
     [newUrl, onAnalyze, onClose],
   );
 
-  if (!open) return null;
-
-  const filtered = conversations.filter((c) =>
-    (c.title + " " + (c.last_snippet ?? ""))
-      .toLowerCase()
-      .includes(query.toLowerCase()),
+  const filtered = useMemo(
+    () =>
+      conversations.filter((c) =>
+        (c.title + " " + (c.last_snippet ?? ""))
+          .toLowerCase()
+          .includes(query.toLowerCase()),
+      ),
+    [conversations, query],
   );
-  const grouped = groupBy(filtered);
+
+  const grouped = useMemo(() => groupBy(filtered), [filtered]);
+
+  const selectedCount = selectedSummaryIds.size;
+  const canCreate = selectedCount >= MIN_SELECTION;
+
+  if (!open) return null;
 
   const renderGroup = (label: string, items: HubConversation[]) => {
     if (items.length === 0) return null;
@@ -98,61 +173,96 @@ export const ConversationsDrawer: React.FC<Props> = ({
         <p className="font-mono text-[10px] tracking-[.12em] text-white/35 uppercase px-3 mb-1.5">
           {label}
         </p>
-        {items.map((c) => (
-          <button
-            key={c.id}
-            type="button"
-            data-conv-id={c.id}
-            onClick={() => {
-              onSelect(c.id);
-              onClose();
-            }}
-            className={
-              "w-full px-3 py-2 rounded-lg mb-0.5 flex gap-2.5 items-start text-left transition-colors " +
-              (c.id === activeConvId
-                ? "bg-indigo-500/15 border border-indigo-500/40 ring-2 ring-indigo-500/30"
-                : "border border-transparent hover:bg-white/[0.04]")
-            }
-          >
-            {c.video_thumbnail_url ? (
-              <div className="w-10 h-6 rounded overflow-hidden bg-white/[0.04] flex-shrink-0 mt-0.5">
-                <img
-                  src={c.video_thumbnail_url}
-                  alt=""
-                  className="w-full h-full object-cover"
-                />
+        {items.map((c) => {
+          const isChecked =
+            c.summary_id !== null && selectedSummaryIds.has(c.summary_id);
+          const isActive = c.id === activeConvId && !isSelectMode;
+          // Conversations free-form (sans summary_id) sont visibles mais non
+          // sélectionnables en mode select — visuellement dimmed.
+          const isSelectable = isSelectMode && c.summary_id !== null;
+          const isDimmedInSelectMode = isSelectMode && c.summary_id === null;
+
+          return (
+            <button
+              key={c.id}
+              type="button"
+              data-conv-id={c.id}
+              aria-pressed={isSelectMode ? isChecked : undefined}
+              onClick={() => {
+                if (isSelectMode) {
+                  toggleSelection(c.summary_id);
+                  return;
+                }
+                onSelect(c.id);
+                onClose();
+              }}
+              disabled={isDimmedInSelectMode}
+              className={
+                "w-full px-3 py-2 rounded-lg mb-0.5 flex gap-2.5 items-start text-left transition-colors " +
+                (isActive
+                  ? "bg-indigo-500/15 border border-indigo-500/40 ring-2 ring-indigo-500/30"
+                  : isChecked
+                    ? "bg-indigo-500/10 border border-indigo-500/30"
+                    : "border border-transparent hover:bg-white/[0.04]") +
+                (isDimmedInSelectMode ? " opacity-40 cursor-not-allowed" : "")
+              }
+            >
+              {isSelectMode && (
+                <div
+                  className="w-4 h-4 flex-shrink-0 mt-0.5 grid place-items-center"
+                  aria-hidden="true"
+                >
+                  {isSelectable ? (
+                    isChecked ? (
+                      <CheckSquare className="w-4 h-4 text-indigo-400" />
+                    ) : (
+                      <Square className="w-4 h-4 text-white/40" />
+                    )
+                  ) : (
+                    <Square className="w-4 h-4 text-white/15" />
+                  )}
+                </div>
+              )}
+              {c.video_thumbnail_url ? (
+                <div className="w-10 h-6 rounded overflow-hidden bg-white/[0.04] flex-shrink-0 mt-0.5">
+                  <img
+                    src={c.video_thumbnail_url}
+                    alt=""
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+              ) : c.video_source && PLATFORM_ICON[c.video_source] ? (
+                <div className="w-4 h-4 flex-shrink-0 mt-0.5 grid place-items-center">
+                  <img
+                    src={PLATFORM_ICON[c.video_source].src}
+                    alt={PLATFORM_ICON[c.video_source].alt}
+                    width={16}
+                    height={16}
+                    className="opacity-90"
+                  />
+                </div>
+              ) : (
+                <div className="w-4 h-4 flex-shrink-0 mt-0.5 rounded bg-white/[0.04]" />
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-[13px] text-white/85 truncate">{c.title}</p>
+                <p className="text-[11px] text-white/45 truncate mt-0.5 flex items-center gap-1.5">
+                  {c.last_snippet ? (
+                    <span className="truncate">{c.last_snippet}</span>
+                  ) : null}
+                  {c.last_snippet && fmtShortDate(c.updated_at) && (
+                    <span className="text-white/30">·</span>
+                  )}
+                  {fmtShortDate(c.updated_at) && (
+                    <span className="font-mono text-white/35 flex-shrink-0">
+                      {fmtShortDate(c.updated_at)}
+                    </span>
+                  )}
+                </p>
               </div>
-            ) : c.video_source && PLATFORM_ICON[c.video_source] ? (
-              <div className="w-4 h-4 flex-shrink-0 mt-0.5 grid place-items-center">
-                <img
-                  src={PLATFORM_ICON[c.video_source].src}
-                  alt={PLATFORM_ICON[c.video_source].alt}
-                  width={16}
-                  height={16}
-                  className="opacity-90"
-                />
-              </div>
-            ) : (
-              <div className="w-4 h-4 flex-shrink-0 mt-0.5 rounded bg-white/[0.04]" />
-            )}
-            <div className="flex-1 min-w-0">
-              <p className="text-[13px] text-white/85 truncate">{c.title}</p>
-              <p className="text-[11px] text-white/45 truncate mt-0.5 flex items-center gap-1.5">
-                {c.last_snippet ? (
-                  <span className="truncate">{c.last_snippet}</span>
-                ) : null}
-                {c.last_snippet && fmtShortDate(c.updated_at) && (
-                  <span className="text-white/30">·</span>
-                )}
-                {fmtShortDate(c.updated_at) && (
-                  <span className="font-mono text-white/35 flex-shrink-0">
-                    {fmtShortDate(c.updated_at)}
-                  </span>
-                )}
-              </p>
-            </div>
-          </button>
-        ))}
+            </button>
+          );
+        })}
       </div>
     );
   };
@@ -175,21 +285,67 @@ export const ConversationsDrawer: React.FC<Props> = ({
         transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
         className="fixed inset-y-0 left-0 z-50 w-[320px] max-w-[85vw] bg-[#0c0c14] border-r border-white/10 flex flex-col"
       >
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-white/10">
-          <button
-            type="button"
-            aria-label="fermer"
-            onClick={onClose}
-            className="w-8 h-8 grid place-items-center rounded-lg hover:bg-white/[0.06] text-white/65"
-          >
-            <X className="w-4 h-4" />
-          </button>
-          <span className="flex-1 text-sm font-medium text-white">
-            Conversations
-          </span>
-        </div>
+        {/* ─── Header ─────────────────────────────────────────────── */}
+        {isSelectMode ? (
+          <div className="flex items-center gap-2 px-3 py-3 border-b border-white/10 bg-indigo-500/[0.06]">
+            <span className="flex-1 text-[13px] font-medium text-white">
+              {selectedCount} / {MAX_SELECTION} sélectionnée
+              {selectedCount > 1 ? "s" : ""}
+            </span>
+            <button
+              type="button"
+              onClick={exitSelectMode}
+              className="px-2.5 py-1 rounded-md text-[12px] text-white/65 hover:bg-white/[0.06] transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="button"
+              disabled={!canCreate}
+              onClick={() => setCreateModalOpen(true)}
+              className="px-3 py-1 rounded-md bg-indigo-500 text-white text-[12px] font-medium hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Créer Workspace
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3 px-4 py-3 border-b border-white/10">
+            <button
+              type="button"
+              aria-label="fermer"
+              onClick={onClose}
+              className="w-8 h-8 grid place-items-center rounded-lg hover:bg-white/[0.06] text-white/65"
+            >
+              <X className="w-4 h-4" />
+            </button>
+            <span className="flex-1 text-sm font-medium text-white">
+              Conversations
+            </span>
+            {canUseHubWorkspace ? (
+              <button
+                type="button"
+                aria-label="Sélectionner pour créer un workspace"
+                title="Sélectionner pour créer un workspace"
+                onClick={() => setIsSelectMode(true)}
+                className="w-8 h-8 grid place-items-center rounded-lg hover:bg-white/[0.06] text-white/65 hover:text-indigo-300 transition-colors"
+              >
+                <CheckSquare className="w-4 h-4" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                aria-label="Hub Workspace est réservé au plan Expert"
+                title="Hub Workspace est réservé au plan Expert — cliquez pour passer à Expert"
+                onClick={() => navigate("/upgrade")}
+                className="w-8 h-8 grid place-items-center rounded-lg hover:bg-amber-500/10 text-white/40 hover:text-amber-300 transition-colors"
+              >
+                <Lock className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </div>
+        )}
 
-        {onAnalyze && (
+        {!isSelectMode && onAnalyze && (
           <div className="px-3 pt-3 pb-1">
             <form onSubmit={handleAnalyzeSubmit} className="relative">
               <Sparkles className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-indigo-400 pointer-events-none" />
@@ -216,6 +372,15 @@ export const ConversationsDrawer: React.FC<Props> = ({
           </div>
         )}
 
+        {isSelectMode && (
+          <div className="px-3 pt-2 pb-1">
+            <p className="text-[11px] text-white/55 leading-relaxed">
+              Sélectionnez {MIN_SELECTION} à {MAX_SELECTION} analyses pour créer
+              un workspace Miro.
+            </p>
+          </div>
+        )}
+
         <div className="px-3 pt-2 pb-2 relative">
           <Search className="absolute left-5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
           <input
@@ -238,6 +403,20 @@ export const ConversationsDrawer: React.FC<Props> = ({
           )}
         </div>
       </motion.aside>
+
+      <CreateWorkspaceModal
+        isOpen={createModalOpen}
+        onClose={() => setCreateModalOpen(false)}
+        initialSummaryIds={Array.from(selectedSummaryIds)}
+        onCreated={() => {
+          // Le store push déjà le workspace dans la liste — on quitte le
+          // mode select et on ferme le drawer pour laisser place au feedback
+          // visuel (toast + retour au Hub).
+          exitSelectMode();
+          onClose();
+        }}
+      />
+      {ToastComponent}
     </AnimatePresence>
   );
 };

--- a/frontend/src/components/hub/CreateWorkspaceModal.tsx
+++ b/frontend/src/components/hub/CreateWorkspaceModal.tsx
@@ -1,0 +1,266 @@
+/**
+ * CreateWorkspaceModal — modal de création d'un Hub Workspace Miro à partir
+ * d'une sélection de 2..20 analyses.
+ *
+ * Sprint Hub Miro Workspace MVP — Wave 2b Agent C.
+ * Backend : POST /api/hub/workspaces (PR #335).
+ * Store   : useHubWorkspacesStore (PR #337, Wave 2a Agent B).
+ *
+ * Comportement :
+ *   - Champ `name` (max 200 chars, required, non-vide après trim).
+ *   - Affiche le compteur "${initialSummaryIds.length} analyses sélectionnées".
+ *   - Au submit : appelle store.createWorkspace(payload). Le store push déjà
+ *     le workspace en tête de liste sur succès.
+ *   - Sur succès : appelle onCreated(workspace.id) puis onClose().
+ *   - Sur erreur : message friendly du store + cas spéciaux :
+ *       * isQuotaError (429) → message rouge + lien "Voir mes workspaces"
+ *         qui ferme le modal et redirige /hub/workspaces.
+ *       * isGatingError (403) → message + CTA "Mettre à niveau" → /upgrade
+ *         (defense in depth — bouton parent est déjà gated par plan).
+ *       * Autre → message générique du store.
+ *   - Loading : spinner inline + boutons disabled + click backdrop bloqué.
+ *   - A11y : role="dialog", aria-modal, escape pour fermer, focus auto sur input.
+ */
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Loader2, AlertCircle, ExternalLink, Sparkles } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useHubWorkspacesStore } from "../../store/useHubWorkspacesStore";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Garanti 2..20 par l'appelant (cap appliqué côté ConversationsDrawer). */
+  initialSummaryIds: number[];
+  /** Callback optionnel post-création (ex. navigation vers /hub/workspaces/:id). */
+  onCreated?: (workspaceId: number) => void;
+}
+
+const NAME_MAX_LEN = 200;
+
+export const CreateWorkspaceModal: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  initialSummaryIds,
+  onCreated,
+}) => {
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [name, setName] = useState("");
+  const isCreating = useHubWorkspacesStore((s) => s.isCreating);
+  const createError = useHubWorkspacesStore((s) => s.createError);
+  const createWorkspace = useHubWorkspacesStore((s) => s.createWorkspace);
+  const clearErrors = useHubWorkspacesStore((s) => s.clearErrors);
+
+  // Reset state lorsque le modal se ferme.
+  useEffect(() => {
+    if (!isOpen) {
+      setName("");
+      clearErrors();
+    }
+  }, [isOpen, clearErrors]);
+
+  // Focus auto sur l'input à l'ouverture.
+  useEffect(() => {
+    if (isOpen) {
+      const t = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [isOpen]);
+
+  // Escape pour fermer (mais pas pendant le loading).
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !isCreating) {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isOpen, isCreating, onClose]);
+
+  const handleSubmit = useCallback(
+    async (e?: React.FormEvent) => {
+      e?.preventDefault();
+      const trimmed = name.trim();
+      if (!trimmed || isCreating) return;
+      try {
+        const ws = await createWorkspace({
+          name: trimmed,
+          summary_ids: initialSummaryIds,
+        });
+        onCreated?.(ws.id);
+        onClose();
+      } catch {
+        // L'erreur est déjà capturée dans le store (createError).
+        // On ne ferme PAS le modal : l'utilisateur voit le message friendly.
+      }
+    },
+    [name, isCreating, createWorkspace, initialSummaryIds, onCreated, onClose],
+  );
+
+  const handleQuotaRedirect = useCallback(() => {
+    onClose();
+    navigate("/hub/workspaces");
+  }, [onClose, navigate]);
+
+  const handleUpgradeRedirect = useCallback(() => {
+    onClose();
+    navigate("/upgrade");
+  }, [onClose, navigate]);
+
+  if (!isOpen) return null;
+
+  const trimmedName = name.trim();
+  const submitDisabled = isCreating || trimmedName.length === 0;
+  const count = initialSummaryIds.length;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        key="create-workspace-backdrop"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black/70 backdrop-blur-md z-50"
+        onClick={isCreating ? undefined : onClose}
+      />
+      <motion.div
+        key="create-workspace-modal"
+        initial={{ opacity: 0, scale: 0.95, y: 20 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 20 }}
+        transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[min(540px,90vw)] bg-[#0c0c14] border border-white/10 rounded-2xl shadow-[0_24px_64px_rgba(0,0,0,.6)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-workspace-title"
+      >
+        <form onSubmit={handleSubmit}>
+          <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+            <div className="flex items-center gap-2">
+              <Sparkles className="w-4 h-4 text-indigo-400" />
+              <h2
+                id="create-workspace-title"
+                className="text-sm font-medium text-white"
+              >
+                Créer un workspace Hub
+              </h2>
+            </div>
+            <button
+              type="button"
+              aria-label="Fermer"
+              onClick={onClose}
+              disabled={isCreating}
+              className="w-7 h-7 grid place-items-center rounded-lg hover:bg-white/[0.06] text-white/55 disabled:opacity-30"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          <div className="px-5 py-4 flex flex-col gap-3">
+            <p className="text-[13px] text-white/60 leading-relaxed">
+              Donnez un nom à votre workspace. Un board Miro sera généré
+              automatiquement à partir des analyses sélectionnées.
+            </p>
+
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-indigo-500/10 border border-indigo-500/25">
+              <span className="text-[12px] text-indigo-200 font-mono">
+                {count}{" "}
+                {count > 1 ? "analyses sélectionnées" : "analyse sélectionnée"}
+              </span>
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="workspace-name"
+                className="text-[11px] text-white/50 font-medium uppercase tracking-wider"
+              >
+                Nom du workspace
+              </label>
+              <input
+                ref={inputRef}
+                id="workspace-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={isCreating}
+                maxLength={NAME_MAX_LEN}
+                placeholder="Ex. Conscience & cognition — avril 2026"
+                className="w-full bg-white/[0.04] border border-white/10 rounded-lg px-3 py-2.5 text-[13px] text-white placeholder-white/30 outline-none focus:border-indigo-500/40 disabled:opacity-50"
+              />
+              <p className="text-[10px] text-white/35 px-1">
+                {name.length}/{NAME_MAX_LEN}
+              </p>
+            </div>
+
+            {createError && (
+              <div className="flex flex-col gap-2 px-3 py-2.5 rounded-lg bg-red-500/10 border border-red-500/25">
+                <div className="flex items-start gap-2 text-[12px] text-red-300">
+                  <AlertCircle className="w-3.5 h-3.5 mt-px flex-shrink-0" />
+                  <span>{createError.message}</span>
+                </div>
+                {createError.isQuotaError && (
+                  <button
+                    type="button"
+                    onClick={handleQuotaRedirect}
+                    className="self-start flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-red-500/15 hover:bg-red-500/25 border border-red-500/30 text-[11px] text-red-200 transition-colors"
+                  >
+                    <ExternalLink className="w-3 h-3" />
+                    Voir mes workspaces
+                  </button>
+                )}
+                {createError.isGatingError && (
+                  <button
+                    type="button"
+                    onClick={handleUpgradeRedirect}
+                    className="self-start flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-amber-500/15 hover:bg-amber-500/25 border border-amber-500/30 text-[11px] text-amber-200 transition-colors"
+                  >
+                    <ExternalLink className="w-3 h-3" />
+                    Passer au plan Expert
+                  </button>
+                )}
+              </div>
+            )}
+
+            {isCreating && (
+              <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-indigo-500/10 border border-indigo-500/20">
+                <Loader2 className="w-3.5 h-3.5 animate-spin text-indigo-300" />
+                <span className="text-[12px] text-indigo-200">
+                  Création du workspace…
+                </span>
+              </div>
+            )}
+          </div>
+
+          <div className="px-5 py-4 border-t border-white/10 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isCreating}
+              className="px-3.5 py-1.5 rounded-lg text-[13px] text-white/65 hover:bg-white/[0.04] disabled:opacity-30"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={submitDisabled}
+              className="px-4 py-1.5 rounded-lg bg-indigo-500 text-white text-[13px] font-medium hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
+            >
+              {isCreating ? (
+                <>
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  Création…
+                </>
+              ) : (
+                "Créer"
+              )}
+            </button>
+          </div>
+        </form>
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/frontend/src/components/hub/__tests__/ConversationsDrawer.test.tsx
+++ b/frontend/src/components/hub/__tests__/ConversationsDrawer.test.tsx
@@ -1,7 +1,31 @@
+import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { ConversationsDrawer } from "../ConversationsDrawer";
+import { AuthProvider } from "../../../contexts/AuthContext";
 import type { HubConversation } from "../types";
+import type { User } from "../../../types/api";
+
+// Mock useHubWorkspacesStore — pas utilisé par les tests existants mais
+// présent dans la chaîne d'import depuis Wave 2b (CreateWorkspaceModal).
+vi.mock("../../../store/useHubWorkspacesStore", () => {
+  const useHubWorkspacesStore = <T,>(
+    selector: (s: {
+      isCreating: boolean;
+      createError: null;
+      createWorkspace: () => Promise<unknown>;
+      clearErrors: () => void;
+    }) => T,
+  ): T =>
+    selector({
+      isCreating: false,
+      createError: null,
+      createWorkspace: vi.fn(),
+      clearErrors: vi.fn(),
+    });
+  return { useHubWorkspacesStore };
+});
 
 const convs: HubConversation[] = [
   {
@@ -24,59 +48,91 @@ const convs: HubConversation[] = [
   },
 ];
 
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    username: "test",
+    email: "test@example.com",
+    email_verified: true,
+    plan: "free",
+    credits: 0,
+    credits_monthly: 0,
+    is_admin: false,
+    total_videos: 0,
+    total_words: 0,
+    total_playlists: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderDrawer(
+  drawerProps: Parameters<typeof ConversationsDrawer>[0],
+  user: User | null = makeUser(),
+) {
+  const authValue = {
+    user,
+    loading: false,
+    error: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    register: vi.fn(),
+    loginWithGoogle: vi.fn(),
+  };
+  return render(
+    <MemoryRouter>
+      <AuthProvider value={authValue}>
+        <ConversationsDrawer {...drawerProps} />
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
 describe("ConversationsDrawer", () => {
   it("renders nothing when closed", () => {
-    const { container } = render(
-      <ConversationsDrawer
-        open={false}
-        onClose={() => {}}
-        conversations={convs}
-        activeConvId={null}
-        onSelect={() => {}}
-      />,
-    );
+    const { container } = renderDrawer({
+      open: false,
+      onClose: () => {},
+      conversations: convs,
+      activeConvId: null,
+      onSelect: () => {},
+    });
     expect(container.firstChild).toBeNull();
   });
 
   it("renders conversations when open", () => {
-    render(
-      <ConversationsDrawer
-        open={true}
-        onClose={() => {}}
-        conversations={convs}
-        activeConvId={null}
-        onSelect={() => {}}
-      />,
-    );
+    renderDrawer({
+      open: true,
+      onClose: () => {},
+      conversations: convs,
+      activeConvId: null,
+      onSelect: () => {},
+    });
     expect(screen.getByText("Lex Fridman · conscience")).toBeInTheDocument();
     expect(screen.getByText("Naval · le levier")).toBeInTheDocument();
   });
 
   it("calls onSelect with conv id when clicked", () => {
     const onSelect = vi.fn();
-    render(
-      <ConversationsDrawer
-        open={true}
-        onClose={() => {}}
-        conversations={convs}
-        activeConvId={null}
-        onSelect={onSelect}
-      />,
-    );
+    renderDrawer({
+      open: true,
+      onClose: () => {},
+      conversations: convs,
+      activeConvId: null,
+      onSelect,
+    });
     fireEvent.click(screen.getByText("Naval · le levier"));
     expect(onSelect).toHaveBeenCalledWith(2);
   });
 
   it("filters by search query", () => {
-    render(
-      <ConversationsDrawer
-        open={true}
-        onClose={() => {}}
-        conversations={convs}
-        activeConvId={null}
-        onSelect={() => {}}
-      />,
-    );
+    renderDrawer({
+      open: true,
+      onClose: () => {},
+      conversations: convs,
+      activeConvId: null,
+      onSelect: () => {},
+    });
     fireEvent.change(screen.getByPlaceholderText(/rechercher/i), {
       target: { value: "Naval" },
     });
@@ -85,40 +141,122 @@ describe("ConversationsDrawer", () => {
   });
 
   it("active conv item has visible indigo ring (F13)", () => {
-    const { container } = render(
-      <ConversationsDrawer
-        open={true}
-        onClose={() => {}}
-        conversations={convs}
-        activeConvId={2}
-        onSelect={() => {}}
-      />,
-    );
+    const { container } = renderDrawer({
+      open: true,
+      onClose: () => {},
+      conversations: convs,
+      activeConvId: 2,
+      onSelect: () => {},
+    });
     const activeBtn = container.querySelector('[data-conv-id="2"]');
     expect(activeBtn?.className).toMatch(/ring-2/);
     expect(activeBtn?.className).toMatch(/ring-indigo/);
   });
 
   it("displays short date under each conversation title (F13)", () => {
-    render(
-      <ConversationsDrawer
-        open={true}
-        onClose={() => {}}
-        conversations={[
-          {
-            id: 99,
-            summary_id: 99,
-            title: "Conv avec date",
-            video_source: "youtube",
-            video_thumbnail_url: null,
-            updated_at: "2026-04-15T10:00:00Z",
-          },
-        ]}
-        activeConvId={null}
-        onSelect={() => {}}
-      />,
-    );
+    renderDrawer({
+      open: true,
+      onClose: () => {},
+      conversations: [
+        {
+          id: 99,
+          summary_id: 99,
+          title: "Conv avec date",
+          video_source: "youtube",
+          video_thumbnail_url: null,
+          updated_at: "2026-04-15T10:00:00Z",
+        },
+      ],
+      activeConvId: null,
+      onSelect: () => {},
+    });
     // Format FR : "15 avr." en 2026
     expect(screen.getByText(/15 avr/)).toBeInTheDocument();
+  });
+
+  // ─── Multi-select gating (Wave 2b Agent C) ──────────────────────────────
+  it("shows lock icon when user is on free plan", () => {
+    renderDrawer(
+      {
+        open: true,
+        onClose: () => {},
+        conversations: convs,
+        activeConvId: null,
+        onSelect: () => {},
+      },
+      makeUser({ plan: "free" }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: /hub workspace est réservé au plan expert/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows select button when user is on expert plan", () => {
+    renderDrawer(
+      {
+        open: true,
+        onClose: () => {},
+        conversations: convs,
+        activeConvId: null,
+        onSelect: () => {},
+      },
+      makeUser({ plan: "expert" }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: /sélectionner pour créer un workspace/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("entering select mode disables conversation navigation and toggles selection", () => {
+    const onSelect = vi.fn();
+    renderDrawer(
+      {
+        open: true,
+        onClose: () => {},
+        conversations: convs,
+        activeConvId: null,
+        onSelect,
+      },
+      makeUser({ plan: "expert" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /sélectionner pour créer un workspace/i,
+      }),
+    );
+    // Header bascule en mode select.
+    expect(screen.getByText(/0 \/ 20 sélectionnée/i)).toBeInTheDocument();
+    // Click sur une conv → toggle, pas navigation.
+    fireEvent.click(screen.getByText("Lex Fridman · conscience"));
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByText(/1 \/ 20 sélectionnée/i)).toBeInTheDocument();
+  });
+
+  it("create workspace button is disabled with less than 2 selections", () => {
+    renderDrawer(
+      {
+        open: true,
+        onClose: () => {},
+        conversations: convs,
+        activeConvId: null,
+        onSelect: () => {},
+      },
+      makeUser({ plan: "expert" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /sélectionner pour créer un workspace/i,
+      }),
+    );
+    const createBtn = screen.getByRole("button", { name: /créer workspace/i });
+    expect(createBtn).toBeDisabled();
+    fireEvent.click(screen.getByText("Lex Fridman · conscience"));
+    expect(createBtn).toBeDisabled();
+    fireEvent.click(screen.getByText("Naval · le levier"));
+    expect(createBtn).not.toBeDisabled();
   });
 });

--- a/frontend/src/components/hub/__tests__/CreateWorkspaceModal.test.tsx
+++ b/frontend/src/components/hub/__tests__/CreateWorkspaceModal.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Tests Vitest pour CreateWorkspaceModal.
+ * Wave 2b Agent C — Sprint Hub Miro Workspace MVP.
+ *
+ * Mocks :
+ *   - useHubWorkspacesStore (vi.mock du module store)
+ *   - react-router-dom : on garde le vrai mais wrap dans MemoryRouter
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { CreateWorkspaceModal } from "../CreateWorkspaceModal";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// State mutable utilisé pour reproduire le store Zustand côté test.
+interface FakeStoreState {
+  isCreating: boolean;
+  createError: {
+    status: number;
+    message: string;
+    isQuotaError: boolean;
+    isGatingError: boolean;
+  } | null;
+  createWorkspace: ReturnType<typeof vi.fn>;
+  clearErrors: ReturnType<typeof vi.fn>;
+}
+
+const fakeState: FakeStoreState = {
+  isCreating: false,
+  createError: null,
+  createWorkspace: vi.fn(),
+  clearErrors: vi.fn(),
+};
+
+vi.mock("../../../store/useHubWorkspacesStore", () => {
+  // Le composant utilise le selector pattern : useStore(s => s.isCreating).
+  // On expose une fonction qui prend un selector et lui passe fakeState.
+  const useHubWorkspacesStore = <T,>(selector: (s: FakeStoreState) => T): T =>
+    selector(fakeState);
+  return { useHubWorkspacesStore };
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function renderModal(
+  overrides: Partial<{
+    isOpen: boolean;
+    initialSummaryIds: number[];
+    onClose: () => void;
+    onCreated: (id: number) => void;
+  }> = {},
+) {
+  const props = {
+    isOpen: true,
+    onClose: vi.fn(),
+    initialSummaryIds: [10, 20, 30],
+    onCreated: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(
+    <MemoryRouter>
+      <CreateWorkspaceModal {...props} />
+    </MemoryRouter>,
+  );
+  return { ...utils, props };
+}
+
+function resetFakeState() {
+  fakeState.isCreating = false;
+  fakeState.createError = null;
+  fakeState.createWorkspace = vi.fn();
+  fakeState.clearErrors = vi.fn();
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("CreateWorkspaceModal", () => {
+  beforeEach(() => {
+    resetFakeState();
+    mockNavigate.mockReset();
+  });
+
+  it("renders disabled when name empty", () => {
+    renderModal();
+    const submitBtn = screen.getByRole("button", { name: /^créer$/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it("submits with correct payload to store", async () => {
+    fakeState.createWorkspace = vi.fn().mockResolvedValue({
+      id: 99,
+      name: "Mon workspace",
+      summary_ids: [10, 20, 30],
+      miro_board_id: null,
+      miro_board_url: null,
+      status: "pending",
+      error_message: null,
+      created_at: "2026-05-05T12:00:00Z",
+      updated_at: "2026-05-05T12:00:00Z",
+    });
+
+    const { props } = renderModal();
+    const input = screen.getByLabelText(/nom du workspace/i);
+    fireEvent.change(input, { target: { value: "Mon workspace" } });
+    const submitBtn = screen.getByRole("button", { name: /^créer$/i });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() =>
+      expect(fakeState.createWorkspace).toHaveBeenCalledWith({
+        name: "Mon workspace",
+        summary_ids: [10, 20, 30],
+      }),
+    );
+    await waitFor(() => expect(props.onCreated).toHaveBeenCalledWith(99));
+    await waitFor(() => expect(props.onClose).toHaveBeenCalled());
+  });
+
+  it("shows quota error with link to /hub/workspaces", async () => {
+    fakeState.createError = {
+      status: 429,
+      message:
+        "Limite 5 workspaces atteinte sur les 30 derniers jours. Supprimez un workspace existant pour en créer un nouveau.",
+      isQuotaError: true,
+      isGatingError: false,
+    };
+    const { props } = renderModal();
+    expect(screen.getByText(/limite 5 workspaces atteinte/i)).toBeInTheDocument();
+    const link = screen.getByRole("button", { name: /voir mes workspaces/i });
+    fireEvent.click(link);
+    expect(props.onClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/hub/workspaces");
+  });
+
+  it("shows gating error with upgrade CTA", async () => {
+    fakeState.createError = {
+      status: 403,
+      message:
+        "Cette fonctionnalité est réservée au plan Expert. Mettez à niveau votre abonnement pour créer des workspaces Hub.",
+      isQuotaError: false,
+      isGatingError: true,
+    };
+    const { props } = renderModal();
+    expect(screen.getByText(/réservée au plan expert/i)).toBeInTheDocument();
+    const upgradeBtn = screen.getByRole("button", {
+      name: /passer au plan expert/i,
+    });
+    fireEvent.click(upgradeBtn);
+    expect(props.onClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/upgrade");
+  });
+
+  it("calls onCreated and onClose on success", async () => {
+    fakeState.createWorkspace = vi.fn().mockResolvedValue({
+      id: 42,
+      name: "WS",
+      summary_ids: [1, 2],
+      miro_board_id: null,
+      miro_board_url: null,
+      status: "pending",
+      error_message: null,
+      created_at: "2026-05-05T12:00:00Z",
+      updated_at: "2026-05-05T12:00:00Z",
+    });
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    renderModal({ onCreated, onClose, initialSummaryIds: [1, 2] });
+    fireEvent.change(screen.getByLabelText(/nom du workspace/i), {
+      target: { value: "Ok" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^créer$/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(42));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("closes on Escape key", () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Wave 2b Agent C — Hub Miro Workspace MVP

Câble UX de sélection 2..20 analyses + modal de création. Gating Expert visible (lock + upgrade CTA pour Pro/Free). Erreurs friendly (429 quota / 403 gating).

### Changements

**ConversationsDrawer** (`frontend/src/components/hub/ConversationsDrawer.tsx`)
- Nouveau mode opt-in `isSelectMode` + `selectedSummaryIds: Set<number>`.
- Header gating : `CheckSquare` (Expert) | `Lock` → `/upgrade` (Free/Pro).
- En mode select : header `${count} / 20 sélectionnée(s)` + Annuler + Créer Workspace (disabled `<2`).
- Click conv = toggle (pas navigation) ; conv sans `summary_id` dimmées non-sélectionnables.
- 21ᵉ sélection → toast warning (`useToast` existant).
- Reset auto à la fermeture du drawer — zéro impact sur le comportement default.

**CreateWorkspaceModal** (nouveau, `frontend/src/components/hub/CreateWorkspaceModal.tsx`)
- Modal contrôlé glassmorphism dark + Framer Motion.
- Champ `name` (max 200 chars, trim required) + compteur sélection.
- Submit → `useHubWorkspacesStore.createWorkspace`. Re-throw géré pour afficher l'erreur friendly du store.
- `isQuotaError` (429) → message rouge + lien `/hub/workspaces`.
- `isGatingError` (403) → CTA amber `/upgrade` (defense in depth).
- A11y : `role=dialog`, `aria-modal`, focus auto, Escape pour fermer.

### Tests Vitest

- 6/6 `CreateWorkspaceModal.test.tsx` (nouveau) — disabled-empty, payload, 429, 403, success, Escape.
- 10/10 `ConversationsDrawer.test.tsx` (étendu) — wrap MemoryRouter+AuthProvider + 4 tests couvrant gating + select mode.

### Spec & contexte

- Spec : PR #334 (planning)
- Backend : PR #335 (`POST /api/hub/workspaces`)
- Wave 2a : PR #336 (MiroBoardEmbed factorisé) + PR #337 (api.ts + useHubWorkspacesStore)

### Vérifications

- `tsc --noEmit` : aucune nouvelle erreur sur les fichiers touchés.
- Vitest : 16/16 verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)