### PR TITLE
fix(miro): set sharingPolicy.access=view so board is embeddable on Personal Starter

### DIFF
--- a/backend/src/debate/miro_service.py
+++ b/backend/src/debate/miro_service.py
@@ -178,10 +178,11 @@ async def generate_debate_board(
 
     async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
         # ─── 1. Create board ─────────────────────────────────────────────
-        # Policy options omitted: `permissionsPolicy.sharingAccess` and
-        # `sharingPolicy.organizationAccess`/`teamAccess` require Miro Team
-        # plan and produce 403 4.0602 on Personal Starter accounts. Miro
-        # applies sensible defaults when policy is absent.
+        # `sharingPolicy.access: "view"` makes the board readable via its
+        # viewLink (required for the embed iframe). Other policy options
+        # (`permissionsPolicy.sharingAccess`, `organizationAccess`,
+        # `teamAccess`) require Miro Team plan and produce 403 4.0602 on
+        # Personal Starter — keep them out so default policy applies.
         # Cf. https://developers.miro.com/reference/create-board
         board_body = {
             "name": board_name,
@@ -189,6 +190,9 @@ async def generate_debate_board(
                 f"Débat IA généré par DeepSight — {topic}. "
                 f"Comparaison automatique entre {len(perspectives) + 1} vidéos."
             )[:500],
+            "policy": {
+                "sharingPolicy": {"access": "view"},
+            },
         }
         board = await _miro_post(client, "/boards", token, board_body)
         board_id: str = str(board.get("id") or "")
@@ -383,13 +387,17 @@ async def create_hub_workspace_board(
         # ─── 1. Create board ──────────────────────────────────────────────
         # Policy options omitted: `permissionsPolicy.sharingAccess` and
         # `sharingPolicy.organizationAccess`/`teamAccess` require Miro Team
-        # plan and produce 403 4.0602 on Personal Starter accounts. Miro
-        # applies sensible defaults when policy is absent.
+        # plan and produce 403 4.0602 on Personal Starter accounts. Adding
+        # `sharingPolicy.access: "view"` is necessary so the embed iframe
+        # can load the board (defaults to "private" otherwise).
         board_body = {
             "name": safe_name,
             "description": (
                 f"DeepSight Hub Workspace — {len(summaries)} analyses"
             )[:500],
+            "policy": {
+                "sharingPolicy": {"access": "view"},
+            },
         }
         board = await _miro_post(client, "/boards", token, board_body)
         board_id: str = str(board.get("id") or "")


### PR DESCRIPTION
## Symptôme

After PR #353 (which dropped policy entirely), Hub Workspace status reaches `ready` (board created OK) but the **embed iframe is blocked** by Miro with *"Ce contenu est bloqué"*. Cause: omitting policy makes Miro default to `sharingPolicy.access: "private"`, so the public embed URL can't load the board.

## Fix

Add a minimal `policy.sharingPolicy: {access: "view"}` to both create_hub_workspace_board and generate_debate_board. Verified directly via curl on the prod token:
- `{name, policy:{sharingPolicy:{access:"view"}}}` → 201 OK ✅ (compatible Personal Starter)
- The other team-only options (organizationAccess, teamAccess, permissionsPolicy.sharingAccess) remain absent → no 4.0602.

This makes the board readable via its viewLink, which is what `MiroBoardEmbed` uses for the iframe.

## No tests touched

Existing tests mock the Miro API; payload shape change isn't covered by assertions.