### PR TITLE
feat(hub-canvas): v2 — synthesis + theme.description + key_quote (suite feedback)

### DIFF
--- a/backend/src/hub/canvas_service.py
+++ b/backend/src/hub/canvas_service.py
@@ -1,19 +1,29 @@
 """
 ╔════════════════════════════════════════════════════════════════════════════════════╗
-║  🎨 HUB CANVAS SERVICE — extraction Mistral pour rendu natif Workspace            ║
+║  🎨 HUB CANVAS SERVICE v2 — extraction Mistral riche pour rendu natif Workspace   ║
 ╠════════════════════════════════════════════════════════════════════════════════════╣
-║  Pivot 2026-05-06 : remplace l'embed Miro iframe (limitation plan Personal         ║
-║  Starter $8/mo) par un rendu HTML/React natif inspiré du composant                 ║
-║  DebateConvergenceDivergence.                                                      ║
+║  Pivot 2026-05-06 (canvas v1) → enrichissement 2026-05-06 (v2) suite feedback     ║
+║  utilisateur "il manque clairement de contenu, il faut plus d'informations".       ║
 ║                                                                                    ║
 ║  Génère, pour un workspace de N analyses (2 ≤ N ≤ 20) :                            ║
-║    - shared_concepts : liste de concepts partagés par 2+ analyses                  ║
-║    - themes : sections thématiques, chacune avec 1 extrait par analyse pertinente  ║
+║    - synthesis : paragraphe d'overview transversal (3-5 phrases)                  ║
+║    - shared_concepts : 5 à 10 concepts partagés par 2+ analyses                   ║
+║    - themes : 4 à 7 thématiques avec :                                             ║
+║        - theme : titre court                                                       ║
+║        - description : 1-2 phrases de contexte                                     ║
+║        - perspectives : N cards par analyse pertinente, chacune avec :             ║
+║            - summary_id : id de l'analyse                                          ║
+║            - excerpt : 3-5 phrases factuelles (vs 1-2 en v1)                       ║
+║            - key_quote : citation directe optionnelle si extraite du contenu       ║
 ║                                                                                    ║
 ║  Mistral via core.llm_provider.llm_complete (json_mode=True). Modèle :             ║
-║  mistral-large-2512 (plan Expert only, 262K context). Best-effort : si Mistral     ║
-║  fail ou JSON invalide → retourne None et le frontend bascule sur MiroBoardEmbed   ║
-║  (rétro-compat).                                                                   ║
+║  mistral-large-2512 (262K context, capacité d'extraction nuancée). Best-effort :  ║
+║  si Mistral fail ou JSON invalide → retourne None et le frontend bascule sur       ║
+║  MiroBoardEmbed (rétro-compat workspaces pré-pivot).                              ║
+║                                                                                    ║
+║  Backward-compat frontend : tous les champs nouveaux (synthesis, description,      ║
+║  key_quote) sont OPTIONNELS dans la shape retournée. Un workspace v1 (canvas      ║
+║  généré avant ce changement) restera valide et continuera de s'afficher.          ║
 ╚════════════════════════════════════════════════════════════════════════════════════╝
 """
 
@@ -34,19 +44,19 @@ logger = logging.getLogger(__name__)
 # Constants
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Modèle Mistral utilisé pour l'extraction.
-# Note 2026-05-06 : `mistral-large-2512` retourne 401 sur la clé prod
-# (modèle non encore libéré côté Mistral SaaS, ou non couvert par notre licence).
-# `llm_complete` ne fallback PAS sur 401 (uniquement sur 429/5xx) → on utilise
-# directement `mistral-medium-2508` (131K context, confirmé fonctionnel prod).
-CANVAS_MODEL = "mistral-medium-2508"
+# Modèle Mistral pour l'extraction.
+# - `mistral-large-2512` : Expert tier, 262K context, plus capable d'extraction
+#   nuancée et de raisonnement transversal sur N analyses. Confirmé fonctionnel
+#   prod 2026-05-06 avec la clé du workspace `laborat` (org Deep Sight).
+CANVAS_MODEL = "mistral-large-2512"
 
-# Tronque chaque extrait de summary à cette longueur pour rester sous la limite
-# de tokens (mistral-medium-2508 = 131K context, on vise <= 60K input).
-MAX_CHARS_PER_SUMMARY = 6000
+# Tronque chaque extrait de summary à cette longueur. mistral-large-2512 a 262K
+# context, on peut viser ~120K input (10K × 12 analyses moyennes) sans saturer.
+MAX_CHARS_PER_SUMMARY = 10_000
 
-# Max tokens pour la réponse JSON Mistral.
-MAX_RESPONSE_TOKENS = 4096
+# Max tokens réponse JSON Mistral. Avec 4-7 thèmes × 2-N perspectives × excerpts
+# de 3-5 phrases + synthesis + shared_concepts, viser ~8K tokens output.
+MAX_RESPONSE_TOKENS = 8192
 
 # Retry max si parsing JSON échoue.
 MAX_RETRIES = 2
