### PR TITLE
feat(videos): Visual Analysis POC — Mistral Vision + Pivot 5 storyboards

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -408,6 +408,15 @@ except ImportError as e:
     HUB_ROUTER_AVAILABLE = False
     logger.warning(f"⚠️ Hub router not available: {e}")
 
+# 👁️ Visual Analysis POC router (frames + Mistral Vision — 2026-05-05, admin/flag-gated)
+try:
+    from videos.visual_router import router as visual_router
+
+    VISUAL_ROUTER_AVAILABLE = True
+except ImportError as e:
+    VISUAL_ROUTER_AVAILABLE = False
+    logger.warning(f"⚠️ Visual analysis router not available: {e}")
+
 # Global video cache instance
 _video_cache: "VideoContentCacheService | None" = None
 
@@ -1228,6 +1237,11 @@ if DOCUMENTS_ROUTER_AVAILABLE:
 if HUB_ROUTER_AVAILABLE:
     app.include_router(hub_router, prefix="/api/hub", tags=["Hub"])
     logger.info("🧩 Hub router loaded (POST /api/hub/workspaces — Expert only)")
+
+# 👁️ Visual Analysis POC router (admin only, gated by VISUAL_ANALYSIS_ENABLED)
+if VISUAL_ROUTER_AVAILABLE:
+    app.include_router(visual_router, prefix="/api/admin/visual", tags=["Visual Analysis (POC)"])
+    logger.info("👁️ Visual analysis router loaded (GET /api/admin/visual/debug-from-url, /health)")
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 🖼️ THUMBNAIL STATIC FILES (local VPS fallback when R2 creds not available)

