### PR TITLE
feat(summary): spike enrichment alongside — quotes + takeaways + chapter themes

### DIFF
--- a/backend/alembic/versions/022_summary_extras.py
+++ b/backend/alembic/versions/022_summary_extras.py
@@ -1,0 +1,60 @@
+"""summary_extras — enrichissement post-processing pour synthèses détaillées
+
+Revision ID: 022_summary_extras
+Revises: 021_hub_workspace_canvas_data
+Create Date: 2026-05-06
+
+Spike "synthèses détaillées enrichies" 2026-05-06 — applique la technique du
+canvas Hub (Mistral json_mode + validation stricte + retry + champs optionnels)
+au Summary classique, sans toucher à `summary_content` (prose existante).
+
+Ajoute la colonne `summary_extras JSON NULL` qui stockera :
+    {
+      "key_quotes": [{"quote": str, "context": str | null}, ...],
+      "key_takeaways": [str, ...],
+      "chapter_themes": [{"theme": str, "summary": str | null}, ...]
+    }
+
+NULL = enrichissement pas encore généré (génération à la demande via endpoint
+POST /api/videos/summary/{id}/enrich).
+
+Idempotente : check si la colonne existe avant ALTER TABLE.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "022_summary_extras"
+down_revision: Union[str, None] = "021_hub_workspace_canvas_data"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "summary_extras" not in columns:
+        op.add_column(
+            "summaries",
+            sa.Column("summary_extras", sa.JSON(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "summary_extras" in columns:
+        op.drop_column("summaries", "summary_extras")

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -246,6 +246,13 @@ class Summary(Base):
     enrichment_sources = Column(Text, nullable=True)  # JSON: [{title, url, snippet}]
     enrichment_data = Column(Text, nullable=True)  # JSON: {level, sources, enriched_at}
 
+    # Summary extras (spike 2026-05-06) — enrichissement post-processing Mistral
+    # appliqué à la demande sur le summary_content existant.
+    # Forme : {key_quotes: [{quote, context?}], key_takeaways: [str], chapter_themes: [{theme, summary?}]}
+    # NULL = enrichissement pas encore généré (POST /api/videos/summary/{id}/enrich).
+    # Migration : alembic 022_summary_extras.py.
+    summary_extras = Column(JSON, nullable=True)
+
     # Hierarchical Digest Pipeline (Feb 2026)
     full_digest = Column(Text, nullable=True)  # Assembled full digest from chunk digests (~6-10K chars)
 

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3685,6 +3685,70 @@ async def get_summary(
         music_author=getattr(summary, "music_author", None),
         source_tags=_source_tags,
         carousel_images=_carousel_images,
+        # Summary extras (spike 2026-05-06) — null tant que pas généré
+        summary_extras=getattr(summary, "summary_extras", None),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📚 SUMMARY EXTRAS — enrichissement post-processing Mistral (spike 2026-05-06)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post("/summary/{summary_id}/enrich")
+async def enrich_summary(
+    summary_id: int,
+    force: bool = Query(default=False, description="Force regen même si cache présent"),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Génère (ou retourne du cache) les extras Mistral d'une analyse.
+
+    Idempotent : si `summary_extras` est déjà populé, retourne le cache
+    sans regénérer (sauf si `force=true`).
+
+    Best-effort : si Mistral échoue, retourne 502 mais ne casse pas l'analyse.
+    """
+    summary = await get_summary_by_id(session, summary_id, current_user.id)
+    if not summary:
+        raise HTTPException(status_code=404, detail="Summary not found")
+
+    existing = getattr(summary, "summary_extras", None)
+    if existing and not force:
+        from videos.schemas import SummaryEnrichResponse
+
+        return SummaryEnrichResponse(
+            summary_id=summary.id,
+            cached=True,
+            extras=existing,  # type: ignore[arg-type]  # Pydantic coerces dict→model
+        )
+
+    # Génération Mistral
+    from videos.summary_enrichment_service import generate_summary_extras
+
+    extras = await generate_summary_extras(summary)
+    if extras is None:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "summary_enrichment_failed",
+                "message": (
+                    "L'enrichissement Mistral a échoué. Réessaie dans quelques "
+                    "secondes ou contacte le support si le problème persiste."
+                ),
+            },
+        )
+
+    # Persist
+    summary.summary_extras = extras
+    await session.commit()
+
+    from videos.schemas import SummaryEnrichResponse
+
+    return SummaryEnrichResponse(
+        summary_id=summary.id,
+        cached=False,
+        extras=extras,  # type: ignore[arg-type]
     )
 
 

--- a/backend/src/videos/schemas.py
+++ b/backend/src/videos/schemas.py
@@ -280,8 +280,51 @@ class SummaryResponse(BaseModel):
     source_tags: Optional[List[str]] = None
     carousel_images: Optional[List[str]] = None
 
+    # 📚 Summary extras (spike 2026-05-06) — enrichissement post-processing
+    # Mistral à la demande sur le contenu existant. NULL si pas encore généré.
+    # Forme : {key_quotes: [{quote, context?}], key_takeaways: [str], chapter_themes: [{theme, summary?}]}
+    summary_extras: Optional[Dict[str, Any]] = None
+
     class Config:
         from_attributes = True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📚 SUMMARY EXTRAS (spike 2026-05-06)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class SummaryQuote(BaseModel):
