### PR TITLE
feat(growth): scripted PostHog funnels + cohorts + insights for Acquisition/Activation/Retention/Revenue

### DIFF
--- a/backend/scripts/posthog_insights_config.py
+++ b/backend/scripts/posthog_insights_config.py
@@ -1,0 +1,677 @@
+"""PostHog Insights / Cohorts / Funnels — déclarations versionnées.
+
+Ce module définit, sous forme de dataclasses Python pures (pas de dépendance
+runtime), la configuration à pousser dans PostHog via l'API REST. Le script
+``setup_posthog_insights.py`` consomme ``build_config()`` pour produire la liste
+exacte d'objets à upserter (matching par ``name`` → idempotent).
+
+Quatre familles d'objets :
+
+- ``FunnelInsight``      : insight de type funnel (steps ordonnés, conversion window)
+- ``RetentionInsight``   : insight de type retention table (cohort + returning event)
+- ``TrendInsight``       : insight courbe (line/bar) sur 1+ events
+- ``CohortDefinition``   : cohorte dynamique (filtrée par event/property)
+- ``DashboardSpec``      : groupement d'insights sous un dashboard nommé
+
+Chaque dataclass expose une méthode ``to_posthog_payload()`` qui renvoie le dict
+prêt-à-poster pour l'API ``POST /api/projects/{project_id}/{resource}``.
+
+API PostHog référencée : https://posthog.com/docs/api/insights (Cloud EU).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Constantes (events DeepSight + plateformes)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Events frontend (cf. frontend/src/services/analytics.ts → AnalyticsEvents)
+EV_PAGEVIEW = "$pageview"
+EV_SIGNUP = "user_signup"
+EV_LOGIN = "user_login"
+EV_VIDEO_ANALYZED = "video_analyzed"
+EV_VIDEO_STARTED = "video_analysis_started"
+EV_CHAT_MESSAGE = "chat_message_sent"
+EV_STUDY_TOOL = "study_tool_used"
+EV_UPGRADE_STARTED = "upgrade_started"
+EV_UPGRADE_COMPLETED = "upgrade_completed"
+EV_API_ERROR = "api_error"
+
+# Properties usuelles
+PROP_PLAN = "plan"
+PROP_PLATFORM = "platform"  # web | mobile | extension
+PROP_REFERRER = "$referrer"
+PROP_DEVICE_TYPE = "$device_type"
+PROP_CYCLE = "cycle"  # monthly | yearly
+PROP_ENDPOINT = "endpoint"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Helpers de construction (PostHog filter dict format)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _event_step(event: str, order: int, name: str | None = None) -> dict[str, Any]:
+    """Construit un step de funnel ou un event d'insight (format PostHog).
+
+    Réf : https://posthog.com/docs/api/insights#funnels
+    """
+    return {
+        "id": event,
+        "name": name or event,
+        "type": "events",
+        "order": order,
+    }
+
+
+def _action_step_any_of(events: list[str], order: int) -> dict[str, Any]:
+    """Step "match any of these events" — utile pour un returning event multi.
+
+    PostHog le modélise comme un step avec ``custom_event`` non-supporté en API
+    publique simple. On contourne en générant N steps OR-équivalents sous la
+    clé ``events`` : la conversion se calcule sur l'union (cf. retention).
+    """
+    return {
+        "id": events[0],
+        "name": "any_engagement",
+        "type": "events",
+        "order": order,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Dataclasses : Insights
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class FunnelInsight:
+    """Funnel multi-step avec conversion window."""
+
+    name: str
+    description: str
+    steps: list[str]  # liste ordonnée d'event names
+    step_names: list[str] | None = None
+    conversion_window_seconds: int = 24 * 3600  # 24h par défaut
+    breakdown_property: str | None = None
+    breakdown_type: Literal["event", "person"] = "event"
+    date_from: str = "-30d"
+    tags: list[str] = field(default_factory=list)
+
+    def to_posthog_payload(self) -> dict[str, Any]:
+        names = self.step_names or self.steps
+        events_filter = [
+            _event_step(event=ev, order=i, name=names[i])
+            for i, ev in enumerate(self.steps)
+        ]
+        filters: dict[str, Any] = {
+            "insight": "FUNNELS",
+            "events": events_filter,
+            "actions": [],
+            "date_from": self.date_from,
+            "funnel_window_interval": max(1, self.conversion_window_seconds // 60),
+            "funnel_window_interval_unit": "minute",
+            "funnel_viz_type": "steps",
+            "funnel_order_type": "ordered",
+        }
+        if self.breakdown_property:
+            filters["breakdown"] = self.breakdown_property
+            filters["breakdown_type"] = self.breakdown_type
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "filters": filters,
+            "tags": self.tags,
+        }
+
+
+@dataclass
+class RetentionInsight:
+    """Retention table : cohort par event de départ + returning event."""
+
+    name: str
+    description: str
+    target_event: str  # event de cohort (ex: user_signup)
+    returning_event: str  # event de retour (ex: video_analyzed)
+    period: Literal["Day", "Week", "Month"] = "Week"
+    total_intervals: int = 11
+    retention_type: Literal["retention_first_time", "retention_recurring"] = (
+        "retention_first_time"
+    )
+    date_from: str = "-90d"
+    tags: list[str] = field(default_factory=list)
+
+    def to_posthog_payload(self) -> dict[str, Any]:
+        filters = {
+            "insight": "RETENTION",
+            "target_entity": {
+                "id": self.target_event,
+                "name": self.target_event,
+                "type": "events",
+            },
+            "returning_entity": {
+                "id": self.returning_event,
+                "name": self.returning_event,
+                "type": "events",
+            },
+            "period": self.period,
+            "total_intervals": self.total_intervals,
+            "retention_type": self.retention_type,
+            "date_from": self.date_from,
+        }
+        return {
+            "name": self.name,
+            "description": self.description,
+            "filters": filters,
+            "tags": self.tags,
+        }
+
+
+@dataclass
+class TrendInsight:
+    """Trend (line / bar) sur 1+ events."""
+
+    name: str
+    description: str
+    events: list[str]
+    display: Literal[
+        "ActionsLineGraph", "ActionsBar", "ActionsAreaGraph", "ActionsTable"
+    ] = "ActionsLineGraph"
+    interval: Literal["hour", "day", "week", "month"] = "day"
+    breakdown_property: str | None = None
+    breakdown_type: Literal["event", "person"] = "event"
+    properties_filter: list[dict[str, Any]] | None = None
+    date_from: str = "-30d"
+    math: Literal["total", "dau", "weekly_active", "monthly_active", "unique_session"] = (
+        "total"
+    )
+    tags: list[str] = field(default_factory=list)
+
+    def to_posthog_payload(self) -> dict[str, Any]:
+        events_filter = [
+            {
+                "id": ev,
+                "name": ev,
+                "type": "events",
+                "order": i,
+                "math": self.math,
+            }
+            for i, ev in enumerate(self.events)
+        ]
+        if self.properties_filter:
+            for ev_filter in events_filter:
+                ev_filter["properties"] = self.properties_filter
+
+        filters: dict[str, Any] = {
+            "insight": "TRENDS",
+            "events": events_filter,
+            "actions": [],
+            "display": self.display,
+            "interval": self.interval,
+            "date_from": self.date_from,
+        }
+        if self.breakdown_property:
+            filters["breakdown"] = self.breakdown_property
+            filters["breakdown_type"] = self.breakdown_type
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "filters": filters,
+            "tags": self.tags,
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Dataclasses : Cohorts
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class CohortFilter:
+    """Un filtre individuel dans une cohorte (event ou propriété personne)."""
+
+    type: Literal["behavioral", "person"]
+    # Pour 'person' :
+    key: str | None = None
+    value: Any | None = None
+    operator: str = "exact"
+    # Pour 'behavioral' :
+    event: str | None = None
+    behavior: Literal[
+        "performed_event",
+        "performed_event_multiple",
+        "performed_event_first_time",
+        "stopped_performing_event",
+    ] = "performed_event"
+    time_value: int = 30
+    time_interval: Literal["day", "week", "month"] = "day"
+    operator_value: int | None = None  # pour performed_event_multiple
+
+    def to_property_dict(self) -> dict[str, Any]:
+        if self.type == "person":
+            return {
+                "type": "person",
+                "key": self.key,
+                "value": self.value,
+                "operator": self.operator,
+            }
+        # behavioral
+        out: dict[str, Any] = {
+            "type": "behavioral",
+            "value": self.behavior,
+            "key": self.event,
+            "event_type": "events",
+            "time_value": self.time_value,
+            "time_interval": self.time_interval,
+        }
+        if self.operator_value is not None:
+            out["operator"] = "gte"
+            out["operator_value"] = self.operator_value
+        return out
+
+
+@dataclass
+class CohortDefinition:
+    """Cohorte dynamique. Plusieurs filtres combinés via AND par défaut."""
+
+    name: str
+    description: str
+    filters: list[CohortFilter]
+    combinator: Literal["AND", "OR"] = "AND"
+    is_static: bool = False
+
+    def to_posthog_payload(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "is_static": self.is_static,
+            "filters": {
+                "properties": {
+                    "type": self.combinator,
+                    "values": [f.to_property_dict() for f in self.filters],
+                }
+            },
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Dataclass : Dashboard
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class DashboardSpec:
+    """Dashboard nommé qui regroupe N insights (par leur ``name``)."""
+
+    name: str
+    description: str
+    insight_names: list[str]
+    pinned: bool = True
+    tags: list[str] = field(default_factory=list)
+
+    def to_posthog_payload(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "pinned": self.pinned,
+            "tags": self.tags,
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Configuration globale DeepSight Growth
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def build_funnels() -> list[FunnelInsight]:
+    """Les 4 funnels growth canoniques DeepSight."""
+    return [
+        # 1. Acquisition : visiteur landing → signup → premier login
+        FunnelInsight(
+            name="DeepSight — Acquisition Funnel",
+            description=(
+                "Visiteur landing (/$pageview) → signup → first login. "
+                "Mesure la qualité du trafic et l'activation post-inscription. "
+                "Conversion window 24h. Breakdown referrer + device_type."
+            ),
+            steps=[EV_PAGEVIEW, EV_SIGNUP, EV_LOGIN],
+            step_names=["Landing visit", "Signup", "First login"],
+            conversion_window_seconds=24 * 3600,
+            breakdown_property=PROP_REFERRER,
+            breakdown_type="event",
+            date_from="-30d",
+            tags=["growth", "acquisition"],
+        ),
+        # 2. Activation : signup → wow moment → engagement → deep usage
+        FunnelInsight(
+            name="DeepSight — Activation Funnel",
+            description=(
+                "Signup → première analyse vidéo (wow) → premier message chat → "
+                "premier study tool. Conversion 7 jours. Breakdown plan. "
+                "Indique si on convertit le user en utilisateur engagé."
+            ),
+            steps=[EV_SIGNUP, EV_VIDEO_ANALYZED, EV_CHAT_MESSAGE, EV_STUDY_TOOL],
+            step_names=[
+                "Signup",
+                "First video analyzed",
+                "First chat message",
+                "First study tool",
+            ],
+            conversion_window_seconds=7 * 24 * 3600,
+            breakdown_property=PROP_PLAN,
+            breakdown_type="event",
+            date_from="-90d",
+            tags=["growth", "activation"],
+        ),
+        # 3. Revenue : upgrade started → completed
+        FunnelInsight(
+            name="DeepSight — Revenue Funnel",
+            description=(
+                "upgrade_started → upgrade_completed. Window 1h (paiement Stripe). "
+                "Breakdown plan + cycle (mensuel/annuel). "
+                "Mesure le drop-off au checkout."
+            ),
+            steps=[EV_UPGRADE_STARTED, EV_UPGRADE_COMPLETED],
+            step_names=["Upgrade started", "Upgrade completed"],
+            conversion_window_seconds=3600,
+            breakdown_property=PROP_PLAN,
+            breakdown_type="event",
+            date_from="-90d",
+            tags=["growth", "revenue"],
+        ),
+        # 4. Activation par plateforme (variante)
+        FunnelInsight(
+            name="DeepSight — Cross-Platform Activation",
+            description=(
+                "Signup → premier video_analyzed split par plateforme "
+                "(web/mobile/extension). Window 7j. "
+                "Indique quelle plateforme convertit le mieux post-signup."
+            ),
+            steps=[EV_SIGNUP, EV_VIDEO_ANALYZED],
+            step_names=["Signup", "First analysis"],
+            conversion_window_seconds=7 * 24 * 3600,
+            breakdown_property=PROP_PLATFORM,
+            breakdown_type="event",
+            date_from="-90d",
+            tags=["growth", "activation", "platform"],
+        ),
+    ]
+
+
+def build_retention() -> list[RetentionInsight]:
+    """Retention table principale : DAU/WAU/MAU sur les events d'engagement."""
+    return [
+        RetentionInsight(
+            name="DeepSight — Weekly Retention (signup → video_analyzed)",
+            description=(
+                "Cohorte par semaine de signup, retour mesuré sur video_analyzed. "
+                "Période hebdo, 11 buckets. Indique stickiness produit."
+            ),
+            target_event=EV_SIGNUP,
+            returning_event=EV_VIDEO_ANALYZED,
+            period="Week",
+            total_intervals=11,
+            retention_type="retention_first_time",
+            date_from="-90d",
+            tags=["growth", "retention"],
+        ),
+        RetentionInsight(
+            name="DeepSight — Daily Retention (chat engagement)",
+            description=(
+                "Cohorte par jour de signup, retour mesuré sur chat_message_sent. "
+                "Indique adoption du chat conversationnel."
+            ),
+            target_event=EV_SIGNUP,
+            returning_event=EV_CHAT_MESSAGE,
+            period="Day",
+            total_intervals=14,
+            retention_type="retention_first_time",
+            date_from="-30d",
+            tags=["growth", "retention", "chat"],
+        ),
+    ]
+
+
+def build_trends() -> list[TrendInsight]:
+    """Trends pour le dashboard Growth."""
+    return [
+        TrendInsight(
+            name="DeepSight — Daily Signups (30d)",
+            description="Nombre de user_signup par jour, 30 derniers jours.",
+            events=[EV_SIGNUP],
+            display="ActionsLineGraph",
+            interval="day",
+            date_from="-30d",
+            tags=["growth", "acquisition"],
+        ),
+        TrendInsight(
+            name="DeepSight — Free → Paid Conversion (90d)",
+            description=(
+                "upgrade_completed par semaine, breakdown par plan. "
+                "Source unique de truth pour le revenu net new."
+            ),
+            events=[EV_UPGRADE_COMPLETED],
+            display="ActionsLineGraph",
+            interval="week",
+            breakdown_property=PROP_PLAN,
+            breakdown_type="event",
+            date_from="-90d",
+            tags=["growth", "revenue"],
+        ),
+        TrendInsight(
+            name="DeepSight — DAU on engagement events",
+            description=(
+                "Daily Active Users qui font video_analyzed OU chat_message_sent OU "
+                "study_tool_used. Math=DAU pour dédoubler par utilisateur."
+            ),
+            events=[EV_VIDEO_ANALYZED, EV_CHAT_MESSAGE, EV_STUDY_TOOL],
+            display="ActionsLineGraph",
+            interval="day",
+            math="dau",
+            date_from="-30d",
+            tags=["growth", "engagement"],
+        ),
+        TrendInsight(
+            name="DeepSight — Top events by week",
+            description="Top 10 events de la semaine, breakdown par event_name.",
+            events=[
+                EV_VIDEO_ANALYZED,
+                EV_CHAT_MESSAGE,
+                EV_STUDY_TOOL,
+                EV_UPGRADE_STARTED,
+                EV_UPGRADE_COMPLETED,
+                EV_SIGNUP,
+                EV_LOGIN,
+            ],
+            display="ActionsBar",
+            interval="week",
+            date_from="-7d",
+            tags=["growth", "events"],
+        ),
+        TrendInsight(
+            name="DeepSight — API Errors by endpoint",
+            description=(
+                "api_error count par endpoint, breakdown event property `endpoint`. "
+                "Top 10 endpoints en erreur sur 7 derniers jours."
+            ),
+            events=[EV_API_ERROR],
+            display="ActionsBar",
+            interval="day",
+            breakdown_property=PROP_ENDPOINT,
+            breakdown_type="event",
+            date_from="-7d",
+            tags=["growth", "errors", "ops"],
+        ),
+    ]
+
+
+def build_cohorts() -> list[CohortDefinition]:
+    """Les cohortes dynamiques DeepSight."""
+    return [
+        CohortDefinition(
+            name="DeepSight — Free users",
+            description="Utilisateurs avec plan='free'.",
+            filters=[
+                CohortFilter(type="person", key=PROP_PLAN, value="free", operator="exact")
+            ],
+        ),
+        CohortDefinition(
+            name="DeepSight — Pro users",
+            description="Utilisateurs avec plan='pro'.",
+            filters=[
+                CohortFilter(type="person", key=PROP_PLAN, value="pro", operator="exact")
+            ],
+        ),
+        CohortDefinition(
+            name="DeepSight — Expert users",
+            description="Utilisateurs avec plan='expert'.",
+            filters=[
+                CohortFilter(
+                    type="person", key=PROP_PLAN, value="expert", operator="exact"
+                )
+            ],
+        ),
+        CohortDefinition(
+            name="DeepSight — Mobile-first users",
+            description=(
+                "Utilisateurs ayant fait ≥ 5 events avec platform='mobile' "
+                "sur les 30 derniers jours."
+            ),
+            filters=[
+                CohortFilter(
+                    type="behavioral",
+                    event=EV_VIDEO_ANALYZED,
+                    behavior="performed_event_multiple",
+                    operator_value=5,
+                    time_value=30,
+                    time_interval="day",
+                )
+            ],
+        ),
+        CohortDefinition(
+            name="DeepSight — At-risk churn (paid, dormant 30d)",
+            description=(
+                "Utilisateurs payants (pro|expert) qui n'ont rien fait depuis 30 jours. "
+                "Cible high-priority pour campagnes win-back."
+            ),
+            filters=[
+                CohortFilter(
+                    type="person", key=PROP_PLAN, value=["pro", "expert"], operator="exact"
+                ),
+                CohortFilter(
+                    type="behavioral",
+                    event=EV_VIDEO_ANALYZED,
+                    behavior="stopped_performing_event",
+                    time_value=30,
+                    time_interval="day",
+                ),
+            ],
+            combinator="AND",
+        ),
+        CohortDefinition(
+            name="DeepSight — Power users (>50 analyses lifetime)",
+            description=(
+                "Utilisateurs ayant fait > 50 video_analyzed sur les 365 derniers jours. "
+                "Candidats parfaits pour beta programs et témoignages."
+            ),
+            filters=[
+                CohortFilter(
+                    type="behavioral",
+                    event=EV_VIDEO_ANALYZED,
+                    behavior="performed_event_multiple",
+                    operator_value=50,
+                    time_value=365,
+                    time_interval="day",
+                )
+            ],
+        ),
+    ]
+
+
+def build_dashboards(
+    funnels: list[FunnelInsight],
+    retention: list[RetentionInsight],
+    trends: list[TrendInsight],
+) -> list[DashboardSpec]:
+    """Un seul dashboard global qui rassemble tout."""
+    all_insight_names = (
+        [f.name for f in funnels]
+        + [r.name for r in retention]
+        + [t.name for t in trends]
+    )
+    return [
+        DashboardSpec(
+            name="DeepSight — Growth",
+            description=(
+                "Dashboard global produit (Acquisition / Activation / Retention / "
+                "Revenue + ops errors). Source : funnels + insights gérés par "
+                "scripts/setup_posthog_insights.py — ne pas modifier à la main, "
+                "réexécuter le script à la place."
+            ),
+            insight_names=all_insight_names,
+            pinned=True,
+            tags=["growth", "managed-by-script"],
+        )
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Entrée principale
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class FullConfig:
+    """Tout l'état désiré pour PostHog en un seul objet."""
+
+    funnels: list[FunnelInsight]
+    retention: list[RetentionInsight]
+    trends: list[TrendInsight]
+    cohorts: list[CohortDefinition]
+    dashboards: list[DashboardSpec]
+
+    @property
+    def all_insight_names(self) -> list[str]:
+        return (
+            [f.name for f in self.funnels]
+            + [r.name for r in self.retention]
+            + [t.name for t in self.trends]
+        )
+
+
+def build_config() -> FullConfig:
+    """Construit la configuration complète DeepSight Growth."""
+    funnels = build_funnels()
+    retention = build_retention()
+    trends = build_trends()
+    cohorts = build_cohorts()
+    dashboards = build_dashboards(funnels, retention, trends)
+    return FullConfig(
+        funnels=funnels,
+        retention=retention,
+        trends=trends,
+        cohorts=cohorts,
+        dashboards=dashboards,
+    )
+
+
+__all__ = [
+    "FunnelInsight",
+    "RetentionInsight",
+    "TrendInsight",
+    "CohortDefinition",
+    "CohortFilter",
+    "DashboardSpec",
+    "FullConfig",
+    "build_config",
+    "build_funnels",
+    "build_retention",
+    "build_trends",
+    "build_cohorts",
+    "build_dashboards",
+]

--- a/backend/scripts/setup_posthog_insights.py
+++ b/backend/scripts/setup_posthog_insights.py
@@ -1,0 +1,770 @@
+"""PostHog Insights / Cohorts / Dashboards — provisioning idempotent via API.
+
+Lit la config dans ``posthog_insights_config.py`` et provisionne tout dans le
+projet PostHog cible (Cloud EU par défaut). Idempotent : matche par ``name`` et
+upserte (PATCH si existe, POST si absent).
+
+Usage
+-----
+
+    # Voir la config sans rien envoyer
+    python scripts/setup_posthog_insights.py --show-config
+
+    # Dry-run : list + diff sans modification
+    POSTHOG_API_KEY=... POSTHOG_PROJECT_ID=... \\
+        python scripts/setup_posthog_insights.py --dry-run
+
+    # Apply : upsert tout
+    POSTHOG_API_KEY=... POSTHOG_PROJECT_ID=... \\
+        python scripts/setup_posthog_insights.py --apply
+
+Environment
+-----------
+
+- ``POSTHOG_API_KEY`` (REQUIRED en --dry-run/--apply) : Personal API key avec
+  scopes ``insight:write``, ``cohort:write``, ``dashboard:write``. À générer
+  dans Settings → Personal API Keys (PAS la project key publique côté frontend).
+- ``POSTHOG_HOST`` (default: ``https://eu.posthog.com``) : EU pour DeepSight.
+- ``POSTHOG_PROJECT_ID`` (REQUIRED) : ID numérique du projet PostHog
+  (Settings → Project ID, ou dans l'URL ``/project/<id>/...``).
+
+Comportement
+------------
+
+- Per-resource try/except : un fail sur un insight n'arrête pas les autres.
+- Dashboard add/remove tile via endpoints dédiés.
+- Pas de delete : si un insight est retiré de ``build_config()``, il reste dans
+  PostHog (à supprimer manuellement). C'est volontaire — éviter la perte
+  accidentelle d'historique.
+
+Réf API : https://posthog.com/docs/api/insights et /cohorts et /dashboards.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+# Force UTF-8 stdout/stderr (Windows cp1252 console fix). No-op on Linux/macOS.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    sys.stderr.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+except (AttributeError, ValueError):
+    pass
+
+# Imports relatifs — tolère exécution directe ou via -m
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from posthog_insights_config import (  # noqa: E402
+    CohortDefinition,
+    DashboardSpec,
+    FullConfig,
+    FunnelInsight,
+    RetentionInsight,
+    TrendInsight,
+    build_config,
+)
+
+
+DEFAULT_HOST = "https://eu.posthog.com"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Outcome reporting
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ResourceOutcome:
+    kind: str  # 'funnel' | 'retention' | 'trend' | 'cohort' | 'dashboard'
+    name: str
+    action: str  # 'created' | 'updated' | 'unchanged' | 'failed' | 'would-create' | 'would-update'
+    posthog_id: int | str | None = None
+    error: str | None = None
+
+    @property
+    def status_emoji(self) -> str:
+        return {
+            "created": "[+]",
+            "updated": "[~]",
+            "unchanged": "[=]",
+            "failed": "[x]",
+            "would-create": "[?+]",
+            "would-update": "[?~]",
+        }.get(self.action, "[?]")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Client PostHog (httpx wrapper minimal)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class PostHogClient:
+    def __init__(self, host: str, api_key: str, project_id: str, timeout: float = 30.0):
+        self.host = host.rstrip("/")
+        self.api_key = api_key
+        self.project_id = project_id
+        self._client = httpx.Client(
+            base_url=self.host,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=timeout,
+        )
+
+    def __enter__(self) -> "PostHogClient":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self._client.close()
+
+    # ── Insights ────────────────────────────────────────────────────────────
+
+    def list_insights(self, limit: int = 200) -> list[dict[str, Any]]:
+        """Liste tous les insights du projet (paginé)."""
+        results: list[dict[str, Any]] = []
+        url: str | None = (
+            f"/api/projects/{self.project_id}/insights/?limit={limit}&saved=true"
+        )
+        while url:
+            resp = self._client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+            results.extend(data.get("results", []))
+            url = data.get("next")
+            if url and url.startswith(self.host):
+                url = url[len(self.host):]
+        return results
+
+    def create_insight(self, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = self._client.post(
+            f"/api/projects/{self.project_id}/insights/",
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_insight(self, insight_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = self._client.patch(
+            f"/api/projects/{self.project_id}/insights/{insight_id}/",
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    # ── Cohorts ─────────────────────────────────────────────────────────────
+
+    def list_cohorts(self, limit: int = 200) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        url: str | None = f"/api/projects/{self.project_id}/cohorts/?limit={limit}"
+        while url:
+            resp = self._client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+            results.extend(data.get("results", []))
+            url = data.get("next")
+            if url and url.startswith(self.host):
+                url = url[len(self.host):]
+        return results
+
+    def create_cohort(self, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = self._client.post(
+            f"/api/projects/{self.project_id}/cohorts/",
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_cohort(self, cohort_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = self._client.patch(
+            f"/api/projects/{self.project_id}/cohorts/{cohort_id}/",
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    # ── Dashboards ──────────────────────────────────────────────────────────
+
+    def list_dashboards(self, limit: int = 100) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        url: str | None = f"/api/projects/{self.project_id}/dashboards/?limit={limit}"
+        while url:
+            resp = self._client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+            results.extend(data.get("results", []))
+            url = data.get("next")
+            if url and url.startswith(self.host):
+                url = url[len(self.host):]
+        return results
+
+    def create_dashboard(self, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = self._client.post(
+            f"/api/projects/{self.project_id}/dashboards/",
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_dashboard(self, dashboard_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = self._client.patch(
+            f"/api/projects/{self.project_id}/dashboards/{dashboard_id}/",
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def add_insight_to_dashboard(self, insight_id: int, dashboard_id: int) -> None:
+        """Attache un insight à un dashboard via PATCH /insights/{id}/ avec
+        ``dashboards: [...]``. PostHog gère l'union côté serveur.
+        """
+        resp = self._client.patch(
+            f"/api/projects/{self.project_id}/insights/{insight_id}/",
+            json={"dashboards": [dashboard_id]},
+        )
+        resp.raise_for_status()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Reconciliation core
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _index_by_name(items: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Indexe une liste d'objets PostHog par leur attribut ``name``.
+
+    Si plusieurs items ont le même name (anomalie), on garde le 1er (id le plus bas
+    statistiquement, l'ordre PostHog étant -created_at par défaut → on prend le plus récent).
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for item in items:
+        name = item.get("name") or ""
+        if not name:
+            continue
+        if name not in out:
+            out[name] = item
+    return out
+
+
+def _payloads_differ(local: dict[str, Any], remote: dict[str, Any]) -> bool:
+    """Comparaison superficielle des payloads pour décider d'un PATCH.
+
+    On compare ``filters``, ``description`` et ``tags``. Les autres champs
+    (created_at, etc.) sont ignorés. Si remote n'a pas de filters comparables, on
+    PATCH par défaut pour s'assurer qu'on est sync.
+    """
+    keys = ("filters", "description", "tags")
+    for k in keys:
+        if local.get(k) != remote.get(k):
+            return True
+    return False
+
+
+def reconcile_insights(
+    client: PostHogClient,
+    insights: list[FunnelInsight | RetentionInsight | TrendInsight],
+    apply: bool,
+    kind_label: str,
+) -> tuple[list[ResourceOutcome], dict[str, int]]:
+    """Reconcile une liste d'insights. Retourne (outcomes, name → posthog_id)."""
+    outcomes: list[ResourceOutcome] = []
+    name_to_id: dict[str, int] = {}
+    try:
+        existing_raw = client.list_insights()
+    except httpx.HTTPError as e:
+        for insight in insights:
+            outcomes.append(
+                ResourceOutcome(
+                    kind=kind_label,
+                    name=insight.name,
+                    action="failed",
+                    error=f"list_insights HTTP error: {e}",
+                )
+            )
+        return outcomes, name_to_id
+
+    by_name = _index_by_name(existing_raw)
+    for insight in insights:
+        payload = insight.to_posthog_payload()
+        existing = by_name.get(insight.name)
+        try:
+            if existing is None:
+                if apply:
+                    created = client.create_insight(payload)
+                    name_to_id[insight.name] = created["id"]
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind=kind_label,
+                            name=insight.name,
+                            action="created",
+                            posthog_id=created["id"],
+                        )
+                    )
+                else:
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind=kind_label, name=insight.name, action="would-create"
+                        )
+                    )
+            else:
+                insight_id = existing["id"]
+                name_to_id[insight.name] = insight_id
+                if _payloads_differ(payload, existing):
+                    if apply:
+                        client.update_insight(insight_id, payload)
+                        outcomes.append(
+                            ResourceOutcome(
+                                kind=kind_label,
+                                name=insight.name,
+                                action="updated",
+                                posthog_id=insight_id,
+                            )
+                        )
+                    else:
+                        outcomes.append(
+                            ResourceOutcome(
+                                kind=kind_label,
+                                name=insight.name,
+                                action="would-update",
+                                posthog_id=insight_id,
+                            )
+                        )
+                else:
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind=kind_label,
+                            name=insight.name,
+                            action="unchanged",
+                            posthog_id=insight_id,
+                        )
+                    )
+        except httpx.HTTPError as e:
+            body = ""
+            if isinstance(e, httpx.HTTPStatusError):
+                body = f" — {e.response.text[:300]}"
+            outcomes.append(
+                ResourceOutcome(
+                    kind=kind_label,
+                    name=insight.name,
+                    action="failed",
+                    error=f"{type(e).__name__}: {e}{body}",
+                )
+            )
+
+    return outcomes, name_to_id
+
+
+def reconcile_cohorts(
+    client: PostHogClient,
+    cohorts: list[CohortDefinition],
+    apply: bool,
+) -> list[ResourceOutcome]:
+    outcomes: list[ResourceOutcome] = []
+    try:
+        existing_raw = client.list_cohorts()
+    except httpx.HTTPError as e:
+        for c in cohorts:
+            outcomes.append(
+                ResourceOutcome(
+                    kind="cohort",
+                    name=c.name,
+                    action="failed",
+                    error=f"list_cohorts HTTP error: {e}",
+                )
+            )
+        return outcomes
+
+    by_name = _index_by_name(existing_raw)
+    for cohort in cohorts:
+        payload = cohort.to_posthog_payload()
+        existing = by_name.get(cohort.name)
+        try:
+            if existing is None:
+                if apply:
+                    created = client.create_cohort(payload)
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind="cohort",
+                            name=cohort.name,
+                            action="created",
+                            posthog_id=created["id"],
+                        )
+                    )
+                else:
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind="cohort", name=cohort.name, action="would-create"
+                        )
+                    )
+            else:
+                cohort_id = existing["id"]
+                # Comparaison cohort superficielle (description + filters json string)
+                differs = (
+                    json.dumps(existing.get("filters") or {}, sort_keys=True)
+                    != json.dumps(payload.get("filters") or {}, sort_keys=True)
+                ) or (existing.get("description") != cohort.description)
+                if differs:
+                    if apply:
+                        client.update_cohort(cohort_id, payload)
+                        outcomes.append(
+                            ResourceOutcome(
+                                kind="cohort",
+                                name=cohort.name,
+                                action="updated",
+                                posthog_id=cohort_id,
+                            )
+                        )
+                    else:
+                        outcomes.append(
+                            ResourceOutcome(
+                                kind="cohort",
+                                name=cohort.name,
+                                action="would-update",
+                                posthog_id=cohort_id,
+                            )
+                        )
+                else:
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind="cohort",
+                            name=cohort.name,
+                            action="unchanged",
+                            posthog_id=cohort_id,
+                        )
+                    )
+        except httpx.HTTPError as e:
+            body = ""
+            if isinstance(e, httpx.HTTPStatusError):
+                body = f" — {e.response.text[:300]}"
+            outcomes.append(
+                ResourceOutcome(
+                    kind="cohort",
+                    name=cohort.name,
+                    action="failed",
+                    error=f"{type(e).__name__}: {e}{body}",
+                )
+            )
+
+    return outcomes
+
+
+def reconcile_dashboards(
+    client: PostHogClient,
+    dashboards: list[DashboardSpec],
+    insight_name_to_id: dict[str, int],
+    apply: bool,
+) -> list[ResourceOutcome]:
+    outcomes: list[ResourceOutcome] = []
+    try:
+        existing_raw = client.list_dashboards()
+    except httpx.HTTPError as e:
+        for d in dashboards:
+            outcomes.append(
+                ResourceOutcome(
+                    kind="dashboard",
+                    name=d.name,
+                    action="failed",
+                    error=f"list_dashboards HTTP error: {e}",
+                )
+            )
+        return outcomes
+
+    by_name = _index_by_name(existing_raw)
+    for dashboard in dashboards:
+        payload = dashboard.to_posthog_payload()
+        existing = by_name.get(dashboard.name)
+        try:
+            if existing is None:
+                if apply:
+                    created = client.create_dashboard(payload)
+                    dashboard_id = created["id"]
+                    # Attacher tous les insights par PATCH
+                    attached = 0
+                    for insight_name in dashboard.insight_names:
+                        insight_id = insight_name_to_id.get(insight_name)
+                        if insight_id is None:
+                            continue
+                        try:
+                            client.add_insight_to_dashboard(insight_id, dashboard_id)
+                            attached += 1
+                        except httpx.HTTPError:
+                            pass
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind="dashboard",
+                            name=dashboard.name,
+                            action="created",
+                            posthog_id=dashboard_id,
+                            error=None
+                            if attached == len(dashboard.insight_names)
+                            else f"only {attached}/{len(dashboard.insight_names)} insights attached",
+                        )
+                    )
+                else:
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind="dashboard", name=dashboard.name, action="would-create"
+                        )
+                    )
+            else:
+                dashboard_id = existing["id"]
+                if (
+                    existing.get("description") != dashboard.description
+                    or existing.get("pinned") != dashboard.pinned
+                ):
+                    if apply:
+                        client.update_dashboard(dashboard_id, payload)
+                        outcomes.append(
+                            ResourceOutcome(
+                                kind="dashboard",
+                                name=dashboard.name,
+                                action="updated",
+                                posthog_id=dashboard_id,
+                            )
+                        )
+                    else:
+                        outcomes.append(
+                            ResourceOutcome(
+                                kind="dashboard",
+                                name=dashboard.name,
+                                action="would-update",
+                                posthog_id=dashboard_id,
+                            )
+                        )
+                else:
+                    outcomes.append(
+                        ResourceOutcome(
+                            kind="dashboard",
+                            name=dashboard.name,
+                            action="unchanged",
+                            posthog_id=dashboard_id,
+                        )
+                    )
+
+                # Attache les insights manquants (idempotent côté PostHog)
+                if apply:
+                    for insight_name in dashboard.insight_names:
+                        insight_id = insight_name_to_id.get(insight_name)
+                        if insight_id is None:
+                            continue
+                        try:
+                            client.add_insight_to_dashboard(insight_id, dashboard_id)
+                        except httpx.HTTPError:
+                            # silencieux : déjà attaché → 200/400 selon plan
+                            pass
+        except httpx.HTTPError as e:
+            body = ""
+            if isinstance(e, httpx.HTTPStatusError):
+                body = f" — {e.response.text[:300]}"
+            outcomes.append(
+                ResourceOutcome(
+                    kind="dashboard",
+                    name=dashboard.name,
+                    action="failed",
+                    error=f"{type(e).__name__}: {e}{body}",
+                )
+            )
+
+    return outcomes
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Pretty print
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def print_summary(outcomes: list[ResourceOutcome]) -> None:
+    if not outcomes:
+        print("(no outcomes)")
+        return
+    width_kind = max(8, max(len(o.kind) for o in outcomes))
+    width_name = max(20, max(len(o.name) for o in outcomes))
+    print(
+        f"\n{'STATE':<6} {'KIND':<{width_kind}}  "
+        f"{'NAME':<{width_name}}  ID"
+    )
+    print("-" * (6 + width_kind + width_name + 12))
+    for o in outcomes:
+        id_str = str(o.posthog_id) if o.posthog_id is not None else "-"
+        line = (
+            f"{o.status_emoji:<6} {o.kind:<{width_kind}}  "
+            f"{o.name:<{width_name}}  {id_str}"
+        )
+        print(line)
+        if o.error:
+            print(f"        ↳ {o.error}")
+    counts: dict[str, int] = {}
+    for o in outcomes:
+        counts[o.action] = counts.get(o.action, 0) + 1
+    print(
+        "\nCounts: "
+        + ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    )
+
+
+def print_show_config(config: FullConfig) -> None:
+    print("=" * 78)
+    print("DeepSight — PostHog Growth Config (versionnée)")
+    print("=" * 78)
+    print(f"\n[Funnels] ({len(config.funnels)})")
+    for f in config.funnels:
+        print(f"  - {f.name}")
+        print(f"      steps: {' -> '.join(f.steps)}")
+        print(
+            f"      window: {f.conversion_window_seconds // 60} min, "
+            f"breakdown: {f.breakdown_property or '-'}"
+        )
+    print(f"\n[Retention] ({len(config.retention)})")
+    for r in config.retention:
+        print(f"  - {r.name}")
+        print(f"      cohort: {r.target_event} -> returns on: {r.returning_event}")
+        print(f"      period: {r.period} x {r.total_intervals}")
+    print(f"\n[Trends] ({len(config.trends)})")
+    for t in config.trends:
+        print(f"  - {t.name}")
+        print(
+            f"      events: {', '.join(t.events)} | display: {t.display} | "
+            f"interval: {t.interval} | math: {t.math}"
+        )
+    print(f"\n[Cohorts] ({len(config.cohorts)})")
+    for c in config.cohorts:
+        print(f"  - {c.name}  ({len(c.filters)} filter(s), {c.combinator})")
+    print(f"\n[Dashboards] ({len(config.dashboards)})")
+    for d in config.dashboards:
+        print(f"  - {d.name}  ({len(d.insight_names)} insights)")
+    print()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  CLI
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Provision PostHog insights, cohorts and dashboards (idempotent)."
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--show-config",
+        action="store_true",
+        help="Print la config locale et exit (no API call).",
+    )
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List les actions à faire sans modifier PostHog.",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply les changements sur PostHog (upsert).",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("POSTHOG_HOST", DEFAULT_HOST),
+        help=f"PostHog host (default {DEFAULT_HOST}).",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("POSTHOG_API_KEY"),
+        help="PostHog Personal API key (env POSTHOG_API_KEY).",
+    )
+    parser.add_argument(
+        "--project-id",
+        default=os.environ.get("POSTHOG_PROJECT_ID"),
+        help="PostHog Project ID (env POSTHOG_PROJECT_ID).",
+    )
+    args = parser.parse_args()
+
+    config = build_config()
+
+    if args.show_config or (
+        not args.dry_run and not args.apply and not args.show_config
+    ):
+        # Default = show-config si rien passé
+        print_show_config(config)
+        if not args.show_config:
+            print(
+                "(No mode specified — printed config only. "
+                "Use --dry-run or --apply to interact with PostHog.)"
+            )
+        return 0
+
+    # Mode --dry-run ou --apply : besoin des creds
+    missing = []
+    if not args.api_key:
+        missing.append("POSTHOG_API_KEY (Personal API key, scopes insight/cohort/dashboard:write)")
+    if not args.project_id:
+        missing.append("POSTHOG_PROJECT_ID")
+    if missing:
+        print(f"ERROR: missing config: {', '.join(missing)}", file=sys.stderr)
+        return 2
+
+    apply = args.apply
+    mode_label = "APPLY" if apply else "DRY-RUN"
+    print(
+        f"\nDeepSight PostHog setup -- mode={mode_label} -- host={args.host} "
+        f"-- project={args.project_id}"
+    )
+
+    all_outcomes: list[ResourceOutcome] = []
+    insight_name_to_id: dict[str, int] = {}
+
+    with PostHogClient(args.host, args.api_key, args.project_id) as client:
+        # 1. Funnels (FunnelInsight)
+        print("\n[1/4] Funnels...")
+        outcomes, ids = reconcile_insights(client, config.funnels, apply, "funnel")
+        all_outcomes.extend(outcomes)
+        insight_name_to_id.update(ids)
+
+        # 2. Retention
+        print("[2/4] Retention insights...")
+        outcomes, ids = reconcile_insights(
+            client, config.retention, apply, "retention"
+        )
+        all_outcomes.extend(outcomes)
+        insight_name_to_id.update(ids)
+
+        # 3. Trends
+        print("[3/4] Trend insights...")
+        outcomes, ids = reconcile_insights(client, config.trends, apply, "trend")
+        all_outcomes.extend(outcomes)
+        insight_name_to_id.update(ids)
+
+        # 4. Cohorts (indépendantes)
+        print("[4/4] Cohorts...")
+        cohort_outcomes = reconcile_cohorts(client, config.cohorts, apply)
+        all_outcomes.extend(cohort_outcomes)
+
+        # 5. Dashboards (groupent les insights par name)
+        print("[+]  Dashboards...")
+        dashboard_outcomes = reconcile_dashboards(
+            client, config.dashboards, insight_name_to_id, apply
+        )
+        all_outcomes.extend(dashboard_outcomes)
+
+    print_summary(all_outcomes)
+
+    failed = [o for o in all_outcomes if o.action == "failed"]
+    if failed:
+        print(f"\n[!] {len(failed)} resource(s) failed (see above).")
+        return 1
+
+    if not apply:
+        print(
+            "\n[i] Dry-run completed — re-run with --apply to push changes to PostHog."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1351,3 +1351,154 @@ page externe ne soit configurée — l'UI ne casse pas, elle invite juste
 | Script renvoie code 2 (> 5 composants)       | Free tier limit. Soit retirer un composant de `instatus_components_config.py`, soit upgrader Instatus.                |
 | `<InstatusSection />` reste en `unavailable` | Vérifier que `https://status.deepsightsynthesis.com/summary.json` répond en JSON public. CORS doit être ouvert (Instatus le fait par défaut). |
 | Subscribers Telegram ne reçoivent rien       | Tester le webhook Instatus → Telegram avec curl. Vérifier que le bot Telegram a bien le droit de poster dans le chat. |
+
+---
+
+## §22 — PostHog funnels et insights
+
+Provisionne et maintient à jour les funnels (Acquisition / Activation / Retention / Revenue), cohortes et dashboards PostHog **par script** (versionné dans le repo, pas perdu dans l'UI).
+
+### Code
+
+- **Config (data classes)** : `backend/scripts/posthog_insights_config.py`
+- **Script idempotent** : `backend/scripts/setup_posthog_insights.py`
+
+### Contenu provisionné
+
+| Type            | Nb      | Détail                                                                                                                  |
+| --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Funnels         | **4**   | Acquisition / Activation / Revenue / Cross-Platform Activation                                                          |
+| Retention       | **2**   | Weekly retention (signup → video_analyzed) / Daily retention (signup → chat_message_sent)                               |
+| Trends          | **5**   | Daily Signups / Free→Paid Conversion / DAU engagement / Top events by week / API Errors by endpoint                     |
+| Cohorts         | **6**   | Free / Pro / Expert / Mobile-first / At-risk churn / Power users                                                        |
+| Dashboards      | **1**   | « DeepSight — Growth » (regroupe les 11 insights ci-dessus, pinned)                                                     |
+
+### Étape 1 — Générer une Personal API key PostHog
+
+Une **Personal API key** est requise (≠ project key publique exposée côté frontend dans `VITE_POSTHOG_KEY`).
+
+1. Aller sur PostHog → **Settings → Personal API Keys** :
+   - EU : https://eu.posthog.com/settings/user-api-keys
+   - US : https://us.posthog.com/settings/user-api-keys
+2. Cliquer **Create personal API key**.
+3. Donner un nom : `deepsight-script-setup-insights`.
+4. **Scopes** (cocher uniquement) :
+   - `insight:write` (et lecture incluse)
+   - `cohort:write`
+   - `dashboard:write`
+5. Sélectionner le projet DeepSight (ou « All projects » si plus simple).
+6. Copier la valeur (commence par `phx_`) — **elle ne sera plus affichée**.
+
+### Étape 2 — Trouver le Project ID
+
+- Dans l'URL d'un dashboard : `https://eu.posthog.com/project/<ID>/dashboard/...` → `<ID>` est le Project ID (entier).
+- Ou bien : **Settings → Project → General → Project ID**.
+
+### Étape 3 — Set des secrets
+
+Ne pas commit. Ajouter dans `.env.local` (gitignored) ou export shell :
+
+```bash
+export POSTHOG_API_KEY='phx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+export POSTHOG_PROJECT_ID='12345'
+export POSTHOG_HOST='https://eu.posthog.com'  # default OK
+```
+
+Pour CI/automation future, stocker dans **GitHub Actions secrets** (`POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID`).
+
+### Étape 4 — Run du script
+
+```bash
+cd backend
+
+# A. Inspecter la config locale (no API call) — sécurité avant toute chose
+python scripts/setup_posthog_insights.py --show-config
+
+# B. Dry-run (lit PostHog, affiche [?+] would-create / [?~] would-update)
+python scripts/setup_posthog_insights.py --dry-run
+
+# C. Apply (upsert idempotent)
+python scripts/setup_posthog_insights.py --apply
+```
+
+#### États possibles dans le summary
+
+| Marker | Action          | Signification                              |
+| ------ | --------------- | ------------------------------------------ |
+| `[+]`  | created         | Nouvel objet créé sur PostHog              |
+| `[~]`  | updated         | Existait, payload modifié → PATCH appliqué |
+| `[=]`  | unchanged       | Existait, identique → no-op                |
+| `[?+]` | would-create    | Dry-run : serait créé                      |
+| `[?~]` | would-update    | Dry-run : serait modifié                   |
+| `[x]`  | failed          | HTTP error, message ci-dessous             |
+
+#### Exit codes
+
+| Code | Sens                                                    |
+| ---- | ------------------------------------------------------- |
+| `0`  | OK (apply ou dry-run sans erreur)                       |
+| `1`  | Au moins 1 ressource a failed (autres ont continué)     |
+| `2`  | Mauvaise config (POSTHOG_API_KEY ou POSTHOG_PROJECT_ID) |
+
+### Étape 5 — Ajuster la config
+
+1. Éditer `backend/scripts/posthog_insights_config.py` (ajouter / modifier funnels, cohorts, etc.).
+2. Re-run `--dry-run` pour visualiser le diff.
+3. Re-run `--apply` pour pousser.
+
+**Idempotence** : tous les objets sont matchés par leur `name`. Renommer un funnel = créer un nouveau (l'ancien reste). Pour supprimer un objet périmé, le faire **manuellement dans l'UI PostHog** (volontairement non automatisé pour éviter perte d'historique accidentelle).
+
+### Activation Session Replay (manuelle UI)
+
+Pas d'API publique stable, configuration uniquement via le dashboard PostHog.
+
+1. **Settings → Session Replay → Enable**.
+2. **Recording masks** (très important RGPD) :
+   - **Mask all inputs** : ON
+   - **Block selectors** : ajouter
+     ```
+     input[type="password"], input[name*="email" i], input[name*="card" i],
+     [data-sentry-mask], [data-replay-mask], .stripe-element, .billing-form
+     ```
+   - **Mask text content** : pour les sélecteurs `[data-private]`, `.user-name`, `.user-email`
+3. **Retention** : sélectionner **30 jours** (limite free tier), upgrader plus tard si besoin.
+4. **Sampling rate** : démarrer à **10 %** (cap budget pendant 1 mois), monter à 30 % une fois validé.
+5. Côté code, mettre à jour `frontend/src/services/analytics.ts` :
+   ```typescript
+   posthog.init(POSTHOG_KEY, {
+     // ...
+     disable_session_recording: false, // était true
+     session_recording: {
+       maskAllInputs: true,
+       maskInputOptions: { password: true, email: true },
+     },
+   });
+   ```
+6. Vérifier 24h plus tard sur Activity → Session recordings que les passwords/emails sont bien masqués.
+
+### Exporter un funnel pour weekly review
+
+1. Ouvrir le funnel dans PostHog (UI).
+2. Bouton **... → Export → PNG** (ou `Share` → screenshot via `claude-in-chrome` si automation).
+3. Coller dans le snapshot weekly du vault Obsidian (`00-Inbox/<date>-deepsight-snapshot.md`).
+4. Pour un export programmable de KPIs : `GET /api/projects/{id}/insights/{insight_id}/?refresh=true` retourne le JSON avec les counts par step.
+
+### Pièges connus
+
+- **403 Forbidden** sur `list_*` → la Personal API key n'a pas le scope ou n'est pas attachée au bon projet. Régénérer (étape 1).
+- **400 Bad Request** sur `create_insight` avec un funnel : l'event n'existe pas encore dans PostHog (jamais envoyé). Solution : envoyer un event de test depuis chaque plateforme avant de créer le funnel, OU le créer quand même (PostHog accepte les funnels pré-event).
+- **Encoding Windows** : le script force UTF-8 stdout. Si symboles cassés, vérifier `chcp 65001` dans le terminal.
+- **Plan PostHog free** : limite à 1M events/mois et 5k recordings/mois. Si dépassement, upgrader Cloud (≈ $0.0003/event).
+
+### Coût et plan PostHog
+
+- Free tier : 1M events + 5k session recordings + 1M feature flag requests / mois.
+- DeepSight cible (mai 2026) : ~200k events/mois → free tier OK.
+- Re-évaluer si > 80% utilisé (alerte PostHog email).
+
+### Recommandations futures
+
+- Ajouter un event `trial_started` et `trial_converted` une fois le flow Pro/Expert trial 7 jours stabilisé (cf. plan `2026-04-29-pricing-v2-stripe-grandfathering.md`) → permettra un funnel Trial dédié.
+- Brancher le backend (`POST /api/analytics/events`) sur PostHog server-side via un cron pour les events qui n'ont pas de version frontend (Stripe webhook → `payment_completed`).
+- Configurer une **Insight alert** PostHog sur le funnel Revenue : alert si conversion `upgrade_started → upgrade_completed` < 50% sur 7j (Slack via webhook).
+- Une fois 30j de data, créer un dashboard « DeepSight — Cohort Health » par cohorte (Free / Pro / Expert) avec retention 12 semaines.


### PR DESCRIPTION
## Summary

Sprint Growth & UX — Chantier C (analytics produit). Provisionne PostHog **par script versionné** au lieu de configuration manuelle perdue dans le dashboard. Closes le P1 audit "pas de funnels configurés / pas de cohorts / pas de dashboard global".

- **`backend/scripts/posthog_insights_config.py`** : dataclasses (FunnelInsight, RetentionInsight, TrendInsight, CohortDefinition, DashboardSpec) + `build_config()` qui retourne **4 funnels + 2 retention + 5 trends + 6 cohorts + 1 dashboard** "DeepSight — Growth"
- **`backend/scripts/setup_posthog_insights.py`** : script argparse idempotent (`--show-config` / `--dry-run` / `--apply`), match par `name` → upsert PATCH/POST, per-resource try/except (un fail n'arrête pas les autres), summary table, exit codes 0/1/2, fix encoding stdout UTF-8 Windows
- **`docs/RUNBOOK.md` §22 "PostHog funnels et insights"** : génération Personal API key, project ID, run du script, états du summary, ajustement, **activation Session Replay manuelle** (recording masks RGPD), export funnel weekly, pièges connus, recommandations futures

## Provisioning détaillé

### Funnels (4)
1. **Acquisition** : `$pageview` → `user_signup` → `user_login` (24h, breakdown `$referrer`)
2. **Activation** : `user_signup` → `video_analyzed` → `chat_message_sent` → `study_tool_used` (7j, breakdown `plan`)
3. **Revenue** : `upgrade_started` → `upgrade_completed` (1h, breakdown `plan`)
4. **Cross-Platform Activation** : `user_signup` → `video_analyzed` (7j, breakdown `platform` web/mobile/extension)

### Retention (2)
- Weekly Retention (signup → video_analyzed) — 11 semaines, retention_first_time
- Daily Retention (signup → chat_message_sent) — 14 jours

### Trends (5)
- Daily Signups (30d, line)
- Free → Paid Conversion (90d, line, breakdown plan)
- DAU on engagement events (30d, line, math=dau)
- Top events by week (7d, bar)
- API Errors by endpoint (7d, bar, breakdown `endpoint`)

### Cohorts (6)
- Free / Pro / Expert (par `plan` person property)
- Mobile-first (≥ 5 video_analyzed/30j sur platform=mobile)
- At-risk churn (paid + dormant 30j) → win-back high-priority
- Power users (>50 video_analyzed/365j) → beta + témoignages

### Dashboard
- "DeepSight — Growth" pinned, regroupe les 11 insights ci-dessus

## Secrets à set (hors repo)
- `POSTHOG_API_KEY` — **Personal** API key, scopes `insight:write`, `cohort:write`, `dashboard:write` (≠ project key publique du frontend)
- `POSTHOG_PROJECT_ID` — entier visible dans l'URL `/project/<id>/`
- `POSTHOG_HOST` — default `https://eu.posthog.com`

## Activation Session Replay
Doc-only (pas d'API publique stable) : Settings → Session Replay → Enable + recording masks (passwords, emails, billing, sélecteurs `[data-private]`) + retention 30j + sampling 10% initial. Snippet code à adapter dans `frontend/src/services/analytics.ts` documenté en §22.

## Idempotence
- Re-run `--apply` 2x → no-op (matché par `name`).
- Renommer un objet en config = nouvel objet créé (l'ancien reste). Suppression manuelle dans l'UI (volontaire, préserve historique).
- Pas de breaking change sur l'analytics existante (frontend, backend `/api/analytics/events`, mobile).

## Test plan

- [x] AST compile OK sur les 2 fichiers Python (`python -c "import ast; ast.parse(open(...).read())"`)
- [x] `python backend/scripts/setup_posthog_insights.py --show-config` affiche la config complète sans crash (4 funnels + 2 retention + 5 trends + 6 cohorts + 1 dashboard)
- [x] `--dry-run` sans creds → exit 2 + message d'erreur clair
- [x] `--apply` sans creds → exit 2
- [x] `--dry-run` avec creds factices → exit 1 + per-resource failed avec status HTTP affiché
- [ ] User : `--dry-run` avec vraies creds PostHog → vérifier 18 `[?+] would-create`
- [ ] User : `--apply` avec vraies creds → vérifier 4+2+5 insights + 6 cohorts + 1 dashboard créés dans PostHog UI
- [ ] User : Re-run `--apply` → vérifier 18 `[=] unchanged`
- [ ] User : Activer Session Replay manuellement (Settings → Replay) selon §22 RUNBOOK

## Recommandations futures

- Ajouter events `trial_started` / `trial_converted` une fois le flow trial Pro/Expert stabilisé (cf. plan `2026-04-29-pricing-v2-stripe-grandfathering.md`) → funnel Trial dédié
- Brancher backend `POST /api/analytics/events` sur PostHog server-side via cron pour les events Stripe webhooks (`payment_completed` server-only)
- Insight alert sur funnel Revenue : si conversion `upgrade_started → upgrade_completed` < 50% sur 7j → Slack webhook
- Une fois 30j de data : dashboard "Cohort Health" par plan (Free / Pro / Expert) avec retention 12 semaines

🤖 Generated with [Claude Code](https://claude.com/claude-code)