### PR TITLE
feat(observability): scripted Sentry alert rules + Telegram notifications

### DIFF
--- a/backend/scripts/sentry_alerts_config.py
+++ b/backend/scripts/sentry_alerts_config.py
@@ -1,0 +1,292 @@
+"""Sentry alert rules configuration for DeepSight.
+
+Source-of-truth for the 6 production alert rules managed by
+``setup_sentry_alerts.py``. Edit this file to adjust thresholds,
+add new rules, or change criticality, then re-run the setup script.
+
+Each rule targets a specific Sentry project (backend / frontend / mobile)
+and is matched idempotently by ``name`` + ``project`` on each run.
+
+References:
+- https://docs.sentry.io/api/alerts/create-an-issue-alert-rule-for-a-project/
+- https://docs.sentry.io/api/alerts/create-a-metric-alert-rule-for-an-organization/
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Criticality = Literal["low", "medium", "high"]
+Project = Literal["backend", "frontend", "mobile"]
+RuleKind = Literal["issue", "metric"]
+
+
+@dataclass(frozen=True)
+class IssueAlertRule:
+    """Issue alert rule (filters/conditions on raw events).
+
+    Maps to ``POST /api/0/projects/{org}/{project}/rules/`` in the Sentry API.
+    """
+
+    name: str
+    project: Project
+    criticality: Criticality
+    description: str
+    # Sentry payload fields (see API ref).
+    conditions: list[dict[str, Any]]
+    filters: list[dict[str, Any]] = field(default_factory=list)
+    actions: list[dict[str, Any]] = field(default_factory=list)
+    action_match: Literal["all", "any", "none"] = "all"
+    filter_match: Literal["all", "any", "none"] = "all"
+    frequency: int = 30  # min minutes between repeated alerts for the same issue
+    environment: str | None = "production"
+    kind: RuleKind = "issue"
+
+
+@dataclass(frozen=True)
+class MetricAlertRule:
+    """Metric alert rule (aggregations on transactions / sessions).
+
+    Maps to ``POST /api/0/organizations/{org}/alert-rules/`` in the Sentry API.
+    """
+
+    name: str
+    project: Project
+    criticality: Criticality
+    description: str
+    # Sentry payload fields (see API ref).
+    dataset: Literal["events", "transactions", "metrics", "sessions"]
+    query: str
+    aggregate: str  # ex: "p95(transaction.duration)" or "count()"
+    time_window: int  # minutes
+    threshold_type: int  # 0 = above, 1 = below
+    resolve_threshold: float | None
+    triggers: list[dict[str, Any]]
+    environment: str | None = "production"
+    kind: RuleKind = "metric"
+
+
+# ---------------------------------------------------------------------------
+# Telegram action helper
+# ---------------------------------------------------------------------------
+
+def telegram_action(installation_id: str | None, room: str = "") -> list[dict[str, Any]]:
+    """Build the Sentry "send notification to Telegram" action.
+
+    If ``installation_id`` is None, falls back to the default project mail
+    action so the rule still fires (without Telegram). The Telegram
+    integration must be installed manually first (see RUNBOOK §17).
+    """
+    if not installation_id:
+        # Fallback: send to all members on the project's mail plugin.
+        return [
+            {
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetType": "IssueOwners",
+                "targetIdentifier": "",
+                "fallthroughType": "ActiveMembers",
+            }
+        ]
+    return [
+        {
+            "id": "sentry.integrations.telegram.notify_action.TelegramNotifyServiceAction",
+            "integration": installation_id,
+            "room": room,
+            "tags": "level,environment",
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Rule definitions — 6 alerts (3 backend, 2 frontend, 1 mobile)
+# ---------------------------------------------------------------------------
+
+def build_rules(telegram_installation_id: str | None) -> list[IssueAlertRule | MetricAlertRule]:
+    """Return the canonical list of 6 production alert rules."""
+    tg = telegram_action(telegram_installation_id)
+
+    return [
+        # -------------------------------------------------------------------
+        # 1. BACKEND — HTTP 500 spike (>10 events/hour at level:error)
+        # -------------------------------------------------------------------
+        IssueAlertRule(
+            name="[backend] HTTP 500 spike (>10/h)",
+            project="backend",
+            criticality="high",
+            description=(
+                "Triggers when more than 10 ERROR-level events are seen in a "
+                "rolling 1-hour window. Catches sudden 5xx surges from the "
+                "FastAPI app (Mistral failures, DB outages, panic in worker)."
+            ),
+            conditions=[
+                {
+                    "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+                    "value": 10,
+                    "interval": "1h",
+                    "comparisonType": "count",
+                }
+            ],
+            filters=[
+                {
+                    "id": "sentry.rules.filters.level.LevelFilter",
+                    "match": "gte",
+                    "level": "40",  # ERROR
+                }
+            ],
+            actions=tg,
+            action_match="all",
+            filter_match="all",
+            frequency=30,
+        ),
+
+        # -------------------------------------------------------------------
+        # 2. BACKEND — Latency p95 > 5s on transactions (rolling 5 min)
+        # -------------------------------------------------------------------
+        MetricAlertRule(
+            name="[backend] Latency p95 > 5s",
+            project="backend",
+            criticality="high",
+            description=(
+                "Triggers when the p95 of transaction.duration exceeds 5000 ms "
+                "over the last 5 minutes. Production p95 should stay <2s for "
+                "REST handlers and <8s for /api/videos/analyze (excluded via "
+                "the dataset query)."
+            ),
+            dataset="transactions",
+            query='event.type:transaction !transaction:"/api/videos/analyze"',
+            aggregate="p95(transaction.duration)",
+            time_window=5,
+            threshold_type=0,  # above threshold
+            resolve_threshold=3000.0,
+            triggers=[
+                {
+                    "label": "critical",
+                    "alertThreshold": 5000.0,
+                    "actions": tg,
+                }
+            ],
+        ),
+
+        # -------------------------------------------------------------------
+        # 3. BACKEND — Sentry quota approaching (>80% of monthly events ingested)
+        # -------------------------------------------------------------------
+        # NOTE: Sentry does not expose a clean "quota %" metric in alert rules,
+        # so we approximate it with a high-volume event-frequency rule that
+        # matches when raw event count crosses an org-tuned threshold over 24h.
+        # Adjust ``value`` to match your monthly quota / 30 / 0.8.
+        IssueAlertRule(
+            name="[backend] Sentry quota approaching (80%)",
+            project="backend",
+            criticality="low",
+            description=(
+                "Daily proxy for Sentry monthly quota. Triggers when raw event "
+                "count over 24h exceeds 80%% of the daily allotment "
+                "(monthly_quota / 30). Adjust the ``value`` field in code "
+                "when the Sentry plan changes."
+            ),
+            conditions=[
+                {
+                    "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+                    "value": 800,  # ~80% of 1k daily events; tune for your plan
+                    "interval": "24h",
+                    "comparisonType": "count",
+                }
+            ],
+            filters=[],
+            actions=tg,
+            action_match="all",
+            filter_match="all",
+            frequency=1440,  # at most once per day
+        ),
+
+        # -------------------------------------------------------------------
+        # 4. FRONTEND — New issue affecting >5 unique users in 1h
+        # -------------------------------------------------------------------
+        IssueAlertRule(
+            name="[frontend] Issue affecting >5 users (1h)",
+            project="frontend",
+            criticality="high",
+            description=(
+                "Triggers when a single issue impacts more than 5 unique users "
+                "in a 1-hour window. Catches widespread regressions on web."
+            ),
+            conditions=[
+                {
+                    "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
+                    "value": 5,
+                    "interval": "1h",
+                    "comparisonType": "count",
+                }
+            ],
+            filters=[],
+            actions=tg,
+            action_match="all",
+            filter_match="all",
+            frequency=60,
+        ),
+
+        # -------------------------------------------------------------------
+        # 5. FRONTEND — Browser error rate (>100 events/h with exception)
+        # -------------------------------------------------------------------
+        IssueAlertRule(
+            name="[frontend] Browser error rate (>100/h)",
+            project="frontend",
+            criticality="medium",
+            description=(
+                "Triggers when more than 100 events with an exception payload "
+                "are ingested in 1 hour. Watches general browser-side error "
+                "volume independently of unique-user impact."
+            ),
+            conditions=[
+                {
+                    "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+                    "value": 100,
+                    "interval": "1h",
+                    "comparisonType": "count",
+                }
+            ],
+            filters=[
+                {
+                    "id": "sentry.rules.filters.event_attribute.EventAttributeFilter",
+                    "attribute": "exception",
+                    "match": "is",
+                    "value": "",
+                }
+            ],
+            actions=tg,
+            action_match="all",
+            filter_match="any",
+            frequency=60,
+        ),
+
+        # -------------------------------------------------------------------
+        # 6. MOBILE — Crash rate > 1% over 24h (sessions dataset)
+        # -------------------------------------------------------------------
+        MetricAlertRule(
+            name="[mobile] Crash rate > 1% (24h)",
+            project="mobile",
+            criticality="high",
+            description=(
+                "Triggers when the ratio of crashed sessions to total sessions "
+                "exceeds 1%% over a rolling 24-hour window. Standard "
+                "crash-free-rate KPI for the Expo app."
+            ),
+            dataset="sessions",
+            query="",
+            aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alias",
+            time_window=1440,
+            threshold_type=0,  # above
+            resolve_threshold=0.5,
+            triggers=[
+                {
+                    "label": "critical",
+                    "alertThreshold": 1.0,
+                    "actions": tg,
+                }
+            ],
+        ),
+    ]

--- a/backend/scripts/setup_sentry_alerts.py
+++ b/backend/scripts/setup_sentry_alerts.py
@@ -1,0 +1,369 @@
+"""Idempotent Sentry alert rules provisioning for DeepSight.
+
+Reads the rule definitions from :mod:`sentry_alerts_config` and upserts
+them into the configured Sentry organization via the public REST API.
+
+Idempotence
+-----------
+A rule is matched on ``(name, project)``. On every run the script:
+
+1. Lists existing rules for each target project.
+2. Looks for a rule with the exact same ``name``.
+3. If found → updates it in place (no duplicate).
+4. Otherwise → creates a new rule.
+
+So running the script twice does NOT create duplicate rules.
+
+Environment variables
+---------------------
+Required:
+- ``SENTRY_AUTH_TOKEN``           -- bearer token, scope ``alerts:write`` + ``project:read``
+- ``SENTRY_ORG_SLUG``             -- e.g. ``deepsight``
+- ``SENTRY_PROJECT_SLUG_BACKEND`` -- e.g. ``deepsight-backend``
+- ``SENTRY_PROJECT_SLUG_FRONTEND`` -- e.g. ``deepsight-frontend``
+- ``SENTRY_PROJECT_SLUG_MOBILE``  -- e.g. ``deepsight-mobile``
+
+Optional:
+- ``TELEGRAM_INTEGRATION_INSTALLATION_ID`` -- Sentry integration installation id
+  (Settings → Integrations → Telegram → ⓘ → Installation ID).
+  If absent, alerts fall back to the default email action so they still fire.
+
+Usage
+-----
+::
+
+    cd backend
+    python scripts/setup_sentry_alerts.py --dry-run --project all
+    python scripts/setup_sentry_alerts.py --project backend
+    python scripts/setup_sentry_alerts.py --project all
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict
+from typing import Any
+
+import httpx
+
+# Local import (script is run from backend/, so add scripts/ to sys.path)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sentry_alerts_config import (  # noqa: E402
+    IssueAlertRule,
+    MetricAlertRule,
+    build_rules,
+)
+
+SENTRY_API_BASE = "https://sentry.io/api/0"
+
+
+# ---------------------------------------------------------------------------
+# Env loading
+# ---------------------------------------------------------------------------
+
+class EnvError(RuntimeError):
+    """Raised when a required env var is missing."""
+
+
+def _require_env(key: str) -> str:
+    value = os.environ.get(key)
+    if not value:
+        raise EnvError(f"missing required env var: {key}")
+    return value
+
+
+def load_env() -> dict[str, str | None]:
+    return {
+        "auth_token": _require_env("SENTRY_AUTH_TOKEN"),
+        "org_slug": _require_env("SENTRY_ORG_SLUG"),
+        "project_backend": _require_env("SENTRY_PROJECT_SLUG_BACKEND"),
+        "project_frontend": _require_env("SENTRY_PROJECT_SLUG_FRONTEND"),
+        "project_mobile": _require_env("SENTRY_PROJECT_SLUG_MOBILE"),
+        "telegram_installation_id": os.environ.get("TELEGRAM_INTEGRATION_INSTALLATION_ID"),
+    }
+
+
+def project_slug(env: dict[str, str | None], project_name: str) -> str:
+    mapping = {
+        "backend": env["project_backend"],
+        "frontend": env["project_frontend"],
+        "mobile": env["project_mobile"],
+    }
+    slug = mapping.get(project_name)
+    if not slug:
+        raise ValueError(f"unknown project: {project_name}")
+    return slug  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Sentry HTTP client
+# ---------------------------------------------------------------------------
+
+class SentryClient:
+    """Tiny HTTP wrapper using stdlib types via httpx."""
+
+    def __init__(self, auth_token: str, org_slug: str, dry_run: bool = False) -> None:
+        self.org = org_slug
+        self.dry_run = dry_run
+        self._client = httpx.Client(
+            base_url=SENTRY_API_BASE,
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    # ----- Issue alert rules (per-project) -----
+
+    def list_issue_rules(self, project_slug: str) -> list[dict[str, Any]]:
+        resp = self._client.get(f"/projects/{self.org}/{project_slug}/rules/")
+        resp.raise_for_status()
+        return resp.json()
+
+    def create_issue_rule(self, project_slug: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if self.dry_run:
+            return {"id": "DRY-RUN", "name": payload.get("name")}
+        resp = self._client.post(
+            f"/projects/{self.org}/{project_slug}/rules/",
+            content=json.dumps(payload),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_issue_rule(
+        self, project_slug: str, rule_id: int | str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        if self.dry_run:
+            return {"id": rule_id, "name": payload.get("name")}
+        resp = self._client.put(
+            f"/projects/{self.org}/{project_slug}/rules/{rule_id}/",
+            content=json.dumps(payload),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    # ----- Metric alert rules (org-wide, scoped via projects[]) -----
+
+    def list_metric_rules(self) -> list[dict[str, Any]]:
+        resp = self._client.get(f"/organizations/{self.org}/alert-rules/")
+        resp.raise_for_status()
+        return resp.json()
+
+    def create_metric_rule(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self.dry_run:
+            return {"id": "DRY-RUN", "name": payload.get("name")}
+        resp = self._client.post(
+            f"/organizations/{self.org}/alert-rules/",
+            content=json.dumps(payload),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_metric_rule(self, rule_id: int | str, payload: dict[str, Any]) -> dict[str, Any]:
+        if self.dry_run:
+            return {"id": rule_id, "name": payload.get("name")}
+        resp = self._client.put(
+            f"/organizations/{self.org}/alert-rules/{rule_id}/",
+            content=json.dumps(payload),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+def issue_rule_payload(rule: IssueAlertRule) -> dict[str, Any]:
+    """Convert IssueAlertRule into the Sentry API payload."""
+    return {
+        "name": rule.name,
+        "actionMatch": rule.action_match,
+        "filterMatch": rule.filter_match,
+        "conditions": list(rule.conditions),
+        "filters": list(rule.filters),
+        "actions": list(rule.actions),
+        "frequency": rule.frequency,
+        "environment": rule.environment,
+    }
+
+
+def metric_rule_payload(rule: MetricAlertRule, project_slug_value: str) -> dict[str, Any]:
+    """Convert MetricAlertRule into the Sentry org-level alert-rules payload."""
+    return {
+        "name": rule.name,
+        "dataset": rule.dataset,
+        "query": rule.query,
+        "aggregate": rule.aggregate,
+        "timeWindow": rule.time_window,
+        "thresholdType": rule.threshold_type,
+        "resolveThreshold": rule.resolve_threshold,
+        "triggers": list(rule.triggers),
+        "projects": [project_slug_value],
+        "environment": rule.environment,
+        "owner": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Upsert logic
+# ---------------------------------------------------------------------------
+
+def upsert_issue_rule(
+    client: SentryClient,
+    rule: IssueAlertRule,
+    project_slug_value: str,
+) -> tuple[str, str | int]:
+    """Create or update an issue alert rule. Returns (action, rule_id)."""
+    existing = client.list_issue_rules(project_slug_value)
+    payload = issue_rule_payload(rule)
+    for er in existing:
+        if er.get("name") == rule.name:
+            updated = client.update_issue_rule(project_slug_value, er["id"], payload)
+            return ("updated", updated.get("id", er["id"]))
+    created = client.create_issue_rule(project_slug_value, payload)
+    return ("created", created.get("id", "?"))
+
+
+def upsert_metric_rule(
+    client: SentryClient,
+    rule: MetricAlertRule,
+    project_slug_value: str,
+) -> tuple[str, str | int]:
+    """Create or update a metric alert rule. Returns (action, rule_id)."""
+    existing = client.list_metric_rules()
+    payload = metric_rule_payload(rule, project_slug_value)
+    for er in existing:
+        if er.get("name") == rule.name:
+            updated = client.update_metric_rule(er["id"], payload)
+            return ("updated", updated.get("id", er["id"]))
+    created = client.create_metric_rule(payload)
+    return ("created", created.get("id", "?"))
+
+
+# ---------------------------------------------------------------------------
+# Main runner
+# ---------------------------------------------------------------------------
+
+def run(scope: str, dry_run: bool) -> int:
+    try:
+        env = load_env()
+    except EnvError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if dry_run:
+        print(">>> DRY RUN — no API writes will be performed.")
+    print(f"Org slug: {env['org_slug']}")
+    print(f"Telegram installation id: {env.get('telegram_installation_id') or '(none — falling back to email action)'}")
+    print()
+
+    rules = build_rules(env.get("telegram_installation_id"))
+
+    if scope != "all":
+        rules = [r for r in rules if r.project == scope]
+    if not rules:
+        print(f"No rules to apply for scope={scope}", file=sys.stderr)
+        return 1
+
+    client = SentryClient(
+        auth_token=env["auth_token"],  # type: ignore[arg-type]
+        org_slug=env["org_slug"],  # type: ignore[arg-type]
+        dry_run=dry_run,
+    )
+
+    # Pretty table output.
+    header = f"{'PROJECT':<10} {'KIND':<7} {'CRIT':<7} {'NAME':<46} {'ACTION':<10} ID"
+    print(header)
+    print("-" * len(header))
+
+    successes = 0
+    failures: list[tuple[str, str]] = []
+
+    try:
+        for rule in rules:
+            slug = project_slug(env, rule.project)
+            try:
+                if isinstance(rule, IssueAlertRule):
+                    action, rule_id = upsert_issue_rule(client, rule, slug)
+                elif isinstance(rule, MetricAlertRule):
+                    action, rule_id = upsert_metric_rule(client, rule, slug)
+                else:  # pragma: no cover -- unreachable
+                    raise TypeError(f"unknown rule type: {type(rule)!r}")
+                successes += 1
+                print(
+                    f"{rule.project:<10} {rule.kind:<7} {rule.criticality:<7} "
+                    f"{rule.name[:46]:<46} {action:<10} {rule_id}"
+                )
+            except httpx.HTTPStatusError as exc:
+                detail = ""
+                try:
+                    detail = exc.response.text[:300]
+                except Exception:
+                    pass
+                failures.append((rule.name, f"HTTP {exc.response.status_code}: {detail}"))
+                print(
+                    f"{rule.project:<10} {rule.kind:<7} {rule.criticality:<7} "
+                    f"{rule.name[:46]:<46} {'FAILED':<10} -"
+                )
+            except Exception as exc:  # noqa: BLE001
+                failures.append((rule.name, str(exc)))
+                print(
+                    f"{rule.project:<10} {rule.kind:<7} {rule.criticality:<7} "
+                    f"{rule.name[:46]:<46} {'ERROR':<10} -"
+                )
+    finally:
+        client.close()
+
+    print()
+    print(f"Summary: {successes} ok / {len(failures)} failed / {len(rules)} total")
+    if failures:
+        print("\nFailures:")
+        for name, reason in failures:
+            print(f"  - {name}: {reason}")
+        return 1
+
+    if dry_run:
+        print("\n(dry-run) preview only -- re-run without --dry-run to apply.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Provision DeepSight Sentry alert rules idempotently.",
+    )
+    parser.add_argument(
+        "--project",
+        choices=["backend", "frontend", "mobile", "all"],
+        default="all",
+        help="scope: which Sentry project to touch (default: all)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the plan without performing any API writes",
+    )
+    parser.add_argument(
+        "--show-config",
+        action="store_true",
+        help="dump the resolved rule definitions as JSON and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.show_config:
+        rules = build_rules(os.environ.get("TELEGRAM_INTEGRATION_INSTALLATION_ID"))
+        # ``asdict`` works on frozen dataclasses too.
+        print(json.dumps([asdict(r) for r in rules], indent=2, default=str))
+        return 0
+
+    return run(scope=args.project, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -606,3 +606,150 @@ A `200 OK` confirms the token + dataset combo works.
 - Drain Caddy access logs via the `caddy-axiom` plugin or a sidecar `vector` container. Skipped here to avoid touching the Caddyfile bind-mount.
 - Add a `/api/admin/axiom-stats` endpoint that surfaces `get_axiom_stats()` so we can graph drop rates without SSH.
 - Pipe APScheduler job heartbeats with a stable `job_id` field for easier alerting on missed backups.
+
+---
+
+## 17. Sentry alert rules
+
+Sentry alerts for the 4 platforms (backend / frontend / mobile / extension)
+are provisioned **programmatically** by
+`backend/scripts/setup_sentry_alerts.py`. Rule definitions live in
+`backend/scripts/sentry_alerts_config.py` (single source of truth).
+
+The script is idempotent: it matches existing rules by `(name, project)`
+and updates them in place, so it can be re-run safely after a threshold
+change.
+
+### 17.1 Setting up the auth token (one-time per machine)
+
+1. Go to <https://sentry.io/settings/account/api/auth-tokens/>.
+2. Click **Create New Token**.
+3. Required scopes:
+   - `project:read`
+   - `project:write`
+   - `alerts:read`
+   - `alerts:write`
+4. Copy the token and export it locally:
+
+   ```bash
+   export SENTRY_AUTH_TOKEN=sntrys_…
+   ```
+
+   For permanent CI use, store it as a GitHub repository secret named
+   `SENTRY_AUTH_TOKEN`.
+
+5. Find the org and project slugs in the Sentry URL bar
+   (`https://sentry.io/organizations/<ORG_SLUG>/projects/<PROJECT_SLUG>/`).
+
+   ```bash
+   export SENTRY_ORG_SLUG=deepsight
+   export SENTRY_PROJECT_SLUG_BACKEND=deepsight-backend
+   export SENTRY_PROJECT_SLUG_FRONTEND=deepsight-frontend
+   export SENTRY_PROJECT_SLUG_MOBILE=deepsight-mobile
+   ```
+
+### 17.2 Activating the Telegram integration (one-time)
+
+The Telegram integration must be installed manually on the Sentry org
+before the script can route alerts to Telegram.
+
+1. Open <https://sentry.io/settings/integrations/telegram/>.
+2. Click **Add Installation**. Sentry asks for a Telegram bot token; reuse
+   the existing DeepSight bot (`TELEGRAM_BOT_TOKEN` already used by the
+   deploy workflow) or create a dedicated one with **@BotFather**.
+3. After install, open the integration page and copy the **Installation
+   ID** displayed in the URL or in the integration's settings panel
+   (numeric string, e.g. `123456`).
+4. Export it before running the script:
+
+   ```bash
+   export TELEGRAM_INTEGRATION_INSTALLATION_ID=123456
+   ```
+
+5. Add the bot to the destination chat (`TELEGRAM_CHAT_ID`) so it can
+   post messages. Use **@deepsight_alerts_bot** with **/start** in the
+   target chat or group.
+
+If `TELEGRAM_INTEGRATION_INSTALLATION_ID` is unset the script falls back
+to the default Sentry **email** action — alerts still fire, they just
+don't reach Telegram.
+
+### 17.3 Running the script
+
+```bash
+cd backend
+
+# Preview the changes without writing.
+python scripts/setup_sentry_alerts.py --dry-run --project all
+
+# Apply to all projects (default scope).
+python scripts/setup_sentry_alerts.py --project all
+
+# Or scope to a single Sentry project.
+python scripts/setup_sentry_alerts.py --project backend
+python scripts/setup_sentry_alerts.py --project frontend
+python scripts/setup_sentry_alerts.py --project mobile
+
+# Inspect the resolved rule definitions as JSON (no API calls).
+python scripts/setup_sentry_alerts.py --show-config | jq .
+```
+
+The script prints a table summarising each rule's project, kind (issue
+vs metric), criticality, action (`created` / `updated` / `FAILED`), and
+the resulting Sentry rule ID. Failures of one rule do not abort the
+others.
+
+### 17.4 Provisioned alert rules
+
+The 6 rules below are defined in `sentry_alerts_config.py`. Adjust the
+numeric thresholds in that file and re-run the script to roll changes
+out.
+
+| #   | Project   | Name                                 | Threshold                                        | Window | Criticality |
+| --- | --------- | ------------------------------------ | ------------------------------------------------ | ------ | ----------- |
+| 1   | backend   | HTTP 500 spike (>10/h)               | `>10` ERROR-level events                         | 1h     | high        |
+| 2   | backend   | Latency p95 > 5s                     | `p95(transaction.duration) > 5000 ms`            | 5min   | high        |
+| 3   | backend   | Sentry quota approaching (80%)       | `>800` events in 24h (≈80% of daily allotment)   | 24h    | low         |
+| 4   | frontend  | Issue affecting >5 users (1h)        | `>5` unique users on a single issue              | 1h     | high        |
+| 5   | frontend  | Browser error rate (>100/h)          | `>100` events with `exception` payload           | 1h     | medium      |
+| 6   | mobile    | Crash rate > 1% (24h)                | `percentage(sessions_crashed, sessions) > 1.0`   | 24h    | high        |
+
+### 17.5 Adjusting thresholds
+
+1. Edit `backend/scripts/sentry_alerts_config.py`. Each rule is a
+   frozen dataclass — change the value, save the file.
+2. Re-run with `--dry-run` to verify the diff is what you expect.
+3. Re-run without `--dry-run` to apply. The script matches by `name`
+   so the existing Sentry rule is updated in place.
+4. Commit the config change so the next operator picks up the same
+   threshold.
+
+### 17.6 Adding a new rule
+
+1. Append a new `IssueAlertRule(...)` or `MetricAlertRule(...)` to
+   `build_rules()` in `sentry_alerts_config.py`.
+2. Pick a unique `name` (used as the idempotence key).
+3. Run the script with `--dry-run`, then for real.
+
+### 17.7 Removing a rule
+
+The script never deletes rules (by design — operator can disable any
+alert in the Sentry UI without losing automation history). To purge
+a rule definitively:
+
+1. Remove the entry from `sentry_alerts_config.py`.
+2. Delete the rule manually in the Sentry UI (Project → Alerts → ⋯ → Delete).
+3. Commit the config change.
+
+### 17.8 Required GitHub Actions secrets (future CI integration)
+
+If the script is later wired into a workflow:
+
+- `SENTRY_AUTH_TOKEN`
+- `SENTRY_ORG_SLUG`
+- `SENTRY_PROJECT_SLUG_BACKEND`
+- `SENTRY_PROJECT_SLUG_FRONTEND`
+- `SENTRY_PROJECT_SLUG_MOBILE`
+- `TELEGRAM_INTEGRATION_INSTALLATION_ID` (optional)
+
+Use `gh secret set <NAME>` to set them.


### PR DESCRIPTION
## Summary

Sprint observability — chantier B. Adds a one-shot, idempotent Python
script that provisions the production Sentry alert rules for the 4
DeepSight platforms via the Sentry REST API, with optional routing to
the existing Telegram bot integration.

- `backend/scripts/sentry_alerts_config.py` — frozen-dataclass rule
  definitions (single source of truth).
- `backend/scripts/setup_sentry_alerts.py` — argparse CLI (`--dry-run`,
  `--project backend|frontend|mobile|all`, `--show-config`). Idempotent
  upsert by `(name, project)`. Per-rule error handling.
- `docs/RUNBOOK.md` — new ops runbook, section 17 "Sentry alert rules"
  documents auth-token setup, Telegram activation, threshold tuning, and
  the 6 canonical rules.

## Provisioned alert rules

| #   | Project   | Name                                 | Threshold                                        | Window | Criticality |
| --- | --------- | ------------------------------------ | ------------------------------------------------ | ------ | ----------- |
| 1   | backend   | HTTP 500 spike (>10/h)               | `>10` ERROR-level events                         | 1h     | high        |
| 2   | backend   | Latency p95 > 5s                     | `p95(transaction.duration) > 5000 ms`            | 5min   | high        |
| 3   | backend   | Sentry quota approaching (80%)       | `>800` events in 24h                             | 24h    | low         |
| 4   | frontend  | Issue affecting >5 users (1h)        | `>5` unique users on a single issue              | 1h     | high        |
| 5   | frontend  | Browser error rate (>100/h)          | `>100` events with `exception` payload           | 1h     | medium      |
| 6   | mobile    | Crash rate > 1% (24h)                | `percentage(sessions_crashed, sessions) > 1.0`   | 24h    | high        |

## Maxime's action items after merge

1. **Sentry auth token** — generate at
   <https://sentry.io/settings/account/api/auth-tokens/> with scopes
   `project:read`, `project:write`, `alerts:read`, `alerts:write`. Export
   as `SENTRY_AUTH_TOKEN`.
2. **Org/project slugs** — read from the Sentry URL bar and export
   `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG_BACKEND`,
   `SENTRY_PROJECT_SLUG_FRONTEND`, `SENTRY_PROJECT_SLUG_MOBILE`.
3. **Telegram integration** — Sentry → Settings → Integrations →
   Telegram → Add Installation, reuse the DeepSight bot token. Copy the
   Installation ID and export `TELEGRAM_INTEGRATION_INSTALLATION_ID`
   (optional — without it the script falls back to the email action).
4. **Run** `cd backend && python scripts/setup_sentry_alerts.py --dry-run --project all`
   then re-run without `--dry-run` to apply.

## Constraints respected

- No app code changed. Scripts + doc only.
- No live Sentry API call from CI — script is run manually.
- `httpx` already in `backend/requirements.txt`, no new dependency.
- AST compile-check OK (`python -c "import ast; ast.parse(...)"`).
- `--show-config` produces valid JSON for the 6 rules.

## Test plan

- [x] `python -c "import ast; ast.parse(...)"` on both new Python files
- [x] `python scripts/setup_sentry_alerts.py --show-config` returns 6 valid JSON rules
- [x] Missing env vars → script exits with code 2 and clear error
- [x] Mock env + invalid token → script lists all 6 rules as `FAILED`
      with HTTP 401 details, returns code 1, no crash
- [ ] (Maxime) Run `--dry-run --project all` against real Sentry org
- [ ] (Maxime) Run `--project all` to apply
- [ ] (Maxime) Trigger a synthetic 500 in prod to verify Telegram delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)