+    """Une citation extraite par Mistral d'un Summary (avec mini-contexte optionnel)."""
+
+    quote: str
+    context: Optional[str] = None
+
+
+class SummaryChapterTheme(BaseModel):
+    """Un chapitre / thème structuré du Summary (table des matières enrichie)."""
+
+    theme: str
+    summary: Optional[str] = None
+
+
+class SummaryExtrasData(BaseModel):
+    """Forme stockée dans `summaries.summary_extras` (JSON nullable)."""
+
+    key_quotes: List[SummaryQuote] = Field(default_factory=list)
+    key_takeaways: List[str] = Field(default_factory=list)
+    chapter_themes: List[SummaryChapterTheme] = Field(default_factory=list)
+
+
+class SummaryEnrichResponse(BaseModel):
+    """Réponse de POST /api/videos/summary/{id}/enrich.
+
+    `cached=True` si l'enrichissement existait déjà (pas de regen Mistral).
+    """
+
+    summary_id: int
+    cached: bool
+    extras: Optional[SummaryExtrasData] = None
 
 
 class SummaryListItem(BaseModel):

--- a/backend/src/videos/summary_enrichment_service.py
+++ b/backend/src/videos/summary_enrichment_service.py
@@ -1,0 +1,271 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  📚 SUMMARY ENRICHMENT SERVICE — spike post-processing pour synthèses détaillées  ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  2026-05-06 : applique la technique du Hub Canvas (Mistral json_mode + validation ║
+║  stricte + retry + champs optionnels) au Summary classique sans toucher à         ║
+║  `summary_content` (la prose continue qui plaît aux utilisateurs reste intacte).   ║
+║                                                                                    ║
+║  Génère 3 sections d'enrichissement dérivées de l'analyse existante :              ║
+║    - key_quotes : 3-5 citations littérales du contenu avec mini-contexte          ║
+║    - key_takeaways : 4-7 takeaways courts en bullets                              ║
+║    - chapter_themes : 3-6 thèmes structurés type table des matières enrichie      ║
+║                                                                                    ║
+║  Mistral via core.llm_provider.llm_complete (json_mode=True). Modèle :             ║
+║  mistral-medium-2508 (131K context, économique pour spike). Best-effort : si      ║
+║  Mistral fail ou JSON invalide → retourne None et l'endpoint API 502.             ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from core.llm_provider import llm_complete
+from db.database import Summary
+
+
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════════════
+
+ENRICHMENT_MODEL = "mistral-medium-2508"
+MAX_CHARS_INPUT = 12_000  # full_digest moyen ~6-10K chars, on garde une marge
+MAX_RESPONSE_TOKENS = 4096
+MAX_RETRIES = 2
+
+# Caps pour éviter UI surcharge.
+MAX_QUOTES = 5
+MAX_TAKEAWAYS = 7
+MAX_THEMES = 6
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _build_input_text(summary: Summary) -> str:
+    """Construit le texte source pour l'enrichissement.
+
+    Priorité : full_digest (assembled hierarchical, ~6-10K) > summary_content > transcript.
+    Tronque à MAX_CHARS_INPUT.
+    """
+    text = (
+        summary.full_digest
+        or summary.summary_content
+        or summary.transcript_context
+        or ""
+    ).strip()
+    if not text:
+        return ""
+    if len(text) > MAX_CHARS_INPUT:
+        return text[:MAX_CHARS_INPUT] + "…"
+    return text
+
+
+def _build_messages(summary: Summary) -> list[dict[str, str]]:
+    """Construit les messages system+user pour Mistral."""
+    input_text = _build_input_text(summary)
+
+    system_prompt = (
+        "Tu es un assistant éditorial pour DeepSight. À partir d'une analyse "
+        "détaillée d'une vidéo (synthèse + transcription), tu produis 3 "
+        "sections d'enrichissement qui complètent la lecture sans la "
+        "remplacer.\n\n"
+        "Réponds UNIQUEMENT en JSON valide, sans texte avant ni après, avec "
+        "EXACTEMENT cette structure :\n"
+        "{\n"
+        '  "key_quotes": [\n'
+        "    {\n"
+        '      "quote": "Citation littérale tirée du contenu (1-3 phrases max).",\n'
+        '      "context": "1 phrase qui explique en quoi cette citation est marquante (optionnel)."\n'
+        "    },\n"
+        "    ...\n"
+        "  ],\n"
+        '  "key_takeaways": [\n'
+        '    "Takeaway 1 — phrase courte et actionnable.",\n'
+        "    ...\n"
+        "  ],\n"
+        '  "chapter_themes": [\n'
+        "    {\n"
+        '      "theme": "Titre court d\'un chapitre / thème (3-7 mots).",\n'
+        '      "summary": "Synthèse du thème en 1-2 phrases (optionnel)."\n'
+        "    },\n"
+        "    ...\n"
+        "  ]\n"
+        "}\n\n"
+        "Règles strictes :\n"
+        f"- key_quotes : 3 à {MAX_QUOTES} citations LITTÉRALES tirées du contenu (pas reformulées). "
+        "Si aucune citation forte ne ressort, OMETTRE des entrées plutôt qu'en fabriquer.\n"
+        f"- key_takeaways : 4 à {MAX_TAKEAWAYS} takeaways courts (1 phrase chacun, pas de markdown). "
+        "Vise des insights actionnables ou des conclusions saillantes.\n"
+        f"- chapter_themes : 3 à {MAX_THEMES} thèmes structurés. summary optionnel mais recommandé.\n"
+        "- Tout en français.\n"
+        "- Ne JAMAIS inventer du contenu hors de l'analyse fournie."
+    )
+
+    user_content = (
+        f"VIDÉO : {summary.video_title or 'Sans titre'}\n"
+        f"CHAÎNE : {summary.video_channel or 'Inconnue'}\n\n"
+        f"CONTENU DE L'ANALYSE :\n{input_text}"
+    )
+
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_content},
+    ]
+
+
+def _validate_extras_shape(data: Any) -> Optional[dict[str, Any]]:
+    """Valide la forme du JSON Mistral. Retourne dict normalisé ou None."""
+    if not isinstance(data, dict):
+        return None
+
+    # ─── key_quotes ───
+    quotes_raw = data.get("key_quotes")
+    quotes: list[dict[str, Any]] = []
+    if isinstance(quotes_raw, list):
+        for q in quotes_raw:
+            if not isinstance(q, dict):
+                continue
+            quote_str = q.get("quote")
+            if not isinstance(quote_str, str) or not quote_str.strip():
+                continue
+            entry: dict[str, Any] = {"quote": quote_str.strip()}
+            ctx = q.get("context")
+            if isinstance(ctx, str) and ctx.strip():
+                entry["context"] = ctx.strip()
+            quotes.append(entry)
+            if len(quotes) >= MAX_QUOTES:
+                break
+
+    # ─── key_takeaways ───
+    takeaways_raw = data.get("key_takeaways")
+    takeaways: list[str] = []
+    if isinstance(takeaways_raw, list):
+        seen_lower: set[str] = set()
+        for t in takeaways_raw:
+            if not isinstance(t, str):
+                continue
+            cleaned = t.strip()
+            if not cleaned:
+                continue
+            key = cleaned.lower()
+            if key in seen_lower:
+                continue
+            seen_lower.add(key)
+            takeaways.append(cleaned)
+            if len(takeaways) >= MAX_TAKEAWAYS:
+                break
+
+    # ─── chapter_themes ───
+    themes_raw = data.get("chapter_themes")
+    themes: list[dict[str, Any]] = []
+    if isinstance(themes_raw, list):
+        for th in themes_raw:
+            if not isinstance(th, dict):
+                continue
+            theme_title = th.get("theme")
+            if not isinstance(theme_title, str) or not theme_title.strip():
+                continue
+            entry: dict[str, Any] = {"theme": theme_title.strip()}
+            summary_str = th.get("summary")
+            if isinstance(summary_str, str) and summary_str.strip():
+                entry["summary"] = summary_str.strip()
+            themes.append(entry)
+            if len(themes) >= MAX_THEMES:
+                break
+
+    if not quotes and not takeaways and not themes:
+        return None
+
+    return {
+        "key_quotes": quotes,
+        "key_takeaways": takeaways,
+        "chapter_themes": themes,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Public API
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def generate_summary_extras(summary: Summary) -> Optional[dict[str, Any]]:
+    """Génère l'enrichissement (quotes + takeaways + themes) d'un Summary.
+
+    Best-effort : retourne None sur échec Mistral / JSON invalide après
+    `MAX_RETRIES` tentatives.
+
+    Args:
+        summary: instance Summary (lit full_digest > summary_content > transcript_context).
+
+    Returns:
+        dict avec keys "key_quotes", "key_takeaways", "chapter_themes" ou None.
+    """
+    if not _build_input_text(summary):
+        logger.warning(
+            "[SUMMARY-ENRICH] generate_summary_extras: empty input for summary %s",
+            summary.id,
+        )
+        return None
+
+    messages = _build_messages(summary)
+
+    extras: Optional[dict[str, Any]] = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        result = await llm_complete(
+            messages=messages,
+            model=ENRICHMENT_MODEL,
+            max_tokens=MAX_RESPONSE_TOKENS,
+            temperature=0.3,
+            json_mode=True,
+        )
+        if result is None or not result.content:
+            logger.warning(
+                "[SUMMARY-ENRICH] llm_complete empty (attempt %d/%d) summary=%s",
+                attempt,
+                MAX_RETRIES,
+                summary.id,
+            )
+            continue
+
+        try:
+            parsed = json.loads(result.content)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "[SUMMARY-ENRICH] JSON decode error (attempt %d/%d) summary=%s: %s",
+                attempt,
+                MAX_RETRIES,
+                summary.id,
+                exc,
+            )
+            continue
+
+        validated = _validate_extras_shape(parsed)
+        if validated is None:
+            logger.warning(
+                "[SUMMARY-ENRICH] Shape validation failed (attempt %d/%d) summary=%s",
+                attempt,
+                MAX_RETRIES,
+                summary.id,
+            )
+            continue
+
+        extras = validated
+        logger.info(
+            "[SUMMARY-ENRICH] Extras generated OK summary=%s (quotes=%d, takeaways=%d, themes=%d)",
+            summary.id,
+            len(validated["key_quotes"]),
+            len(validated["key_takeaways"]),
+            len(validated["chapter_themes"]),
+        )
+        break
+
+    return extras

