### PR TITLE
feat(infra): Cloudflare WAF + DNS proxy on api.deepsightsynthesis.com

### DIFF
--- a/backend/scripts/cloudflare_rules_config.py
+++ b/backend/scripts/cloudflare_rules_config.py
@@ -1,0 +1,345 @@
+"""Cloudflare WAF + Rate Limit + Cache + Page rules config (declarative).
+
+Source de vérité de la configuration que ``setup_cloudflare_waf.py`` applique
+de manière idempotente sur la zone Cloudflare de DeepSight.
+
+Ce module est volontairement séparé du script main pour rester lisible et
+facilement reviewable — un dev qui veut comprendre ce qui sera appliqué peut
+ouvrir UNIQUEMENT ce fichier.
+
+Conventions :
+- Le champ ``description`` de chaque rule est la **clé d'idempotence**.
+  Le script list les rules existantes, match par description, puis upsert.
+  ⚠️ Ne JAMAIS dupliquer une description ou changer une description existante
+     sans réfléchir : ça créera une rule dupliquée plutôt qu'un update.
+- Toutes les rules sont taggées ``managed_by=setup_cloudflare_waf`` via leur
+  description (suffixe ``[managed]``) → un humain qui édite à la main dans le
+  dashboard Cloudflare voit immédiatement que la rule est gérée par le script.
+
+Référence Cloudflare Rules language :
+https://developers.cloudflare.com/ruleset-engine/rules-language/
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Constantes
+# ---------------------------------------------------------------------------
+
+DEFAULT_HOSTNAME = "api.deepsightsynthesis.com"
+MANAGED_TAG = "[managed]"  # Suffixe ajouté à chaque description pour traçabilité
+
+# Stripe webhook source IPs (publiées par Stripe, mises à jour rarement).
+# Source : https://stripe.com/files/ips/ips_webhooks.txt
+# ⚠️ À re-vérifier 1×/an — Stripe peut ajouter des ranges.
+STRIPE_WEBHOOK_IPS: tuple[str, ...] = (
+    "3.18.12.63",
+    "3.130.192.231",
+    "13.235.14.237",
+    "13.235.122.149",
+    "18.211.135.69",
+    "35.154.171.200",
+    "52.15.183.38",
+    "54.88.130.119",
+    "54.88.130.237",
+    "54.187.174.169",
+    "54.187.205.235",
+    "54.187.216.72",
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CustomRule:
+    """A Cloudflare WAF custom rule (Ruleset Engine, phase=http_request_firewall_custom).
+
+    Attributes
+    ----------
+    description :
+        Human-readable description. **Clé d'idempotence** — doit être unique
+        à travers toutes les rules custom de la zone.
+    expression :
+        Cloudflare Rules language expression. Évaluée pour CHAQUE requête entrante.
+    action :
+        Action à appliquer si l'expression matche.
+        - ``block``     : reject 403
+        - ``challenge`` : Managed Challenge (CAPTCHA-like)
+        - ``js_challenge`` : JavaScript challenge (silent for legitimate browsers)
+        - ``log``       : laisse passer mais log dans Cloudflare Analytics
+        - ``skip``      : skip d'autres rules (avancé, pas utilisé ici)
+    enabled :
+        Pour disable une rule sans la supprimer (debug).
+    """
+
+    description: str
+    expression: str
+    action: Literal["block", "challenge", "js_challenge", "log", "managed_challenge"]
+    enabled: bool = True
+
+    def cf_description(self) -> str:
+        """Description avec suffixe managed (utilisé pour idempotence)."""
+        return f"{self.description} {MANAGED_TAG}"
+
+
+@dataclass(frozen=True)
+class RateLimitRule:
+    """A Cloudflare rate-limiting rule (Ruleset Engine, phase=http_ratelimit).
+
+    Attributes
+    ----------
+    description :
+        Clé d'idempotence (idem CustomRule).
+    expression :
+        Quelles requêtes compter (ex: ``http.request.uri.path eq "/api/auth/login"``).
+    requests_per_period :
+        Nombre maximal de requêtes autorisées par période.
+    period_seconds :
+        Fenêtre glissante (10, 60, 600, 3600 supportés par Cloudflare).
+    action :
+        Action quand le seuil est atteint.
+    mitigation_timeout_seconds :
+        Pour combien de temps l'IP est blockée/challengée après dépassement.
+        Ex: 3600 = 1h.
+    characteristics :
+        Critères de groupement (par défaut IP). Voir
+        https://developers.cloudflare.com/waf/rate-limiting-rules/parameters/#counting-characteristics
+    """
+
+    description: str
+    expression: str
+    requests_per_period: int
+    period_seconds: int
+    action: Literal["block", "challenge", "managed_challenge", "log"]
+    mitigation_timeout_seconds: int = 3600
+    characteristics: tuple[str, ...] = ("ip.src", "cf.colo.id")
+
+    def cf_description(self) -> str:
+        return f"{self.description} {MANAGED_TAG}"
+
+
+@dataclass(frozen=True)
+class CacheRule:
+    """A Cloudflare cache rule (Ruleset Engine, phase=http_request_cache_settings)."""
+
+    description: str
+    expression: str
+    edge_ttl_seconds: int
+    cache: bool = True  # True = force cache, False = bypass cache
+
+    def cf_description(self) -> str:
+        return f"{self.description} {MANAGED_TAG}"
+
+
+@dataclass(frozen=True)
+class CloudflareConfig:
+    """Top-level configuration container."""
+
+    hostname: str = DEFAULT_HOSTNAME
+    custom_rules: tuple[CustomRule, ...] = field(default_factory=tuple)
+    rate_limit_rules: tuple[RateLimitRule, ...] = field(default_factory=tuple)
+    cache_rules: tuple[CacheRule, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Helpers d'expressions (lisibilité)
+# ---------------------------------------------------------------------------
+
+
+def _stripe_ips_expression() -> str:
+    """Expression Cloudflare matchant les IPs Stripe webhooks (whitelist)."""
+    ips = " ".join(f'"{ip}"' for ip in STRIPE_WEBHOOK_IPS)
+    return f"(ip.src in {{{ips}}})"
+
+
+def _path_eq(path: str) -> str:
+    return f'(http.request.uri.path eq "{path}")'
+
+
+def _path_starts(prefix: str) -> str:
+    return f'(starts_with(http.request.uri.path, "{prefix}"))'
+
+
+def _hostname_match(hostname: str) -> str:
+    """Limite la rule à notre hostname API (évite de spammer d'autres zones)."""
+    return f'(http.host eq "{hostname}")'
+
+
+# ---------------------------------------------------------------------------
+# Configuration cible
+# ---------------------------------------------------------------------------
+
+
+def build_config(hostname: str = DEFAULT_HOSTNAME) -> CloudflareConfig:
+    """Construit la configuration complète à appliquer sur la zone."""
+
+    host = _hostname_match(hostname)
+
+    # ------------------------------ WAF custom rules ----------------------
+    custom_rules: tuple[CustomRule, ...] = (
+        # 1. Block requests with empty User-Agent or known scrapers
+        # ⚠️ User-Agents légitimes attendus :
+        #   - Stripe (whitelist handled separately)
+        #   - Browsers, mobile app httpx, Chrome extension fetch
+        # Bots scrapers communs : python-requests, curl/, scrapy, nikto, sqlmap
+        CustomRule(
+            description="Block empty UA or known scrapers",
+            expression=(
+                f"{host} and ("
+                '(http.user_agent eq "")'
+                ' or (lower(http.user_agent) contains "sqlmap")'
+                ' or (lower(http.user_agent) contains "nikto")'
+                ' or (lower(http.user_agent) contains "scrapy")'
+                ' or (lower(http.user_agent) contains "curl/7.")'
+                ' or (lower(http.user_agent) contains "python-requests/")'
+                ")"
+            ),
+            action="block",
+        ),
+        # 2. Challenge requests sur /api/billing/webhook qui ne viennent pas de Stripe
+        # ⚠️ Stripe webhooks nécessitent latence faible & 200 OK rapide → pas de
+        # block. On challenge juste les imposters. Page rule (séparée) désactive
+        # bot-fight pour cette URL côté Stripe légitime.
+        CustomRule(
+            description="Challenge non-Stripe IPs on billing webhook",
+            expression=(
+                f"{host} and "
+                f'{_path_eq("/api/billing/webhook")} '
+                f"and not {_stripe_ips_expression()}"
+            ),
+            action="managed_challenge",
+        ),
+        # 3. Block large body (>10MB) sauf sur /api/exports
+        # Un POST à 10MB sur /api/auth/login = clairement abusif
+        CustomRule(
+            description="Block oversize body except on exports",
+            expression=(
+                f"{host} and "
+                "(http.request.body.size gt 10485760) "
+                f"and not {_path_starts('/api/exports')}"
+            ),
+            action="block",
+        ),
+        # 4. Challenge auth POST sur ratelimit failover (defence-in-depth)
+        # Le rate limit ci-dessous gère le throttling normal. Cette rule
+        # filtre des patterns explicitement mauvais (POST sans CT JSON).
+        CustomRule(
+            description="Challenge non-JSON POST on auth endpoints",
+            expression=(
+                f"{host} and "
+                f'(http.request.method eq "POST") '
+                f'and {_path_starts("/api/auth/")} '
+                'and not (http.request.headers["content-type"][0] contains "application/json")'
+            ),
+            action="managed_challenge",
+        ),
+    )
+
+    # ------------------------------ Rate limit rules ----------------------
+    rate_limit_rules: tuple[RateLimitRule, ...] = (
+        # /api/auth/login : 5 req/min → block 1h
+        # Protection brute-force credential stuffing
+        RateLimitRule(
+            description="Rate limit /api/auth/login 5/min",
+            expression=(
+                f'{host} and {_path_eq("/api/auth/login")} '
+                'and (http.request.method eq "POST")'
+            ),
+            requests_per_period=5,
+            period_seconds=60,
+            action="block",
+            mitigation_timeout_seconds=3600,
+        ),
+        # /api/auth/register : 3 req/min → block 1h
+        # Anti-spam création de comptes
+        RateLimitRule(
+            description="Rate limit /api/auth/register 3/min",
+            expression=(
+                f'{host} and {_path_eq("/api/auth/register")} '
+                'and (http.request.method eq "POST")'
+            ),
+            requests_per_period=3,
+            period_seconds=60,
+            action="block",
+            mitigation_timeout_seconds=3600,
+        ),
+        # /api/videos/analyze : 10 req/min — défence-en-profondeur
+        # (le backend FastAPI a déjà un middleware Redis-backed, mais si backend
+        #  down → cette rule continue de protéger l'infra)
+        RateLimitRule(
+            description="Rate limit /api/videos/analyze 10/min",
+            expression=(
+                f'{host} and {_path_eq("/api/videos/analyze")} '
+                'and (http.request.method eq "POST")'
+            ),
+            requests_per_period=10,
+            period_seconds=60,
+            action="challenge",
+            mitigation_timeout_seconds=600,
+        ),
+        # Wildcard /api/* : 100 req/min → challenge
+        # Filet de sécurité global. Un user normal (frontend + mobile) reste sous
+        # 100/min largement. Un script abusif sera challenged.
+        RateLimitRule(
+            description="Rate limit /api/* wildcard 100/min",
+            expression=f'{host} and {_path_starts("/api/")}',
+            requests_per_period=100,
+            period_seconds=60,
+            action="managed_challenge",
+            mitigation_timeout_seconds=300,
+        ),
+    )
+
+    # ------------------------------ Cache rules ---------------------------
+    cache_rules: tuple[CacheRule, ...] = (
+        # /api/health : edge cache 30s
+        # → réduit drastiquement charge backend (UptimeRobot ping toutes les 60s,
+        #   plus extension health checks, plus mobile, etc.)
+        CacheRule(
+            description="Edge cache /api/health 30s",
+            expression=f'{host} and {_path_eq("/api/health")}',
+            edge_ttl_seconds=30,
+            cache=True,
+        ),
+        # /api/tournesol/* : edge cache 5min
+        # Données Tournesol évoluent lentement (refresh hourly côté upstream).
+        # Cache edge évite N requêtes simultanées au backend qui proxie ensuite
+        # vers tournesol.app.
+        CacheRule(
+            description="Edge cache /api/tournesol/* 5min",
+            expression=f'{host} and {_path_starts("/api/tournesol/")} '
+            'and (http.request.method eq "GET")',
+            edge_ttl_seconds=300,
+            cache=True,
+        ),
+    )
+
+    return CloudflareConfig(
+        hostname=hostname,
+        custom_rules=custom_rules,
+        rate_limit_rules=rate_limit_rules,
+        cache_rules=cache_rules,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Note Page Rules
+# ---------------------------------------------------------------------------
+# Les Page Rules legacy (Cloudflare Free tier limité à 3 par zone) ne sont
+# **pas** créées par ce script — l'utilisateur les configure manuellement
+# dans le dashboard, étape documentée dans docs/RUNBOOK.md §18.
+#
+# Page rule à créer manuellement :
+#   URL pattern : api.deepsightsynthesis.com/api/billing/webhook
+#   Settings    :
+#     - Browser Integrity Check : Off
+#     - Security Level         : Essentially Off
+#     - Cache Level            : Bypass
+#   Raison : Stripe envoie des webhooks signés HMAC ; toute interception CF
+#   peut casser la signature. Bot-fight mode déjà bypass via custom rule #2,
+#   mais belt-and-suspenders.

--- a/backend/scripts/setup_cloudflare_waf.py
+++ b/backend/scripts/setup_cloudflare_waf.py
@@ -1,0 +1,573 @@
+"""Idempotent Cloudflare WAF + Rate Limit + Cache setup for DeepSight API.
+
+Usage
+-----
+    # Affiche la config qui sera appliquée (read-only, aucun appel API)
+    python backend/scripts/setup_cloudflare_waf.py --show-config
+
+    # Liste les rules existantes côté Cloudflare et affiche un diff (no-write)
+    CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... \
+        python backend/scripts/setup_cloudflare_waf.py --dry-run
+
+    # Applique réellement (upsert) les rules sur la zone
+    CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... \
+        python backend/scripts/setup_cloudflare_waf.py --apply
+
+Comportement
+------------
+- Idempotent : matche les rules existantes par leur ``description`` (suffixée
+  ``[managed]``). Si une rule existante porte la même description que celle
+  définie en config → UPDATE. Sinon → CREATE.
+- Robust : erreur sur une rule n'arrête pas le script ; reporting final
+  table-formatted (created / updated / skipped / failed).
+- Pas de delete : si on retire une rule de la config Python, le script ne la
+  supprime pas automatiquement (safety). Suppression manuelle dans le
+  dashboard, ou via flag `--prune` (NON IMPLÉMENTÉ V1, voir TODO).
+
+Pré-requis
+----------
+1. Domaine ``deepsightsynthesis.com`` géré par Cloudflare (déjà le cas en prod).
+2. ``api.deepsightsynthesis.com`` en mode proxied (orange cloud).
+3. SSL/TLS de la zone configuré en **Full (strict)**.
+4. ``CLOUDFLARE_API_TOKEN`` créé avec scopes ``Zone:Read`` + ``Zone WAF:Edit``.
+5. ``CLOUDFLARE_ZONE_ID`` récupéré dans l'overview de la zone.
+
+Voir docs/RUNBOOK.md §18 pour la procédure complète.
+
+Limitations connues
+-------------------
+- Page rules (legacy) NON gérées par ce script — config manuelle UI.
+- Suppression de rules orphelines : NON IMPLÉMENTÉ (TODO --prune).
+- Cloudflare Free Plan limite : 5 custom WAF rules + Pro tier requis pour rate
+  limiting avancé (>= 10K req/mo). Vérifier votre plan avant d'apply.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+# Permettre d'exécuter le script depuis backend/ ou root
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cloudflare_rules_config import (  # noqa: E402
+    DEFAULT_HOSTNAME,
+    CacheRule,
+    CloudflareConfig,
+    CustomRule,
+    RateLimitRule,
+    build_config,
+)
+
+
+CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4"
+HTTP_TIMEOUT = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Result tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RuleResult:
+    """Result of upserting a single rule."""
+
+    description: str
+    kind: str  # "custom" | "rate_limit" | "cache"
+    status: str  # "created" | "updated" | "skipped" | "failed" | "would-create" | "would-update"
+    detail: str = ""
+
+    def emoji(self) -> str:
+        return {
+            "created": "[+]",
+            "updated": "[~]",
+            "skipped": "[=]",
+            "failed": "[!]",
+            "would-create": "[?+]",
+            "would-update": "[?~]",
+        }.get(self.status, "[ ]")
+
+
+# ---------------------------------------------------------------------------
+# Cloudflare API client
+# ---------------------------------------------------------------------------
+
+
+class CloudflareClient:
+    """Minimal Cloudflare v4 API client used by this script.
+
+    Uses ``httpx`` (already in deps). No SDK because we only need a handful of
+    endpoints and want zero magic.
+    """
+
+    def __init__(self, api_token: str, zone_id: str) -> None:
+        if not api_token:
+            raise ValueError("CLOUDFLARE_API_TOKEN env var is required")
+        if not zone_id:
+            raise ValueError("CLOUDFLARE_ZONE_ID env var is required")
+        self.zone_id = zone_id
+        self._client = httpx.Client(
+            base_url=CLOUDFLARE_API_BASE,
+            headers={
+                "Authorization": f"Bearer {api_token}",
+                "Content-Type": "application/json",
+            },
+            timeout=HTTP_TIMEOUT,
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "CloudflareClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # --- low-level helpers ------------------------------------------------
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        resp = self._client.request(method, path, **kwargs)
+        if resp.status_code >= 400:
+            try:
+                payload = resp.json()
+            except Exception:  # noqa: BLE001
+                payload = {"raw": resp.text}
+            raise CloudflareApiError(
+                status=resp.status_code,
+                method=method,
+                path=path,
+                payload=payload,
+            )
+        data = resp.json()
+        if not data.get("success", True):
+            raise CloudflareApiError(
+                status=resp.status_code,
+                method=method,
+                path=path,
+                payload=data,
+            )
+        return data
+
+    # --- entrypoints used by the script ----------------------------------
+
+    def verify_token(self) -> None:
+        """Vérifie que le token est valide."""
+        self._request("GET", "/user/tokens/verify")
+
+    def get_zone(self) -> dict[str, Any]:
+        """Récupère les infos de la zone (sanity check + nom)."""
+        return self._request("GET", f"/zones/{self.zone_id}")["result"]
+
+    # --- Rulesets (Engine V2) --------------------------------------------
+    # Cloudflare has migrated WAF custom + rate limiting + cache settings
+    # to the unified "Ruleset Engine". Each phase has its own entrypoint
+    # ruleset per zone.
+
+    def get_or_create_entrypoint_ruleset(self, phase: str) -> dict[str, Any]:
+        """Get the zone-level entrypoint ruleset for ``phase``, creating if needed.
+
+        Phases used by this script :
+        - ``http_request_firewall_custom``      : WAF custom rules
+        - ``http_ratelimit``                    : rate limit rules
+        - ``http_request_cache_settings``       : cache rules
+        """
+        try:
+            return self._request(
+                "GET",
+                f"/zones/{self.zone_id}/rulesets/phases/{phase}/entrypoint",
+            )["result"]
+        except CloudflareApiError as exc:
+            # Cloudflare returns 404 when the entrypoint doesn't exist yet
+            if exc.status == 404:
+                created = self._request(
+                    "POST",
+                    f"/zones/{self.zone_id}/rulesets",
+                    json={
+                        "name": f"DeepSight managed — {phase}",
+                        "description": "Auto-created by setup_cloudflare_waf.py",
+                        "kind": "zone",
+                        "phase": phase,
+                        "rules": [],
+                    },
+                )["result"]
+                return created
+            raise
+
+    def add_rule(self, ruleset_id: str, rule: dict[str, Any]) -> dict[str, Any]:
+        """Append a rule to a ruleset (server-side append)."""
+        return self._request(
+            "POST",
+            f"/zones/{self.zone_id}/rulesets/{ruleset_id}/rules",
+            json=rule,
+        )["result"]
+
+    def update_rule(
+        self, ruleset_id: str, rule_id: str, rule: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Update a single rule by ID."""
+        return self._request(
+            "PATCH",
+            f"/zones/{self.zone_id}/rulesets/{ruleset_id}/rules/{rule_id}",
+            json=rule,
+        )["result"]
+
+
+class CloudflareApiError(Exception):
+    """Raised when Cloudflare API returns a non-success response."""
+
+    def __init__(
+        self,
+        *,
+        status: int,
+        method: str,
+        path: str,
+        payload: dict[str, Any],
+    ) -> None:
+        self.status = status
+        self.method = method
+        self.path = path
+        self.payload = payload
+        errors = payload.get("errors") if isinstance(payload, dict) else None
+        msg = (
+            f"Cloudflare API {method} {path} -> HTTP {status} : "
+            f"{errors or payload}"
+        )
+        super().__init__(msg)
+
+
+# ---------------------------------------------------------------------------
+# Rule serialization (dataclass → Cloudflare API JSON)
+# ---------------------------------------------------------------------------
+
+
+def _serialize_custom_rule(rule: CustomRule) -> dict[str, Any]:
+    return {
+        "description": rule.cf_description(),
+        "expression": rule.expression,
+        "action": rule.action,
+        "enabled": rule.enabled,
+    }
+
+
+def _serialize_rate_limit_rule(rule: RateLimitRule) -> dict[str, Any]:
+    return {
+        "description": rule.cf_description(),
+        "expression": rule.expression,
+        "action": rule.action,
+        "ratelimit": {
+            "characteristics": list(rule.characteristics),
+            "period": rule.period_seconds,
+            "requests_per_period": rule.requests_per_period,
+            "mitigation_timeout": rule.mitigation_timeout_seconds,
+        },
+        "enabled": True,
+    }
+
+
+def _serialize_cache_rule(rule: CacheRule) -> dict[str, Any]:
+    """Cache rules use ``set_cache_settings`` action with parameters."""
+    return {
+        "description": rule.cf_description(),
+        "expression": rule.expression,
+        "action": "set_cache_settings",
+        "action_parameters": {
+            "cache": rule.cache,
+            "edge_ttl": {
+                "mode": "override_origin",
+                "default": rule.edge_ttl_seconds,
+            },
+        },
+        "enabled": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Upsert logic (idempotent)
+# ---------------------------------------------------------------------------
+
+
+def _find_existing(rules: list[dict[str, Any]], description: str) -> dict[str, Any] | None:
+    """Trouve une rule existante par description exacte."""
+    for r in rules:
+        if r.get("description") == description:
+            return r
+    return None
+
+
+def _rules_differ(existing: dict[str, Any], desired: dict[str, Any]) -> bool:
+    """Détermine s'il y a un vrai diff entre rule existante et desired.
+
+    On compare uniquement les champs qu'on contrôle (expression, action,
+    enabled, ratelimit, action_parameters). Cloudflare ajoute des champs
+    serveur (id, ref, version, last_updated) qu'on ignore.
+    """
+    keys = ("expression", "action", "enabled", "ratelimit", "action_parameters")
+    for k in keys:
+        if existing.get(k) != desired.get(k):
+            return True
+    return False
+
+
+def _upsert_rules(
+    cf: CloudflareClient,
+    *,
+    phase: str,
+    kind: str,
+    serialized: list[dict[str, Any]],
+    apply: bool,
+    results: list[RuleResult],
+) -> None:
+    """Upsert a list of serialized rules in a single phase ruleset."""
+    try:
+        ruleset = cf.get_or_create_entrypoint_ruleset(phase)
+    except CloudflareApiError as exc:
+        for r in serialized:
+            results.append(
+                RuleResult(
+                    description=r["description"],
+                    kind=kind,
+                    status="failed",
+                    detail=f"ruleset fetch: {exc}",
+                )
+            )
+        return
+
+    existing_rules = ruleset.get("rules") or []
+    ruleset_id = ruleset["id"]
+
+    for desired in serialized:
+        desc = desired["description"]
+        try:
+            match = _find_existing(existing_rules, desc)
+            if match is None:
+                if not apply:
+                    results.append(
+                        RuleResult(desc, kind, "would-create", "no existing match")
+                    )
+                    continue
+                cf.add_rule(ruleset_id, desired)
+                results.append(RuleResult(desc, kind, "created"))
+            else:
+                if not _rules_differ(match, desired):
+                    results.append(RuleResult(desc, kind, "skipped", "in sync"))
+                    continue
+                if not apply:
+                    results.append(
+                        RuleResult(desc, kind, "would-update", "diff detected")
+                    )
+                    continue
+                cf.update_rule(ruleset_id, match["id"], desired)
+                results.append(RuleResult(desc, kind, "updated"))
+        except CloudflareApiError as exc:
+            results.append(RuleResult(desc, kind, "failed", str(exc)))
+        except Exception as exc:  # noqa: BLE001
+            results.append(RuleResult(desc, kind, "failed", repr(exc)))
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _print_config(cfg: CloudflareConfig) -> None:
+    print(f"Hostname target : {cfg.hostname}")
+    print()
+    print(f"=== {len(cfg.custom_rules)} WAF custom rules ===")
+    for r in cfg.custom_rules:
+        print(f"  - {r.cf_description()}")
+        print(f"    action     : {r.action}")
+        print(f"    expression : {r.expression[:120]}{'...' if len(r.expression) > 120 else ''}")
+    print()
+    print(f"=== {len(cfg.rate_limit_rules)} rate limit rules ===")
+    for r in cfg.rate_limit_rules:
+        print(f"  - {r.cf_description()}")
+        print(
+            f"    {r.requests_per_period}/{r.period_seconds}s -> {r.action} "
+            f"(timeout {r.mitigation_timeout_seconds}s)"
+        )
+        print(f"    expression : {r.expression[:120]}{'...' if len(r.expression) > 120 else ''}")
+    print()
+    print(f"=== {len(cfg.cache_rules)} cache rules ===")
+    for r in cfg.cache_rules:
+        print(
+            f"  - {r.cf_description()} "
+            f"(edge_ttl={r.edge_ttl_seconds}s, cache={r.cache})"
+        )
+    print()
+    print("Page Rules : configurer manuellement (voir docs/RUNBOOK.md §18)")
+    print("  - api.deepsightsynthesis.com/api/billing/webhook -> Security: Off")
+
+
+def _print_results_table(results: list[RuleResult]) -> None:
+    if not results:
+        print("(no rules processed)")
+        return
+
+    by_status: dict[str, int] = {}
+    for r in results:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+
+    print()
+    print("=" * 80)
+    print(f"{'STATUS':<14} {'KIND':<12} DESCRIPTION")
+    print("-" * 80)
+    for r in results:
+        desc = r.description if len(r.description) <= 50 else r.description[:47] + "..."
+        line = f"{r.emoji()} {r.status:<10} {r.kind:<12} {desc}"
+        if r.detail and r.status in ("failed", "would-update"):
+            line += f"\n              {r.detail[:200]}"
+        print(line)
+    print("=" * 80)
+
+    summary_parts = [f"{count} {status}" for status, count in sorted(by_status.items())]
+    print(f"Summary : {', '.join(summary_parts)}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+_HELP_EPILOG = """\
+Examples:
+  # Print desired config (no API call)
+  python backend/scripts/setup_cloudflare_waf.py --show-config
+
+  # Diff against Cloudflare without writing
+  CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... \\
+      python backend/scripts/setup_cloudflare_waf.py --dry-run
+
+  # Apply (create/update) rules on Cloudflare
+  CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... \\
+      python backend/scripts/setup_cloudflare_waf.py --apply
+
+See docs/RUNBOOK.md section 18 for the full procedure.
+"""
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Idempotent Cloudflare WAF + Rate Limit + Cache setup for DeepSight API.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_HELP_EPILOG,
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--show-config",
+        action="store_true",
+        help="Print the desired configuration (no API calls).",
+    )
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute diff against current Cloudflare state but DON'T apply.",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually create/update rules on Cloudflare.",
+    )
+    p.add_argument(
+        "--hostname",
+        default=os.environ.get("CLOUDFLARE_HOSTNAME", DEFAULT_HOSTNAME),
+        help="Hostname filter for rules (default: api.deepsightsynthesis.com)",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    cfg = build_config(hostname=args.hostname)
+
+    if args.show_config:
+        _print_config(cfg)
+        return 0
+
+    api_token = os.environ.get("CLOUDFLARE_API_TOKEN", "")
+    zone_id = os.environ.get("CLOUDFLARE_ZONE_ID", "")
+    if not api_token or not zone_id:
+        print(
+            "ERROR : CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID env vars are required.",
+            file=sys.stderr,
+        )
+        print(
+            "Create token at https://dash.cloudflare.com/profile/api-tokens",
+            file=sys.stderr,
+        )
+        print("Find zone ID in dashboard -> Overview -> API panel.", file=sys.stderr)
+        return 2
+
+    apply = args.apply
+
+    print(f"Mode : {'APPLY' if apply else 'DRY-RUN'}")
+    print(f"Hostname : {args.hostname}")
+    print(f"Zone ID : {zone_id[:8]}***{zone_id[-4:]}")
+
+    try:
+        with CloudflareClient(api_token=api_token, zone_id=zone_id) as cf:
+            cf.verify_token()
+            zone = cf.get_zone()
+            print(f"Zone name : {zone.get('name')} (status={zone.get('status')})")
+            print()
+
+            results: list[RuleResult] = []
+
+            _upsert_rules(
+                cf,
+                phase="http_request_firewall_custom",
+                kind="custom",
+                serialized=[_serialize_custom_rule(r) for r in cfg.custom_rules],
+                apply=apply,
+                results=results,
+            )
+            _upsert_rules(
+                cf,
+                phase="http_ratelimit",
+                kind="rate_limit",
+                serialized=[_serialize_rate_limit_rule(r) for r in cfg.rate_limit_rules],
+                apply=apply,
+                results=results,
+            )
+            _upsert_rules(
+                cf,
+                phase="http_request_cache_settings",
+                kind="cache",
+                serialized=[_serialize_cache_rule(r) for r in cfg.cache_rules],
+                apply=apply,
+                results=results,
+            )
+
+            _print_results_table(results)
+
+            failures = [r for r in results if r.status == "failed"]
+            if failures:
+                print(
+                    f"\n{len(failures)} rule(s) failed — see detail above.",
+                    file=sys.stderr,
+                )
+                return 1
+
+            if not apply:
+                print(
+                    "\nDry-run complete. Re-run with --apply to actually create/update rules."
+                )
+            else:
+                print("\nApply complete. Verify in Cloudflare dashboard -> Security -> WAF.")
+            return 0
+
+    except CloudflareApiError as exc:
+        print(f"FATAL : {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"FATAL : {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -753,3 +753,284 @@ If the script is later wired into a workflow:
 - `TELEGRAM_INTEGRATION_INSTALLATION_ID` (optional)
 
 Use `gh secret set <NAME>` to set them.
+
+---
+
+## 18. Cloudflare WAF + DNS proxy on `api.deepsightsynthesis.com`
+
+> **Sprint Scalability — Chantier A (audit P0).** Mitigates DDoS, brute-force,
+> and OWASP-class threats by putting Cloudflare's edge in front of the Hetzner
+> single-VPS backend.
+
+### 18.1 — Why
+
+The Hetzner VPS (`89.167.23.214`, 16 GB RAM) is currently the only hop between
+the public internet and the FastAPI backend. Issues this section addresses:
+
+- **Unfiltered DDoS** — a script kiddie can saturate the VPS via SSL handshake
+  flood, slow-loris, GET spam.
+- **No global rate limiting that survives backend down-time** — the FastAPI
+  Redis-backed limiter only protects when the backend is up.
+- **No WAF in front** — SQL injection / OWASP top 10 reach the application.
+
+The mitigation is to move `api.*` from DNS-only to Cloudflare-proxied (orange
+cloud) and apply WAF custom rules + rate-limit rules + edge cache rules. Stripe
+webhooks and Caddy auto-SSL must continue to function.
+
+### 18.2 — Architecture after rollout
+
+```
+Internet
+    |
+    v
+Cloudflare edge (WAF + rate limit + cache)
+    |  (only on api.deepsightsynthesis.com)
+    v
+Hetzner VPS 89.167.23.214
+    |  port 80/443
+    v
+Caddy (auto-SSL Let's Encrypt, reverse proxy)
+    |
+    v
+FastAPI 4 workers (port 8080)
+```
+
+`www.deepsightsynthesis.com` keeps Vercel's edge in front (unchanged).
+
+### 18.3 — Pre-requisites
+
+- The zone `deepsightsynthesis.com` is already managed by Cloudflare
+  (confirmed by sub-processors note: "Cloudflare R2 — backups").
+- Cloudflare plan : Free is enough for custom rules and 1 cache rule, but
+  rate-limiting requires **at least Pro tier** for advanced thresholds.
+  → If on Free plan, the rate-limit upserts will fail gracefully; the script
+  reports `failed` and continues with WAF + cache.
+- An SSH-reachable Caddy that already serves a valid Let's Encrypt cert on
+  `api.deepsightsynthesis.com` (current state in production).
+
+### 18.4 — Manual steps in Cloudflare dashboard (one-time)
+
+These can NOT be done via the script — they are zone-level toggles.
+
+1. **Bascule DNS proxy on `api`**
+   - Dashboard > zone `deepsightsynthesis.com` > **DNS** > Records
+   - Find the `A` record `api -> 89.167.23.214`
+   - Toggle the proxy status from **DNS only (grey cloud)** to **Proxied (orange cloud)**
+   - Save
+
+2. **SSL/TLS mode = Full (strict)**
+   - Dashboard > zone > **SSL/TLS** > Overview
+   - Set encryption mode to **Full (strict)** (not Flexible, not Full)
+   - Reason : Caddy already serves a valid Let's Encrypt cert on origin.
+     Cloudflare will validate it. Flexible mode would downgrade origin to
+     plain HTTP and break HSTS guarantees.
+
+3. **Verify Caddy auto-SSL still works after the proxy flip**
+   - Wait ~3 min for Cloudflare to reload DNS.
+   - From your laptop : `curl -sI https://api.deepsightsynthesis.com/health`
+   - Expected : `HTTP/2 200` and a `cf-ray` header (proves traffic goes through Cloudflare).
+   - If 502/521 from Cloudflare : Caddy origin not reachable on 443 from Cloudflare's IPs.
+     Check Hetzner firewall rules — ensure 443/tcp is open to `0.0.0.0/0` (Cloudflare uses many IPs).
+
+4. **Configure the Stripe webhook page rule (legacy Page Rules, manual only)**
+   - Dashboard > zone > **Rules** > Page Rules > Create Page Rule
+   - URL : `api.deepsightsynthesis.com/api/billing/webhook`
+   - Settings :
+     - Browser Integrity Check : `Off`
+     - Security Level : `Essentially Off`
+     - Cache Level : `Bypass`
+   - Save & Deploy.
+   - Reason : Stripe sends signed webhooks (HMAC); any Cloudflare interception
+     can break the signature. The custom WAF rule "Challenge non-Stripe IPs on
+     billing webhook" already filters imposters; this Page Rule is belt-and-suspenders.
+
+### 18.5 — Generate the Cloudflare API token
+
+Dashboard > **My Profile** > **API Tokens** > **Create Token** > **Custom token**
+
+Required permissions:
+
+| Resource          | Permission |
+| ----------------- | ---------- |
+| Zone              | Read       |
+| Zone WAF          | Edit       |
+| Zone Rate Limit   | Edit       |
+| Zone Cache Rules  | Edit       |
+
+Zone Resources: `Include > Specific zone > deepsightsynthesis.com`
+
+Save the token (shown only once). It's referenced as `CLOUDFLARE_API_TOKEN`
+below.
+
+### 18.6 — Find the Zone ID
+
+Dashboard > zone `deepsightsynthesis.com` > **Overview** (right sidebar) >
+**API** section > copy `Zone ID` (32-char hex string). It's referenced as
+`CLOUDFLARE_ZONE_ID` below.
+
+### 18.7 — Run the setup script
+
+The script `backend/scripts/setup_cloudflare_waf.py` is idempotent: matches
+existing rules by description (suffixed `[managed]`) and upserts.
+
+```bash
+cd C:/Users/33667/DeepSight-Main
+
+# 1) Inspect what will be applied (no API call)
+python backend/scripts/setup_cloudflare_waf.py --show-config
+
+# 2) Diff against current Cloudflare state (read-only)
+export CLOUDFLARE_API_TOKEN="<your token>"
+export CLOUDFLARE_ZONE_ID="<your zone id>"
+python backend/scripts/setup_cloudflare_waf.py --dry-run
+
+# 3) Apply (create/update) rules
+python backend/scripts/setup_cloudflare_waf.py --apply
+```
+
+The script outputs a final table:
+
+```
+STATUS         KIND         DESCRIPTION
+[+] created    custom       Block empty UA or known scrapers [managed]
+[~] updated    rate_limit   Rate limit /api/auth/login 5/min [managed]
+[=] skipped    cache        Edge cache /api/health 30s [managed]
+[!] failed     rate_limit   ...                       (only on plan-restricted features)
+```
+
+Re-running with `--apply` is safe: rules already in sync are reported as
+`skipped`.
+
+### 18.8 — Rules that will be created
+
+| Type       | Description                                                | Action                  |
+| ---------- | ---------------------------------------------------------- | ----------------------- |
+| WAF        | Block empty UA or known scrapers                           | block                   |
+| WAF        | Challenge non-Stripe IPs on billing webhook                | managed_challenge       |
+| WAF        | Block oversize body except on exports (>10 MB)             | block                   |
+| WAF        | Challenge non-JSON POST on auth endpoints                  | managed_challenge       |
+| Rate limit | `/api/auth/login` 5/min                                    | block 1h                |
+| Rate limit | `/api/auth/register` 3/min                                 | block 1h                |
+| Rate limit | `/api/videos/analyze` 10/min                               | challenge 10min         |
+| Rate limit | `/api/*` wildcard 100/min                                  | managed_challenge 5min  |
+| Cache      | `/api/health` edge TTL 30s                                 | cache                   |
+| Cache      | `/api/tournesol/*` GET edge TTL 5min                       | cache                   |
+
+Source of truth : `backend/scripts/cloudflare_rules_config.py`.
+
+### 18.9 — Critical rules and risk levels
+
+| Rule                                                  | Why critical                                                                                         | Risk if removed                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Page Rule on `/api/billing/webhook`                   | Stripe HMAC-signed webhooks rely on byte-exact body. Any Cloudflare manipulation breaks the signature. | Stripe webhooks 4xx, billing breaks silently. |
+| `Challenge non-Stripe IPs on billing webhook`         | Reverses the page rule scope: legit Stripe IPs are NEVER challenged.                                 | Stripe IPs hit captcha; payments fail.        |
+| `Rate limit /api/auth/login`                          | Brute-force credential stuffing today's #1 SaaS attack vector.                                        | Account takeovers via leaked passwords.       |
+| `Block empty UA or known scrapers`                    | Cuts 90% of script-based volumetric attacks.                                                         | VPS CPU saturation under bot load.            |
+
+### 18.10 — Rollback
+
+If anything goes wrong (Stripe down, Caddy SSL renewal fails, latency spike), the
+fastest rollback is to put the API back on DNS-only mode:
+
+1. Dashboard > zone > DNS > Records
+2. Find `api` A record > toggle proxy status to **DNS only (grey cloud)** > Save
+3. Wait ~30s for global DNS propagation.
+
+Cloudflare WAF rules stay in place but are no longer evaluated. Re-enable later
+by flipping the cloud back to orange.
+
+To roll back individual rules, edit them in the dashboard
+(`Security > WAF > Custom rules` / `Security > Bots & DDoS > Rate limiting`).
+The script never deletes rules, only upserts; manual deletion is fine.
+
+### 18.11 — Troubleshooting
+
+#### Stripe webhooks suddenly fail with 400
+
+- Check that the Page Rule on `/api/billing/webhook` is active and on top of any other matching rules (Page Rule order matters).
+- Check that `Challenge non-Stripe IPs on billing webhook` custom rule did NOT challenge a legit Stripe IP. Cloudflare changes Stripe IPs ~1×/year; if so, update `STRIPE_WEBHOOK_IPS` in `backend/scripts/cloudflare_rules_config.py` from https://stripe.com/files/ips/ips_webhooks.txt and re-run `--apply`.
+- In Cloudflare dashboard > **Security** > Events, filter by URI = `/api/billing/webhook` and last 24h to see what triggered.
+
+#### Caddy auto-SSL renewal fails after orange-cloud flip
+
+Caddy uses HTTP-01 challenge by default on port 80. Cloudflare proxies port 80,
+which usually works, but if the auto-SSL fails:
+
+- Switch Caddy to **DNS-01 challenge** (using Cloudflare API token with `Zone:DNS:Edit`):
+  - Edit `deploy/hetzner/caddy/Caddyfile`. ⚠️ Bind-mount inode bug in production
+    means you can NOT just rewrite the host file. See `reference_caddy-bind-mount-inode-bug` memory.
+  - Workaround: extract the version inside the container, edit, copy back via
+    `docker cp`, then `docker exec repo-caddy-1 caddy reload`.
+- Or temporarily flip back to grey-cloud for 1 renewal cycle (90 days).
+
+#### `--apply` fails on rate limit rules with HTTP 403
+
+Most common cause: the zone is on Free plan. Rate limiting rules need at least
+**Pro plan** ($20/mo). Either upgrade or accept that only WAF custom rules + cache rules apply (the script reports `failed` but completes).
+
+#### Wildcard `/api/*` rate limit triggers on legitimate users
+
+Threshold is 100 req/min per IP. Heavy-usage Expert-plan users may hit it
+during long sessions. To raise:
+
+- Edit `backend/scripts/cloudflare_rules_config.py` >
+  `Rate limit /api/* wildcard 100/min` > bump `requests_per_period`
+- Re-run `python backend/scripts/setup_cloudflare_waf.py --apply` (idempotent;
+  the existing rule is updated in place).
+
+#### YouTube IP ban on Hetzner stays active
+
+Cloudflare proxy does NOT change the egress IP DeepSight uses to call YouTube.
+The Hetzner VPS still talks to YouTube directly. If YouTube blocks the Hetzner
+IP, only Webshare proxy (`YOUTUBE_PROXY` env var) or Supadata fallback help.
+This RUNBOOK section is unrelated to that issue.
+
+### 18.12 — Verification post-rollout
+
+```bash
+# 1) DNS proxy active
+dig api.deepsightsynthesis.com +short
+# Expected: a Cloudflare anycast IP (104.x or 172.x), NOT 89.167.23.214
+
+# 2) HTTP path through Cloudflare
+curl -sI https://api.deepsightsynthesis.com/health | grep -i 'cf-ray\|server'
+# Expected: cf-ray header present, server: cloudflare
+
+# 3) Origin still reachable on 443 from Cloudflare's IPs
+curl -sI -k --resolve api.deepsightsynthesis.com:443:89.167.23.214 \
+  https://api.deepsightsynthesis.com/health
+# Expected: HTTP/2 200 (proves origin works for Cloudflare)
+
+# 4) Stripe test webhook (Stripe CLI)
+stripe trigger checkout.session.completed --api-key sk_test_xxx
+# Expected: 200 in Stripe Dashboard > Developers > Webhooks > attempt log
+
+# 5) Rate limit triggers as expected
+for i in $(seq 1 10); do
+  curl -sI -X POST https://api.deepsightsynthesis.com/api/auth/login \
+    -d '{"email":"x@x","password":"x"}' \
+    -H 'Content-Type: application/json'
+done
+# Expected: requests 1-5 = 401 (bad creds, normal), 6-10 = 429 from Cloudflare
+```
+
+### 18.13 — Updating the configuration
+
+To add/edit/disable a rule:
+
+1. Edit `backend/scripts/cloudflare_rules_config.py`. Keep the `description`
+   field stable (it's the idempotency key); change only `expression`/`action`/`enabled`.
+2. Run `--dry-run` first, sanity-check the diff.
+3. Run `--apply`.
+
+To **remove** a rule, delete it manually in the Cloudflare dashboard. The script does not delete (safety). Future enhancement: `--prune` flag.
+
+### 18.14 — Open follow-ups
+
+- Move the Stripe webhook IP list to `core/config.py` so backend and Cloudflare
+  setup share one source of truth.
+- Consider a 2nd Hetzner VPS in another region with a Cloudflare Load Balancer
+  for active-active HA (out of scope for this sprint, but enabled by having
+  Cloudflare in front).
+- Add a Cloudflare Worker on `/api/auth/*` to issue short-lived bot challenge
+  tokens, removing the need for `managed_challenge` UX hits on legit mobile users.


### PR DESCRIPTION
## Summary

Sprint scalability — **Chantier A (audit P0)** : moves `api.deepsightsynthesis.com`
behind Cloudflare's edge to mitigate DDoS, brute-force, and OWASP-class threats
hitting the Hetzner single-VPS backend (89.167.23.214). The Hetzner VPS remains
the only origin, but Cloudflare WAF + rate-limit + edge cache now stand in
front and continue protecting even if the backend goes down.

No live prod change in this PR — the script (`backend/scripts/setup_cloudflare_waf.py`)
must be run manually by Maxime AFTER reviewing this PR. All Caddyfile, backend
code, and DNS records are untouched.

## What's added

- `backend/scripts/cloudflare_rules_config.py` — declarative source of truth for
  10 production rules (4 WAF, 4 rate limit, 2 cache). Stripe webhook IPs
  whitelist embedded.
- `backend/scripts/setup_cloudflare_waf.py` — idempotent upsert script using
  `httpx`. Three modes: `--show-config` (offline preview), `--dry-run` (live
  diff vs Cloudflare, no write), `--apply` (commit). Rules matched by
  `description` (suffixed `[managed]`) for idempotency. Per-rule
  try/except + final results table.
- `docs/RUNBOOK.md` §18 — full operations procedure: pre-requisites, manual UI
  steps (DNS proxy, SSL Full strict, Stripe webhook page rule), API token
  scopes, script invocation, rules table with criticality + risk levels,
  rollback (grey-cloud), troubleshooting (Stripe 400, Caddy SSL renewal,
  Free-vs-Pro plan rate-limit limits, YouTube IP ban out-of-scope),
  verification curl recipes, and update workflow.

## Configured rules

| Type       | Description                                                | Action                  |
| ---------- | ---------------------------------------------------------- | ----------------------- |
| WAF        | Block empty UA or known scrapers                           | block                   |
| WAF        | Challenge non-Stripe IPs on billing webhook                | managed_challenge       |
| WAF        | Block oversize body except on exports (>10 MB)             | block                   |
| WAF        | Challenge non-JSON POST on auth endpoints                  | managed_challenge       |
| Rate limit | `/api/auth/login` 5/min                                    | block 1h                |
| Rate limit | `/api/auth/register` 3/min                                 | block 1h                |
| Rate limit | `/api/videos/analyze` 10/min                               | challenge 10min         |
| Rate limit | `/api/*` wildcard 100/min                                  | managed_challenge 5min  |
| Cache      | `/api/health` edge TTL 30s                                 | cache                   |
| Cache      | `/api/tournesol/*` GET edge TTL 5min                       | cache                   |

## Secrets to set

- `CLOUDFLARE_API_TOKEN` — created at https://dash.cloudflare.com/profile/api-tokens
  with scopes Zone:Read + Zone WAF:Edit + Zone Rate Limit:Edit + Zone Cache Rules:Edit.
- `CLOUDFLARE_ZONE_ID` — Cloudflare dashboard > zone `deepsightsynthesis.com` > Overview > API panel.

These are NEVER committed. They're env vars passed to the script at run time only.

## Constraints respected

- No live prod modification — script run manually after PR review.
- Caddyfile untouched (avoids bind-mount inode bug from prior incident).
- `/api/billing/webhook` protected by both a custom WAF rule (challenge non-Stripe IPs) AND a manual Page Rule (security off) — belt-and-suspenders for HMAC integrity.
- Caddy auto-SSL kept intact: rollback documented if the proxy flip breaks Let's Encrypt renewal (DNS-01 fallback).

## Initial enable procedure (for Maxime)

1. **Manual Cloudflare UI** (one-time):
   - Toggle DNS A record `api -> 89.167.23.214` from grey-cloud to orange-cloud (proxied).
   - SSL/TLS encryption mode: Full (strict).
   - Verify Caddy auto-SSL still works: `curl -sI https://api.deepsightsynthesis.com/health` returns `cf-ray` header.
   - Create Page Rule on `/api/billing/webhook`: Security Off + Cache Bypass.
2. **Generate API token** + grab Zone ID (see RUNBOOK §18.5–6).
3. **Run script**:
   ```bash
   python backend/scripts/setup_cloudflare_waf.py --show-config   # preview
   CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... \
     python backend/scripts/setup_cloudflare_waf.py --dry-run     # diff
   CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... \
     python backend/scripts/setup_cloudflare_waf.py --apply       # commit
   ```

## Test plan

- [x] AST compile OK on both new Python modules
- [x] `--show-config` runs offline, prints all 10 rules
- [x] `--help` displays cleanly on Windows cp1252 console
- [x] `--dry-run` without env vars exits 2 with clear error
- [x] Smoke test: dataclass build + serializers round-trip + unique descriptions
- [ ] **Maxime manual**: bascule DNS proxy + dry-run vs live zone
- [ ] **Maxime manual**: `--apply` then verify in Cloudflare dashboard > Security > WAF + Bots & DDoS > Rate limiting + Caching > Cache Rules
- [ ] **Maxime manual**: smoke `curl` on `/api/health` (cf-ray header present)
- [ ] **Maxime manual**: Stripe test webhook returns 200
- [ ] **Maxime manual**: 6 rapid POST `/api/auth/login` returns 429 from Cloudflare on attempt 6+

## Caveats / known risks

- **Cloudflare Free plan** : rate limit rules require Pro tier ($20/mo). On Free, the `--apply` will report `failed` for rate-limit rules but keep applying WAF + cache rules.
- **Stripe webhook IP list** : embedded statically; Stripe may add IPs ~1×/year. Re-fetch from https://stripe.com/files/ips/ips_webhooks.txt if billing webhooks start failing.
- **`/api/*` 100/min wildcard** : Expert-plan power users on long sessions may occasionally trip the threshold. Action is `managed_challenge` (silent for browsers), not block. Bump in `cloudflare_rules_config.py` if needed.
- **Cache `/api/health` 30s** : if health checks suddenly green when backend is dead, that's the edge serving stale 200s. UptimeRobot should poll `/health/strict` (no cache) for accurate alerts.
- **No `--prune`** : the script never deletes Cloudflare-side rules removed from the Python config. Manual deletion only (safety). Future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)