### PR TITLE
fix(hub-canvas): use mistral-medium-2508 (large-2512 → 401 prod)

### DIFF
--- a/backend/src/hub/canvas_service.py
+++ b/backend/src/hub/canvas_service.py
@@ -34,12 +34,15 @@ logger = logging.getLogger(__name__)
 # Constants
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Modèle Mistral utilisé pour l'extraction (Expert plan only, 262K context).
-CANVAS_MODEL = "mistral-large-2512"
+# Modèle Mistral utilisé pour l'extraction.
+# Note 2026-05-06 : `mistral-large-2512` retourne 401 sur la clé prod
+# (modèle non encore libéré côté Mistral SaaS, ou non couvert par notre licence).
+# `llm_complete` ne fallback PAS sur 401 (uniquement sur 429/5xx) → on utilise
+# directement `mistral-medium-2508` (131K context, confirmé fonctionnel prod).
+CANVAS_MODEL = "mistral-medium-2508"
 
 # Tronque chaque extrait de summary à cette longueur pour rester sous la limite
-# de tokens (mistral-large-2512 = 262K context, mais on vise <= 50K input pour
-# rester économique et rapide).
+# de tokens (mistral-medium-2508 = 131K context, on vise <= 60K input).
 MAX_CHARS_PER_SUMMARY = 6000
 
 # Max tokens pour la réponse JSON Mistral.

--- a/backend/tests/test_hub_canvas.py
+++ b/backend/tests/test_hub_canvas.py
@@ -50,7 +50,7 @@ def _llm_result(content: str):
 
     return LLMResult(
         content=content,
-        model_used="mistral-large-2512",
+        model_used="mistral-medium-2508",
         provider="mistral",
         attempts=1,
     )


### PR DESCRIPTION
## Hotfix #384 — workspace canvas always falls back to Miro

Logs prod après merge du pivot canvas natif :
\`\`\`
❌ [LLM] mistral:mistral-large-2512 error 401: {\"detail\":\"Unauthorized\"}
[HUB-CANVAS] llm_complete returned empty (attempt 1/2)
[HUB-CANVAS] llm_complete returned empty (attempt 2/2)
[HUB] Canvas natif None ws=8 — fallback Miro côté front
\`\`\`

## Cause

\`mistral-large-2512\` retourne **401 Unauthorized** sur la clé Mistral prod (modèle non libéré côté Mistral SaaS ou non inclus dans notre licence). \`llm_complete\` ne fallback **que sur 429/5xx**, pas sur 401 → canvas\_data reste null pour TOUS les nouveaux workspaces → tout le monde voit le fallback \`MiroBoardEmbed\`.

## Fix

Switch \`CANVAS_MODEL\` vers \`mistral-medium-2508\` :
- 131K context (largement suffisant : 20 summaries × 6K = 120K worst case)
- Confirmé fonctionnel prod (default Pro plan, déjà utilisé partout)

Tests : 12/12 ✅ (pas de régression).

## À surveiller (hors scope hotfix)

Pourquoi \`mistral-large-2512\` est-il référencé partout dans \`config.py\` (default Expert plan) s'il retourne 401 ? Les autres call sites Expert (chat v4.0, analyses video) sont peut-être affectés aussi mais marchent grâce à la fallback chain qui catch leurs 429/5xx. À auditer dans un second temps.

## Test plan

- [x] Tests unitaires \`test_hub_canvas.py\` 12/12 verts
- [ ] Deploy prod via deploy-backend.yml
- [ ] Créer un nouveau workspace via /hub : vérifier \`canvas_data\` populé en DB + UI native rendue

🤖 Generated with [Claude Code](https://claude.com/claude-code)