--- a/backend/tests/test_summary_enrichment.py
+++ b/backend/tests/test_summary_enrichment.py
@@ -1,0 +1,233 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TEST SUMMARY ENRICHMENT SERVICE — spike 2026-05-06                             ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Tests unitaires pour generate_summary_extras + _validate_extras_shape.            ║
+║  llm_complete mocké (AsyncMock) pour éviter tout appel Mistral réel.               ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import json
+import os
+import sys
+import pytest
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+def _make_summary(sid: int = 1, content: str = "Long content to enrich " * 50):
+    """Stub Summary minimal avec full_digest exploitable."""
+    from db.database import Summary
+
+    return Summary(
+        id=sid,
+        user_id=1,
+        video_id=f"vid{sid}",
+        video_title="Test video",
+        video_channel="Test channel",
+        summary_content=content,
+        full_digest=f"Hierarchical digest #{sid} — {content}",
+    )
+
+
+def _llm_result(content: str):
+    from core.llm_provider import LLMResult
+
+    return LLMResult(
+        content=content,
+        model_used="mistral-medium-2508",
+        provider="mistral",
+        attempts=1,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _validate_extras_shape
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_validate_extras_shape_full_v2_shape():
+    from videos.summary_enrichment_service import _validate_extras_shape
+
+    raw = {
+        "key_quotes": [
+            {"quote": "Citation 1", "context": "Contexte"},
+            {"quote": "Citation 2"},  # context optionnel
+        ],
+        "key_takeaways": ["Takeaway A", "Takeaway B"],
+        "chapter_themes": [
+            {"theme": "Chapter 1", "summary": "Synthèse"},
+            {"theme": "Chapter 2"},  # summary optionnel
+        ],
+    }
+    out = _validate_extras_shape(raw)
+    assert out is not None
+    assert len(out["key_quotes"]) == 2
+    assert out["key_quotes"][0]["quote"] == "Citation 1"
+    assert out["key_quotes"][0]["context"] == "Contexte"
+    assert "context" not in out["key_quotes"][1]
+    assert out["key_takeaways"] == ["Takeaway A", "Takeaway B"]
+    assert len(out["chapter_themes"]) == 2
+    assert out["chapter_themes"][0]["summary"] == "Synthèse"
+    assert "summary" not in out["chapter_themes"][1]
+
+
+def test_validate_extras_shape_empty_returns_none():
+    from videos.summary_enrichment_service import _validate_extras_shape
+
+    raw = {"key_quotes": [], "key_takeaways": [], "chapter_themes": []}
+    assert _validate_extras_shape(raw) is None
+
+
+def test_validate_extras_shape_caps_quotes_at_5():
+    from videos.summary_enrichment_service import (
+        MAX_QUOTES,
+        _validate_extras_shape,
+    )
+
+    raw = {
+        "key_quotes": [{"quote": f"Q{i}"} for i in range(20)],
+        "key_takeaways": [],
+        "chapter_themes": [],
+    }
+    out = _validate_extras_shape(raw)
+    assert out is not None
+    assert len(out["key_quotes"]) == MAX_QUOTES
+
+
+def test_validate_extras_shape_dedup_takeaways_case_insensitive():
+    from videos.summary_enrichment_service import _validate_extras_shape
+
+    raw = {
+        "key_quotes": [],
+        "key_takeaways": ["Takeaway A", "TAKEAWAY A", "  takeaway a  ", "Other"],
+        "chapter_themes": [],
+    }
+    out = _validate_extras_shape(raw)
+    assert out is not None
+    assert out["key_takeaways"] == ["Takeaway A", "Other"]
+
+
+def test_validate_extras_shape_rejects_non_dict_input():
+    from videos.summary_enrichment_service import _validate_extras_shape
+
+    assert _validate_extras_shape(None) is None
+    assert _validate_extras_shape([]) is None
+    assert _validate_extras_shape("string") is None
+
+
+def test_validate_extras_shape_partial_fields_ok():
+    """Only takeaways → still valid (les autres champs sont optionnels)."""
+    from videos.summary_enrichment_service import _validate_extras_shape
+
+    raw = {"key_quotes": [], "key_takeaways": ["just one"], "chapter_themes": []}
+    out = _validate_extras_shape(raw)
+    assert out is not None
+    assert out["key_takeaways"] == ["just one"]
+    assert out["key_quotes"] == []
+    assert out["chapter_themes"] == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# generate_summary_extras (Mistral mocked)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_extras_happy_path():
+    summary = _make_summary()
+
+    valid_json = json.dumps(
+        {
+            "key_quotes": [{"quote": "Marquante", "context": "Pourquoi"}],
+            "key_takeaways": ["TK1", "TK2", "TK3", "TK4"],
+            "chapter_themes": [
+                {"theme": "Ch1", "summary": "S1"},
+                {"theme": "Ch2"},
+            ],
+        }
+    )
+
+    with patch(
+        "videos.summary_enrichment_service.llm_complete",
+        new_callable=AsyncMock,
+        return_value=_llm_result(valid_json),
+    ):
+        from videos.summary_enrichment_service import generate_summary_extras
+
+        result = await generate_summary_extras(summary)
+
+    assert result is not None
+    assert len(result["key_quotes"]) == 1
+    assert len(result["key_takeaways"]) == 4
+    assert len(result["chapter_themes"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_extras_returns_none_on_total_failure():
+    summary = _make_summary()
+    with patch(
+        "videos.summary_enrichment_service.llm_complete",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        from videos.summary_enrichment_service import generate_summary_extras
+
+        result = await generate_summary_extras(summary)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_extras_returns_none_on_empty_input():
+    """Summary sans full_digest, summary_content, ni transcript_context → None."""
+    from db.database import Summary
+
+    empty_summary = Summary(
+        id=1,
+        user_id=1,
+        video_id="empty",
+        video_title="Empty",
+        summary_content=None,
+        full_digest=None,
+        transcript_context=None,
+    )
+
+    with patch(
+        "videos.summary_enrichment_service.llm_complete",
+        new_callable=AsyncMock,
+    ) as mock:
+        from videos.summary_enrichment_service import generate_summary_extras
+
+        result = await generate_summary_extras(empty_summary)
+        assert result is None
+        mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_extras_retries_on_invalid_json():
+    summary = _make_summary()
+    valid_json = json.dumps(
+        {
+            "key_quotes": [],
+            "key_takeaways": ["A", "B"],
+            "chapter_themes": [],
+        }
+    )
+    mock = AsyncMock(
+        side_effect=[
+            _llm_result("not json {{{"),
+            _llm_result(valid_json),
+        ]
+    )
+    with patch("videos.summary_enrichment_service.llm_complete", new=mock):
+        from videos.summary_enrichment_service import generate_summary_extras
+
+        result = await generate_summary_extras(summary)
+
+    assert result is not None
+    assert mock.await_count == 2

--- a/frontend/src/components/AnalysisHub/SynthesisTab.tsx
+++ b/frontend/src/components/AnalysisHub/SynthesisTab.tsx
@@ -24,6 +24,7 @@ import { DeepSightSpinnerMicro } from "../ui";
 import { AudioPlayerButton } from "../AudioPlayerButton";
 import { AudioSummaryButton } from "../AudioSummaryButton";
 import { EnrichedMarkdown } from "../EnrichedMarkdown";
+import { SummaryEnrichments } from "../summary/SummaryEnrichments";
 import { DeepResearchSources } from "../SummaryReader";
 import { ConceptsGlossary } from "../ConceptsGlossary";
 import { AcademicSourcesPanel } from "../academic";
@@ -248,6 +249,16 @@ export const SynthesisTab: React.FC<SynthesisTabProps> = ({
         >
           {selectedSummary.summary_content || ""}
         </EnrichedMarkdown>
+
+        {/* 📚 Spike 2026-05-06 — Enrichissements Mistral à la demande
+            (key_quotes + key_takeaways + chapter_themes). Bouton initial
+            si non généré, sinon rendu direct depuis cache DB. */}
+        <div className="mt-6 not-prose">
+          <SummaryEnrichments
+            summaryId={selectedSummary.id}
+            initialExtras={selectedSummary.summary_extras}
+          />
+        </div>
 
         {/* Glossaire des concepts */}
         <div className="mt-6">

--- a/frontend/src/components/summary/SummaryEnrichments.tsx
+++ b/frontend/src/components/summary/SummaryEnrichments.tsx
@@ -1,0 +1,332 @@
+/**
+ * ╔════════════════════════════════════════════════════════════════════════════════════╗
+ * ║  📚 SUMMARY ENRICHMENTS — spike post-processing pour synthèses détaillées          ║
+ * ╠════════════════════════════════════════════════════════════════════════════════════╣
+ * ║  Affiche 3 sections d'enrichissement Mistral générées à la demande sur un Summary  ║
+ * ║  existant : key_quotes, key_takeaways, chapter_themes.                             ║
+ * ║                                                                                    ║
+ * ║  - Si `summary_extras` null + bouton non cliqué → affiche un bouton "Enrichir".    ║
+ * ║  - Sur click : POST /api/videos/summary/{id}/enrich, loading state, puis render.   ║
+ * ║  - Si `summary_extras` déjà présent → render direct (cache).                       ║
+ * ║                                                                                    ║
+ * ║  Composant prop-driven sur summaryId + extras initiaux ; gère son propre fetch.    ║
+ * ╚════════════════════════════════════════════════════════════════════════════════════╝
+ */
+
+import React, { useState, useCallback } from "react";
+import { motion } from "framer-motion";
+import {
+  Sparkles,
+  Quote,
+  ListChecks,
+  BookMarked,
+  AlertCircle,
+} from "lucide-react";
+
+import { videoApi } from "../../services/api";
+import type { SummaryExtrasData } from "../../services/api";
+import { DeepSightSpinnerSmall } from "../ui/DeepSightSpinner";
+
+export interface SummaryEnrichmentsProps {
+  summaryId: number;
+  /** Extras initiaux (depuis le GET /summary/{id}). Si null → affiche le bouton. */
+  initialExtras: SummaryExtrasData | null | undefined;
+  /** Callback quand un nouvel enrichment est généré (pour update parent). */
+  onEnrichmentReady?: (extras: SummaryExtrasData) => void;
+  className?: string;
+}
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.05, delayChildren: 0.05 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.25 } },
+};
+
+// ─── Sub-section : Citations marquantes ───────────────────────────────────────
+
+const QuotesSection: React.FC<{ quotes: SummaryExtrasData["key_quotes"] }> = ({
+  quotes,
+}) => (
+  <div
+    className="rounded-xl bg-white/5 border border-violet-500/20 backdrop-blur-xl p-5"
+    data-testid="summary-enrich-quotes"
+  >
+    <div className="flex items-center gap-2 mb-4">
+      <div className="w-8 h-8 rounded-lg bg-violet-500/15 flex items-center justify-center">
+        <Quote className="w-4 h-4 text-violet-400" aria-hidden />
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-white">
+          Citations marquantes
+        </h3>
+        <p className="text-xs text-text-muted">
+          Extraits littéraux du contenu
+        </p>
+      </div>
+    </div>
+    <motion.ul
+      className="space-y-3"
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+    >
+      {quotes.map((q, i) => (
+        <motion.li
+          key={i}
+          variants={itemVariants}
+          className="rounded-lg bg-violet-500/[0.05] border border-violet-500/10 p-4 space-y-2"
+          data-testid={`summary-enrich-quote-${i}`}
+        >
+          <p className="text-sm text-text-primary italic leading-relaxed">
+            « {q.quote} »
+          </p>
+          {q.context && (
+            <p className="text-xs text-text-muted leading-relaxed pl-2 border-l-2 border-violet-400/30">
+              {q.context}
+            </p>
+          )}
+        </motion.li>
+      ))}
+    </motion.ul>
+  </div>
+);
+
+// ─── Sub-section : Takeaways ───────────────────────────────────────────────────
+
+const TakeawaysSection: React.FC<{ takeaways: string[] }> = ({ takeaways }) => (
+  <div
+    className="rounded-xl bg-white/5 border border-emerald-500/20 backdrop-blur-xl p-5"
+    data-testid="summary-enrich-takeaways"
+  >
+    <div className="flex items-center gap-2 mb-4">
+      <div className="w-8 h-8 rounded-lg bg-emerald-500/15 flex items-center justify-center">
+        <ListChecks className="w-4 h-4 text-emerald-400" aria-hidden />
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-white">
+          À retenir
+        </h3>
+        <p className="text-xs text-text-muted">
+          Insights clés et conclusions saillantes
+        </p>
+      </div>
+    </div>
+    <motion.ul
+      className="space-y-2"
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+    >
+      {takeaways.map((t, i) => (
+        <motion.li
+          key={i}
+          variants={itemVariants}
+          className="flex items-start gap-2.5 rounded-lg bg-emerald-500/[0.05] border border-emerald-500/10 p-3"
+          data-testid={`summary-enrich-takeaway-${i}`}
+        >
+          <div className="w-5 h-5 rounded-full bg-emerald-500/20 flex items-center justify-center shrink-0 mt-0.5">
+            <span className="text-emerald-400 text-[10px] font-bold">
+              {i + 1}
+            </span>
+          </div>
+          <p className="text-sm text-text-primary leading-relaxed">{t}</p>
+        </motion.li>
+      ))}
+    </motion.ul>
+  </div>
+);
+
+// ─── Sub-section : Chapter themes ─────────────────────────────────────────────
+
+const ChapterThemesSection: React.FC<{
+  themes: SummaryExtrasData["chapter_themes"];
+}> = ({ themes }) => (
+  <div
+    className="rounded-xl bg-white/5 border border-indigo-500/20 backdrop-blur-xl p-5"
+    data-testid="summary-enrich-themes"
+  >
+    <div className="flex items-center gap-2 mb-4">
+      <div className="w-8 h-8 rounded-lg bg-indigo-500/15 flex items-center justify-center">
+        <BookMarked className="w-4 h-4 text-indigo-400" aria-hidden />
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-white">
+          Table des matières enrichie
+        </h3>
+        <p className="text-xs text-text-muted">
+          Thèmes et chapitres structurés
+        </p>
+      </div>
+    </div>
+    <motion.ol
+      className="space-y-2"
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+    >
+      {themes.map((t, i) => (
+        <motion.li
+          key={i}
+          variants={itemVariants}
+          className="rounded-lg bg-indigo-500/[0.05] border border-indigo-500/10 p-3 space-y-1"
+          data-testid={`summary-enrich-theme-${i}`}
+        >
+          <p className="text-sm font-semibold text-indigo-300">
+            <span className="text-indigo-400/70 mr-2">
+              {String(i + 1).padStart(2, "0")}.
+            </span>
+            {t.theme}
+          </p>
+          {t.summary && (
+            <p className="text-xs text-text-secondary leading-relaxed pl-7">
+              {t.summary}
+            </p>
+          )}
+        </motion.li>
+      ))}
+    </motion.ol>
+  </div>
+);
+
+// ─── Composant principal ──────────────────────────────────────────────────────
+
+export const SummaryEnrichments: React.FC<SummaryEnrichmentsProps> = ({
+  summaryId,
+  initialExtras,
+  onEnrichmentReady,
+  className = "",
+}) => {
+  const [extras, setExtras] = useState<SummaryExtrasData | null>(
+    initialExtras ?? null,
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleEnrich = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await videoApi.enrichSummary(summaryId);
+      if (res.extras) {
+        setExtras(res.extras);
+        onEnrichmentReady?.(res.extras);
+      } else {
+        setError("Aucun enrichissement renvoyé par le backend.");
+      }
+    } catch (e) {
+      const msg =
+        e instanceof Error
+          ? e.message
+          : "Erreur inattendue lors de l'enrichissement.";
+      setError(msg);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [summaryId, onEnrichmentReady]);
+
+  // ─── Bouton "Enrichir" (initial state) ───
+  if (!extras) {
+    return (
+      <div
+        className={`rounded-xl bg-gradient-to-br from-cyan-500/[0.07] to-indigo-500/[0.05] border border-cyan-500/20 backdrop-blur-xl p-5 ${className}`}
+        data-testid="summary-enrich-cta"
+      >
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 w-9 h-9 rounded-lg bg-cyan-500/15 border border-cyan-500/25 flex items-center justify-center">
+            <Sparkles className="w-4 h-4 text-cyan-400" aria-hidden />
+          </div>
+          <div className="flex-1 min-w-0 space-y-2">
+            <div>
+              <p className="text-sm font-semibold text-white">
+                Enrichir l'analyse
+              </p>
+              <p className="text-xs text-text-muted leading-relaxed">
+                Génère 3 sections supplémentaires : citations marquantes,
+                takeaways, et table des matières structurée.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleEnrich}
+              disabled={isLoading}
+              data-testid="summary-enrich-button"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gradient-to-r from-cyan-500 to-indigo-500 hover:from-cyan-400 hover:to-indigo-400 disabled:opacity-50 disabled:cursor-not-allowed text-xs font-semibold text-white transition-all shadow-lg shadow-cyan-500/20 hover:shadow-cyan-500/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/60"
+            >
+              {isLoading ? (
+                <>
+                  <DeepSightSpinnerSmall />
+                  Génération en cours…
+                </>
+              ) : (
+                <>
+                  <Sparkles className="w-3.5 h-3.5" />
+                  Enrichir avec Mistral
+                </>
+              )}
+            </button>
+            {error && (
+              <div
+                role="alert"
+                data-testid="summary-enrich-error"
+                className="flex items-start gap-2 mt-2 p-2.5 rounded-lg bg-red-500/10 border border-red-500/20"
+              >
+                <AlertCircle
+                  className="w-3.5 h-3.5 text-red-400 shrink-0 mt-0.5"
+                  aria-hidden
+                />
+                <p className="text-xs text-red-300 break-words">{error}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Render extras (cached or freshly generated) ───
+  const isEmpty =
+    extras.key_quotes.length === 0 &&
+    extras.key_takeaways.length === 0 &&
+    extras.chapter_themes.length === 0;
+
+  if (isEmpty) {
+    return (
+      <div
+        className={`rounded-xl bg-white/5 border border-white/10 backdrop-blur-xl p-5 text-center ${className}`}
+        data-testid="summary-enrich-empty"
+      >
+        <p className="text-xs text-text-muted">
+          Aucun enrichissement n'a pu être extrait pour cette analyse.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      role="region"
+      aria-label="Enrichissements de l'analyse"
+      data-testid="summary-enrichments"
+      className={`space-y-4 ${className}`}
+    >
+      {extras.key_quotes.length > 0 && (
+        <QuotesSection quotes={extras.key_quotes} />
+      )}
+      {extras.key_takeaways.length > 0 && (
+        <TakeawaysSection takeaways={extras.key_takeaways} />
+      )}
+      {extras.chapter_themes.length > 0 && (
+        <ChapterThemesSection themes={extras.chapter_themes} />
+      )}
+    </section>
+  );
+};
+
+export default SummaryEnrichments;

--- a/frontend/src/components/summary/__tests__/SummaryEnrichments.test.tsx
+++ b/frontend/src/components/summary/__tests__/SummaryEnrichments.test.tsx
@@ -1,0 +1,159 @@
+// frontend/src/components/summary/__tests__/SummaryEnrichments.test.tsx
+//
+// Tests spike 2026-05-06 : SummaryEnrichments component.
+//
+// Couverture :
+//   1. initialExtras null → bouton "Enrichir" affiché
+//   2. Click button → loading state + appel videoApi.enrichSummary
+//   3. Success → 3 sections rendues (quotes, takeaways, themes)
+//   4. Error → message d'erreur affiché
+//   5. initialExtras déjà présent → render direct sans bouton
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { SummaryEnrichments } from "../SummaryEnrichments";
+import type { SummaryExtrasData } from "../../../services/api";
+
+// Mock videoApi.enrichSummary
+vi.mock("../../../services/api", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/api")
+  >("../../../services/api");
+  return {
+    ...actual,
+    videoApi: {
+      ...actual.videoApi,
+      enrichSummary: vi.fn(),
+    },
+  };
+});
+
+// Helper to access the mocked function with proper type
+import * as apiModule from "../../../services/api";
+const mockedEnrich = apiModule.videoApi.enrichSummary as ReturnType<
+  typeof vi.fn
+>;
+
+const VALID_EXTRAS: SummaryExtrasData = {
+  key_quotes: [
+    {
+      quote: "Citation marquante",
+      context: "Pourquoi elle compte",
+    },
+    { quote: "Autre citation sans contexte" },
+  ],
+  key_takeaways: ["Insight 1", "Insight 2", "Insight 3"],
+  chapter_themes: [
+    { theme: "Chapitre A", summary: "Synthèse A" },
+    { theme: "Chapitre B" },
+  ],
+};
+
+describe("SummaryEnrichments", () => {
+  beforeEach(() => {
+    mockedEnrich.mockReset();
+  });
+
+  it("renders button CTA when initialExtras is null", () => {
+    render(<SummaryEnrichments summaryId={42} initialExtras={null} />);
+    expect(screen.getByTestId("summary-enrich-cta")).toBeInTheDocument();
+    expect(screen.getByTestId("summary-enrich-button")).toBeInTheDocument();
+    expect(screen.getByText(/Enrichir avec Mistral/)).toBeInTheDocument();
+    // Sections not rendered yet
+    expect(screen.queryByTestId("summary-enrich-quotes")).toBeNull();
+  });
+
+  it("clicks button → calls enrichSummary, shows loading, then renders sections", async () => {
+    mockedEnrich.mockResolvedValueOnce({
+      summary_id: 42,
+      cached: false,
+      extras: VALID_EXTRAS,
+    });
+
+    const user = userEvent.setup();
+    render(<SummaryEnrichments summaryId={42} initialExtras={null} />);
+
+    await user.click(screen.getByTestId("summary-enrich-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-enrichments")).toBeInTheDocument();
+    });
+
+    // 3 sections rendered
+    expect(screen.getByTestId("summary-enrich-quotes")).toBeInTheDocument();
+    expect(screen.getByTestId("summary-enrich-takeaways")).toBeInTheDocument();
+    expect(screen.getByTestId("summary-enrich-themes")).toBeInTheDocument();
+
+    // Quote content
+    expect(screen.getByText(/Citation marquante/)).toBeInTheDocument();
+    // Takeaway content
+    expect(screen.getByText("Insight 1")).toBeInTheDocument();
+    // Theme content
+    expect(screen.getByText("Chapitre A")).toBeInTheDocument();
+
+    expect(mockedEnrich).toHaveBeenCalledWith(42);
+  });
+
+  it("renders extras directly when initialExtras is provided (cached)", () => {
+    render(
+      <SummaryEnrichments summaryId={42} initialExtras={VALID_EXTRAS} />,
+    );
+    expect(screen.getByTestId("summary-enrichments")).toBeInTheDocument();
+    expect(screen.queryByTestId("summary-enrich-cta")).toBeNull();
+    // Pas d'appel API quand cache disponible
+    expect(mockedEnrich).not.toHaveBeenCalled();
+  });
+
+  it("shows error message when enrichSummary throws", async () => {
+    mockedEnrich.mockRejectedValueOnce(new Error("Mistral indisponible"));
+
+    const user = userEvent.setup();
+    render(<SummaryEnrichments summaryId={42} initialExtras={null} />);
+
+    await user.click(screen.getByTestId("summary-enrich-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-enrich-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Mistral indisponible/)).toBeInTheDocument();
+    // Bouton CTA reste visible (user peut retry)
+    expect(screen.getByTestId("summary-enrich-cta")).toBeInTheDocument();
+  });
+
+  it("renders empty state when extras is fully empty", () => {
+    const emptyExtras: SummaryExtrasData = {
+      key_quotes: [],
+      key_takeaways: [],
+      chapter_themes: [],
+    };
+    render(
+      <SummaryEnrichments summaryId={42} initialExtras={emptyExtras} />,
+    );
+    expect(screen.getByTestId("summary-enrich-empty")).toBeInTheDocument();
+  });
+
+  it("calls onEnrichmentReady callback after successful generation", async () => {
+    mockedEnrich.mockResolvedValueOnce({
+      summary_id: 42,
+      cached: false,
+      extras: VALID_EXTRAS,
+    });
+    const onReady = vi.fn();
+
+    const user = userEvent.setup();
+    render(
+      <SummaryEnrichments
+        summaryId={42}
+        initialExtras={null}
+        onEnrichmentReady={onReady}
+      />,
+    );
+    await user.click(screen.getByTestId("summary-enrich-button"));
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalledWith(VALID_EXTRAS);
+    });
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -157,6 +157,34 @@ export interface Summary {
   deep_research?: boolean;
   enrichment_sources?: string; // JSON string: [{title, url, snippet}]
   enrichment_data?: string; // JSON string: {level, sources, enriched_at}
+
+  // 📚 Summary extras (spike 2026-05-06) — enrichissement post-processing
+  // Mistral à la demande. NULL si pas encore généré.
+  summary_extras?: SummaryExtrasData | null;
+}
+
+// ─── Summary extras (spike 2026-05-06) ────────────────────────────────────────
+
+export interface SummaryQuote {
+  quote: string;
+  context?: string;
+}
+
+export interface SummaryChapterTheme {
+  theme: string;
+  summary?: string;
+}
+
+export interface SummaryExtrasData {
+  key_quotes: SummaryQuote[];
+  key_takeaways: string[];
+  chapter_themes: SummaryChapterTheme[];
+}
+
+export interface SummaryEnrichResponse {
+  summary_id: number;
+  cached: boolean;
+  extras: SummaryExtrasData | null;
 }
 
 export interface TranscriptSegment {
@@ -1239,6 +1267,24 @@ export const videoApi = {
 
   async getSummary(summaryId: number): Promise<Summary> {
     return request(`/api/videos/summary/${summaryId}`);
+  },
+
+  /**
+   * 📚 Spike 2026-05-06 : enrichit une analyse avec key_quotes + key_takeaways
+   * + chapter_themes via Mistral. Idempotent : retourne le cache si déjà
+   * généré (sauf si force=true).
+   *
+   * Endpoint: POST /api/videos/summary/{id}/enrich
+   */
+  async enrichSummary(
+    summaryId: number,
+    force: boolean = false,
+  ): Promise<SummaryEnrichResponse> {
+    const qs = force ? "?force=true" : "";
+    return request(`/api/videos/summary/${summaryId}/enrich${qs}`, {
+      method: "POST",
+      timeout: 60000,
+    });
   },
 
   async getConcepts(


### PR DESCRIPTION
## Spike post-processing pour synthèses détaillées

Suite discussion 2026-05-06 — appliquer la technique du Hub Canvas (Mistral json_mode + validation + retry + champs optionnels) aux synthèses single-video.

**Choix architectural** : enrichissement **alongside** (à la demande, en plus de la prose), PAS rewrite du flow Summary.

## Backend

- **Migration alembic 022** : \`summary_extras JSON NULL\` (idempotente).
- **\`videos/summary_enrichment_service.py\`** : \`generate_summary_extras(summary)\` via \`llm_complete\` json_mode (mistral-medium-2508).
- **\`POST /api/videos/summary/{id}/enrich\`** : idempotent, cache en DB, \`?force=true\` pour regen.
- **Schemas Pydantic** : \`SummaryQuote\`, \`SummaryChapterTheme\`, \`SummaryExtrasData\`, \`SummaryEnrichResponse\`.
- **10 tests verts** (\`test_summary_enrichment.py\`).

## Frontend

- **Interfaces** : \`SummaryExtrasData\` + \`videoApi.enrichSummary()\`.
- **Nouveau composant \`<SummaryEnrichments>\`** (frontend/src/components/summary/) :
  - Bouton CTA gradient cyan→indigo (initial state si pas généré)
  - 3 sections glassmorphism : Citations marquantes (violet), À retenir (emerald), Table des matières (indigo)
  - Loading / error / empty states
- **Intégration** : ajouté dans \`<SynthesisTab>\` entre la prose Markdown et le glossaire concepts.
- **6 tests verts** (\`SummaryEnrichments.test.tsx\`).
- **Typecheck propre**.

## Risques mitigés

- ✅ \`summary_content\` (prose existante) intact
- ✅ Aucun breaking change sur l'API GET existant (champ ajouté optionnel)
- ✅ Opt-in via bouton (pas de coût Mistral auto)
- ✅ Cache en DB (re-affichage gratuit)

## Test plan

- [x] Backend tests 10/10 ✅
- [x] Frontend tests 6/6 ✅
- [x] Typecheck propre
- [ ] Deploy prod via deploy-backend.yml
- [ ] Migration 022 appliquée (auto via entrypoint? ou stamp manuel ssh)
- [ ] User clique "Enrichir" sur une analyse existante → 3 sections rendues

🤖 Generated with [Claude Code](https://claude.com/claude-code)