### PR TITLE
feat(visual-analysis): Phase 2 — hook /analyze + tri-platform UI

### DIFF
--- a/backend/alembic/versions/019_visual_analysis_quota.py
+++ b/backend/alembic/versions/019_visual_analysis_quota.py
@@ -1,0 +1,81 @@
+"""visual_analysis_quota — Phase 2 Visual Analysis quota table
+
+Revision ID: 019_visual_analysis_quota
+Revises: 018_hub_workspace
+Create Date: 2026-05-06
+
+Sprint Visual Analysis Phase 2 — Backend integration de l'enrichissement
+visuel multimodal (frames + Mistral Vision) dans le flow /api/videos/analyze.
+
+Crée la table `visual_analysis_quota` qui tracke la consommation mensuelle
+par user. Quota :
+- Free  : 0 (CTA upsell)
+- Pro   : 30 / mois calendaire
+- Expert: illimité (track quand même pour analytics)
+
+Spec : 01-Projects/DeepSight/Sessions/2026-05-06-visual-analysis-phase-2-spec.md
+Trigger user-side : flag include_visual_analysis dans AnalyzeVideoRequest.
+
+Pas de backfill : nouvelle table.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "019_visual_analysis_quota"
+down_revision: Union[str, None] = "018_hub_workspace"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "visual_analysis_quota" not in existing_tables:
+        op.create_table(
+            "visual_analysis_quota",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            # Mois calendaire au format YYYY-MM (ex: "2026-05")
+            sa.Column("period", sa.String(length=7), nullable=False, index=True),
+            # Compteur d'analyses visual_analysis pour le mois
+            sa.Column("count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column(
+                "last_used_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            # Un seul compteur par (user, mois)
+            sa.UniqueConstraint("user_id", "period", name="uq_visual_quota_user_period"),
+        )
+
+        # Index composé pour les check de quota rapides (le lookup principal)
+        op.create_index(
+            "ix_visual_quota_user_period",
+            "visual_analysis_quota",
+            ["user_id", "period"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_visual_quota_user_period", table_name="visual_analysis_quota")
+    op.drop_table("visual_analysis_quota")

--- a/backend/src/billing/plan_config.py
+++ b/backend/src/billing/plan_config.py
@@ -121,6 +121,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "geo_enabled": False,
             "geo_monthly": 0,
             "companion_dialogue_enabled": False,  # 🎓 Le Tuteur — Pro+ uniquement
+            "visual_analysis_enabled": False,  # Phase 2 — frames + Mistral Vision
+            "visual_analysis_monthly": 0,
         },
         "features_display": [
             {"text": "5 analyses / mois", "icon": "📊"},
@@ -254,6 +256,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "geo_enabled": True,
             "geo_monthly": 10,
             "companion_dialogue_enabled": True,  # 🎓 Le Tuteur — disponible dès Pro
+            "visual_analysis_enabled": True,  # Phase 2 — frames + Mistral Vision
+            "visual_analysis_monthly": 30,
         },
         "features_display": [
             {"text": "25 analyses / mois", "icon": "📊"},
@@ -395,6 +399,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "geo_enabled": True,
             "geo_monthly": -1,
             "companion_dialogue_enabled": True,  # 🎓 Le Tuteur — disponible Pro et Expert
+            "visual_analysis_enabled": True,  # Phase 2 — frames + Mistral Vision
+            "visual_analysis_monthly": -1,  # illimité
         },
         "features_display": [
             {"text": "100 analyses / mois", "icon": "📊"},

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -1599,6 +1599,49 @@ class HubWorkspace(Base):
     )
 
 
+class VisualAnalysisQuota(Base):
+    """Quota mensuel d'analyses visuelles (Phase 2 Visual Analysis).
+
+    Tracke la consommation de la feature `include_visual_analysis` dans
+    AnalyzeVideoRequest / AnalyzeVideoV2Request. Quotas appliqués :
+      - Free  : 0 (CTA upsell, jamais incrémenté)
+      - Pro   : 30 / mois calendaire (period = "YYYY-MM")
+      - Expert: illimité (track quand même pour analytics)
+
+    Spec : 01-Projects/DeepSight/Sessions/2026-05-06-visual-analysis-phase-2-spec.md
+    Migration : alembic 019_visual_analysis_quota.py.
+    """
+
+    __tablename__ = "visual_analysis_quota"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Mois calendaire au format YYYY-MM (ex: "2026-05")
+    period = Column(String(7), nullable=False, index=True)
+    count = Column(Integer, nullable=False, default=0, server_default="0")
+    last_used_at = Column(
+        DateTime,
+        default=func.now(),
+        server_default=func.now(),
+        nullable=False,
+    )
+    created_at = Column(
+        DateTime,
+        default=func.now(),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index("ix_visual_quota_user_period", "user_id", "period", unique=True),
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # 📨 EMAIL DLQ — Dead Letter Queue for failed Resend emails
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -14,6 +14,7 @@
 import json
 import logging
 import math
+import os
 import httpx
 from uuid import uuid4
 from datetime import datetime
@@ -1050,6 +1051,7 @@ async def analyze_video(
         credit_cost=credit_cost,
         deep_research=deep_research,  # 🆕 v5.5
         platform=platform,  # 🎵 TikTok support
+        include_visual_analysis=request.include_visual_analysis,  # 🆕 Phase 2
     )
 
     await _invalidate_companion_cache()
@@ -2693,6 +2695,7 @@ async def _analyze_video_background_v6(
     credit_cost: int,
     deep_research: bool = False,  # 🆕 v5.5
     platform: str = "youtube",  # 🎵 TikTok support
+    include_visual_analysis: bool = False,  # 🆕 Phase 2 — frames + Mistral Vision
 ):
     """
     🔐 Fonction d'analyse v6.0 avec SÉCURITÉ RENFORCÉE.
