### PR TITLE
feat(hub): native HTML canvas replacing Miro embed (pivot 2026-05-06)

### DIFF
--- a/backend/alembic/versions/021_hub_workspace_canvas_data.py
+++ b/backend/alembic/versions/021_hub_workspace_canvas_data.py
@@ -1,0 +1,65 @@
+"""hub_workspace_canvas_data — pivot Hub vers rendu natif (DebateConvergenceDivergence-inspired)
+
+Revision ID: 021_hub_workspace_canvas_data
+Revises: 020_add_email_dlq
+Create Date: 2026-05-06
+
+Pivot Hub Workspace MVP : on abandonne l'embed Miro iframe (limitation plan
+Personal Starter $8/mo : pas d'embed iframe externe) pour un rendu HTML/React
+natif inspiré du composant DebateConvergenceDivergence (style apprécié par
+l'utilisateur sur la feature Débat IA).
+
+Ajoute la colonne `canvas_data JSON NULL` à `hub_workspaces`. Stocke un dict
+issu de Mistral :
+    {
+      "shared_concepts": [str, ...],
+      "themes": [
+        {"theme": str, "perspectives": [{"summary_id": int, "excerpt": str}, ...]},
+        ...
+      ]
+    }
+
+NULL = workspace pré-pivot ou Mistral fail → fallback sur MiroBoardEmbed côté
+frontend (rétro-compat workspaces existants).
+
+Idempotente : check si la colonne existe avant ALTER TABLE.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "021_hub_workspace_canvas_data"
+down_revision: Union[str, None] = "020_add_email_dlq"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "hub_workspaces" not in inspector.get_table_names():
+        # Pas de table → migration 018 pas appliquée ; nothing to do.
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("hub_workspaces")}
+    if "canvas_data" not in columns:
+        op.add_column(
+            "hub_workspaces",
+            sa.Column("canvas_data", sa.JSON(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "hub_workspaces" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("hub_workspaces")}
+    if "canvas_data" in columns:
+        op.drop_column("hub_workspaces", "canvas_data")

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -1566,6 +1566,14 @@ class HubWorkspace(Base):
     )
     error_message = Column(Text, nullable=True)
 
+    # Canvas natif (pivot 2026-05-06) — rendu HTML/React inspiré de
+    # DebateConvergenceDivergence remplaçant l'embed Miro iframe.
+    # Forme : {"shared_concepts": [...], "themes": [{"theme": str,
+    # "perspectives": [{"summary_id": int, "excerpt": str}, ...]}]}
+    # NULL = workspace pré-pivot ou Mistral fail → fallback MiroBoardEmbed.
+    # Migration : alembic 021_hub_workspace_canvas_data.py.
+    canvas_data = Column(JSON, nullable=True)
+
     # Timestamps
     created_at = Column(
         DateTime, default=func.now(), server_default=func.now(), nullable=False, index=True

--- a/backend/src/hub/canvas_service.py
+++ b/backend/src/hub/canvas_service.py
@@ -1,0 +1,290 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎨 HUB CANVAS SERVICE — extraction Mistral pour rendu natif Workspace            ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Pivot 2026-05-06 : remplace l'embed Miro iframe (limitation plan Personal         ║
+║  Starter $8/mo) par un rendu HTML/React natif inspiré du composant                 ║
+║  DebateConvergenceDivergence.                                                      ║
+║                                                                                    ║
+║  Génère, pour un workspace de N analyses (2 ≤ N ≤ 20) :                            ║
+║    - shared_concepts : liste de concepts partagés par 2+ analyses                  ║
+║    - themes : sections thématiques, chacune avec 1 extrait par analyse pertinente  ║
+║                                                                                    ║
+║  Mistral via core.llm_provider.llm_complete (json_mode=True). Modèle :             ║
+║  mistral-large-2512 (plan Expert only, 262K context). Best-effort : si Mistral     ║
+║  fail ou JSON invalide → retourne None et le frontend bascule sur MiroBoardEmbed   ║
+║  (rétro-compat).                                                                   ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from core.llm_provider import llm_complete
+from db.database import Summary
+
+
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Modèle Mistral utilisé pour l'extraction (Expert plan only, 262K context).
+CANVAS_MODEL = "mistral-large-2512"
+
+# Tronque chaque extrait de summary à cette longueur pour rester sous la limite
+# de tokens (mistral-large-2512 = 262K context, mais on vise <= 50K input pour
+# rester économique et rapide).
+MAX_CHARS_PER_SUMMARY = 6000
+
+# Max tokens pour la réponse JSON Mistral.
+MAX_RESPONSE_TOKENS = 4096
+
+# Retry max si parsing JSON échoue.
+MAX_RETRIES = 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _build_summary_excerpt(summary: Summary) -> str:
+    """Retourne un extrait textuel exploitable pour l'analyse Mistral.
+
+    Priorité : full_digest (assembled hierarchical digest, ~6-10K chars) >
+    summary_content (analysis raw).
+    """
+    text = (summary.full_digest or summary.summary_content or "").strip()
+    if not text:
+        return ""
+    if len(text) > MAX_CHARS_PER_SUMMARY:
+        return text[:MAX_CHARS_PER_SUMMARY] + "…"
+    return text
+
+
+def _build_messages(
+    summaries: list[Summary], workspace_name: str
+) -> list[dict[str, str]]:
+    """Construit les messages system+user pour Mistral.
+
+    Le prompt demande explicitement le format JSON cible (shared_concepts +
+    themes avec perspectives par summary_id).
+    """
+    summaries_block_lines: list[str] = []
+    for s in summaries:
+        excerpt = _build_summary_excerpt(s)
+        if not excerpt:
+            continue
+        summaries_block_lines.append(
+            f"=== ANALYSE #{s.id} — {s.video_title or 'Sans titre'} ===\n"
+            f"Chaîne : {s.video_channel or 'Inconnue'}\n"
+            f"Extrait :\n{excerpt}\n"
+        )
+    summaries_block = "\n".join(summaries_block_lines)
+
+    summary_ids = [s.id for s in summaries]
+
+    system_prompt = (
+        "Tu es un analyste expert en synthèse transversale de contenus vidéo. "
+        "On te fournit N analyses de vidéos sélectionnées par l'utilisateur "
+        "pour un workspace transversal. Ton rôle : extraire (1) les concepts "
+        "partagés par au moins 2 analyses, et (2) regrouper les perspectives "
+        "complémentaires en thématiques avec un extrait spécifique par "
+        "analyse pertinente.\n\n"
+        "Réponds UNIQUEMENT en JSON valide, sans texte avant ni après, "
+        "avec EXACTEMENT ce format :\n"
+        "{\n"
+        '  "shared_concepts": ["concept partagé 1", "concept partagé 2", ...],\n'
+        '  "themes": [\n'
+        '    {\n'
+        '      "theme": "Titre court de la thématique",\n'
+        '      "perspectives": [\n'
+        '        {"summary_id": <int>, "excerpt": "Ce que cette analyse apporte sur ce thème (1-2 phrases)"},\n'
+        '        ...\n'
+        '      ]\n'
+        '    },\n'
+        '    ...\n'
+        '  ]\n'
+        "}\n\n"
+        "Règles strictes :\n"
+        f"- summary_id ∈ {summary_ids} (uniquement les IDs fournis, en int).\n"
+        "- shared_concepts : 3 à 8 concepts max, chacun en 2-6 mots.\n"
+        "- themes : 2 à 6 thématiques max, distinctes des shared_concepts.\n"
+        "- Chaque thème doit contenir 2 à N perspectives (au moins 2 analyses pertinentes).\n"
+        "- excerpt : 1 à 2 phrases factuelles, en français, fidèles au contenu de l'analyse.\n"
+        "- Si une analyse ne traite pas du thème, NE PAS l'inclure dans perspectives.\n"
+        "- Pas de markdown, pas de listes à puces dans excerpt — juste du texte brut."
+    )
+
+    user_content = (
+        f"WORKSPACE : {workspace_name}\n"
+        f"NOMBRE D'ANALYSES : {len(summaries)}\n\n"
+        f"{summaries_block}"
+    )
+
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_content},
+    ]
+
+
+def _validate_canvas_shape(
+    data: Any, valid_summary_ids: set[int]
+) -> Optional[dict[str, Any]]:
+    """Valide la forme du JSON retourné par Mistral.
+
+    Retourne le dict normalisé si OK, None sinon.
+    """
+    if not isinstance(data, dict):
+        return None
+
+    shared_concepts_raw = data.get("shared_concepts")
+    themes_raw = data.get("themes")
+
+    if not isinstance(shared_concepts_raw, list) or not isinstance(themes_raw, list):
+        return None
+
+    # Normalise shared_concepts : str only, dédup case-insensitive,
+    # cap at 8 items.
+    shared_concepts: list[str] = []
+    seen_lower: set[str] = set()
+    for item in shared_concepts_raw:
+        if not isinstance(item, str):
+            continue
+        cleaned = item.strip()
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key in seen_lower:
+            continue
+        seen_lower.add(key)
+        shared_concepts.append(cleaned)
+        if len(shared_concepts) >= 8:
+            break
+
+    # Normalise themes.
+    themes: list[dict[str, Any]] = []
+    for theme_raw in themes_raw:
+        if not isinstance(theme_raw, dict):
+            continue
+        theme_title = theme_raw.get("theme")
+        perspectives_raw = theme_raw.get("perspectives")
+        if not isinstance(theme_title, str) or not theme_title.strip():
+            continue
+        if not isinstance(perspectives_raw, list):
+            continue
+        perspectives: list[dict[str, Any]] = []
+        seen_summary_ids_in_theme: set[int] = set()
+        for p in perspectives_raw:
+            if not isinstance(p, dict):
+                continue
+            sid = p.get("summary_id")
+            excerpt = p.get("excerpt")
+            if not isinstance(sid, int) or sid not in valid_summary_ids:
+                continue
+            if sid in seen_summary_ids_in_theme:
+                continue
+            if not isinstance(excerpt, str) or not excerpt.strip():
+                continue
+            seen_summary_ids_in_theme.add(sid)
+            perspectives.append({"summary_id": sid, "excerpt": excerpt.strip()})
+        if len(perspectives) < 2:
+            # On garde la règle "≥ 2 perspectives par thème" pour avoir un
+            # vrai contraste à l'écran. Si Mistral en propose <2, on saute.
+            continue
+        themes.append(
+            {"theme": theme_title.strip(), "perspectives": perspectives}
+        )
+        if len(themes) >= 6:
+            break
+
+    # Empty canvas = no value for the user.
+    if not shared_concepts and not themes:
+        return None
+
+    return {"shared_concepts": shared_concepts, "themes": themes}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Public API
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def generate_workspace_canvas(
+    summaries: list[Summary], workspace_name: str
+) -> Optional[dict[str, Any]]:
+    """Extrait le canvas natif (shared_concepts + themes) d'un workspace.
+
+    Best-effort : retourne None sur échec Mistral / JSON invalide après
+    `MAX_RETRIES` tentatives. Le caller sauvera None en DB → frontend
+    fallback sur MiroBoardEmbed (rétro-compat workspaces pré-pivot).
+
+    Args:
+        summaries: liste de Summary (2 à 20 items, ordre préservé).
+        workspace_name: nom du workspace (sert de contexte au prompt).
+
+    Returns:
+        dict {"shared_concepts": [...], "themes": [...]} ou None.
+    """
+    if not summaries:
+        logger.warning("[HUB-CANVAS] generate_workspace_canvas called with no summaries")
+        return None
+
+    valid_summary_ids = {s.id for s in summaries}
+    messages = _build_messages(summaries, workspace_name)
+
+    canvas_data: Optional[dict[str, Any]] = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        result = await llm_complete(
+            messages=messages,
+            model=CANVAS_MODEL,
+            max_tokens=MAX_RESPONSE_TOKENS,
+            temperature=0.3,
+            json_mode=True,
+        )
+        if result is None or not result.content:
+            logger.warning(
+                "[HUB-CANVAS] llm_complete returned empty (attempt %d/%d)",
+                attempt,
+                MAX_RETRIES,
+            )
+            continue
+
+        try:
+            parsed = json.loads(result.content)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "[HUB-CANVAS] JSON decode error attempt %d/%d: %s — first 400 chars: %s",
+                attempt,
+                MAX_RETRIES,
+                exc,
+                (result.content or "")[:400],
+            )
+            continue
+
+        validated = _validate_canvas_shape(parsed, valid_summary_ids)
+        if validated is None:
+            logger.warning(
+                "[HUB-CANVAS] Canvas shape validation failed (attempt %d/%d)",
+                attempt,
+                MAX_RETRIES,
+            )
+            continue
+
+        canvas_data = validated
+        logger.info(
+            "[HUB-CANVAS] Canvas generated OK on attempt %d "
+            "(shared=%d, themes=%d)",
+            attempt,
+            len(validated["shared_concepts"]),
+            len(validated["themes"]),
+        )
+        break
+
+    return canvas_data

--- a/backend/src/hub/schemas.py
+++ b/backend/src/hub/schemas.py
@@ -9,7 +9,7 @@ Spec : docs/superpowers/specs/2026-05-05-hub-miro-workspace-mvp.md
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -76,8 +76,38 @@ class HubWorkspaceCreate(BaseModel):
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+class CanvasPerspective(BaseModel):
+    """Une perspective dans une thématique du canvas natif (Hub Workspace)."""
+
+    summary_id: int
+    excerpt: str
+
+
+class CanvasTheme(BaseModel):
+    """Une thématique du canvas natif, regroupant N perspectives par analyse."""
+
+    theme: str
+    perspectives: list[CanvasPerspective]
+
+
+class WorkspaceCanvasData(BaseModel):
+    """Canvas natif Hub Workspace (pivot 2026-05-06).
+
+    Forme stockée dans `hub_workspaces.canvas_data` (JSON nullable).
+    NULL = workspace pré-pivot ou Mistral fail → frontend fallback MiroBoardEmbed.
+    """
+
+    shared_concepts: list[str]
+    themes: list[CanvasTheme]
+
+
 class HubWorkspaceResponse(BaseModel):
-    """Représentation d'un workspace Miro renvoyée par l'API."""
+    """Représentation d'un workspace renvoyée par l'API.
+
+    `canvas_data` (pivot 2026-05-06) est populé en background après création
+    du board Miro pour les nouveaux workspaces. NULL pour workspaces
+    pré-pivot → frontend bascule sur MiroBoardEmbed.
+    """
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -89,6 +119,7 @@ class HubWorkspaceResponse(BaseModel):
     miro_board_url: Optional[str] = None
     status: str  # pending | creating | ready | failed
     error_message: Optional[str] = None
+    canvas_data: Optional[dict[str, Any]] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/src/hub/service.py
+++ b/backend/src/hub/service.py
@@ -345,17 +345,52 @@ async def _create_miro_board_async(workspace_id: int) -> None:
                 )
                 return
 
-            # 5. status='ready'
+            # 5. Persiste les infos Miro mais on garde status='creating'
+            # tant que le canvas natif n'est pas tenté → le polling frontend
+            # continue jusqu'à voir status='ready' avec canvas_data populé
+            # (ou null sur fail Mistral).
             workspace.miro_board_id = board.get("board_id")
             workspace.miro_board_url = board.get("view_link")
-            workspace.status = "ready"
             workspace.error_message = None
             await session.commit()
 
+            # 6. Pivot 2026-05-06 : génération du canvas natif Mistral.
+            # Best-effort — si Mistral échoue, canvas_data reste null et le
+            # frontend bascule sur MiroBoardEmbed (rétro-compat).
+            try:
+                from .canvas_service import generate_workspace_canvas
+
+                canvas_data = await generate_workspace_canvas(
+                    summaries=ordered,
+                    workspace_name=workspace.name,
+                )
+                if canvas_data is not None:
+                    workspace.canvas_data = canvas_data
+                    logger.info(
+                        "[HUB] Canvas natif généré ws=%s themes=%d shared=%d",
+                        workspace_id,
+                        len(canvas_data.get("themes", [])),
+                        len(canvas_data.get("shared_concepts", [])),
+                    )
+                else:
+                    logger.warning(
+                        "[HUB] Canvas natif None ws=%s — fallback Miro côté front",
+                        workspace_id,
+                    )
+            except Exception:  # pragma: no cover — defensive
+                logger.exception(
+                    "[HUB] Canvas natif failed ws=%s — fallback Miro côté front",
+                    workspace_id,
+                )
+
+            # 7. status='ready' (canvas_data populé ou null) → polling stop.
+            workspace.status = "ready"
+            await session.commit()
             logger.info(
-                "[HUB] Workspace ready id=%s board=%s",
+                "[HUB] Workspace ready id=%s board=%s canvas=%s",
                 workspace_id,
                 workspace.miro_board_id,
+                "yes" if workspace.canvas_data else "no",
             )
         except Exception as exc:  # pragma: no cover — defensive
             logger.exception(

--- a/backend/tests/test_hub_canvas.py
+++ b/backend/tests/test_hub_canvas.py
@@ -1,0 +1,333 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TEST HUB CANVAS SERVICE — pivot 2026-05-06                                     ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Tests unitaires pour generate_workspace_canvas + _validate_canvas_shape.          ║
+║                                                                                    ║
+║  llm_complete est mocké (AsyncMock) pour éviter tout appel Mistral réel.           ║
+║  On vérifie : extraction JSON valide, retry sur JSON invalide, retry sur shape     ║
+║  invalide, fallback None sur Mistral down, validation summary_ids out-of-range.    ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import json
+import os
+import sys
+import pytest
+from unittest.mock import AsyncMock, patch
+
+# ── Env defaults pour import safety ───────────────────────────────────────────
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_summary(sid: int, title: str = "Vidéo", content: str = "Lorem ipsum"):
+    """Stub Summary — uniquement les attributs lus par canvas_service."""
+    from db.database import Summary
+
+    return Summary(
+        id=sid,
+        user_id=1,
+        video_id=f"vid{sid}",
+        video_title=title,
+        video_channel="Test Channel",
+        summary_content=content,
+        full_digest=f"Digest hierarchique #{sid} — {content}",
+    )
+
+
+def _llm_result(content: str):
+    """Stub minimal pour LLMResult."""
+    from core.llm_provider import LLMResult
+
+    return LLMResult(
+        content=content,
+        model_used="mistral-large-2512",
+        provider="mistral",
+        attempts=1,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _validate_canvas_shape
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_validate_canvas_shape_valid_minimal():
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "shared_concepts": ["concept A", "concept B"],
+        "themes": [
+            {
+                "theme": "Thématique X",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "Position 1"},
+                    {"summary_id": 2, "excerpt": "Position 2"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    assert out["shared_concepts"] == ["concept A", "concept B"]
+    assert len(out["themes"]) == 1
+    assert out["themes"][0]["theme"] == "Thématique X"
+    assert len(out["themes"][0]["perspectives"]) == 2
+
+
+def test_validate_canvas_shape_drops_unknown_summary_ids():
+    """Un perspective avec summary_id pas dans le workspace est éjecté."""
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "shared_concepts": ["c1"],
+        "themes": [
+            {
+                "theme": "Theme",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "OK"},
+                    {"summary_id": 99, "excerpt": "Hors-workspace"},  # rejeté
+                    {"summary_id": 2, "excerpt": "OK"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    perspectives = out["themes"][0]["perspectives"]
+    assert {p["summary_id"] for p in perspectives} == {1, 2}
+
+
+def test_validate_canvas_shape_drops_themes_with_less_than_2_perspectives():
+    """Un thème avec 1 seule perspective est skip (<2 = no contrast)."""
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "shared_concepts": ["c"],
+        "themes": [
+            {
+                "theme": "Solo",
+                "perspectives": [{"summary_id": 1, "excerpt": "Solo"}],
+            },
+            {
+                "theme": "Duo",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "A"},
+                    {"summary_id": 2, "excerpt": "B"},
+                ],
+            },
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    assert [t["theme"] for t in out["themes"]] == ["Duo"]
+
+
+def test_validate_canvas_shape_dedup_shared_concepts_case_insensitive():
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "shared_concepts": ["IA", "ia", " IA ", "Mistral", "MISTRAL"],
+        "themes": [
+            {
+                "theme": "T",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "A"},
+                    {"summary_id": 2, "excerpt": "B"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    # On garde la première occurrence (en lower-case key) → "IA" et "Mistral"
+    assert out["shared_concepts"] == ["IA", "Mistral"]
+
+
+def test_validate_canvas_shape_returns_none_if_empty():
+    """Si Mistral retourne shared=[] ET themes=[] → None (no value)."""
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {"shared_concepts": [], "themes": []}
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is None
+
+
+def test_validate_canvas_shape_rejects_non_dict_input():
+    from hub.canvas_service import _validate_canvas_shape
+
+    assert _validate_canvas_shape("not a dict", {1, 2}) is None
+    assert _validate_canvas_shape([], {1, 2}) is None
+    assert _validate_canvas_shape(None, {1, 2}) is None
+
+
+def test_validate_canvas_shape_caps_themes_at_6():
+    """Limite dure à 6 thèmes pour éviter UI surcharge."""
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "shared_concepts": [],
+        "themes": [
+            {
+                "theme": f"T{i}",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "A"},
+                    {"summary_id": 2, "excerpt": "B"},
+                ],
+            }
+            for i in range(10)
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    assert len(out["themes"]) == 6
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# generate_workspace_canvas (Mistral mocked)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_generate_workspace_canvas_happy_path():
+    """Mistral renvoie un JSON valide → canvas_data populé."""
+    summaries = [_make_summary(1), _make_summary(2)]
+
+    valid_json = json.dumps(
+        {
+            "shared_concepts": ["IA française", "RGPD"],
+            "themes": [
+                {
+                    "theme": "Confidentialité",
+                    "perspectives": [
+                        {"summary_id": 1, "excerpt": "Vidéo 1 dit X"},
+                        {"summary_id": 2, "excerpt": "Vidéo 2 dit Y"},
+                    ],
+                }
+            ],
+        }
+    )
+
+    with patch(
+        "hub.canvas_service.llm_complete",
+        new_callable=AsyncMock,
+        return_value=_llm_result(valid_json),
+    ):
+        from hub.canvas_service import generate_workspace_canvas
+
+        result = await generate_workspace_canvas(summaries, "Mon workspace")
+
+    assert result is not None
+    assert result["shared_concepts"] == ["IA française", "RGPD"]
+    assert len(result["themes"]) == 1
+    assert result["themes"][0]["theme"] == "Confidentialité"
+
+
+@pytest.mark.asyncio
+async def test_generate_workspace_canvas_retries_on_invalid_json():
+    """Mistral renvoie JSON invalide en attempt 1, valide en attempt 2."""
+    summaries = [_make_summary(1), _make_summary(2)]
+
+    valid_json = json.dumps(
+        {
+            "shared_concepts": ["c"],
+            "themes": [
+                {
+                    "theme": "T",
+                    "perspectives": [
+                        {"summary_id": 1, "excerpt": "A"},
+                        {"summary_id": 2, "excerpt": "B"},
+                    ],
+                }
+            ],
+        }
+    )
+
+    mock = AsyncMock(
+        side_effect=[
+            _llm_result("not json {{{"),
+            _llm_result(valid_json),
+        ]
+    )
+
+    with patch("hub.canvas_service.llm_complete", new=mock):
+        from hub.canvas_service import generate_workspace_canvas
+
+        result = await generate_workspace_canvas(summaries, "ws")
+
+    assert result is not None
+    assert mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_workspace_canvas_returns_none_on_total_failure():
+    """Si Mistral down sur tous les retries → None."""
+    summaries = [_make_summary(1), _make_summary(2)]
+
+    with patch(
+        "hub.canvas_service.llm_complete",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        from hub.canvas_service import generate_workspace_canvas
+
+        result = await generate_workspace_canvas(summaries, "ws")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_workspace_canvas_returns_none_if_no_summaries():
+    """Aucun summary fourni → None immédiat (no Mistral call)."""
+    with patch(
+        "hub.canvas_service.llm_complete", new_callable=AsyncMock
+    ) as mock:
+        from hub.canvas_service import generate_workspace_canvas
+
+        result = await generate_workspace_canvas([], "ws")
+        assert result is None
+        mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_workspace_canvas_filters_unknown_summary_ids():
+    """Mistral hallucine summary_id=99 hors-workspace → filtré silencieusement."""
+    summaries = [_make_summary(1), _make_summary(2)]
+
+    raw_json = json.dumps(
+        {
+            "shared_concepts": ["c"],
+            "themes": [
+                {
+                    "theme": "T",
+                    "perspectives": [
+                        {"summary_id": 1, "excerpt": "OK"},
+                        {"summary_id": 99, "excerpt": "Hallu"},
+                        {"summary_id": 2, "excerpt": "OK"},
+                    ],
+                }
+            ],
+        }
+    )
+
+    with patch(
+        "hub.canvas_service.llm_complete",
+        new_callable=AsyncMock,
+        return_value=_llm_result(raw_json),
+    ):
+        from hub.canvas_service import generate_workspace_canvas
+
+        result = await generate_workspace_canvas(summaries, "ws")
+
+    assert result is not None
+    perspectives = result["themes"][0]["perspectives"]
+    assert {p["summary_id"] for p in perspectives} == {1, 2}

--- a/frontend/src/components/hub/HubWorkspaceCanvas.tsx
+++ b/frontend/src/components/hub/HubWorkspaceCanvas.tsx
@@ -1,0 +1,273 @@
+/**
+ * ╔════════════════════════════════════════════════════════════════════════════════════╗
+ * ║  🎨 HUB WORKSPACE CANVAS — rendu natif (pivot 2026-05-06)                          ║
+ * ╠════════════════════════════════════════════════════════════════════════════════════╣
+ * ║  Remplace l'embed Miro iframe par un rendu HTML/React natif inspiré du composant   ║
+ * ║  DebateConvergenceDivergence (style apprécié par l'utilisateur sur Débat IA).      ║
+ * ║                                                                                    ║
+ * ║  - canvasData absent (pré-pivot ou Mistral fail) → fallback sur MiroBoardEmbed     ║
+ * ║  - canvasData présent → 2 sections glassmorphism dark mode :                       ║
+ * ║      1. Concepts partagés (équivalent Convergence, palette emerald)                ║
+ * ║      2. Perspectives complémentaires (équivalent Divergence, indigo/violet)        ║
+ * ║                                                                                    ║
+ * ║  Composant pur prop-driven : aucun appel API, aucun state global. La section       ║
+ * ║  "Vue d'ensemble" (analyses cards) reste rendue par HubWorkspacesPage.             ║
+ * ╚════════════════════════════════════════════════════════════════════════════════════╝
+ */
+
+import React from "react";
+import { motion } from "framer-motion";
+import { Handshake, Layers, Sparkles } from "lucide-react";
+
+import { MiroBoardEmbed } from "./MiroBoardEmbed";
+import type {
+  CanvasTheme,
+  HubWorkspaceStatus,
+  WorkspaceCanvasData,
+} from "../../services/api";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SummaryPreview {
+  title: string;
+  thumbnail?: string;
+  channel?: string;
+}
+
+export interface HubWorkspaceCanvasProps {
+  /** Canvas Mistral. Null = workspace pré-pivot ou Mistral fail → fallback Miro. */
+  canvasData: WorkspaceCanvasData | null;
+  /** Titres + thumbnails des analyses pour enrichir les cards perspectives. */
+  summaryDetails: Record<number, SummaryPreview | null>;
+  /** Nom du workspace, pour aria-label. */
+  workspaceName: string;
+  // ─── Props passées à MiroBoardEmbed quand canvas_data est null ───
+  /** Miro board ID (rétro-compat workspaces pré-pivot). */
+  boardId: string | null;
+  viewLink?: string | null;
+  status: HubWorkspaceStatus;
+  errorMessage?: string | null;
+  onRetry?: () => void;
+  className?: string;
+}
+
+// ─── Animations ───────────────────────────────────────────────────────────────
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.06, delayChildren: 0.1 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+};
+
+// ─── Sub-section : Concepts partagés ───────────────────────────────────────────
+
+interface SharedConceptsSectionProps {
+  concepts: string[];
+}
+
+const SharedConceptsSection: React.FC<SharedConceptsSectionProps> = ({
+  concepts,
+}) => (
+  <div
+    className="rounded-xl bg-white/5 border border-emerald-500/20 backdrop-blur-xl p-5"
+    data-testid="hub-canvas-shared-concepts"
+  >
+    <div className="flex items-center gap-2 mb-4">
+      <div className="w-8 h-8 rounded-lg bg-emerald-500/15 flex items-center justify-center">
+        <Handshake className="w-4 h-4 text-emerald-400" aria-hidden />
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-white">Concepts partagés</h3>
+        <p className="text-xs text-text-muted">
+          Ce que plusieurs analyses ont en commun
+        </p>
+      </div>
+    </div>
+
+    <motion.ul
+      className="space-y-2"
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+    >
+      {concepts.map((concept, i) => (
+        <motion.li
+          key={`${i}-${concept}`}
+          variants={itemVariants}
+          className="flex items-start gap-2.5 rounded-lg bg-emerald-500/[0.05] border border-emerald-500/10 p-3"
+          data-testid={`hub-canvas-shared-concept-${i}`}
+        >
+          <div className="w-5 h-5 rounded-full bg-emerald-500/20 flex items-center justify-center shrink-0 mt-0.5">
+            <span className="text-emerald-400 text-[10px] font-bold">
+              {i + 1}
+            </span>
+          </div>
+          <p className="text-sm text-text-primary leading-relaxed">{concept}</p>
+        </motion.li>
+      ))}
+    </motion.ul>
+  </div>
+);
+
+// ─── Sub-section : Perspectives complémentaires ────────────────────────────────
+
+interface ThemesSectionProps {
+  themes: CanvasTheme[];
+  summaryDetails: Record<number, SummaryPreview | null>;
+}
+
+const ThemesSection: React.FC<ThemesSectionProps> = ({
+  themes,
+  summaryDetails,
+}) => (
+  <div
+    className="rounded-xl bg-white/5 border border-indigo-500/20 backdrop-blur-xl p-5"
+    data-testid="hub-canvas-themes"
+  >
+    <div className="flex items-center gap-2 mb-4">
+      <div className="w-8 h-8 rounded-lg bg-indigo-500/15 flex items-center justify-center">
+        <Layers className="w-4 h-4 text-indigo-400" aria-hidden />
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-white">
+          Perspectives complémentaires
+        </h3>
+        <p className="text-xs text-text-muted">
+          Chaque thématique vue par les analyses concernées
+        </p>
+      </div>
+    </div>
+
+    <motion.div
+      className="space-y-5"
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+    >
+      {themes.map((theme, i) => (
+        <motion.div
+          key={`${i}-${theme.theme}`}
+          variants={itemVariants}
+          className="rounded-lg bg-indigo-500/[0.05] border border-indigo-500/10 p-4 space-y-3"
+          data-testid={`hub-canvas-theme-${i}`}
+        >
+          <p className="text-xs font-semibold text-indigo-400 uppercase tracking-wider">
+            {theme.theme}
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {theme.perspectives.map((perspective, j) => {
+              const detail = summaryDetails[perspective.summary_id];
+              const fallbackTitle = `Analyse #${perspective.summary_id}`;
+              return (
+                <div
+                  key={`${i}-${j}-${perspective.summary_id}`}
+                  className="rounded-md bg-violet-500/[0.06] border border-violet-500/15 p-2.5"
+                  data-testid={`hub-canvas-perspective-${i}-${perspective.summary_id}`}
+                >
+                  <div className="flex items-start gap-2 mb-1.5">
+                    {detail?.thumbnail ? (
+                      <img
+                        src={detail.thumbnail}
+                        alt=""
+                        className="w-12 h-7 rounded object-cover shrink-0 bg-white/[0.04]"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-12 h-7 rounded bg-white/[0.04] shrink-0" />
+                    )}
+                    <p className="text-[11px] font-semibold text-violet-300 leading-tight line-clamp-2 flex-1">
+                      {detail?.title ?? fallbackTitle}
+                    </p>
+                  </div>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {perspective.excerpt}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        </motion.div>
+      ))}
+    </motion.div>
+  </div>
+);
+
+// ─── Empty state (canvas vide après validation backend, très rare) ──────────────
+
+const CanvasEmptyState: React.FC = () => (
+  <div
+    className="rounded-xl bg-white/5 border border-white/10 backdrop-blur-xl p-8 text-center"
+    data-testid="hub-canvas-empty"
+  >
+    <Sparkles
+      className="w-6 h-6 text-text-muted mx-auto mb-2"
+      aria-hidden
+    />
+    <p className="text-sm font-medium text-white mb-1">
+      Pas de canvas généré
+    </p>
+    <p className="text-xs text-text-muted">
+      Le canvas natif n'a pas pu être généré pour ce workspace.
+    </p>
+  </div>
+);
+
+// ─── Composant principal ──────────────────────────────────────────────────────
+
+export const HubWorkspaceCanvas: React.FC<HubWorkspaceCanvasProps> = ({
+  canvasData,
+  summaryDetails,
+  workspaceName,
+  boardId,
+  viewLink,
+  status,
+  errorMessage,
+  onRetry,
+  className = "",
+}) => {
+  // Pivot fallback : workspaces pré-pivot ou Mistral fail → MiroBoardEmbed.
+  // Aussi quand status pending/creating/failed : on garde le rendu Miro
+  // (skeleton/erreur) jusqu'à status='ready'.
+  if (!canvasData || status !== "ready") {
+    return (
+      <MiroBoardEmbed
+        boardId={boardId}
+        viewLink={viewLink}
+        status={status}
+        errorMessage={errorMessage}
+        height={700}
+        onRetry={onRetry}
+        className={className}
+      />
+    );
+  }
+
+  const { shared_concepts: sharedConcepts, themes } = canvasData;
+  const isEmpty = sharedConcepts.length === 0 && themes.length === 0;
+
+  return (
+    <section
+      role="region"
+      aria-label={`Canvas du workspace ${workspaceName}`}
+      data-testid="hub-workspace-canvas"
+      className={`space-y-6 ${className}`}
+    >
+      {sharedConcepts.length > 0 && (
+        <SharedConceptsSection concepts={sharedConcepts} />
+      )}
+      {themes.length > 0 && (
+        <ThemesSection themes={themes} summaryDetails={summaryDetails} />
+      )}
+      {isEmpty && <CanvasEmptyState />}
+    </section>
+  );
+};
+
+export default HubWorkspaceCanvas;

--- a/frontend/src/components/hub/__tests__/HubWorkspaceCanvas.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubWorkspaceCanvas.test.tsx
@@ -1,0 +1,187 @@
+// frontend/src/components/hub/__tests__/HubWorkspaceCanvas.test.tsx
+//
+// Tests pivot 2026-05-06 : Hub Workspace canvas natif (DebateConvergenceDivergence-inspired).
+//
+// Couverture :
+//   1. canvasData null → fallback MiroBoardEmbed (rétro-compat workspaces pré-pivot)
+//   2. canvasData null + status=creating → MiroBoardEmbed skeleton
+//   3. canvasData présent + status=ready → 2 sections natives rendues
+//   4. shared_concepts vide mais themes présents → seule la section themes rendue
+//   5. canvasData empty → empty state
+//   6. summaryDetails fournis → titres et thumbnails affichés dans perspectives
+//   7. summaryDetails manquants → fallback "Analyse #{id}"
+
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { HubWorkspaceCanvas } from "../HubWorkspaceCanvas";
+import type { WorkspaceCanvasData } from "../../../services/api";
+
+const VALID_CANVAS: WorkspaceCanvasData = {
+  shared_concepts: ["IA française", "Souveraineté donnée"],
+  themes: [
+    {
+      theme: "Confidentialité",
+      perspectives: [
+        { summary_id: 1, excerpt: "La vidéo 1 insiste sur le RGPD." },
+        { summary_id: 2, excerpt: "La vidéo 2 nuance l'argument RGPD." },
+      ],
+    },
+    {
+      theme: "Performance",
+      perspectives: [
+        { summary_id: 1, excerpt: "Vidéo 1 : Mistral est plus rapide." },
+        { summary_id: 2, excerpt: "Vidéo 2 : OpenAI conserve l'avance." },
+      ],
+    },
+  ],
+};
+
+describe("HubWorkspaceCanvas", () => {
+  it("falls back to MiroBoardEmbed when canvasData is null", () => {
+    render(
+      <HubWorkspaceCanvas
+        canvasData={null}
+        summaryDetails={{}}
+        workspaceName="WS test"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    // MiroBoardEmbed ready card is rendered (rétro-compat workspaces pré-pivot)
+    expect(screen.getByTestId("miro-board-embed-ready")).toBeInTheDocument();
+    // Le canvas natif n'est PAS rendu
+    expect(screen.queryByTestId("hub-workspace-canvas")).toBeNull();
+  });
+
+  it("falls back to MiroBoardEmbed skeleton when status=creating", () => {
+    render(
+      <HubWorkspaceCanvas
+        canvasData={VALID_CANVAS}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="creating"
+      />,
+    );
+    // Tant que status != ready, on garde le rendu Miro (skeleton)
+    expect(screen.getByTestId("miro-board-embed-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("hub-workspace-canvas")).toBeNull();
+  });
+
+  it("renders both shared concepts and themes sections when canvasData is present and status=ready", () => {
+    render(
+      <HubWorkspaceCanvas
+        canvasData={VALID_CANVAS}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    expect(screen.getByTestId("hub-workspace-canvas")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hub-canvas-shared-concepts"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("hub-canvas-themes")).toBeInTheDocument();
+
+    // Les concepts s'affichent
+    expect(screen.getByText("IA française")).toBeInTheDocument();
+    expect(screen.getByText("Souveraineté donnée")).toBeInTheDocument();
+
+    // Les thèmes s'affichent
+    expect(screen.getByText("Confidentialité")).toBeInTheDocument();
+    expect(screen.getByText("Performance")).toBeInTheDocument();
+
+    // 2 thèmes rendus
+    expect(screen.getByTestId("hub-canvas-theme-0")).toBeInTheDocument();
+    expect(screen.getByTestId("hub-canvas-theme-1")).toBeInTheDocument();
+  });
+
+  it("uses summaryDetails.title in perspective cards when provided", () => {
+    render(
+      <HubWorkspaceCanvas
+        canvasData={VALID_CANVAS}
+        summaryDetails={{
+          1: {
+            title: "L'IA souveraine",
+            channel: "Tech FR",
+            thumbnail: "https://example.com/thumb1.jpg",
+          },
+          2: {
+            title: "Mistral vs OpenAI",
+            channel: "AI Daily",
+          },
+        }}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    // Les vrais titres apparaissent au moins une fois (présents dans plusieurs thèmes)
+    expect(screen.getAllByText("L'IA souveraine").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Mistral vs OpenAI").length).toBeGreaterThan(0);
+    // Pas de fallback "Analyse #X" quand on a les vrais titres
+    expect(screen.queryByText(/Analyse #1/)).toBeNull();
+    expect(screen.queryByText(/Analyse #2/)).toBeNull();
+  });
+
+  it("falls back to 'Analyse #ID' when summaryDetails entry missing", () => {
+    render(
+      <HubWorkspaceCanvas
+        canvasData={VALID_CANVAS}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    // 4 perspectives au total (2 thèmes × 2 perspectives) → fallback partout
+    const fallbacks = screen.getAllByText(/Analyse #(1|2)/);
+    expect(fallbacks.length).toBe(4);
+  });
+
+  it("renders only themes section when shared_concepts is empty", () => {
+    const canvas: WorkspaceCanvasData = {
+      shared_concepts: [],
+      themes: VALID_CANVAS.themes,
+    };
+    render(
+      <HubWorkspaceCanvas
+        canvasData={canvas}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    expect(screen.queryByTestId("hub-canvas-shared-concepts")).toBeNull();
+    expect(screen.getByTestId("hub-canvas-themes")).toBeInTheDocument();
+  });
+
+  it("renders empty state when canvasData has no concepts and no themes", () => {
+    const canvas: WorkspaceCanvasData = {
+      shared_concepts: [],
+      themes: [],
+    };
+    render(
+      <HubWorkspaceCanvas
+        canvasData={canvas}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    expect(screen.getByTestId("hub-canvas-empty")).toBeInTheDocument();
+    expect(screen.getByText(/Pas de canvas généré/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/hub/index.ts
+++ b/frontend/src/components/hub/index.ts
@@ -1,2 +1,7 @@
 export { MiroBoardEmbed } from "./MiroBoardEmbed";
 export type { MiroBoardEmbedProps } from "./MiroBoardEmbed";
+export { HubWorkspaceCanvas } from "./HubWorkspaceCanvas";
+export type {
+  HubWorkspaceCanvasProps,
+  SummaryPreview,
+} from "./HubWorkspaceCanvas";

--- a/frontend/src/pages/HubWorkspacesPage.tsx
+++ b/frontend/src/pages/HubWorkspacesPage.tsx
@@ -39,7 +39,8 @@ import { Sidebar } from "../components/layout/Sidebar";
 import DoodleBackground from "../components/DoodleBackground";
 import { SEO } from "../components/SEO";
 import { DoodleEmptyState } from "../components/doodles";
-import { MiroBoardEmbed } from "../components/hub";
+import { HubWorkspaceCanvas } from "../components/hub";
+import type { SummaryPreview } from "../components/hub";
 import { DeepSightSpinnerSmall } from "../components/ui/DeepSightSpinner";
 import { useAuth } from "../hooks/useAuth";
 import {
@@ -414,12 +415,6 @@ interface DetailModeProps {
   onDelete: (id: number) => void;
 }
 
-interface SummaryPreview {
-  title: string;
-  thumbnail?: string;
-  channel?: string;
-}
-
 const DetailMode: React.FC<DetailModeProps> = ({
   id,
   workspace,
@@ -559,13 +554,16 @@ const DetailMode: React.FC<DetailModeProps> = ({
         </div>
       </header>
 
-      {/* Miro embed */}
-      <MiroBoardEmbed
+      {/* Canvas natif (pivot 2026-05-06) — fallback Miro embed quand
+          canvas_data est null (workspaces pré-pivot ou Mistral fail). */}
+      <HubWorkspaceCanvas
+        canvasData={workspace.canvas_data}
+        summaryDetails={summaryDetails}
+        workspaceName={workspace.name}
         boardId={workspace.miro_board_id}
         viewLink={workspace.miro_board_url}
         status={workspace.status}
         errorMessage={workspace.error_message}
-        height={700}
         onRetry={onRefetch}
       />
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3427,6 +3427,28 @@ export const keywordImageApi = {
 
 export type HubWorkspaceStatus = "pending" | "creating" | "ready" | "failed";
 
+/**
+ * Canvas natif Hub Workspace (pivot 2026-05-06).
+ *
+ * Remplace l'embed Miro iframe pour les nouveaux workspaces. Stocké côté
+ * backend dans `hub_workspaces.canvas_data` (JSON nullable). Aligné sur le
+ * Pydantic `WorkspaceCanvasData` (backend/src/hub/schemas.py).
+ */
+export interface CanvasPerspective {
+  summary_id: number;
+  excerpt: string;
+}
+
+export interface CanvasTheme {
+  theme: string;
+  perspectives: CanvasPerspective[];
+}
+
+export interface WorkspaceCanvasData {
+  shared_concepts: string[];
+  themes: CanvasTheme[];
+}
+
 export interface HubWorkspace {
   id: number;
   name: string;
@@ -3435,6 +3457,11 @@ export interface HubWorkspace {
   miro_board_url: string | null;
   status: HubWorkspaceStatus;
   error_message: string | null;
+  /**
+   * Canvas natif (pivot 2026-05-06). NULL pour workspaces pré-pivot ou si
+   * Mistral fail → frontend bascule sur MiroBoardEmbed (rétro-compat).
+   */
+  canvas_data: WorkspaceCanvasData | null;
   created_at: string; // ISO
   updated_at: string; // ISO
 }


### PR DESCRIPTION
## Pivot stratégique 2026-05-06

Abandon de l'embed Miro iframe (limitation plan Miro Personal Starter \$8/mo qui ne supporte pas l'embed externe) au profit d'un **rendu HTML/React natif** style \`DebateConvergenceDivergence\` (apprécié par l'utilisateur sur la feature Débat IA).

Le code Miro existant reste **intact** : workspaces pré-pivot et échec Mistral basculent automatiquement sur \`MiroBoardEmbed\` (rétro-compat préservée).

## Backend

- **Alembic 021** : \`ALTER TABLE hub_workspaces ADD COLUMN canvas_data JSON NULL\` (idempotente).
- **\`hub/canvas_service.py\`** : extraction Mistral via \`llm_complete\` (\`mistral-large-2512\`, json_mode=True). Retourne :
  \`\`\`json
  {
    "shared_concepts": ["concept partagé 1", ...],
    "themes": [{"theme": "Titre", "perspectives": [{"summary_id": int, "excerpt": "..."}]}]
  }
  \`\`\`
  Retry x2 sur JSON invalide, fallback None silencieux sur échec total. Validation stricte de la forme : \`summary_id\` doit appartenir au workspace, ≥ 2 perspectives par thème, dédup case-insensitive des concepts, cap themes à 6.
- **\`hub/service.py\`** : \`_create_miro_board_async\` exécute Miro PUIS canvas avant le flip \`status='ready'\` → le polling frontend continue jusqu'à voir \`canvas_data\` populé ou null.
- **\`hub/schemas.py\`** : \`HubWorkspaceResponse.canvas_data: Optional[dict[str, Any]]\`.
- **12 tests** \`test_hub_canvas.py\` (validation shape + Mistral mocké, ✅).

## Frontend

- **\`services/api.ts\`** : interfaces \`WorkspaceCanvasData / CanvasTheme / CanvasPerspective\` alignées Pydantic. Champ \`canvas_data: WorkspaceCanvasData | null\` ajouté à \`HubWorkspace\`.
- **\`<HubWorkspaceCanvas />\`** (nouveau) : composant pur prop-driven. Si \`canvasData\` null OU \`status !== 'ready'\` → fallback \`<MiroBoardEmbed>\`. Sinon : 2 sections glassmorphism dark mode :
  1. **Concepts partagés** (palette emerald) — liste numérotée
  2. **Perspectives complémentaires** (palette indigo/violet) — sections thématiques avec grid de cards (thumbnail + titre + extrait)
- **\`HubWorkspacesPage.tsx\`** : swap \`<MiroBoardEmbed>\` → \`<HubWorkspaceCanvas>\` (passe les props Miro pour fallback).
- **7 tests** \`HubWorkspaceCanvas.test.tsx\` (fallback / sections / empty state / titres réels vs fallback, ✅).
- Tous les tests existants restent verts (\`test_hub_workspace\` 13/13, \`HubWorkspacesPage\` 7/7).

## Workspaces concernés

| Cas | Comportement |
|-----|-------------|
| Workspaces existants (IDs 1-6, \`canvas_data\` null) | Fallback \`MiroBoardEmbed\` "Ouvrir dans Miro" — inchangé |
| Nouveaux workspaces, Mistral OK | Rendu natif 2 sections |
| Nouveaux workspaces, Mistral fail | \`canvas_data\` reste null → fallback Miro |
| Débat IA (autre feature) | Aucun impact, code intact |

## Test plan

- [x] Tests unitaires backend : 12/12 ✅ (\`test_hub_canvas.py\`)
- [x] Tests unitaires frontend : 7/7 ✅ (\`HubWorkspaceCanvas.test.tsx\`)
- [x] Tests existants verts (\`test_hub_workspace\` 13/13, \`HubWorkspacesPage\` 7/7)
- [x] Frontend typecheck propre
- [ ] Hetzner deploy : alembic 021 appliquée + créer un nouveau workspace, vérifier \`canvas_data\` populé en DB via SSH
- [ ] Vercel deploy : ouvrir un workspace existant (fallback Miro intact) + un nouveau (rendu natif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)