### PR TITLE
fix(auth): purge user R2 files in delete_account (GDPR Art 17)

### DIFF
--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -181,8 +181,17 @@ async def delete_account(
     Supprime le compte de l'utilisateur connecté.
     Requiert le mot de passe pour les comptes email.
     Les comptes Google peuvent être supprimés sans mot de passe.
+
+    RGPD Article 17 — suppression sans délai indu :
+    1. Purge des fichiers user-specific R2 (audio summaries TTS) avant cascade
+    2. Cascade DELETE PG (summaries, chat_messages, quotas, sessions, etc.)
+    3. Les backups S3 expirent à J+30 (BACKUP_RETENTION_DAYS).
     """
-    from db.database import verify_password
+    import logging
+    from sqlalchemy import select
+    from db.database import verify_password, Summary
+
+    _logger = logging.getLogger(__name__)
 
     # Vérifier le mot de passe pour les comptes avec mot de passe
     if current_user.password_hash:
@@ -190,6 +199,34 @@ async def delete_account(
             raise HTTPException(status_code=400, detail="Mot de passe requis")
         if not verify_password(data.password, current_user.password_hash):
             raise HTTPException(status_code=401, detail="Mot de passe incorrect")
+
+    user_id = current_user.id
+
+    # Purge des fichiers user-specific R2 AVANT cascade DELETE PG.
+    # Best-effort: si R2 est indisponible on continue (Article 17 prioritaire).
+    try:
+        from storage.r2 import delete_objects_by_prefix
+        from tts.audio_summary import R2_AUDIO_PREFIX
+
+        summary_ids_result = await session.scalars(select(Summary.id).where(Summary.user_id == user_id))
+        summary_ids = list(summary_ids_result.all())
+
+        objects_deleted = 0
+        for sid in summary_ids:
+            objects_deleted += await delete_objects_by_prefix(f"{R2_AUDIO_PREFIX}/{sid}/")
+
+        _logger.info(
+            "R2 purge during account deletion: user_id=%s summaries=%d objects_deleted=%d",
+            user_id,
+            len(summary_ids),
+            objects_deleted,
+        )
+    except Exception as exc:
+        _logger.error(
+            "R2 purge failed during account deletion (proceeding with PG cascade): user_id=%s error=%s",
+            user_id,
+            exc,
+        )
 
     # Invalider la session avant suppression
     await invalidate_user_session(session, current_user.id)

--- a/backend/src/storage/r2.py
+++ b/backend/src/storage/r2.py
@@ -158,3 +158,93 @@ async def _check_exists_r2_remote(key: str) -> bool:
         return True
     except ClientError:
         return False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bulk delete by prefix (used by GDPR account deletion)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def delete_objects_by_prefix(prefix: str) -> int:
+    """Delete every stored object whose key starts with `prefix`. Best-effort.
+
+    Returns the number of objects successfully removed. Errors are logged but
+    not raised: callers (e.g. RGPD account deletion) must keep going even if
+    storage is partially unreachable.
+    """
+    if not prefix:
+        return 0
+    if _is_r2_credentials_set():
+        return await asyncio.to_thread(_delete_r2_by_prefix_sync, prefix)
+    return await asyncio.to_thread(_delete_local_by_prefix_sync, prefix)
+
+
+def _delete_r2_by_prefix_sync(prefix: str) -> int:
+    """List + batch-delete every R2 object under `prefix` (max 1000/batch)."""
+    from botocore.exceptions import ClientError
+
+    try:
+        client = _get_r2_client()
+    except Exception as exc:
+        logger.error(f"R2 client unavailable for prefix delete {prefix}: {exc}")
+        return 0
+
+    bucket = R2_CONFIG["BUCKET"]
+    deleted = 0
+    paginator = client.get_paginator("list_objects_v2")
+
+    try:
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            contents = page.get("Contents") or []
+            if not contents:
+                continue
+            objects = [{"Key": obj["Key"]} for obj in contents]
+            try:
+                response = client.delete_objects(
+                    Bucket=bucket,
+                    Delete={"Objects": objects, "Quiet": True},
+                )
+                errors = response.get("Errors", [])
+                deleted += len(objects) - len(errors)
+                if errors:
+                    logger.error(
+                        f"R2 batch delete partial failure for {prefix}: "
+                        f"{len(errors)} errors (first: {errors[0]})"
+                    )
+            except ClientError as exc:
+                logger.error(f"R2 batch delete failed for prefix {prefix}: {exc}")
+    except ClientError as exc:
+        logger.error(f"R2 list_objects failed for prefix {prefix}: {exc}")
+
+    return deleted
+
+
+def _delete_local_by_prefix_sync(prefix: str) -> int:
+    """Delete every local file under LOCAL_THUMB_DIR/<prefix>. Best-effort."""
+    target = LOCAL_THUMB_DIR / prefix
+    if not target.exists():
+        return 0
+
+    deleted = 0
+    if target.is_file():
+        try:
+            target.unlink()
+            return 1
+        except OSError as exc:
+            logger.error(f"Local delete failed for {target}: {exc}")
+            return 0
+
+    for path in target.rglob("*"):
+        if path.is_file():
+            try:
+                path.unlink()
+                deleted += 1
+            except OSError as exc:
+                logger.error(f"Local delete failed for {path}: {exc}")
+
+    try:
+        target.rmdir()
+    except OSError:
+        pass
+
+    return deleted

--- a/backend/tests/storage/test_r2_delete.py
+++ b/backend/tests/storage/test_r2_delete.py
@@ -1,0 +1,158 @@
+"""
+Tests pour storage.r2.delete_objects_by_prefix — RGPD Article 17 helper.
+
+Couvre :
+1. Prefix vide → 0 deleted, pas d'appel R2
+2. R2 mode → list_objects_v2 paginated + delete_objects batched
+3. R2 mode → erreurs partielles loggées mais comptage correct
+4. R2 mode → ClientError sur list → 0 deleted, pas de raise
+5. Local fallback → suppression récursive des fichiers sous LOCAL_THUMB_DIR/<prefix>
+"""
+
+import importlib
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Marker partagé : skip les tests R2 mode si boto3/botocore absent en dev local.
+# Le code prod l'importe lazily, donc l'absence locale n'affecte pas la prod.
+_HAS_BOTOCORE = importlib.util.find_spec("botocore") is not None
+needs_botocore = pytest.mark.skipif(not _HAS_BOTOCORE, reason="boto3/botocore not installed locally")
+
+
+@pytest.mark.asyncio
+async def test_empty_prefix_returns_zero():
+    """Un prefix vide doit retourner 0 sans toucher R2 ni le filesystem."""
+    from storage.r2 import delete_objects_by_prefix
+
+    with patch("storage.r2._is_r2_credentials_set", return_value=True), patch(
+        "storage.r2._get_r2_client"
+    ) as mock_client:
+        deleted = await delete_objects_by_prefix("")
+
+    assert deleted == 0
+    mock_client.assert_not_called()
+
+
+@needs_botocore
+@pytest.mark.asyncio
+async def test_r2_mode_lists_and_batch_deletes():
+    """En mode R2, doit paginer list_objects_v2 et batcher delete_objects."""
+    from storage.r2 import delete_objects_by_prefix
+
+    fake_client = MagicMock()
+    page_iterator = iter(
+        [
+            {"Contents": [{"Key": "audio-summaries/42/a.mp3"}, {"Key": "audio-summaries/42/b.mp3"}]},
+            {"Contents": [{"Key": "audio-summaries/42/c.mp3"}]},
+        ]
+    )
+    paginator = MagicMock()
+    paginator.paginate.return_value = page_iterator
+    fake_client.get_paginator.return_value = paginator
+    fake_client.delete_objects.return_value = {"Errors": []}
+
+    with patch("storage.r2._is_r2_credentials_set", return_value=True), patch(
+        "storage.r2._get_r2_client", return_value=fake_client
+    ), patch.dict("storage.r2.R2_CONFIG", {"BUCKET": "test-bucket"}, clear=False):
+        deleted = await delete_objects_by_prefix("audio-summaries/42/")
+
+    assert deleted == 3
+    assert fake_client.delete_objects.call_count == 2
+    # Premier batch contient bien les deux objets de la première page
+    first_call_kwargs = fake_client.delete_objects.call_args_list[0].kwargs
+    assert first_call_kwargs["Bucket"] == "test-bucket"
+    assert {o["Key"] for o in first_call_kwargs["Delete"]["Objects"]} == {
+        "audio-summaries/42/a.mp3",
+        "audio-summaries/42/b.mp3",
+    }
+
+
+@needs_botocore
+@pytest.mark.asyncio
+async def test_r2_mode_partial_errors_counted_correctly():
+    """Si delete_objects renvoie 1 Error sur 3, on ne compte que 2 deleted."""
+    from storage.r2 import delete_objects_by_prefix
+
+    fake_client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = iter(
+        [
+            {
+                "Contents": [
+                    {"Key": "audio-summaries/7/x.mp3"},
+                    {"Key": "audio-summaries/7/y.mp3"},
+                    {"Key": "audio-summaries/7/z.mp3"},
+                ]
+            }
+        ]
+    )
+    fake_client.get_paginator.return_value = paginator
+    fake_client.delete_objects.return_value = {
+        "Errors": [{"Key": "audio-summaries/7/y.mp3", "Code": "AccessDenied"}]
+    }
+
+    with patch("storage.r2._is_r2_credentials_set", return_value=True), patch(
+        "storage.r2._get_r2_client", return_value=fake_client
+    ), patch.dict("storage.r2.R2_CONFIG", {"BUCKET": "test-bucket"}, clear=False):
+        deleted = await delete_objects_by_prefix("audio-summaries/7/")
+
+    assert deleted == 2
+
+
+@needs_botocore
+@pytest.mark.asyncio
+async def test_r2_mode_list_failure_returns_zero_no_raise():
+    """Si list_objects_v2 lève ClientError, on log et retourne 0 sans raise."""
+    from botocore.exceptions import ClientError
+    from storage.r2 import delete_objects_by_prefix
+
+    fake_client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchBucket", "Message": "boom"}}, "ListObjectsV2"
+    )
+    fake_client.get_paginator.return_value = paginator
+
+    with patch("storage.r2._is_r2_credentials_set", return_value=True), patch(
+        "storage.r2._get_r2_client", return_value=fake_client
+    ), patch.dict("storage.r2.R2_CONFIG", {"BUCKET": "test-bucket"}, clear=False):
+        deleted = await delete_objects_by_prefix("audio-summaries/42/")
+
+    assert deleted == 0
+    fake_client.delete_objects.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_deletes_files_under_prefix(tmp_path):
+    """En mode local fallback (pas de creds R2), supprime les fichiers sous le prefix."""
+    from storage import r2 as r2_module
+
+    target = tmp_path / "audio-summaries" / "99"
+    target.mkdir(parents=True)
+    (target / "a.mp3").write_bytes(b"x")
+    (target / "b.mp3").write_bytes(b"y")
+    (target / "sub").mkdir()
+    (target / "sub" / "c.mp3").write_bytes(b"z")
+
+    with patch("storage.r2._is_r2_credentials_set", return_value=False), patch.object(
+        r2_module, "LOCAL_THUMB_DIR", tmp_path
+    ):
+        deleted = await r2_module.delete_objects_by_prefix("audio-summaries/99")
+
+    assert deleted == 3
+    assert not (target / "a.mp3").exists()
+    assert not (target / "sub" / "c.mp3").exists()
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_missing_prefix_returns_zero(tmp_path):
+    """Si le dossier prefix n'existe pas localement, retourne 0 sans erreur."""
+    from storage import r2 as r2_module
+
+    with patch("storage.r2._is_r2_credentials_set", return_value=False), patch.object(
+        r2_module, "LOCAL_THUMB_DIR", tmp_path
+    ):
+        deleted = await r2_module.delete_objects_by_prefix("audio-summaries/inexistant")
+
+    assert deleted == 0

--- a/backend/tests/test_auth_delete_account.py
+++ b/backend/tests/test_auth_delete_account.py
@@ -1,0 +1,199 @@
+"""
+Tests pour DELETE /api/auth/account — RGPD Article 17 (suppression sans délai indu).
+
+Couvre la séquence :
+1. Vérification mot de passe (skip pour comptes Google)
+2. Purge R2 audio summaries par prefix (best-effort, non-blocking)
+3. Invalidate session
+4. Audit log
+5. Cascade DELETE PG
+
+Cas testés :
+- A. Compte Google avec 3 summaries → R2 purge appelé 3× avec bons prefixes
+- B. R2 lève Exception → cascade PG s'exécute quand même
+- C. Compte sans summaries → pas d'appel R2, cascade PG OK
+- D. Compte email avec mauvais mot de passe → 401, pas de purge ni cascade
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _google_user(user_id: int = 42, plan: str = "pro") -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    user.password_hash = ""  # compte Google → pas de password
+    user.google_id = "google_xyz"
+    user.plan = plan
+    return user
+
+
+def _email_user(user_id: int = 42, plan: str = "pro") -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    user.password_hash = "$2b$12$abcdef..."  # bcrypt hash
+    user.google_id = ""
+    user.plan = plan
+    return user
+
+
+def _session_with_summary_ids(ids: list[int]) -> AsyncMock:
+    session = AsyncMock()
+    scalar_result = MagicMock()
+    scalar_result.all = MagicMock(return_value=ids)
+    session.scalars = AsyncMock(return_value=scalar_result)
+    session.delete = AsyncMock()
+    session.commit = AsyncMock()
+    return session
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cas A — Compte Google avec summaries → R2 purgé par prefix
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_delete_account_purges_r2_for_each_summary():
+    from auth.router import delete_account
+    from auth.schemas import DeleteAccountRequest
+
+    user = _google_user(user_id=42)
+    session = _session_with_summary_ids([101, 102, 103])
+
+    captured_prefixes: list[str] = []
+
+    async def fake_delete(prefix: str) -> int:
+        captured_prefixes.append(prefix)
+        return 1
+
+    with patch("storage.r2.delete_objects_by_prefix", side_effect=fake_delete), patch(
+        "auth.router.invalidate_user_session", new=AsyncMock()
+    ), patch("auth.router.log_audit", new=AsyncMock()):
+        result = await delete_account(
+            data=DeleteAccountRequest(password=None),
+            current_user=user,
+            session=session,
+        )
+
+    assert captured_prefixes == [
+        "audio-summaries/101/",
+        "audio-summaries/102/",
+        "audio-summaries/103/",
+    ]
+    session.delete.assert_called_once_with(user)
+    session.commit.assert_called_once()
+    assert result.success is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cas B — R2 indisponible → cascade PG continue (Article 17 prioritaire)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_delete_account_proceeds_when_r2_fails():
+    from auth.router import delete_account
+    from auth.schemas import DeleteAccountRequest
+
+    user = _google_user(user_id=42)
+    session = _session_with_summary_ids([101])
+
+    async def r2_boom(prefix: str) -> int:
+        raise RuntimeError("R2 unreachable")
+
+    invalidate_mock = AsyncMock()
+    audit_mock = AsyncMock()
+
+    with patch("storage.r2.delete_objects_by_prefix", side_effect=r2_boom), patch(
+        "auth.router.invalidate_user_session", new=invalidate_mock
+    ), patch("auth.router.log_audit", new=audit_mock):
+        result = await delete_account(
+            data=DeleteAccountRequest(password=None),
+            current_user=user,
+            session=session,
+        )
+
+    # Tous les steps post-R2 doivent s'exécuter
+    invalidate_mock.assert_awaited_once()
+    audit_mock.assert_awaited_once()
+    session.delete.assert_called_once_with(user)
+    session.commit.assert_called_once()
+    assert result.success is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cas C — User sans summaries → aucun appel R2, cascade PG OK
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_delete_account_skips_r2_when_no_summaries():
+    from auth.router import delete_account
+    from auth.schemas import DeleteAccountRequest
+
+    user = _google_user(user_id=42)
+    session = _session_with_summary_ids([])
+
+    captured_calls = 0
+
+    async def fake_delete(prefix: str) -> int:
+        nonlocal captured_calls
+        captured_calls += 1
+        return 0
+
+    with patch("storage.r2.delete_objects_by_prefix", side_effect=fake_delete), patch(
+        "auth.router.invalidate_user_session", new=AsyncMock()
+    ), patch("auth.router.log_audit", new=AsyncMock()):
+        result = await delete_account(
+            data=DeleteAccountRequest(password=None),
+            current_user=user,
+            session=session,
+        )
+
+    assert captured_calls == 0
+    session.delete.assert_called_once_with(user)
+    assert result.success is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cas D — Compte email avec mauvais mot de passe → 401, pas de purge
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_delete_account_wrong_password_blocks_everything():
+    from fastapi import HTTPException
+    from auth.router import delete_account
+    from auth.schemas import DeleteAccountRequest
+
+    user = _email_user(user_id=42)
+    session = _session_with_summary_ids([101])
+
+    captured_calls = 0
+
+    async def fake_delete(prefix: str) -> int:
+        nonlocal captured_calls
+        captured_calls += 1
+        return 1
+
+    with patch("storage.r2.delete_objects_by_prefix", side_effect=fake_delete), patch(
+        "auth.router.invalidate_user_session", new=AsyncMock()
+    ), patch("auth.router.log_audit", new=AsyncMock()), patch(
+        "db.database.verify_password", return_value=False
+    ):
+        with pytest.raises(HTTPException) as excinfo:
+            await delete_account(
+                data=DeleteAccountRequest(password="wrongpass"),
+                current_user=user,
+                session=session,
+            )
+
+    assert excinfo.value.status_code == 401
+    assert captured_calls == 0
+    session.delete.assert_not_called()
+    session.commit.assert_not_called()


### PR DESCRIPTION
## Summary

- `DELETE /api/auth/account` now purges user-specific Cloudflare R2 files (audio summaries) **before** the PG cascade — the DPA "hard delete sous 30j" claim was previously partially false (only PG was purged).
- Added `delete_objects_by_prefix(prefix)` helper in `storage/r2.py` (R2 batched delete via boto3 + local-filesystem fallback; best-effort, never raises so PG cascade always runs).
- Backups S3 still expire automatically at J+30 via `BACKUP_RETENTION_DAYS=30`.

## Why now

J-9 of public launch sprint. Audited 3 critical DPA claims (Sentry EU, daily backup AES-256 retention 30d, hard-delete 30d) before sending the DPA + Annexe II drafts to data-privacy lawyer (J-7 = 2026-05-08). Two passed code audit, hard-delete was the gap. Full audit: `Vault/00-Inbox/2026-05-06-audit-infra-dpa-resultats.md`.

## What changed

| File | Change |
|---|---|
| `backend/src/storage/r2.py` | +`delete_objects_by_prefix` (async) + `_delete_r2_by_prefix_sync` + `_delete_local_by_prefix_sync` |
| `backend/src/auth/router.py` | `delete_account` now fetches `Summary.id` for the user and purges R2 prefix `audio-summaries/{sid}/` for each before invalidate-session + audit-log + cascade DELETE |
| `backend/tests/storage/test_r2_delete.py` | 6 unit tests (3 R2 mode skipif botocore absent + 3 local fallback) |
| `backend/tests/test_auth_delete_account.py` | 4 integration tests: success / R2 down / no summaries / wrong password blocks all |

The diff on `storage/r2.py` looks huge because `Edit` normalized line endings (CRLF → LF). The actual logic delta is ~+90 lines; all 11 original functions are preserved (verified via `grep -E '^(def|async def)'`).

## Tests

```bash
$ python -m pytest tests/storage/test_r2_delete.py tests/test_auth_delete_account.py -v
7 passed, 3 skipped (botocore not installed in dev), 0 failed

$ python -m pytest tests/test_auth_comprehensive.py tests/test_auth_flow.py tests/auth/ -v
64 passed, 0 failed   # zero regression on existing auth suite
```

The 3 R2-mode unit tests will run green on CI where boto3 is installed (already in `requirements.txt`).

## Test plan

- [x] Unit tests for `delete_objects_by_prefix` (empty / R2 paginate+batch / partial errors / list failure / local fallback files / local fallback missing prefix)
- [x] Integration tests for `delete_account` (Google account success / R2 down → PG still runs / no summaries / email account wrong password)
- [x] Existing 64 auth tests still pass (no regression)
- [ ] Post-merge: tester en prod avec compte burner — créer compte → générer audio summary (TTS) → vérifier objet R2 → DELETE /api/auth/account → vérifier objet R2 supprimé + cascade PG OK

## RGPD Article 17 compliance after merge

| Donnée | Délai effectif |
|---|---|
| PG (toutes 25 tables liées au user) | **0s** après commit (cascade SQLAlchemy + FK ondelete=CASCADE) |
| R2 audio summaries user-specific | **0s** après purge best-effort (avant cascade) |
| Sessions Redis | invalidées via `invalidate_user_session` |
| Backups S3 contenant données pré-deletion | **30j max** (retention auto via `cleanup_old_backups`) |

→ "Sans délai indu" Article 17 RGPD respecté ; DPA claim "hard delete sous 30 jours" cohérente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)