### PR TITLE
feat(frontend): câblage CTA Réanalyser avec le visuel

### DIFF
--- a/frontend/src/components/AnalysisHub/VisualTab.tsx
+++ b/frontend/src/components/AnalysisHub/VisualTab.tsx
@@ -30,6 +30,7 @@ import {
   Zap,
   Image as ImageIcon,
   Info,
+  Loader2,
 } from "lucide-react";
 import type {
   VisualAnalysis,
@@ -45,6 +46,17 @@ import type {
 interface VisualTabProps {
   visualAnalysis: VisualAnalysis | null | undefined;
   language: "fr" | "en";
+  /**
+   * Callback déclenché par le CTA "Réanalyser avec le visuel" de l'empty state.
+   * Si fourni, le bouton devient interactif. Si absent, le CTA reste un badge
+   * informatif inerte (rétrocompat tests / pages legacy).
+   */
+  onReanalyze?: () => void;
+  /**
+   * Indique qu'une re-analyse est en cours — affiche un spinner et désactive
+   * le bouton pour éviter les double-clicks.
+   */
+  isReanalyzing?: boolean;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -179,29 +191,78 @@ const BooleanBadge: React.FC<{
 // 🚫 EMPTY STATE — Phase 2 non activée pour cette analyse
 // ═══════════════════════════════════════════════════════════════════════════════
 
-const EmptyVisualState: React.FC<{ language: "fr" | "en" }> = ({
+interface EmptyVisualStateProps {
+  language: "fr" | "en";
+  onReanalyze?: () => void;
+  isReanalyzing?: boolean;
+}
+
+const EmptyVisualState: React.FC<EmptyVisualStateProps> = ({
   language,
-}) => (
-  <div className="p-8 sm:p-12 text-center">
-    <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-white/5 border border-white/10 mb-4">
-      <Eye className="w-8 h-8 text-text-tertiary" aria-hidden="true" />
-    </div>
-    <h3 className="text-lg font-semibold text-text-primary mb-2">
-      {t(language, "Analyse visuelle non disponible", "Visual analysis unavailable")}
-    </h3>
-    <p className="text-sm text-text-tertiary max-w-md mx-auto mb-4">
-      {t(
-        language,
-        "Cette analyse n'a pas inclus la couche visuelle. Réanalysez la vidéo en activant l'option « Analyse visuelle » pour voir le hook, la structure, les moments clés et les indicateurs SEO visuels extraits par Mistral Vision.",
-        "This analysis did not include the visual layer. Re-run the analysis with the « Visual analysis » option enabled to see the hook, structure, key moments and SEO indicators extracted by Mistral Vision.",
+  onReanalyze,
+  isReanalyzing,
+}) => {
+  const ctaLabel = isReanalyzing
+    ? t(language, "Analyse en cours…", "Analysis in progress…")
+    : t(language, "Réanalyser avec le visuel", "Re-analyze with visuals");
+
+  // Common pill classes (button + badge fallback partagent l'esthétique).
+  const pillBase =
+    "inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium border transition-colors";
+  const pillIdle =
+    "bg-indigo-500/10 text-indigo-300 border-indigo-500/20 hover:bg-indigo-500/20";
+  const pillBusy =
+    "bg-indigo-500/5 text-indigo-300/70 border-indigo-500/10 cursor-wait";
+  const pillStatic = "bg-indigo-500/10 text-indigo-300 border-indigo-500/20";
+
+  return (
+    <div className="p-8 sm:p-12 text-center">
+      <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-white/5 border border-white/10 mb-4">
+        <Eye className="w-8 h-8 text-text-tertiary" aria-hidden="true" />
+      </div>
+      <h3 className="text-lg font-semibold text-text-primary mb-2">
+        {t(
+          language,
+          "Analyse visuelle non disponible",
+          "Visual analysis unavailable",
+        )}
+      </h3>
+      <p className="text-sm text-text-tertiary max-w-md mx-auto mb-4">
+        {t(
+          language,
+          "Cette analyse n'a pas inclus la couche visuelle. Réanalysez la vidéo en activant l'option « Analyse visuelle » pour voir le hook, la structure, les moments clés et les indicateurs SEO visuels extraits par Mistral Vision.",
+          "This analysis did not include the visual layer. Re-run the analysis with the « Visual analysis » option enabled to see the hook, structure, key moments and SEO indicators extracted by Mistral Vision.",
+        )}
+      </p>
+      {onReanalyze ? (
+        <button
+          type="button"
+          onClick={onReanalyze}
+          disabled={isReanalyzing}
+          aria-busy={isReanalyzing || undefined}
+          className={`${pillBase} ${
+            isReanalyzing ? pillBusy : pillIdle
+          } disabled:opacity-80`}
+        >
+          {isReanalyzing ? (
+            <Loader2
+              className="w-4 h-4 animate-spin"
+              aria-hidden="true"
+            />
+          ) : (
+            <Sparkles className="w-4 h-4" aria-hidden="true" />
+          )}
+          {ctaLabel}
+        </button>
+      ) : (
+        <span className={`${pillBase} ${pillStatic}`}>
+          <Sparkles className="w-4 h-4" aria-hidden="true" />
+          {ctaLabel}
+        </span>
       )}
-    </p>
-    <span className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-indigo-500/10 text-indigo-300 text-sm font-medium border border-indigo-500/20">
-      <Sparkles className="w-4 h-4" aria-hidden="true" />
-      {t(language, "Réanalyser avec le visuel", "Re-analyze with visuals")}
-    </span>
-  </div>
-);
+    </div>
+  );
+};
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // 🎯 COMPOSANT PRINCIPAL

--- a/frontend/src/components/AnalysisHub/index.tsx
+++ b/frontend/src/components/AnalysisHub/index.tsx
@@ -12,7 +12,7 @@ import { FlashcardsTab } from "./FlashcardsTab";
 import { ReliabilityTab } from "./ReliabilityTab";
 import { GeoTab } from "./GeoTab";
 import { VisualTab } from "./VisualTab";
-import { studyApi } from "../../services/api";
+import { studyApi, videoApi } from "../../services/api";
 import type {
   Summary,
   EnrichedConcept,
@@ -251,6 +251,41 @@ export const AnalysisHub: React.FC<AnalysisHubProps> = ({
     }
   }, [selectedSummary.id, language]);
 
+  // Re-analyse with visual layer (CTA empty state du tab Visuel)
+  const [isReanalyzingVisual, setIsReanalyzingVisual] = useState(false);
+  const handleReanalyzeVisual = useCallback(async () => {
+    if (isReanalyzingVisual) return;
+    const url =
+      (selectedSummary as { video_url?: string; url?: string }).video_url ||
+      (selectedSummary as { url?: string }).url;
+    if (!url) return;
+    setIsReanalyzingVisual(true);
+    try {
+      await videoApi.analyze(
+        url,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        language,
+        { includeVisualAnalysis: true, forceRefresh: true },
+      );
+      window.alert(
+        language === "fr"
+          ? "Re-analyse lancée avec la couche visuelle. Retrouvez le résultat dans votre historique dans quelques instants."
+          : "Re-analysis started with the visual layer. The result will appear in your history shortly.",
+      );
+    } catch (e) {
+      window.alert(
+        language === "fr"
+          ? "Échec du lancement de la re-analyse. Réessayez plus tard."
+          : "Failed to trigger re-analysis. Please try again later.",
+      );
+    } finally {
+      setIsReanalyzingVisual(false);
+    }
+  }, [isReanalyzingVisual, selectedSummary, language]);
+
   // Badges
   const getTabBadge = (tabId: TabType): string | null => {
     if (tabId === "quiz" && quizQuestions) return `${quizQuestions.length}`;
@@ -371,6 +406,8 @@ export const AnalysisHub: React.FC<AnalysisHubProps> = ({
         <VisualTab
           visualAnalysis={selectedSummary.visual_analysis}
           language={language}
+          onReanalyze={handleReanalyzeVisual}
+          isReanalyzing={isReanalyzingVisual}
         />
       )}
     </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1076,6 +1076,7 @@ export const videoApi = {
    * @param model - Modèle IA (mistral-small, medium, large)
    * @param deepResearch - Recherche approfondie (Expert only)
    * @param lang - Langue pour le résumé (fr/en) - IMPORTANT: doit être la langue de l'interface
+   * @param options - Options additionnelles (Phase 2 visual analysis, force refresh)
    */
   async analyze(
     url: string,
@@ -1084,21 +1085,30 @@ export const videoApi = {
     model?: string,
     deepResearch?: boolean,
     lang?: string,
+    options?: {
+      /** 🆕 Phase 2 : enrichir l'analyse avec une couche visuelle (Mistral Vision). Pro/Expert uniquement. */
+      includeVisualAnalysis?: boolean;
+      /** Bypass cache et forcer une nouvelle analyse fresh. */
+      forceRefresh?: boolean;
+    },
   ): Promise<{
     task_id: string;
     status: string;
     result?: { summary_id: number };
   }> {
+    const body: Record<string, unknown> = {
+      url,
+      category: category || "auto",
+      mode: mode || "standard",
+      model: model || "mistral-small-2603",
+      deep_research: deepResearch || false,
+      lang: lang || "fr", // 🌐 Langue du résumé
+    };
+    if (options?.includeVisualAnalysis) body.include_visual_analysis = true;
+    if (options?.forceRefresh) body.force_refresh = true;
     return request("/api/videos/analyze", {
       method: "POST",
-      body: {
-        url,
-        category: category || "auto",
-        mode: mode || "standard",
-        model: model || "mistral-small-2603",
-        deep_research: deepResearch || false,
-        lang: lang || "fr", // 🌐 Langue du résumé
-      },
+      body,
       timeout: 300000,
     });
   },


### PR DESCRIPTION
## Summary
- Le CTA "Réanalyser avec le visuel" du tab Visuel (PR #393 mergée) était inerte
- Câbler via `videoApi.analyze({includeVisualAnalysis: true, forceRefresh: true})` + state `isReanalyzing` + spinner
- Empty state devient actionnable

## Changes
- `frontend/src/services/api.ts` : signature `videoApi.analyze` étend avec `options?: {includeVisualAnalysis, forceRefresh}` (rétrocompat)
- `frontend/src/components/AnalysisHub/VisualTab.tsx` : props `onReanalyze`, `isReanalyzing` (rétrocompat tests)
- `frontend/src/components/AnalysisHub/index.tsx` : state + handler + plumbing à VisualTab

## Test plan
- [ ] CI typecheck pass
- [ ] Test post-deploy : empty state Visuel → click CTA → alert + analyse trigger backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)