@@ -74,10 +84,10 @@ def _build_summary_excerpt(summary: Summary) -> str:
 def _build_messages(
     summaries: list[Summary], workspace_name: str
 ) -> list[dict[str, str]]:
-    """Construit les messages system+user pour Mistral.
+    """Construit les messages system+user pour Mistral (prompt v2 enrichi).
 
-    Le prompt demande explicitement le format JSON cible (shared_concepts +
-    themes avec perspectives par summary_id).
+    Le prompt demande explicitement la nouvelle shape avec synthesis, theme
+    descriptions et excerpts longs.
     """
     summaries_block_lines: list[str] = []
     for s in summaries:
@@ -87,42 +97,67 @@ def _build_messages(
         summaries_block_lines.append(
             f"=== ANALYSE #{s.id} — {s.video_title or 'Sans titre'} ===\n"
             f"Chaîne : {s.video_channel or 'Inconnue'}\n"
-            f"Extrait :\n{excerpt}\n"
+            f"Contenu :\n{excerpt}\n"
         )
     summaries_block = "\n".join(summaries_block_lines)
 
     summary_ids = [s.id for s in summaries]
 
     system_prompt = (
-        "Tu es un analyste expert en synthèse transversale de contenus vidéo. "
-        "On te fournit N analyses de vidéos sélectionnées par l'utilisateur "
-        "pour un workspace transversal. Ton rôle : extraire (1) les concepts "
-        "partagés par au moins 2 analyses, et (2) regrouper les perspectives "
-        "complémentaires en thématiques avec un extrait spécifique par "
-        "analyse pertinente.\n\n"
-        "Réponds UNIQUEMENT en JSON valide, sans texte avant ni après, "
-        "avec EXACTEMENT ce format :\n"
+        "Tu es un analyste expert en synthèse transversale de contenus vidéo "
+        "pour un workspace DeepSight. On te fournit N analyses de vidéos "
+        "sélectionnées par l'utilisateur ; ton rôle est de produire un canvas "
+        "riche, dense et lisible qui fait émerger ce que les analyses ont en "
+        "commun ET les perspectives complémentaires qu'elles apportent.\n\n"
+        "Réponds UNIQUEMENT en JSON valide, sans texte avant ni après, avec "
+        "EXACTEMENT cette structure :\n"
         "{\n"
-        '  "shared_concepts": ["concept partagé 1", "concept partagé 2", ...],\n'
+        '  "synthesis": "Paragraphe d\'overview transversal en 3 à 5 phrases. '
+        "Présente la convergence générale, les angles distincts, et la valeur "
+        'ajoutée de la mise en relation des analyses.",\n'
+        '  "shared_concepts": ["Concept partagé 1 (2-6 mots)", ..., "Concept '
+        '10 (max)"],\n'
         '  "themes": [\n'
-        '    {\n'
-        '      "theme": "Titre court de la thématique",\n'
+        "    {\n"
+        '      "theme": "Titre court de la thématique (3-7 mots)",\n'
+        '      "description": "1 à 2 phrases de contexte qui posent l\'enjeu '
+        'de ce thème transversal aux analyses.",\n'
         '      "perspectives": [\n'
-        '        {"summary_id": <int>, "excerpt": "Ce que cette analyse apporte sur ce thème (1-2 phrases)"},\n'
-        '        ...\n'
-        '      ]\n'
-        '    },\n'
-        '    ...\n'
-        '  ]\n'
+        "        {\n"
+        '          "summary_id": <int>,\n'
+        '          "excerpt": "3 à 5 phrases factuelles décrivant ce que '
+        "cette analyse apporte SPÉCIFIQUEMENT sur ce thème : argument central, "
+        'preuves/exemples cités, mécanismes décrits, nuances importantes.",\n'
+        '          "key_quote": "Citation directe extraite du contenu si elle '
+        'illustre puissamment le propos (sinon omettre ce champ)."\n'
+        "        },\n"
+        "        ...\n"
+        "      ]\n"
+        "    },\n"
+        "    ...\n"
+        "  ]\n"
         "}\n\n"
         "Règles strictes :\n"
         f"- summary_id ∈ {summary_ids} (uniquement les IDs fournis, en int).\n"
-        "- shared_concepts : 3 à 8 concepts max, chacun en 2-6 mots.\n"
-        "- themes : 2 à 6 thématiques max, distinctes des shared_concepts.\n"
-        "- Chaque thème doit contenir 2 à N perspectives (au moins 2 analyses pertinentes).\n"
-        "- excerpt : 1 à 2 phrases factuelles, en français, fidèles au contenu de l'analyse.\n"
-        "- Si une analyse ne traite pas du thème, NE PAS l'inclure dans perspectives.\n"
-        "- Pas de markdown, pas de listes à puces dans excerpt — juste du texte brut."
+        "- synthesis : 3 à 5 phrases en français, riches en contenu, qui "
+        "donnent envie de scroller plus bas. Pas de méta-commentaire générique.\n"
+        "- shared_concepts : 5 à 10 concepts (vise le haut de la fourchette si "
+        "le contenu le permet), 2-6 mots chacun, distincts entre eux.\n"
+        "- themes : 4 à 7 thématiques (vise 5-6 si le contenu est riche), "
+        "distinctes des shared_concepts, structurées pour faire émerger des "
+        "axes de comparaison ou de complémentarité.\n"
+        "- description (par thème) : 1-2 phrases qui posent l'enjeu, pas un "
+        "résumé des perspectives qui suivent.\n"
+        "- perspectives : INCLURE TOUTES LES ANALYSES qui traitent réellement "
+        "du thème (au moins 2). Si une analyse ne traite pas du thème, "
+        "l'omettre proprement de cette thématique.\n"
+        "- excerpt : 3 à 5 phrases factuelles, denses en contenu, ancrées dans "
+        "le matériel de l'analyse (pas de paraphrase vague). Cite arguments, "
+        "exemples, données, mécanismes, nuances. Français, pas de markdown.\n"
+        "- key_quote : OMETTRE le champ si aucune citation directe ne ressort "
+        "naturellement du contenu (mieux vaut pas de quote qu'une quote "
+        "fabriquée). Quand présent, c'est une citation littérale.\n"
+        "- Ne JAMAIS inventer du contenu hors des analyses fournies."
     )
 
     user_content = (
@@ -140,21 +175,30 @@ def _build_messages(
 def _validate_canvas_shape(
     data: Any, valid_summary_ids: set[int]
 ) -> Optional[dict[str, Any]]:
-    """Valide la forme du JSON retourné par Mistral.
+    """Valide la forme du JSON retourné par Mistral (shape v2).
 
-    Retourne le dict normalisé si OK, None sinon.
+    Retourne le dict normalisé si OK, None si la shape est inutilisable.
+    Champs optionnels (synthesis, theme.description, perspective.key_quote)
+    omis silencieusement quand absents/invalides.
     """
     if not isinstance(data, dict):
         return None
 
