### PR TITLE
feat(visual): persist visual_analysis + activate par défaut tri-platform

### DIFF
--- a/backend/alembic/versions/024_summary_visual_analysis.py
+++ b/backend/alembic/versions/024_summary_visual_analysis.py
@@ -1,0 +1,67 @@
+"""summary_visual_analysis — persist VisualAnalysis sur Summary (Phase 2 plumbing)
+
+Revision ID: 024_summary_visual_analysis
+Revises: 023_voice_quota_purchased_minutes_catchup
+Create Date: 2026-05-06
+
+Phase 2 visual analysis branchait `analyze_frames` sur le hook /api/videos/analyze
+mais persistait UNIQUEMENT le résultat dans `web_context` du prompt LLM. Aucune
+trace après la requête → tabs UI (web/mobile/extension) lisaient toujours `null`.
+
+Ajoute la colonne `summaries.visual_analysis JSON NULL` qui stockera le dict
+sérialisé d'une `VisualAnalysis` (cf `videos/visual_analyzer.py`) :
+    {
+      "visual_hook": str,
+      "visual_structure": str,
+      "key_moments": [{"timestamp_s": float, "description": str, "type": str}, ...],
+      "visible_text": str,
+      "visual_seo_indicators": {...},
+      "summary_visual": str,
+      "model_used": str,
+      "frames_analyzed": int,
+      "frames_downsampled": bool
+    }
+
+NULL = pas analysé visuellement (analyse legacy avant Phase 2 plumbing,
+ou flag `include_visual_analysis=false`, ou quota dépassé, ou échec Mistral).
+
+Idempotente : check si la colonne existe avant ALTER TABLE.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "024_summary_visual_analysis"
+down_revision: Union[str, None] = "023_voice_quota_purchased_minutes_catchup"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "visual_analysis" not in columns:
+        op.add_column(
+            "summaries",
+            sa.Column("visual_analysis", sa.JSON(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "visual_analysis" in columns:
+        op.drop_column("summaries", "visual_analysis")

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -253,6 +253,12 @@ class Summary(Base):
     # Migration : alembic 022_summary_extras.py.
     summary_extras = Column(JSON, nullable=True)
 
+    # Visual analysis persistence (Phase 2 plumbing — alembic 024).
+    # Dict sérialisé d'une VisualAnalysis (cf videos/visual_analyzer.py) ou None.
+    # Forme : {visual_hook, visual_structure, key_moments[], visible_text,
+    # visual_seo_indicators{}, summary_visual, model_used, frames_analyzed, frames_downsampled}.
+    visual_analysis = Column(JSON, nullable=True)
+
     # Hierarchical Digest Pipeline (Feb 2026)
     full_digest = Column(Text, nullable=True)  # Assembled full digest from chunk digests (~6-10K chars)
 

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3079,6 +3079,7 @@ async def _analyze_video_background_v6(
             # 🆕 PHASE 2 — VISUAL ANALYSIS ENRICHMENT (frames + Mistral Vision)
             # Best-effort : si échec, on continue sans la couche visuelle.
             # ═══════════════════════════════════════════════════════════════════
+            _visual_analysis_data: Optional[Dict[str, Any]] = None
             if include_visual_analysis and platform == "youtube":
                 try:
                     from .visual_integration import (
@@ -3114,6 +3115,10 @@ async def _analyze_video_background_v6(
                                     web_context = (
                                         (web_context or "") + "\n\n" + _visual_block
                                     )
+                                # 👁️ Phase 2 plumbing — capture le dict serialisé
+                                # pour persistance dans Summary.visual_analysis
+                                # après save_summary() (alembic 024).
+                                _visual_analysis_data = _visual.get("analysis")
                                 logger.info(
                                     "👁️ [VISUAL] enrichment OK: frames=%d model=%s elapsed=%.1fs",
                                     _visual.get("frame_count", 0),
@@ -3343,6 +3348,27 @@ async def _analyze_video_background_v6(
             )
 
             logger.info(f"💾 Summary saved: id={summary_id}")
+
+            # 👁️ Phase 2 plumbing : persiste visual_analysis si capturé.
+            # Best-effort — ne fait pas échouer le flow si ça plante.
+            if _visual_analysis_data is not None:
+                try:
+                    from sqlalchemy import update as sql_update
+                    await session.execute(
+                        sql_update(Summary)
+                        .where(Summary.id == summary_id)
+                        .values(visual_analysis=_visual_analysis_data)
+                    )
+                    await session.commit()
+                    logger.info(
+                        "👁️ [VISUAL] persisted to Summary.visual_analysis (id=%s)",
+                        summary_id,
+                    )
+                except Exception as _vpe:
+                    logger.warning(
+                        "👁️ [VISUAL] persist failed (graceful): %s", _vpe
+                    )
+                    await session.rollback()
 
             _task_store[task_id]["progress"] = 97
             _task_store[task_id]["message"] = "🧩 Indexation et finalisation..."

--- a/backend/src/videos/schemas.py
+++ b/backend/src/videos/schemas.py
@@ -46,8 +46,8 @@ class AnalyzeVideoRequest(BaseModel):
     deep_research: bool = Field(default=False, description="🆕 Recherche approfondie (Expert only)")
     force_refresh: bool = Field(default=False, description="🆕 Ignorer le cache et forcer une nouvelle analyse")
     include_visual_analysis: bool = Field(
-        default=False,
-        description="🆕 Phase 2 : enrichir l'analyse avec une couche visuelle (frames + Mistral Vision). Pro/Expert uniquement, +2 crédits, quota mensuel 30 (Pro) / illimité (Expert).",
+        default=True,
+        description="🆕 Phase 2 (default ON): enrichir l'analyse avec une couche visuelle (frames + Mistral Vision). Pro/Expert uniquement, quota mensuel 30 (Pro) / illimité (Expert). Free skippé silencieusement par le quota check.",
     )
 
 
@@ -104,8 +104,8 @@ class AnalyzeVideoV2Request(BaseModel):
 
     # 🆕 Phase 2 : Visual Analysis (frames + Mistral Vision)
     include_visual_analysis: bool = Field(
-        default=False,
-        description="🆕 Phase 2 : enrichir l'analyse avec une couche visuelle (storyboards YouTube + Mistral Vision). Pro/Expert uniquement, +2 crédits, quota mensuel 30 (Pro) / illimité (Expert).",
+        default=True,
+        description="🆕 Phase 2 (default ON): enrichir l'analyse avec une couche visuelle (storyboards YouTube + Mistral Vision). Pro/Expert uniquement, quota mensuel 30 (Pro) / illimité (Expert). Free skippé silencieusement par le quota check.",
     )
 
     class Config:
@@ -294,6 +294,12 @@ class SummaryResponse(BaseModel):
     # Mistral à la demande sur le contenu existant. NULL si pas encore généré.
     # Forme : {key_quotes: [{quote, context?}], key_takeaways: [str], chapter_themes: [{theme, summary?}]}
     summary_extras: Optional[Dict[str, Any]] = None
+
+    # 👁️ Visual analysis (Phase 2 plumbing — alembic 024).
+    # Dict sérialisé d'une VisualAnalysis (frames + Mistral Vision).
+    # NULL = pas analysé visuellement (legacy avant Phase 2 plumbing, flag OFF,
+    # quota dépassé, ou Mistral fail).
+    visual_analysis: Optional[Dict[str, Any]] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- Phase 2 hook calculait `visual_analysis` mais ne le persistait pas → tabs UI affichaient `null` systématiquement
- Migration alembic 024 ajoute `summaries.visual_analysis JSON NULL`
- Storage du dict sérialisé après `save_summary()` (best-effort, graceful)
- Expose dans `SummaryResponse` schema (Pydantic from_attributes mappe auto)
- Flag `include_visual_analysis: bool` default `True` sur V1 + V2 requests
- Free skippé silencieusement par le quota check (gating existant maintenu)
- Pro 30/mois, Expert ∞ (quotas existants Phase 2)

## Test plan
- [x] Python syntax check (py_compile) sur tous les fichiers modifiés
- [ ] CI backend pytest pass
- [ ] Post-deploy : alembic upgrade head appliquera 024 automatiquement (entrypoint.sh) → table summaries a la colonne `visual_analysis`
- [ ] Test E2E : POST /api/videos/analyze sans `include_visual_analysis` → response GET /api/videos/{id} contient visual_analysis non-null pour user Pro

## Out of scope (follow-ups)
- ExtensionSummaryResponse — pas modifié, peut nécessiter le même champ si un user de l'extension veut afficher visual_analysis
- Tests régression backend dédiés (compter sur les tests E2E + smoke tests CI existants)
- Backfill : aucun — les analyses legacy n'auront pas visual_analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)