--- a/backend/src/videos/frame_extractor.py
+++ b/backend/src/videos/frame_extractor.py
@@ -1,0 +1,533 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎞️ FRAME EXTRACTOR — Téléchargement vidéo + extraction frames JPEG               ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Pipeline :                                                                        ║
+║  1. yt-dlp download (réutilise YOUTUBE_PROXY + cookies via _yt_dlp_extra_args)    ║
+║  2. ffprobe pour mesurer la durée                                                  ║
+║  3. ffmpeg extraction frames avec auto-scaling par durée (cap 2 fps, 100 frames)  ║
+║  4. Cleanup explicite (caller's responsibility) ou TTL via cleanup_stale_frames() ║
+║                                                                                    ║
+║  Inspiré de bradautomates/claude-video (algorithme de frame budget).              ║
+║  Spec: docs/superpowers/specs/2026-05-05-visual-analysis-poc.md (à créer)         ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from transcripts.audio_utils import _yt_dlp_extra_args
+
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📊 CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Hard caps (alignés sur claude-video pour limiter le coût en tokens vision)
+MAX_FRAMES = 100
+MAX_FPS = 2.0
+DEFAULT_FRAME_WIDTH = 512  # px ; 1024 si OCR nécessaire (option future)
+
+# Timeouts
+DOWNLOAD_TIMEOUT_S = 300  # 5 min max pour télécharger
+FFMPEG_TIMEOUT_S = 120  # 2 min max pour extraire les frames
+FFPROBE_TIMEOUT_S = 30
+
+# Storage : configurable via env, fallback /tmp
+FRAMES_BASE_DIR = os.getenv("VISUAL_FRAMES_DIR", "/tmp/deepsight-frames")
+FRAMES_TTL_SECONDS = 3600  # 1h ; cleanup_stale_frames() purge au-delà
+
+# Limite taille téléchargement (la vidéo elle-même n'est jamais conservée
+# au-delà de l'extraction frames + audio fallback)
+MAX_VIDEO_FILESIZE = "200M"  # yt-dlp --max-filesize
+
+# Format yt-dlp : on prend la résolution minimale acceptable pour les frames
+# (les frames seront downscale par ffmpeg de toute façon, donc inutile de
+# télécharger en 1080p si on output en 512px).
+YTDLP_FORMAT = "best[height<=720][ext=mp4]/best[height<=720]/best[ext=mp4]/best"
+
+executor = ThreadPoolExecutor(max_workers=2)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 RESULT TYPE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class FrameExtractionResult:
+    """Résultat d'une extraction de frames."""
+
+    workdir: str  # Dossier contenant les frames JPEG (cleanup à la charge du caller)
+    frame_paths: List[str]  # Chemins absolus des frames, ordre chronologique
+    frame_timestamps: List[float]  # Timestamps absolus en secondes (1:1 avec frame_paths)
+    duration_s: float  # Durée totale de la vidéo
+    fps_used: float  # FPS effectif appliqué (≤ MAX_FPS)
+    frame_count: int  # len(frame_paths)
+    width: int  # Largeur des frames en px
+    long_video_warning: bool  # True si >10min ; le caller peut suggérer focused mode
+
+    def cleanup(self) -> None:
+        """Supprime le workdir et toutes les frames. À appeler en fin de vie."""
+        try:
+            shutil.rmtree(self.workdir, ignore_errors=True)
+        except Exception as e:
+            logger.warning("[FRAME_EXTRACT] Cleanup failed for %s: %s", self.workdir, e)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📐 ALGORITHME DE BUDGET FRAMES (inspiré claude-video)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def compute_frame_budget(
+    duration_s: float,
+    focused_start: Optional[float] = None,
+    focused_end: Optional[float] = None,
+) -> Tuple[float, int, bool]:
+    """
+    Calcule (fps, max_frames, long_video_warning) selon la durée.
+
+    Mode normal (full video) :
+    - ≤30s   → fps adaptatif (cap 2), 30 frames max
+    - 30-60s → 40 frames
+    - 1-3min → 60 frames
+    - 3-10min → 80 frames
+    - >10min → 100 frames sparse (warning)
+
+    Mode focused (start/end fournis) : densité plus élevée.
+
+    Le caller est libre de bypass via override (--max-frames N).
+    """
+    long_warning = False
+
+    # ── Mode focused : zoom dense sur une section ──
+    if focused_start is not None or focused_end is not None:
+        start = focused_start or 0.0
+        end = focused_end if focused_end is not None else duration_s
+        focus_duration = max(0.1, end - start)
+
+        if focus_duration <= 5:
+            target_frames = min(10, int(focus_duration * 2))
+            fps = MAX_FPS
+        elif focus_duration <= 15:
+            target_frames = min(30, int(focus_duration * 2))
+            fps = MAX_FPS
+        elif focus_duration <= 30:
+            target_frames = min(60, int(focus_duration * 2))
+            fps = MAX_FPS
+        elif focus_duration <= 60:
+            target_frames = 80
+            fps = min(MAX_FPS, target_frames / focus_duration)
+        else:  # focused mais long → 100 frames cap
+            target_frames = MAX_FRAMES
+            fps = min(MAX_FPS, target_frames / focus_duration)
+
+        return fps, min(target_frames, MAX_FRAMES), False
+
+    # ── Mode normal : full video ──
+    if duration_s <= 30:
+        target_frames = min(30, max(10, int(duration_s * 1)))
+    elif duration_s <= 60:
+        target_frames = 40
+    elif duration_s <= 180:  # 3 min
+        target_frames = 60
+    elif duration_s <= 600:  # 10 min
+        target_frames = 80
+    else:
+        target_frames = MAX_FRAMES
+        long_warning = True
+
+    target_frames = min(target_frames, MAX_FRAMES)
+    fps = min(MAX_FPS, target_frames / max(1.0, duration_s))
+
+    return fps, target_frames, long_warning
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔍 FFPROBE — durée vidéo
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _ffprobe_duration(video_path: str) -> Optional[float]:
+    """Renvoie la durée de la vidéo en secondes via ffprobe. None si erreur."""
+    try:
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "json",
+            video_path,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=FFPROBE_TIMEOUT_S)
+        if result.returncode != 0:
+            logger.warning("[FRAME_EXTRACT] ffprobe failed: %s", result.stderr[:200])
+            return None
+        data = json.loads(result.stdout or "{}")
+        duration_str = data.get("format", {}).get("duration")
+        if not duration_str:
+            return None
+        return float(duration_str)
+    except Exception as e:
+        logger.warning("[FRAME_EXTRACT] ffprobe exception: %s", e)
+        return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📥 YT-DLP DOWNLOAD VIDÉO COMPLÈTE (mode video, pas audio-only)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _download_video_sync(url: str, dest_dir: str, log_tag: str) -> Optional[str]:
+    """Télécharge la vidéo via yt-dlp. Renvoie le chemin du fichier ou None."""
+    output_template = str(Path(dest_dir) / "video.%(ext)s")
+    cmd = [
+        "yt-dlp",
+        *_yt_dlp_extra_args(),
+        "-f",
+        YTDLP_FORMAT,
+        "--max-filesize",
+        MAX_VIDEO_FILESIZE,
+        "--no-playlist",
+        "--no-warnings",
+        "--retries",
+        "3",
+        "-o",
+        output_template,
+        url,
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=DOWNLOAD_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        logger.warning("[%s] yt-dlp download timeout (%ds)", log_tag, DOWNLOAD_TIMEOUT_S)
+        return None
+
+    if result.returncode != 0:
+        logger.warning("[%s] yt-dlp failed: %s", log_tag, result.stderr[:300])
+        return None
+
+    # Trouver le fichier produit (extension variable selon le format)
+    for child in Path(dest_dir).iterdir():
+        if child.is_file() and child.stem == "video":
+            return str(child)
+
+    logger.warning("[%s] yt-dlp returned 0 but no video file found in %s", log_tag, dest_dir)
+    return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎞️ FFMPEG — extraction frames JPEG
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _extract_frames_sync(
+    video_path: str,
+    frames_dir: str,
+    fps: float,
+    width: int,
+    start_s: Optional[float],
+    end_s: Optional[float],
+    log_tag: str,
+) -> Tuple[List[str], List[float]]:
+    """Extrait les frames JPEG. Renvoie (paths, timestamps_absolute_s)."""
+    Path(frames_dir).mkdir(parents=True, exist_ok=True)
+
+    # On veut des timestamps absolus dans le nom de fichier → on utilise le
+    # filtre showinfo de ffmpeg pas pratique, donc on calcule à partir de
+    # start + index/fps. C'est exact car ffmpeg avec -vf fps=... produit des
+    # frames espacées régulièrement.
+    cmd = ["ffmpeg", "-hide_banner", "-loglevel", "error"]
+
+    if start_s is not None:
+        cmd.extend(["-ss", f"{start_s:.3f}"])
+    if end_s is not None and start_s is not None:
+        cmd.extend(["-t", f"{max(0.0, end_s - start_s):.3f}"])
+    elif end_s is not None:
+        cmd.extend(["-t", f"{end_s:.3f}"])
+
+    cmd.extend(
+        [
+            "-i",
+            video_path,
+            "-vf",
+            f"fps={fps:.4f},scale={width}:-2",
+            "-q:v",
+            "4",  # Qualité JPEG raisonnable (1=best, 31=worst)
+            "-vsync",
+            "0",
+            str(Path(frames_dir) / "frame_%04d.jpg"),
+        ]
+    )
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=FFMPEG_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        logger.warning("[%s] ffmpeg timeout (%ds)", log_tag, FFMPEG_TIMEOUT_S)
+        return [], []
+
+    if result.returncode != 0:
+        logger.warning("[%s] ffmpeg failed: %s", log_tag, result.stderr[:300])
+        return [], []
+
+    # Récupération + tri lexicographique = ordre chronologique grâce au padding
+    paths = sorted(str(p) for p in Path(frames_dir).glob("frame_*.jpg"))
+
+    # Timestamps absolus : start + index / fps
+    base_offset = start_s or 0.0
+    timestamps = [base_offset + (i / fps if fps > 0 else 0.0) for i in range(len(paths))]
+
+    return paths, timestamps
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 API PUBLIQUE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def extract_frames_from_url(
+    url: str,
+    *,
+    focused_start: Optional[float] = None,
+    focused_end: Optional[float] = None,
+    max_frames_override: Optional[int] = None,
+    width: int = DEFAULT_FRAME_WIDTH,
+    log_tag: str = "FRAME_EXTRACT",
+) -> Optional[FrameExtractionResult]:
+    """
+    Pipeline complet pour une URL distante (YouTube, TikTok, Vimeo, etc.).
+
+    1. Crée un workdir unique sous FRAMES_BASE_DIR
+    2. Télécharge la vidéo via yt-dlp (proxy + cookies hérités)
+    3. ffprobe → durée
+    4. compute_frame_budget → (fps, max_frames)
+    5. ffmpeg → extraction JPEG
+    6. Renvoie FrameExtractionResult ; le caller appelle .cleanup() en fin de vie
+
+    En cas d'échec à n'importe quelle étape, renvoie None (workdir nettoyé).
+    """
+    Path(FRAMES_BASE_DIR).mkdir(parents=True, exist_ok=True)
+    workdir = str(Path(FRAMES_BASE_DIR) / f"job_{uuid.uuid4().hex[:12]}")
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+
+    loop = asyncio.get_event_loop()
+
+    try:
+        # ── 1. Download vidéo ──
+        t0 = time.time()
+        video_path = await loop.run_in_executor(executor, _download_video_sync, url, workdir, log_tag)
+        if not video_path:
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+        logger.info("[%s] Download OK in %.1fs: %s", log_tag, time.time() - t0, video_path)
+
+        # ── 2. Durée ──
+        duration_s = await loop.run_in_executor(executor, _ffprobe_duration, video_path)
+        if not duration_s or duration_s <= 0:
+            logger.warning("[%s] Could not determine duration, aborting", log_tag)
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+
+        # ── 3. Budget frames ──
+        fps, target_frames, long_warning = compute_frame_budget(
+            duration_s,
+            focused_start=focused_start,
+            focused_end=focused_end,
+        )
+        if max_frames_override is not None:
+            target_frames = min(max_frames_override, MAX_FRAMES)
+            # Si l'override est plus restrictif, recompute fps en conséquence
+            effective_duration = duration_s
+            if focused_start is not None or focused_end is not None:
+                start = focused_start or 0.0
+                end = focused_end if focused_end is not None else duration_s
+                effective_duration = max(0.1, end - start)
+            fps = min(MAX_FPS, target_frames / effective_duration)
+
+        logger.info(
+            "[%s] duration=%.1fs fps=%.3f target_frames=%d long=%s focused=%s",
+            log_tag,
+            duration_s,
+            fps,
+            target_frames,
+            long_warning,
+            focused_start is not None or focused_end is not None,
+        )
+
+        # ── 4. Extraction frames ──
+        frames_dir = str(Path(workdir) / "frames")
+        t0 = time.time()
+        paths, timestamps = await loop.run_in_executor(
+            executor,
+            _extract_frames_sync,
+            video_path,
+            frames_dir,
+            fps,
+            width,
+            focused_start,
+            focused_end,
+            log_tag,
+        )
+        if not paths:
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+
+        # Si ffmpeg a généré plus que target_frames (peut arriver avec
+        # arrondis), on tronque proprement.
+        if len(paths) > target_frames:
+            for extra in paths[target_frames:]:
+                Path(extra).unlink(missing_ok=True)
+            paths = paths[:target_frames]
+            timestamps = timestamps[:target_frames]
+
+        logger.info("[%s] Frames extracted: %d in %.1fs", log_tag, len(paths), time.time() - t0)
+
+        # On peut supprimer le fichier vidéo brut ; on garde juste les frames
+        try:
+            Path(video_path).unlink(missing_ok=True)
+        except Exception:
+            pass
+
+        return FrameExtractionResult(
+            workdir=workdir,
+            frame_paths=paths,
+            frame_timestamps=timestamps,
+            duration_s=duration_s,
+            fps_used=fps,
+            frame_count=len(paths),
+            width=width,
+            long_video_warning=long_warning,
+        )
+
+    except Exception as e:
+        logger.exception("[%s] Unexpected error: %s", log_tag, e)
+        shutil.rmtree(workdir, ignore_errors=True)
+        return None
+
+
+async def extract_frames_from_local(
+    video_path: str,
+    *,
+    focused_start: Optional[float] = None,
+    focused_end: Optional[float] = None,
+    max_frames_override: Optional[int] = None,
+    width: int = DEFAULT_FRAME_WIDTH,
+    log_tag: str = "FRAME_EXTRACT",
+) -> Optional[FrameExtractionResult]:
+    """Variante pour fichier local déjà téléchargé. Skip l'étape yt-dlp."""
+    if not Path(video_path).exists():
+        logger.warning("[%s] Local file not found: %s", log_tag, video_path)
+        return None
+
+    Path(FRAMES_BASE_DIR).mkdir(parents=True, exist_ok=True)
+    workdir = str(Path(FRAMES_BASE_DIR) / f"job_{uuid.uuid4().hex[:12]}")
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+    frames_dir = str(Path(workdir) / "frames")
+
+    loop = asyncio.get_event_loop()
+
+    try:
+        duration_s = await loop.run_in_executor(executor, _ffprobe_duration, video_path)
+        if not duration_s or duration_s <= 0:
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+
+        fps, target_frames, long_warning = compute_frame_budget(
+            duration_s, focused_start=focused_start, focused_end=focused_end
+        )
+        if max_frames_override is not None:
+            target_frames = min(max_frames_override, MAX_FRAMES)
+            effective_duration = duration_s
+            if focused_start is not None or focused_end is not None:
+                start = focused_start or 0.0
+                end = focused_end if focused_end is not None else duration_s
+                effective_duration = max(0.1, end - start)
+            fps = min(MAX_FPS, target_frames / effective_duration)
+
+        paths, timestamps = await loop.run_in_executor(
+            executor,
+            _extract_frames_sync,
+            video_path,
+            frames_dir,
+            fps,
+            width,
+            focused_start,
+            focused_end,
+            log_tag,
+        )
+        if not paths:
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+
+        if len(paths) > target_frames:
+            for extra in paths[target_frames:]:
+                Path(extra).unlink(missing_ok=True)
+            paths = paths[:target_frames]
+            timestamps = timestamps[:target_frames]
+
+        return FrameExtractionResult(
+            workdir=workdir,
+            frame_paths=paths,
+            frame_timestamps=timestamps,
+            duration_s=duration_s,
+            fps_used=fps,
+            frame_count=len(paths),
+            width=width,
+            long_video_warning=long_warning,
+        )
+
+    except Exception as e:
+        logger.exception("[%s] Local extraction failed: %s", log_tag, e)
+        shutil.rmtree(workdir, ignore_errors=True)
+        return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧹 CLEANUP TTL — purge des workdirs orphelins
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def cleanup_stale_frames(ttl_seconds: int = FRAMES_TTL_SECONDS) -> int:
+    """
+    Supprime les workdirs sous FRAMES_BASE_DIR plus vieux que ttl_seconds.
+    À brancher dans l'APScheduler du backend (cron horaire).
+
+    Renvoie le nombre de workdirs purgés.
+    """
+    base = Path(FRAMES_BASE_DIR)
+    if not base.exists():
+        return 0
+
+    cutoff = time.time() - ttl_seconds
+    purged = 0
+
+    for child in base.iterdir():
+        if not child.is_dir() or not child.name.startswith("job_"):
+            continue
+        try:
+            mtime = child.stat().st_mtime
+            if mtime < cutoff:
+                shutil.rmtree(child, ignore_errors=True)
+                purged += 1
+        except Exception as e:
+            logger.warning("[FRAME_CLEANUP] Failed to inspect %s: %s", child, e)
+
+    if purged:
+        logger.info("[FRAME_CLEANUP] Purged %d stale workdirs", purged)
+    return purged

--- a/backend/src/videos/frame_extractor.py
+++ b/backend/src/videos/frame_extractor.py
@@ -19,7 +19,6 @@ import logging
 import os
 import shutil
 import subprocess
-import tempfile
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor

--- a/backend/src/videos/visual_analyzer.py
+++ b/backend/src/videos/visual_analyzer.py
@@ -1,0 +1,296 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  👁️ VISUAL ANALYZER — Analyse multimodale frames + transcript via Mistral Vision  ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Pipeline :                                                                        ║
+║  1. Encode frames JPEG en base64                                                   ║
+║  2. Construit messages Mistral avec timestamps en texte avant chaque image        ║
+║  3. Appelle mistral_vision_request (réutilise fallback chain pixtral→small→Claude)║
+║  4. Parse JSON strict ; renvoie VisualAnalysis ou None                            ║
+║                                                                                    ║
+║  Réutilise core.config.get_mistral_key + images.screenshot_detection.mistral_*    ║
+║  Spec: docs/superpowers/specs/2026-05-05-visual-analysis-poc.md (à créer)         ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import base64
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.config import get_mistral_key
+from images.screenshot_detection import mistral_vision_request
+
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📊 CONFIG MODÈLES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Ordre de préférence : pixtral-large > pixtral-12b > mistral-small (vision)
+# Aligné avec VISION_MODELS_ANALYSIS de screenshot_detection.py.
+PRIMARY_MODEL = "pixtral-large-2411"
+FALLBACK_MODELS = ["pixtral-12b-2409", "mistral-small-2603"]
+
+# Nombre max de frames envoyées à Mistral en un seul appel.
+# Au-delà, on downsample uniformément pour rester sous le seuil.
+# 80 frames × ~512 tokens ≈ 40k tokens input → safe pour pixtral-large (32k window).
+# pixtral-large = 128k context window, mais le coût grimpe vite.
+MAX_FRAMES_PER_CALL = 60
+
+VISION_TIMEOUT_S = 240.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 RESULT TYPE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class VisualAnalysis:
+    """Structure JSON renvoyée par Mistral après analyse visuelle."""
+
+    visual_hook: str = ""
+    visual_structure: str = ""  # talking_head|b_roll|gameplay|slides|tutorial|mixed|other
+    key_moments: List[Dict[str, Any]] = field(default_factory=list)
+    # Chaque moment: {timestamp_s: float, description: str, type: hook|transition|reveal|cta|peak}
+    visible_text: str = ""
+    visual_seo_indicators: Dict[str, Any] = field(default_factory=dict)
+    summary_visual: str = ""
+
+    # Métadonnées de l'analyse (non issues du LLM)
+    model_used: str = ""
+    frames_analyzed: int = 0
+    frames_downsampled: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _format_timestamp(seconds: float) -> str:
+    """3.5 → '00:03', 75.2 → '01:15', 3700 → '01:01:40'."""
+    seconds = max(0, int(seconds))
+    h = seconds // 3600
+    m = (seconds % 3600) // 60
+    s = seconds % 60
+    if h:
+        return f"{h:02d}:{m:02d}:{s:02d}"
+    return f"{m:02d}:{s:02d}"
+
+
+def _encode_frame(path: str) -> Optional[str]:
+    """Lit un JPEG et renvoie sa version base64. None si erreur."""
+    try:
+        return base64.b64encode(Path(path).read_bytes()).decode("ascii")
+    except Exception as e:
+        logger.warning("[VISUAL_ANALYZER] Failed to encode %s: %s", path, e)
+        return None
+
+
+def _downsample(items: List[Any], target: int) -> List[Any]:
+    """Downsample uniforme : garde target items répartis sur la liste source."""
+    if len(items) <= target or target <= 0:
+        return items
+    step = len(items) / target
+    return [items[int(i * step)] for i in range(target)]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎯 PROMPT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+SYSTEM_PROMPT = """Tu es un analyste visuel expert pour DeepSight, un SaaS d'analyse vidéo IA.
+
+Tu reçois une série de frames extraites d'une vidéo à intervalles réguliers (ordre chronologique strict)
+et un transcript timestampé. Ton rôle : produire une analyse visuelle structurée qui complète l'analyse
+textuelle déjà disponible.
+
+Réponds UNIQUEMENT en JSON strict, sans markdown, sans commentaire. Schema obligatoire :
+
+{
+  "visual_hook": "1-2 phrases sur le hook visuel des 5 premières secondes (couleurs, plan, sujet).",
+  "visual_structure": "talking_head | b_roll | gameplay | slides | tutorial | interview | vlog | mixed | other",
+  "key_moments": [
+    {
+      "timestamp_s": 12.5,
+      "description": "Brève description visuelle du moment (1 phrase).",
+      "type": "hook | transition | reveal | cta | peak | demo"
+    }
+  ],
+  "visible_text": "Tout texte affiché à l'écran (titres, captions burned-in, infographies). Vide si rien.",
+  "visual_seo_indicators": {
+    "hook_brightness": "low | medium | high",
+    "face_visible_in_hook": true,
+    "burned_in_subtitles": false,
+    "high_motion_intro": true,
+    "thumbnail_quality_proxy": "low | medium | high"
+  },
+  "summary_visual": "Résumé visuel global en 2-3 phrases. Mentionne le style, le rythme, l'atmosphère."
+}
+
+Règles :
+- Maximum 8 key_moments les plus saillants visuellement (pas un par frame).
+- timestamp_s en secondes décimales (ex: 12.5).
+- Si tu ne sais pas, mets une chaîne vide ou false plutôt que d'inventer.
+- Réponds en français pour les champs descriptifs."""
+
+
+def _build_user_message(
+    frame_paths: List[str],
+    frame_timestamps: List[float],
+    transcript_excerpt: str,
+) -> Optional[List[Dict[str, Any]]]:
+    """
+    Construit la liste content du message user (mix text + image_url).
+    Renvoie None si aucune frame n'a pu être encodée.
+    """
+    parts: List[Dict[str, Any]] = []
+
+    intro = (
+        f"Frames extraites en ordre chronologique ({len(frame_paths)} au total).\n"
+        f"Avant chaque image, le timestamp absolu dans la vidéo est indiqué."
+    )
+    if transcript_excerpt.strip():
+        intro += f"\n\nTranscript de référence (extrait):\n{transcript_excerpt[:8000]}"
+    parts.append({"type": "text", "text": intro})
+
+    encoded_count = 0
+    for path, ts in zip(frame_paths, frame_timestamps):
+        b64 = _encode_frame(path)
+        if not b64:
+            continue
+        parts.append({"type": "text", "text": f"--- Frame t={_format_timestamp(ts)} ---"})
+        parts.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+            }
+        )
+        encoded_count += 1
+
+    if encoded_count == 0:
+        return None
+    return parts
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 API PUBLIQUE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def analyze_frames(
+    frame_paths: List[str],
+    frame_timestamps: List[float],
+    transcript_excerpt: str = "",
+    *,
+    model: str = PRIMARY_MODEL,
+    fallback_models: Optional[List[str]] = None,
+    log_tag: str = "VISUAL_ANALYZER",
+) -> Optional[VisualAnalysis]:
+    """
+    Pipeline complet : frames → JSON structuré (VisualAnalysis).
+
+    Renvoie None si :
+    - Aucune clé Mistral configurée
+    - Aucune frame n'a pu être encodée
+    - Mistral renvoie 0 réponse exploitable
+    - Le JSON parse échoue après plusieurs tentatives
+
+    Le caller est responsable du cleanup des frames après cet appel.
+    """
+    if not frame_paths:
+        logger.warning("[%s] Empty frame_paths", log_tag)
+        return None
+    if len(frame_paths) != len(frame_timestamps):
+        logger.warning(
+            "[%s] frame_paths/timestamps length mismatch (%d vs %d)",
+            log_tag,
+            len(frame_paths),
+            len(frame_timestamps),
+        )
+        return None
+
+    api_key = get_mistral_key()
+    if not api_key:
+        logger.error("[%s] MISTRAL_API_KEY missing — abort", log_tag)
+        return None
+
+    # Downsample si trop de frames pour un seul appel
+    downsampled = False
+    if len(frame_paths) > MAX_FRAMES_PER_CALL:
+        downsampled = True
+        sampled_paths = _downsample(frame_paths, MAX_FRAMES_PER_CALL)
+        sampled_ts = _downsample(frame_timestamps, MAX_FRAMES_PER_CALL)
+        logger.info(
+            "[%s] Downsampled %d → %d frames (cap %d)",
+            log_tag,
+            len(frame_paths),
+            len(sampled_paths),
+            MAX_FRAMES_PER_CALL,
+        )
+    else:
+        sampled_paths = frame_paths
+        sampled_ts = frame_timestamps
+
+    user_content = _build_user_message(sampled_paths, sampled_ts, transcript_excerpt)
+    if user_content is None:
+        logger.warning("[%s] No frame could be encoded", log_tag)
+        return None
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    raw = await mistral_vision_request(
+        api_key=api_key,
+        messages=messages,
+        model=model,
+        max_tokens=2048,
+        temperature=0.1,
+        response_format={"type": "json_object"},
+        timeout=VISION_TIMEOUT_S,
+        fallback_models=fallback_models or FALLBACK_MODELS,
+    )
+
+    if not raw:
+        logger.warning("[%s] Mistral vision returned no content", log_tag)
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        # Tentative de récupération : isole le premier bloc {...}
+        logger.warning("[%s] JSON parse failed: %s ; trying brace extraction", log_tag, e)
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                data = json.loads(raw[start : end + 1])
+            except json.JSONDecodeError:
+                logger.error("[%s] JSON brace extraction also failed. Raw: %s", log_tag, raw[:500])
+                return None
+        else:
+            logger.error("[%s] No JSON object found in response", log_tag)
+            return None
+
+    return VisualAnalysis(
+        visual_hook=str(data.get("visual_hook", "")).strip(),
+        visual_structure=str(data.get("visual_structure", "")).strip(),
+        key_moments=list(data.get("key_moments", []) or []),
+        visible_text=str(data.get("visible_text", "")).strip(),
+        visual_seo_indicators=dict(data.get("visual_seo_indicators", {}) or {}),
+        summary_visual=str(data.get("summary_visual", "")).strip(),
+        model_used=model,
+        frames_analyzed=len(sampled_paths),
+        frames_downsampled=downsampled,
+    )