+    # synthesis (optionnel — backward compat avec v1 où il n'existe pas)
+    synthesis_raw = data.get("synthesis")
+    synthesis: Optional[str] = None
+    if isinstance(synthesis_raw, str) and synthesis_raw.strip():
+        synthesis = synthesis_raw.strip()
+
     shared_concepts_raw = data.get("shared_concepts")
     themes_raw = data.get("themes")
 
-    if not isinstance(shared_concepts_raw, list) or not isinstance(themes_raw, list):
+    if not isinstance(shared_concepts_raw, list) or not isinstance(
+        themes_raw, list
+    ):
         return None
 
-    # Normalise shared_concepts : str only, dédup case-insensitive,
-    # cap at 8 items.
+    # Normalise shared_concepts : str only, dédup case-insensitive, cap 10.
     shared_concepts: list[str] = []
     seen_lower: set[str] = set()
     for item in shared_concepts_raw:
@@ -168,10 +212,10 @@ def _validate_canvas_shape(
             continue
         seen_lower.add(key)
         shared_concepts.append(cleaned)
-        if len(shared_concepts) >= 8:
+        if len(shared_concepts) >= 10:
             break
 
-    # Normalise themes.
+    # Normalise themes (cap 7 maintenant vs 6 en v1).
     themes: list[dict[str, Any]] = []
     for theme_raw in themes_raw:
         if not isinstance(theme_raw, dict):
@@ -182,6 +226,13 @@ def _validate_canvas_shape(
             continue
         if not isinstance(perspectives_raw, list):
             continue
+
+        # description (optionnel)
+        description_raw = theme_raw.get("description")
+        description: Optional[str] = None
+        if isinstance(description_raw, str) and description_raw.strip():
+            description = description_raw.strip()
+
         perspectives: list[dict[str, Any]] = []
         seen_summary_ids_in_theme: set[int] = set()
         for p in perspectives_raw:
@@ -196,22 +247,45 @@ def _validate_canvas_shape(
             if not isinstance(excerpt, str) or not excerpt.strip():
                 continue
             seen_summary_ids_in_theme.add(sid)
-            perspectives.append({"summary_id": sid, "excerpt": excerpt.strip()})
+
+            perspective_entry: dict[str, Any] = {
+                "summary_id": sid,
+                "excerpt": excerpt.strip(),
+            }
+            # key_quote (optionnel)
+            key_quote_raw = p.get("key_quote")
+            if isinstance(key_quote_raw, str) and key_quote_raw.strip():
+                perspective_entry["key_quote"] = key_quote_raw.strip()
+
+            perspectives.append(perspective_entry)
+
         if len(perspectives) < 2:
-            # On garde la règle "≥ 2 perspectives par thème" pour avoir un
-            # vrai contraste à l'écran. Si Mistral en propose <2, on saute.
+            # Garder règle "≥ 2 perspectives par thème" pour avoir un vrai
+            # contraste à l'écran.
             continue
-        themes.append(
-            {"theme": theme_title.strip(), "perspectives": perspectives}
-        )
-        if len(themes) >= 6:
+
+        theme_entry: dict[str, Any] = {
+            "theme": theme_title.strip(),
+            "perspectives": perspectives,
+        }
+        if description is not None:
+            theme_entry["description"] = description
+        themes.append(theme_entry)
+
+        if len(themes) >= 7:
             break
 
     # Empty canvas = no value for the user.
     if not shared_concepts and not themes:
         return None
 
-    return {"shared_concepts": shared_concepts, "themes": themes}
+    result: dict[str, Any] = {
+        "shared_concepts": shared_concepts,
+        "themes": themes,
+    }
+    if synthesis is not None:
+        result["synthesis"] = synthesis
+    return result
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -222,7 +296,7 @@ def _validate_canvas_shape(
 async def generate_workspace_canvas(
     summaries: list[Summary], workspace_name: str
 ) -> Optional[dict[str, Any]]:
-    """Extrait le canvas natif (shared_concepts + themes) d'un workspace.
+    """Extrait le canvas natif riche (v2) d'un workspace.
 
     Best-effort : retourne None sur échec Mistral / JSON invalide après
     `MAX_RETRIES` tentatives. Le caller sauvera None en DB → frontend
@@ -233,7 +307,11 @@ async def generate_workspace_canvas(
         workspace_name: nom du workspace (sert de contexte au prompt).
 
     Returns:
-        dict {"shared_concepts": [...], "themes": [...]} ou None.
+        dict avec keys :
+          - "shared_concepts": list[str] (5-10 items)
+          - "themes": list[{theme, description?, perspectives:[{summary_id, excerpt, key_quote?}]}]
+          - "synthesis": str (optionnel — overview)
+        Ou None si échec.
     """
     if not summaries:
         logger.warning("[HUB-CANVAS] generate_workspace_canvas called with no summaries")
@@ -282,11 +360,13 @@ async def generate_workspace_canvas(
 
         canvas_data = validated
         logger.info(
-            "[HUB-CANVAS] Canvas generated OK on attempt %d "
-            "(shared=%d, themes=%d)",
+            "[HUB-CANVAS] Canvas v2 generated OK on attempt %d "
+            "(synthesis=%s, shared=%d, themes=%d, perspectives_total=%d)",
             attempt,
+            "yes" if validated.get("synthesis") else "no",
             len(validated["shared_concepts"]),
             len(validated["themes"]),
+            sum(len(t["perspectives"]) for t in validated["themes"]),
         )
         break
 

--- a/backend/src/hub/schemas.py
+++ b/backend/src/hub/schemas.py
@@ -77,28 +77,41 @@ class HubWorkspaceCreate(BaseModel):
 
 
 class CanvasPerspective(BaseModel):
-    """Une perspective dans une thématique du canvas natif (Hub Workspace)."""
+    """Une perspective dans une thématique du canvas natif (Hub Workspace).
+
+    `key_quote` (v2, 2026-05-06) : citation littérale optionnelle extraite du
+    contenu de l'analyse pour illustrer puissamment le propos.
+    """
 
     summary_id: int
     excerpt: str
+    key_quote: Optional[str] = None
 
 
 class CanvasTheme(BaseModel):
-    """Une thématique du canvas natif, regroupant N perspectives par analyse."""
+    """Une thématique du canvas natif, regroupant N perspectives par analyse.
+
+    `description` (v2, 2026-05-06) : 1-2 phrases optionnelles posant l'enjeu du
+    thème avant de lister les perspectives par analyse.
+    """
 
     theme: str
+    description: Optional[str] = None
     perspectives: list[CanvasPerspective]
 
 
 class WorkspaceCanvasData(BaseModel):
-    """Canvas natif Hub Workspace (pivot 2026-05-06).
+    """Canvas natif Hub Workspace (pivot 2026-05-06, v2 enrichi).
 
     Forme stockée dans `hub_workspaces.canvas_data` (JSON nullable).
     NULL = workspace pré-pivot ou Mistral fail → frontend fallback MiroBoardEmbed.
+
+    v2 (2026-05-06) : ajout `synthesis` (overview transversal optionnel).
     """
 
     shared_concepts: list[str]
     themes: list[CanvasTheme]
+    synthesis: Optional[str] = None
 
 
 class HubWorkspaceResponse(BaseModel):

--- a/backend/tests/test_hub_canvas.py
+++ b/backend/tests/test_hub_canvas.py
@@ -50,7 +50,7 @@ def _llm_result(content: str):
 
     return LLMResult(
         content=content,
-        model_used="mistral-medium-2508",
+        model_used="mistral-large-2512",
         provider="mistral",
         attempts=1,
     )
@@ -170,8 +170,8 @@ def test_validate_canvas_shape_rejects_non_dict_input():
     assert _validate_canvas_shape(None, {1, 2}) is None
 
 
-def test_validate_canvas_shape_caps_themes_at_6():
-    """Limite dure à 6 thèmes pour éviter UI surcharge."""
+def test_validate_canvas_shape_caps_themes_at_7():
+    """v2 : limite dure à 7 thèmes (vs 6 en v1) pour offrir plus de richesse."""
     from hub.canvas_service import _validate_canvas_shape
 
     raw = {
@@ -189,7 +189,147 @@ def test_validate_canvas_shape_caps_themes_at_6():
     }
     out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
     assert out is not None
-    assert len(out["themes"]) == 6
+    assert len(out["themes"]) == 7
+
+
+def test_validate_canvas_shape_caps_shared_concepts_at_10():
+    """v2 : cap shared_concepts à 10 (vs 8 en v1)."""
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "shared_concepts": [f"concept-{i}" for i in range(15)],
+        "themes": [
+            {
+                "theme": "T",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "A"},
+                    {"summary_id": 2, "excerpt": "B"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    assert len(out["shared_concepts"]) == 10
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# v2 — synthesis / theme.description / perspective.key_quote (champs optionnels)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_validate_canvas_shape_v2_extracts_synthesis_when_present():
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "synthesis": "  Overview transversal en plusieurs phrases.  ",
+        "shared_concepts": ["c"],
+        "themes": [
+            {
+                "theme": "T",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "A"},
+                    {"summary_id": 2, "excerpt": "B"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    assert out["synthesis"] == "Overview transversal en plusieurs phrases."
+
+
+def test_validate_canvas_shape_v2_omits_synthesis_when_invalid():
+    """Synthesis vide / non-str → champ omis (pas d'erreur)."""
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "synthesis": "",
+        "shared_concepts": ["c"],
+        "themes": [
+            {
+                "theme": "T",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "A"},
+                    {"summary_id": 2, "excerpt": "B"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    assert "synthesis" not in out
+
+
+def test_validate_canvas_shape_v2_extracts_theme_description():
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "shared_concepts": ["c"],
+        "themes": [
+            {
+                "theme": "T",
+                "description": "  Pose l'enjeu en 1 phrase.  ",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "A"},
+                    {"summary_id": 2, "excerpt": "B"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    assert out["themes"][0]["description"] == "Pose l'enjeu en 1 phrase."
+
+
+def test_validate_canvas_shape_v2_extracts_key_quote_when_present():
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw = {
+        "shared_concepts": ["c"],
+        "themes": [
+            {
+                "theme": "T",
+                "perspectives": [
+                    {
+                        "summary_id": 1,
+                        "excerpt": "Argument complet en plusieurs phrases.",
+                        "key_quote": "Citation littérale tirée du contenu.",
+                    },
+                    {"summary_id": 2, "excerpt": "B sans quote"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw, valid_summary_ids={1, 2})
+    assert out is not None
+    perspectives = out["themes"][0]["perspectives"]
+    assert perspectives[0]["key_quote"] == "Citation littérale tirée du contenu."
+    # Perspective sans key_quote → champ omis (pas null)
+    assert "key_quote" not in perspectives[1]
+
+
+def test_validate_canvas_shape_v2_backward_compat_v1_data():
+    """Un canvas v1 (sans synthesis/description/key_quote) reste valide."""
+    from hub.canvas_service import _validate_canvas_shape
+
+    raw_v1 = {
+        "shared_concepts": ["c1", "c2"],
+        "themes": [
+            {
+                "theme": "T1",
+                "perspectives": [
+                    {"summary_id": 1, "excerpt": "A"},
+                    {"summary_id": 2, "excerpt": "B"},
+                ],
+            }
+        ],
+    }
+    out = _validate_canvas_shape(raw_v1, valid_summary_ids={1, 2})
+    assert out is not None
+    assert "synthesis" not in out
+    assert "description" not in out["themes"][0]
+    assert "key_quote" not in out["themes"][0]["perspectives"][0]
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/frontend/src/components/hub/HubWorkspaceCanvas.tsx
+++ b/frontend/src/components/hub/HubWorkspaceCanvas.tsx
@@ -1,23 +1,29 @@
 /**
  * ╔════════════════════════════════════════════════════════════════════════════════════╗
- * ║  🎨 HUB WORKSPACE CANVAS — rendu natif (pivot 2026-05-06)                          ║
+ * ║  🎨 HUB WORKSPACE CANVAS v2 — rendu natif enrichi (2026-05-06)                     ║
  * ╠════════════════════════════════════════════════════════════════════════════════════╣
  * ║  Remplace l'embed Miro iframe par un rendu HTML/React natif inspiré du composant   ║
  * ║  DebateConvergenceDivergence (style apprécié par l'utilisateur sur Débat IA).      ║
  * ║                                                                                    ║
- * ║  - canvasData absent (pré-pivot ou Mistral fail) → fallback sur MiroBoardEmbed     ║
- * ║  - canvasData présent → 2 sections glassmorphism dark mode :                       ║
- * ║      1. Concepts partagés (équivalent Convergence, palette emerald)                ║
- * ║      2. Perspectives complémentaires (équivalent Divergence, indigo/violet)        ║
+ * ║  v1 (initial) : 2 sections (concepts partagés + perspectives par thème).           ║
+ * ║  v2 (enrichi) : ajoute synthesis + theme.description + perspective.key_quote.      ║
  * ║                                                                                    ║
- * ║  Composant pur prop-driven : aucun appel API, aucun state global. La section       ║
- * ║  "Vue d'ensemble" (analyses cards) reste rendue par HubWorkspacesPage.             ║
+ * ║  Sections rendues :                                                                ║
+ * ║    1. Synthèse transversale (cyan, optionnel — affiché si présent)                 ║
+ * ║    2. Concepts partagés (emerald)                                                  ║
+ * ║    3. Perspectives complémentaires (indigo/violet) avec :                          ║
+ * ║         - description du thème (optionnel)                                         ║
+ * ║         - excerpt riche par analyse                                                ║
+ * ║         - key_quote en italique (optionnel)                                        ║
+ * ║                                                                                    ║
+ * ║  Backward-compat : un canvas v1 (sans synthesis/description/key_quote) reste       ║
+ * ║  parfaitement rendu. Workspaces pré-pivot ou Mistral fail → fallback Miro.        ║
  * ╚════════════════════════════════════════════════════════════════════════════════════╝
  */
 
 import React from "react";
 import { motion } from "framer-motion";
-import { Handshake, Layers, Sparkles } from "lucide-react";
+import { Handshake, Layers, Quote, Sparkles } from "lucide-react";
 
 import { MiroBoardEmbed } from "./MiroBoardEmbed";
 import type {
@@ -66,6 +72,37 @@ const itemVariants = {
   visible: { opacity: 1, y: 0, transition: { duration: 0.3 } },
 };
 
+// ─── Sub-section v2 : Synthèse transversale (optionnel) ──────────────────────
+
+interface SynthesisSectionProps {
+  synthesis: string;
+}
+
+const SynthesisSection: React.FC<SynthesisSectionProps> = ({ synthesis }) => (
+  <motion.div
+    initial={{ opacity: 0, y: 8 }}
+    animate={{ opacity: 1, y: 0 }}
+    transition={{ duration: 0.4 }}
+    className="rounded-xl bg-gradient-to-br from-cyan-500/[0.07] to-indigo-500/[0.05] border border-cyan-500/20 backdrop-blur-xl p-5"
+    data-testid="hub-canvas-synthesis"
+  >
+    <div className="flex items-center gap-2 mb-3">
+      <div className="w-8 h-8 rounded-lg bg-cyan-500/15 flex items-center justify-center">
+        <Sparkles className="w-4 h-4 text-cyan-400" aria-hidden />
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-white">Synthèse transversale</h3>
+        <p className="text-xs text-text-muted">
+          Vue d'ensemble du workspace
+        </p>
+      </div>
+    </div>
+    <p className="text-sm text-text-primary leading-relaxed whitespace-pre-line">
+      {synthesis}
+    </p>
+  </motion.div>
+);
+
 // ─── Sub-section : Concepts partagés ───────────────────────────────────────────
 
 interface SharedConceptsSectionProps {
@@ -92,7 +129,7 @@ const SharedConceptsSection: React.FC<SharedConceptsSectionProps> = ({
     </div>
 
     <motion.ul
-      className="space-y-2"
+      className="grid grid-cols-1 sm:grid-cols-2 gap-2"
       variants={containerVariants}
       initial="hidden"
       animate="visible"
@@ -158,20 +195,34 @@ const ThemesSection: React.FC<ThemesSectionProps> = ({
           className="rounded-lg bg-indigo-500/[0.05] border border-indigo-500/10 p-4 space-y-3"
           data-testid={`hub-canvas-theme-${i}`}
         >
-          <p className="text-xs font-semibold text-indigo-400 uppercase tracking-wider">
-            {theme.theme}
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {/* Theme header : title + (optional) description */}
+          <div className="space-y-1.5">
+            <p className="text-xs font-semibold text-indigo-400 uppercase tracking-wider">
+              {theme.theme}
+            </p>
+            {theme.description && (
+              <p
+                className="text-xs text-text-secondary leading-relaxed italic"
+                data-testid={`hub-canvas-theme-description-${i}`}
+              >
+                {theme.description}
+              </p>
+            )}
+          </div>
+
+          {/* Perspectives grid */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
             {theme.perspectives.map((perspective, j) => {
               const detail = summaryDetails[perspective.summary_id];
               const fallbackTitle = `Analyse #${perspective.summary_id}`;
               return (
                 <div
                   key={`${i}-${j}-${perspective.summary_id}`}
-                  className="rounded-md bg-violet-500/[0.06] border border-violet-500/15 p-2.5"
+                  className="rounded-md bg-violet-500/[0.06] border border-violet-500/15 p-3 flex flex-col gap-2"
                   data-testid={`hub-canvas-perspective-${i}-${perspective.summary_id}`}
                 >
-                  <div className="flex items-start gap-2 mb-1.5">
+                  {/* Header : thumbnail + title */}
+                  <div className="flex items-start gap-2">
                     {detail?.thumbnail ? (
                       <img
                         src={detail.thumbnail}
@@ -186,9 +237,27 @@ const ThemesSection: React.FC<ThemesSectionProps> = ({
                       {detail?.title ?? fallbackTitle}
                     </p>
                   </div>
-                  <p className="text-xs text-text-secondary leading-relaxed">
+
+                  {/* Excerpt — riche v2 (3-5 phrases) */}
+                  <p className="text-xs text-text-secondary leading-relaxed whitespace-pre-line">
                     {perspective.excerpt}
                   </p>
+
+                  {/* key_quote optionnel v2 */}
+                  {perspective.key_quote && (
+                    <div
+                      className="flex items-start gap-1.5 pl-2 border-l-2 border-violet-400/40 mt-0.5"
+                      data-testid={`hub-canvas-key-quote-${i}-${perspective.summary_id}`}
+                    >
+                      <Quote
+                        className="w-3 h-3 text-violet-400/70 shrink-0 mt-0.5"
+                        aria-hidden
+                      />
+                      <p className="text-[11px] text-violet-200/90 italic leading-relaxed">
+                        {perspective.key_quote}
+                      </p>
+                    </div>
+                  )}
                 </div>
               );
             })}
@@ -249,7 +318,11 @@ export const HubWorkspaceCanvas: React.FC<HubWorkspaceCanvasProps> = ({
     );
   }
 
-  const { shared_concepts: sharedConcepts, themes } = canvasData;
+  const {
+    shared_concepts: sharedConcepts,
+    themes,
+    synthesis,
+  } = canvasData;
   const isEmpty = sharedConcepts.length === 0 && themes.length === 0;
 
   return (
@@ -259,6 +332,7 @@ export const HubWorkspaceCanvas: React.FC<HubWorkspaceCanvasProps> = ({
       data-testid="hub-workspace-canvas"
       className={`space-y-6 ${className}`}
     >
+      {synthesis && <SynthesisSection synthesis={synthesis} />}
       {sharedConcepts.length > 0 && (
         <SharedConceptsSection concepts={sharedConcepts} />
       )}

--- a/frontend/src/components/hub/__tests__/HubWorkspaceCanvas.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubWorkspaceCanvas.test.tsx
@@ -166,6 +166,123 @@ describe("HubWorkspaceCanvas", () => {
     expect(screen.getByTestId("hub-canvas-themes")).toBeInTheDocument();
   });
 
+  it("does NOT render synthesis section for v1 canvas (backward compat)", () => {
+    render(
+      <HubWorkspaceCanvas
+        canvasData={VALID_CANVAS}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    expect(screen.queryByTestId("hub-canvas-synthesis")).toBeNull();
+  });
+
+  it("renders synthesis section when canvasData.synthesis is present (v2)", () => {
+    const canvas: WorkspaceCanvasData = {
+      ...VALID_CANVAS,
+      synthesis:
+        "Cette synthèse transversale présente l'ensemble des analyses du workspace. Elle articule les points de convergence et les angles distincts.",
+    };
+    render(
+      <HubWorkspaceCanvas
+        canvasData={canvas}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    expect(screen.getByTestId("hub-canvas-synthesis")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cette synthèse transversale présente/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders theme.description when present (v2) and omits when absent", () => {
+    const canvas: WorkspaceCanvasData = {
+      shared_concepts: [],
+      themes: [
+        {
+          theme: "Thème AVEC description",
+          description: "Cet enjeu pose une question transversale clé.",
+          perspectives: [
+            { summary_id: 1, excerpt: "P1" },
+            { summary_id: 2, excerpt: "P2" },
+          ],
+        },
+        {
+          theme: "Thème SANS description",
+          perspectives: [
+            { summary_id: 1, excerpt: "P3" },
+            { summary_id: 2, excerpt: "P4" },
+          ],
+        },
+      ],
+    };
+    render(
+      <HubWorkspaceCanvas
+        canvasData={canvas}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    // Theme 0 a une description
+    expect(
+      screen.getByTestId("hub-canvas-theme-description-0"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Cet enjeu pose une question transversale clé."),
+    ).toBeInTheDocument();
+    // Theme 1 n'a pas de description
+    expect(screen.queryByTestId("hub-canvas-theme-description-1")).toBeNull();
+  });
+
+  it("renders perspective.key_quote when present (v2) and omits when absent", () => {
+    const canvas: WorkspaceCanvasData = {
+      shared_concepts: [],
+      themes: [
+        {
+          theme: "Thème quote",
+          perspectives: [
+            {
+              summary_id: 1,
+              excerpt: "Argument complet en plusieurs phrases.",
+              key_quote: "Citation littérale du contenu.",
+            },
+            {
+              summary_id: 2,
+              excerpt: "Argument sans quote.",
+            },
+          ],
+        },
+      ],
+    };
+    render(
+      <HubWorkspaceCanvas
+        canvasData={canvas}
+        summaryDetails={{}}
+        workspaceName="WS"
+        boardId="abc123"
+        viewLink={null}
+        status="ready"
+      />,
+    );
+    // P1 a une key_quote
+    expect(screen.getByTestId("hub-canvas-key-quote-0-1")).toBeInTheDocument();
+    expect(
+      screen.getByText("Citation littérale du contenu."),
+    ).toBeInTheDocument();
+    // P2 n'en a pas
+    expect(screen.queryByTestId("hub-canvas-key-quote-0-2")).toBeNull();
+  });
+
   it("renders empty state when canvasData has no concepts and no themes", () => {
     const canvas: WorkspaceCanvasData = {
       shared_concepts: [],

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3428,25 +3428,35 @@ export const keywordImageApi = {
 export type HubWorkspaceStatus = "pending" | "creating" | "ready" | "failed";
 
 /**
- * Canvas natif Hub Workspace (pivot 2026-05-06).
+ * Canvas natif Hub Workspace (pivot 2026-05-06, v2 enrichi).
  *
  * Remplace l'embed Miro iframe pour les nouveaux workspaces. Stocké côté
  * backend dans `hub_workspaces.canvas_data` (JSON nullable). Aligné sur le
  * Pydantic `WorkspaceCanvasData` (backend/src/hub/schemas.py).
+ *
+ * v2 (2026-05-06) ajoute des champs OPTIONNELS pour enrichir le rendu :
+ * - `synthesis` (top-level) : paragraphe d'overview transversal
+ * - `theme.description` : 1-2 phrases d'enjeu par thématique
+ * - `perspective.key_quote` : citation littérale optionnelle
+ *
+ * Backward-compat : un canvas v1 (sans ces champs) reste affichable.
  */
 export interface CanvasPerspective {
   summary_id: number;
   excerpt: string;
+  key_quote?: string;
 }
 
 export interface CanvasTheme {
   theme: string;
+  description?: string;
   perspectives: CanvasPerspective[];
 }
 
 export interface WorkspaceCanvasData {
   shared_concepts: string[];
   themes: CanvasTheme[];
+  synthesis?: string;
 }
 
 export interface HubWorkspace {


### PR DESCRIPTION
## Suite feedback utilisateur

Post-deploy v1 (PR #384/#385), feedback utilisateur sur le workspace #9 :
> "C'est pas mal mais il manque clairement de contenu, il faut plus d'informations."

## Changements

### Backend
- **Modèle** : \`mistral-medium-2508\` → \`mistral-large-2512\` (262K context, Expert tier).
- **Tokens** : 4096 → 8192 réponse, 6K → 10K input par summary.
- **Prompt enrichi** : vise 5-10 shared_concepts, 4-7 thèmes, excerpts 3-5 phrases.
- **3 nouveaux champs OPTIONNELS** :
  - \`synthesis\` (top-level) : paragraphe overview transversal
  - \`theme.description\` : 1-2 phrases d'enjeu par thématique
  - \`perspective.key_quote\` : citation littérale optionnelle
- 18 tests backend verts (12 v1 + 6 nouveaux v2).

### Frontend
- Nouvelle section \`<SynthesisSection>\` (palette cyan, gradient) rendue en premier.
- \`theme.description\` en italique sous le titre du thème.
- \`key_quote\` en bloc italique avec bordure violette + icône Quote dans cards perspectives.
- 11 tests frontend verts (7 v1 + 4 nouveaux v2).
- Typecheck propre.

### Backward-compat 100%
- Workspace #9 (canvas v1) s'affiche identiquement à avant (pas de synthesis/description/key_quote → champs simplement omis dans le JSX).
- Workspaces antérieurs avec \`canvas_data\` NULL → fallback Miro inchangé.

## Test plan

- [x] Backend : 18/18 \`test_hub_canvas.py\`
- [x] Frontend : 11/11 \`HubWorkspaceCanvas.test.tsx\`
- [x] Typecheck propre
- [ ] Deploy prod via deploy-backend.yml
- [ ] User crée un nouveau workspace via /hub → vérifier sections enrichies (synthesis + descriptions + quotes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)