### PR TITLE
feat(legal): EU compliance sprint — Stripe Tax, audit logs, RGPD export, sub-processors, consent UX

### DIFF
--- a/backend/alembic/versions/019_add_audit_logs.py
+++ b/backend/alembic/versions/019_add_audit_logs.py
@@ -1,0 +1,99 @@
+"""audit_logs — RGPD-compliant audit trail for sensitive user actions.
+
+Revision ID: 019_add_audit_logs
+Revises: 018_hub_workspace
+Create Date: 2026-05-05
+
+EU compliance sprint — chantier C2.
+
+Records sensitive actions a user (or admin acting on behalf of a user)
+takes on an account: deletion, plan change, password change/reset, data
+export. Distinct from `admin_logs` (which only covers admin-initiated
+actions) — this table is the canonical Article 30 GDPR processing record.
+
+No backfill — historical actions are not retroactively recorded.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "019_add_audit_logs"
+down_revision: Union[str, None] = "018_hub_workspace"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "audit_logs" not in existing_tables:
+        op.create_table(
+            "audit_logs",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            # The user the action is ABOUT (target). NULL only if the user
+            # was deleted and we want to preserve the audit trail.
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+                index=True,
+            ),
+            # The user who PERFORMED the action. Same as user_id for self-
+            # actions, different when an admin acts on behalf of a user.
+            # NULL for system-initiated actions (cron, webhook, scheduler).
+            sa.Column(
+                "actor_id",
+                sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+                index=True,
+            ),
+            # Action identifier in dot notation. e.g.:
+            #   account.deleted, plan.changed, password.changed,
+            #   password.reset, data.exported, account.created, login.failed
+            sa.Column("action", sa.String(length=80), nullable=False, index=True),
+            # Free-form JSON context: {"from_plan": "free", "to_plan": "pro"}
+            sa.Column("details", sa.JSON(), nullable=True),
+            sa.Column("ip_address", sa.String(length=45), nullable=True),  # IPv6 max
+            sa.Column("user_agent", sa.String(length=500), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
+                index=True,
+            ),
+        )
+        op.create_index(
+            "idx_audit_logs_user_created",
+            "audit_logs",
+            ["user_id", sa.text("created_at DESC")],
+        )
+        op.create_index(
+            "idx_audit_logs_action_created",
+            "audit_logs",
+            ["action", sa.text("created_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "audit_logs" in existing_tables:
+        try:
+            op.drop_index("idx_audit_logs_action_created", table_name="audit_logs")
+        except Exception:
+            pass
+        try:
+            op.drop_index("idx_audit_logs_user_created", table_name="audit_logs")
+        except Exception:
+            pass
+        op.drop_table("audit_logs")

--- a/backend/src/auth/export.py
+++ b/backend/src/auth/export.py
@@ -1,0 +1,211 @@
+"""GDPR Article 20 — Right to data portability.
+
+Builds an in-memory ZIP archive of a user's personal data, served via the
+GET /api/auth/me/export endpoint.
+
+The archive contains JSON files for each major personal-data table:
+- user.json (profile, no password)
+- analyses.json (video analyses)
+- chats.json (chat messages)
+- transactions.json (billing history)
+- audit_logs.json (sensitive action history)
+- README.md (human-readable explanation)
+
+Defensive: uses getattr() for optional columns so schema drifts don't crash
+the export. The export is best-effort — partial data is better than no
+data when the user is exercising their portability right.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import (
+    User,
+    Summary,
+    ChatMessage,
+    CreditTransaction,
+    AuditLog,
+)
+
+
+def _iso(dt) -> str | None:
+    return dt.isoformat() if dt else None
+
+
+def _serialize_user(user: User) -> dict[str, Any]:
+    """User profile WITHOUT password_hash or sensitive auth tokens."""
+    return {
+        "id": user.id,
+        "email": user.email,
+        "plan": user.plan,
+        "credits_remaining": getattr(user, "credits_remaining", None),
+        "auth_method": "google" if getattr(user, "google_id", None) else "email",
+        "google_id": getattr(user, "google_id", None),
+        "stripe_customer_id": getattr(user, "stripe_customer_id", None),
+        "preferences": getattr(user, "preferences", None),
+        "is_legacy_pricing": getattr(user, "is_legacy_pricing", False),
+        "email_verified": getattr(user, "email_verified", False),
+        "created_at": _iso(getattr(user, "created_at", None)),
+        "updated_at": _iso(getattr(user, "updated_at", None)),
+    }
+
+
+def _serialize_summary(s: Summary) -> dict[str, Any]:
+    return {
+        "id": s.id,
+        "video_id": getattr(s, "video_id", None),
+        "platform": getattr(s, "platform", None),
+        "title": getattr(s, "title", None),
+        "url": getattr(s, "url", None),
+        "content": getattr(s, "content", None),
+        "duration": getattr(s, "duration", None),
+        "language": getattr(s, "language", None),
+        "created_at": _iso(getattr(s, "created_at", None)),
+    }
+
+
+def _serialize_chat(c: ChatMessage) -> dict[str, Any]:
+    return {
+        "id": c.id,
+        "summary_id": getattr(c, "summary_id", None),
+        "role": getattr(c, "role", None),
+        "content": getattr(c, "content", None),
+        "web_search_used": getattr(c, "web_search_used", False),
+        "created_at": _iso(getattr(c, "created_at", None)),
+    }
+
+
+def _serialize_transaction(t: CreditTransaction) -> dict[str, Any]:
+    return {
+        "id": t.id,
+        "transaction_type": getattr(t, "transaction_type", None),
+        "amount": getattr(t, "amount", None),
+        "credits_delta": getattr(t, "credits_delta", None),
+        "stripe_session_id": getattr(t, "stripe_session_id", None),
+        "created_at": _iso(getattr(t, "created_at", None)),
+    }
+
+
+def _serialize_audit(a: AuditLog) -> dict[str, Any]:
+    return {
+        "id": a.id,
+        "action": a.action,
+        "details": a.details,
+        "ip_address": a.ip_address,
+        "user_agent": a.user_agent,
+        "created_at": _iso(a.created_at),
+    }
+
+
+async def build_user_export_zip(session: AsyncSession, user: User) -> bytes:
+    """Build a ZIP of all the user's personal data (Article 20 GDPR).
+
+    Returns the raw bytes of the ZIP. The caller is responsible for
+    serving it as an HTTP attachment with Content-Disposition.
+    """
+    summaries = (
+        (await session.execute(select(Summary).where(Summary.user_id == user.id)))
+        .scalars()
+        .all()
+    )
+
+    summary_ids = [s.id for s in summaries]
+    chats: list[ChatMessage] = []
+    if summary_ids:
+        chats = (
+            (
+                await session.execute(
+                    select(ChatMessage).where(ChatMessage.summary_id.in_(summary_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    transactions = (
+        (
+            await session.execute(
+                select(CreditTransaction).where(CreditTransaction.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    audit_logs = (
+        (await session.execute(select(AuditLog).where(AuditLog.user_id == user.id)))
+        .scalars()
+        .all()
+    )
+
+    buf = io.BytesIO()
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    readme = (
+        f"# DeepSight — Export de vos données personnelles\n\n"
+        f"Généré : {now_iso}\n"
+        f"Compte : {user.email} (id={user.id})\n\n"
+        f"Cette archive contient un export JSON de vos données personnelles,\n"
+        f"conformément à l'article 20 du RGPD (droit à la portabilité).\n\n"
+        f"## Fichiers\n"
+        f"- `user.json` : profil (sans mot de passe)\n"
+        f"- `analyses.json` : analyses vidéo ({len(summaries)} entrées)\n"
+        f"- `chats.json` : messages de chat ({len(chats)} entrées)\n"
+        f"- `transactions.json` : historique de facturation ({len(transactions)} entrées)\n"
+        f"- `audit_logs.json` : historique des actions sensibles ({len(audit_logs)} entrées)\n\n"
+        f"## Format\n\n"
+        f"Tous les fichiers sont en JSON UTF-8, avec horodatages ISO 8601 UTC.\n"
+        f"Le format est documenté à : https://www.deepsightsynthesis.com/legal/privacy\n\n"
+        f"## Questions\n\n"
+        f"Pour toute question relative à vos données, contactez :\n"
+        f"  legal@deepsightsynthesis.com\n"
+    )
+
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("README.md", readme)
+        zf.writestr(
+            "user.json",
+            json.dumps(_serialize_user(user), indent=2, ensure_ascii=False),
+        )
+        zf.writestr(
+            "analyses.json",
+            json.dumps(
+                [_serialize_summary(s) for s in summaries],
+                indent=2,
+                ensure_ascii=False,
+            ),
+        )
+        zf.writestr(
+            "chats.json",
+            json.dumps(
+                [_serialize_chat(c) for c in chats],
+                indent=2,
+                ensure_ascii=False,
+            ),
+        )
+        zf.writestr(
+            "transactions.json",
+            json.dumps(
+                [_serialize_transaction(t) for t in transactions],
+                indent=2,
+                ensure_ascii=False,
+            ),
+        )
+        zf.writestr(
+            "audit_logs.json",
+            json.dumps(
+                [_serialize_audit(a) for a in audit_logs],
+                indent=2,
+                ensure_ascii=False,
+            ),
+        )
+
+    return buf.getvalue()

--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -4,7 +4,9 @@
 ╚════════════════════════════════════════════════════════════════════════════════════╝
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Optional
@@ -321,6 +323,40 @@ async def change_password_endpoint(
 # ═══════════════════════════════════════════════════════════════════════════════
 # 👤 PROFIL UTILISATEUR
 # ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.get("/me/export")
+async def export_my_data(
+    request: Request,
+    current_user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """RGPD Article 20 — Export de toutes les données personnelles en ZIP.
+
+    Returns a ZIP archive (user.json + analyses.json + chats.json +
+    transactions.json + audit_logs.json + README.md). The download is
+    audit-logged.
+    """
+    from auth.export import build_user_export_zip
+
+    zip_bytes = await build_user_export_zip(session, current_user)
+
+    await log_audit(
+        session,
+        action="data.exported",
+        user_id=current_user.id,
+        request=request,
+        details={"size_bytes": len(zip_bytes)},
+    )
+    await session.commit()
+
+    today = datetime.now(timezone.utc).strftime("%Y%m%d")
+    filename = f"deepsight-export-{current_user.id}-{today}.zip"
+    return Response(
+        content=zip_bytes,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.get("/me", response_model=UserResponse)

--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -53,6 +53,7 @@ from .service import (
     validate_session_token,
     verify_google_id_token,
 )
+from services.audit_log import log_audit
 from .dependencies import get_current_user
 from .email import send_verification_email, send_password_reset_email, send_welcome_email
 
@@ -191,6 +192,17 @@ async def delete_account(
     # Invalider la session avant suppression
     await invalidate_user_session(session, current_user.id)
 
+    # Audit log RGPD AVANT delete — capture user_id avant cascade SET NULL.
+    await log_audit(
+        session,
+        action="account.deleted",
+        user_id=current_user.id,
+        details={
+            "plan": current_user.plan,
+            "auth_method": "google" if current_user.google_id else "email",
+        },
+    )
+
     # Supprimer l'utilisateur (cascade delete automatique)
     await session.delete(current_user)
     await session.commit()
@@ -283,6 +295,10 @@ async def reset_password_endpoint(data: ResetPasswordRequest, session: AsyncSess
     if not success:
         raise HTTPException(status_code=400, detail=message)
 
+    # Audit log RGPD — user_id absent (flow anonyme), email dans details.
+    await log_audit(session, action="password.reset", details={"email": data.email})
+    await session.commit()
+
     return MessageResponse(success=True, message=message)
 
 
@@ -295,6 +311,9 @@ async def change_password_endpoint(
 
     if not success:
         raise HTTPException(status_code=400, detail=message)
+
+    await log_audit(session, action="password.changed", user_id=current_user.id)
+    await session.commit()
 
     return MessageResponse(success=True, message=message)
 

--- a/backend/src/billing/router.py
+++ b/backend/src/billing/router.py
@@ -27,6 +27,7 @@ from db.database import (
 )
 from auth.dependencies import get_current_user, get_current_user_optional
 from core.config import STRIPE_CONFIG, FRONTEND_URL, get_stripe_key, STRIPE_AUTOMATIC_TAX_ENABLED
+from services.audit_log import log_audit
 from .plan_config import (
     PLANS,
     PLAN_HIERARCHY,
@@ -889,6 +890,17 @@ async def change_subscription_plan(
     valid_plans = [p for p in PLAN_HIERARCHY if p != "free"]
     if new_plan not in valid_plans:
         raise HTTPException(status_code=400, detail=f"Invalid plan: {new_plan}")
+
+    # Audit log RGPD — log l'intention. Effectif tracé via Stripe webhook
+    # (subscription.updated → users.plan). Multi-branch endpoint, log avant
+    # toute mutation Stripe.
+    await log_audit(
+        session,
+        action="plan.changed",
+        user_id=current_user.id,
+        details={"from": current_plan, "to": new_plan},
+    )
+    await session.commit()
 
     # Si même plan, rien à faire
     if new_plan == current_plan:

--- a/backend/src/billing/router.py
+++ b/backend/src/billing/router.py
@@ -675,6 +675,8 @@ async def create_checkout_session(
             "payment_method_types": ["card"],
             "line_items": [{"price": price_id, "quantity": 1}],
             "mode": "subscription",
+            # Stripe Tax (TVA EU / VAT MOSS) — env-driven, see RUNBOOK §9.
+            "automatic_tax": {"enabled": STRIPE_AUTOMATIC_TAX_ENABLED},
             "success_url": success_url,
             "cancel_url": cancel_url,
             "allow_promotion_codes": True,
@@ -792,6 +794,8 @@ async def create_checkout_by_plan_id(
             payment_method_types=["card"],
             line_items=[{"price": price_id, "quantity": 1}],
             mode="subscription",
+            # Stripe Tax (TVA EU / VAT MOSS) — env-driven, see RUNBOOK §9.
+            automatic_tax={"enabled": STRIPE_AUTOMATIC_TAX_ENABLED},
             success_url=success_url,
             cancel_url=cancel_url,
             allow_promotion_codes=True,
@@ -916,6 +920,8 @@ async def change_subscription_plan(
             payment_method_types=["card"],
             line_items=[{"price": price_id, "quantity": 1}],
             mode="subscription",
+            # Stripe Tax (TVA EU / VAT MOSS) — env-driven, see RUNBOOK §9.
+            automatic_tax={"enabled": STRIPE_AUTOMATIC_TAX_ENABLED},
             success_url=f"{FRONTEND_URL}/payment/success?session_id={{CHECKOUT_SESSION_ID}}&plan={new_plan}",
             cancel_url=f"{FRONTEND_URL}/upgrade",
             allow_promotion_codes=True,
@@ -2259,6 +2265,8 @@ async def create_credit_pack_checkout(
         customer=customer_id,
         mode="payment",
         payment_method_types=["card"],
+        # Stripe Tax (TVA EU / VAT MOSS) — env-driven, see RUNBOOK §9.
+        automatic_tax={"enabled": STRIPE_AUTOMATIC_TAX_ENABLED},
         line_items=[
             {
                 "price_data": {

--- a/backend/src/billing/voice_packs_router.py
+++ b/backend/src/billing/voice_packs_router.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import get_current_user
-from core.config import FRONTEND_URL, STRIPE_CONFIG, get_stripe_key
+from core.config import FRONTEND_URL, STRIPE_CONFIG, get_stripe_key, STRIPE_AUTOMATIC_TAX_ENABLED
 from db.database import User, get_session
 from billing.voice_packs_service import (
     list_active_packs,
@@ -176,7 +176,9 @@ async def create_checkout(
             mode="payment",
             payment_method_types=["card"],
             line_items=line_items,
-            automatic_tax={"enabled": True},
+            # Stripe Tax env-driven (was hardcoded True — caused latent bug if
+            # Stripe Tax not enabled in Dashboard). See RUNBOOK §9.
+            automatic_tax={"enabled": STRIPE_AUTOMATIC_TAX_ENABLED},
             success_url=success_url,
             cancel_url=cancel_url,
             metadata={

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -480,6 +480,39 @@ class AdminLog(Base):
     created_at = Column(DateTime, default=func.now())
 
 
+class AuditLog(Base):
+    """RGPD-compliant audit trail for sensitive user actions.
+
+    Distinct from AdminLog — this table records actions a user takes on
+    their own account (or that an admin takes on a user's account) that
+    have legal/compliance significance: account deletion, plan change,
+    password change/reset, data export.
+
+    Article 30 GDPR processing record.
+    """
+
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    actor_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    action = Column(String(80), nullable=False, index=True)
+    details = Column(JSON, nullable=True)
+    ip_address = Column(String(45), nullable=True)
+    user_agent = Column(String(500), nullable=True)
+    created_at = Column(DateTime, default=func.now(), nullable=False, index=True)
+
+
 class ApiStatus(Base):
     """Table du status des APIs externes"""
 

--- a/backend/src/services/audit_log.py
+++ b/backend/src/services/audit_log.py
@@ -1,0 +1,74 @@
+"""RGPD audit log helper.
+
+Records sensitive user actions in the `audit_logs` table for Article 30
+GDPR compliance. Use the `log_audit()` helper from any endpoint that
+mutates user-significant state.
+
+Design:
+- Caller controls transaction boundary (no commit inside).
+- Failures are logged but never raised — audit logging must not break
+  the parent flow (worst case: missing audit entry, surfaced via Sentry).
+- IP and User-Agent extracted from FastAPI Request when provided.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.logging import logger
+from db.database import AuditLog
+
+
+async def log_audit(
+    session: AsyncSession,
+    *,
+    action: str,
+    user_id: Optional[int] = None,
+    actor_id: Optional[int] = None,
+    details: Optional[dict[str, Any]] = None,
+    request: Optional[Request] = None,
+) -> None:
+    """Append an audit log entry.
+
+    Args:
+        session: Active SQLAlchemy AsyncSession (caller commits).
+        action: Dot-notation action identifier (e.g. "plan.changed",
+            "account.deleted", "password.reset", "data.exported").
+        user_id: Target user (subject of the action). For self-actions
+            this is the same as actor_id.
+        actor_id: User who performed the action. Defaults to user_id
+            for self-service flows. Pass an admin's id when an admin
+            acts on behalf of a user.
+        details: Free-form JSON context (e.g. {"from_plan": "free",
+            "to_plan": "pro", "stripe_session_id": "cs_..."}).
+        request: FastAPI Request — if provided, IP and User-Agent are
+            captured for forensic purposes.
+
+    Never raises. Failures are logged via Sentry-aware logger.
+    """
+    try:
+        ip_address: Optional[str] = None
+        user_agent: Optional[str] = None
+        if request is not None:
+            try:
+                ip_address = request.client.host if request.client else None
+                user_agent = (request.headers.get("user-agent") or "")[:500] or None
+            except Exception:
+                pass
+
+        entry = AuditLog(
+            user_id=user_id,
+            actor_id=actor_id if actor_id is not None else user_id,
+            action=action,
+            details=details,
+            ip_address=ip_address,
+            user_agent=user_agent,
+        )
+        session.add(entry)
+        # Caller commits as part of the parent transaction.
+    except Exception as e:
+        # Never break the calling flow — audit failure is non-fatal.
+        logger.error("audit_log: failed to record action=%s: %s", action, e)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -330,6 +330,9 @@ const ExtensionWelcomePage = lazyWithRetry(
   () => import("./pages/ExtensionWelcomePage"),
 );
 const PrivacyPolicy = lazyWithRetry(() => import("./pages/PrivacyPolicy"));
+const LegalSubProcessors = lazyWithRetry(
+  () => import("./pages/LegalSubProcessors"),
+);
 const ApiDocsPage = lazyWithRetry(() => import("./pages/ApiDocsPage"));
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -628,6 +631,22 @@ const AppRoutes = () => {
                               fallback={<PageSkeleton variant="full" />}
                             >
                               <PrivacyPolicy />
+                            </Suspense>
+                          </RouteErrorBoundary>
+                        }
+                      />
+
+                      <Route
+                        path="/legal/sub-processors"
+                        element={
+                          <RouteErrorBoundary
+                            variant="full"
+                            componentName="LegalSubProcessors"
+                          >
+                            <Suspense
+                              fallback={<PageSkeleton variant="full" />}
+                            >
+                              <LegalSubProcessors />
                             </Suspense>
                           </RouteErrorBoundary>
                         }

--- a/frontend/src/components/CookieBanner.tsx
+++ b/frontend/src/components/CookieBanner.tsx
@@ -62,6 +62,26 @@ export function hasGivenConsent(): boolean {
   return getStoredConsent() !== null;
 }
 
+/**
+ * Efface le consentement existant et rouvre le bandeau.
+ * Permet à l'utilisateur de revenir sur son choix depuis MyAccount.
+ */
+export function resetCookieConsent(): void {
+  try {
+    localStorage.removeItem(CONSENT_STORAGE_KEY);
+  } catch {
+    /* Safari private mode */
+  }
+  // Notifier les services analytics qu'ils doivent se désactiver
+  window.dispatchEvent(
+    new CustomEvent("cookie-consent-updated", {
+      detail: { essential: true, analytics: false, marketing: false },
+    }),
+  );
+  // Re-afficher le banner
+  window.dispatchEvent(new CustomEvent("cookie-banner-show"));
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // 🎯 COMPONENT
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -80,6 +100,20 @@ export const CookieBanner: React.FC = () => {
       const timer = setTimeout(() => setVisible(true), 800);
       return () => clearTimeout(timer);
     }
+  }, []);
+
+  // Listener pour réouverture manuelle (depuis MyAccount → resetCookieConsent)
+  useEffect(() => {
+    const handler = () => {
+      // Reset les checkboxes à leurs valeurs précédentes (ou défaut false)
+      const consent = getStoredConsent();
+      setAnalyticsChecked(consent?.analytics ?? false);
+      setMarketingChecked(consent?.marketing ?? false);
+      setShowDetails(true);
+      setVisible(true);
+    };
+    window.addEventListener("cookie-banner-show", handler);
+    return () => window.removeEventListener("cookie-banner-show", handler);
   }, []);
 
   const saveAndClose = useCallback(

--- a/frontend/src/pages/LegalSubProcessors.tsx
+++ b/frontend/src/pages/LegalSubProcessors.tsx
@@ -1,0 +1,260 @@
+import { motion } from "framer-motion";
+import { ExternalLink } from "lucide-react";
+import { SEO } from "../components/SEO";
+import { useLanguage } from "../contexts/LanguageContext";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-processors registry — RGPD Article 28 / Art. 30
+//
+// To add a new sub-processor: add an entry below + sign their DPA + notify
+// users via in-app banner or email. Keep the list ordered by criticality
+// (auth > payments > AI > storage > observability).
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface SubProcessor {
+  name: string;
+  purposeFr: string;
+  purposeEn: string;
+  region: string;
+  dpaUrl: string;
+}
+
+const SUB_PROCESSORS: SubProcessor[] = [
+  {
+    name: "Hetzner",
+    purposeFr: "Hébergement VPS principal (backend, DB, Redis)",
+    purposeEn: "Primary VPS hosting (backend, DB, Redis)",
+    region: "Allemagne 🇩🇪",
+    dpaUrl: "https://www.hetzner.com/legal/privacy-policy",
+  },
+  {
+    name: "Vercel",
+    purposeFr: "Hébergement frontend web (CDN edge)",
+    purposeEn: "Web frontend hosting (edge CDN)",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://vercel.com/legal/dpa",
+  },
+  {
+    name: "Stripe",
+    purposeFr: "Paiements, facturation, gestion des abonnements",
+    purposeEn: "Payments, invoicing, subscription management",
+    region: "Irlande 🇮🇪 (EU)",
+    dpaUrl: "https://stripe.com/legal/dpa",
+  },
+  {
+    name: "Mistral AI",
+    purposeFr: "Modèles IA (analyses vidéo, chat, agents)",
+    purposeEn: "AI models (video analyses, chat, agents)",
+    region: "France 🇫🇷",
+    dpaUrl: "https://mistral.ai/terms#data-processing-agreement",
+  },
+  {
+    name: "Google Cloud",
+    purposeFr: "OAuth (connexion Google)",
+    purposeEn: "OAuth (Google sign-in)",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://cloud.google.com/terms/data-processing-addendum",
+  },
+  {
+    name: "Resend",
+    purposeFr: "Emails transactionnels (vérification, reset, etc.)",
+    purposeEn: "Transactional emails (verification, reset, etc.)",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://resend.com/legal/dpa",
+  },
+  {
+    name: "ElevenLabs",
+    purposeFr: "Synthèse vocale et reconnaissance audio (Quick Voice Call)",
+    purposeEn: "Text-to-speech and audio recognition (Quick Voice Call)",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://elevenlabs.io/dpa",
+  },
+  {
+    name: "Supadata",
+    purposeFr: "Récupération de transcriptions YouTube",
+    purposeEn: "YouTube transcript retrieval",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://supadata.ai/privacy",
+  },
+  {
+    name: "Perplexity AI",
+    purposeFr: "Enrichissement web (recherche pour le chat)",
+    purposeEn: "Web enrichment (chat web search)",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://www.perplexity.ai/hub/legal/privacy-policy",
+  },
+  {
+    name: "Brave Search",
+    purposeFr: "Recherche web (fact-checking)",
+    purposeEn: "Web search (fact-checking)",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://brave.com/privacy/browser/",
+  },
+  {
+    name: "Cloudflare R2",
+    purposeFr: "Sauvegardes redondantes (DB + thumbnails)",
+    purposeEn: "Redundant backups (DB + thumbnails)",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://www.cloudflare.com/cloudflare-customer-dpa/",
+  },
+  {
+    name: "AWS S3",
+    purposeFr: "Sauvegardes primaires de la base de données",
+    purposeEn: "Primary database backups",
+    region: "EU (eu-west-3) 🇪🇺",
+    dpaUrl: "https://aws.amazon.com/service-terms/",
+  },
+  {
+    name: "Sentry",
+    purposeFr: "Monitoring d'erreurs (rapports anonymisés)",
+    purposeEn: "Error monitoring (anonymized reports)",
+    region: "USA 🇺🇸",
+    dpaUrl: "https://sentry.io/legal/dpa/",
+  },
+  {
+    name: "PostHog",
+    purposeFr: "Analytics produit (consentement utilisateur requis)",
+    purposeEn: "Product analytics (user consent required)",
+    region: "EU (eu.i.posthog.com) 🇪🇺",
+    dpaUrl: "https://posthog.com/dpa",
+  },
+];
+
+export default function LegalSubProcessors() {
+  const { language } = useLanguage();
+  const t = (fr: string, en: string) => (language === "fr" ? fr : en);
+
+  return (
+    <>
+      <SEO
+        title={t("Sous-traitants RGPD", "GDPR Sub-processors")}
+        description={t(
+          "Liste des sous-traitants utilisés par DeepSight pour traiter vos données.",
+          "List of sub-processors used by DeepSight to process your data.",
+        )}
+      />
+      <div className="min-h-screen bg-bg-primary p-4 md:p-8">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="mx-auto max-w-4xl"
+        >
+          <header className="mb-8">
+            <h1 className="text-4xl font-bold text-text-primary">
+              {t("Sous-traitants", "Sub-processors")}
+            </h1>
+            <p className="mt-3 text-text-secondary">
+              {t(
+                "DeepSight collabore avec les sous-traitants ci-dessous pour fournir le service. Conformément au RGPD (article 28), nous tenons à jour cette liste publique.",
+                "DeepSight relies on the sub-processors below to deliver the service. In line with GDPR Article 28, we keep this public list up to date.",
+              )}
+            </p>
+            <p className="mt-2 text-sm text-text-tertiary">
+              {t("Dernière mise à jour : ", "Last updated: ")}
+              <time dateTime="2026-05-05">2026-05-05</time>
+            </p>
+          </header>
+
+          <div className="overflow-x-auto rounded-lg border border-white/5 bg-bg-secondary/50">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-white/10 bg-bg-secondary text-xs uppercase tracking-wider text-text-tertiary">
+                <tr>
+                  <th className="px-4 py-3">{t("Nom", "Name")}</th>
+                  <th className="px-4 py-3">{t("Finalité", "Purpose")}</th>
+                  <th className="px-4 py-3">{t("Région", "Region")}</th>
+                  <th className="px-4 py-3">DPA</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {SUB_PROCESSORS.map((sp) => (
+                  <tr
+                    key={sp.name}
+                    className="transition-colors hover:bg-white/5"
+                  >
+                    <td className="px-4 py-3 font-medium text-text-primary">
+                      {sp.name}
+                    </td>
+                    <td className="px-4 py-3 text-text-secondary">
+                      {t(sp.purposeFr, sp.purposeEn)}
+                    </td>
+                    <td className="px-4 py-3 text-text-secondary">
+                      {sp.region}
+                    </td>
+                    <td className="px-4 py-3">
+                      <a
+                        href={sp.dpaUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-accent-primary hover:underline"
+                      >
+                        {t("Voir", "View")}
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <section className="mt-10 space-y-4 text-text-secondary">
+            <h2 className="text-2xl font-semibold text-text-primary">
+              {t("Notifications de changement", "Change notifications")}
+            </h2>
+            <p>
+              {t(
+                "Tout ajout ou retrait d'un sous-traitant est notifié aux utilisateurs au moins 30 jours avant son entrée en vigueur, soit par email, soit via une bannière dans l'application.",
+                "Any addition or removal of a sub-processor is communicated to users at least 30 days before it takes effect, either by email or via an in-app banner.",
+              )}
+            </p>
+
+            <h2 className="text-2xl font-semibold text-text-primary">
+              {t("Hébergement des données", "Data hosting")}
+            </h2>
+            <p>
+              {t(
+                "Les données utilisateur (compte, analyses, conversations) sont stockées sur un VPS Hetzner en Allemagne. Les sauvegardes sont répliquées sur AWS S3 (UE) et Cloudflare R2 (USA, en redondance).",
+                "User data (account, analyses, conversations) is stored on a Hetzner VPS in Germany. Backups are replicated to AWS S3 (EU) and Cloudflare R2 (USA, for redundancy).",
+              )}
+            </p>
+
+            <h2 className="text-2xl font-semibold text-text-primary">
+              {t("Vos droits", "Your rights")}
+            </h2>
+            <p>
+              {t(
+                "Vous pouvez exercer vos droits RGPD (accès, rectification, portabilité, effacement) directement depuis ",
+                "You can exercise your GDPR rights (access, rectification, portability, erasure) directly from ",
+              )}
+              <a
+                href="/account"
+                className="text-accent-primary hover:underline"
+              >
+                {t("votre compte", "your account")}
+              </a>
+              {t(" ou en écrivant à ", " or by writing to ")}
+              <a
+                href="mailto:legal@deepsightsynthesis.com"
+                className="text-accent-primary hover:underline"
+              >
+                legal@deepsightsynthesis.com
+              </a>
+              .
+            </p>
+          </section>
+
+          <footer className="mt-12 border-t border-white/5 pt-6 text-sm text-text-tertiary">
+            <a href="/legal/privacy" className="hover:underline">
+              ←{" "}
+              {t(
+                "Retour à la politique de confidentialité",
+                "Back to Privacy Policy",
+              )}
+            </a>
+          </footer>
+        </motion.div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/MyAccount.tsx
+++ b/frontend/src/pages/MyAccount.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "../hooks/useAuth";
 import { useTranslation } from "../hooks/useTranslation";
 import { Sidebar } from "../components/layout/Sidebar";
 import { billingApi, authApi, type ApiBillingMyPlan } from "../services/api";
+import { resetCookieConsent } from "../components/CookieBanner";
 import {
   PLANS_INFO,
   getMinPlanForFeature,
@@ -24,6 +25,7 @@ import {
   Key,
   Trash2,
   Download,
+  Cookie,
   LogOut,
   Check,
   AlertCircle,
@@ -1365,7 +1367,7 @@ export const MyAccount: React.FC = () => {
                   {tr("Vos données", "Your data")}
                 </h2>
               </div>
-              <div className="panel-body">
+              <div className="panel-body space-y-3">
                 <button
                   onClick={handleExportData}
                   disabled={isExporting}
@@ -1390,6 +1392,39 @@ export const MyAccount: React.FC = () => {
                   ) : (
                     <ChevronRight className="w-5 h-5 text-text-tertiary" />
                   )}
+                </button>
+
+                <button
+                  onClick={() => {
+                    resetCookieConsent();
+                    showToast(
+                      tr(
+                        "Préférences cookies réinitialisées",
+                        "Cookie preferences reset",
+                      ),
+                      "success",
+                    );
+                  }}
+                  className="w-full flex items-center justify-between p-4 rounded-lg bg-bg-secondary hover:bg-bg-tertiary transition-colors text-left"
+                >
+                  <div className="flex items-center gap-3">
+                    <Cookie className="w-5 h-5 text-accent-primary" />
+                    <div>
+                      <p className="font-medium">
+                        {tr(
+                          "Modifier mes préférences cookies",
+                          "Manage cookie preferences",
+                        )}
+                      </p>
+                      <p className="text-sm text-text-tertiary">
+                        {tr(
+                          "Réouvre le bandeau pour ajuster votre consentement (analyse, marketing)",
+                          "Reopens the banner so you can adjust your consent (analytics, marketing)",
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-text-tertiary" />
                 </button>
               </div>
             </section>

--- a/frontend/src/pages/MyAccount.tsx
+++ b/frontend/src/pages/MyAccount.tsx
@@ -23,6 +23,7 @@ import {
   Shield,
   Key,
   Trash2,
+  Download,
   LogOut,
   Check,
   AlertCircle,
@@ -103,6 +104,7 @@ export const MyAccount: React.FC = () => {
   const [deleteConfirmText, setDeleteConfirmText] = useState("");
   const [deletePassword, setDeletePassword] = useState("");
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
 
   const normalizedPlan = normalizePlanId(user?.plan);
   const isPaidUser = normalizedPlan !== "free";
@@ -141,6 +143,31 @@ export const MyAccount: React.FC = () => {
       showToast(message, "error");
     } finally {
       setDeleteLoading(false);
+    }
+  };
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // 📦 Export GDPR (Article 20)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  const handleExportData = async () => {
+    setIsExporting(true);
+    try {
+      await authApi.exportMyData();
+      showToast(
+        tr(
+          "Export téléchargé. Vérifiez vos téléchargements.",
+          "Export downloaded. Check your downloads.",
+        ),
+        "success",
+      );
+    } catch (error: any) {
+      const message =
+        error?.message ||
+        tr("Erreur lors de l'export", "Error exporting data");
+      showToast(message, "error");
+    } finally {
+      setIsExporting(false);
     }
   };
 
@@ -1326,6 +1353,43 @@ export const MyAccount: React.FC = () => {
                     </div>
                   </div>
                   <ChevronRight className="w-5 h-5 text-text-tertiary" />
+                </button>
+              </div>
+            </section>
+
+            {/* Vos données — RGPD Article 20 */}
+            <section className="card">
+              <div className="panel-header">
+                <h2 className="font-semibold flex items-center gap-2">
+                  <Download className="w-5 h-5" />
+                  {tr("Vos données", "Your data")}
+                </h2>
+              </div>
+              <div className="panel-body">
+                <button
+                  onClick={handleExportData}
+                  disabled={isExporting}
+                  className="w-full flex items-center justify-between p-4 rounded-lg bg-bg-secondary hover:bg-bg-tertiary transition-colors text-left disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  <div className="flex items-center gap-3">
+                    <Download className="w-5 h-5 text-accent-primary" />
+                    <div>
+                      <p className="font-medium">
+                        {tr("Exporter mes données", "Export my data")}
+                      </p>
+                      <p className="text-sm text-text-tertiary">
+                        {tr(
+                          "Téléchargez un ZIP avec toutes vos données personnelles (RGPD Article 20)",
+                          "Download a ZIP with all your personal data (GDPR Article 20)",
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                  {isExporting ? (
+                    <DeepSightSpinnerMicro />
+                  ) : (
+                    <ChevronRight className="w-5 h-5 text-text-tertiary" />
+                  )}
                 </button>
               </div>
             </section>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -888,6 +888,32 @@ export const authApi = {
     clearTokens();
     return response;
   },
+
+  /**
+   * RGPD Article 20 — Right to data portability.
+   * Downloads a ZIP archive with the user's personal data.
+   * Triggers a browser file download (no return value).
+   */
+  async exportMyData(): Promise<void> {
+    const token = getAccessToken();
+    const response = await fetch(`${API_URL}/api/auth/me/export`, {
+      method: "GET",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!response.ok) {
+      throw new Error(`Export failed: ${response.status} ${response.statusText}`);
+    }
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const today = new Date().toISOString().slice(0, 10);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `deepsight-export-${today}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  },
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Contexte

Sprint conformité EU pour passer DeepSight au-dessus du minimum RGPD requis pour vendre en B2B et lancer en prod EU. 5 chantiers, 5 commits atomiques, ~700 lignes net.

⚠️ **Dépend de #341 (audit quick wins)** — partage le flag `STRIPE_AUTOMATIC_TAX_ENABLED` introduit dans le commit Quick Wins. Si #341 est mergé en premier, ce PR sera rebasé sans conflit. Si ce PR est mergé en premier, #341 restera mergeable car les modifs sont disjointes (sauf import + 1 ligne dans `billing/router.py`, conflit trivial).

## Chantiers livrés

### C1 — Étendre Stripe `automatic_tax` aux 5 autres Checkout calls
- `billing/router.py` : 4 calls additionnels (create-checkout-by-plan-id, start-pro-trial, change-plan, credit_packs payment)
- `voice_packs_router.py` : 1 call (était hardcodé `True`, **bug latent corrigé** — crashait si Stripe Tax pas activé Dashboard)
- Tous les 6 calls partagent maintenant le même flag `STRIPE_AUTOMATIC_TAX_ENABLED`

### C2 — Audit logs RGPD (Article 30)
- **Alembic 019** : table `audit_logs` (user_id + actor_id FK SET NULL, action dot-notation, JSON details, IP, UA, indexée)
- **Model** `AuditLog` dans `db.database` — distinct d'`AdminLog` (qui couvre uniquement les actions admin)
- **Helper** `services/audit_log.py` `log_audit()` — caller controls commit, échecs non-fatals
- **Branchement** sur 4 endpoints sensibles :
  - `DELETE /api/auth/account` → `account.deleted` (logged AVANT cascade)
  - `POST /api/auth/reset-password` → `password.reset`
  - `POST /api/auth/change-password` → `password.changed`
  - `POST /api/billing/change-plan` → `plan.changed` (intent log, succès tracé via webhook Stripe)

### C3 — Export RGPD Article 20 (portabilité)
- **Endpoint** `GET /api/auth/me/export` retourne ZIP attachment avec :
  - `user.json` (profil sans password)
  - `analyses.json` (Summary)
  - `chats.json` (ChatMessage)
  - `transactions.json` (CreditTransaction)
  - `audit_logs.json` (AuditLog)
  - `README.md` (FR, explication format + contact)
- **Audit-loggé** via `log_audit(action="data.exported", details={size_bytes})`
- **UI** : nouveau bouton "Exporter mes données" dans `MyAccount` section "Vos données" (FR/EN, loading state, toast feedback)

### C4 — Page publique `/legal/sub-processors` (RGPD Article 28)
- 14 sous-traitants listés : Hetzner, Vercel, Stripe, Mistral AI, Google Cloud, Resend, ElevenLabs, Supadata, Perplexity, Brave, Cloudflare R2, AWS S3, Sentry, PostHog
- Table avec nom + finalité + région + DPA URL
- 3 sections : notifications de changement (30j notice), hébergement des données, vos droits
- FR/EN via `useLanguage()`, lazy-loaded route publique

### C5 — Consentement cookies — UX de modification
- PostHog **déjà** parfaitement branché au consentement (`services/analytics.ts` L80-88 listener) — pas de change nécessaire
- **`resetCookieConsent()`** exporté depuis `CookieBanner` : clear localStorage + dispatch events analytics-off + banner re-show
- **Listener** `cookie-banner-show` dans `CookieBanner` : repopule les checkboxes avec le state actuel + reouvre en mode détails
- **Bouton MyAccount** "Modifier mes préférences cookies" dans la section "Vos données"
- Sentry non gated (legitimate interest pour crash monitoring)

## Out of scope (à suivre)

- Activer Stripe Tax dans le Dashboard Stripe + flip `STRIPE_AUTOMATIC_TAX_ENABLED=true` Hetzner (action Maxime, RUNBOOK §9 dans #341)
- Audit log middleware générique pour tous les `@router.post/.delete/.put` (au lieu de calls explicites) — perd en précision RGPD, gain en couverture
- Capturer Request IP/UA dans tous les `log_audit()` (signature 3 endpoints à modifier — par batch)
- Page de modification d'email avec audit log
- Export incrémental ZIP > 50MB (streaming au lieu d'in-memory) — utile uniquement si user a > 1k analyses

## Test plan

- [ ] CI verts (backend, frontend, mobile, extension, gitleaks, smoke)
- [ ] Backend Python AST ✅ déjà vérifié localement (`python -c "import ast; ast.parse(...)"`)
- [ ] Frontend `tsc --noEmit` ✅ no new errors
- [ ] Migration Alembic 019 dry-run sur staging avant deploy prod
- [ ] Manuel : `GET /api/auth/me/export` retourne un ZIP valide (5 JSONs + README)
- [ ] Manuel : bouton "Exporter mes données" → fichier `deepsight-export-*-*.zip` téléchargé
- [ ] Manuel : visiter `/legal/sub-processors` → table affichée correctement, liens DPA fonctionnels
- [ ] Manuel : bouton "Modifier mes préférences cookies" → bandeau réouvert en mode détails avec checkboxes pré-cochées selon stored consent
- [ ] Manuel : DELETE /account, change-plan, change-password, reset-password → entries `audit_logs` créées avec bonnes actions et user_ids
- [ ] Stripe Test mode : checkout avec `STRIPE_AUTOMATIC_TAX_ENABLED=False` → comportement actuel inchangé (pas de tax line)

## Migration DB Hetzner

⚠️ Après merge sur main, l'auto-deploy Hetzner exécutera `alembic upgrade head` au container start (via `entrypoint.sh`). Migration 019 ajoute la table `audit_logs` (idempotente — `if not exists`). Pas de backfill, pas de downtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)