### PR TITLE
fix(miro): drop board policy options incompatible with Personal Starter plan

### DIFF
--- a/backend/src/debate/miro_service.py
+++ b/backend/src/debate/miro_service.py
@@ -178,7 +178,10 @@ async def generate_debate_board(
 
     async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
         # ─── 1. Create board ─────────────────────────────────────────────
-        # Sharing policy : view = lecture seule pour quiconque a le lien.
+        # Policy options omitted: `permissionsPolicy.sharingAccess` and
+        # `sharingPolicy.organizationAccess`/`teamAccess` require Miro Team
+        # plan and produce 403 4.0602 on Personal Starter accounts. Miro
+        # applies sensible defaults when policy is absent.
         # Cf. https://developers.miro.com/reference/create-board
         board_body = {
             "name": board_name,
@@ -186,19 +189,6 @@ async def generate_debate_board(
                 f"Débat IA généré par DeepSight — {topic}. "
                 f"Comparaison automatique entre {len(perspectives) + 1} vidéos."
             )[:500],
-            "policy": {
-                "permissionsPolicy": {
-                    "collaborationToolsStartAccess": "all_editors",
-                    "copyAccess": "anyone",
-                    "sharingAccess": "team_members_with_editing_rights",
-                },
-                "sharingPolicy": {
-                    "access": "view",  # lecture seule via viewLink
-                    "inviteToAccountAndBoardLinkAccess": "no_access",
-                    "organizationAccess": "view",
-                    "teamAccess": "view",
-                },
-            },
         }
         board = await _miro_post(client, "/boards", token, board_body)
         board_id: str = str(board.get("id") or "")
@@ -391,24 +381,15 @@ async def create_hub_workspace_board(
 
     async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
         # ─── 1. Create board ──────────────────────────────────────────────
+        # Policy options omitted: `permissionsPolicy.sharingAccess` and
+        # `sharingPolicy.organizationAccess`/`teamAccess` require Miro Team
+        # plan and produce 403 4.0602 on Personal Starter accounts. Miro
+        # applies sensible defaults when policy is absent.
         board_body = {
             "name": safe_name,
             "description": (
                 f"DeepSight Hub Workspace — {len(summaries)} analyses"
             )[:500],
-            "policy": {
-                "permissionsPolicy": {
-                    "collaborationToolsStartAccess": "all_editors",
-                    "copyAccess": "anyone",
-                    "sharingAccess": "team_members_with_editing_rights",
-                },
-                "sharingPolicy": {
-                    "access": "view",
-                    "inviteToAccountAndBoardLinkAccess": "no_access",
-                    "organizationAccess": "view",
-                    "teamAccess": "view",
-                },
-            },
         }
         board = await _miro_post(client, "/boards", token, board_body)
         board_id: str = str(board.get("id") or "")


### PR DESCRIPTION
## Symptôme prod

Hub Workspaces creation systematically fails with `Miro API error 403 4.0602 Insufficient permissions to perform operation` on Personal Starter accounts ($8/mo).

## Cause racine

The current `board_body` POST to `/v2/boards` includes a `policy` block with options that require a Miro Team plan (or higher):

- `permissionsPolicy.sharingAccess: "team_members_with_editing_rights"`
- `sharingPolicy.organizationAccess: "view"`
- `sharingPolicy.teamAccess: "view"`
- `sharingPolicy.inviteToAccountAndBoardLinkAccess: "no_access"`

On Personal Starter, Miro returns 403 even with a valid token+scopes installed on the right team.

## Reproduction

Same valid token (DeepSight Hub app installed on First team, scopes `boards:read,boards:write,identity:read`):

- `curl -X POST -d '{"name":"x"}' /v2/boards` → **201 OK** (board created)
- `curl -X POST -d '{"name":"x","policy":{...full backend body...}}' /v2/boards` → **403 4.0602**

## Fix

Strip the `policy` key from `board_body` in both helpers:
- `create_hub_workspace_board()` (Hub Workspace MVP, sprint 2026-05-05)
- `generate_debate_board()` (Débat IA, also impacted but not yet observed in prod)

Miro applies sensible defaults when policy is absent (board accessible via viewLink, no over-restrictive sharing).

## Test

Direct curl from Hetzner backend container with the new minimal body returns 201 + valid `id` and `viewLink`.

## No tests touched

Existing tests mock the Miro API entirely, no impact on test surface.