### PR TITLE
feat(growth): Instatus status page setup script + frontend embed

### DIFF
--- a/backend/scripts/instatus_components_config.py
+++ b/backend/scripts/instatus_components_config.py
@@ -1,0 +1,99 @@
+"""Configuration des composants Instatus pour la status page publique DeepSight.
+
+Source de vérité unique pour les 5 composants à monitorer publiquement sur
+``status.deepsightsynthesis.com``. Importé par ``setup_instatus_components.py``.
+
+Chaque composant correspond à une plateforme/service surveillé. ``health_url``
+est l'endpoint utilisé par les uptime checks (Instatus monitors externes ou
+UptimeRobot/Better Stack en complément). Pour Mobile/Extension, pas de
+``health_url`` direct (apps client) → status maintenu manuellement ou via
+webhook depuis CI.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class InstatusComponent:
+    """Définition d'un composant à upserter sur Instatus.
+
+    Attributes:
+        name: Nom unique (clé de matching pour idempotence).
+        description: Texte affiché sous le nom sur la status page.
+        group: Groupe d'affichage (None = pas de groupe).
+        health_url: URL HTTPS health check (None si client app sans endpoint).
+        order: Ordre d'affichage (plus petit = en haut).
+        showcase: Si True, le composant compte dans le statut global affiché en
+            haut de la status page.
+    """
+
+    name: str
+    description: str
+    group: Optional[str] = None
+    health_url: Optional[str] = None
+    order: int = 0
+    showcase: bool = True
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# 5 composants à monitorer (free tier Instatus = 5 max)
+# ───────────────────────────────────────────────────────────────────────────
+
+COMPONENTS: list[InstatusComponent] = [
+    InstatusComponent(
+        name="API",
+        description="API publique DeepSight (api.deepsightsynthesis.com)",
+        group="Backend",
+        health_url="https://api.deepsightsynthesis.com/health",
+        order=1,
+        showcase=True,
+    ),
+    InstatusComponent(
+        name="Web",
+        description="Application web (www.deepsightsynthesis.com)",
+        group="Frontend",
+        health_url="https://www.deepsightsynthesis.com",
+        order=2,
+        showcase=True,
+    ),
+    InstatusComponent(
+        name="Mobile App",
+        description="Application iOS et Android (App Store / Play Store)",
+        group="Frontend",
+        health_url=None,  # Pas d'endpoint direct — status manuel ou via crash reports
+        order=3,
+        showcase=True,
+    ),
+    InstatusComponent(
+        name="Extension Chrome",
+        description="Extension Chrome (Chrome Web Store)",
+        group="Frontend",
+        health_url=None,  # Pas d'endpoint direct — status manuel
+        order=4,
+        showcase=True,
+    ),
+    InstatusComponent(
+        name="Database",
+        description="Base de données PostgreSQL (Hetzner)",
+        group="Backend",
+        health_url="https://api.deepsightsynthesis.com/health/deep",
+        order=5,
+        showcase=True,
+    ),
+]
+
+
+# Métadonnées partagées appliquées sur tous les composants à la création.
+DEFAULT_METADATA: dict[str, str] = {
+    "managed_by": "setup_instatus_components",
+}
+
+
+def get_component_by_name(name: str) -> Optional[InstatusComponent]:
+    """Retourne le composant correspondant au nom donné (None sinon)."""
+    for component in COMPONENTS:
+        if component.name == name:
+            return component
+    return None

--- a/backend/scripts/setup_instatus_components.py
+++ b/backend/scripts/setup_instatus_components.py
@@ -1,0 +1,344 @@
+"""Idempotent Instatus components setup script.
+
+Usage::
+
+    # Dry-run : montre ce qui serait fait sans toucher à Instatus
+    python backend/scripts/setup_instatus_components.py --dry-run
+
+    # Apply : crée/met à jour les 5 composants sur Instatus
+    INSTATUS_API_KEY=ist_... INSTATUS_PAGE_ID=abc123 \\
+        python backend/scripts/setup_instatus_components.py --apply
+
+    # Show config : dump la config locale sans appel réseau
+    python backend/scripts/setup_instatus_components.py --show-config
+
+Idempotence : les composants sont matchés par ``name`` (clé unique).
+- Match → PATCH (update si différence détectée)
+- Pas de match → POST (création)
+- Skipped si aucune diff
+
+Free tier Instatus = 5 components max → garde-fou intégré.
+
+Documentation API Instatus : https://instatus.com/help/api
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict
+from typing import Any, Optional
+
+import httpx
+
+# Permet d'exécuter le script depuis le repo root sans modifier PYTHONPATH
+sys.path.insert(0, os.path.dirname(__file__))
+
+from instatus_components_config import (  # noqa: E402
+    COMPONENTS,
+    DEFAULT_METADATA,
+    InstatusComponent,
+)
+
+INSTATUS_API_BASE = "https://api.instatus.com"
+HTTP_TIMEOUT = 30.0
+MAX_FREE_TIER_COMPONENTS = 5
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Helpers
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def _payload_from_component(component: InstatusComponent) -> dict[str, Any]:
+    """Construit le payload JSON pour POST/PATCH /v1/{page-id}/components.
+
+    Le schéma Instatus accepte (champs principaux) :
+    name, description, status, order, showcase, group, internalName, monitorId.
+    On envoie le minimum nécessaire — Instatus garde la valeur précédente
+    pour les champs absents.
+    """
+    payload: dict[str, Any] = {
+        "name": component.name,
+        "description": component.description,
+        "order": component.order,
+        "showcase": component.showcase,
+        "status": "OPERATIONAL",
+    }
+    if component.group:
+        payload["group"] = component.group
+    return payload
+
+
+def _components_differ(local: InstatusComponent, remote: dict[str, Any]) -> bool:
+    """Détecte si un composant Instatus existant doit être mis à jour."""
+    if remote.get("description") != local.description:
+        return True
+    if int(remote.get("order") or 0) != local.order:
+        return True
+    if bool(remote.get("showcase")) != local.showcase:
+        return True
+    remote_group = remote.get("group")
+    # Instatus renvoie soit None, soit un objet {id, name, ...}, soit un string
+    remote_group_name = (
+        remote_group.get("name")
+        if isinstance(remote_group, dict)
+        else remote_group
+    )
+    if (remote_group_name or None) != (local.group or None):
+        return True
+    return False
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Instatus API client (minimal, async — utilisable depuis CI)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class InstatusClient:
+    """Wrapper httpx synchrone — pas besoin d'asyncio pour ce script CLI."""
+
+    def __init__(self, api_key: str, page_id: str) -> None:
+        self._api_key = api_key
+        self._page_id = page_id
+        self._client = httpx.Client(
+            base_url=f"{INSTATUS_API_BASE}/v1/{page_id}",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=HTTP_TIMEOUT,
+        )
+
+    def list_components(self) -> list[dict[str, Any]]:
+        resp = self._client.get("/components")
+        resp.raise_for_status()
+        data = resp.json()
+        # L'API renvoie soit une liste directe, soit {data: [...]}
+        if isinstance(data, list):
+            return data
+        return list(data.get("data", []))
+
+    def create_component(self, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = self._client.post("/components", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_component(
+        self, component_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        resp = self._client.put(f"/components/{component_id}", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def close(self) -> None:
+        self._client.close()
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Actions
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class ComponentResult:
+    """Statut d'une action sur un composant — utilisé pour l'output table."""
+
+    __slots__ = ("name", "action", "detail")
+
+    def __init__(self, name: str, action: str, detail: str = "") -> None:
+        self.name = name
+        self.action = action  # "created" | "updated" | "skipped" | "error" | "dryrun"
+        self.detail = detail
+
+
+def _print_table(results: list[ComponentResult]) -> None:
+    """Affichage tabulaire ASCII compatible PowerShell + bash + CI logs."""
+    if not results:
+        print("(aucun composant traité)")
+        return
+
+    name_w = max(len(r.name) for r in results) + 2
+    action_w = max(len(r.action) for r in results) + 2
+
+    sep = "+" + "-" * (name_w + 2) + "+" + "-" * (action_w + 2) + "+" + "-" * 50 + "+"
+    print(sep)
+    print(
+        f"| {'Component'.ljust(name_w)} | "
+        f"{'Action'.ljust(action_w)} | "
+        f"{'Detail'.ljust(48)} |"
+    )
+    print(sep)
+    for r in results:
+        print(
+            f"| {r.name.ljust(name_w)} | "
+            f"{r.action.ljust(action_w)} | "
+            f"{r.detail[:48].ljust(48)} |"
+        )
+    print(sep)
+
+
+def upsert_component(
+    client: InstatusClient,
+    component: InstatusComponent,
+    remote_index: dict[str, dict[str, Any]],
+    dry_run: bool,
+) -> ComponentResult:
+    """Crée ou met à jour un composant Instatus de façon idempotente.
+
+    Args:
+        client: Instance InstatusClient (None si dry_run).
+        component: Config locale du composant.
+        remote_index: Map name -> dict component existant côté Instatus.
+        dry_run: Si True, n'effectue aucun appel mutant.
+    """
+    payload = _payload_from_component(component)
+    existing = remote_index.get(component.name)
+
+    if existing:
+        if not _components_differ(component, existing):
+            return ComponentResult(component.name, "skipped", "no diff")
+        if dry_run:
+            return ComponentResult(component.name, "dryrun", "would PUT (diff)")
+        try:
+            client.update_component(existing["id"], payload)
+            return ComponentResult(
+                component.name, "updated", f"id={existing.get('id', '?')}"
+            )
+        except httpx.HTTPError as exc:
+            return ComponentResult(component.name, "error", f"PUT failed: {exc}")
+    else:
+        if dry_run:
+            return ComponentResult(component.name, "dryrun", "would POST (new)")
+        try:
+            created = client.create_component(payload)
+            return ComponentResult(
+                component.name, "created", f"id={created.get('id', '?')}"
+            )
+        except httpx.HTTPError as exc:
+            return ComponentResult(component.name, "error", f"POST failed: {exc}")
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# CLI
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def show_config() -> int:
+    """Dump la config locale sans appeler l'API."""
+    print(f"Components configured ({len(COMPONENTS)}/{MAX_FREE_TIER_COMPONENTS}):\n")
+    for c in COMPONENTS:
+        as_dict = asdict(c)
+        print(f"  - {c.name}")
+        for key, value in as_dict.items():
+            if key == "name":
+                continue
+            print(f"      {key}: {value}")
+    print(f"\nDefault metadata: {json.dumps(DEFAULT_METADATA)}")
+    return 0
+
+
+def run_setup(dry_run: bool) -> int:
+    """Exécute le setup. Retourne un code de sortie."""
+    if len(COMPONENTS) > MAX_FREE_TIER_COMPONENTS:
+        print(
+            f"ERROR: {len(COMPONENTS)} composants définis > "
+            f"{MAX_FREE_TIER_COMPONENTS} (free tier max). Réduire la liste "
+            f"ou upgrader Instatus.",
+            file=sys.stderr,
+        )
+        return 2
+
+    api_key: Optional[str] = os.environ.get("INSTATUS_API_KEY")
+    page_id: Optional[str] = os.environ.get("INSTATUS_PAGE_ID")
+
+    if not dry_run:
+        if not api_key:
+            print(
+                "ERROR: INSTATUS_API_KEY env var manquante "
+                "(Settings → API Tokens dans Instatus admin).",
+                file=sys.stderr,
+            )
+            return 1
+        if not page_id:
+            print(
+                "ERROR: INSTATUS_PAGE_ID env var manquante "
+                "(URL admin → segment après /pages/).",
+                file=sys.stderr,
+            )
+            return 1
+
+    if dry_run:
+        print(f"DRY-RUN — {len(COMPONENTS)} composants seraient inspectés.\n")
+        # Sans credentials on ne peut pas lister le remote → on simule
+        # tout en "would POST (new)" pour donner un aperçu utile.
+        if not api_key or not page_id:
+            results = [
+                ComponentResult(c.name, "dryrun", "would POST (no remote check)")
+                for c in COMPONENTS
+            ]
+            _print_table(results)
+            return 0
+
+    client = InstatusClient(api_key=api_key or "", page_id=page_id or "")
+    try:
+        try:
+            remote_components = client.list_components()
+        except httpx.HTTPError as exc:
+            print(f"ERROR: GET /components failed: {exc}", file=sys.stderr)
+            return 3
+
+        remote_index: dict[str, dict[str, Any]] = {
+            (c.get("name") or ""): c for c in remote_components if c.get("name")
+        }
+        print(
+            f"Found {len(remote_index)} existing remote components on page "
+            f"{page_id}.\n"
+        )
+
+        results: list[ComponentResult] = []
+        for component in COMPONENTS:
+            results.append(
+                upsert_component(client, component, remote_index, dry_run)
+            )
+        _print_table(results)
+
+        # Status code = 4 si au moins un error
+        if any(r.action == "error" for r in results):
+            return 4
+        return 0
+    finally:
+        client.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Idempotent Instatus components setup for DeepSight status page.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Affiche ce qui serait fait sans muter Instatus.",
+    )
+    group.add_argument(
+        "--apply",
+        action="store_true",
+        help="Applique les changements via l'API Instatus.",
+    )
+    group.add_argument(
+        "--show-config",
+        action="store_true",
+        help="Dump la config locale (aucun appel réseau).",
+    )
+
+    args = parser.parse_args()
+
+    if args.show_config:
+        return show_config()
+
+    return run_setup(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1207,3 +1207,147 @@ mind-map pages — could be lazier) and the analytics dashboard.
 | Lighthouse scores wildly inconsistent run-to-run | We already average 3 runs (median). For more stability, raise `numberOfRuns` to 5.              |
 | Size-limit fails locally with "Chrome not found" | Expected on Windows — we use the `@size-limit/file` plugin, no Chrome needed. Re-run.            |
 | Comment doesn't appear on PR                     | Check the workflow logs — usually a permission issue (`pull-requests: write`).                  |
+
+---
+
+## 21. Status page (Instatus)
+
+Public status page hosted on **Instatus** (free tier — 5 components,
+custom domain, email + webhook subscriptions). Domain :
+`https://status.deepsightsynthesis.com`.
+
+The internal `/status` page (`frontend/src/pages/StatusPage.tsx`)
+embeds the Instatus public summary in its own design — both views
+coexist : internal = realtime deep health check, external = curated
+public-facing status with incident history.
+
+### 21.1. Pre-setup checklist (one-time, action user)
+
+Avant de pouvoir lancer le script, il faut :
+
+- [ ] **Compte Instatus créé** sur https://instatus.com avec
+      `ops@deepsightsynthesis.com` (free plan suffit).
+- [ ] **Page créée** dans Instatus admin :
+      - Name : `DeepSight`
+      - Subdomain : `deepsight` (URL Instatus par défaut :
+        `deepsight.instatus.com`).
+      - Logo : upload `frontend/public/logo.svg`.
+      - Brand color : `#6366f1` (indigo DeepSight).
+- [ ] **Custom domain** `status.deepsightsynthesis.com` :
+      Instatus admin → Settings → Custom domain → ajouter le domaine.
+      Côté DNS Cloudflare → ajouter un `CNAME status` pointant vers
+      `stats.instatus.com`. **Activer le SSL automatique** (let's encrypt)
+      côté Instatus une fois le CNAME propagé (~5–30 min).
+- [ ] **5 components stub créés manuellement** (peuvent rester vides — le
+      script va les enrichir/recréer en idempotent) :
+      `API`, `Web`, `Mobile App`, `Extension Chrome`, `Database`.
+      (Ou laissez le script tout créer — voir §21.4.)
+
+### 21.2. Récupérer `INSTATUS_API_KEY`
+
+1. Instatus admin → User menu (top right) → **API Tokens**.
+2. Cliquer **Create token**, nom `setup-script`, permission
+   **Manage components** (read/write).
+3. Copier la clé `ist_...` (visible une seule fois).
+4. Stocker dans le password manager + GitHub Actions secrets si
+   automation prévue.
+
+### 21.3. Récupérer `INSTATUS_PAGE_ID`
+
+1. Instatus admin → ouvrir la page `DeepSight`.
+2. Regarder l'URL : `https://dashboard.instatus.com/pages/{PAGE_ID}`.
+3. Le segment après `/pages/` est l'ID. Le copier dans les secrets/env.
+
+### 21.4. Run du script de setup
+
+```bash
+# Étape 1 — show config (aucun appel réseau, sanity check de la config locale)
+python backend/scripts/setup_instatus_components.py --show-config
+
+# Étape 2 — dry-run (besoin OPTIONNEL des credentials pour comparer au remote ;
+# sans credentials, la commande affiche simplement "would POST" pour les 5)
+INSTATUS_API_KEY=ist_xxx INSTATUS_PAGE_ID=abcd1234 \
+    python backend/scripts/setup_instatus_components.py --dry-run
+
+# Étape 3 — apply (création/mise à jour idempotente)
+INSTATUS_API_KEY=ist_xxx INSTATUS_PAGE_ID=abcd1234 \
+    python backend/scripts/setup_instatus_components.py --apply
+```
+
+Codes de sortie :
+
+| Code | Signification                                                       |
+| ---- | ------------------------------------------------------------------- |
+| 0    | OK (tous les composants créés/à jour ou rien à faire)               |
+| 1    | Variables d'environnement manquantes                                |
+| 2    | Plus de 5 composants définis (free tier max — éditer le config.py)  |
+| 3    | Échec de l'appel `GET /components` (clé invalide ou page inexistante) |
+| 4    | Au moins un composant a échoué (PUT/POST) — relire la table         |
+
+Le script peut être ré-exécuté à volonté : il match les composants par
+`name` et applique uniquement les diffs.
+
+### 21.5. Subscriptions (Instatus admin)
+
+- **Email** : `Subscribers → Email → Enable opt-in form`. Les visiteurs
+  de la status page peuvent s'abonner sans compte. RGPD : opt-in
+  explicite, désinscription un clic.
+- **Telegram (via webhook)** : `Subscribers → Webhook → Add webhook` →
+  URL :
+  `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=${TELEGRAM_CHAT_ID}&text=`.
+  Format JSON : Instatus envoie `{ event, page, incident, components }`.
+  Pour parser proprement, intercaler un bridge léger (Cloudflare Worker
+  ou route Next API) qui formate avant de POST sur l'API Telegram.
+  Tokens à réutiliser : secrets GitHub `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`.
+- **Slack-compatible webhook** (générique) : pour intégrations futures
+  (Discord, MS Teams, etc.) — utiliser le format Slack-compatible payload
+  proposé par Instatus.
+
+### 21.6. Poster un incident manuellement
+
+Instatus admin → **Incidents** → **New incident** :
+
+1. Title (court, en français côté public — ex. « Lenteurs API »)
+2. Affected components (cocher les bons, ex. `API` + `Database`)
+3. Status initial : `INVESTIGATING`
+4. Message public (markdown supporté) — toujours dater + signer
+5. Notify subscribers : ON
+6. Update status au fur et à mesure : `IDENTIFIED` → `MONITORING` → `RESOLVED`
+
+### 21.7. Automatisation future (hors scope ce PR)
+
+- **Sentry → Instatus auto-incident** : configurer une Sentry alert
+  rule → webhook → endpoint Instatus
+  `POST https://api.instatus.com/v1/{page-id}/incidents` quand un seuil
+  d'erreurs est dépassé (ex. > 50 erreurs/5 min sur le router `videos`).
+  Nécessite un bridge (Cloudflare Worker) pour adapter le payload Sentry
+  au schéma Instatus.
+- **UptimeRobot → Instatus** : Instatus supporte un webhook entrant
+  natif (à activer dans `Components → Connect monitor`). Parking pour
+  plus tard si on veut éviter de payer le tier Instatus monitors.
+
+### 21.8. Embed dans `frontend/src/pages/StatusPage.tsx`
+
+La section `<InstatusSection />` fait un `fetch('/summary.json')` sur
+le custom domain (pas d'auth, pas de token). Trois états :
+
+| État          | Affichage                                                              |
+| ------------- | ---------------------------------------------------------------------- |
+| `loading`     | Skeleton glassmorphism (4 cards)                                       |
+| `ready`       | Banner global + cards composants + liste incidents actifs              |
+| `unavailable` | Message FR : « Statut externe en cours de configuration. »             |
+
+Le fallback graceful permet de merger ce PR **avant** que la status
+page externe ne soit configurée — l'UI ne casse pas, elle invite juste
+à finaliser le setup.
+
+### 21.9. Troubleshooting
+
+| Symptom                                       | Fix                                                                                                                  |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `CNAME` ne propage pas (commande `dig` vide)  | Attendre 5–30 min. Si > 1h, vérifier que le record Cloudflare est sur **DNS only** (pas proxy) au moins pour validation initiale. |
+| SSL Instatus en `Pending` après 24h          | Désactiver puis réactiver le custom domain dans Instatus admin. Vérifier que le proxy Cloudflare est désactivé pour ce CNAME. |
+| Script renvoie code 3 (`GET /components` KO) | Clé `INSTATUS_API_KEY` invalide ou révoquée. Régénérer dans admin → API Tokens.                                       |
+| Script renvoie code 2 (> 5 composants)       | Free tier limit. Soit retirer un composant de `instatus_components_config.py`, soit upgrader Instatus.                |
+| `<InstatusSection />` reste en `unavailable` | Vérifier que `https://status.deepsightsynthesis.com/summary.json` répond en JSON public. CORS doit être ouvert (Instatus le fait par défaut). |
+| Subscribers Telegram ne reçoivent rien       | Tester le webhook Instatus → Telegram avec curl. Vérifier que le bot Telegram a bien le droit de poster dans le chat. |

--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -2,6 +2,11 @@
  * Page de statut interne — accessible aux utilisateurs connectés.
  * Appelle le proxy Vercel /api/status (deep health check) toutes les 60s.
  * Fallback public /api/health/status si le proxy échoue.
+ *
+ * Section "Live status (Instatus)" en bas : fetch le summary.json public
+ * de la status page externe https://status.deepsightsynthesis.com et
+ * affiche les composants en cards cohérentes avec le design DeepSight.
+ * Fallback gracieux si Instatus pas encore configuré.
  */
 
 import { useEffect, useState, useCallback, useRef } from "react";
@@ -20,6 +25,8 @@ import {
   Mail,
   HardDrive,
   Cpu,
+  ExternalLink,
+  Globe,
 } from "lucide-react";
 import {
   statusApi,
@@ -34,6 +41,89 @@ import DoodleBackground from "../components/DoodleBackground";
 // ───────────────────────────────────────────────────────────────────────────
 
 const POLL_INTERVAL = 60; // seconds
+
+// ───────────────────────────────────────────────────────────────────────────
+// Instatus public summary endpoint (no auth required, served by status page
+// custom domain). Format documenté : https://instatus.com/help/api
+// ───────────────────────────────────────────────────────────────────────────
+
+const INSTATUS_SUMMARY_URL =
+  "https://status.deepsightsynthesis.com/summary.json";
+const INSTATUS_PUBLIC_URL = "https://status.deepsightsynthesis.com";
+
+type InstatusComponentStatus =
+  | "OPERATIONAL"
+  | "UNDERMAINTENANCE"
+  | "DEGRADEDPERFORMANCE"
+  | "PARTIALOUTAGE"
+  | "MAJOROUTAGE";
+
+type InstatusPageStatus =
+  | "UP"
+  | "HASISSUES"
+  | "UNDERMAINTENANCE"
+  | "DOWN";
+
+interface InstatusComponent {
+  id: string;
+  name: string;
+  status: InstatusComponentStatus;
+  showcase?: boolean;
+  group?: { id: string; name: string } | null;
+}
+
+interface InstatusSummary {
+  page: { name: string; url: string; status: InstatusPageStatus };
+  activeIncidents: ReadonlyArray<{ id: string; name: string; status: string }>;
+  components: ReadonlyArray<InstatusComponent>;
+  activeMaintenances: ReadonlyArray<{ id: string; name: string }>;
+}
+
+function instatusStatusColor(status: InstatusComponentStatus): string {
+  switch (status) {
+    case "OPERATIONAL":
+      return "var(--status-success, #10b981)";
+    case "UNDERMAINTENANCE":
+    case "DEGRADEDPERFORMANCE":
+      return "var(--status-warning, #f59e0b)";
+    case "PARTIALOUTAGE":
+    case "MAJOROUTAGE":
+    default:
+      return "var(--status-error, #ef4444)";
+  }
+}
+
+function instatusStatusLabel(status: InstatusComponentStatus): string {
+  switch (status) {
+    case "OPERATIONAL":
+      return "Opérationnel";
+    case "UNDERMAINTENANCE":
+      return "En maintenance";
+    case "DEGRADEDPERFORMANCE":
+      return "Performances dégradées";
+    case "PARTIALOUTAGE":
+      return "Panne partielle";
+    case "MAJOROUTAGE":
+      return "Panne majeure";
+    default:
+      return "Inconnu";
+  }
+}
+
+function instatusPageLabel(status: InstatusPageStatus): string {
+  switch (status) {
+    case "UP":
+      return "Tous les services sont opérationnels";
+    case "HASISSUES":
+      return "Incident en cours";
+    case "UNDERMAINTENANCE":
+      return "Maintenance planifiée";
+    case "DOWN":
+      return "Service indisponible";
+    default:
+      return "Statut inconnu";
+  }
+}
 
 const SERVICE_META: Record<
   string,
@@ -124,6 +214,215 @@ function statusLabel(status: string): string {
   if (status === "operational") return "Op\u00e9rationnel";
   if (status === "degraded") return "D\u00e9grad\u00e9";
   return "Hors service";
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Instatus section — fetch public summary.json + render in DeepSight design
+// ───────────────────────────────────────────────────────────────────────────
+
+function InstatusSection() {
+  const [summary, setSummary] = useState<InstatusSummary | null>(null);
+  const [state, setState] = useState<"loading" | "ready" | "unavailable">(
+    "loading",
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+
+    (async () => {
+      try {
+        const resp = await fetch(INSTATUS_SUMMARY_URL, {
+          signal: controller.signal,
+          // No credentials — public endpoint
+          mode: "cors",
+        });
+        if (!resp.ok) {
+          if (!cancelled) setState("unavailable");
+          return;
+        }
+        const json = (await resp.json()) as InstatusSummary;
+        if (cancelled) return;
+        // Sanity check : si la forme attendue n'est pas là, fallback gracieux
+        if (!json || typeof json !== "object" || !Array.isArray(json.components)) {
+          setState("unavailable");
+          return;
+        }
+        setSummary(json);
+        setState("ready");
+      } catch {
+        if (!cancelled) setState("unavailable");
+      } finally {
+        clearTimeout(timeout);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  // Header commun à tous les états (loading/ready/unavailable)
+  const header = (
+    <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center gap-2">
+        <Globe size={18} style={{ color: "var(--accent-primary, #6366f1)" }} />
+        <h2 className="text-lg font-semibold">Statut public (Instatus)</h2>
+      </div>
+      <a
+        href={INSTATUS_PUBLIC_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 text-xs text-[var(--text-tertiary,#6b6b80)] hover:text-[var(--accent-primary,#6366f1)] transition-colors"
+      >
+        Page complète
+        <ExternalLink size={12} />
+      </a>
+    </div>
+  );
+
+  if (state === "loading") {
+    return (
+      <section aria-label="Statut Instatus" className="space-y-2">
+        {header}
+        <div className="rounded-xl p-5 border border-[var(--border-subtle,#ffffff0d)] bg-[var(--bg-secondary,#111118)]">
+          <div className="animate-pulse space-y-3">
+            <div className="h-4 w-48 rounded bg-[var(--bg-tertiary,#1a1a24)]" />
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {[1, 2, 3, 4].map((i) => (
+                <div
+                  key={i}
+                  className="h-14 rounded-lg bg-[var(--bg-tertiary,#1a1a24)]"
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (state === "unavailable" || !summary) {
+    return (
+      <section aria-label="Statut Instatus" className="space-y-2">
+        {header}
+        <div className="rounded-xl p-5 border border-[var(--border-subtle,#ffffff0d)] bg-[var(--bg-secondary,#111118)] text-center">
+          <p className="text-sm text-[var(--text-secondary,#a1a1b5)]">
+            Statut externe en cours de configuration.
+          </p>
+          <p className="text-xs text-[var(--text-tertiary,#6b6b80)] mt-1">
+            La page publique sera bientôt disponible sur{" "}
+            <code className="text-[var(--accent-primary,#6366f1)]">
+              status.deepsightsynthesis.com
+            </code>
+            .
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const showcaseComponents = summary.components.filter(
+    (c) => c.showcase !== false,
+  );
+  const pageColor =
+    summary.page.status === "UP"
+      ? "var(--status-success, #10b981)"
+      : summary.page.status === "UNDERMAINTENANCE"
+        ? "var(--status-warning, #f59e0b)"
+        : "var(--status-error, #ef4444)";
+
+  return (
+    <section aria-label="Statut Instatus" className="space-y-2">
+      {header}
+
+      {/* Status global Instatus */}
+      <div
+        className="rounded-xl p-5 border"
+        style={{
+          borderColor: `${pageColor}33`,
+          background: `${pageColor}0a`,
+        }}
+      >
+        <div className="flex items-center gap-2 mb-4">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full"
+            style={{ backgroundColor: pageColor }}
+            aria-hidden="true"
+          />
+          <span
+            className="text-sm font-medium"
+            style={{ color: pageColor }}
+          >
+            {instatusPageLabel(summary.page.status)}
+          </span>
+          {summary.activeIncidents.length > 0 && (
+            <span className="ml-auto text-xs text-[var(--text-tertiary,#6b6b80)]">
+              {summary.activeIncidents.length} incident
+              {summary.activeIncidents.length > 1 ? "s" : ""} actif
+              {summary.activeIncidents.length > 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+
+        {/* Cards composants */}
+        {showcaseComponents.length === 0 ? (
+          <p className="text-xs text-[var(--text-tertiary,#6b6b80)]">
+            Aucun composant configuré.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {showcaseComponents.map((c) => {
+              const color = instatusStatusColor(c.status);
+              return (
+                <div
+                  key={c.id}
+                  className="rounded-lg px-3 py-2.5 border border-[var(--border-subtle,#ffffff0d)] bg-[var(--bg-tertiary,#1a1a24)]/40 flex items-center justify-between"
+                >
+                  <div className="min-w-0 flex-1 mr-2">
+                    <p className="text-sm font-medium truncate">{c.name}</p>
+                    {c.group && (
+                      <p className="text-xs text-[var(--text-tertiary,#6b6b80)] truncate">
+                        {c.group.name}
+                      </p>
+                    )}
+                  </div>
+                  <span
+                    className="text-xs font-medium tabular-nums shrink-0"
+                    style={{ color }}
+                  >
+                    {instatusStatusLabel(c.status)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Incidents actifs */}
+      {summary.activeIncidents.length > 0 && (
+        <div className="rounded-xl p-4 border border-[var(--status-error,#ef4444)]/30 bg-[var(--status-error,#ef4444)]/5">
+          <h3 className="text-sm font-semibold text-[var(--status-error,#ef4444)] mb-2">
+            Incidents en cours
+          </h3>
+          <ul className="space-y-1">
+            {summary.activeIncidents.map((inc) => (
+              <li
+                key={inc.id}
+                className="text-xs text-[var(--text-secondary,#a1a1b5)]"
+              >
+                {inc.name}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -382,6 +681,9 @@ export default function StatusPage() {
             );
           })}
         </div>
+
+        {/* Live status (Instatus) — section additive, pas de breaking change */}
+        <InstatusSection />
 
         {/* Footer */}
         <div className="text-center text-xs text-[var(--text-muted,#45455a)] space-y-1 pt-4">


### PR DESCRIPTION
## Summary

Sprint **Growth & UX — chantier A** : status page publique sur
`status.deepsightsynthesis.com` via **Instatus** (free tier — 5
components, custom domain, embed widget, email + Telegram subscriptions).

## Changes

### Backend — script idempotent
- **`backend/scripts/instatus_components_config.py`** : dataclass des 5
  composants (API, Web, Mobile App, Extension Chrome, Database). Clé
  d'idempotence = `name` unique. Free tier guard.
- **`backend/scripts/setup_instatus_components.py`** : script CLI argparse.
  Modes mutuellement exclusifs `--show-config` / `--dry-run` / `--apply`.
  Match par nom côté Instatus, PUT si diff, POST sinon, skip si à jour.
  Output table ASCII portable (PowerShell + bash + CI). Codes de sortie
  granulaires (1=env manquant, 2=>5 composants, 3=API key KO, 4=erreurs
  partielles).

### Frontend — embed additif
- **`frontend/src/pages/StatusPage.tsx`** : nouveau composant
  `<InstatusSection />` ajouté entre les service cards et le footer.
  **Zéro breaking change** sur la page existante. Fetch
  `https://status.deepsightsynthesis.com/summary.json` (endpoint Instatus
  public, pas d'auth, pas de SDK). Trois états :
  - `loading` → skeleton glassmorphism (4 cards)
  - `ready` → banner global + cards composants + liste incidents actifs
  - `unavailable` → fallback FR « Statut externe en cours de configuration »
  
  TypeScript strict, types Instatus dédiés (`InstatusComponentStatus`,
  `InstatusPageStatus`, `InstatusSummary`), zéro `any`.

### Doc
- **`docs/RUNBOOK.md` §21 (nouvelle section)** :
  pre-setup checklist (compte Instatus + page + custom domain CNAME via
  Cloudflare), récup `INSTATUS_API_KEY` (Settings → API Tokens) +
  `INSTATUS_PAGE_ID` (URL admin), runs `--show-config` / `--dry-run` /
  `--apply`, codes de sortie, subscriptions email + Telegram webhook
  (réutilise `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` GitHub secrets),
  procédure incident manuel, automation future (Sentry → Instatus —
  hors scope ce PR), troubleshooting CNAME/SSL/CORS.

## Procédure de déploiement (action user post-merge)

1. Créer le compte Instatus + la page `DeepSight` (5 composants stub)
2. CNAME Cloudflare : `status` → `stats.instatus.com` (DNS only)
3. Activer SSL custom domain dans Instatus admin (~5–30 min)
4. Récupérer `INSTATUS_API_KEY` + `INSTATUS_PAGE_ID`
5. Runner `python backend/scripts/setup_instatus_components.py --apply`
6. Activer Email subscriptions + Telegram webhook subscriptions
7. Vérifier que `<InstatusSection />` passe de `unavailable` à `ready`
   sur `/status`

## Secrets à set

- `INSTATUS_API_KEY` : token Bearer Instatus (manage components)
- `INSTATUS_PAGE_ID` : ID de la page admin Instatus

## Caveats / risques connus

- **Free tier 5 components max** — tout ajout futur déclenche le code
  de sortie 2 du script. Si besoin, upgrader le plan ou retirer un
  composant moins critique.
- **CNAME SSL delay** : 5–30 min minimum. Si > 1h, désactiver le proxy
  Cloudflare temporairement (DNS only) le temps de la validation Let's
  Encrypt.
- **CORS public summary.json** : Instatus l'autorise par défaut. Si
  jamais bloqué, `<InstatusSection />` tombe gracieusement en
  `unavailable`.
- **Mobile App + Extension Chrome** : pas d'endpoint health direct →
  status maintenu manuellement ou via webhook depuis CI (futur).
- **Pas d'`entrypoint.sh` Hetzner** → ce script tourne en local ou en
  CI, pas en bootstrap container.

## Test plan

- [x] `python backend/scripts/setup_instatus_components.py --show-config` → output OK (5/5 composants)
- [x] `python backend/scripts/setup_instatus_components.py --dry-run` → table dryrun OK
- [x] AST parse OK sur les 2 scripts Python
- [x] `cd frontend && npx tsc --noEmit -p tsconfig.app.json` → 156 erreurs pré-existantes inchangées, **zéro nouvelle erreur sur StatusPage.tsx**
- [ ] Manual : visit `/status` post-déploiement, vérifier que la section Instatus apparaît en `unavailable` (pre-setup) puis en `ready` (post-setup)
- [ ] Manual : poster un incident test depuis l'admin Instatus, vérifier qu'il s'affiche dans la section frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)