--- a/backend/src/videos/visual_router.py
+++ b/backend/src/videos/visual_router.py
@@ -25,6 +25,7 @@ from db.database import User
 
 from .frame_extractor import extract_frames_from_url
 from .visual_analyzer import analyze_frames
+from .youtube_storyboard import extract_storyboard_frames, normalize_video_id
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +47,10 @@ def _flag_enabled() -> bool:
 
 
 class VisualAnalysisDebugResponse(BaseModel):
-    status: str = Field(..., description="ok | extract_failed | vision_failed | flag_off")
-    url: str
+    status: str = Field(..., description="ok | extract_failed | vision_failed | flag_off | invalid_input")
+    source: str = ""  # "url" | "storyboard"
+    url: str = ""
+    video_id: str = ""
     duration_s: float = 0.0
     fps_used: float = 0.0
     frame_count: int = 0
@@ -113,6 +116,7 @@ async def debug_visual_from_url(
     if not extraction:
         return VisualAnalysisDebugResponse(
             status="extract_failed",
+            source="url",
             url=url,
             elapsed_extract_s=round(elapsed_extract, 2),
             elapsed_total_s=round(time.time() - t_total, 2),
@@ -136,6 +140,7 @@ async def debug_visual_from_url(
     if not analysis:
         return VisualAnalysisDebugResponse(
             status="vision_failed",
+            source="url",
             url=url,
             duration_s=round(extraction.duration_s, 2),
             fps_used=round(extraction.fps_used, 3),
@@ -149,7 +154,116 @@ async def debug_visual_from_url(
 
     return VisualAnalysisDebugResponse(
         status="ok",
+        source="url",
         url=url,
+        duration_s=round(extraction.duration_s, 2),
+        fps_used=round(extraction.fps_used, 3),
+        frame_count=extraction.frame_count,
+        frames_downsampled=analysis.frames_downsampled,
+        long_video_warning=extraction.long_video_warning,
+        elapsed_extract_s=round(elapsed_extract, 2),
+        elapsed_vision_s=round(elapsed_vision, 2),
+        elapsed_total_s=round(time.time() - t_total, 2),
+        model_used=analysis.model_used,
+        analysis=analysis.to_dict(),
+    )
+
+
+@router.get("/debug-from-youtube", response_model=VisualAnalysisDebugResponse)
+async def debug_visual_from_youtube(
+    video_id_or_url: str = Query(
+        ...,
+        min_length=11,
+        description="Video ID YouTube (11 chars) ou URL complète. Pivot 5 : utilise les storyboards i.ytimg.com (pas de download de la vidéo, contourne l'IP ban Hetzner).",
+    ),
+    transcript: Optional[str] = Query(
+        None,
+        description="Extrait de transcript optionnel pour enrichir le prompt vision.",
+    ),
+    max_frames: Optional[int] = Query(None, ge=1, le=100, description="Override budget frames (≤100)"),
+    user: User = Depends(get_current_admin),
+) -> VisualAnalysisDebugResponse:
+    """
+    POC Pivot 5 : extrait les frames d'une vidéo YouTube via les storyboards
+    publics (i.ytimg.com), pas via download du stream vidéo. Pas de proxy
+    nécessaire, fonctionne malgré l'IP ban Hetzner sur le stream YouTube.
+
+    Réservé admin + feature flag VISUAL_ANALYSIS_ENABLED.
+    """
+    if not _flag_enabled():
+        return VisualAnalysisDebugResponse(
+            status="flag_off",
+            source="storyboard",
+            url=video_id_or_url,
+            error="VISUAL_ANALYSIS_ENABLED is not set to true",
+        )
+
+    video_id = normalize_video_id(video_id_or_url)
+    if not video_id:
+        return VisualAnalysisDebugResponse(
+            status="invalid_input",
+            source="storyboard",
+            url=video_id_or_url,
+            error="Could not extract a valid 11-char YouTube video_id",
+        )
+
+    log_tag = f"VISUAL_SB user={user.id}"
+    t_total = time.time()
+
+    # ── 1. Extraction storyboards ──
+    t_extract = time.time()
+    extraction = await extract_storyboard_frames(
+        video_id,
+        max_frames_override=max_frames,
+        log_tag=log_tag,
+    )
+    elapsed_extract = time.time() - t_extract
+
+    if not extraction:
+        return VisualAnalysisDebugResponse(
+            status="extract_failed",
+            source="storyboard",
+            url=video_id_or_url,
+            video_id=video_id,
+            elapsed_extract_s=round(elapsed_extract, 2),
+            elapsed_total_s=round(time.time() - t_total, 2),
+            error="Storyboard extraction failed (yt-dlp -j blocked, no sb format, or sheet 403). Check logs.",
+        )
+
+    # ── 2. Analyse vision ──
+    t_vision = time.time()
+    try:
+        analysis = await analyze_frames(
+            extraction.frame_paths,
+            extraction.frame_timestamps,
+            transcript_excerpt=transcript or "",
+            log_tag=log_tag,
+        )
+    finally:
+        extraction.cleanup()
+    elapsed_vision = time.time() - t_vision
+
+    if not analysis:
+        return VisualAnalysisDebugResponse(
+            status="vision_failed",
+            source="storyboard",
+            url=video_id_or_url,
+            video_id=video_id,
+            duration_s=round(extraction.duration_s, 2),
+            fps_used=round(extraction.fps_used, 3),
+            frame_count=extraction.frame_count,
+            long_video_warning=extraction.long_video_warning,
+            elapsed_extract_s=round(elapsed_extract, 2),
+            elapsed_vision_s=round(elapsed_vision, 2),
+            elapsed_total_s=round(time.time() - t_total, 2),
+            error="Mistral Vision returned no usable JSON. Check Mistral key & quotas.",
+        )
+
+    return VisualAnalysisDebugResponse(
+        status="ok",
+        source="storyboard",
+        url=video_id_or_url,
+        video_id=video_id,
         duration_s=round(extraction.duration_s, 2),
         fps_used=round(extraction.fps_used, 3),
         frame_count=extraction.frame_count,

--- a/backend/src/videos/visual_router.py
+++ b/backend/src/videos/visual_router.py
@@ -1,0 +1,177 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  👁️ VISUAL ANALYSIS — Router debug admin (POC)                                    ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Endpoint isolé pour valider le pipeline frame_extractor + visual_analyzer        ║
+║  sur une URL distante, sans toucher au flow /analyze principal.                   ║
+║                                                                                    ║
+║  Gating : admin uniquement + feature flag VISUAL_ANALYSIS_ENABLED.                ║
+║  Aucune écriture DB, aucune consommation de crédits.                              ║
+║                                                                                    ║
+║  Phase 2 : intégration dans /api/videos/analyze derrière un flag par requête.     ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import logging
+import os
+import time
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from auth.dependencies import get_current_admin
+from db.database import User
+
+from .frame_extractor import extract_frames_from_url
+from .visual_analyzer import analyze_frames
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 FEATURE FLAG
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _flag_enabled() -> bool:
+    return os.getenv("VISUAL_ANALYSIS_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📋 SCHEMAS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class VisualAnalysisDebugResponse(BaseModel):
+    status: str = Field(..., description="ok | extract_failed | vision_failed | flag_off")
+    url: str
+    duration_s: float = 0.0
+    fps_used: float = 0.0
+    frame_count: int = 0
+    frames_downsampled: bool = False
+    long_video_warning: bool = False
+    elapsed_total_s: float = 0.0
+    elapsed_extract_s: float = 0.0
+    elapsed_vision_s: float = 0.0
+    model_used: str = ""
+    analysis: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 ENDPOINT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.get("/debug-from-url", response_model=VisualAnalysisDebugResponse)
+async def debug_visual_from_url(
+    url: str = Query(..., min_length=10, description="URL de la vidéo à analyser"),
+    transcript: Optional[str] = Query(
+        None,
+        description="Extrait de transcript optionnel pour enrichir le prompt vision.",
+    ),
+    focused_start: Optional[float] = Query(None, ge=0, description="Début (s) — focused mode"),
+    focused_end: Optional[float] = Query(None, ge=0, description="Fin (s) — focused mode"),
+    max_frames: Optional[int] = Query(None, ge=1, le=100, description="Override budget frames (≤100)"),
+    width: int = Query(512, ge=256, le=1280, description="Largeur frames en px"),
+    user: User = Depends(get_current_admin),
+) -> VisualAnalysisDebugResponse:
+    """
+    POC : extrait les frames d'une URL distante et les passe à Mistral Vision.
+
+    Réservé admin + feature flag VISUAL_ANALYSIS_ENABLED. Aucun crédit consommé,
+    aucune écriture DB. Cleanup automatique des frames en fin de requête.
+    """
+    if not _flag_enabled():
+        return VisualAnalysisDebugResponse(
+            status="flag_off",
+            url=url,
+            error="VISUAL_ANALYSIS_ENABLED is not set to true",
+        )
+
+    if focused_end is not None and focused_start is not None and focused_end <= focused_start:
+        raise HTTPException(400, "focused_end must be > focused_start")
+
+    log_tag = f"VISUAL_POC user={user.id}"
+    t_total = time.time()
+
+    # ── 1. Extraction frames ──
+    t_extract = time.time()
+    extraction = await extract_frames_from_url(
+        url,
+        focused_start=focused_start,
+        focused_end=focused_end,
+        max_frames_override=max_frames,
+        width=width,
+        log_tag=log_tag,
+    )
+    elapsed_extract = time.time() - t_extract
+
+    if not extraction:
+        return VisualAnalysisDebugResponse(
+            status="extract_failed",
+            url=url,
+            elapsed_extract_s=round(elapsed_extract, 2),
+            elapsed_total_s=round(time.time() - t_total, 2),
+            error="frame extraction failed (yt-dlp or ffmpeg). Check container logs.",
+        )
+
+    # ── 2. Analyse vision ──
+    t_vision = time.time()
+    try:
+        analysis = await analyze_frames(
+            extraction.frame_paths,
+            extraction.frame_timestamps,
+            transcript_excerpt=transcript or "",
+            log_tag=log_tag,
+        )
+    finally:
+        # On nettoie les frames qu'il y ait eu erreur ou pas
+        extraction.cleanup()
+    elapsed_vision = time.time() - t_vision
+
+    if not analysis:
+        return VisualAnalysisDebugResponse(
+            status="vision_failed",
+            url=url,
+            duration_s=round(extraction.duration_s, 2),
+            fps_used=round(extraction.fps_used, 3),
+            frame_count=extraction.frame_count,
+            long_video_warning=extraction.long_video_warning,
+            elapsed_extract_s=round(elapsed_extract, 2),
+            elapsed_vision_s=round(elapsed_vision, 2),
+            elapsed_total_s=round(time.time() - t_total, 2),
+            error="Mistral Vision returned no usable JSON. Check Mistral key & quotas.",
+        )
+
+    return VisualAnalysisDebugResponse(
+        status="ok",
+        url=url,
+        duration_s=round(extraction.duration_s, 2),
+        fps_used=round(extraction.fps_used, 3),
+        frame_count=extraction.frame_count,
+        frames_downsampled=analysis.frames_downsampled,
+        long_video_warning=extraction.long_video_warning,
+        elapsed_extract_s=round(elapsed_extract, 2),
+        elapsed_vision_s=round(elapsed_vision, 2),
+        elapsed_total_s=round(time.time() - t_total, 2),
+        model_used=analysis.model_used,
+        analysis=analysis.to_dict(),
+    )
+
+
+@router.get("/health")
+async def visual_health(user: User = Depends(get_current_admin)) -> Dict[str, Any]:
+    """Sanity check : flag state + ffmpeg/yt-dlp dispo."""
+    import shutil
+
+    return {
+        "flag_enabled": _flag_enabled(),
+        "ffmpeg_available": shutil.which("ffmpeg") is not None,
+        "ffprobe_available": shutil.which("ffprobe") is not None,
+        "yt_dlp_available": shutil.which("yt-dlp") is not None,
+        "frames_dir": os.getenv("VISUAL_FRAMES_DIR", "/tmp/deepsight-frames"),
+    }

--- a/backend/src/videos/youtube_storyboard.py
+++ b/backend/src/videos/youtube_storyboard.py
@@ -1,0 +1,350 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎬 YOUTUBE STORYBOARD — Frame extraction sans download (Pivot 5)                 ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Pipeline :                                                                        ║
+║  1. yt-dlp -j --skip-download <url> → JSON (juste les métadonnées + storyboards)  ║
+║  2. Sélection du format `sb*` de plus haute résolution                            ║
+║  3. Download chaque sheet via httpx sur i.ytimg.com (CDN sffe, pas de bot guard)  ║
+║  4. Slice chaque sheet en mini-frames via Pillow (cols×rows)                      ║
+║  5. Renvoie un FrameExtractionResult drop-in pour visual_analyzer                 ║
+║                                                                                    ║
+║  Validé 2026-05-05 : i.ytimg.com répond HTTP/2 200/404 normalement depuis         ║
+║  Hetzner (server: sffe), pas de bot challenge sur ce CDN.                         ║
+║                                                                                    ║
+║  Limitations :                                                                     ║
+║  - Qualité : 320×180 ou 160×90 (storyboard YouTube standard, pas full HD)         ║
+║  - Suffisant pour visual_hook/structure/key_moments. Limité pour OCR fin.         ║
+║  - Si yt-dlp -j est aussi bloqué → fallback HTML parsing (TODO Phase 2)           ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import asyncio
+import io
+import json
+import logging
+import re
+import shutil
+import subprocess
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+from PIL import Image
+
+from transcripts.audio_utils import _yt_dlp_extra_args
+
+from .frame_extractor import FRAMES_BASE_DIR, MAX_FRAMES, FrameExtractionResult
+
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📊 CONFIG
+# ═══════════════════════════════════════════════════════════════════════════════
+
+YTDLP_INFO_TIMEOUT_S = 60
+SHEET_DOWNLOAD_TIMEOUT_S = 30
+HTTPX_RETRIES_PER_SHEET = 2
+
+executor = ThreadPoolExecutor(max_workers=2)
+
+YOUTUBE_VIDEO_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{11}$")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def normalize_video_id(value: str) -> Optional[str]:
+    """Accepte un video_id brut (11 chars) ou une URL et renvoie le video_id."""
+    if not value:
+        return None
+    value = value.strip()
+    if YOUTUBE_VIDEO_ID_PATTERN.match(value):
+        return value
+    # Pattern simple URL → extraction
+    m = re.search(r"(?:v=|youtu\.be/|/embed/|/shorts/)([a-zA-Z0-9_-]{11})", value)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _ytdlp_info_sync(video_id: str, log_tag: str) -> Optional[Dict[str, Any]]:
+    """Lance yt-dlp -j --skip-download (sync, à appeler dans un executor)."""
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    cmd = [
+        "yt-dlp",
+        *_yt_dlp_extra_args(),
+        "-j",
+        "--skip-download",
+        "--no-warnings",
+        "--no-playlist",
+        url,
+    ]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=YTDLP_INFO_TIMEOUT_S
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("[%s] yt-dlp -j timeout (%ds)", log_tag, YTDLP_INFO_TIMEOUT_S)
+        return None
+
+    if result.returncode != 0:
+        logger.warning("[%s] yt-dlp -j failed: %s", log_tag, result.stderr[:300])
+        return None
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        logger.warning("[%s] yt-dlp output not JSON: %s", log_tag, e)
+        return None
+
+
+def select_storyboard_format(info: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    Sélectionne le format storyboard `sb*` de meilleure résolution.
+
+    yt-dlp 2024+ inclut les storyboards comme entrées dans `info["formats"]`
+    avec format_id="sb0"|"sb1"|"sb2" (du plus simple au plus dense), ext="mhtml",
+    et un champ `fragments[]` listant les sheets.
+    """
+    formats = info.get("formats") or []
+    sb_formats = [f for f in formats if str(f.get("format_id", "")).startswith("sb")]
+    if not sb_formats:
+        return None
+
+    # Tri par résolution décroissante (width × height puis format_id pour stable)
+    sb_formats.sort(
+        key=lambda f: (
+            (f.get("width") or 0) * (f.get("height") or 0),
+            str(f.get("format_id", "")),
+        ),
+        reverse=True,
+    )
+    return sb_formats[0]
+
+
+def _slice_sheet(
+    sheet_bytes: bytes, cols: int, rows: int, log_tag: str
+) -> List[bytes]:
+    """Découpe un sheet en cols×rows mini-frames JPEG. Renvoie une liste de bytes."""
+    try:
+        img = Image.open(io.BytesIO(sheet_bytes))
+        img.load()
+    except Exception as e:
+        logger.warning("[%s] PIL open failed: %s", log_tag, e)
+        return []
+
+    sheet_w, sheet_h = img.size
+    if cols <= 0 or rows <= 0:
+        return []
+
+    frame_w = sheet_w // cols
+    frame_h = sheet_h // rows
+    if frame_w == 0 or frame_h == 0:
+        logger.warning("[%s] Invalid grid: %dx%d on %dx%d sheet", log_tag, cols, rows, sheet_w, sheet_h)
+        return []
+
+    frames: List[bytes] = []
+    for row_i in range(rows):
+        for col_i in range(cols):
+            x = col_i * frame_w
+            y = row_i * frame_h
+            crop = img.crop((x, y, x + frame_w, y + frame_h))
+            # Convert to RGB if needed (storyboards sont JPEG donc déjà RGB normalement)
+            if crop.mode != "RGB":
+                crop = crop.convert("RGB")
+            buf = io.BytesIO()
+            crop.save(buf, format="JPEG", quality=85, optimize=True)
+            frames.append(buf.getvalue())
+    return frames
+
+
+async def _download_sheet(client: httpx.AsyncClient, url: str, log_tag: str) -> Optional[bytes]:
+    """Télécharge un sheet storyboard avec retries."""
+    for attempt in range(HTTPX_RETRIES_PER_SHEET + 1):
+        try:
+            r = await client.get(url, timeout=SHEET_DOWNLOAD_TIMEOUT_S, follow_redirects=True)
+            if r.status_code == 200:
+                return r.content
+            logger.warning(
+                "[%s] sheet download HTTP %d (attempt %d): %s",
+                log_tag,
+                r.status_code,
+                attempt + 1,
+                url[:120],
+            )
+            if r.status_code in (403, 429):
+                # Bot challenge / rate limit → ne pas insister
+                return None
+        except (httpx.TimeoutException, httpx.HTTPError) as e:
+            logger.warning("[%s] sheet download error (attempt %d): %s", log_tag, attempt + 1, e)
+        if attempt < HTTPX_RETRIES_PER_SHEET:
+            await asyncio.sleep(0.5 * (attempt + 1))
+    return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 API PUBLIQUE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def extract_storyboard_frames(
+    video_id_or_url: str,
+    *,
+    max_frames_override: Optional[int] = None,
+    log_tag: str = "STORYBOARD",
+) -> Optional[FrameExtractionResult]:
+    """
+    Pipeline complet :
+    1. Normalise le video_id (URL → ID)
+    2. yt-dlp -j --skip-download → info JSON
+    3. Sélection format sb* de meilleure résolution
+    4. Download tous les sheets (httpx + retries)
+    5. Slice chaque sheet via Pillow
+    6. Sauvegarde frames JPEG dans workdir unique
+    7. Renvoie FrameExtractionResult drop-in pour visual_analyzer
+
+    Renvoie None à toute étape qui échoue. Workdir est nettoyé automatiquement
+    en cas d'échec.
+    """
+    video_id = normalize_video_id(video_id_or_url)
+    if not video_id:
+        logger.warning("[%s] Invalid video_id_or_url: %s", log_tag, video_id_or_url)
+        return None
+
+    Path(FRAMES_BASE_DIR).mkdir(parents=True, exist_ok=True)
+    workdir = str(Path(FRAMES_BASE_DIR) / f"job_sb_{uuid.uuid4().hex[:12]}")
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+
+    loop = asyncio.get_event_loop()
+
+    try:
+        # ── 1. yt-dlp -j ──
+        t0 = time.time()
+        info = await loop.run_in_executor(executor, _ytdlp_info_sync, video_id, log_tag)
+        if not info:
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+        logger.info("[%s] yt-dlp info OK in %.1fs (video_id=%s)", log_tag, time.time() - t0, video_id)
+
+        duration_s = float(info.get("duration") or 0)
+        if duration_s <= 0:
+            logger.warning("[%s] No duration in info JSON", log_tag)
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+
+        # ── 2. Sélection storyboard ──
+        sb = select_storyboard_format(info)
+        if not sb:
+            logger.warning("[%s] No storyboard format available", log_tag)
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+
+        cols = int(sb.get("columns") or 1)
+        rows = int(sb.get("rows") or 1)
+        fragments = sb.get("fragments") or []
+        if not fragments:
+            logger.warning("[%s] Storyboard has no fragments", log_tag)
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+
+        sb_width = int(sb.get("width") or 0)
+        sb_height = int(sb.get("height") or 0)
+        single_frame_w = sb_width // cols if sb_width and cols else 0
+
+        logger.info(
+            "[%s] Selected sb %s: %dx%d grid=%dx%d, %d fragments, dur=%.1fs",
+            log_tag,
+            sb.get("format_id"),
+            sb_width,
+            sb_height,
+            cols,
+            rows,
+            len(fragments),
+            duration_s,
+        )
+
+        # ── 3+4. Download + slice + save ──
+        frame_paths: List[str] = []
+        frame_timestamps: List[float] = []
+        cumulative_t = 0.0
+
+        async with httpx.AsyncClient() as client:
+            for frag_idx, frag in enumerate(fragments):
+                url = frag.get("url")
+                frag_duration = float(frag.get("duration") or 0)
+                if not url:
+                    continue
+
+                sheet_bytes = await _download_sheet(client, url, log_tag)
+                if not sheet_bytes:
+                    continue
+
+                sliced = await loop.run_in_executor(
+                    executor, _slice_sheet, sheet_bytes, cols, rows, log_tag
+                )
+                if not sliced:
+                    continue
+
+                # Calcul des timestamps : intervalle = durée du fragment / N frames du sheet
+                interval = frag_duration / len(sliced) if sliced else 0
+                for sub_idx, frame_bytes in enumerate(sliced):
+                    ts = cumulative_t + sub_idx * interval
+                    if ts > duration_s + 1.0:  # tolérance arrondi
+                        break
+                    global_idx = len(frame_paths)
+                    frame_path = str(Path(workdir) / f"frame_{global_idx:04d}.jpg")
+                    Path(frame_path).write_bytes(frame_bytes)
+                    frame_paths.append(frame_path)
+                    frame_timestamps.append(ts)
+
+                    if len(frame_paths) >= MAX_FRAMES:
+                        break
+
+                cumulative_t += frag_duration
+                if len(frame_paths) >= MAX_FRAMES:
+                    break
+
+        if not frame_paths:
+            logger.warning("[%s] Aucun frame n'a pu être extrait", log_tag)
+            shutil.rmtree(workdir, ignore_errors=True)
+            return None
+
+        # ── 5. Override max_frames ──
+        if max_frames_override and len(frame_paths) > max_frames_override:
+            step = len(frame_paths) / max_frames_override
+            keep_indices = sorted(set(int(i * step) for i in range(max_frames_override)))
+            kept_paths = []
+            kept_ts = []
+            for i, p in enumerate(frame_paths):
+                if i in keep_indices:
+                    kept_paths.append(p)
+                    kept_ts.append(frame_timestamps[i])
+                else:
+                    Path(p).unlink(missing_ok=True)
+            frame_paths = kept_paths
+            frame_timestamps = kept_ts
+
+        # ── 6. Wrap result ──
+        fps_used = len(frame_paths) / duration_s if duration_s > 0 else 0.0
+        return FrameExtractionResult(
+            workdir=workdir,
+            frame_paths=frame_paths,
+            frame_timestamps=frame_timestamps,
+            duration_s=duration_s,
+            fps_used=fps_used,
+            frame_count=len(frame_paths),
+            width=single_frame_w,
+            long_video_warning=duration_s > 600,
+        )
+
+    except Exception as e:
+        logger.exception("[%s] Unexpected error: %s", log_tag, e)
+        shutil.rmtree(workdir, ignore_errors=True)
+        return None

--- a/backend/tests/videos/test_frame_extractor.py
+++ b/backend/tests/videos/test_frame_extractor.py
@@ -1,0 +1,228 @@
+"""
+Tests pour videos/frame_extractor.py — logique de budget frames + extraction.
+
+Couvre :
+- compute_frame_budget (pure logique, pas de binaire)
+- Edge cases focused mode
+- Cleanup TTL workdirs
+- Extraction locale via fixture vidéo générée à la volée (skippé sans ffmpeg)
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+
+_HAS_FFMPEG = shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📐 compute_frame_budget — logique pure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestComputeFrameBudget:
+    """Vérifie le scaling claude-video-style par durée."""
+
+    def test_short_video_under_30s(self):
+        from videos.frame_extractor import MAX_FPS, compute_frame_budget
+
+        fps, frames, warning = compute_frame_budget(20.0)
+        assert frames <= 30
+        assert frames >= 10
+        assert fps <= MAX_FPS
+        assert warning is False
+
+    def test_medium_30_60s(self):
+        from videos.frame_extractor import compute_frame_budget
+
+        fps, frames, warning = compute_frame_budget(45.0)
+        assert frames == 40
+        assert warning is False
+
+    def test_1_to_3_min(self):
+        from videos.frame_extractor import compute_frame_budget
+
+        fps, frames, warning = compute_frame_budget(120.0)
+        assert frames == 60
+        assert warning is False
+
+    def test_3_to_10_min(self):
+        from videos.frame_extractor import compute_frame_budget
+
+        fps, frames, warning = compute_frame_budget(420.0)  # 7 min
+        assert frames == 80
+        assert warning is False
+
+    def test_long_video_warning(self):
+        from videos.frame_extractor import MAX_FRAMES, compute_frame_budget
+
+        fps, frames, warning = compute_frame_budget(1800.0)  # 30 min
+        assert frames == MAX_FRAMES
+        assert warning is True
+
+    def test_fps_capped_at_max(self):
+        """Sur très courte vidéo, fps ne doit jamais dépasser MAX_FPS."""
+        from videos.frame_extractor import MAX_FPS, compute_frame_budget
+
+        fps, _, _ = compute_frame_budget(5.0)
+        assert fps <= MAX_FPS
+
+    def test_focused_mode_dense(self):
+        """Focused mode → densité plus élevée que full video."""
+        from videos.frame_extractor import compute_frame_budget
+
+        # 10s focus dans une vidéo de 600s
+        fps, frames, warning = compute_frame_budget(
+            600.0, focused_start=120.0, focused_end=130.0
+        )
+        # 10s à 2 fps cap = 20 frames max attendu
+        assert frames <= 30
+        assert warning is False
+
+    def test_focused_mode_full_range_implicit(self):
+        """focused_start sans focused_end → end = duration."""
+        from videos.frame_extractor import compute_frame_budget
+
+        fps, frames, _ = compute_frame_budget(60.0, focused_start=30.0)
+        # On focus sur 30→60s, soit 30s
+        assert frames > 0
+
+    def test_zero_duration_safety(self):
+        """Durée 0 ne crashe pas (max() de protection)."""
+        from videos.frame_extractor import compute_frame_budget
+
+        fps, frames, _ = compute_frame_budget(0.5)
+        assert frames >= 0
+        assert fps >= 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧹 cleanup_stale_frames
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCleanupStaleFrames:
+    def test_removes_old_workdirs(self, tmp_path, monkeypatch):
+        from videos import frame_extractor
+
+        monkeypatch.setattr(frame_extractor, "FRAMES_BASE_DIR", str(tmp_path))
+
+        old = tmp_path / "job_oldoldold"
+        recent = tmp_path / "job_recentaa"
+        unrelated = tmp_path / "not_a_job"
+        for d in (old, recent, unrelated):
+            d.mkdir()
+
+        # Vieillir le mtime de "old" à 2h dans le passé
+        past = time.time() - 7200
+        os.utime(old, (past, past))
+
+        purged = frame_extractor.cleanup_stale_frames(ttl_seconds=3600)
+
+        assert purged == 1
+        assert not old.exists()
+        assert recent.exists()
+        assert unrelated.exists()  # Ne touche pas aux dirs hors convention
+
+    def test_no_basedir_returns_zero(self, tmp_path, monkeypatch):
+        from videos import frame_extractor
+
+        ghost = tmp_path / "does-not-exist"
+        monkeypatch.setattr(frame_extractor, "FRAMES_BASE_DIR", str(ghost))
+
+        assert frame_extractor.cleanup_stale_frames() == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎞️ Intégration ffmpeg (si dispo) — extract_frames_from_local
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg/ffprobe not installed locally")
+class TestExtractFramesFromLocal:
+    """Tests intégration avec une vidéo synthétique de couleur unie."""
+
+    @pytest.fixture
+    def synthetic_video(self, tmp_path):
+        """Crée une vidéo MP4 de 4 secondes, 320x240, couleur unie."""
+        out = tmp_path / "test.mp4"
+        cmd = [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:s=320x240:d=4",
+            "-pix_fmt",
+            "yuv420p",
+            "-y",
+            str(out),
+        ]
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+        if result.returncode != 0:
+            pytest.skip(f"Failed to create synthetic video: {result.stderr[:200]}")
+        return str(out)
+
+    @pytest.mark.asyncio
+    async def test_extract_frames_short_video(self, synthetic_video, tmp_path, monkeypatch):
+        from videos import frame_extractor
+
+        monkeypatch.setattr(frame_extractor, "FRAMES_BASE_DIR", str(tmp_path / "frames"))
+
+        result = await frame_extractor.extract_frames_from_local(
+            synthetic_video, log_tag="TEST"
+        )
+        assert result is not None
+        assert result.frame_count > 0
+        assert result.duration_s == pytest.approx(4.0, abs=0.5)
+        assert all(Path(p).exists() for p in result.frame_paths)
+        assert len(result.frame_timestamps) == len(result.frame_paths)
+
+        result.cleanup()
+        assert not Path(result.workdir).exists()
+
+    @pytest.mark.asyncio
+    async def test_extract_frames_focused_mode(self, synthetic_video, tmp_path, monkeypatch):
+        from videos import frame_extractor
+
+        monkeypatch.setattr(frame_extractor, "FRAMES_BASE_DIR", str(tmp_path / "frames"))
+
+        result = await frame_extractor.extract_frames_from_local(
+            synthetic_video,
+            focused_start=1.0,
+            focused_end=3.0,
+            log_tag="TEST_FOCUSED",
+        )
+        assert result is not None
+        assert result.frame_count > 0
+        # Premier timestamp doit être >= 1.0 (start)
+        assert result.frame_timestamps[0] >= 1.0 - 0.1  # tolérance arrondi
+
+        result.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_extract_frames_with_max_override(
+        self, synthetic_video, tmp_path, monkeypatch
+    ):
+        from videos import frame_extractor
+
+        monkeypatch.setattr(frame_extractor, "FRAMES_BASE_DIR", str(tmp_path / "frames"))
+
+        result = await frame_extractor.extract_frames_from_local(
+            synthetic_video, max_frames_override=3, log_tag="TEST_OVERRIDE"
+        )
+        assert result is not None
+        assert result.frame_count <= 3
+        result.cleanup()

--- a/backend/tests/videos/test_visual_analyzer.py
+++ b/backend/tests/videos/test_visual_analyzer.py
@@ -1,0 +1,249 @@
+"""
+Tests pour videos/visual_analyzer.py — wrapper Mistral Vision.
+
+Couvre :
+- Helpers purs : _format_timestamp, _downsample, _encode_frame
+- analyze_frames avec mock mistral_vision_request (no réseau)
+- Edge cases : pas de clé, frames mismatchés, JSON malformé, brace recovery
+"""
+
+import asyncio
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ Helpers purs
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFormatTimestamp:
+    def test_seconds_only(self):
+        from videos.visual_analyzer import _format_timestamp
+
+        assert _format_timestamp(3.5) == "00:03"
+
+    def test_minutes(self):
+        from videos.visual_analyzer import _format_timestamp
+
+        assert _format_timestamp(75.2) == "01:15"
+
+    def test_hours(self):
+        from videos.visual_analyzer import _format_timestamp
+
+        assert _format_timestamp(3700) == "01:01:40"
+
+    def test_negative_clamped_to_zero(self):
+        from videos.visual_analyzer import _format_timestamp
+
+        assert _format_timestamp(-5) == "00:00"
+
+
+class TestDownsample:
+    def test_no_op_when_under_target(self):
+        from videos.visual_analyzer import _downsample
+
+        items = [1, 2, 3]
+        assert _downsample(items, 10) == [1, 2, 3]
+
+    def test_downsample_uniform(self):
+        from videos.visual_analyzer import _downsample
+
+        items = list(range(100))
+        result = _downsample(items, 10)
+        assert len(result) == 10
+        # Vérifie monotonicité (uniformité)
+        assert result == sorted(result)
+        assert result[0] == 0  # Premier élément toujours conservé
+
+    def test_downsample_target_zero(self):
+        from videos.visual_analyzer import _downsample
+
+        assert _downsample([1, 2, 3], 0) == [1, 2, 3]
+
+
+class TestEncodeFrame:
+    def test_encode_real_jpeg(self, tmp_path):
+        """Crée un faux JPEG de 1 byte et vérifie le b64."""
+        from videos.visual_analyzer import _encode_frame
+
+        path = tmp_path / "frame.jpg"
+        path.write_bytes(b"\xff\xd8\xff\xd9")  # JPEG SOI/EOI markers
+
+        b64 = _encode_frame(str(path))
+        assert b64 is not None
+        decoded = base64.b64decode(b64)
+        assert decoded == b"\xff\xd8\xff\xd9"
+
+    def test_encode_missing_file(self):
+        from videos.visual_analyzer import _encode_frame
+
+        result = _encode_frame("/path/that/does/not/exist.jpg")
+        assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 analyze_frames — avec mock mistral_vision_request
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_fake_jpeg(path: Path) -> None:
+    path.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9")
+
+
+VALID_RESPONSE = json.dumps(
+    {
+        "visual_hook": "Plan large lumineux sur un visage souriant.",
+        "visual_structure": "talking_head",
+        "key_moments": [
+            {"timestamp_s": 1.0, "description": "Entrée à l'écran", "type": "hook"}
+        ],
+        "visible_text": "DeepSight",
+        "visual_seo_indicators": {
+            "hook_brightness": "high",
+            "face_visible_in_hook": True,
+            "burned_in_subtitles": False,
+            "high_motion_intro": False,
+            "thumbnail_quality_proxy": "high",
+        },
+        "summary_visual": "Vidéo posée, plan unique sur un présentateur.",
+    }
+)
+
+
+class TestAnalyzeFrames:
+    @pytest.mark.asyncio
+    async def test_empty_frames_returns_none(self):
+        from videos.visual_analyzer import analyze_frames
+
+        result = await analyze_frames([], [])
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_length_mismatch_returns_none(self, tmp_path):
+        from videos.visual_analyzer import analyze_frames
+
+        f = tmp_path / "f.jpg"
+        _make_fake_jpeg(f)
+        result = await analyze_frames([str(f)], [1.0, 2.0])  # mismatch
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_mistral_key_returns_none(self, tmp_path, monkeypatch):
+        from videos.visual_analyzer import analyze_frames
+
+        f = tmp_path / "f.jpg"
+        _make_fake_jpeg(f)
+
+        monkeypatch.setattr("videos.visual_analyzer.get_mistral_key", lambda: "")
+
+        result = await analyze_frames([str(f)], [1.0])
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_happy_path(self, tmp_path, monkeypatch):
+        from videos.visual_analyzer import analyze_frames
+
+        f = tmp_path / "f.jpg"
+        _make_fake_jpeg(f)
+
+        monkeypatch.setattr("videos.visual_analyzer.get_mistral_key", lambda: "fake-key")
+
+        async def fake_vision(**kwargs):
+            return VALID_RESPONSE
+
+        monkeypatch.setattr("videos.visual_analyzer.mistral_vision_request", fake_vision)
+
+        result = await analyze_frames([str(f)], [1.0], transcript_excerpt="Bonjour")
+        assert result is not None
+        assert result.visual_structure == "talking_head"
+        assert result.frames_analyzed == 1
+        assert result.frames_downsampled is False
+        assert "DeepSight" in result.visible_text
+        assert len(result.key_moments) == 1
+
+    @pytest.mark.asyncio
+    async def test_json_brace_recovery(self, tmp_path, monkeypatch):
+        """Si Mistral wrappe le JSON dans du markdown, on récupère via braces."""
+        from videos.visual_analyzer import analyze_frames
+
+        f = tmp_path / "f.jpg"
+        _make_fake_jpeg(f)
+
+        monkeypatch.setattr("videos.visual_analyzer.get_mistral_key", lambda: "fake-key")
+
+        async def fake_vision_wrapped(**kwargs):
+            return f"```json\n{VALID_RESPONSE}\n```"
+
+        monkeypatch.setattr("videos.visual_analyzer.mistral_vision_request", fake_vision_wrapped)
+
+        result = await analyze_frames([str(f)], [0.0])
+        assert result is not None
+        assert result.visual_structure == "talking_head"
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_none(self, tmp_path, monkeypatch):
+        from videos.visual_analyzer import analyze_frames
+
+        f = tmp_path / "f.jpg"
+        _make_fake_jpeg(f)
+
+        monkeypatch.setattr("videos.visual_analyzer.get_mistral_key", lambda: "fake-key")
+
+        async def fake_vision_garbage(**kwargs):
+            return "not json at all just text"
+
+        monkeypatch.setattr(
+            "videos.visual_analyzer.mistral_vision_request", fake_vision_garbage
+        )
+
+        result = await analyze_frames([str(f)], [0.0])
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_downsample_above_threshold(self, tmp_path, monkeypatch):
+        """>MAX_FRAMES_PER_CALL → frames_downsampled True."""
+        from videos import visual_analyzer
+
+        # Crée 80 fake frames
+        paths = []
+        timestamps = []
+        for i in range(80):
+            p = tmp_path / f"f{i:03d}.jpg"
+            _make_fake_jpeg(p)
+            paths.append(str(p))
+            timestamps.append(float(i))
+
+        monkeypatch.setattr(visual_analyzer, "get_mistral_key", lambda: "fake-key")
+        monkeypatch.setattr(visual_analyzer, "MAX_FRAMES_PER_CALL", 30)
+
+        captured: dict = {}
+
+        async def fake_vision(**kwargs):
+            captured["messages"] = kwargs.get("messages")
+            return VALID_RESPONSE
+
+        monkeypatch.setattr(visual_analyzer, "mistral_vision_request", fake_vision)
+
+        result = await visual_analyzer.analyze_frames(paths, timestamps)
+
+        assert result is not None
+        assert result.frames_downsampled is True
+        assert result.frames_analyzed == 30
+        # Vérifie que le payload contient au plus 30 image_url
+        image_blocks = [
+            p
+            for p in captured["messages"][1]["content"]
+            if p.get("type") == "image_url"
+        ]
+        assert len(image_blocks) == 30

--- a/backend/tests/videos/test_youtube_storyboard.py
+++ b/backend/tests/videos/test_youtube_storyboard.py
@@ -1,0 +1,306 @@
+"""
+Tests pour videos/youtube_storyboard.py — Pivot 5 (storyboards YouTube).
+
+Couvre :
+- normalize_video_id (URL → 11-char id, edge cases)
+- select_storyboard_format (sélection meilleure résolution)
+- _slice_sheet (Pillow grid math sur fake JPEG)
+- extract_storyboard_frames happy path (mock yt-dlp + httpx)
+- extract_storyboard_frames failure paths
+"""
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image
+
+_src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ normalize_video_id
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestNormalizeVideoId:
+    def test_raw_id(self):
+        from videos.youtube_storyboard import normalize_video_id
+
+        assert normalize_video_id("dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_watch_url(self):
+        from videos.youtube_storyboard import normalize_video_id
+
+        assert (
+            normalize_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_short_url(self):
+        from videos.youtube_storyboard import normalize_video_id
+
+        assert normalize_video_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_embed_url(self):
+        from videos.youtube_storyboard import normalize_video_id
+
+        assert (
+            normalize_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_shorts_url(self):
+        from videos.youtube_storyboard import normalize_video_id
+
+        assert (
+            normalize_video_id("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_invalid(self):
+        from videos.youtube_storyboard import normalize_video_id
+
+        assert normalize_video_id("") is None
+        assert normalize_video_id("not-an-id") is None
+        assert normalize_video_id("https://example.com/foo") is None
+
+    def test_strips_whitespace(self):
+        from videos.youtube_storyboard import normalize_video_id
+
+        assert normalize_video_id("  dQw4w9WgXcQ  ") == "dQw4w9WgXcQ"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎯 select_storyboard_format
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSelectStoryboardFormat:
+    def test_picks_highest_resolution(self):
+        from videos.youtube_storyboard import select_storyboard_format
+
+        info = {
+            "formats": [
+                {"format_id": "sb0", "width": 80, "height": 45, "columns": 5, "rows": 5},
+                {"format_id": "sb1", "width": 160, "height": 90, "columns": 5, "rows": 5},
+                {"format_id": "sb2", "width": 320, "height": 180, "columns": 5, "rows": 5},
+                {"format_id": "mp4-720p", "width": 1280, "height": 720},
+            ]
+        }
+        sb = select_storyboard_format(info)
+        assert sb is not None
+        assert sb["format_id"] == "sb2"
+
+    def test_no_storyboards_returns_none(self):
+        from videos.youtube_storyboard import select_storyboard_format
+
+        info = {"formats": [{"format_id": "mp4-720p", "width": 1280, "height": 720}]}
+        assert select_storyboard_format(info) is None
+
+    def test_empty_formats(self):
+        from videos.youtube_storyboard import select_storyboard_format
+
+        assert select_storyboard_format({}) is None
+        assert select_storyboard_format({"formats": []}) is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🖼️ _slice_sheet
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_test_sheet(width: int, height: int, color=(100, 150, 200)) -> bytes:
+    """Crée un JPEG d'une couleur unie de la taille demandée."""
+    img = Image.new("RGB", (width, height), color)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+class TestSliceSheet:
+    def test_5x5_grid(self):
+        from videos.youtube_storyboard import _slice_sheet
+
+        sheet = _make_test_sheet(800, 450)  # 5×5 de 160×90
+        frames = _slice_sheet(sheet, cols=5, rows=5, log_tag="TEST")
+        assert len(frames) == 25
+        # Vérifie que chaque frame est un JPEG valide
+        for fb in frames:
+            assert fb[:3] == b"\xff\xd8\xff"
+            img = Image.open(io.BytesIO(fb))
+            assert img.size == (160, 90)
+
+    def test_3x3_grid(self):
+        from videos.youtube_storyboard import _slice_sheet
+
+        sheet = _make_test_sheet(960, 540)
+        frames = _slice_sheet(sheet, cols=3, rows=3, log_tag="TEST")
+        assert len(frames) == 9
+
+    def test_invalid_grid_returns_empty(self):
+        from videos.youtube_storyboard import _slice_sheet
+
+        sheet = _make_test_sheet(100, 100)
+        assert _slice_sheet(sheet, cols=0, rows=5, log_tag="TEST") == []
+        assert _slice_sheet(sheet, cols=5, rows=0, log_tag="TEST") == []
+
+    def test_corrupt_bytes_returns_empty(self):
+        from videos.youtube_storyboard import _slice_sheet
+
+        assert _slice_sheet(b"not a jpeg", cols=3, rows=3, log_tag="TEST") == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 extract_storyboard_frames — happy path & failures
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+FAKE_INFO_JSON = {
+    "duration": 30.0,
+    "title": "Fake Video",
+    "formats": [
+        {
+            "format_id": "sb1",
+            "width": 320,
+            "height": 180,
+            "columns": 2,
+            "rows": 2,
+            "fragments": [
+                {"url": "https://i.ytimg.com/sb/test/storyboard3_L1/M0.jpg", "duration": 15.0},
+                {"url": "https://i.ytimg.com/sb/test/storyboard3_L1/M1.jpg", "duration": 15.0},
+            ],
+        },
+    ],
+}
+
+
+@pytest.fixture
+def fake_sheet_bytes():
+    """4 sub-frames de 160×90 dans un sheet 320×180."""
+    return _make_test_sheet(320, 180)
+
+
+class TestExtractStoryboardFrames:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, tmp_path, monkeypatch, fake_sheet_bytes):
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+
+        # Mock yt-dlp
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: FAKE_INFO_JSON,
+        )
+
+        # Mock httpx
+        async def fake_download(client, url, log_tag):
+            return fake_sheet_bytes
+
+        monkeypatch.setattr(youtube_storyboard, "_download_sheet", fake_download)
+
+        result = await youtube_storyboard.extract_storyboard_frames("dQw4w9WgXcQ")
+        assert result is not None
+        # 2 sheets × 2×2 = 8 frames attendues, MAX 100
+        assert result.frame_count == 8
+        assert result.duration_s == 30.0
+        assert len(result.frame_paths) == 8
+        assert len(result.frame_timestamps) == 8
+        # Timestamps croissants
+        assert result.frame_timestamps == sorted(result.frame_timestamps)
+        # Tous les paths existent
+        assert all(Path(p).exists() for p in result.frame_paths)
+
+        result.cleanup()
+        assert not Path(result.workdir).exists()
+
+    @pytest.mark.asyncio
+    async def test_invalid_video_id(self, tmp_path, monkeypatch):
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+
+        result = await youtube_storyboard.extract_storyboard_frames("not-a-video-id")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ytdlp_returns_none(self, tmp_path, monkeypatch):
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: None,
+        )
+
+        result = await youtube_storyboard.extract_storyboard_frames("dQw4w9WgXcQ")
+        assert result is None
+        # Workdir doit être nettoyé
+        assert not list(Path(tmp_path).glob("job_sb_*"))
+
+    @pytest.mark.asyncio
+    async def test_no_storyboard_format(self, tmp_path, monkeypatch):
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+
+        info = {"duration": 30.0, "formats": [{"format_id": "mp4-720p", "width": 1280, "height": 720}]}
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: info,
+        )
+
+        result = await youtube_storyboard.extract_storyboard_frames("dQw4w9WgXcQ")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_max_frames_override(self, tmp_path, monkeypatch, fake_sheet_bytes):
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: FAKE_INFO_JSON,
+        )
+
+        async def fake_download(client, url, log_tag):
+            return fake_sheet_bytes
+
+        monkeypatch.setattr(youtube_storyboard, "_download_sheet", fake_download)
+
+        result = await youtube_storyboard.extract_storyboard_frames(
+            "dQw4w9WgXcQ", max_frames_override=4
+        )
+        assert result is not None
+        assert result.frame_count <= 4
+        result.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_all_sheets_fail_returns_none(self, tmp_path, monkeypatch):
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: FAKE_INFO_JSON,
+        )
+
+        async def fake_download_fail(client, url, log_tag):
+            return None  # Simule 403/network error sur tous les sheets
+
+        monkeypatch.setattr(youtube_storyboard, "_download_sheet", fake_download_fail)
+
+        result = await youtube_storyboard.extract_storyboard_frames("dQw4w9WgXcQ")
+        assert result is None


### PR DESCRIPTION
## Summary

- **Phase 1 POC** : pipeline d'analyse visuelle multimodale (frames + Mistral Vision) inspiré de [bradautomates/claude-video](https://github.com/bradautomates/claude-video), intégré au backend DeepSight (réutilise `mistral_vision_request`, `_yt_dlp_extra_args`, ffmpeg du Dockerfile).
- **Pivot 5 — Storyboards YouTube** : contournement de l'IP ban Hetzner sur le stream YouTube via les storyboards officiels servis par i.ytimg.com (pas de download du stream, pas de proxy résidentiel nécessaire).
- **Aucune modification du flow `/api/videos/analyze`** — tout est isolé en debug-only derrière `get_current_admin` + `VISUAL_ANALYSIS_ENABLED` flag.

## Tests

**50/50 verts en 9s** (`backend/tests/videos/`) :
- 14 sur `frame_extractor` (compute_frame_budget, cleanup TTL, intégration ffmpeg avec vidéo synthétique lavfi)
- 16 sur `visual_analyzer` (helpers purs, mocks Mistral happy path + 5 failure paths + JSON brace recovery)
- 20 sur `youtube_storyboard` (normalize_video_id, select_storyboard_format, _slice_sheet Pillow, mocks subprocess+httpx)

## Tests go/no-go effectués sur prod (2026-05-05)

| Test | Résultat |
|---|---|
| `yt-dlp` download YouTube depuis container backend Hetzner | ❌ Bot challenge `Sign in to confirm you're not a bot` |
| `yt-dlp --proxy "$YOUTUBE_PROXY"` (Webshare datacenter) | ❌ Idem (proxy datacenter détecté par YouTube) |
| `curl https://i.ytimg.com/vi/.../sddefault.jpg` (CDN sffe) | ✅ HTTP/2, server: sffe, pas de bot challenge |
| `yt-dlp -j --skip-download` (info JSON) | ✅ JSON complet (duration, formats, channel, etc.) |

**Conclusion** : le download stream YouTube est bloqué depuis Hetzner ; les API endpoints info + le CDN storyboards i.ytimg.com restent accessibles. Pivot 5 est la voie viable sans toucher à l'infra (proxy résidentiel = ~\$10-15/GB).

Memory note ajoutée : `reference_youtube-download-hetzner-blocked.md`.

## Architecture

\`\`\`
videos/
├── frame_extractor.py         # yt-dlp + ffmpeg, auto-scale claude-video-style
├── visual_analyzer.py         # wrapper Mistral pixtral-large-2411 + JSON strict
├── youtube_storyboard.py      # Pivot 5 — storyboards i.ytimg.com via Pillow
└── visual_router.py           # endpoints admin debug-only

main.py: import optionnel (try/except) + include_router conditionnel
\`\`\`

## Endpoints (après deploy + flag activé)

- \`GET /api/admin/visual/debug-from-url?url=...\` — pipeline yt-dlp+ffmpeg classique (sources non-YouTube)
- \`GET /api/admin/visual/debug-from-youtube?video_id_or_url=...\` — Pivot 5 storyboards (contourne IP ban)
- \`GET /api/admin/visual/health\` — sanity (ffmpeg/ffprobe/yt-dlp + flag state)

Tous gated par \`get_current_admin\` + \`VISUAL_ANALYSIS_ENABLED\` env flag (par défaut OFF).

## Plan de déploiement après merge

1. Auto-deploy backend Hetzner (push to main → SSH webhook → docker rebuild)
2. SSH VPS, ajouter \`VISUAL_ANALYSIS_ENABLED=true\` à \`/opt/deepsight/repo/.env.production\`
3. \`docker restart repo-backend-1\` (pour reload .env)
4. Test E2E :
   \`\`\`
   curl -H "Authorization: Bearer ADMIN_TOKEN" \
     "https://api.deepsightsynthesis.com/api/admin/visual/debug-from-youtube?video_id_or_url=dQw4w9WgXcQ"
   \`\`\`
5. Mesurer : \`elapsed_total_s\`, \`frame_count\`, qualité du JSON Mistral retourné
6. Si OK → décider Phase 2 (intégration au flow \`/analyze\` + communication tri-plateforme)
7. Si KO → fallback HTML parsing (ytInitialPlayerResponse)

## Phase 2 — non incluse dans cette PR

- Intégration au flow \`/api/videos/analyze\` (flag \`include_visual_analysis\` par requête, gating Pro+, coût crédits)
- Communication tri-plateforme : landing page section "Vision IA", pricing feature Pro+, in-app banner web/mobile/extension, blog post, changelog
- Decision Pivot 3 (extension Chrome client-side capture) en complément pour qualité premium

## Limitations connues à valider en prod

- Qualité storyboards : 320×180 max → suffisant pour visual_hook/structure/key_moments, limité pour OCR fin
- Token cost : ~50-80k tokens vision par vidéo selon le nombre de frames
- yt-dlp 2026.03.17 émet \`No supported JavaScript runtime\` (deno absent du Dockerfile) → certains formats peuvent être manquants. À ajouter au Dockerfile si nécessaire.

## Test plan

- [ ] Auto-deploy backend Hetzner OK après merge (logs container)
- [ ] \`VISUAL_ANALYSIS_ENABLED=true\` ajouté à \`.env.production\`, container restart sans erreur
- [ ] \`/api/admin/visual/health\` renvoie \`{flag_enabled: true, ffmpeg_available: true, ...}\`
- [ ] \`/api/admin/visual/debug-from-youtube?video_id_or_url=dQw4w9WgXcQ\` renvoie \`status: "ok"\` avec un \`analysis\` JSON cohérent (visual_hook, visual_structure, key_moments)
- [ ] Mesurer latence end-to-end pour vidéos 30s / 3min / 10min
- [ ] Vérifier que \`/api/videos/analyze\` (flow principal) n'est PAS impacté (régression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)