### PR TITLE
feat(frontend): tab Visuel dans détail d'analyse

### DIFF
--- a/frontend/src/components/AnalysisHub/VisualTab.tsx
+++ b/frontend/src/components/AnalysisHub/VisualTab.tsx
@@ -1,0 +1,480 @@
+/**
+ * DEEP SIGHT — AnalysisHub / VisualTab
+ *
+ * Onglet "Visuel" : consomme `analysis.visual_analysis` (payload Phase 2 —
+ * Mistral Vision sur storyboards YouTube) et le rend en 6 sections :
+ *   1. Hook visuel (gros texte d'intro)
+ *   2. Structure visuelle (badge)
+ *   3. Moments clés (timeline timestamp + description + type)
+ *   4. Texte visible à l'écran
+ *   5. Indicateurs SEO visuels (grid)
+ *   6. Résumé visuel (prose)
+ *
+ * Empty state : affiche un message + CTA quand `visual_analysis` est null
+ * ou undefined (analyse non lancée / Phase 2 désactivée). Le tab est
+ * toujours rendu — la décision de masquer le bouton se fait en amont
+ * dans le HubTabBar / AnalysisHub si on veut le hide selon plan/feature.
+ */
+
+import React from "react";
+import {
+  Eye,
+  Film,
+  Clock,
+  Type,
+  Sparkles,
+  FileVideo,
+  Sun,
+  User,
+  Subtitles,
+  Zap,
+  Image as ImageIcon,
+  Info,
+} from "lucide-react";
+import type {
+  VisualAnalysis,
+  VisualStructure,
+  VisualSeoIndicators,
+  VisualQualitativeLevel,
+} from "../../types/analysis";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 📦 PROPS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface VisualTabProps {
+  visualAnalysis: VisualAnalysis | null | undefined;
+  language: "fr" | "en";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎨 LABEL HELPERS — i18n minimal local (pas de dépendance i18n côté tab)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const STRUCTURE_LABELS: Record<
+  VisualStructure,
+  { fr: string; en: string }
+> = {
+  talking_head: { fr: "Talking head", en: "Talking head" },
+  b_roll: { fr: "B-roll", en: "B-roll" },
+  gameplay: { fr: "Gameplay", en: "Gameplay" },
+  slides: { fr: "Slides", en: "Slides" },
+  tutorial: { fr: "Tutoriel", en: "Tutorial" },
+  interview: { fr: "Interview", en: "Interview" },
+  vlog: { fr: "Vlog", en: "Vlog" },
+  mixed: { fr: "Mixte", en: "Mixed" },
+  other: { fr: "Autre", en: "Other" },
+};
+
+const QUALITATIVE_LABELS: Record<
+  VisualQualitativeLevel,
+  { fr: string; en: string }
+> = {
+  low: { fr: "Faible", en: "Low" },
+  medium: { fr: "Moyen", en: "Medium" },
+  high: { fr: "Élevé", en: "High" },
+};
+
+const QUALITATIVE_COLORS: Record<VisualQualitativeLevel, string> = {
+  low: "text-amber-300 bg-amber-500/10 border-amber-500/20",
+  medium: "text-blue-300 bg-blue-500/10 border-blue-500/20",
+  high: "text-emerald-300 bg-emerald-500/10 border-emerald-500/20",
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🛠️ UTILS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/** Formate un timestamp (secondes) en MM:SS ou H:MM:SS si > 1h. */
+function formatTimestamp(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(safe / 3600);
+  const m = Math.floor((safe % 3600) / 60);
+  const s = safe % 60;
+  const mm = String(m).padStart(2, "0");
+  const ss = String(s).padStart(2, "0");
+  if (h > 0) {
+    return `${h}:${mm}:${ss}`;
+  }
+  return `${mm}:${ss}`;
+}
+
+const t = (lang: "fr" | "en", fr: string, en: string) =>
+  lang === "fr" ? fr : en;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🧩 SOUS-COMPOSANTS — petits, isolés, lisibles
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const SectionTitle: React.FC<{
+  icon: React.ComponentType<{ className?: string }>;
+  iconColor: string;
+  children: React.ReactNode;
+}> = ({ icon: Icon, iconColor, children }) => (
+  <h3 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-text-secondary mb-3">
+    <Icon className={`w-4 h-4 ${iconColor}`} />
+    <span>{children}</span>
+  </h3>
+);
+
+interface IndicatorTileProps {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  /** Texte de droite — soit valeur qualitative, soit "Oui/Non/—". */
+  valueNode: React.ReactNode;
+}
+
+const IndicatorTile: React.FC<IndicatorTileProps> = ({
+  icon: Icon,
+  label,
+  valueNode,
+}) => (
+  <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-white/[0.03] border border-white/5 hover:border-white/10 transition-colors">
+    <div className="flex items-center gap-2 min-w-0">
+      <Icon className="w-4 h-4 text-text-tertiary flex-shrink-0" />
+      <span className="text-xs text-text-tertiary truncate">{label}</span>
+    </div>
+    <div className="flex-shrink-0">{valueNode}</div>
+  </div>
+);
+
+const QualitativeBadge: React.FC<{
+  level: VisualQualitativeLevel | undefined;
+  language: "fr" | "en";
+}> = ({ level, language }) => {
+  if (!level) {
+    return <span className="text-xs text-text-tertiary font-mono">—</span>;
+  }
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-semibold border ${QUALITATIVE_COLORS[level]}`}
+    >
+      {QUALITATIVE_LABELS[level][language]}
+    </span>
+  );
+};
+
+const BooleanBadge: React.FC<{
+  value: boolean | undefined;
+  language: "fr" | "en";
+}> = ({ value, language }) => {
+  if (value === undefined) {
+    return <span className="text-xs text-text-tertiary font-mono">—</span>;
+  }
+  if (value) {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-semibold border text-emerald-300 bg-emerald-500/10 border-emerald-500/20">
+        {t(language, "Oui", "Yes")}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-semibold border text-text-tertiary bg-white/5 border-white/10">
+      {t(language, "Non", "No")}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🚫 EMPTY STATE — Phase 2 non activée pour cette analyse
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const EmptyVisualState: React.FC<{ language: "fr" | "en" }> = ({
+  language,
+}) => (
+  <div className="p-8 sm:p-12 text-center">
+    <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-white/5 border border-white/10 mb-4">
+      <Eye className="w-8 h-8 text-text-tertiary" aria-hidden="true" />
+    </div>
+    <h3 className="text-lg font-semibold text-text-primary mb-2">
+      {t(language, "Analyse visuelle non disponible", "Visual analysis unavailable")}
+    </h3>
+    <p className="text-sm text-text-tertiary max-w-md mx-auto mb-4">
+      {t(
+        language,
+        "Cette analyse n'a pas inclus la couche visuelle. Réanalysez la vidéo en activant l'option « Analyse visuelle » pour voir le hook, la structure, les moments clés et les indicateurs SEO visuels extraits par Mistral Vision.",
+        "This analysis did not include the visual layer. Re-run the analysis with the « Visual analysis » option enabled to see the hook, structure, key moments and SEO indicators extracted by Mistral Vision.",
+      )}
+    </p>
+    <span className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-indigo-500/10 text-indigo-300 text-sm font-medium border border-indigo-500/20">
+      <Sparkles className="w-4 h-4" aria-hidden="true" />
+      {t(language, "Réanalyser avec le visuel", "Re-analyze with visuals")}
+    </span>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎯 COMPOSANT PRINCIPAL
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const VisualTab: React.FC<VisualTabProps> = ({
+  visualAnalysis,
+  language,
+}) => {
+  // Empty state quand le payload est absent (Phase 2 non lancée)
+  if (!visualAnalysis) {
+    return <EmptyVisualState language={language} />;
+  }
+
+  const {
+    visual_hook,
+    visual_structure,
+    key_moments,
+    visible_text,
+    visual_seo_indicators,
+    summary_visual,
+    model_used,
+    frames_analyzed,
+    frames_downsampled,
+  } = visualAnalysis;
+
+  const structureLabel =
+    STRUCTURE_LABELS[visual_structure]?.[language] ?? visual_structure;
+
+  // Tri des moments clés par timestamp pour cohérence visuelle
+  const sortedMoments = [...(key_moments || [])].sort(
+    (a, b) => a.timestamp_s - b.timestamp_s,
+  );
+
+  return (
+    <div className="p-4 sm:p-6 space-y-8">
+      {/* ─── 1. HOOK VISUEL ─── */}
+      <section aria-labelledby="visual-hook-title">
+        <SectionTitle icon={Eye} iconColor="text-indigo-400">
+          <span id="visual-hook-title">
+            {t(language, "Hook visuel", "Visual hook")}
+          </span>
+        </SectionTitle>
+        <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-xl p-4 sm:p-5">
+          <p className="text-base sm:text-lg leading-relaxed text-text-primary">
+            {visual_hook || (
+              <span className="italic text-text-tertiary">
+                {t(language, "Aucun hook détecté.", "No hook detected.")}
+              </span>
+            )}
+          </p>
+        </div>
+      </section>
+
+      {/* ─── 2. STRUCTURE VISUELLE ─── */}
+      <section aria-labelledby="visual-structure-title">
+        <SectionTitle icon={Film} iconColor="text-violet-400">
+          <span id="visual-structure-title">
+            {t(language, "Structure", "Structure")}
+          </span>
+        </SectionTitle>
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold border bg-violet-500/10 text-violet-300 border-violet-500/20">
+            <FileVideo className="w-4 h-4" aria-hidden="true" />
+            {structureLabel}
+          </span>
+        </div>
+      </section>
+
+      {/* ─── 3. MOMENTS CLÉS ─── */}
+      <section aria-labelledby="visual-moments-title">
+        <SectionTitle icon={Clock} iconColor="text-cyan-400">
+          <span id="visual-moments-title">
+            {t(language, "Moments clés", "Key moments")}
+          </span>
+        </SectionTitle>
+        {sortedMoments.length === 0 ? (
+          <p className="text-sm italic text-text-tertiary">
+            {t(
+              language,
+              "Aucun moment clé détecté.",
+              "No key moments detected.",
+            )}
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {sortedMoments.map((moment, idx) => (
+              <li
+                key={`${moment.timestamp_s}-${idx}`}
+                className="flex items-start gap-3 p-3 rounded-lg bg-white/[0.03] border border-white/5 hover:border-white/10 transition-colors"
+              >
+                <span
+                  className="flex-shrink-0 inline-flex items-center justify-center min-w-[58px] px-2 py-1 rounded-md font-mono text-[11px] font-semibold tracking-wider text-cyan-300 bg-cyan-500/10 border border-cyan-500/20"
+                  style={{ fontFamily: "JetBrains Mono, monospace" }}
+                  aria-label={t(language, "Timestamp", "Timestamp")}
+                >
+                  {formatTimestamp(moment.timestamp_s)}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm text-text-primary leading-relaxed">
+                    {moment.description}
+                  </p>
+                </div>
+                {moment.type && (
+                  <span className="flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-semibold uppercase tracking-wide border text-text-secondary bg-white/5 border-white/10">
+                    {moment.type}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      {/* ─── 4. TEXTE VISIBLE ─── */}
+      <section aria-labelledby="visual-text-title">
+        <SectionTitle icon={Type} iconColor="text-amber-400">
+          <span id="visual-text-title">
+            {t(language, "Texte visible à l'écran", "On-screen text")}
+          </span>
+        </SectionTitle>
+        <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-xl p-4">
+          {visible_text && visible_text.trim() ? (
+            <p className="text-sm text-text-primary leading-relaxed whitespace-pre-wrap">
+              {visible_text}
+            </p>
+          ) : (
+            <p className="text-sm italic text-text-tertiary">
+              {t(
+                language,
+                "Aucun texte détecté.",
+                "No text detected.",
+              )}
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* ─── 5. INDICATEURS SEO VISUELS ─── */}
+      <section aria-labelledby="visual-seo-title">
+        <SectionTitle icon={Sparkles} iconColor="text-emerald-400">
+          <span id="visual-seo-title">
+            {t(
+              language,
+              "Indicateurs SEO visuels",
+              "Visual SEO indicators",
+            )}
+          </span>
+        </SectionTitle>
+        <SeoIndicatorsGrid
+          indicators={visual_seo_indicators}
+          language={language}
+        />
+      </section>
+
+      {/* ─── 6. RÉSUMÉ VISUEL ─── */}
+      <section aria-labelledby="visual-summary-title">
+        <SectionTitle icon={Info} iconColor="text-blue-400">
+          <span id="visual-summary-title">
+            {t(language, "Résumé visuel", "Visual summary")}
+          </span>
+        </SectionTitle>
+        <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-xl p-4 sm:p-5">
+          {summary_visual ? (
+            <p className="text-sm text-text-secondary leading-relaxed whitespace-pre-wrap">
+              {summary_visual}
+            </p>
+          ) : (
+            <p className="text-sm italic text-text-tertiary">
+              {t(
+                language,
+                "Aucun résumé visuel généré.",
+                "No visual summary generated.",
+              )}
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* ─── METADATA (footer discret) ─── */}
+      <footer className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-text-tertiary border-t border-white/5 pt-4">
+        <span>
+          {t(language, "Modèle", "Model")}:{" "}
+          <span
+            className="font-mono text-text-secondary"
+            style={{ fontFamily: "JetBrains Mono, monospace" }}
+          >
+            {model_used || "—"}
+          </span>
+        </span>
+        <span>
+          {t(language, "Frames analysées", "Frames analyzed")}:{" "}
+          <span
+            className="font-mono text-text-secondary"
+            style={{ fontFamily: "JetBrains Mono, monospace" }}
+          >
+            {frames_analyzed}
+          </span>
+        </span>
+        {frames_downsampled && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-amber-500/10 text-amber-300 border border-amber-500/20">
+            {t(language, "Échantillonné", "Downsampled")}
+          </span>
+        )}
+      </footer>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🧮 GRID DES INDICATEURS SEO — extrait pour lisibilité
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const SeoIndicatorsGrid: React.FC<{
+  indicators: VisualSeoIndicators;
+  language: "fr" | "en";
+}> = ({ indicators, language }) => {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <IndicatorTile
+        icon={Sun}
+        label={t(language, "Luminosité du hook", "Hook brightness")}
+        valueNode={
+          <QualitativeBadge
+            level={indicators.hook_brightness}
+            language={language}
+          />
+        }
+      />
+      <IndicatorTile
+        icon={User}
+        label={t(language, "Visage dans le hook", "Face in hook")}
+        valueNode={
+          <BooleanBadge
+            value={indicators.face_visible_in_hook}
+            language={language}
+          />
+        }
+      />
+      <IndicatorTile
+        icon={Subtitles}
+        label={t(language, "Sous-titres incrustés", "Burned-in subtitles")}
+        valueNode={
+          <BooleanBadge
+            value={indicators.burned_in_subtitles}
+            language={language}
+          />
+        }
+      />
+      <IndicatorTile
+        icon={Zap}
+        label={t(language, "Intro à fort mouvement", "High-motion intro")}
+        valueNode={
+          <BooleanBadge
+            value={indicators.high_motion_intro}
+            language={language}
+          />
+        }
+      />
+      <IndicatorTile
+        icon={ImageIcon}
+        label={t(
+          language,
+          "Qualité miniature (proxy)",
+          "Thumbnail quality (proxy)",
+        )}
+        valueNode={
+          <QualitativeBadge
+            level={indicators.thumbnail_quality_proxy}
+            language={language}
+          />
+        }
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/AnalysisHub/__tests__/VisualTab.test.tsx
+++ b/frontend/src/components/AnalysisHub/__tests__/VisualTab.test.tsx
@@ -1,0 +1,164 @@
+// frontend/src/components/AnalysisHub/__tests__/VisualTab.test.tsx
+//
+// Smoke tests pour le tab "Visuel" de l'AnalysisHub. Couvre :
+//   - Empty state quand visualAnalysis est null/undefined.
+//   - Rendu complet avec un payload Mistral Vision typique.
+//   - Format MM:SS / H:MM:SS pour les timestamps.
+//   - Indicateurs SEO (qualitatifs + booléens) avec valeurs absentes.
+//
+// Pas de mock — le composant est pur (props in / DOM out), pas d'API.
+
+import { describe, it, expect } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+import { VisualTab } from "../VisualTab";
+import type { VisualAnalysis } from "../../../types/analysis";
+
+const fullPayload: VisualAnalysis = {
+  visual_hook:
+    "Ouverture sur un gros plan du présentateur avec un titre rouge incrusté.",
+  visual_structure: "talking_head",
+  key_moments: [
+    {
+      timestamp_s: 0,
+      description: "Title card avec le sujet de la vidéo",
+      type: "title_card",
+    },
+    {
+      timestamp_s: 95,
+      description: "Insertion d'une infographie animée",
+      type: "infographic",
+    },
+    {
+      timestamp_s: 3725,
+      description: "CTA d'abonnement en fin de vidéo",
+      type: "cta",
+    },
+  ],
+  visible_text: "Abonnez-vous • Lien en description",
+  visual_seo_indicators: {
+    hook_brightness: "high",
+    face_visible_in_hook: true,
+    burned_in_subtitles: false,
+    high_motion_intro: false,
+    thumbnail_quality_proxy: "medium",
+  },
+  summary_visual:
+    "La vidéo alterne talking head et b-roll avec des incrustations textuelles fréquentes.",
+  model_used: "pixtral-12b-2409",
+  frames_analyzed: 24,
+  frames_downsampled: false,
+};
+
+describe("VisualTab", () => {
+  afterEach(() => cleanup());
+
+  it("affiche un empty state quand visualAnalysis est null", () => {
+    render(<VisualTab visualAnalysis={null} language="fr" />);
+    expect(
+      screen.getByText(/Analyse visuelle non disponible/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Réanalyser avec le visuel/i),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche un empty state quand visualAnalysis est undefined", () => {
+    render(<VisualTab visualAnalysis={undefined} language="fr" />);
+    expect(
+      screen.getByText(/Analyse visuelle non disponible/i),
+    ).toBeInTheDocument();
+  });
+
+  it("rend le hook visuel et la structure", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(screen.getByText(fullPayload.visual_hook)).toBeInTheDocument();
+    // talking_head → "Talking head" (label FR)
+    expect(screen.getByText("Talking head")).toBeInTheDocument();
+  });
+
+  it("formate les timestamps en MM:SS et H:MM:SS", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    // 0s → "00:00"
+    expect(screen.getByText("00:00")).toBeInTheDocument();
+    // 95s → "01:35"
+    expect(screen.getByText("01:35")).toBeInTheDocument();
+    // 3725s → "1:02:05"
+    expect(screen.getByText("1:02:05")).toBeInTheDocument();
+  });
+
+  it("affiche les descriptions des moments clés", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(
+      screen.getByText("Title card avec le sujet de la vidéo"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Insertion d'une infographie animée"),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche le texte visible quand présent", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(
+      screen.getByText("Abonnez-vous • Lien en description"),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche un message italique quand visible_text est vide", () => {
+    const noText: VisualAnalysis = { ...fullPayload, visible_text: "" };
+    render(<VisualTab visualAnalysis={noText} language="fr" />);
+    expect(screen.getByText(/Aucun texte détecté/i)).toBeInTheDocument();
+  });
+
+  it("affiche les indicateurs SEO en français", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(screen.getByText(/Luminosité du hook/i)).toBeInTheDocument();
+    expect(screen.getByText(/Visage dans le hook/i)).toBeInTheDocument();
+  });
+
+  it("affiche des badges Oui/Non pour les indicateurs booléens", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    // face_visible_in_hook = true → au moins un "Oui"
+    expect(screen.getAllByText("Oui").length).toBeGreaterThan(0);
+    // burned_in_subtitles = false → au moins un "Non"
+    expect(screen.getAllByText("Non").length).toBeGreaterThan(0);
+  });
+
+  it("affiche le résumé visuel et les métadonnées model_used / frames_analyzed", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="fr" />);
+    expect(screen.getByText(fullPayload.summary_visual)).toBeInTheDocument();
+    expect(screen.getByText(fullPayload.model_used)).toBeInTheDocument();
+    expect(
+      screen.getByText(String(fullPayload.frames_analyzed)),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche le badge 'Échantillonné' quand frames_downsampled=true", () => {
+    const downsampled: VisualAnalysis = {
+      ...fullPayload,
+      frames_downsampled: true,
+    };
+    render(<VisualTab visualAnalysis={downsampled} language="fr" />);
+    expect(screen.getByText(/Échantillonné/i)).toBeInTheDocument();
+  });
+
+  it("rend en anglais quand language='en'", () => {
+    render(<VisualTab visualAnalysis={fullPayload} language="en" />);
+    expect(screen.getByText(/Visual hook/i)).toBeInTheDocument();
+    expect(screen.getByText(/Key moments/i)).toBeInTheDocument();
+    expect(screen.getByText(/On-screen text/i)).toBeInTheDocument();
+  });
+
+  it("affiche un dash pour les indicateurs absents", () => {
+    const partial: VisualAnalysis = {
+      ...fullPayload,
+      visual_seo_indicators: {
+        hook_brightness: "high",
+        // les autres champs absents
+      },
+    };
+    render(<VisualTab visualAnalysis={partial} language="fr" />);
+    // Présence d'au moins un "—" pour les indicateurs absents
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/AnalysisHub/index.tsx
+++ b/frontend/src/components/AnalysisHub/index.tsx
@@ -5,12 +5,13 @@
  */
 
 import React, { useState, useEffect, useCallback } from "react";
-import { BookOpen, Brain, BookMarked, Shield, Target } from "lucide-react";
+import { BookOpen, Brain, BookMarked, Shield, Target, Eye } from "lucide-react";
 import { SynthesisTab } from "./SynthesisTab";
 import { QuizTab } from "./QuizTab";
 import { FlashcardsTab } from "./FlashcardsTab";
 import { ReliabilityTab } from "./ReliabilityTab";
 import { GeoTab } from "./GeoTab";
+import { VisualTab } from "./VisualTab";
 import { studyApi } from "../../services/api";
 import type {
   Summary,
@@ -25,7 +26,13 @@ import type { TimecodeInfo } from "../TimecodeRenderer";
 // 📦 TYPES
 // ═══════════════════════════════════════════════════════════════════════════════
 
-type TabType = "synthesis" | "quiz" | "flashcards" | "reliability" | "geo";
+type TabType =
+  | "synthesis"
+  | "quiz"
+  | "flashcards"
+  | "reliability"
+  | "geo"
+  | "visual";
 
 interface AnalysisHubProps {
   selectedSummary: Summary;
@@ -112,6 +119,14 @@ const TABS: {
     icon: Target,
     activeColor: "text-teal-400",
     activeBorder: "border-teal-500",
+  },
+  {
+    id: "visual",
+    labelFr: "Visuel",
+    labelEn: "Visual",
+    icon: Eye,
+    activeColor: "text-indigo-400",
+    activeBorder: "border-indigo-500",
   },
 ];
 
@@ -348,6 +363,13 @@ export const AnalysisHub: React.FC<AnalysisHubProps> = ({
         <GeoTab
           selectedSummary={selectedSummary}
           user={user}
+          language={language}
+        />
+      )}
+
+      {activeTab === "visual" && (
+        <VisualTab
+          visualAnalysis={selectedSummary.visual_analysis}
           language={language}
         />
       )}

--- a/frontend/src/components/hub/HubAnalysisPanel.tsx
+++ b/frontend/src/components/hub/HubAnalysisPanel.tsx
@@ -118,7 +118,14 @@ export const HubAnalysisPanel: React.FC<Props> = ({
           onTimecodeClick={handleTimecodeClick}
           onOpenChat={handleOpenChat}
           onNavigate={handleNavigate}
-          enabledTabs={["synthesis", "reliability", "quiz", "flashcards", "geo"]}
+          enabledTabs={[
+            "synthesis",
+            "reliability",
+            "quiz",
+            "flashcards",
+            "geo",
+            "visual",
+          ]}
           showKeywords
           showStudyTools={false}
           showVoice={false}

--- a/frontend/src/components/hub/HubTabBar.tsx
+++ b/frontend/src/components/hub/HubTabBar.tsx
@@ -5,6 +5,7 @@ import {
   BookMarked,
   Shield,
   Target,
+  Eye,
   MessageCircle,
 } from "lucide-react";
 import type { TabId } from "./types";
@@ -61,6 +62,13 @@ const TABS: TabConfig[] = [
     icon: Target,
     activeColor: "text-teal-400",
     activeBorder: "border-teal-500",
+  },
+  {
+    id: "visual",
+    label: "Visuel",
+    icon: Eye,
+    activeColor: "text-indigo-400",
+    activeBorder: "border-indigo-500",
   },
   {
     id: "chat",

--- a/frontend/src/components/hub/__tests__/HubAnalysisPanel.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubAnalysisPanel.test.tsx
@@ -125,9 +125,9 @@ describe("HubAnalysisPanel", () => {
     expect(screen.getByTestId("analysis-hub-mock")).toBeInTheDocument();
     expect(screen.getByTestId("ah-summary-id")).toHaveTextContent("42");
     expect(screen.getByTestId("ah-concepts-count")).toHaveTextContent("1");
-    // The 5 tabs are explicitly enabled by HubAnalysisPanel.
+    // The 6 tabs are explicitly enabled by HubAnalysisPanel.
     expect(screen.getByTestId("ah-tabs")).toHaveTextContent(
-      "synthesis,reliability,quiz,flashcards,geo",
+      "synthesis,reliability,quiz,flashcards,geo,visual",
     );
   });
 

--- a/frontend/src/components/hub/__tests__/HubTabBar.test.tsx
+++ b/frontend/src/components/hub/__tests__/HubTabBar.test.tsx
@@ -10,13 +10,14 @@ describe("HubTabBar", () => {
     factCheckCount: 0,
   };
 
-  it("rend les 6 onglets globaux", () => {
+  it("rend les 7 onglets globaux", () => {
     render(<HubTabBar {...baseProps} />);
     expect(screen.getByRole("tab", { name: /Synthèse/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Quiz/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Flashcards/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Fiabilité/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /GEO/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Visuel/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Chat/ })).toBeInTheDocument();
   });
 

--- a/frontend/src/components/hub/types.ts
+++ b/frontend/src/components/hub/types.ts
@@ -69,9 +69,9 @@ export type HubVoiceState =
   | "call_ending";
 
 /**
- * Identifiant des onglets globaux du Hub. Inclut les 5 onglets d'analyse
- * (synthesis, quiz, flashcards, reliability, geo) ET l'onglet "chat" qui
- * remplace l'ancienne archi single-scroll par une nav sticky globale.
+ * Identifiant des onglets globaux du Hub. Inclut les 6 onglets d'analyse
+ * (synthesis, quiz, flashcards, reliability, geo, visual) ET l'onglet "chat"
+ * qui remplace l'ancienne archi single-scroll par une nav sticky globale.
  *
  * Source de vérité : doit rester en sync avec AnalysisHub.TabType + l'ajout
  * "chat". URL deep-link via `?tab=<TabId>`.
@@ -82,4 +82,5 @@ export type TabId =
   | "flashcards"
   | "reliability"
   | "geo"
+  | "visual"
   | "chat";

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -161,6 +161,12 @@ export interface Summary {
   // 📚 Summary extras (spike 2026-05-06) — enrichissement post-processing
   // Mistral à la demande. NULL si pas encore généré.
   summary_extras?: SummaryExtrasData | null;
+
+  // 🎬 Visual Analysis Phase 2 (mai 2026) — payload Mistral Vision
+  // Présent uniquement quand l'analyse visuelle a été activée et a réussi.
+  // Type importé depuis ../types/analysis pour garder une seule source
+  // de vérité (mirror backend `analysis.visual_analysis`).
+  visual_analysis?: import("../types/analysis").VisualAnalysis | null;
 }
 
 // ─── Summary extras (spike 2026-05-06) ────────────────────────────────────────

--- a/frontend/src/store/hubStore.ts
+++ b/frontend/src/store/hubStore.ts
@@ -111,6 +111,7 @@ const INITIAL: Pick<
     flashcards: 0,
     reliability: 0,
     geo: 0,
+    visual: 0,
     chat: 0,
   },
 };

--- a/frontend/src/types/analysis.ts
+++ b/frontend/src/types/analysis.ts
@@ -381,3 +381,84 @@ export const WRITING_STYLE_CONFIG = WRITING_TONE_CONFIG as unknown as Record<
     emoji: string;
   }
 >;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎬 VISUAL ANALYSIS — Phase 2 (Mistral Vision sur storyboards YouTube)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Type de structure visuelle détectée dans la vidéo.
+ * Aligné avec le backend (`backend/src/videos/visual_analysis.py`).
+ */
+export type VisualStructure =
+  | "talking_head"
+  | "b_roll"
+  | "gameplay"
+  | "slides"
+  | "tutorial"
+  | "interview"
+  | "vlog"
+  | "mixed"
+  | "other";
+
+/**
+ * Niveau qualitatif utilisé par les indicateurs SEO visuels.
+ */
+export type VisualQualitativeLevel = "low" | "medium" | "high";
+
+/**
+ * Un moment clé identifié visuellement dans la vidéo.
+ */
+export interface VisualKeyMoment {
+  /** Timestamp en secondes depuis le début de la vidéo. */
+  timestamp_s: number;
+  /** Description courte (FR) de ce qui est visible. */
+  description: string;
+  /** Catégorie libre (ex : "title_card", "cta", "infographic"). */
+  type: string;
+}
+
+/**
+ * Indicateurs SEO visuels — destinés à éclairer le potentiel de rétention
+ * et de citation dans les moteurs IA. Tous les champs sont optionnels car
+ * le backend peut renvoyer un sous-ensemble selon le modèle utilisé.
+ */
+export interface VisualSeoIndicators {
+  /** Luminosité du hook d'intro (perçue par Mistral Vision). */
+  hook_brightness?: VisualQualitativeLevel;
+  /** Vrai si un visage est visible dans les ~3 premières secondes. */
+  face_visible_in_hook?: boolean;
+  /** Vrai si des sous-titres "burned-in" (incrustés) sont détectés. */
+  burned_in_subtitles?: boolean;
+  /** Vrai si l'intro contient des mouvements de caméra/zoom rapides. */
+  high_motion_intro?: boolean;
+  /** Estimation qualitative du soin apporté à la miniature/branding. */
+  thumbnail_quality_proxy?: VisualQualitativeLevel;
+}
+
+/**
+ * Payload Visual Analysis renvoyé par /api/videos/analyze quand Phase 2
+ * est activée. Embarqué dans l'objet `analysis` (réponse `Summary`) sous
+ * la clé `visual_analysis`. Peut être null si l'analyse n'a pas été lancée
+ * ou a échoué silencieusement (le tab UI affichera alors un empty state).
+ */
+export interface VisualAnalysis {
+  /** Hook visuel — ce qu'on voit dans les 3 premières secondes. */
+  visual_hook: string;
+  /** Type de structure visuelle dominante. */
+  visual_structure: VisualStructure;
+  /** Liste de moments visuels remarquables (1-10 typiquement). */
+  key_moments: VisualKeyMoment[];
+  /** Texte visible à l'écran (titres, sous-titres incrustés, CTA). */
+  visible_text: string;
+  /** Heuristiques de SEO/rétention dérivées de l'analyse visuelle. */
+  visual_seo_indicators: VisualSeoIndicators;
+  /** Résumé en prose de la couche visuelle. */
+  summary_visual: string;
+  /** Modèle Mistral Vision utilisé (ex: "pixtral-12b-2409"). */
+  model_used: string;
+  /** Nombre de frames extraites du storyboard analysées. */
+  frames_analyzed: number;
+  /** Vrai si le storyboard a été sous-échantillonné (cap budget). */
+  frames_downsampled: boolean;
+}


### PR DESCRIPTION
## Summary

Ajoute le tab **Visuel** dans le hub d'analyse pour consommer le payload `analysis.visual_analysis` (Phase 2 — Mistral Vision sur storyboards YouTube). Le tab affiche les 6 sections demandées par la spec :

1. **Hook visuel** — gros texte d'intro (`visual_hook`)
2. **Structure** — badge avec `visual_structure` (talking_head, b_roll, slides…)
3. **Moments clés** — liste timestampée (MM:SS / H:MM:SS si > 1h) + description + badge type
4. **Texte visible à l'écran** — `visible_text` (ou italique « Aucun texte détecté »)
5. **Indicateurs SEO visuels** — grille (luminosité hook, visage, sous-titres incrustés, intro motion, qualité miniature)
6. **Résumé visuel** — `summary_visual` en prose

Footer discret avec `model_used` / `frames_analyzed` / badge « Échantillonné » si downsampling.

**Empty state recommandé** : tab toujours rendu, message explicite + CTA « Réanalyser avec le visuel » quand `visual_analysis` est null/undefined.

## Fichiers

- `frontend/src/types/analysis.ts` — types `VisualAnalysis`, `VisualStructure`, `VisualKeyMoment`, `VisualSeoIndicators`, `VisualQualitativeLevel`
- `frontend/src/services/api.ts` — champ `visual_analysis?: VisualAnalysis | null` sur `Summary`
- `frontend/src/components/AnalysisHub/VisualTab.tsx` — nouveau composant (480 lignes)
- `frontend/src/components/AnalysisHub/__tests__/VisualTab.test.tsx` — 13 tests smoke
- `frontend/src/components/AnalysisHub/index.tsx` — `TabType` + entry tab + render
- `frontend/src/components/hub/HubTabBar.tsx` + `types.ts` + `HubAnalysisPanel.tsx` — enable `visual` dans la barre globale + `enabledTabs`
- `frontend/src/store/hubStore.ts` — scrollPosition tab `visual`
- Tests `HubTabBar.test.tsx` + `HubAnalysisPanel.test.tsx` mis à jour pour 7 onglets / liste enabledTabs étendue

## Conventions DeepSight

- Dark mode first (`#0a0a0f` / `#12121a` / `white/5%`)
- Glass morphism (`backdrop-blur-xl bg-white/5 border border-white/10`)
- Accents indigo `#6366f1` (icône Eye + tab) + cyan pour timestamps + violet pour structure
- `JetBrains Mono` pour les timestamps et la metadata `model_used`
- TypeScript strict, zéro `any`
- i18n FR + EN local au composant (`t(lang, fr, en)` helper)

## Test plan

- [x] `npm run typecheck` — aucune nouvelle erreur introduite (4 erreurs résolues, baseline 115 → 111). Erreurs restantes sont préexistantes et hors scope.
- [x] `npm run build` — succès (`✓ built in 56.52s`)
- [x] `npx vitest run src/components/AnalysisHub/__tests__/VisualTab.test.tsx` — 13/13 tests passent (empty state, render full payload, format MM:SS/H:MM:SS, badges Oui/Non, dash pour valeurs absentes, FR/EN, downsampled)
- [x] `npx vitest run src/components/hub/__tests__/HubTabBar.test.tsx` — 6/6 tests passent (mis à jour pour 7 onglets)
- [x] `npx vitest run src/components/hub/__tests__/HubAnalysisPanel.test.tsx` — 3/3 tests passent (mis à jour pour `enabledTabs` étendu)
- [ ] À valider visuellement après merge dans `feat/visual-analysis-phase-2` quand le backend renvoie un vrai payload `visual_analysis`.

## Notes

- Mobile et extension sont gérés par d'autres agents — cette PR ne touche que le frontend web.
- Le tab est ajouté à la fin de la liste (après GEO, avant Chat) pour ne pas casser l'ordre établi des onglets existants.
- Le baseline `feat/visual-analysis-phase-2` a 115 erreurs typecheck préexistantes (debate.ts, History.tsx, HubPage.tsx, etc.) qui ne sont pas adressées ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)