### PR TITLE
feat(hub): Sidebar Workspaces nav item — Wave 2c discoverability fix

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -25,6 +25,7 @@ import {
   User,
   MessageCircle,
   GraduationCap,
+  LayoutGrid,
   Menu,
 } from "lucide-react";
 import { useAuth } from "../../hooks/useAuth";
@@ -85,6 +86,11 @@ interface NavItemProps {
   badge?: string;
   badgeClassName?: string;
   external?: boolean;
+  /**
+   * Si true, l'item n'est actif que sur l'URL exacte (pas les enfants).
+   * Utile quand un parent et un enfant existent dans la nav (ex: /hub vs /hub/workspaces).
+   */
+  end?: boolean;
 }
 
 const NavItem: React.FC<NavItemProps> = ({
@@ -95,6 +101,7 @@ const NavItem: React.FC<NavItemProps> = ({
   badge,
   badgeClassName,
   external,
+  end,
 }) => {
   const baseClasses =
     "flex items-center gap-2.5 px-2.5 py-2 rounded-md transition-all text-[0.8125rem] font-medium relative";
@@ -122,6 +129,7 @@ const NavItem: React.FC<NavItemProps> = ({
   return (
     <NavLink
       to={to}
+      end={end}
       className={({ isActive }) =>
         `${baseClasses} ${
           isActive
@@ -349,6 +357,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const ADMIN_EMAIL = "maximeleparc3@gmail.com";
   const isUserAdmin =
     user?.is_admin || user?.email?.toLowerCase() === ADMIN_EMAIL.toLowerCase();
+
+  // Hub Workspaces — gated Expert (cohérent avec ConversationsDrawer).
+  // Admin bypass : voir l'item même hors plan Expert pour debug/preview.
+  const canSeeHubWorkspaces = userPlan === "expert" || isUserAdmin;
   const handleLogoClick = () => {
     navigate("/dashboard");
     closeMobile();
@@ -462,8 +474,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
               icon={MessageCircle}
               label="Hub"
               collapsed={collapsed}
+              // Si Workspaces est visible, ne match que `/hub` exact pour éviter
+              // que les deux items soient actifs sur `/hub/workspaces`.
+              end={canSeeHubWorkspaces}
               {...getBadge(minPlanHub)}
             />
+            {canSeeHubWorkspaces && (
+              <NavItem
+                to="/hub/workspaces"
+                icon={LayoutGrid}
+                label="Workspaces"
+                collapsed={collapsed}
+              />
+            )}
             <NavItem
               to="/study"
               icon={GraduationCap}

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -4,16 +4,29 @@
  *
  * PR #214 a fusionné /chat + /voice-call dans /hub. Ces tests garantissent
  * qu'aucune NavLink/Link/onClick navigate ne renvoie sur l'ancienne route.
+ *
+ * Wave 2c — ajout de tests pour la visibilité conditionnelle de l'item
+ * "Workspaces" (Expert + admin uniquement).
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 // --- Mocks pour Sidebar.tsx ---
+// User mutable entre tests — permet de simuler free / pro / expert / admin.
+const mockUser = vi.hoisted(() => ({
+  current: {
+    id: 1,
+    email: "test@test.com",
+    plan: "free" as "free" | "pro" | "expert",
+    is_admin: false as boolean,
+  },
+}));
+
 vi.mock("../../../hooks/useAuth", () => ({
   useAuth: () => ({
-    user: { id: 1, email: "test@test.com", plan: "free" },
+    user: mockUser.current,
     logout: vi.fn(),
     refreshUser: vi.fn(),
   }),
@@ -66,6 +79,16 @@ import { SidebarNav } from "../../sidebar/SidebarNav";
 const renderWith = (ui: React.ReactElement, route = "/dashboard") =>
   render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>);
 
+// Reset user à `free` avant chaque test pour isoler.
+beforeEach(() => {
+  mockUser.current = {
+    id: 1,
+    email: "test@test.com",
+    plan: "free",
+    is_admin: false,
+  };
+});
+
 describe("Hub navigation — no legacy /chat or /voice-call links", () => {
   it("Sidebar exposes a single Hub entry pointing to /hub", () => {
     renderWith(<Sidebar />);
@@ -103,5 +126,52 @@ describe("Hub navigation — no legacy /chat or /voice-call links", () => {
       const label = btn.getAttribute("aria-label") || btn.textContent || "";
       expect(label.toLowerCase()).not.toContain("voix");
     }
+  });
+});
+
+describe("Sidebar — Workspaces nav item (Wave 2c discoverability)", () => {
+  it("renders Workspaces nav item for Expert user", () => {
+    mockUser.current = {
+      id: 42,
+      email: "expert@test.com",
+      plan: "expert",
+      is_admin: false,
+    };
+    renderWith(<Sidebar />);
+    const link = screen.getByRole("link", { name: /workspaces/i });
+    expect(link).toHaveAttribute("href", "/hub/workspaces");
+  });
+
+  it("does NOT render Workspaces nav item for Pro user", () => {
+    mockUser.current = {
+      id: 7,
+      email: "pro@test.com",
+      plan: "pro",
+      is_admin: false,
+    };
+    renderWith(<Sidebar />);
+    expect(
+      screen.queryByRole("link", { name: /workspaces/i }),
+    ).toBeNull();
+  });
+
+  it("does NOT render Workspaces nav item for Free user", () => {
+    // mockUser réinitialisé à free par beforeEach.
+    renderWith(<Sidebar />);
+    expect(
+      screen.queryByRole("link", { name: /workspaces/i }),
+    ).toBeNull();
+  });
+
+  it("renders Workspaces nav item for admin (bypass plan)", () => {
+    mockUser.current = {
+      id: 1,
+      email: "admin@test.com",
+      plan: "free",
+      is_admin: true,
+    };
+    renderWith(<Sidebar />);
+    const link = screen.getByRole("link", { name: /workspaces/i });
+    expect(link).toHaveAttribute("href", "/hub/workspaces");
   });
 });


### PR DESCRIPTION
## Wave 2c Agent E — Discoverability fix

Sans cet item, la seule entrée pour activer le mode multi-select et créer un workspace Miro était le **bouton CheckSquare caché dans le ConversationsDrawer** (PR #339). Maxime a signalé ne pas le trouver — feature invisible.

## Diff

- Ajoute un `NavItem` **\"Workspaces\"** dans la `Sidebar` (juste après Hub)
- Icon `LayoutGrid` (lucide-react), route `/hub/workspaces`
- **Visibilité gated** : `userPlan === 'expert'` OU `user.is_admin === true`
- Free/Pro : item caché complètement (pas de Lock — UX simple, l'item n'existe juste pas)
- Ajoute prop optionnel `end` à `NavItem` (forwarded sur `NavLink`) pour éviter le double-active state Hub + Workspaces sur `/hub/workspaces`

## Tests

4 nouveaux tests Vitest dans `Sidebar.test.tsx` (mock `useAuth` mutable via `vi.hoisted`) :
- ✅ renders Workspaces nav item for Expert user
- ✅ does NOT render Workspaces nav item for Pro user
- ✅ does NOT render Workspaces nav item for Free user
- ✅ renders Workspaces nav item for admin (bypass plan)

7/7 verts. Typecheck OK.

## Refs

- Sprint Hub Miro Workspace MVP : PRs #334-#339
- Spec : ConversationsDrawer.tsx L101 (`canUseHubWorkspace = user?.plan === 'expert'`)