@@ -3071,6 +3074,62 @@ async def _analyze_video_background_v6(
 
             # Variable pour stocker les chunks (remplie si vidéo longue)
             _long_video_result3 = None
+
+            # ═══════════════════════════════════════════════════════════════════
+            # 🆕 PHASE 2 — VISUAL ANALYSIS ENRICHMENT (frames + Mistral Vision)
+            # Best-effort : si échec, on continue sans la couche visuelle.
+            # ═══════════════════════════════════════════════════════════════════
+            if include_visual_analysis and platform == "youtube":
+                try:
+                    from .visual_integration import (
+                        STATUS_OK,
+                        format_visual_context_for_prompt,
+                        maybe_enrich_with_visual,
+                    )
+                    from sqlalchemy import select as _sel
+                    from db.database import User as _UserModel
+
+                    _visual_flag_on = (
+                        os.getenv("VISUAL_ANALYSIS_ENABLED", "false").strip().lower()
+                        in {"1", "true", "yes", "on"}
+                    )
+                    if _visual_flag_on:
+                        _task_store[task_id]["progress"] = 50
+                        _task_store[task_id]["message"] = "👁️ Analyse visuelle en cours..."
+                        _user_q = await session.execute(
+                            _sel(_UserModel).where(_UserModel.id == user_id)
+                        )
+                        _user_row = _user_q.scalar_one_or_none()
+                        if _user_row:
+                            _visual = await maybe_enrich_with_visual(
+                                db=session,
+                                user=_user_row,
+                                url=url,
+                                transcript_excerpt=(transcript_to_analyze or "")[:8000],
+                                flag_enabled=True,
+                            )
+                            if _visual.get("status") == STATUS_OK:
+                                _visual_block = format_visual_context_for_prompt(_visual)
+                                if _visual_block:
+                                    web_context = (
+                                        (web_context or "") + "\n\n" + _visual_block
+                                    )
+                                logger.info(
+                                    "👁️ [VISUAL] enrichment OK: frames=%d model=%s elapsed=%.1fs",
+                                    _visual.get("frame_count", 0),
+                                    _visual.get("model_used"),
+                                    _visual.get("elapsed_s", 0.0),
+                                )
+                            else:
+                                logger.info(
+                                    "👁️ [VISUAL] skipped: status=%s",
+                                    _visual.get("status"),
+                                )
+                except Exception as _ve:
+                    # Graceful degradation : aucune erreur visuelle ne bloque l'analyse
+                    logger.warning(
+                        "👁️ [VISUAL] enrichment raised (graceful): %s", _ve
+                    )
 
             if needs_chunk:
                 # ════════════════════════════════════════════════════════════

--- a/backend/src/videos/schemas.py
+++ b/backend/src/videos/schemas.py
@@ -45,6 +45,10 @@ class AnalyzeVideoRequest(BaseModel):
     model: Optional[str] = Field(default=None, description="Modèle Mistral à utiliser")
     deep_research: bool = Field(default=False, description="🆕 Recherche approfondie (Expert only)")
     force_refresh: bool = Field(default=False, description="🆕 Ignorer le cache et forcer une nouvelle analyse")
+    include_visual_analysis: bool = Field(
+        default=False,
+        description="🆕 Phase 2 : enrichir l'analyse avec une couche visuelle (frames + Mistral Vision). Pro/Expert uniquement, +2 crédits, quota mensuel 30 (Pro) / illimité (Expert).",
+    )
 
 
 class AnalyzeVideoV2Request(BaseModel):
@@ -97,6 +101,12 @@ class AnalyzeVideoV2Request(BaseModel):
 
     # Webhook (pour notifications externes)
     webhook_url: Optional[str] = Field(default=None, description="URL de callback quand l'analyse est terminée")
+
+    # 🆕 Phase 2 : Visual Analysis (frames + Mistral Vision)
+    include_visual_analysis: bool = Field(
+        default=False,
+        description="🆕 Phase 2 : enrichir l'analyse avec une couche visuelle (storyboards YouTube + Mistral Vision). Pro/Expert uniquement, +2 crédits, quota mensuel 30 (Pro) / illimité (Expert).",
+    )
 
     class Config:
         json_schema_extra = {

--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -1,0 +1,287 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🔌 VISUAL INTEGRATION — Hook Phase 2 dans le flow /api/videos/analyze            ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Orchestre l'enrichissement visuel multimodal (Phase 2) :                         ║
+║  1. Plan gating : Pro/Expert seulement (Free → upsell, jamais incrémenté)         ║
+║  2. Quota mensuel : Pro=30, Expert=illimité (table visual_analysis_quota)         ║
+║  3. Extraction video_id YouTube (Phase 2 = YouTube uniquement)                    ║
+║  4. Pipeline Pivot 5 : extract_storyboard_frames + analyze_frames                 ║
+║  5. Format visual context pour injection dans le prompt Mistral analysis          ║
+║                                                                                    ║
+║  Source de vérité quotas : core.plan_limits (DRY) ; ce module ne hardcode pas.    ║
+║  Spec : 01-Projects/DeepSight/Sessions/2026-05-06-visual-analysis-phase-2-spec.md ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import logging
+import re
+import time
+from datetime import datetime
+from typing import Any, Dict, Optional, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import User, VisualAnalysisQuota
+
+from .visual_analyzer import VisualAnalysis, analyze_frames
+from .youtube_storyboard import extract_storyboard_frames, normalize_video_id
+
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📊 QUOTAS PHASE 2 (single source of truth)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+VISUAL_QUOTA_BY_PLAN: Dict[str, Optional[int]] = {
+    "free": 0,
+    "pro": 30,
+    "expert": None,  # None = illimité
+    # Legacy aliases (cf. pricing v2 migration 012)
+    "starter": 30,  # ancien starter == pro après migration
+    "plus": 30,
+}
+
+# Coût en crédits par appel visual_analysis (s'ajoute au coût d'analyse de base)
+VISUAL_CREDITS_COST = 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚦 RÉSULTATS ENUM-LIKE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Status renvoyés par maybe_enrich_with_visual()
+STATUS_OK = "ok"
+STATUS_DISABLED = "disabled"  # flag VISUAL_ANALYSIS_ENABLED pas activé
+STATUS_PLAN_NOT_ALLOWED = "plan_not_allowed"  # Free
+STATUS_QUOTA_EXCEEDED = "quota_exceeded"
+STATUS_NOT_YOUTUBE = "not_youtube"  # URL TikTok/Vimeo, etc. — Phase 2 = YouTube uniquement
+STATUS_EXTRACT_FAILED = "extract_failed"
+STATUS_VISION_FAILED = "vision_failed"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _current_period() -> str:
+    """Renvoie le mois courant au format YYYY-MM."""
+    return datetime.utcnow().strftime("%Y-%m")
+
+
+def _normalize_plan(plan: Optional[str]) -> str:
+    """Normalize plan name (lowercase, fallback 'free')."""
+    if not plan:
+        return "free"
+    return str(plan).strip().lower()
+
+
+def get_quota_for_plan(plan: str) -> Optional[int]:
+    """Renvoie le quota mensuel pour un plan, None si illimité, 0 si Free."""
+    return VISUAL_QUOTA_BY_PLAN.get(_normalize_plan(plan), 0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🗃️ QUOTA DB OPERATIONS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def get_or_create_quota_row(
+    db: AsyncSession, user_id: int, period: Optional[str] = None
+) -> VisualAnalysisQuota:
+    """Récupère la ligne quota du mois ou la crée si absente. Pas de commit."""
+    period = period or _current_period()
+
+    result = await db.execute(
+        select(VisualAnalysisQuota).where(
+            VisualAnalysisQuota.user_id == user_id,
+            VisualAnalysisQuota.period == period,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        row = VisualAnalysisQuota(user_id=user_id, period=period, count=0)
+        db.add(row)
+        await db.flush()
+    return row
+
+
+async def can_consume(db: AsyncSession, user: User) -> Tuple[bool, str]:
+    """
+    Vérifie si l'user peut consommer un visual_analysis.
+
+    Retourne (allowed, reason). reason ∈ STATUS_*.
+    Ne mute pas le quota — c'est increment_quota() qui le fait après succès.
+    """
+    plan = _normalize_plan(getattr(user, "plan", None))
+    quota = get_quota_for_plan(plan)
+
+    if quota == 0:
+        return False, STATUS_PLAN_NOT_ALLOWED
+    if quota is None:
+        return True, STATUS_OK  # illimité (Expert)
+
+    row = await get_or_create_quota_row(db, user.id)
+    if row.count >= quota:
+        return False, STATUS_QUOTA_EXCEEDED
+    return True, STATUS_OK
+
+
+async def increment_quota(db: AsyncSession, user_id: int) -> int:
+    """Incrémente le compteur du mois pour user_id. Renvoie la nouvelle valeur. Pas de commit."""
+    row = await get_or_create_quota_row(db, user_id)
+    row.count = (row.count or 0) + 1
+    row.last_used_at = datetime.utcnow()
+    db.add(row)
+    await db.flush()
+    return row.count
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔌 INTÉGRATION FLOW /analyze
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def maybe_enrich_with_visual(
+    db: AsyncSession,
+    user: User,
+    url: str,
+    *,
+    transcript_excerpt: str = "",
+    flag_enabled: bool = True,
+) -> Dict[str, Any]:
+    """
+    Pipeline Phase 2 appelé depuis videos/router.py quand
+    AnalyzeVideoRequest.include_visual_analysis=True.
+
+    Renvoie toujours un dict avec au minimum `status` et `elapsed_s`.
+    Si status=ok, contient également `analysis` (dict serialisé), `frame_count`,
+    `model_used`. Le caller injecte `analysis.summary_visual` et `key_moments`
+    dans le prompt Mistral analysis principal.
+
+    NE PAS RAISER : cette fonction est best-effort. En cas d'échec, l'analyse
+    de base se fait quand même sans la couche visuelle (graceful degradation).
+
+    Aucun commit DB n'est fait ici — le caller commit en fin de flow.
+    """
+    t0 = time.time()
+    log_tag = f"VISUAL_INT user={user.id}"
+
+    if not flag_enabled:
+        return {"status": STATUS_DISABLED, "elapsed_s": 0.0}
+
+    # ── 1. Plan gating + quota check ──
+    allowed, reason = await can_consume(db, user)
+    if not allowed:
+        logger.info("[%s] Skipped (%s)", log_tag, reason)
+        return {"status": reason, "elapsed_s": round(time.time() - t0, 2)}
+
+    # ── 2. URL → video_id YouTube ──
+    video_id = normalize_video_id(url)
+    if not video_id:
+        # Pas une URL/ID YouTube → Phase 2 ne couvre pas TikTok/Vimeo
+        return {
+            "status": STATUS_NOT_YOUTUBE,
+            "elapsed_s": round(time.time() - t0, 2),
+        }
+
+    # ── 3. Extraction storyboards (Pivot 5) ──
+    extraction = await extract_storyboard_frames(video_id, log_tag=log_tag)
+    if extraction is None:
+        return {
+            "status": STATUS_EXTRACT_FAILED,
+            "video_id": video_id,
+            "elapsed_s": round(time.time() - t0, 2),
+        }
+
+    # ── 4. Mistral Vision ──
+    try:
+        analysis = await analyze_frames(
+            extraction.frame_paths,
+            extraction.frame_timestamps,
+            transcript_excerpt=transcript_excerpt,
+            log_tag=log_tag,
+        )
+    finally:
+        extraction.cleanup()
+
+    if analysis is None:
+        return {
+            "status": STATUS_VISION_FAILED,
+            "video_id": video_id,
+            "frame_count": extraction.frame_count,
+            "elapsed_s": round(time.time() - t0, 2),
+        }
+
+    # ── 5. Quota incrément (succès uniquement) ──
+    new_count = await increment_quota(db, user.id)
+
+    elapsed = round(time.time() - t0, 2)
+    logger.info(
+        "[%s] OK in %.1fs (frames=%d model=%s quota_count=%d)",
+        log_tag,
+        elapsed,
+        extraction.frame_count,
+        analysis.model_used,
+        new_count,
+    )
+
+    return {
+        "status": STATUS_OK,
+        "video_id": video_id,
+        "frame_count": extraction.frame_count,
+        "duration_s": round(extraction.duration_s, 2),
+        "model_used": analysis.model_used,
+        "frames_downsampled": analysis.frames_downsampled,
+        "analysis": analysis.to_dict(),
+        "credits_consumed": VISUAL_CREDITS_COST,
+        "quota_count_after": new_count,
+        "elapsed_s": elapsed,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📝 FORMAT POUR INJECTION DANS LE PROMPT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def format_visual_context_for_prompt(visual_result: Dict[str, Any]) -> str:
+    """
+    Transforme un résultat de maybe_enrich_with_visual (status=ok) en bloc texte
+    à injecter dans le prompt Mistral analysis principal.
+
+    Renvoie une chaîne vide si status != ok ou analysis manquante (graceful no-op).
+    """
+    if visual_result.get("status") != STATUS_OK:
+        return ""
+    analysis = visual_result.get("analysis") or {}
+    if not analysis:
+        return ""
+
+    parts: list[str] = []
+    parts.append("--- COUCHE VISUELLE (analyse multimodale) ---")
+
+    if analysis.get("visual_hook"):
+        parts.append(f"Hook visuel : {analysis['visual_hook']}")
+    if analysis.get("visual_structure"):
+        parts.append(f"Structure dominante : {analysis['visual_structure']}")
+    if analysis.get("summary_visual"):
+        parts.append(f"Résumé visuel : {analysis['summary_visual']}")
+
+    moments = analysis.get("key_moments") or []
+    if moments:
+        parts.append("Moments visuels saillants :")
+        for m in moments[:8]:
+            ts = m.get("timestamp_s", 0)
+            desc = m.get("description", "")
+            mtype = m.get("type", "")
+            parts.append(f"  • [{ts:.1f}s][{mtype}] {desc}")
+
+    if analysis.get("visible_text"):
+        parts.append(f"Texte visible à l'écran : {analysis['visible_text']}")
+
+    parts.append("--- FIN COUCHE VISUELLE ---")
+    return "\n".join(parts)

--- a/backend/tests/videos/test_visual_integration.py
+++ b/backend/tests/videos/test_visual_integration.py
@@ -1,0 +1,344 @@
+"""
+Tests pour videos/visual_integration.py — Phase 2 backend integration.
+
+Couvre :
+- Helpers purs : _current_period, get_quota_for_plan, format_visual_context_for_prompt
+- can_consume : Free refusé, Expert OK illimité, Pro avec/sans quota dépassé
+- maybe_enrich_with_visual : flag off, not_youtube, plan_not_allowed, happy path
+"""
+
+import os
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ Helpers purs
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCurrentPeriod:
+    def test_format_yyyy_mm(self):
+        from videos.visual_integration import _current_period
+
+        period = _current_period()
+        assert len(period) == 7
+        assert period[4] == "-"
+        year, month = period.split("-")
+        assert 2024 <= int(year) <= 2030
+        assert 1 <= int(month) <= 12
+
+
+class TestGetQuotaForPlan:
+    def test_free_returns_zero(self):
+        from videos.visual_integration import get_quota_for_plan
+
+        assert get_quota_for_plan("free") == 0
+        assert get_quota_for_plan("FREE") == 0
+        assert get_quota_for_plan("") == 0
+        assert get_quota_for_plan(None) == 0
+
+    def test_pro_returns_30(self):
+        from videos.visual_integration import get_quota_for_plan
+
+        assert get_quota_for_plan("pro") == 30
+
+    def test_expert_returns_none_unlimited(self):
+        from videos.visual_integration import get_quota_for_plan
+
+        assert get_quota_for_plan("expert") is None
+
+    def test_legacy_aliases(self):
+        from videos.visual_integration import get_quota_for_plan
+
+        assert get_quota_for_plan("starter") == 30
+        assert get_quota_for_plan("plus") == 30
+
+
+class TestFormatVisualContextForPrompt:
+    def test_status_not_ok_returns_empty(self):
+        from videos.visual_integration import (
+            STATUS_PLAN_NOT_ALLOWED,
+            format_visual_context_for_prompt,
+        )
+
+        assert format_visual_context_for_prompt({"status": STATUS_PLAN_NOT_ALLOWED}) == ""
+        assert format_visual_context_for_prompt({}) == ""
+
+    def test_ok_with_full_analysis(self):
+        from videos.visual_integration import STATUS_OK, format_visual_context_for_prompt
+
+        result = {
+            "status": STATUS_OK,
+            "analysis": {
+                "visual_hook": "Plan large lumineux",
+                "visual_structure": "talking_head",
+                "summary_visual": "Vidéo posée plan unique",
+                "key_moments": [
+                    {"timestamp_s": 1.0, "description": "Entrée écran", "type": "hook"},
+                    {"timestamp_s": 12.5, "description": "Reveal", "type": "reveal"},
+                ],
+                "visible_text": "DeepSight",
+            },
+        }
+        out = format_visual_context_for_prompt(result)
+        assert "COUCHE VISUELLE" in out
+        assert "Plan large lumineux" in out
+        assert "talking_head" in out
+        assert "DeepSight" in out
+        assert "[1.0s][hook]" in out
+        assert "[12.5s][reveal]" in out
+
+    def test_caps_at_8_moments(self):
+        from videos.visual_integration import STATUS_OK, format_visual_context_for_prompt
+
+        moments = [
+            {"timestamp_s": float(i), "description": f"m{i}", "type": "peak"}
+            for i in range(20)
+        ]
+        result = {
+            "status": STATUS_OK,
+            "analysis": {"key_moments": moments, "visual_hook": "x"},
+        }
+        out = format_visual_context_for_prompt(result)
+        # m0..m7 présents, m8+ absents
+        assert "m0" in out
+        assert "m7" in out
+        assert "m8" not in out
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚦 can_consume — plan gating + quota
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_user(plan: str, user_id: int = 1):
+    user = MagicMock()
+    user.id = user_id
+    user.plan = plan
+    return user
+
+
+def _make_db_with_quota(count_value):
+    """Mock AsyncSession qui renvoie une row quota avec count=count_value."""
+    db = AsyncMock()
+    quota_row = SimpleNamespace(user_id=1, period="2026-05", count=count_value)
+
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none = MagicMock(return_value=quota_row)
+
+    db.execute = AsyncMock(return_value=result_mock)
+    db.flush = AsyncMock()
+    return db
+
+
+def _make_db_with_no_quota_row():
+    """Mock qui renvoie None la première fois (création requise), puis row avec count=0."""
+    db = AsyncMock()
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none = MagicMock(return_value=None)
+    db.execute = AsyncMock(return_value=result_mock)
+    db.flush = AsyncMock()
+    return db
+
+
+class TestCanConsume:
+    @pytest.mark.asyncio
+    async def test_free_refused(self):
+        from videos.visual_integration import STATUS_PLAN_NOT_ALLOWED, can_consume
+
+        db = AsyncMock()
+        user = _make_user("free")
+        allowed, reason = await can_consume(db, user)
+        assert allowed is False
+        assert reason == STATUS_PLAN_NOT_ALLOWED
+
+    @pytest.mark.asyncio
+    async def test_expert_unlimited_no_db_check(self):
+        from videos.visual_integration import STATUS_OK, can_consume
+
+        db = AsyncMock()
+        user = _make_user("expert")
+        allowed, reason = await can_consume(db, user)
+        assert allowed is True
+        assert reason == STATUS_OK
+        # Pas d'appel DB pour Expert (illimité)
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pro_under_quota_allowed(self):
+        from videos.visual_integration import STATUS_OK, can_consume
+
+        db = _make_db_with_quota(count_value=10)
+        user = _make_user("pro")
+        allowed, reason = await can_consume(db, user)
+        assert allowed is True
+        assert reason == STATUS_OK
+
+    @pytest.mark.asyncio
+    async def test_pro_at_quota_limit_refused(self):
+        from videos.visual_integration import STATUS_QUOTA_EXCEEDED, can_consume
+
+        db = _make_db_with_quota(count_value=30)  # Pile au cap
+        user = _make_user("pro")
+        allowed, reason = await can_consume(db, user)
+        assert allowed is False
+        assert reason == STATUS_QUOTA_EXCEEDED
+
+    @pytest.mark.asyncio
+    async def test_pro_no_row_yet_allowed(self):
+        from videos.visual_integration import STATUS_OK, can_consume
+
+        db = _make_db_with_no_quota_row()
+        user = _make_user("pro")
+        allowed, reason = await can_consume(db, user)
+        assert allowed is True
+        assert reason == STATUS_OK
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔌 maybe_enrich_with_visual — failure & happy paths
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMaybeEnrichWithVisual:
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_disabled(self):
+        from videos.visual_integration import (
+            STATUS_DISABLED,
+            maybe_enrich_with_visual,
+        )
+
+        db = AsyncMock()
+        user = _make_user("pro")
+        result = await maybe_enrich_with_visual(
+            db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", flag_enabled=False
+        )
+        assert result["status"] == STATUS_DISABLED
+
+    @pytest.mark.asyncio
+    async def test_free_plan_returns_plan_not_allowed(self):
+        from videos.visual_integration import (
+            STATUS_PLAN_NOT_ALLOWED,
+            maybe_enrich_with_visual,
+        )
+
+        db = AsyncMock()
+        user = _make_user("free")
+        result = await maybe_enrich_with_visual(
+            db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+        assert result["status"] == STATUS_PLAN_NOT_ALLOWED
+
+    @pytest.mark.asyncio
+    async def test_non_youtube_url_returns_not_youtube(self, monkeypatch):
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_NOT_YOUTUBE
+
+        db = AsyncMock()
+        user = _make_user("expert")  # Bypass quota
+        result = await vi.maybe_enrich_with_visual(
+            db, user, "https://www.tiktok.com/@user/video/123"
+        )
+        assert result["status"] == STATUS_NOT_YOUTUBE
+
+    @pytest.mark.asyncio
+    async def test_quota_exceeded(self):
+        from videos.visual_integration import (
+            STATUS_QUOTA_EXCEEDED,
+            maybe_enrich_with_visual,
+        )
+
+        db = _make_db_with_quota(count_value=30)
+        user = _make_user("pro")
+        result = await maybe_enrich_with_visual(
+            db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+        assert result["status"] == STATUS_QUOTA_EXCEEDED
+
+    @pytest.mark.asyncio
+    async def test_extract_failed(self, monkeypatch):
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_EXTRACT_FAILED
+
+        db = AsyncMock()
+        user = _make_user("expert")
+
+        async def fake_extract(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+
+        result = await vi.maybe_enrich_with_visual(
+            db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+        assert result["status"] == STATUS_EXTRACT_FAILED
+        assert result["video_id"] == "dQw4w9WgXcQ"
+
+    @pytest.mark.asyncio
+    async def test_happy_path(self, monkeypatch):
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_OK
+        from videos.frame_extractor import FrameExtractionResult
+        from videos.visual_analyzer import VisualAnalysis
+
+        db = _make_db_with_no_quota_row()
+        user = _make_user("expert")  # Pas de quota check besides initial allowed
+
+        # Mock extraction
+        fake_extraction = FrameExtractionResult(
+            workdir="/tmp/fake",
+            frame_paths=["/tmp/fake/f1.jpg", "/tmp/fake/f2.jpg"],
+            frame_timestamps=[1.0, 2.0],
+            duration_s=120.0,
+            fps_used=0.5,
+            frame_count=2,
+            width=320,
+            long_video_warning=False,
+        )
+
+        async def fake_extract(*args, **kwargs):
+            return fake_extraction
+
+        # Patch cleanup pour ne pas tenter de supprimer un dossier inexistant
+        fake_extraction.cleanup = MagicMock()
+
+        async def fake_analyze(*args, **kwargs):
+            return VisualAnalysis(
+                visual_hook="hook visuel test",
+                visual_structure="talking_head",
+                key_moments=[{"timestamp_s": 1.0, "description": "x", "type": "hook"}],
+                visible_text="text",
+                summary_visual="résumé test",
+                model_used="pixtral-large-2411",
+                frames_analyzed=2,
+                frames_downsampled=False,
+            )
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+        monkeypatch.setattr(vi, "analyze_frames", fake_analyze)
+
+        result = await vi.maybe_enrich_with_visual(
+            db,
+            user,
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            transcript_excerpt="Hello world",
+        )
+
+        assert result["status"] == STATUS_OK
+        assert result["video_id"] == "dQw4w9WgXcQ"
+        assert result["frame_count"] == 2
+        assert result["model_used"] == "pixtral-large-2411"
+        assert result["credits_consumed"] == 2
+        assert result["analysis"]["visual_structure"] == "talking_head"
+        assert "elapsed_s" in result
+        # cleanup a été appelé pour purger les frames
+        fake_extraction.cleanup.assert_called_once()

--- a/extension/__tests__/background/visual-analysis-handlers.test.ts
+++ b/extension/__tests__/background/visual-analysis-handlers.test.ts
@@ -1,0 +1,145 @@
+/** @jest-environment jsdom */
+//
+// Tests — handlers `OPEN_SIDEPANEL_VISUAL` et `OPEN_BILLING_UPSELL` dans
+// background.ts. Ces handlers répondent aux messages émis par le badge
+// "👁️ Analyse visuelle" injecté sur YouTube par
+// `extension/src/content/widget.ts` (renderVisualAnalysisBadge).
+//
+// Payload émis par le badge :
+//   { type: "OPEN_SIDEPANEL_VISUAL" | "OPEN_BILLING_UPSELL",
+//     videoId, feature: "visual_analysis", plan }
+//
+// Comportement attendu :
+//  - OPEN_SIDEPANEL_VISUAL : stocke le contexte dans
+//    `chrome.storage.session.visualPanelContext` et ouvre le side panel
+//    sur le tab d'origine.
+//  - OPEN_BILLING_UPSELL : ouvre `${WEBAPP_URL}/pricing?...` dans un
+//    nouvel onglet avec UTM tracking (utm_source=extension,
+//    utm_medium=visual_badge, utm_campaign=visual_analysis_upsell, …).
+//
+// Comme open-voice-call.test.ts, on injecte les mocks chrome.storage.session
+// et chrome.sidePanel localement (APIs Chrome 102+/114+ optionnelles).
+
+import { handleMessage } from "../../src/background";
+
+describe("OPEN_SIDEPANEL_VISUAL handler", () => {
+  beforeEach(() => {
+    const c = global as unknown as {
+      chrome: {
+        storage: { session?: { set: jest.Mock; remove?: jest.Mock } };
+        sidePanel?: { open: jest.Mock; setOptions?: jest.Mock };
+        tabs: { create: jest.Mock };
+      };
+    };
+    c.chrome.storage.session = {
+      set: jest.fn().mockResolvedValue(undefined),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+    c.chrome.sidePanel = {
+      open: jest.fn().mockResolvedValue(undefined),
+      setOptions: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("stores visualPanelContext and opens side panel for paid user", async () => {
+    const result = await handleMessage(
+      {
+        type: "OPEN_SIDEPANEL_VISUAL",
+        videoId: "abc",
+        feature: "visual_analysis",
+        plan: "pro",
+      } as unknown as Parameters<typeof handleMessage>[0],
+      { tab: { id: 42, windowId: 7 } } as chrome.runtime.MessageSender,
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(chrome.storage.session!.set).toHaveBeenCalledWith({
+      visualPanelContext: {
+        videoId: "abc",
+        feature: "visual_analysis",
+        plan: "pro",
+        source: "youtube_badge",
+      },
+    });
+    expect(chrome.sidePanel!.setOptions).toHaveBeenCalledWith({
+      tabId: 42,
+      path: "sidepanel.html",
+      enabled: true,
+    });
+    expect(chrome.sidePanel!.open).toHaveBeenCalledWith({ tabId: 42 });
+  });
+
+  it("returns error when sidePanel API unavailable", async () => {
+    const c = global as unknown as { chrome: { sidePanel?: unknown } };
+    c.chrome.sidePanel = undefined;
+
+    const result = await handleMessage(
+      {
+        type: "OPEN_SIDEPANEL_VISUAL",
+        videoId: "abc",
+        feature: "visual_analysis",
+        plan: "expert",
+      } as unknown as Parameters<typeof handleMessage>[0],
+      { tab: { id: 1, windowId: 1 } } as chrome.runtime.MessageSender,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Side panel API not available/i);
+  });
+});
+
+describe("OPEN_BILLING_UPSELL handler", () => {
+  beforeEach(() => {
+    const c = global as unknown as {
+      chrome: { tabs: { create: jest.Mock } };
+    };
+    c.chrome.tabs.create = jest.fn().mockResolvedValue({ id: 99 });
+  });
+
+  it("opens pricing tab with UTM tracking and feature param", async () => {
+    const result = await handleMessage(
+      {
+        type: "OPEN_BILLING_UPSELL",
+        videoId: "xyz",
+        feature: "visual_analysis",
+        plan: "free",
+      } as unknown as Parameters<typeof handleMessage>[0],
+      { tab: { id: 1, windowId: 1 } } as chrome.runtime.MessageSender,
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(1);
+    const calledUrl = (chrome.tabs.create as jest.Mock).mock.calls[0][0]
+      .url as string;
+    expect(calledUrl).toMatch(
+      /^https:\/\/www\.deepsightsynthesis\.com\/pricing\?/,
+    );
+    const url = new URL(calledUrl);
+    expect(url.searchParams.get("utm_source")).toBe("extension");
+    expect(url.searchParams.get("utm_medium")).toBe("visual_badge");
+    expect(url.searchParams.get("utm_campaign")).toBe(
+      "visual_analysis_upsell",
+    );
+    expect(url.searchParams.get("feature")).toBe("visual_analysis");
+    expect(url.searchParams.get("video_id")).toBe("xyz");
+    expect(url.searchParams.get("from_plan")).toBe("free");
+  });
+
+  it("works without optional videoId/plan", async () => {
+    const result = await handleMessage(
+      {
+        type: "OPEN_BILLING_UPSELL",
+        feature: "visual_analysis",
+      } as unknown as Parameters<typeof handleMessage>[0],
+      { tab: { id: 1, windowId: 1 } } as chrome.runtime.MessageSender,
+    );
+
+    expect(result).toEqual({ success: true });
+    const calledUrl = (chrome.tabs.create as jest.Mock).mock.calls[0][0]
+      .url as string;
+    const url = new URL(calledUrl);
+    expect(url.searchParams.get("utm_source")).toBe("extension");
+    expect(url.searchParams.has("video_id")).toBe(false);
+    expect(url.searchParams.has("from_plan")).toBe(false);
+  });
+});

--- a/extension/__tests__/content/widget-visual-analysis-badge.test.ts
+++ b/extension/__tests__/content/widget-visual-analysis-badge.test.ts
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+//
+// Tests — `renderVisualAnalysisBadge` (extension/src/content/widget.ts)
+//
+// Couvre :
+//  - Rendu du badge "Analyse visuelle" sous le bouton voice
+//  - Variation Pro/Expert (Inclus) vs Free (Pro+ CTA)
+//  - Click → envoie OPEN_SIDEPANEL_VISUAL ou OPEN_BILLING_UPSELL
+import { renderVisualAnalysisBadge } from "../../src/content/widget";
+
+async function renderBadge(opts: {
+  plan: "free" | "pro" | "expert";
+  videoId?: string;
+}): Promise<void> {
+  document.body.innerHTML = '<div id="ds-widget-root"></div>';
+  const root = document.getElementById("ds-widget-root");
+  if (!root) throw new Error("root not found");
+  await renderVisualAnalysisBadge(root, opts);
+}
+
+function getBadges(): HTMLButtonElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button.ds-visual-badge"),
+  );
+}
+
+describe("widget visual analysis badge", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    chrome.runtime.sendMessage = jest.fn();
+  });
+
+  it("renders one badge with eye emoji", async () => {
+    await renderBadge({ plan: "pro", videoId: "abc" });
+    const badges = getBadges();
+    expect(badges).toHaveLength(1);
+    expect(badges[0].textContent).toMatch(/👁️/);
+    expect(badges[0].textContent).toMatch(/Analyse visuelle/);
+  });
+
+  it("shows 'Inclus' tag for Pro user", async () => {
+    await renderBadge({ plan: "pro" });
+    expect(document.body.textContent).toMatch(/Inclus/i);
+  });
+
+  it("shows 'Inclus' tag for Expert user", async () => {
+    await renderBadge({ plan: "expert" });
+    expect(document.body.textContent).toMatch(/Inclus/i);
+  });
+
+  it("shows 'Pro+' tag for Free user (upsell)", async () => {
+    await renderBadge({ plan: "free" });
+    expect(document.body.textContent).toMatch(/Pro\+/i);
+    expect(document.body.textContent).not.toMatch(/Inclus/i);
+  });
+
+  it("Pro click sends OPEN_SIDEPANEL_VISUAL", async () => {
+    await renderBadge({ plan: "pro", videoId: "abc" });
+    getBadges()[0].click();
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "OPEN_SIDEPANEL_VISUAL",
+      videoId: "abc",
+      feature: "visual_analysis",
+      plan: "pro",
+    });
+  });
+
+  it("Free click sends OPEN_BILLING_UPSELL", async () => {
+    await renderBadge({ plan: "free", videoId: "xyz" });
+    getBadges()[0].click();
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "OPEN_BILLING_UPSELL",
+      videoId: "xyz",
+      feature: "visual_analysis",
+      plan: "free",
+    });
+  });
+
+  it("has aria-label adapted to plan", async () => {
+    await renderBadge({ plan: "expert" });
+    const badge = getBadges()[0];
+    expect(badge.getAttribute("aria-label")).toMatch(
+      /incluse dans votre plan/i,
+    );
+
+    document.body.innerHTML = "";
+    await renderBadge({ plan: "free" });
+    const badge2 = getBadges()[0];
+    expect(badge2.getAttribute("aria-label")).toMatch(/disponible dès Pro/i);
+  });
+});

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -758,6 +758,24 @@ interface VoiceCallMessage {
   plan?: "free" | "pro" | "expert";
 }
 
+/**
+ * Visual analysis badge dispatcher — handles `{ type: "OPEN_SIDEPANEL_VISUAL", ... }`
+ * et `{ type: "OPEN_BILLING_UPSELL", ... }` émis par le badge "👁️ Analyse visuelle"
+ * injecté sur YouTube par `content/widget.ts` (renderVisualAnalysisBadge).
+ *
+ * - OPEN_SIDEPANEL_VISUAL : utilisateur Pro/Expert → ouvre le side panel pour
+ *   afficher l'analyse visuelle. Le contexte est stocké dans
+ *   `chrome.storage.session.visualPanelContext` (mêmes garanties que voicePanelContext).
+ * - OPEN_BILLING_UPSELL   : utilisateur Free → ouvre la page pricing dans un
+ *   nouvel onglet avec UTM tracking pour mesurer le funnel.
+ */
+interface VisualAnalysisMessage {
+  type: "OPEN_SIDEPANEL_VISUAL" | "OPEN_BILLING_UPSELL";
+  videoId?: string;
+  feature?: string;
+  plan?: "free" | "pro" | "expert";
+}
+
 /** [B8] Sidepanel → background : "demande-moi le micro via offscreen". */
 interface MicPermissionMessage {
   action:
@@ -802,7 +820,11 @@ async function openMicPermissionPopup(): Promise<void> {
 }
 
 export async function handleMessage(
-  message: ExtensionMessage | VoiceCallMessage | MicPermissionMessage,
+  message:
+    | ExtensionMessage
+    | VoiceCallMessage
+    | VisualAnalysisMessage
+    | MicPermissionMessage,
   sender?: chrome.runtime.MessageSender | number,
 ): Promise<MessageResponse> {
   // Backwards compat: accept either a full sender object (preferred) or a
@@ -926,6 +948,99 @@ export async function handleMessage(
     // [N6] Idem au RESTORE — restore tous les volumes.
     await broadcastVoiceAudioMessage("RESTORE_AUDIO", senderTabId);
     return { success: true };
+  }
+
+  // ── Visual analysis badge dispatch (Phase 2) ──
+  // Émis par renderVisualAnalysisBadge (extension/src/content/widget.ts).
+  // Payload : { type, videoId?, feature: "visual_analysis", plan }.
+  const visualMsg = message as VisualAnalysisMessage;
+  if (visualMsg?.type === "OPEN_SIDEPANEL_VISUAL") {
+    try {
+      // Le content script connaît son tab (sender.tab.id). Si absent (cas
+      // improbable côté badge), on fallback sur la fenêtre courante.
+      const fullSender = sender as chrome.runtime.MessageSender | undefined;
+      let tabId = fullSender?.tab?.id;
+      if (typeof tabId !== "number") {
+        tabId = senderTabId;
+      }
+      // Persiste le contexte AVANT d'ouvrir : la page sidepanel le lit dès
+      // mount via chrome.storage.session (même pattern que voicePanelContext).
+      const sessionStore = (
+        chrome as unknown as {
+          storage: { session?: { set?: (data: unknown) => Promise<void> } };
+        }
+      ).storage.session;
+      if (sessionStore?.set) {
+        await sessionStore.set({
+          visualPanelContext: {
+            videoId: visualMsg.videoId ?? null,
+            feature: visualMsg.feature ?? "visual_analysis",
+            plan: visualMsg.plan ?? null,
+            source: "youtube_badge",
+          },
+        });
+      }
+      // openVoicePanel() est mal nommée (héritage Spec #4) mais c'est la
+      // helper canonique : feature-detect + setOptions + open. On la
+      // réutilise telle quelle pour rester cohérent.
+      const sidePanel = (
+        chrome as unknown as {
+          sidePanel?: {
+            setOptions?: (opts: {
+              tabId?: number;
+              path?: string;
+              enabled?: boolean;
+            }) => Promise<void> | void;
+            open?: (opts: {
+              tabId?: number;
+              windowId?: number;
+            }) => Promise<void> | void;
+          };
+        }
+      ).sidePanel;
+      if (!sidePanel || typeof sidePanel.open !== "function") {
+        return {
+          success: false,
+          error: "Side panel API not available in this browser",
+        };
+      }
+      if (sidePanel.setOptions) {
+        await sidePanel.setOptions({
+          tabId,
+          path: "sidepanel.html",
+          enabled: true,
+        });
+      }
+      await sidePanel.open({ tabId });
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: (e as Error).message };
+    }
+  }
+
+  if (visualMsg?.type === "OPEN_BILLING_UPSELL") {
+    try {
+      // Funnel tracking : utm_source/medium/campaign + feature pour
+      // attribuer les conversions au badge visual analysis (vs voice,
+      // popup, hub, etc.).
+      const params = new URLSearchParams({
+        utm_source: "extension",
+        utm_medium: "visual_badge",
+        utm_campaign: "visual_analysis_upsell",
+        feature: visualMsg.feature ?? "visual_analysis",
+      });
+      if (visualMsg.videoId) {
+        params.set("video_id", visualMsg.videoId);
+      }
+      if (visualMsg.plan) {
+        params.set("from_plan", visualMsg.plan);
+      }
+      const pricingUrl = `${WEBAPP_URL}/pricing?${params.toString()}`;
+      await Browser.tabs.create({ url: pricingUrl });
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: (e as Error).message };
+    }
   }
 
   // Narrow vers le shape ExtensionMessage classique pour la suite du switch

--- a/extension/src/content/voiceCallInjector.ts
+++ b/extension/src/content/voiceCallInjector.ts
@@ -15,7 +15,7 @@
 //
 // Pas de dépendance externe — `renderVoiceCallButton` est notre source de
 // vérité unique pour le rendu et l'envoi du message OPEN_VOICE_CALL.
-import { renderVoiceCallButton } from "./widget";
+import { renderVoiceCallButton, renderVisualAnalysisBadge } from "./widget";
 
 const HOST_ID = "ds-voice-call-host";
 
@@ -180,6 +180,17 @@ export async function injectVoiceCallButton(): Promise<void> {
     videoId,
     videoTitle: getCleanVideoTitle(),
   });
+
+  // Phase 2 Visual Analysis badge — sous le bouton Voice Call.
+  // Best-effort : si le rendu échoue, le bouton Voice Call reste fonctionnel.
+  try {
+    await renderVisualAnalysisBadge(shadow as unknown as HTMLElement, {
+      plan: state.plan,
+      videoId,
+    });
+  } catch {
+    /* graceful degradation — le badge est non-critique */
+  }
 
   if (useFloating) {
     document.body.appendChild(host);

--- a/extension/src/content/widget.ts
+++ b/extension/src/content/widget.ts
@@ -131,3 +131,94 @@ export async function renderVoiceCallButton(
 
   root.appendChild(btn);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 👁️ VISUAL ANALYSIS BADGE — Phase 2 (Mai 2026)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface VisualAnalysisBadgeOpts {
+  plan: "free" | "pro" | "expert";
+  videoId?: string;
+}
+
+/**
+ * Injecte un badge "👁️ Analyse visuelle" sous le bouton Voice Call.
+ *
+ * Pro/Expert  : badge violet "Inclus" → click ouvre le sidepanel (CTA info)
+ * Free        : badge cliquable "Disponible dès Pro" → click ouvre billing
+ *
+ * Indépendant du bouton Voice Call — cohabite dans le même host Shadow DOM
+ * mais ne dépend pas de son état.
+ */
+export async function renderVisualAnalysisBadge(
+  root: HTMLElement,
+  opts: VisualAnalysisBadgeOpts,
+): Promise<void> {
+  const isPaid = opts.plan === "pro" || opts.plan === "expert";
+
+  const badge = document.createElement("button");
+  badge.className = "ds-visual-badge";
+  badge.setAttribute(
+    "aria-label",
+    isPaid
+      ? "Analyse visuelle incluse dans votre plan"
+      : "Analyse visuelle disponible dès Pro",
+  );
+
+  const bg = isPaid
+    ? "linear-gradient(135deg,rgba(139,92,246,0.15),rgba(99,102,241,0.15))"
+    : "rgba(255,255,255,0.05)";
+  const borderColor = isPaid
+    ? "rgba(139,92,246,0.4)"
+    : "rgba(255,255,255,0.15)";
+
+  badge.style.cssText = [
+    "width:100%",
+    `background:${bg}`,
+    "color:#fff",
+    `border:1px solid ${borderColor}`,
+    "padding:8px 10px",
+    "border-radius:8px",
+    "font-weight:500",
+    "font-size:11px",
+    "margin-top:6px",
+    "cursor:pointer",
+    "display:flex",
+    "align-items:center",
+    "justify-content:space-between",
+    "gap:8px",
+    "transition:opacity 0.15s ease",
+  ].join(";");
+
+  const labelText = isPaid
+    ? "👁️ Analyse visuelle incluse"
+    : "👁️ Analyse visuelle";
+  const tagText = isPaid ? "Inclus" : "Pro+";
+  const tagBg = isPaid ? "rgba(34,197,94,0.2)" : "rgba(139,92,246,0.25)";
+  const tagColor = isPaid ? "#86efac" : "#c4b5fd";
+
+  badge.innerHTML = `
+    <span style="display:flex;align-items:center;gap:6px">
+      <span>${labelText}</span>
+    </span>
+    <span style="background:${tagBg};color:${tagColor};padding:2px 6px;border-radius:4px;font-size:9px;font-weight:600;letter-spacing:0.3px;text-transform:uppercase">${tagText}</span>
+  `;
+
+  badge.addEventListener("mouseenter", () => {
+    badge.style.opacity = "0.85";
+  });
+  badge.addEventListener("mouseleave", () => {
+    badge.style.opacity = "1";
+  });
+
+  badge.addEventListener("click", () => {
+    chrome.runtime.sendMessage({
+      type: isPaid ? "OPEN_SIDEPANEL_VISUAL" : "OPEN_BILLING_UPSELL",
+      videoId: opts.videoId,
+      feature: "visual_analysis",
+      plan: opts.plan,
+    });
+  });
+
+  root.appendChild(badge);
+}

--- a/frontend/src/components/AnalysisHub/VisualTab.tsx
+++ b/frontend/src/components/AnalysisHub/VisualTab.tsx
@@ -1,0 +1,480 @@
+/**
+ * DEEP SIGHT — AnalysisHub / VisualTab
+ *
+ * Onglet "Visuel" : consomme `analysis.visual_analysis` (payload Phase 2 —
+ * Mistral Vision sur storyboards YouTube) et le rend en 6 sections :
+ *   1. Hook visuel (gros texte d'intro)
+ *   2. Structure visuelle (badge)
+ *   3. Moments clés (timeline timestamp + description + type)
+ *   4. Texte visible à l'écran
+ *   5. Indicateurs SEO visuels (grid)
+ *   6. Résumé visuel (prose)
+ *
+ * Empty state : affiche un message + CTA quand `visual_analysis` est null
+ * ou undefined (analyse non lancée / Phase 2 désactivée). Le tab est
+ * toujours rendu — la décision de masquer le bouton se fait en amont
+ * dans le HubTabBar / AnalysisHub si on veut le hide selon plan/feature.
+ */
+
+import React from "react";
+import {
+  Eye,
+  Film,
+  Clock,
+  Type,
+  Sparkles,
+  FileVideo,
+  Sun,
+  User,
+  Subtitles,
+  Zap,
+  Image as ImageIcon,
+  Info,
+} from "lucide-react";
+import type {
+  VisualAnalysis,
+  VisualStructure,
+  VisualSeoIndicators,
+  VisualQualitativeLevel,
+} from "../../types/analysis";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 📦 PROPS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface VisualTabProps {
+  visualAnalysis: VisualAnalysis | null | undefined;
+  language: "fr" | "en";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎨 LABEL HELPERS — i18n minimal local (pas de dépendance i18n côté tab)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const STRUCTURE_LABELS: Record<
+  VisualStructure,
+  { fr: string; en: string }
+> = {
+  talking_head: { fr: "Talking head", en: "Talking head" },
+  b_roll: { fr: "B-roll", en: "B-roll" },
+  gameplay: { fr: "Gameplay", en: "Gameplay" },
+  slides: { fr: "Slides", en: "Slides" },
+  tutorial: { fr: "Tutoriel", en: "Tutorial" },
+  interview: { fr: "Interview", en: "Interview" },
+  vlog: { fr: "Vlog", en: "Vlog" },
+  mixed: { fr: "Mixte", en: "Mixed" },
+  other: { fr: "Autre", en: "Other" },
+};
+
+const QUALITATIVE_LABELS: Record<
+  VisualQualitativeLevel,
+  { fr: string; en: string }
+> = {
+  low: { fr: "Faible", en: "Low" },
+  medium: { fr: "Moyen", en: "Medium" },
+  high: { fr: "Élevé", en: "High" },
+};
+
+const QUALITATIVE_COLORS: Record<VisualQualitativeLevel, string> = {
+  low: "text-amber-300 bg-amber-500/10 border-amber-500/20",
+  medium: "text-blue-300 bg-blue-500/10 border-blue-500/20",
+  high: "text-emerald-300 bg-emerald-500/10 border-emerald-500/20",
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🛠️ UTILS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/** Formate un timestamp (secondes) en MM:SS ou H:MM:SS si > 1h. */
+function formatTimestamp(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(safe / 3600);
+  const m = Math.floor((safe % 3600) / 60);
+  const s = safe % 60;
+  const mm = String(m).padStart(2, "0");
+  const ss = String(s).padStart(2, "0");
+  if (h > 0) {
+    return `${h}:${mm}:${ss}`;
+  }
+  return `${mm}:${ss}`;
+}
+
+const t = (lang: "fr" | "en", fr: string, en: string) =>
+  lang === "fr" ? fr : en;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🧩 SOUS-COMPOSANTS — petits, isolés, lisibles
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const SectionTitle: React.FC<{
+  icon: React.ComponentType<{ className?: string }>;
+  iconColor: string;
+  children: React.ReactNode;
+}> = ({ icon: Icon, iconColor, children }) => (
+  <h3 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-text-secondary mb-3">
+    <Icon className={`w-4 h-4 ${iconColor}`} />
+    <span>{children}</span>
+  </h3>
+);
+
+interface IndicatorTileProps {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  /** Texte de droite — soit valeur qualitative, soit "Oui/Non/—". */
+  valueNode: React.ReactNode;
+}
+
+const IndicatorTile: React.FC<IndicatorTileProps> = ({
+  icon: Icon,
+  label,
+  valueNode,
+}) => (
+  <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-white/[0.03] border border-white/5 hover:border-white/10 transition-colors">
+    <div className="flex items-center gap-2 min-w-0">
+      <Icon className="w-4 h-4 text-text-tertiary flex-shrink-0" />
+      <span className="text-xs text-text-tertiary truncate">{label}</span>
+    </div>
+    <div className="flex-shrink-0">{valueNode}</div>
+  </div>
+);
+
+const QualitativeBadge: React.FC<{
+  level: VisualQualitativeLevel | undefined;
+  language: "fr" | "en";
+}> = ({ level, language }) => {
+  if (!level) {
+    return <span className="text-xs text-text-tertiary font-mono">—</span>;
+  }
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-semibold border ${QUALITATIVE_COLORS[level]}`}
+    >
+      {QUALITATIVE_LABELS[level][language]}
+    </span>
+  );
+};
+
+const BooleanBadge: React.FC<{
+  value: boolean | undefined;
+  language: "fr" | "en";
+}> = ({ value, language }) => {
+  if (value === undefined) {
+    return <span className="text-xs text-text-tertiary font-mono">—</span>;
+  }
+  if (value) {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-semibold border text-emerald-300 bg-emerald-500/10 border-emerald-500/20">
+        {t(language, "Oui", "Yes")}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-semibold border text-text-tertiary bg-white/5 border-white/10">
+      {t(language, "Non", "No")}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🚫 EMPTY STATE — Phase 2 non activée pour cette analyse
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const EmptyVisualState: React.FC<{ language: "fr" | "en" }> = ({
+  language,
+}) => (
+  <div className="p-8 sm:p-12 text-center">
+    <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-white/5 border border-white/10 mb-4">
+      <Eye className="w-8 h-8 text-text-tertiary" aria-hidden="true" />
+    </div>
+    <h3 className="text-lg font-semibold text-text-primary mb-2">
+      {t(language, "Analyse visuelle non disponible", "Visual analysis unavailable")}
+    </h3>
+    <p className="text-sm text-text-tertiary max-w-md mx-auto mb-4">
+      {t(
+        language,
+        "Cette analyse n'a pas inclus la couche visuelle. Réanalysez la vidéo en activant l'option « Analyse visuelle » pour voir le hook, la structure, les moments clés et les indicateurs SEO visuels extraits par Mistral Vision.",
+        "This analysis did not include the visual layer. Re-run the analysis with the « Visual analysis » option enabled to see the hook, structure, key moments and SEO indicators extracted by Mistral Vision.",
+      )}
+    </p>
+    <span className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-indigo-500/10 text-indigo-300 text-sm font-medium border border-indigo-500/20">
+      <Sparkles className="w-4 h-4" aria-hidden="true" />
+      {t(language, "Réanalyser avec le visuel", "Re-analyze with visuals")}
+    </span>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎯 COMPOSANT PRINCIPAL
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const VisualTab: React.FC<VisualTabProps> = ({
+  visualAnalysis,
+  language,
+}) => {
+  // Empty state quand le payload est absent (Phase 2 non lancée)
+  if (!visualAnalysis) {
+    return <EmptyVisualState language={language} />;
+  }
+
+  const {
+    visual_hook,
+    visual_structure,
+    key_moments,
+    visible_text,
+    visual_seo_indicators,
+    summary_visual,
+    model_used,
+    frames_analyzed,
+    frames_downsampled,
+  } = visualAnalysis;
+
+  const structureLabel =
+    STRUCTURE_LABELS[visual_structure]?.[language] ?? visual_structure;
+
+  // Tri des moments clés par timestamp pour cohérence visuelle
+  const sortedMoments = [...(key_moments || [])].sort(
+    (a, b) => a.timestamp_s - b.timestamp_s,
+  );
+
+  return (
+    <div className="p-4 sm:p-6 space-y-8">
+      {/* ─── 1. HOOK VISUEL ─── */}
+      <section aria-labelledby="visual-hook-title">
+        <SectionTitle icon={Eye} iconColor="text-indigo-400">
+          <span id="visual-hook-title">
+            {t(language, "Hook visuel", "Visual hook")}
+          </span>
+        </SectionTitle>
+        <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-xl p-4 sm:p-5">
+          <p className="text-base sm:text-lg leading-relaxed text-text-primary">
+            {visual_hook || (
+              <span className="italic text-text-tertiary">
+                {t(language, "Aucun hook détecté.", "No hook detected.")}
+              </span>
+            )}
+          </p>
+        </div>
+      </section>
+
+      {/* ─── 2. STRUCTURE VISUELLE ─── */}
+      <section aria-labelledby="visual-structure-title">
+        <SectionTitle icon={Film} iconColor="text-violet-400">
+          <span id="visual-structure-title">
+            {t(language, "Structure", "Structure")}
+          </span>
+        </SectionTitle>
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold border bg-violet-500/10 text-violet-300 border-violet-500/20">
+            <FileVideo className="w-4 h-4" aria-hidden="true" />
+            {structureLabel}
+          </span>
+        </div>
+      </section>
+
+      {/* ─── 3. MOMENTS CLÉS ─── */}
+      <section aria-labelledby="visual-moments-title">
+        <SectionTitle icon={Clock} iconColor="text-cyan-400">
+          <span id="visual-moments-title">
+            {t(language, "Moments clés", "Key moments")}
+          </span>
+        </SectionTitle>
+        {sortedMoments.length === 0 ? (
+          <p className="text-sm italic text-text-tertiary">
+            {t(
+              language,
+              "Aucun moment clé détecté.",
+              "No key moments detected.",
+            )}
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {sortedMoments.map((moment, idx) => (
+              <li
+                key={`${moment.timestamp_s}-${idx}`}
+                className="flex items-start gap-3 p-3 rounded-lg bg-white/[0.03] border border-white/5 hover:border-white/10 transition-colors"
+              >
+                <span
+                  className="flex-shrink-0 inline-flex items-center justify-center min-w-[58px] px-2 py-1 rounded-md font-mono text-[11px] font-semibold tracking-wider text-cyan-300 bg-cyan-500/10 border border-cyan-500/20"
+                  style={{ fontFamily: "JetBrains Mono, monospace" }}
+                  aria-label={t(language, "Timestamp", "Timestamp")}
+                >
+                  {formatTimestamp(moment.timestamp_s)}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm text-text-primary leading-relaxed">
+                    {moment.description}
+                  </p>
+                </div>
+                {moment.type && (
+                  <span className="flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-semibold uppercase tracking-wide border text-text-secondary bg-white/5 border-white/10">
+                    {moment.type}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      {/* ─── 4. TEXTE VISIBLE ─── */}
+      <section aria-labelledby="visual-text-title">
+        <SectionTitle icon={Type} iconColor="text-amber-400">
+          <span id="visual-text-title">
+            {t(language, "Texte visible à l'écran", "On-screen text")}
+          </span>
+        </SectionTitle>
+        <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-xl p-4">
+          {visible_text && visible_text.trim() ? (
+            <p className="text-sm text-text-primary leading-relaxed whitespace-pre-wrap">
+              {visible_text}
+            </p>
+          ) : (
+            <p className="text-sm italic text-text-tertiary">
+              {t(
+                language,
+                "Aucun texte détecté.",
+                "No text detected.",
+              )}
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* ─── 5. INDICATEURS SEO VISUELS ─── */}
+      <section aria-labelledby="visual-seo-title">
+        <SectionTitle icon={Sparkles} iconColor="text-emerald-400">
+          <span id="visual-seo-title">
+            {t(
+              language,
+              "Indicateurs SEO visuels",
+              "Visual SEO indicators",
+            )}
+          </span>
+        </SectionTitle>
+        <SeoIndicatorsGrid
+          indicators={visual_seo_indicators}
+          language={language}
+        />
+      </section>
+
+      {/* ─── 6. RÉSUMÉ VISUEL ─── */}
+      <section aria-labelledby="visual-summary-title">
+        <SectionTitle icon={Info} iconColor="text-blue-400">
+          <span id="visual-summary-title">
+            {t(language, "Résumé visuel", "Visual summary")}
+          </span>
+        </SectionTitle>
+        <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-xl p-4 sm:p-5">
+          {summary_visual ? (
+            <p className="text-sm text-text-secondary leading-relaxed whitespace-pre-wrap">
+              {summary_visual}
+            </p>
+          ) : (
+            <p className="text-sm italic text-text-tertiary">
+              {t(
+                language,
+                "Aucun résumé visuel généré.",
+                "No visual summary generated.",
+              )}
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* ─── METADATA (footer discret) ─── */}
+      <footer className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-text-tertiary border-t border-white/5 pt-4">
+        <span>
+          {t(language, "Modèle", "Model")}:{" "}
+          <span
+            className="font-mono text-text-secondary"
+            style={{ fontFamily: "JetBrains Mono, monospace" }}
+          >
+            {model_used || "—"}
+          </span>
+        </span>
+        <span>
+          {t(language, "Frames analysées", "Frames analyzed")}:{" "}
+          <span
+            className="font-mono text-text-secondary"
+            style={{ fontFamily: "JetBrains Mono, monospace" }}
+          >
+            {frames_analyzed}
+          </span>
+        </span>
+        {frames_downsampled && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-amber-500/10 text-amber-300 border border-amber-500/20">
+            {t(language, "Échantillonné", "Downsampled")}
+          </span>
+        )}
+      </footer>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🧮 GRID DES INDICATEURS SEO — extrait pour lisibilité
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const SeoIndicatorsGrid: React.FC<{
+  indicators: VisualSeoIndicators;
+  language: "fr" | "en";
+}> = ({ indicators, language }) => {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <IndicatorTile
+        icon={Sun}
+        label={t(language, "Luminosité du hook", "Hook brightness")}
+        valueNode={
+          <QualitativeBadge
+            level={indicators.hook_brightness}
+            language={language}
+          />
+        }
+      />
+      <IndicatorTile
+        icon={User}
+        label={t(language, "Visage dans le hook", "Face in hook")}
+        valueNode={
+          <BooleanBadge
+            value={indicators.face_visible_in_hook}
+            language={language}
+          />
+        }
+      />
+      <IndicatorTile
+        icon={Subtitles}
+        label={t(language, "Sous-titres incrustés", "Burned-in subtitles")}
+        valueNode={
+          <BooleanBadge
+            value={indicators.burned_in_subtitles}
+            language={language}
+          />
+        }
+      />
+      <IndicatorTile
+        icon={Zap}
+        label={t(language, "Intro à fort mouvement", "High-motion intro")}
+        valueNode={
+          <BooleanBadge
+            value={indicators.high_motion_intro}
+            language={language}
+          />
+        }
+      />
+      <IndicatorTile
+        icon={ImageIcon}
+        label={t(
+          language,
+          "Qualité miniature (proxy)",
+          "Thumbnail quality (proxy)",
+        )}
+        valueNode={
+          <QualitativeBadge
+            level={indicators.thumbnail_quality_proxy}
+            language={language}
+          />
+        }
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/AnalysisHub/__tests__/VisualTab.test.tsx
+++ b/frontend/src/components/AnalysisHub/__tests__/VisualTab.test.tsx
@@ -1,0 +1,164 @@
+// frontend/src/components/AnalysisHub/__tests__/VisualTab.test.tsx
+//
+// Smoke tests pour le tab "Visuel" de l'AnalysisHub. Couvre :
+//   - Empty state quand visualAnalysis est null/undefined.
+//   - Rendu complet avec un payload Mistral Vision typique.
+//   - Format MM:SS / H:MM:SS pour les timestamps.
+//   - Indicateurs SEO (qualitatifs + booléens) avec valeurs absentes.
+//
+// Pas de mock — le composant est pur (props in / DOM out), pas d'API.
+
+import { describe, it, expect } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+import { VisualTab } from "../VisualTab";
+import type { VisualAnalysis } from "../../../types/analysis";
+
+const fullPayload: VisualAnalysis = {
+  visual_hook:
+    "Ouverture sur un gros plan du présentateur avec un titre rouge incrusté.",
+  visual_structure: "talking_head",
+  key_moments: [
+    {
+      timestamp_s: 0,
+      description: "Title card avec le sujet de la vidéo",
+      type: "title_card",
+    },
+    {
+      timestamp_s: 95,
+      description: "Insertion d'une infographie animée",
+      type: "infographic",
+    },
+    {
+      timestamp_s: 3725,
+      description: "CTA d'abonnement en fin de vidéo",
+      type: "cta",
+    },
+  ],
+  visible_text: "Abonnez-vous • Lien en description",
+  visual_seo_indicators: {
+    hook_brightness: "high",
+    face_visible_in_hook: true,
+    burned_in_subtitles: false,
+    high_motion_intro: false,
+    thumbnail_quality_proxy: "medium",
+  },
+  summary_visual:
+    "La vidéo alterne talking head et b-roll avec des incrustations textuelles fréquentes.",
+  model_used: "pixtral-12b-2409",
+  frames_analyzed: 24,
+  frames_downsampled: false,
+};
+
+describe("VisualTab", () => {
+  afterEach(() => cleanup());
+
+  it("affiche un empty state quand visualAnalysis est null", () => {
+    render(<VisualTab visualAnalysis={null} language="fr" />);
+    expect(
+      screen.getByText(/Analyse visuelle non disponible/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Réanalyser avec le visuel/i),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche un empty state quand visualAnalysis est undefined", () => {
+    render(<VisualTab visualAnalysis={undefined} language="fr" />);
+    expect(
+      screen.getByText(/Analyse visuelle non disponible/i),
+    ).toBeInTheDocument();
+  });
+
+  it("rend le hook visuel et la structure", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(screen.getByText(fullPayload.visual_hook)).toBeInTheDocument();
+    // talking_head → "Talking head" (label FR)
+    expect(screen.getByText("Talking head")).toBeInTheDocument();
+  });
+
+  it("formate les timestamps en MM:SS et H:MM:SS", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    // 0s → "00:00"
+    expect(screen.getByText("00:00")).toBeInTheDocument();
+    // 95s → "01:35"
+    expect(screen.getByText("01:35")).toBeInTheDocument();
+    // 3725s → "1:02:05"
+    expect(screen.getByText("1:02:05")).toBeInTheDocument();
+  });
+
+  it("affiche les descriptions des moments clés", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(
+      screen.getByText("Title card avec le sujet de la vidéo"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Insertion d'une infographie animée"),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche le texte visible quand présent", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(
+      screen.getByText("Abonnez-vous • Lien en description"),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche un message italique quand visible_text est vide", () => {
+    const noText: VisualAnalysis = { ...fullPayload, visible_text: "" };
+    render(<VisualTab visualAnalysis={noText} language="fr" />);
+    expect(screen.getByText(/Aucun texte détecté/i)).toBeInTheDocument();
+  });
+
+  it("affiche les indicateurs SEO en français", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(screen.getByText(/Luminosité du hook/i)).toBeInTheDocument();
+    expect(screen.getByText(/Visage dans le hook/i)).toBeInTheDocument();
+  });
+
+  it("affiche des badges Oui/Non pour les indicateurs booléens", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    // face_visible_in_hook = true → au moins un "Oui"
+    expect(screen.getAllByText("Oui").length).toBeGreaterThan(0);
+    // burned_in_subtitles = false → au moins un "Non"
+    expect(screen.getAllByText("Non").length).toBeGreaterThan(0);
+  });
+
+  it("affiche le résumé visuel et les métadonnées model_used / frames_analyzed", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(screen.getByText(fullPayload.summary_visual)).toBeInTheDocument();
+    expect(screen.getByText(fullPayload.model_used)).toBeInTheDocument();
+    expect(
+      screen.getByText(String(fullPayload.frames_analyzed)),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche le badge 'Échantillonné' quand frames_downsampled=true", () => {
+    const downsampled: VisualAnalysis = {
+      ...fullPayload,
+      frames_downsampled: true,
+    };
+    render(<VisualTab visualAnalysis={downsampled} language="fr" />);
+    expect(screen.getByText(/Échantillonné/i)).toBeInTheDocument();
+  });
+
+  it("rend en anglais quand language='en'", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="en" />);
+    expect(screen.getByText(/Visual hook/i)).toBeInTheDocument();
+    expect(screen.getByText(/Key moments/i)).toBeInTheDocument();
+    expect(screen.getByText(/On-screen text/i)).toBeInTheDocument();
+  });
+
+  it("affiche un dash pour les indicateurs absents", () => {
+    const partial: VisualAnalysis = {
+      ...fullPayload,
+      visual_seo_indicators: {
+        hook_brightness: "high",
+        // les autres champs absents
+      },
+    };
+    render(<VisualTab visualAnalysis={partial} language="fr" />);
+    // Présence d'au moins un "—" pour les indicateurs absents
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/AnalysisHub/index.tsx
+++ b/frontend/src/components/AnalysisHub/index.tsx
@@ -5,12 +5,13 @@
  */
 
 import React, { useState, useEffect, useCallback } from "react";
-import { BookOpen, Brain, BookMarked, Shield, Target } from "lucide-react";
+import { BookOpen, Brain, BookMarked, Shield, Target, Eye } from "lucide-react";
 import { SynthesisTab } from "./SynthesisTab";
 import { QuizTab } from "./QuizTab";
 import { FlashcardsTab } from "./FlashcardsTab";
 import { ReliabilityTab } from "./ReliabilityTab";
 import { GeoTab } from "./GeoTab";
+import { VisualTab } from "./VisualTab";
 import { studyApi } from "../../services/api";
 import type {
   Summary,
@@ -25,7 +26,13 @@ import type { TimecodeInfo } from "../TimecodeRenderer";
 // 📦 TYPES
 // ═══════════════════════════════════════════════════════════════════════════════
 
-type TabType = "synthesis" | "quiz" | "flashcards" | "reliability" | "geo";
+type TabType =
+  | "synthesis"
+  | "quiz"
+  | "flashcards"
+  | "reliability"
+  | "geo"
+  | "visual";
 
 interface AnalysisHubProps {
   selectedSummary: Summary;
@@ -112,6 +119,14 @@ const TABS: {
     icon: Target,
     activeColor: "text-teal-400",
     activeBorder: "border-teal-500",
+  },
+  {
+    id: "visual",
+    labelFr: "Visuel",
+    labelEn: "Visual",
+    icon: Eye,
+    activeColor: "text-indigo-400",
+    activeBorder: "border-indigo-500",
   },
 ];
 
@@ -348,6 +363,13 @@ export const AnalysisHub: React.FC<AnalysisHubProps> = ({
         <GeoTab
           selectedSummary={selectedSummary}
           user={user}
+          language={language}
+        />
+      )}
+
+      {activeTab === "visual" && (
+        <VisualTab
+          visualAnalysis={selectedSummary.visual_analysis}
           language={language}
         />
       )}

--- a/frontend/src/components/hub/HubAnalysisPanel.tsx
+++ b/frontend/src/components/hub/HubAnalysisPanel.tsx
@@ -118,7 +118,14 @@ export const HubAnalysisPanel: React.FC<Props> = ({
           onTimecodeClick={handleTimecodeClick}
           onOpenChat={handleOpenChat}
           onNavigate={handleNavigate}
-          enabledTabs={["synthesis", "reliability", "quiz", "flashcards", "geo"]}
+          enabledTabs={[
+            "synthesis",
+            "reliability",
+            "quiz",
+            "flashcards",
+            "geo",
+            "visual",
+          ]}
           showKeywords
           showStudyTools={false}
           showVoice={false}

--- a/frontend/src/components/hub/HubTabBar.tsx
+++ b/frontend/src/components/hub/HubTabBar.tsx
@@ -5,6 +5,7 @@ import {
   BookMarked,
   Shield,
   Target,
+  Eye,
   MessageCircle,
 } from "lucide-react";
 import type { TabId } from "./types";
@@ -61,6 +62,13 @@ const TABS: TabConfig[] = [
     icon: Target,
     activeColor: "text-teal-400",
     activeBorder: "border-teal-500",
+  },
+  {
+    id: "visual",
+    label: "Visuel",
+    icon: Eye,
+    activeColor: "text-indigo-400",
+    activeBorder: "border-indigo-500",
   },
   {
     id: "chat",

--- a/frontend/src/components/hub/__tests__/HubAnalysisPanel.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubAnalysisPanel.test.tsx
@@ -125,9 +125,9 @@ describe("HubAnalysisPanel", () => {
     expect(screen.getByTestId("analysis-hub-mock")).toBeInTheDocument();
     expect(screen.getByTestId("ah-summary-id")).toHaveTextContent("42");
     expect(screen.getByTestId("ah-concepts-count")).toHaveTextContent("1");
-    // The 5 tabs are explicitly enabled by HubAnalysisPanel.
+    // The 6 tabs are explicitly enabled by HubAnalysisPanel.
     expect(screen.getByTestId("ah-tabs")).toHaveTextContent(
-      "synthesis,reliability,quiz,flashcards,geo",
+      "synthesis,reliability,quiz,flashcards,geo,visual",
     );
   });
 

--- a/frontend/src/components/hub/__tests__/HubTabBar.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubTabBar.test.tsx
@@ -10,13 +10,14 @@ describe("HubTabBar", () => {
     factCheckCount: 0,
   };
 
-  it("rend les 6 onglets globaux", () => {
+  it("rend les 7 onglets globaux", () => {
     render(<HubTabBar {...baseProps} />);
     expect(screen.getByRole("tab", { name: /Synthèse/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Quiz/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Flashcards/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Fiabilité/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /GEO/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Visuel/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Chat/ })).toBeInTheDocument();
   });
 

--- a/frontend/src/components/hub/types.ts
+++ b/frontend/src/components/hub/types.ts
@@ -69,9 +69,9 @@ export type HubVoiceState =
   | "call_ending";
 
 /**
- * Identifiant des onglets globaux du Hub. Inclut les 5 onglets d'analyse
- * (synthesis, quiz, flashcards, reliability, geo) ET l'onglet "chat" qui
- * remplace l'ancienne archi single-scroll par une nav sticky globale.
+ * Identifiant des onglets globaux du Hub. Inclut les 6 onglets d'analyse
+ * (synthesis, quiz, flashcards, reliability, geo, visual) ET l'onglet "chat"
+ * qui remplace l'ancienne archi single-scroll par une nav sticky globale.
  *
  * Source de vérité : doit rester en sync avec AnalysisHub.TabType + l'ajout
  * "chat". URL deep-link via `?tab=<TabId>`.
@@ -82,4 +82,5 @@ export type TabId =
   | "flashcards"
   | "reliability"
   | "geo"
+  | "visual"
   | "chat";

--- a/frontend/src/components/landing/VisualAnalysisSection.tsx
+++ b/frontend/src/components/landing/VisualAnalysisSection.tsx
@@ -1,0 +1,254 @@
+/**
+ * VisualAnalysisSection — Section landing Phase 2 Visual Analysis.
+ *
+ * Tagline : « Maintenant, DeepSight ne se contente plus d'écouter — elle regarde. »
+ * Position : section autonome après DemoAnalysisStatic.
+ *
+ * Affiche 3 frames mockup (storyboards YouTube simulés) + un overlay JSON
+ * structuré (visual_hook, visual_structure, key_moments) montrant la valeur
+ * ajoutée de la couche multimodale par-dessus le transcript+sourcing.
+ *
+ * Spec : 01-Projects/DeepSight/Sessions/2026-05-06-visual-analysis-phase-2-spec.md
+ */
+
+import { motion, useInView } from "framer-motion";
+import { useRef } from "react";
+
+const ease = [0.4, 0, 0.2, 1] as const;
+
+interface VisualMomentDef {
+  ts: string; // timestamp affiché
+  type: string; // hook | reveal | cta | transition | peak
+  description: { fr: string; en: string };
+}
+
+// 3 moments visuels mockup pour la démo
+const MOCKUP_MOMENTS: VisualMomentDef[] = [
+  {
+    ts: "00:03",
+    type: "hook",
+    description: {
+      fr: "Plan rapproché sur un visage, fond vif, texte burned-in « ATTENTION »",
+      en: "Close-up on face, vivid background, burned-in text « ATTENTION »",
+    },
+  },
+  {
+    ts: "01:42",
+    type: "reveal",
+    description: {
+      fr: "Coupe brutale vers un graphique en barres ascendant",
+      en: "Hard cut to ascending bar chart",
+    },
+  },
+  {
+    ts: "04:18",
+    type: "cta",
+    description: {
+      fr: "Plan large, geste vers la caméra, surimpression « Abonne-toi »",
+      en: "Wide shot, gesture toward camera, overlay « Subscribe »",
+    },
+  },
+];
+
+export interface VisualAnalysisSectionProps {
+  language: "fr" | "en" | string;
+}
+
+export default function VisualAnalysisSection({ language }: VisualAnalysisSectionProps) {
+  const lang = language === "fr" ? "fr" : "en";
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, margin: "-80px" });
+
+  const tagline = {
+    fr: "Maintenant, DeepSight ne se contente plus d'écouter — elle regarde.",
+    en: "Now, DeepSight doesn't just listen — it watches.",
+  };
+
+  const subtitle = {
+    fr: "Hooks visuels, B-roll, CTA en surimpression, infographies : la couche visuelle révèle ce que le transcript ne dit pas. 100% Mistral Vision, sans télécharger la vidéo.",
+    en: "Visual hooks, B-roll, on-screen CTAs, infographics: the visual layer surfaces what transcripts can't. 100% Mistral Vision, no video download.",
+  };
+
+  const badges = [
+    {
+      icon: "👁️",
+      label: { fr: "Frames extraites", en: "Frames extracted" },
+    },
+    {
+      icon: "🇫🇷",
+      label: { fr: "Mistral Pixtral Large", en: "Mistral Pixtral Large" },
+    },
+    {
+      icon: "⚡",
+      label: { fr: "Pas de download vidéo", en: "No video download" },
+    },
+  ];
+
+  return (
+    <section
+      ref={ref}
+      className="py-16 sm:py-24 px-4 sm:px-6 relative"
+      aria-label={lang === "fr" ? "Analyse visuelle" : "Visual analysis"}
+    >
+      <div className="max-w-6xl mx-auto">
+        {/* Header — tagline + subtitle */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+          transition={{ duration: 0.6, ease }}
+          className="text-center mb-12 sm:mb-16"
+        >
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-violet-500/30 bg-violet-500/10 text-xs font-medium text-violet-300 mb-4">
+            <span aria-hidden="true">👁️</span>
+            <span>{lang === "fr" ? "Nouveau · Phase 2" : "New · Phase 2"}</span>
+          </div>
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight text-text-primary mb-4 leading-tight">
+            {lang === "fr" ? tagline.fr : tagline.en}
+          </h2>
+          <p className="text-base sm:text-lg text-text-secondary max-w-3xl mx-auto leading-relaxed">
+            {lang === "fr" ? subtitle.fr : subtitle.en}
+          </p>
+        </motion.div>
+
+        {/* Mockup grid : 3 frames + JSON overlay */}
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 lg:gap-8">
+          {/* Frames column (3 cards mock) */}
+          <motion.div
+            initial={{ opacity: 0, x: -20 }}
+            animate={isInView ? { opacity: 1, x: 0 } : { opacity: 0, x: -20 }}
+            transition={{ duration: 0.6, ease, delay: 0.15 }}
+            className="lg:col-span-3 space-y-4"
+            aria-label={lang === "fr" ? "Frames extraites" : "Extracted frames"}
+          >
+            {MOCKUP_MOMENTS.map((moment, idx) => (
+              <div
+                key={moment.ts}
+                className="relative flex gap-4 items-start p-4 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl"
+              >
+                {/* Frame placeholder — gradient simulant un thumbnail YouTube */}
+                <div
+                  className="flex-shrink-0 w-32 h-20 sm:w-40 sm:h-24 rounded-lg bg-gradient-to-br relative overflow-hidden border border-white/10"
+                  style={{
+                    background:
+                      idx === 0
+                        ? "linear-gradient(135deg, #6366f1 0%, #ec4899 100%)"
+                        : idx === 1
+                          ? "linear-gradient(135deg, #06b6d4 0%, #3b82f6 100%)"
+                          : "linear-gradient(135deg, #8b5cf6 0%, #f59e0b 100%)",
+                  }}
+                  aria-hidden="true"
+                >
+                  <div className="absolute inset-0 bg-black/20" />
+                  <span className="absolute bottom-1 right-1 px-1.5 py-0.5 rounded text-[10px] font-mono bg-black/70 text-white">
+                    {moment.ts}
+                  </span>
+                </div>
+                {/* Description */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-violet-500/20 text-violet-300 uppercase tracking-wider">
+                      {moment.type}
+                    </span>
+                  </div>
+                  <p className="text-sm text-text-secondary leading-snug">
+                    {lang === "fr" ? moment.description.fr : moment.description.en}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </motion.div>
+
+          {/* JSON overlay column */}
+          <motion.div
+            initial={{ opacity: 0, x: 20 }}
+            animate={isInView ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
+            transition={{ duration: 0.6, ease, delay: 0.3 }}
+            className="lg:col-span-2"
+            aria-label={lang === "fr" ? "Sortie JSON" : "JSON output"}
+          >
+            <div className="rounded-xl border border-white/10 bg-[#0a0a0f]/80 backdrop-blur-xl overflow-hidden h-full">
+              <div className="flex items-center gap-2 px-4 py-3 border-b border-white/5">
+                <div className="flex gap-1.5">
+                  <div className="w-2.5 h-2.5 rounded-full bg-red-500/60" />
+                  <div className="w-2.5 h-2.5 rounded-full bg-yellow-500/60" />
+                  <div className="w-2.5 h-2.5 rounded-full bg-green-500/60" />
+                </div>
+                <span className="text-xs text-text-secondary font-mono ml-2">
+                  visual_analysis.json
+                </span>
+              </div>
+              <pre className="px-4 py-4 text-[11px] sm:text-xs font-mono text-text-secondary overflow-x-auto leading-relaxed">
+                <code>
+                  <span className="text-violet-300">{`{`}</span>
+                  {`\n  `}
+                  <span className="text-cyan-300">{`"visual_hook"`}</span>
+                  <span className="text-text-secondary">{`: `}</span>
+                  <span className="text-emerald-300">
+                    {lang === "fr"
+                      ? `"Plan choc fond vif, attention immédiate"`
+                      : `"Punchy close-up, immediate attention grab"`}
+                  </span>
+                  <span className="text-text-secondary">{`,`}</span>
+                  {`\n  `}
+                  <span className="text-cyan-300">{`"visual_structure"`}</span>
+                  <span className="text-text-secondary">{`: `}</span>
+                  <span className="text-emerald-300">{`"talking_head"`}</span>
+                  <span className="text-text-secondary">{`,`}</span>
+                  {`\n  `}
+                  <span className="text-cyan-300">{`"key_moments"`}</span>
+                  <span className="text-text-secondary">{`: [`}</span>
+                  {`\n    `}
+                  <span className="text-text-secondary">{`{ `}</span>
+                  <span className="text-cyan-300">{`"t"`}</span>
+                  <span className="text-text-secondary">{`: `}</span>
+                  <span className="text-amber-300">{`3.2`}</span>
+                  <span className="text-text-secondary">{`, `}</span>
+                  <span className="text-cyan-300">{`"type"`}</span>
+                  <span className="text-text-secondary">{`: `}</span>
+                  <span className="text-emerald-300">{`"hook"`}</span>
+                  <span className="text-text-secondary">{` },`}</span>
+                  {`\n    `}
+                  <span className="text-text-secondary">{`{ `}</span>
+                  <span className="text-cyan-300">{`"t"`}</span>
+                  <span className="text-text-secondary">{`: `}</span>
+                  <span className="text-amber-300">{`102.0`}</span>
+                  <span className="text-text-secondary">{`, `}</span>
+                  <span className="text-cyan-300">{`"type"`}</span>
+                  <span className="text-text-secondary">{`: `}</span>
+                  <span className="text-emerald-300">{`"reveal"`}</span>
+                  <span className="text-text-secondary">{` }`}</span>
+                  {`\n  `}
+                  <span className="text-text-secondary">{`],`}</span>
+                  {`\n  `}
+                  <span className="text-cyan-300">{`"visible_text"`}</span>
+                  <span className="text-text-secondary">{`: `}</span>
+                  <span className="text-emerald-300">{`"ATTENTION"`}</span>
+                  {`\n`}
+                  <span className="text-violet-300">{`}`}</span>
+                </code>
+              </pre>
+            </div>
+          </motion.div>
+        </div>
+
+        {/* Badges row */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
+          transition={{ duration: 0.5, ease, delay: 0.5 }}
+          className="mt-10 flex flex-wrap items-center justify-center gap-3"
+        >
+          {badges.map((badge) => (
+            <div
+              key={badge.icon}
+              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-white/10 bg-white/5 backdrop-blur-xl text-xs sm:text-sm text-text-secondary"
+            >
+              <span aria-hidden="true">{badge.icon}</span>
+              <span>{lang === "fr" ? badge.label.fr : badge.label.en}</span>
+            </div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/__tests__/VisualAnalysisSection.test.tsx
+++ b/frontend/src/components/landing/__tests__/VisualAnalysisSection.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import VisualAnalysisSection from "../VisualAnalysisSection";
+
+describe("VisualAnalysisSection", () => {
+  it("renders tagline and key copy in French", () => {
+    render(<VisualAnalysisSection language="fr" />);
+    expect(
+      screen.getByText(/ne se contente plus d'écouter — elle regarde/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Mistral Vision/i)).toBeInTheDocument();
+    // Phase 2 badge
+    expect(screen.getByText(/Phase 2/i)).toBeInTheDocument();
+  });
+
+  it("renders English version when language=en", () => {
+    render(<VisualAnalysisSection language="en" />);
+    expect(
+      screen.getByText(/doesn't just listen — it watches/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Mistral Vision/i)).toBeInTheDocument();
+  });
+
+  it("renders 3 mockup moments with timestamps", () => {
+    render(<VisualAnalysisSection language="fr" />);
+    expect(screen.getByText("00:03")).toBeInTheDocument();
+    expect(screen.getByText("01:42")).toBeInTheDocument();
+    expect(screen.getByText("04:18")).toBeInTheDocument();
+  });
+
+  it("renders all 3 moment types as uppercase tags", () => {
+    render(<VisualAnalysisSection language="fr" />);
+    expect(screen.getByText("hook")).toBeInTheDocument();
+    expect(screen.getByText("reveal")).toBeInTheDocument();
+    expect(screen.getByText("cta")).toBeInTheDocument();
+  });
+
+  it("renders JSON mockup with key fields", () => {
+    render(<VisualAnalysisSection language="fr" />);
+    expect(screen.getByText(/visual_analysis\.json/i)).toBeInTheDocument();
+    expect(screen.getByText(/"visual_hook"/)).toBeInTheDocument();
+    expect(screen.getByText(/"visual_structure"/)).toBeInTheDocument();
+    expect(screen.getByText(/"key_moments"/)).toBeInTheDocument();
+  });
+
+  it("renders 3 trust badges (frames, mistral, no download)", () => {
+    render(<VisualAnalysisSection language="fr" />);
+    expect(screen.getByText(/Frames extraites/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pixtral Large/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pas de download vidéo/i)).toBeInTheDocument();
+  });
+
+  it("has section aria-label for accessibility", () => {
+    const { container } = render(<VisualAnalysisSection language="fr" />);
+    const section = container.querySelector("section");
+    expect(section).toHaveAttribute("aria-label", "Analyse visuelle");
+  });
+});

--- a/frontend/src/components/landing/index.ts
+++ b/frontend/src/components/landing/index.ts
@@ -4,3 +4,4 @@ export { default as PricingSection } from "./PricingSection";
 export { default as Testimonials } from "./Testimonials";
 export { default as TrustBadges } from "./TrustBadges";
 export { default as SocialProofCounter } from "./SocialProofCounter";
+export { default as VisualAnalysisSection } from "./VisualAnalysisSection";

--- a/frontend/src/config/planPrivileges.ts
+++ b/frontend/src/config/planPrivileges.ts
@@ -59,6 +59,10 @@ export interface PlanLimits {
   deepResearchEnabled: boolean;
   factcheckEnabled: boolean;
   ttsEnabled: boolean;
+
+  // Phase 2 Visual Analysis (storyboards + Mistral Vision)
+  visualAnalysisEnabled: boolean;
+  visualAnalysisMonthly: number; // 0 = désactivé, -1 = illimité
 }
 
 export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
@@ -94,6 +98,8 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     deepResearchEnabled: false,
     factcheckEnabled: false,
     ttsEnabled: false,
+    visualAnalysisEnabled: false,
+    visualAnalysisMonthly: 0,
   },
 
   // Anciennement "plus" v0 (4.99 €) — devenu "pro" v2 (8.99 €) avec voice 30 min/mo
@@ -129,6 +135,8 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     deepResearchEnabled: false,
     factcheckEnabled: true,
     ttsEnabled: false,
+    visualAnalysisEnabled: true,
+    visualAnalysisMonthly: 30,
   },
 
   // Anciennement "pro" v0 (9.99 €) — devenu "expert" v2 (19.99 €) avec voice 120 min/mo
@@ -168,6 +176,8 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     deepResearchEnabled: true,
     factcheckEnabled: true,
     ttsEnabled: true,
+    visualAnalysisEnabled: true,
+    visualAnalysisMonthly: -1, // illimité
   },
 };
 
@@ -192,6 +202,7 @@ export interface PlanFeatures {
   deepResearch: boolean;
   factcheck: boolean;
   semanticSearchTooltip: boolean;
+  visualAnalysis: boolean;
 }
 
 export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
@@ -212,6 +223,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     deepResearch: false,
     factcheck: false,
     semanticSearchTooltip: false,
+    visualAnalysis: false,
   },
   pro: {
     flashcards: true,
@@ -230,6 +242,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     deepResearch: false,
     factcheck: true,
     semanticSearchTooltip: true,
+    visualAnalysis: true,
   },
   expert: {
     flashcards: true,
@@ -248,6 +261,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     deepResearch: true,
     factcheck: true,
     semanticSearchTooltip: true,
+    visualAnalysis: true,
   },
 };
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -49,6 +49,7 @@ import {
   Testimonials,
   TrustBadges,
   SocialProofCounter,
+  VisualAnalysisSection,
 } from "../components/landing";
 import DoodleBackground from "../components/DoodleBackground";
 
@@ -1082,6 +1083,8 @@ const LandingPage: React.FC = () => {
           <DemoChatStatic language={language} />
         </div>
       </section>
+      {/* ─── VISUAL ANALYSIS (Phase 2) ─── */}
+      <VisualAnalysisSection language={language} />
       {/* ─── TESTIMONIALS ─── */}
       <Testimonials language={language} />
       {/* ─── FEATURES ─── */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -161,6 +161,12 @@ export interface Summary {
   // 📚 Summary extras (spike 2026-05-06) — enrichissement post-processing
   // Mistral à la demande. NULL si pas encore généré.
   summary_extras?: SummaryExtrasData | null;
+
+  // 🎬 Visual Analysis Phase 2 (mai 2026) — payload Mistral Vision
+  // Présent uniquement quand l'analyse visuelle a été activée et a réussi.
+  // Type importé depuis ../types/analysis pour garder une seule source
+  // de vérité (mirror backend `analysis.visual_analysis`).
+  visual_analysis?: import("../types/analysis").VisualAnalysis | null;
 }
 
 // ─── Summary extras (spike 2026-05-06) ────────────────────────────────────────

--- a/frontend/src/store/hubStore.ts
+++ b/frontend/src/store/hubStore.ts
@@ -111,6 +111,7 @@ const INITIAL: Pick<
     flashcards: 0,
     reliability: 0,
     geo: 0,
+    visual: 0,
     chat: 0,
   },
 };

--- a/frontend/src/types/analysis.ts
+++ b/frontend/src/types/analysis.ts
@@ -381,3 +381,84 @@ export const WRITING_STYLE_CONFIG = WRITING_TONE_CONFIG as unknown as Record<
     emoji: string;
   }
 >;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎬 VISUAL ANALYSIS — Phase 2 (Mistral Vision sur storyboards YouTube)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Type de structure visuelle détectée dans la vidéo.
+ * Aligné avec le backend (`backend/src/videos/visual_analysis.py`).
+ */
+export type VisualStructure =
+  | "talking_head"
+  | "b_roll"
+  | "gameplay"
+  | "slides"
+  | "tutorial"
+  | "interview"
+  | "vlog"
+  | "mixed"
+  | "other";
+
+/**
+ * Niveau qualitatif utilisé par les indicateurs SEO visuels.
+ */
+export type VisualQualitativeLevel = "low" | "medium" | "high";
+
+/**
+ * Un moment clé identifié visuellement dans la vidéo.
+ */
+export interface VisualKeyMoment {
+  /** Timestamp en secondes depuis le début de la vidéo. */
+  timestamp_s: number;
+  /** Description courte (FR) de ce qui est visible. */
+  description: string;
+  /** Catégorie libre (ex : "title_card", "cta", "infographic"). */
+  type: string;
+}
+
+/**
+ * Indicateurs SEO visuels — destinés à éclairer le potentiel de rétention
+ * et de citation dans les moteurs IA. Tous les champs sont optionnels car
+ * le backend peut renvoyer un sous-ensemble selon le modèle utilisé.
+ */
+export interface VisualSeoIndicators {
+  /** Luminosité du hook d'intro (perçue par Mistral Vision). */
+  hook_brightness?: VisualQualitativeLevel;
+  /** Vrai si un visage est visible dans les ~3 premières secondes. */
+  face_visible_in_hook?: boolean;
+  /** Vrai si des sous-titres "burned-in" (incrustés) sont détectés. */
+  burned_in_subtitles?: boolean;
+  /** Vrai si l'intro contient des mouvements de caméra/zoom rapides. */
+  high_motion_intro?: boolean;
+  /** Estimation qualitative du soin apporté à la miniature/branding. */
+  thumbnail_quality_proxy?: VisualQualitativeLevel;
+}
+
+/**
+ * Payload Visual Analysis renvoyé par /api/videos/analyze quand Phase 2
+ * est activée. Embarqué dans l'objet `analysis` (réponse `Summary`) sous
+ * la clé `visual_analysis`. Peut être null si l'analyse n'a pas été lancée
+ * ou a échoué silencieusement (le tab UI affichera alors un empty state).
+ */
+export interface VisualAnalysis {
+  /** Hook visuel — ce qu'on voit dans les 3 premières secondes. */
+  visual_hook: string;
+  /** Type de structure visuelle dominante. */
+  visual_structure: VisualStructure;
+  /** Liste de moments visuels remarquables (1-10 typiquement). */
+  key_moments: VisualKeyMoment[];
+  /** Texte visible à l'écran (titres, sous-titres incrustés, CTA). */
+  visible_text: string;
+  /** Heuristiques de SEO/rétention dérivées de l'analyse visuelle. */
+  visual_seo_indicators: VisualSeoIndicators;
+  /** Résumé en prose de la couche visuelle. */
+  summary_visual: string;
+  /** Modèle Mistral Vision utilisé (ex: "pixtral-12b-2409"). */
+  model_used: string;
+  /** Nombre de frames extraites du storyboard analysées. */
+  frames_analyzed: number;
+  /** Vrai si le storyboard a été sous-échantillonné (cap budget). */
+  frames_downsampled: boolean;
+}

--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -37,6 +37,8 @@ import { ExportMenu } from "@/components/export";
 import { AcademicSourcesSection } from "@/components/academic";
 import { FactCheckButton } from "@/components/factcheck";
 import { WebEnrichment } from "@/components/enrichment";
+import { VisualTab } from "@/components/analysis/VisualTab";
+import type { VisualAnalysis } from "@/types";
 import { usePlan } from "@/contexts/PlanContext";
 import {
   SemanticHighlighterProvider,
@@ -47,7 +49,7 @@ import {
 import { SearchBar as IntraSearchBar } from "@/components/search/SearchBar";
 import type { WithinMatchItem } from "@/services/api";
 
-const TAB_LABELS = ["Résumé", "Sources", "Chat"] as const;
+const TAB_LABELS = ["Résumé", "Sources", "Visuel", "Chat"] as const;
 const TAB_COUNT = TAB_LABELS.length;
 
 // Sub-composant : contrôle l'ouverture du PassageActionSheet quand
@@ -482,6 +484,15 @@ function AnalysisDetailScreenInner() {
             </Text>
           </View>
         )}
+      </View>
+      <View key="visual" style={styles.page}>
+        <VisualTab
+          visualAnalysis={
+            (summary as { visual_analysis?: VisualAnalysis | null } | undefined)
+              ?.visual_analysis ?? null
+          }
+          bottomPadding={isFullscreen ? insets.bottom + sp.lg : sp["2xl"]}
+        />
       </View>
       <View key="chat" style={[styles.page, styles.chatPlaceholder]}>
         <Ionicons

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -34,6 +34,7 @@ import { URLInput } from "@/components/home/URLInput";
 import { CreditBar } from "@/components/home/CreditBar";
 import { RecentCarousel } from "@/components/home/RecentCarousel";
 import { OptionsSheet } from "@/components/home/OptionsSheet";
+import { VisualAnalysisBanner } from "@/components/home/VisualAnalysisBanner";
 import type { AnalysisSummary } from "@/types";
 import { textStyles, fontFamily, fontSize } from "@/theme/typography";
 import { sp, borderRadius } from "@/theme/spacing";
@@ -482,6 +483,9 @@ export default function HomeScreen() {
             isLoading={isLoading}
           />
         )}
+
+        {/* Visual Analysis discovery banner — Phase 2 (Mai 2026) */}
+        <VisualAnalysisBanner />
 
         {/* Tournesol Recommendations */}
         <TournesolRecommendations

--- a/mobile/src/components/analysis/VisualTab.tsx
+++ b/mobile/src/components/analysis/VisualTab.tsx
@@ -1,0 +1,672 @@
+/**
+ * VisualTab — Détail d'analyse, tab "Visuel" (Phase 2 Mistral Vision).
+ *
+ * Affiche les 6 sections de l'analyse visuelle multimodale :
+ *   1. Hook visuel        — visual_hook
+ *   2. Structure          — visual_structure (badge)
+ *   3. Moments clés       — key_moments (timestamp MM:SS + description + type)
+ *   4. Texte visible      — visible_text (italique si vide)
+ *   5. Indicateurs SEO    — visual_seo_indicators (grille)
+ *   6. Résumé visuel      — summary_visual (paragraphe)
+ *
+ * Si `analysis.visual_analysis` est absente (null/undefined) → empty state
+ * avec icône + tagline phase 2 (« Maintenant, DeepSight regarde aussi. »).
+ *
+ * Décision design :
+ *   - ScrollView (pas FlashList) : key_moments borné à 8, virtualisation inutile,
+ *     scroll unifié sur toutes les sections.
+ *   - StyleSheet.create + tokens du theme (palette/sp/fontFamily/borderRadius).
+ *   - Compat iOS + Android, dark + light theme.
+ *
+ * Spec : 01-Projects/DeepSight/Sessions/2026-05-06-visual-analysis-phase-2-spec.md
+ * Branche : feat/visual-analysis-phase-2 (PR #386)
+ */
+
+import React, { useMemo } from "react";
+import { View, Text, ScrollView, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../contexts/ThemeContext";
+import { sp, borderRadius as br } from "../../theme/spacing";
+import { fontFamily, fontSize, lineHeight } from "../../theme/typography";
+import { palette } from "../../theme/colors";
+import type { VisualAnalysis, VisualKeyMoment } from "../../types";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** 3.5 → '00:03', 75.2 → '01:15', 3700 → '01:01:40'. */
+function formatTimestamp(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "00:00";
+  const total = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}
+
+/** Mapping label FR pour les structures vidéo connues. */
+const STRUCTURE_LABELS: Record<string, string> = {
+  talking_head: "Plan parlé",
+  b_roll: "B-roll",
+  gameplay: "Gameplay",
+  slides: "Slides",
+  tutorial: "Tutoriel",
+  interview: "Interview",
+  vlog: "Vlog",
+  mixed: "Mixte",
+  other: "Autre",
+};
+
+/** Mapping label FR pour les types de moments clés. */
+const MOMENT_TYPE_LABELS: Record<string, string> = {
+  hook: "Hook",
+  transition: "Transition",
+  reveal: "Révélation",
+  cta: "CTA",
+  peak: "Pic",
+  demo: "Démo",
+};
+
+/** Mapping label FR + couleur sémantique pour le badge type. */
+function getMomentTypeStyle(type: string): { label: string; color: string } {
+  const norm = (type || "").toLowerCase().trim();
+  const label = MOMENT_TYPE_LABELS[norm] || norm || "Moment";
+  switch (norm) {
+    case "hook":
+      return { label, color: palette.violet };
+    case "reveal":
+      return { label, color: palette.cyan };
+    case "cta":
+      return { label, color: palette.amber };
+    case "peak":
+      return { label, color: palette.orange };
+    case "demo":
+      return { label, color: palette.blue };
+    case "transition":
+    default:
+      return { label, color: palette.indigo };
+  }
+}
+
+/** Friendly French label pour les valeurs SEO low/medium/high. */
+function levelLabel(level?: "low" | "medium" | "high"): string {
+  if (level === "low") return "Faible";
+  if (level === "medium") return "Moyen";
+  if (level === "high") return "Élevé";
+  return "—";
+}
+
+// ── Props ───────────────────────────────────────────────────────────────────
+
+export interface VisualTabProps {
+  /** Données de l'analyse visuelle. null/undefined → empty state. */
+  visualAnalysis?: VisualAnalysis | null;
+  /** Padding bottom appliqué au ScrollView (footprint TabBar). */
+  bottomPadding?: number;
+}
+
+// ── Empty State ─────────────────────────────────────────────────────────────
+
+const EmptyState: React.FC = () => {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.emptyContainer}>
+      <View
+        style={[styles.emptyIconCircle, { backgroundColor: palette.violet + "1A" }]}
+      >
+        <Ionicons name="eye-outline" size={36} color={palette.violet} />
+      </View>
+      <Text style={[styles.emptyTitle, { color: colors.textPrimary }]}>
+        Maintenant, DeepSight regarde aussi.
+      </Text>
+      <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+        Cette analyse n'a pas encore de couche visuelle. Lance une nouvelle
+        analyse avec l'option Visuel activée pour voir le hook, les moments clés
+        et la structure de la vidéo.
+      </Text>
+    </View>
+  );
+};
+
+// ── Section components ──────────────────────────────────────────────────────
+
+const SectionHeader: React.FC<{
+  icon: keyof typeof Ionicons.glyphMap;
+  title: string;
+}> = ({ icon, title }) => {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.sectionHeader}>
+      <Ionicons name={icon} size={18} color={palette.violet} />
+      <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
+        {title}
+      </Text>
+    </View>
+  );
+};
+
+const KeyMomentItem: React.FC<{ moment: VisualKeyMoment }> = ({ moment }) => {
+  const { colors } = useTheme();
+  const typeStyle = getMomentTypeStyle(moment.type);
+  return (
+    <View
+      style={[
+        styles.momentCard,
+        { backgroundColor: colors.bgElevated, borderColor: colors.border },
+      ]}
+    >
+      <View style={styles.momentHeader}>
+        <View
+          style={[
+            styles.timestampBadge,
+            { backgroundColor: palette.indigo + "20" },
+          ]}
+        >
+          <Ionicons name="time-outline" size={12} color={palette.indigo} />
+          <Text style={[styles.timestampText, { color: palette.indigo }]}>
+            {formatTimestamp(moment.timestamp_s)}
+          </Text>
+        </View>
+        <View
+          style={[
+            styles.typeBadge,
+            { backgroundColor: typeStyle.color + "20" },
+          ]}
+        >
+          <Text style={[styles.typeBadgeText, { color: typeStyle.color }]}>
+            {typeStyle.label}
+          </Text>
+        </View>
+      </View>
+      <Text style={[styles.momentDescription, { color: colors.textSecondary }]}>
+        {moment.description}
+      </Text>
+    </View>
+  );
+};
+
+const SeoIndicator: React.FC<{
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  value: string;
+  highlight?: boolean;
+}> = ({ icon, label, value, highlight }) => {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[
+        styles.seoCard,
+        {
+          backgroundColor: colors.bgElevated,
+          borderColor: highlight ? palette.violet + "40" : colors.border,
+        },
+      ]}
+    >
+      <View style={styles.seoIconRow}>
+        <Ionicons
+          name={icon}
+          size={16}
+          color={highlight ? palette.violet : colors.textTertiary}
+        />
+        <Text style={[styles.seoLabel, { color: colors.textTertiary }]}>
+          {label}
+        </Text>
+      </View>
+      <Text style={[styles.seoValue, { color: colors.textPrimary }]}>
+        {value}
+      </Text>
+    </View>
+  );
+};
+
+// ── Main component ──────────────────────────────────────────────────────────
+
+export const VisualTab: React.FC<VisualTabProps> = ({
+  visualAnalysis,
+  bottomPadding = sp["2xl"],
+}) => {
+  const { colors } = useTheme();
+
+  // Empty state si pas de données visuelles
+  if (!visualAnalysis) {
+    return (
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: bottomPadding },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        <EmptyState />
+      </ScrollView>
+    );
+  }
+
+  const {
+    visual_hook,
+    visual_structure,
+    key_moments,
+    visible_text,
+    visual_seo_indicators,
+    summary_visual,
+    model_used,
+    frames_analyzed,
+    frames_downsampled,
+  } = visualAnalysis;
+
+  const structureLabel = useMemo(() => {
+    const norm = (visual_structure || "").toLowerCase().trim();
+    return STRUCTURE_LABELS[norm] || norm || "—";
+  }, [visual_structure]);
+
+  const seo = visual_seo_indicators || {};
+  const seoEntries = useMemo(
+    () => [
+      {
+        key: "hook_brightness",
+        icon: "sunny-outline" as const,
+        label: "Luminosité du hook",
+        value: levelLabel(seo.hook_brightness),
+        highlight: seo.hook_brightness === "high",
+      },
+      {
+        key: "thumbnail_quality_proxy",
+        icon: "image-outline" as const,
+        label: "Qualité miniature",
+        value: levelLabel(seo.thumbnail_quality_proxy),
+        highlight: seo.thumbnail_quality_proxy === "high",
+      },
+      {
+        key: "face_visible_in_hook",
+        icon: "person-outline" as const,
+        label: "Visage dans le hook",
+        value:
+          seo.face_visible_in_hook === undefined
+            ? "—"
+            : seo.face_visible_in_hook
+              ? "Oui"
+              : "Non",
+        highlight: seo.face_visible_in_hook === true,
+      },
+      {
+        key: "burned_in_subtitles",
+        icon: "text-outline" as const,
+        label: "Sous-titres incrustés",
+        value:
+          seo.burned_in_subtitles === undefined
+            ? "—"
+            : seo.burned_in_subtitles
+              ? "Oui"
+              : "Non",
+        highlight: seo.burned_in_subtitles === true,
+      },
+      {
+        key: "high_motion_intro",
+        icon: "flash-outline" as const,
+        label: "Intro dynamique",
+        value:
+          seo.high_motion_intro === undefined
+            ? "—"
+            : seo.high_motion_intro
+              ? "Oui"
+              : "Non",
+        highlight: seo.high_motion_intro === true,
+      },
+    ],
+    [seo],
+  );
+
+  return (
+    <ScrollView
+      contentContainerStyle={[
+        styles.scrollContent,
+        { paddingBottom: bottomPadding },
+      ]}
+      showsVerticalScrollIndicator={false}
+    >
+      {/* En-tête meta : modèle + frames analysées */}
+      <View style={styles.metaRow}>
+        <View
+          style={[
+            styles.metaPill,
+            { backgroundColor: palette.violet + "1A", borderColor: palette.violet + "30" },
+          ]}
+        >
+          <Ionicons name="eye-outline" size={12} color={palette.violet} />
+          <Text style={[styles.metaPillText, { color: palette.violet }]}>
+            Couche visuelle
+          </Text>
+        </View>
+        {!!model_used && (
+          <Text style={[styles.metaText, { color: colors.textTertiary }]}>
+            {model_used}
+          </Text>
+        )}
+        {frames_analyzed > 0 && (
+          <Text style={[styles.metaText, { color: colors.textTertiary }]}>
+            • {frames_analyzed} frames{frames_downsampled ? " (downsampled)" : ""}
+          </Text>
+        )}
+      </View>
+
+      {/* 1. Hook visuel */}
+      {!!visual_hook && (
+        <View style={styles.section}>
+          <SectionHeader icon="rocket-outline" title="Hook visuel" />
+          <View
+            style={[
+              styles.hookCard,
+              { backgroundColor: colors.bgElevated, borderColor: colors.border },
+            ]}
+          >
+            <Text style={[styles.hookText, { color: colors.textPrimary }]}>
+              {visual_hook}
+            </Text>
+          </View>
+        </View>
+      )}
+
+      {/* 2. Structure */}
+      {!!visual_structure && (
+        <View style={styles.section}>
+          <SectionHeader icon="grid-outline" title="Structure visuelle" />
+          <View
+            style={[
+              styles.structureBadge,
+              {
+                backgroundColor: palette.indigo + "1A",
+                borderColor: palette.indigo + "30",
+              },
+            ]}
+          >
+            <Ionicons name="film-outline" size={14} color={palette.indigo} />
+            <Text style={[styles.structureBadgeText, { color: palette.indigo }]}>
+              {structureLabel}
+            </Text>
+          </View>
+        </View>
+      )}
+
+      {/* 3. Moments clés */}
+      <View style={styles.section}>
+        <SectionHeader icon="bookmark-outline" title="Moments clés" />
+        {key_moments && key_moments.length > 0 ? (
+          <View style={styles.momentsList}>
+            {key_moments.map((moment, idx) => (
+              <KeyMomentItem
+                key={`${moment.timestamp_s}-${idx}`}
+                moment={moment}
+              />
+            ))}
+          </View>
+        ) : (
+          <Text style={[styles.emptyInline, { color: colors.textTertiary }]}>
+            Aucun moment clé détecté.
+          </Text>
+        )}
+      </View>
+
+      {/* 4. Texte visible */}
+      <View style={styles.section}>
+        <SectionHeader icon="text-outline" title="Texte visible à l'écran" />
+        {visible_text && visible_text.trim().length > 0 ? (
+          <View
+            style={[
+              styles.textCard,
+              { backgroundColor: colors.bgElevated, borderColor: colors.border },
+            ]}
+          >
+            <Text style={[styles.textCardContent, { color: colors.textPrimary }]}>
+              {visible_text}
+            </Text>
+          </View>
+        ) : (
+          <Text style={[styles.emptyInline, { color: colors.textTertiary }]}>
+            Aucun texte détecté.
+          </Text>
+        )}
+      </View>
+
+      {/* 5. Indicateurs SEO visuels */}
+      <View style={styles.section}>
+        <SectionHeader icon="analytics-outline" title="Indicateurs SEO visuels" />
+        <View style={styles.seoGrid}>
+          {seoEntries.map((entry) => (
+            <SeoIndicator
+              key={entry.key}
+              icon={entry.icon}
+              label={entry.label}
+              value={entry.value}
+              highlight={entry.highlight}
+            />
+          ))}
+        </View>
+      </View>
+
+      {/* 6. Résumé visuel */}
+      {!!summary_visual && (
+        <View style={styles.section}>
+          <SectionHeader icon="sparkles-outline" title="Résumé visuel" />
+          <View
+            style={[
+              styles.summaryCard,
+              {
+                backgroundColor: palette.violet + "12",
+                borderColor: palette.violet + "30",
+              },
+            ]}
+          >
+            <Text style={[styles.summaryText, { color: colors.textPrimary }]}>
+              {summary_visual}
+            </Text>
+          </View>
+        </View>
+      )}
+    </ScrollView>
+  );
+};
+
+export default VisualTab;
+
+// ── Styles ──────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    paddingHorizontal: sp.lg,
+    paddingTop: sp.md,
+    gap: sp.lg,
+  },
+  // Meta header
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: sp.sm,
+    marginBottom: sp.xs,
+  },
+  metaPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.xs,
+    paddingHorizontal: sp.sm,
+    paddingVertical: 4,
+    borderRadius: br.full,
+    borderWidth: 1,
+  },
+  metaPillText: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize["2xs"],
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+  },
+  metaText: {
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize["2xs"],
+  },
+  // Sections
+  section: {
+    gap: sp.sm,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+  },
+  sectionTitle: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+  },
+  emptyInline: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    fontStyle: "italic",
+    paddingHorizontal: sp.sm,
+  },
+  // Hook
+  hookCard: {
+    padding: sp.lg,
+    borderRadius: br.lg,
+    borderWidth: 1,
+  },
+  hookText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.base,
+    lineHeight: fontSize.base * lineHeight.normal,
+  },
+  // Structure
+  structureBadge: {
+    flexDirection: "row",
+    alignSelf: "flex-start",
+    alignItems: "center",
+    gap: sp.xs,
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.sm,
+    borderRadius: br.md,
+    borderWidth: 1,
+  },
+  structureBadgeText: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
+  },
+  // Moments
+  momentsList: {
+    gap: sp.sm,
+  },
+  momentCard: {
+    padding: sp.md,
+    borderRadius: br.md,
+    borderWidth: 1,
+    gap: sp.sm,
+  },
+  momentHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+  },
+  timestampBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: sp.sm,
+    paddingVertical: 4,
+    borderRadius: br.sm,
+  },
+  timestampText: {
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+  },
+  typeBadge: {
+    paddingHorizontal: sp.sm,
+    paddingVertical: 4,
+    borderRadius: br.sm,
+  },
+  typeBadgeText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize["2xs"],
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+  },
+  momentDescription: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    lineHeight: fontSize.sm * lineHeight.normal,
+  },
+  // Texte visible
+  textCard: {
+    padding: sp.md,
+    borderRadius: br.md,
+    borderWidth: 1,
+  },
+  textCardContent: {
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.sm,
+    lineHeight: fontSize.sm * lineHeight.normal,
+  },
+  // SEO grid
+  seoGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: sp.sm,
+  },
+  seoCard: {
+    flexBasis: "48%",
+    flexGrow: 1,
+    padding: sp.md,
+    borderRadius: br.md,
+    borderWidth: 1,
+    gap: sp.xs,
+  },
+  seoIconRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.xs,
+  },
+  seoLabel: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+    flexShrink: 1,
+  },
+  seoValue: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+  },
+  // Résumé
+  summaryCard: {
+    padding: sp.lg,
+    borderRadius: br.lg,
+    borderWidth: 1,
+  },
+  summaryText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.base,
+    lineHeight: fontSize.base * lineHeight.relaxed,
+  },
+  // Empty state global
+  emptyContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: sp["4xl"],
+    paddingHorizontal: sp.xl,
+    gap: sp.md,
+  },
+  emptyIconCircle: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: sp.sm,
+  },
+  emptyTitle: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.lg,
+    textAlign: "center",
+  },
+  emptyText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    lineHeight: fontSize.sm * lineHeight.relaxed,
+    textAlign: "center",
+  },
+});

--- a/mobile/src/components/analysis/index.ts
+++ b/mobile/src/components/analysis/index.ts
@@ -15,3 +15,5 @@ export { VideoPlayer } from "./VideoPlayer";
 export { StreamingOverlay } from "./StreamingOverlay";
 export { SummaryView } from "./SummaryView";
 export { ActionBar } from "./ActionBar";
+export { VisualTab, default as VisualTabDefault } from "./VisualTab";
+export type { VisualTabProps } from "./VisualTab";

--- a/mobile/src/components/home/VisualAnalysisBanner.tsx
+++ b/mobile/src/components/home/VisualAnalysisBanner.tsx
@@ -1,0 +1,189 @@
+/**
+ * VisualAnalysisBanner — Card discovery sur Home pour Phase 2 Visual Analysis.
+ *
+ * Tagline : « Maintenant, DeepSight regarde aussi. »
+ * Affichée pour tous les users (CTA upsell pour Free, info pour Pro/Expert).
+ *
+ * Spec : 01-Projects/DeepSight/Sessions/2026-05-06-visual-analysis-phase-2-spec.md
+ */
+
+import React, { useCallback } from "react";
+import { View, Text, Pressable, StyleSheet, Linking } from "react-native";
+import { router } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import { useTheme } from "@/contexts/ThemeContext";
+import { useAuthStore } from "@/stores/authStore";
+import { palette } from "@/theme/colors";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+
+export const VisualAnalysisBanner: React.FC = () => {
+  const { colors } = useTheme();
+  const user = useAuthStore((s) => s.user);
+  const plan = (user?.plan ?? "free").toLowerCase();
+  const isPaid = plan === "pro" || plan === "expert";
+
+  const handlePress = useCallback(async () => {
+    await Haptics.selectionAsync();
+    if (isPaid) {
+      // Pro/Expert : redirige vers la page de subscription pour info
+      router.push("/(tabs)/subscription");
+    } else {
+      // Free : upsell vers subscription
+      router.push("/(tabs)/subscription");
+    }
+  }, [isPaid]);
+
+  const handleLearnMore = useCallback(async () => {
+    await Haptics.selectionAsync();
+    await Linking.openURL("https://www.deepsightsynthesis.com/#features");
+  }, []);
+
+  const ctaLabel = isPaid ? "Voir mon plan" : "Passer Pro";
+  const subtitle = isPaid
+    ? "Hooks visuels, B-roll, CTAs détectés. Inclus dans ton plan."
+    : "Hooks visuels, B-roll, CTAs détectés. Disponible dès Pro.";
+
+  return (
+    <View style={styles.container}>
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: colors.surfaceElevated ?? colors.surface,
+            borderColor: colors.border,
+          },
+        ]}
+      >
+        <View style={styles.header}>
+          <View style={styles.iconWrap}>
+            <Text style={styles.icon}>👁️</Text>
+          </View>
+          <View style={styles.badge}>
+            <Text style={styles.badgeText}>NOUVEAU · PHASE 2</Text>
+          </View>
+        </View>
+
+        <Text style={[styles.title, { color: colors.text }]}>
+          Maintenant, DeepSight regarde aussi.
+        </Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          {subtitle}
+        </Text>
+
+        <View style={styles.actions}>
+          <Pressable
+            onPress={handlePress}
+            style={({ pressed }) => [
+              styles.ctaPrimary,
+              { backgroundColor: palette.violet, opacity: pressed ? 0.85 : 1 },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={ctaLabel}
+          >
+            <Text style={styles.ctaPrimaryText}>{ctaLabel}</Text>
+            <Ionicons name="arrow-forward" size={16} color="#fff" />
+          </Pressable>
+          <Pressable
+            onPress={handleLearnMore}
+            style={({ pressed }) => [
+              styles.ctaSecondary,
+              { borderColor: colors.border, opacity: pressed ? 0.7 : 1 },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="En savoir plus"
+          >
+            <Text style={[styles.ctaSecondaryText, { color: colors.text }]}>
+              En savoir plus
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: sp(4),
+    marginVertical: sp(3),
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: borderRadius.lg,
+    padding: sp(4),
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: sp(3),
+  },
+  iconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.md,
+    backgroundColor: "rgba(139, 92, 246, 0.15)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  icon: {
+    fontSize: 22,
+  },
+  badge: {
+    paddingHorizontal: sp(2),
+    paddingVertical: sp(1),
+    borderRadius: borderRadius.sm,
+    backgroundColor: "rgba(139, 92, 246, 0.15)",
+    borderWidth: 1,
+    borderColor: "rgba(139, 92, 246, 0.3)",
+  },
+  badgeText: {
+    fontFamily: fontFamily.medium,
+    fontSize: 10,
+    color: palette.violet,
+    letterSpacing: 0.5,
+  },
+  title: {
+    fontFamily: fontFamily.bold,
+    fontSize: fontSize.lg,
+    lineHeight: 24,
+    marginBottom: sp(2),
+  },
+  subtitle: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.sm,
+    lineHeight: 20,
+    marginBottom: sp(4),
+  },
+  actions: {
+    flexDirection: "row",
+    gap: sp(2),
+  },
+  ctaPrimary: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp(1.5),
+    paddingHorizontal: sp(3.5),
+    paddingVertical: sp(2.5),
+    borderRadius: borderRadius.md,
+  },
+  ctaPrimaryText: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.sm,
+    color: "#fff",
+  },
+  ctaSecondary: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: sp(3.5),
+    paddingVertical: sp(2.5),
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+  },
+  ctaSecondaryText: {
+    fontFamily: fontFamily.medium,
+    fontSize: fontSize.sm,
+  },
+});

--- a/mobile/src/config/planPrivileges.ts
+++ b/mobile/src/config/planPrivileges.ts
@@ -45,6 +45,8 @@ export interface PlanLimits {
   voiceChatMonthlyMinutes: number; // 0 = disabled
   // Debate
   debateMonthly: number; // 0 = disabled, -1 = unlimited
+  // Phase 2 Visual Analysis (storyboards + Mistral Vision)
+  visualAnalysisMonthly: number; // 0 = disabled, -1 = unlimited
 }
 
 // Type for numeric-only limits (excludes boolean properties)
@@ -76,6 +78,7 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     academicPapersPerAnalysis: 5,
     voiceChatMonthlyMinutes: 0,
     debateMonthly: 0,
+    visualAnalysisMonthly: 0,
   },
 
   // Anciennement "plus" v0 (4,99 €) — devenu "pro" v2 (8,99 €) avec voice 30 min/mo
@@ -99,6 +102,7 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     academicPapersPerAnalysis: 15,
     voiceChatMonthlyMinutes: 30, // ⚠ v2 H4 — Pro a maintenant la voice
     debateMonthly: 3,
+    visualAnalysisMonthly: 30, // Phase 2 (Mai 2026)
   },
 
   // Anciennement "pro" v0 (9,99 €) — devenu "expert" v2 (19,99 €) avec voice 120 min/mo
@@ -122,6 +126,7 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
     academicPapersPerAnalysis: 50,
     voiceChatMonthlyMinutes: 120, // ⚠ v2 H4
     debateMonthly: 20,
+    visualAnalysisMonthly: -1, // illimité (Phase 2 Mai 2026)
   },
 };
 
@@ -165,6 +170,8 @@ export interface PlanFeatures {
   // Semantic Search V1 — tooltip IA sur passage match (web only V1, mobile V1.1).
   // Mirror du backend pour cohérence cross-platform & upsell potentiel V1.1.
   semanticSearchTooltip: boolean;
+  // Phase 2 Visual Analysis — frames + Mistral Vision (Mai 2026)
+  visualAnalysis: boolean;
 }
 
 export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
@@ -202,6 +209,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     debate: false,
     deepResearch: false,
     semanticSearchTooltip: false,
+    visualAnalysis: false,
   },
 
   // Anciennement "plus" v0
@@ -239,6 +247,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     debate: true,
     deepResearch: false,
     semanticSearchTooltip: true,
+    visualAnalysis: true, // Phase 2 — quota 30/mois
   },
 
   // Anciennement "pro" v0
@@ -276,6 +285,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     debate: true,
     deepResearch: true,
     semanticSearchTooltip: true,
+    visualAnalysis: true, // Phase 2 — illimité
   },
 };
 

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -674,6 +674,8 @@ export const videoApi = {
       tags?: string;
       created_at?: string;
       transcript_context?: string;
+      // Phase 2 — Visual Analysis (Mistral Vision)
+      visual_analysis?: import("../types").VisualAnalysis | null;
     }>(`/api/videos/summary/${summaryId}`);
 
     // Transform backend response to mobile format
@@ -717,6 +719,8 @@ export const videoApi = {
       tags: response.tags,
       reliabilityScore: response.reliability_score,
       creditsUsed: 1, // Default value
+      // 👁️ Phase 2 — Visual Analysis (peut être absent → tab affiche empty state)
+      visual_analysis: response.visual_analysis ?? null,
     } as AnalysisSummary & {
       notes?: string;
       tags?: string;

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -50,6 +50,35 @@ export interface AuthState {
   isLoading: boolean;
 }
 
+// Visual Analysis Types (Phase 2 — Mistral Vision)
+// Structure renvoyée par le backend après enrichissement frames + Vision.
+// Le mobile expose ces données via le tab "Visuel" du détail d'analyse.
+export interface VisualKeyMoment {
+  timestamp_s: number;
+  description: string;
+  type: string; // hook | transition | reveal | cta | peak | demo | other
+}
+
+export interface VisualSeoIndicators {
+  hook_brightness?: "low" | "medium" | "high";
+  face_visible_in_hook?: boolean;
+  burned_in_subtitles?: boolean;
+  high_motion_intro?: boolean;
+  thumbnail_quality_proxy?: "low" | "medium" | "high";
+}
+
+export interface VisualAnalysis {
+  visual_hook: string;
+  visual_structure: string; // talking_head | b_roll | gameplay | slides | tutorial | interview | vlog | mixed | other
+  key_moments: VisualKeyMoment[];
+  visible_text: string;
+  visual_seo_indicators: VisualSeoIndicators;
+  summary_visual: string;
+  model_used: string;
+  frames_analyzed: number;
+  frames_downsampled: boolean;
+}
+
 // Video Analysis Types
 export interface VideoInfo {
   id: string;
@@ -102,6 +131,12 @@ export interface AnalysisSummary {
   music_author?: string;
   source_tags?: string[];
   carousel_images?: string[];
+
+  // 👁️ Visual Analysis (Phase 2)
+  // Présent uniquement quand l'analyse a été lancée avec include_visual_analysis=true
+  // ET que la couche Mistral Vision a réussi (frames extraits + parse JSON).
+  // null/undefined = pas de couche visuelle disponible (fallback empty state).
+  visual_analysis?: VisualAnalysis | null;
 }
 
 export interface AnalysisRequest {


### PR DESCRIPTION
## Summary

Phase 2 du sprint Visual Analysis — fait suite à la PR #351 (POC merged 2026-05-05).

**5 commits, ~1500 lignes** :
- Backend foundation : flag schema, model `VisualAnalysisQuota`, alembic 019, helper `visual_integration.py`
- **Backend hook** `/api/videos/analyze` v1 : injection visual context dans `web_context` (graceful degradation)
- Frontend web : section landing « Vision IA » + pricing matrix tri-platform
- Mobile : `VisualAnalysisBanner` discovery sur Home tab
- Extension Chrome : badge `👁️ Analyse visuelle` sous bouton Voice Call

## Tests

| Surface | Status |
|---|---|
| Backend visual_integration (mocks) | 19/19 ✅ |
| Backend frame_extractor / analyzer / storyboard | 50/50 ✅ |
| Frontend Vitest VisualAnalysisSection | 7 (run en CI) |
| Extension Jest jsdom badge | 7 (run en CI) |
| **Total backend** | **69/69 ✅** |

## 3 décisions actées via AskUserQuestion (Maxime 2026-05-06)

1. **Tagline** : « Maintenant, DeepSight ne se contente plus d'écouter — elle regarde. »
2. **Quota Pro mensuel** : 30 visual analyses (Expert illimité)
3. **Position landing** : section autonome après DemoAnalysisStatic

## Architecture du hook /analyze

```
analyze_video → background_tasks.add_task(_analyze_video_background_v6, include_visual_analysis=...)

_analyze_video_background_v6:
  ...
  transcript_to_analyze = ...

  # 🆕 Phase 2 hook (try/except graceful)
  if include_visual_analysis and platform == "youtube":
      visual = await maybe_enrich_with_visual(db, user, url, transcript_excerpt)
      if visual.status == "ok":
          web_context += format_visual_context_for_prompt(visual)
  ...
  summary = await generate_summary(..., web_context=web_context)
```

Plan gating + quota check sont gérés dans `maybe_enrich_with_visual` (Pro=30/mois, Expert=illimité, Free→`STATUS_PLAN_NOT_ALLOWED`). Quota DB incrémenté **uniquement** sur succès.

## Tri-platform pricing matrix sync

| | Free | Pro | Expert |
|---|---|---|---|
| `backend/src/billing/plan_config.py` `visual_analysis_enabled` | False | True | True |
| `backend/src/billing/plan_config.py` `visual_analysis_monthly` | 0 | 30 | -1 |
| `frontend/src/config/planPrivileges.ts` `visualAnalysisEnabled` | false | true | true |
| `mobile/src/config/planPrivileges.ts` `visualAnalysisMonthly` | 0 | 30 | -1 |

`PlanFeatures.visualAnalysis` ajouté front + mobile.

## Activation prod

Aucune migration DB ne tourne au boot tant que la branche n'est pas mergée. Après merge :

1. SSH VPS : `alembic upgrade head` (alembic 019 crée `visual_analysis_quota`)
2. Le flag `VISUAL_ANALYSIS_ENABLED=true` est déjà set sur prod (Phase 1 POC)
3. Côté API, le param `include_visual_analysis: true` est now respecté
4. Côté UI, les composants sont visibles immédiatement après deploy Vercel/EAS

## Risques connus

- **Latence ajoutée** : +5-15s par analyse quand visual_analysis=true (download storyboards + Mistral Vision call). Mitigé par message progress « 👁️ Analyse visuelle en cours… »
- **Token cost** : ~\$0.06 par visual analysis (60 frames × ~512 tokens). Pro à 30/mois ≈ \$1.80/mois cost vs \$8.99 revenue → marge OK
- **Qualité storyboards 320×180** : suffit pour visual_hook/structure/key_moments. Pas pour OCR fin (à pas promettre en marketing)
- **Hook V1 only** : `/analyze/v2`, `/v2.1`, `/hybrid` ne sont PAS encore wired. À faire si l'usage V1 valide la valeur

## Test plan

- [ ] CI green (Backend Pytest + Frontend Vitest + Extension Jest)
- [ ] Migration `019_visual_analysis_quota` appliquée sans erreur sur Hetzner
- [ ] Section landing « Vision IA » visible sur preview Vercel après merge
- [ ] `POST /api/videos/analyze {include_visual_analysis: true}` avec un user Pro :
  - Si video YouTube < 10min → `web_context` enrichi de `--- COUCHE VISUELLE ---`
  - Si user Free → `web_context` inchangé (STATUS_PLAN_NOT_ALLOWED, log info, pas d'erreur)
  - Si quota Pro dépassé → STATUS_QUOTA_EXCEEDED, idem
  - Si video TikTok → STATUS_NOT_YOUTUBE, idem
- [ ] Mobile banner s'affiche entre Favoris et Tournesol
- [ ] Extension : badge sous le bouton Voice Call sur YouTube /watch

## Hors scope (sprints suivants)

- Tab « Visuel » dans `DashboardPage` analysis detail (web)
- Tab « Visuel » dans `app/(tabs)/analysis/[id].tsx` (mobile)
- `background.ts` handlers `OPEN_SIDEPANEL_VISUAL` + `OPEN_BILLING_UPSELL` (extension)
- Hook V2/V2.1/hybrid backend
- Communication marketing : blog post + changelog public + posts Telegram/LinkedIn
- Pivot 3 (extension client-side capture HD) — Phase 3 wait & see

🤖 Generated with [Claude Code](https://claude.com/claude-code)