### PR TITLE
feat(extension): handlers visual badge OPEN_SIDEPANEL_VISUAL + OPEN_BILLING_UPSELL

### DIFF
--- a/extension/__tests__/background/visual-analysis-handlers.test.ts
+++ b/extension/__tests__/background/visual-analysis-handlers.test.ts
@@ -1,0 +1,145 @@
+/** @jest-environment jsdom */
+//
+// Tests — handlers `OPEN_SIDEPANEL_VISUAL` et `OPEN_BILLING_UPSELL` dans
+// background.ts. Ces handlers répondent aux messages émis par le badge
+// "👁️ Analyse visuelle" injecté sur YouTube par
+// `extension/src/content/widget.ts` (renderVisualAnalysisBadge).
+//
+// Payload émis par le badge :
+//   { type: "OPEN_SIDEPANEL_VISUAL" | "OPEN_BILLING_UPSELL",
+//     videoId, feature: "visual_analysis", plan }
+//
+// Comportement attendu :
+//  - OPEN_SIDEPANEL_VISUAL : stocke le contexte dans
+//    `chrome.storage.session.visualPanelContext` et ouvre le side panel
+//    sur le tab d'origine.
+//  - OPEN_BILLING_UPSELL : ouvre `${WEBAPP_URL}/pricing?...` dans un
+//    nouvel onglet avec UTM tracking (utm_source=extension,
+//    utm_medium=visual_badge, utm_campaign=visual_analysis_upsell, …).
+//
+// Comme open-voice-call.test.ts, on injecte les mocks chrome.storage.session
+// et chrome.sidePanel localement (APIs Chrome 102+/114+ optionnelles).
+
+import { handleMessage } from "../../src/background";
+
+describe("OPEN_SIDEPANEL_VISUAL handler", () => {
+  beforeEach(() => {
+    const c = global as unknown as {
+      chrome: {
+        storage: { session?: { set: jest.Mock; remove?: jest.Mock } };
+        sidePanel?: { open: jest.Mock; setOptions?: jest.Mock };
+        tabs: { create: jest.Mock };
+      };
+    };
+    c.chrome.storage.session = {
+      set: jest.fn().mockResolvedValue(undefined),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+    c.chrome.sidePanel = {
+      open: jest.fn().mockResolvedValue(undefined),
+      setOptions: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("stores visualPanelContext and opens side panel for paid user", async () => {
+    const result = await handleMessage(
+      {
+        type: "OPEN_SIDEPANEL_VISUAL",
+        videoId: "abc",
+        feature: "visual_analysis",
+        plan: "pro",
+      } as unknown as Parameters<typeof handleMessage>[0],
+      { tab: { id: 42, windowId: 7 } } as chrome.runtime.MessageSender,
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(chrome.storage.session!.set).toHaveBeenCalledWith({
+      visualPanelContext: {
+        videoId: "abc",
+        feature: "visual_analysis",
+        plan: "pro",
+        source: "youtube_badge",
+      },
+    });
+    expect(chrome.sidePanel!.setOptions).toHaveBeenCalledWith({
+      tabId: 42,
+      path: "sidepanel.html",
+      enabled: true,
+    });
+    expect(chrome.sidePanel!.open).toHaveBeenCalledWith({ tabId: 42 });
+  });
+
+  it("returns error when sidePanel API unavailable", async () => {
+    const c = global as unknown as { chrome: { sidePanel?: unknown } };
+    c.chrome.sidePanel = undefined;
+
+    const result = await handleMessage(
+      {
+        type: "OPEN_SIDEPANEL_VISUAL",
+        videoId: "abc",
+        feature: "visual_analysis",
+        plan: "expert",
+      } as unknown as Parameters<typeof handleMessage>[0],
+      { tab: { id: 1, windowId: 1 } } as chrome.runtime.MessageSender,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Side panel API not available/i);
+  });
+});
+
+describe("OPEN_BILLING_UPSELL handler", () => {
+  beforeEach(() => {
+    const c = global as unknown as {
+      chrome: { tabs: { create: jest.Mock } };
+    };
+    c.chrome.tabs.create = jest.fn().mockResolvedValue({ id: 99 });
+  });
+
+  it("opens pricing tab with UTM tracking and feature param", async () => {
+    const result = await handleMessage(
+      {
+        type: "OPEN_BILLING_UPSELL",
+        videoId: "xyz",
+        feature: "visual_analysis",
+        plan: "free",
+      } as unknown as Parameters<typeof handleMessage>[0],
+      { tab: { id: 1, windowId: 1 } } as chrome.runtime.MessageSender,
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(1);
+    const calledUrl = (chrome.tabs.create as jest.Mock).mock.calls[0][0]
+      .url as string;
+    expect(calledUrl).toMatch(
+      /^https:\/\/www\.deepsightsynthesis\.com\/pricing\?/,
+    );
+    const url = new URL(calledUrl);
+    expect(url.searchParams.get("utm_source")).toBe("extension");
+    expect(url.searchParams.get("utm_medium")).toBe("visual_badge");
+    expect(url.searchParams.get("utm_campaign")).toBe(
+      "visual_analysis_upsell",
+    );
+    expect(url.searchParams.get("feature")).toBe("visual_analysis");
+    expect(url.searchParams.get("video_id")).toBe("xyz");
+    expect(url.searchParams.get("from_plan")).toBe("free");
+  });
+
+  it("works without optional videoId/plan", async () => {
+    const result = await handleMessage(
+      {
+        type: "OPEN_BILLING_UPSELL",
+        feature: "visual_analysis",
+      } as unknown as Parameters<typeof handleMessage>[0],
+      { tab: { id: 1, windowId: 1 } } as chrome.runtime.MessageSender,
+    );
+
+    expect(result).toEqual({ success: true });
+    const calledUrl = (chrome.tabs.create as jest.Mock).mock.calls[0][0]
+      .url as string;
+    const url = new URL(calledUrl);
+    expect(url.searchParams.get("utm_source")).toBe("extension");
+    expect(url.searchParams.has("video_id")).toBe(false);
+    expect(url.searchParams.has("from_plan")).toBe(false);
+  });
+});

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -758,6 +758,24 @@ interface VoiceCallMessage {
   plan?: "free" | "pro" | "expert";
 }
 
+/**
+ * Visual analysis badge dispatcher — handles `{ type: "OPEN_SIDEPANEL_VISUAL", ... }`
+ * et `{ type: "OPEN_BILLING_UPSELL", ... }` émis par le badge "👁️ Analyse visuelle"
+ * injecté sur YouTube par `content/widget.ts` (renderVisualAnalysisBadge).
+ *
+ * - OPEN_SIDEPANEL_VISUAL : utilisateur Pro/Expert → ouvre le side panel pour
+ *   afficher l'analyse visuelle. Le contexte est stocké dans
+ *   `chrome.storage.session.visualPanelContext` (mêmes garanties que voicePanelContext).
+ * - OPEN_BILLING_UPSELL   : utilisateur Free → ouvre la page pricing dans un
+ *   nouvel onglet avec UTM tracking pour mesurer le funnel.
+ */
+interface VisualAnalysisMessage {
+  type: "OPEN_SIDEPANEL_VISUAL" | "OPEN_BILLING_UPSELL";
+  videoId?: string;
+  feature?: string;
+  plan?: "free" | "pro" | "expert";
+}
+
 /** [B8] Sidepanel → background : "demande-moi le micro via offscreen". */
 interface MicPermissionMessage {
   action:
@@ -802,7 +820,11 @@ async function openMicPermissionPopup(): Promise<void> {
 }
 
 export async function handleMessage(
-  message: ExtensionMessage | VoiceCallMessage | MicPermissionMessage,
+  message:
+    | ExtensionMessage
+    | VoiceCallMessage
+    | VisualAnalysisMessage
+    | MicPermissionMessage,
   sender?: chrome.runtime.MessageSender | number,
 ): Promise<MessageResponse> {
   // Backwards compat: accept either a full sender object (preferred) or a
@@ -926,6 +948,99 @@ export async function handleMessage(
     // [N6] Idem au RESTORE — restore tous les volumes.
     await broadcastVoiceAudioMessage("RESTORE_AUDIO", senderTabId);
     return { success: true };
+  }
+
+  // ── Visual analysis badge dispatch (Phase 2) ──
+  // Émis par renderVisualAnalysisBadge (extension/src/content/widget.ts).
+  // Payload : { type, videoId?, feature: "visual_analysis", plan }.
+  const visualMsg = message as VisualAnalysisMessage;
+  if (visualMsg?.type === "OPEN_SIDEPANEL_VISUAL") {
+    try {
+      // Le content script connaît son tab (sender.tab.id). Si absent (cas
+      // improbable côté badge), on fallback sur la fenêtre courante.
+      const fullSender = sender as chrome.runtime.MessageSender | undefined;
+      let tabId = fullSender?.tab?.id;
+      if (typeof tabId !== "number") {
+        tabId = senderTabId;
+      }
+      // Persiste le contexte AVANT d'ouvrir : la page sidepanel le lit dès
+      // mount via chrome.storage.session (même pattern que voicePanelContext).
+      const sessionStore = (
+        chrome as unknown as {
+          storage: { session?: { set?: (data: unknown) => Promise<void> } };
+        }
+      ).storage.session;
+      if (sessionStore?.set) {
+        await sessionStore.set({
+          visualPanelContext: {
+            videoId: visualMsg.videoId ?? null,
+            feature: visualMsg.feature ?? "visual_analysis",
+            plan: visualMsg.plan ?? null,
+            source: "youtube_badge",
+          },
+        });
+      }
+      // openVoicePanel() est mal nommée (héritage Spec #4) mais c'est la
+      // helper canonique : feature-detect + setOptions + open. On la
+      // réutilise telle quelle pour rester cohérent.
+      const sidePanel = (
+        chrome as unknown as {
+          sidePanel?: {
+            setOptions?: (opts: {
+              tabId?: number;
+              path?: string;
+              enabled?: boolean;
+            }) => Promise<void> | void;
+            open?: (opts: {
+              tabId?: number;
+              windowId?: number;
+            }) => Promise<void> | void;
+          };
+        }
+      ).sidePanel;
+      if (!sidePanel || typeof sidePanel.open !== "function") {
+        return {
+          success: false,
+          error: "Side panel API not available in this browser",
+        };
+      }
+      if (sidePanel.setOptions) {
+        await sidePanel.setOptions({
+          tabId,
+          path: "sidepanel.html",
+          enabled: true,
+        });
+      }
+      await sidePanel.open({ tabId });
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: (e as Error).message };
+    }
+  }
+
+  if (visualMsg?.type === "OPEN_BILLING_UPSELL") {
+    try {
+      // Funnel tracking : utm_source/medium/campaign + feature pour
+      // attribuer les conversions au badge visual analysis (vs voice,
+      // popup, hub, etc.).
+      const params = new URLSearchParams({
+        utm_source: "extension",
+        utm_medium: "visual_badge",
+        utm_campaign: "visual_analysis_upsell",
+        feature: visualMsg.feature ?? "visual_analysis",
+      });
+      if (visualMsg.videoId) {
+        params.set("video_id", visualMsg.videoId);
+      }
+      if (visualMsg.plan) {
+        params.set("from_plan", visualMsg.plan);
+      }
+      const pricingUrl = `${WEBAPP_URL}/pricing?${params.toString()}`;
+      await Browser.tabs.create({ url: pricingUrl });
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: (e as Error).message };
+    }
   }
 
   // Narrow vers le shape ExtensionMessage classique pour la suite du switch


### PR DESCRIPTION
## Summary

Implémente les deux handlers `chrome.runtime.onMessage` manquants pour les messages émis par le badge **VisualAnalysisBadge** introduit en Phase 2 (commit `1e032dde`, voir `extension/src/content/widget.ts:214-221`).

Sans cette PR, cliquer sur le badge "👁️ Analyse visuelle" est un no-op silencieux : le message part dans le vide côté service worker.

## Payload émis par le badge

```ts
chrome.runtime.sendMessage({
  type: isPaid ? "OPEN_SIDEPANEL_VISUAL" : "OPEN_BILLING_UPSELL",
  videoId: opts.videoId,
  feature: "visual_analysis",
  plan: opts.plan,
});
```

## Approche

### `OPEN_SIDEPANEL_VISUAL` (Pro/Expert)

- Stocke `visualPanelContext` dans `chrome.storage.session` (clé éphémère, cleared au reboot Chrome — même pattern que `voicePanelContext` et `pendingVoiceCall`).
- Appelle `chrome.sidePanel.setOptions({ tabId, path: "sidepanel.html", enabled: true })` puis `chrome.sidePanel.open({ tabId })` sur le tab d'origine du content script.
- Feature-detect `chrome.sidePanel` pour rester compatible Firefox/Safari (renvoie `success:false` avec error explicite).

### `OPEN_BILLING_UPSELL` (Free)

- `chrome.tabs.create({ url })` vers `${WEBAPP_URL}/pricing?...` avec UTM tracking complet :
  - `utm_source=extension`
  - `utm_medium=visual_badge`
  - `utm_campaign=visual_analysis_upsell`
  - `feature=visual_analysis`
  - `video_id` et `from_plan` si présents

## Manifest

**Aucune modification nécessaire** — le `manifest.json` contient déjà :
- Permission `sidePanel` (line 20)
- `side_panel.default_path: "sidepanel.html"` (lines 82-84)

## Tests

4 nouveaux tests Jest jsdom dans `__tests__/background/visual-analysis-handlers.test.ts` :

| Test | Vérifie |
|------|---------|
| OPEN_SIDEPANEL_VISUAL Pro user | `visualPanelContext` stocké + `setOptions` + `open` sur le bon `tabId` |
| OPEN_SIDEPANEL_VISUAL sans API | Retourne `success:false` avec error explicite si `chrome.sidePanel` absent |
| OPEN_BILLING_UPSELL Free user | URL pricing avec tous les UTM + `video_id` + `from_plan` |
| OPEN_BILLING_UPSELL minimal | URL valide même sans `videoId`/`plan` optionnels |

Tous passent. Les 6 tests existants `widget-visual-analysis-badge.test.ts` continuent de passer.

## Test plan

- [x] `npm run typecheck` — pas d'erreur TS
- [x] `npm run build` — webpack compile OK (warnings size habituels uniquement)
- [x] `npx jest __tests__/background/visual-analysis-handlers.test.ts` — 4/4 passent
- [ ] Test manuel end-to-end (à faire user) :
  - Charger `dist/` dans `chrome://extensions`
  - Aller sur une vidéo YouTube
  - Vérifier que le badge "Analyse visuelle" s'affiche
  - Click sur badge en tant que user Pro/Expert → side panel s'ouvre
  - Click sur badge en tant que user Free → onglet pricing s'ouvre avec UTM
  - Vérifier que `chrome.storage.session.visualPanelContext` est bien set

## Risques / hypothèses

- **Vue sidepanel pas dédiée** : la "view Visual" côté sidepanel (qui consomme `visualPanelContext` pour afficher l'analyse visuelle) n'existe pas encore — le sidepanel rend sa vue par défaut. C'est volontairement out-of-scope pour cette PR (handlers de routing uniquement) et sera traité dans une PR ultérieure.
- **Pas de test E2E navigateur réel** : les tests sont jsdom + mocks. Le flow complet badge → handler → sidePanel.open n'a pas été vérifié dans Chrome réel.
- **Tests `open-voice-call.test.ts` préexistants en échec** : 1/2 tests de cette suite échoue sur la branche source (préexistant, pas causé par cette PR). Vérifié en stashant mes changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)