### PR TITLE
feat(hub): HubHeader Workspaces button + Modal redirect post-create + real analysis titles

### DIFF
--- a/frontend/src/components/hub/CreateWorkspaceModal.tsx
+++ b/frontend/src/components/hub/CreateWorkspaceModal.tsx
@@ -91,14 +91,27 @@ export const CreateWorkspaceModal: React.FC<Props> = ({
           name: trimmed,
           summary_ids: initialSummaryIds,
         });
+        // Wave 2c — preserve onCreated callback for parent cleanup (e.g. exit
+        // select mode dans ConversationsDrawer), puis navigate vers le détail
+        // AVANT onClose() pour que la redirection se déclenche même si le parent
+        // démonte le modal sur close.
         onCreated?.(ws.id);
+        navigate(`/hub/workspaces/${ws.id}`);
         onClose();
       } catch {
         // L'erreur est déjà capturée dans le store (createError).
         // On ne ferme PAS le modal : l'utilisateur voit le message friendly.
       }
     },
-    [name, isCreating, createWorkspace, initialSummaryIds, onCreated, onClose],
+    [
+      name,
+      isCreating,
+      createWorkspace,
+      initialSummaryIds,
+      onCreated,
+      onClose,
+      navigate,
+    ],
   );
 
   const handleQuotaRedirect = useCallback(() => {

--- a/frontend/src/components/hub/HubHeader.tsx
+++ b/frontend/src/components/hub/HubHeader.tsx
@@ -1,7 +1,9 @@
 // frontend/src/components/hub/HubHeader.tsx
 import React from "react";
-import { Menu, Search } from "lucide-react";
+import { Menu, Search, LayoutGrid } from "lucide-react";
+import { Link } from "react-router-dom";
 import { DeepSightLogo } from "./DeepSightLogo";
+import { useAuthContext } from "../../contexts/AuthContext";
 
 interface Props {
   onMenuClick: () => void;
@@ -38,6 +40,12 @@ export const HubHeader: React.FC<Props> = ({
 }) => {
   const sourceIcon =
     videoSource && SOURCE_ICON[videoSource] ? SOURCE_ICON[videoSource] : null;
+
+  // Hub Workspaces — gated Expert/admin (cohérent avec ConversationsDrawer + Sidebar PR #340).
+  // Sur `/hub`, Sidebar globale n'est pas montée, donc on expose le lien ici pour discoverability.
+  const { user } = useAuthContext();
+  const canSeeHubWorkspaces =
+    user?.plan === "expert" || user?.is_admin === true;
 
   return (
     <header className="flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-3 border-b border-white/10 bg-white/[0.02] backdrop-blur-xl sticky top-0 z-20 h-14">
@@ -88,6 +96,20 @@ export const HubHeader: React.FC<Props> = ({
         >
           <Search className="w-4 h-4" />
         </button>
+      )}
+      {canSeeHubWorkspaces && (
+        <Link
+          to="/hub/workspaces"
+          aria-label="Mes Workspaces Miro"
+          title="Mes Workspaces Miro"
+          data-testid="hub-header-workspaces-link"
+          className="flex-shrink-0 inline-flex items-center gap-1.5 h-8 px-2 sm:px-2.5 rounded-lg text-white/65 hover:bg-white/[0.06] hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+        >
+          <LayoutGrid className="w-4 h-4" />
+          <span className="hidden sm:inline text-[12px] font-medium">
+            Workspaces
+          </span>
+        </Link>
       )}
       {pipSlot}
     </header>

--- a/frontend/src/components/hub/__tests__/CreateWorkspaceModal.test.tsx
+++ b/frontend/src/components/hub/__tests__/CreateWorkspaceModal.test.tsx
@@ -187,6 +187,29 @@ describe("CreateWorkspaceModal", () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
+  it("navigates to /hub/workspaces/:id on successful create", async () => {
+    fakeState.createWorkspace = vi.fn().mockResolvedValue({
+      id: 77,
+      name: "Nav target",
+      summary_ids: [5, 6],
+      miro_board_id: null,
+      miro_board_url: null,
+      status: "pending",
+      error_message: null,
+      created_at: "2026-05-05T12:00:00Z",
+      updated_at: "2026-05-05T12:00:00Z",
+    });
+    renderModal({ initialSummaryIds: [5, 6] });
+    fireEvent.change(screen.getByLabelText(/nom du workspace/i), {
+      target: { value: "Nav target" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^créer$/i }));
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("/hub/workspaces/77"),
+    );
+  });
+
   it("closes on Escape key", () => {
     const onClose = vi.fn();
     renderModal({ onClose });

--- a/frontend/src/components/hub/__tests__/HubHeader.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubHeader.test.tsx
@@ -1,49 +1,65 @@
 // frontend/src/components/hub/__tests__/HubHeader.test.tsx
-import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { HubHeader } from "../HubHeader";
 
+// Mock useAuthContext — surchargeable par test via mockUser.
+let mockUser: { plan?: string; is_admin?: boolean } | null = null;
+vi.mock("../../../contexts/AuthContext", () => ({
+  useAuthContext: () => ({ user: mockUser }),
+}));
+
+function renderHeader(props: React.ComponentProps<typeof HubHeader>) {
+  return render(
+    <MemoryRouter>
+      <HubHeader {...props} />
+    </MemoryRouter>,
+  );
+}
+
 describe("HubHeader", () => {
+  beforeEach(() => {
+    mockUser = null;
+  });
+
   it("calls onMenuClick when hamburger pressed", () => {
     const onMenuClick = vi.fn();
-    render(
-      <HubHeader
-        onMenuClick={onMenuClick}
-        title="Conv title"
-        subtitle="YouTube · 18:32"
-      />,
-    );
+    renderHeader({
+      onMenuClick,
+      title: "Conv title",
+      subtitle: "YouTube · 18:32",
+    });
     fireEvent.click(screen.getByRole("button", { name: /conversations/i }));
     expect(onMenuClick).toHaveBeenCalled();
   });
 
   it("renders title + subtitle", () => {
-    render(
-      <HubHeader
-        onMenuClick={() => {}}
-        title="Conv title"
-        subtitle="YouTube · 18:32"
-      />,
-    );
+    renderHeader({
+      onMenuClick: () => {},
+      title: "Conv title",
+      subtitle: "YouTube · 18:32",
+    });
     expect(screen.getByText("Conv title")).toBeInTheDocument();
     expect(screen.getByText(/YouTube/i)).toBeInTheDocument();
   });
 
   it("renders pipSlot child if provided", () => {
-    render(
-      <HubHeader
-        onMenuClick={() => {}}
-        title="t"
-        pipSlot={<div data-testid="pip-mock">PIP</div>}
-      />,
-    );
+    renderHeader({
+      onMenuClick: () => {},
+      title: "t",
+      pipSlot: <div data-testid="pip-mock">PIP</div>,
+    });
     expect(screen.getByTestId("pip-mock")).toBeInTheDocument();
   });
 
   it("renders only the logo as home — no labelled 'Accueil' pill (F2)", () => {
-    render(
-      <HubHeader onMenuClick={() => {}} onHomeClick={() => {}} title="Test" />,
-    );
+    renderHeader({
+      onMenuClick: () => {},
+      onHomeClick: () => {},
+      title: "Test",
+    });
     expect(screen.queryByText("Accueil")).not.toBeInTheDocument();
     const homeButtons = screen.getAllByRole("button", {
       name: "Retour à l'accueil",
@@ -53,11 +69,37 @@ describe("HubHeader", () => {
 
   it("applies line-clamp-1 to long titles (F9)", () => {
     const longTitle = "A".repeat(200);
-    const { container } = render(
-      <HubHeader onMenuClick={() => {}} title={longTitle} />,
-    );
+    const { container } = renderHeader({
+      onMenuClick: () => {},
+      title: longTitle,
+    });
     const titleEl = container.querySelector("p.line-clamp-1");
     expect(titleEl).toBeInTheDocument();
     expect(titleEl?.textContent).toBe(longTitle);
+  });
+
+  // ─── Wave 2c — Workspaces gating Expert/admin ─────────────────────────────
+  it("shows Workspaces link when user.plan = expert", () => {
+    mockUser = { plan: "expert", is_admin: false };
+    renderHeader({ onMenuClick: () => {}, title: "Test" });
+    const link = screen.getByTestId("hub-header-workspaces-link");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/hub/workspaces");
+  });
+
+  it("shows Workspaces link when user.is_admin = true", () => {
+    mockUser = { plan: "free", is_admin: true };
+    renderHeader({ onMenuClick: () => {}, title: "Test" });
+    expect(
+      screen.getByTestId("hub-header-workspaces-link"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Workspaces link for Pro users (non-Expert / non-admin)", () => {
+    mockUser = { plan: "pro", is_admin: false };
+    renderHeader({ onMenuClick: () => {}, title: "Test" });
+    expect(
+      screen.queryByTestId("hub-header-workspaces-link"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/HubWorkspacesPage.tsx
+++ b/frontend/src/pages/HubWorkspacesPage.tsx
@@ -46,6 +46,7 @@ import {
   useHubWorkspacesStore,
   type HubWorkspaceErrorState,
 } from "../store/useHubWorkspacesStore";
+import { videoApi } from "../services/api";
 import type { HubWorkspace, HubWorkspaceStatus } from "../services/api";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -413,6 +414,12 @@ interface DetailModeProps {
   onDelete: (id: number) => void;
 }
 
+interface SummaryPreview {
+  title: string;
+  thumbnail?: string;
+  channel?: string;
+}
+
 const DetailMode: React.FC<DetailModeProps> = ({
   id,
   workspace,
@@ -422,6 +429,53 @@ const DetailMode: React.FC<DetailModeProps> = ({
   onRefetch,
   onDelete,
 }) => {
+  // Wave 2c — fetch les détails des analyses pour afficher les vrais titres
+  // (au lieu de "Analyse #ID" brut). On stocke null = "fetch terminé, échec"
+  // (analyse supprimée / inaccessible) ; absent de la map = "fetch en cours".
+  const [summaryDetails, setSummaryDetails] = useState<
+    Record<number, SummaryPreview | null>
+  >({});
+  const [isLoadingSummaries, setIsLoadingSummaries] = useState(false);
+
+  const summaryIdsKey = workspace?.summary_ids.join(",") ?? "";
+
+  useEffect(() => {
+    if (!workspace || workspace.summary_ids.length === 0) {
+      setSummaryDetails({});
+      setIsLoadingSummaries(false);
+      return;
+    }
+    let cancelled = false;
+    setIsLoadingSummaries(true);
+    setSummaryDetails({});
+    const ids = workspace.summary_ids;
+    Promise.all(
+      ids.map((sid) =>
+        videoApi
+          .getSummary(sid)
+          .then((s): SummaryPreview => ({
+            title: s.video_title,
+            thumbnail: s.thumbnail_url,
+            channel: s.video_channel,
+          }))
+          .catch((): SummaryPreview | null => null),
+      ),
+    ).then((results) => {
+      if (cancelled) return;
+      const next: Record<number, SummaryPreview | null> = {};
+      ids.forEach((sid, idx) => {
+        next[sid] = results[idx];
+      });
+      setSummaryDetails(next);
+      setIsLoadingSummaries(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // summaryIdsKey identifie la liste : se relance si elle change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [summaryIdsKey, workspace?.id]);
+
   if (isLoading && !workspace) {
     return <DetailSkeleton />;
   }
@@ -530,18 +584,96 @@ const DetailMode: React.FC<DetailModeProps> = ({
           </p>
         ) : (
           <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {workspace.summary_ids.map((summaryId) => (
-              <li key={summaryId}>
-                <Link
-                  to={`/analysis/${summaryId}`}
-                  className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-text-secondary hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60"
-                  data-testid={`hub-workspaces-analysis-link-${summaryId}`}
-                >
-                  <span className="truncate">Analyse #{summaryId}</span>
-                  <ArrowUpRight className="w-3.5 h-3.5 shrink-0" aria-hidden />
-                </Link>
-              </li>
-            ))}
+            {workspace.summary_ids.map((summaryId) => {
+              const detail = summaryDetails[summaryId];
+              const hasFetched = summaryId in summaryDetails;
+              const isLoadingItem = !hasFetched && isLoadingSummaries;
+
+              if (isLoadingItem) {
+                return (
+                  <li key={summaryId}>
+                    <div
+                      className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10 animate-pulse"
+                      data-testid={`hub-workspaces-analysis-skeleton-${summaryId}`}
+                    >
+                      <div className="w-10 h-7 rounded bg-white/10 shrink-0" />
+                      <div className="flex-1 min-w-0 space-y-1.5">
+                        <div className="h-3 w-3/4 bg-white/10 rounded" />
+                        <div className="h-2.5 w-1/2 bg-white/5 rounded" />
+                      </div>
+                    </div>
+                  </li>
+                );
+              }
+
+              if (detail === null) {
+                return (
+                  <li key={summaryId}>
+                    <span
+                      className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-white/[0.02] border border-white/5 text-xs text-text-muted italic cursor-not-allowed"
+                      data-testid={`hub-workspaces-analysis-unavailable-${summaryId}`}
+                      aria-label={`Analyse #${summaryId} indisponible`}
+                    >
+                      <span className="truncate">
+                        Analyse #{summaryId} (indisponible)
+                      </span>
+                    </span>
+                  </li>
+                );
+              }
+
+              if (detail) {
+                return (
+                  <li key={summaryId}>
+                    <Link
+                      to={`/analysis/${summaryId}`}
+                      className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-text-secondary hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60"
+                      data-testid={`hub-workspaces-analysis-link-${summaryId}`}
+                    >
+                      {detail.thumbnail ? (
+                        <img
+                          src={detail.thumbnail}
+                          alt=""
+                          className="w-10 h-7 rounded object-cover shrink-0 bg-white/[0.04]"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="w-10 h-7 rounded bg-white/[0.04] shrink-0" />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <p className="truncate text-[12px] font-medium text-white/90">
+                          {detail.title}
+                        </p>
+                        {detail.channel && (
+                          <p className="truncate text-[10px] text-text-muted mt-0.5">
+                            {detail.channel}
+                          </p>
+                        )}
+                      </div>
+                      <ArrowUpRight
+                        className="w-3.5 h-3.5 shrink-0 text-text-muted"
+                        aria-hidden
+                      />
+                    </Link>
+                  </li>
+                );
+              }
+
+              // Fallback (jamais atteint en théorie : détail est defined OU
+              // null une fois fetch fini, OR loading sinon).
+              return (
+                <li key={summaryId}>
+                  <Link
+                    to={`/analysis/${summaryId}`}
+                    className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-text-secondary hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60"
+                    data-testid={`hub-workspaces-analysis-link-${summaryId}`}
+                  >
+                    <span className="truncate">Analyse #{summaryId}</span>
+                    <ArrowUpRight className="w-3.5 h-3.5 shrink-0" aria-hidden />
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         )}
       </section>

--- a/frontend/src/pages/__tests__/HubWorkspacesPage.test.tsx
+++ b/frontend/src/pages/__tests__/HubWorkspacesPage.test.tsx
@@ -27,6 +27,10 @@ vi.mock("../../services/api", async () => {
       getWorkspace: vi.fn(),
       deleteWorkspace: vi.fn(),
     },
+    videoApi: {
+      ...actual.videoApi,
+      getSummary: vi.fn(),
+    },
   };
 });
 
@@ -49,7 +53,7 @@ vi.mock("../../hooks/useAuth", () => ({
   useAuth: () => mockAuthState,
 }));
 
-import { hubApi, type HubWorkspace } from "../../services/api";
+import { hubApi, videoApi, type HubWorkspace } from "../../services/api";
 import { useHubWorkspacesStore } from "../../store/useHubWorkspacesStore";
 import HubWorkspacesPage from "../HubWorkspacesPage";
 
@@ -58,6 +62,10 @@ const mockedHubApi = hubApi as unknown as {
   listWorkspaces: ReturnType<typeof vi.fn>;
   getWorkspace: ReturnType<typeof vi.fn>;
   deleteWorkspace: ReturnType<typeof vi.fn>;
+};
+
+const mockedVideoApi = videoApi as unknown as {
+  getSummary: ReturnType<typeof vi.fn>;
 };
 
 function makeWorkspace(overrides: Partial<HubWorkspace> = {}): HubWorkspace {
@@ -90,11 +98,32 @@ function renderAtPath(path: string) {
 describe("HubWorkspacesPage", () => {
   beforeEach(() => {
     useHubWorkspacesStore.getState().reset();
-    vi.clearAllMocks();
+    // Reset complet (vide implementations + history) — nécessaire pour purger
+    // les mockResolvedValueOnce queued entre tests qui sinon polluent les
+    // tests suivants.
+    mockedHubApi.createWorkspace.mockReset();
+    mockedHubApi.listWorkspaces.mockReset();
+    mockedHubApi.getWorkspace.mockReset();
+    mockedHubApi.deleteWorkspace.mockReset();
+    mockedVideoApi.getSummary.mockReset();
     mockAuthState = {
       user: { plan: "expert", is_admin: false, preferences: {} },
       loading: false,
     };
+    // Default : résout avec un summary générique pour les tests existants qui
+    // n'override pas spécifiquement videoApi.getSummary mais qui montent le
+    // mode détail (mode détail / polling). Évite l'erreur
+    // "Cannot read properties of undefined (reading 'then')" tout en gardant
+    // un lien `hub-workspaces-analysis-link-${id}` cliquable.
+    mockedVideoApi.getSummary.mockImplementation(async (sid: number) => ({
+      id: sid,
+      video_id: `vid-${sid}`,
+      video_title: `Analyse ${sid}`,
+      video_channel: "Test Channel",
+      thumbnail_url: undefined,
+      summary_content: "stub",
+      created_at: "2026-05-05T12:00:00Z",
+    }));
   });
 
   afterEach(() => {
@@ -256,5 +285,78 @@ describe("HubWorkspacesPage", () => {
     ).toBeInTheDocument();
     // Aucun appel API ne doit avoir lieu pour un non-expert
     expect(mockedHubApi.listWorkspaces).not.toHaveBeenCalled();
+  });
+
+  // ─── 7. Detail mode — fetches and displays real titles ─────────────────────
+  it("fetches and displays real titles for summary_ids in detail view", async () => {
+    const ws = makeWorkspace({
+      id: 200,
+      name: "Real Titles WS",
+      status: "ready",
+      miro_board_id: "boardX",
+      summary_ids: [501, 502, 503],
+    });
+    mockedHubApi.getWorkspace.mockResolvedValueOnce(ws);
+
+    // 3 summaries : 2 OK (titres + thumbnail + channel) + 1 fail (indisponible)
+    mockedVideoApi.getSummary.mockImplementation(async (sid: number) => {
+      if (sid === 501) {
+        return {
+          id: 501,
+          video_id: "abc",
+          video_title: "Le futur de l'IA",
+          video_channel: "Science Étonnante",
+          thumbnail_url: "https://img.test/501.jpg",
+          summary_content: "...",
+          created_at: "2026-05-05T12:00:00Z",
+        };
+      }
+      if (sid === 502) {
+        return {
+          id: 502,
+          video_id: "def",
+          video_title: "Conscience et qualia",
+          video_channel: "Monsieur Phi",
+          thumbnail_url: "https://img.test/502.jpg",
+          summary_content: "...",
+          created_at: "2026-05-05T12:00:00Z",
+        };
+      }
+      throw new Error("not found");
+    });
+
+    renderAtPath("/hub/workspaces/200");
+
+    // Vrais titres affichés
+    await waitFor(() => {
+      expect(screen.getByText("Le futur de l'IA")).toBeInTheDocument();
+      expect(screen.getByText("Conscience et qualia")).toBeInTheDocument();
+    });
+
+    // Channel affiché
+    expect(screen.getByText("Science Étonnante")).toBeInTheDocument();
+    expect(screen.getByText("Monsieur Phi")).toBeInTheDocument();
+
+    // Items disponibles : liens cliquables vers /analysis/:id
+    expect(
+      screen.getByTestId("hub-workspaces-analysis-link-501"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hub-workspaces-analysis-link-502"),
+    ).toBeInTheDocument();
+
+    // Item 503 indisponible — fallback italique sans lien
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hub-workspaces-analysis-unavailable-503"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/analyse #503 \(indisponible\)/i)).toBeInTheDocument();
+
+    // 3 fetchs déclenchés
+    expect(mockedVideoApi.getSummary).toHaveBeenCalledTimes(3);
+    expect(mockedVideoApi.getSummary).toHaveBeenCalledWith(501);
+    expect(mockedVideoApi.getSummary).toHaveBeenCalledWith(502);
+    expect(mockedVideoApi.getSummary).toHaveBeenCalledWith(503);
   });
 });


### PR DESCRIPTION
Wave 2c Agent G consolidé. Résout 3 problèmes UX du Sprint Hub Miro Workspace MVP en une PR atomique.

## Problèmes résolus

### 1. Bouton Workspaces dans HubHeader (discoverability)
- Le composant `Sidebar` global ajouté en PR #340 contient bien le lien Workspaces, mais **n'est pas monté sur /hub** (HubPage utilise son propre HubHeader).
- Conséquence : utilisateurs Expert/admin sur /hub ne voient AUCUN point d'entrée vers leurs workspaces, sauf à passer par le drawer + mode select (un peu caché).
- Fix : `<HubHeader>` expose désormais un lien `LayoutGrid → /hub/workspaces`, gated `user.plan === "expert" || user.is_admin === true` via `useAuthContext()` (même pattern que ConversationsDrawer).
- Label visible desktop, icon-only mobile.

### 2. CreateWorkspaceModal redirect post-create
- Avant : sur succès, le modal appelait `onCreated?.()` puis `onClose()` — l'utilisateur restait sur le drawer ou la page courante, sans feedback de localisation du nouveau workspace.
- Après : `navigate('/hub/workspaces/:id')` insertée AVANT `onClose()` (préserve callback `onCreated` parent + gestion d'erreurs 429/403 inchangée).

### 3. HubWorkspacesPage mode détail — vrais titres analyses
- Avant : section "Analyses du workspace" affichait `Analyse #${id}` brut, sans titre, thumbnail, ni channel.
- Après : `Promise.all(summary_ids.map(videoApi.getSummary))` au mount, état loading per-item (skeleton), affichage titre réel + thumbnail + channel + lien `/analysis/:id` cliquable, fallback `Analyse #ID (indisponible)` italique sans lien sur échec API (analyse supprimée / 404).

## Fichiers touchés
- `frontend/src/components/hub/HubHeader.tsx`
- `frontend/src/components/hub/CreateWorkspaceModal.tsx`
- `frontend/src/pages/HubWorkspacesPage.tsx`
- 3 tests (HubHeader, CreateWorkspaceModal, HubWorkspacesPage)

## Tests verts (22/22)
- HubHeader : 3 nouveaux tests gating Expert visible / admin visible / Pro caché (+ 5 existants)
- CreateWorkspaceModal : 1 nouveau test `navigates to /hub/workspaces/:id on successful create` (+ 6 existants)
- HubWorkspacesPage : 1 nouveau test `fetches and displays real titles for summary_ids in detail view` (+ 6 existants)

Aucune régression TypeScript sur les 3 fichiers touchés.

## Test plan
- [ ] Reload page /hub avec user expert → bouton "Workspaces" visible dans le header (côté droit)
- [ ] Click → navigation vers /hub/workspaces
- [ ] Avec user Pro → bouton invisible
- [ ] Drawer → mode select → sélection 2 analyses → "Créer Workspace" → modal → submit → redirect direct vers /hub/workspaces/:newId
- [ ] Page détail workspace → vrais titres + thumbnails + channels affichés (skeleton pendant fetch, fallback indisponible si API fail)

Spec ref : Sprint Hub Miro Workspace MVP (PR #334).