### PR TITLE
feat(visual): V2/V2.1 hook + ExtensionSummary + entrypoint heads plural

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -13,14 +13,22 @@
 # protects against runtime regressions.
 set -e
 
-echo "[entrypoint] Running alembic upgrade head from /app..."
+echo "[entrypoint] Running alembic upgrade heads from /app..."
 cd /app
-if alembic upgrade head; then
-    echo "[entrypoint] alembic upgrade head: OK"
+# Use `heads` (plural) to handle divergent migration branches gracefully —
+# `head` (singular) plante silencieusement quand 2+ heads sont présentes (cas
+# typique après merge de 2 branches feature qui ont chacune ajouté une migration
+# basée sur le même parent). Incident concret : sprint Visual Analysis Phase 2
+# 2026-05-06 — `019_visual_analysis_quota` + `022_summary_extras` divergeaient
+# à `018_hub_workspace`, `alembic upgrade head` échouait, container démarrait
+# sans migrations 023+024 appliquées.
+if alembic upgrade heads; then
+    echo "[entrypoint] alembic upgrade heads: OK"
 else
     echo "[entrypoint] WARNING: alembic upgrade failed (exit $?)."
-    echo "[entrypoint] Likely cause: Base.metadata.create_all() pre-created tables on a previous boot."
-    echo "[entrypoint] Container will start anyway. Run 'docker exec repo-backend-1 alembic stamp head' to resync."
+    echo "[entrypoint] Likely cause: Base.metadata.create_all() pre-created tables on a previous boot,"
+    echo "[entrypoint] OR alembic_version.version_num column trop courte (32 chars default — voir incident 023)."
+    echo "[entrypoint] Container will start anyway. Run 'docker exec repo-backend-1 alembic stamp heads' to resync."
 fi
 
 echo "[entrypoint] Handing off to uvicorn from /app/src..."

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -1466,6 +1466,25 @@ async def _analyze_video_background_v2(
             # Variable pour stocker les chunks (remplie si vidéo longue)
             _long_video_result = None
 
+            # 👁️ Phase 2 visual hook (V2) — enrich full_context + capture pour persist post-save
+            _visual_analysis_data: Optional[Dict[str, Any]] = None
+            if options.get("include_visual_analysis", True) and platform == "youtube":
+                from .visual_integration import enrich_and_capture_visual
+
+                _visual_flag_on = (
+                    os.getenv("VISUAL_ANALYSIS_ENABLED", "false").strip().lower()
+                    in {"1", "true", "yes", "on"}
+                )
+                full_context, _visual_analysis_data = await enrich_and_capture_visual(
+                    db=session,
+                    user_id=user_id,
+                    url=url,
+                    transcript_excerpt=transcript_to_analyze or "",
+                    web_context=full_context or "",
+                    flag_enabled=_visual_flag_on,
+                    log_tag=f"VISUAL_V2 user={user_id}",
+                )
+
             if needs_chunk:
                 _task_store[task_id]["message"] = f"📚 Vidéo longue ({word_count} mots)..."
 
@@ -1642,6 +1661,24 @@ async def _analyze_video_background_v2(
                 music_author=video_info.get("music_author"),
                 carousel_images=video_info.get("carousel_images"),
             )
+
+            # 👁️ Phase 2 plumbing V2 : persist visual_analysis si capturé.
+            if _visual_analysis_data is not None:
+                try:
+                    from sqlalchemy import update as sql_update
+                    await session.execute(
+                        sql_update(Summary)
+                        .where(Summary.id == summary_id)
+                        .values(visual_analysis=_visual_analysis_data)
+                    )
+                    await session.commit()
+                    logger.info(
+                        "👁️ [VISUAL_V2] persisted to Summary.visual_analysis (id=%s)",
+                        summary_id,
+                    )
+                except Exception as _vpe:
+                    logger.warning("👁️ [VISUAL_V2] persist failed (graceful): %s", _vpe)
+                    await session.rollback()
 
             _task_store[task_id]["progress"] = 97
             _task_store[task_id]["message"] = "🧩 Indexation et finalisation..."
@@ -2316,6 +2353,25 @@ async def _analyze_video_background_v2_1(
             # Variable pour stocker les chunks (remplie si vidéo longue)
             _long_video_result2 = None
 
+            # 👁️ Phase 2 visual hook (V2.1) — enrich full_context + capture pour persist post-save
+            _visual_analysis_data: Optional[Dict[str, Any]] = None
+            if options.get("include_visual_analysis", True) and platform == "youtube":
+                from .visual_integration import enrich_and_capture_visual
+
+                _visual_flag_on = (
+                    os.getenv("VISUAL_ANALYSIS_ENABLED", "false").strip().lower()
+                    in {"1", "true", "yes", "on"}
+                )
+                full_context, _visual_analysis_data = await enrich_and_capture_visual(
+                    db=session,
+                    user_id=user_id,
+                    url=url,
+                    transcript_excerpt=transcript_to_analyze or "",
+                    web_context=full_context or "",
+                    flag_enabled=_visual_flag_on,
+                    log_tag=f"VISUAL_V2.1 user={user_id}",
+                )
+
             if needs_chunk:
                 _task_store[task_id]["message"] = f"📚 Vidéo longue ({word_count} mots)..."
 
@@ -2509,6 +2565,24 @@ async def _analyze_video_background_v2_1(
                 music_author=video_info.get("music_author"),
                 carousel_images=video_info.get("carousel_images"),
             )
+
+            # 👁️ Phase 2 plumbing V2.1 : persist visual_analysis si capturé.
+            if _visual_analysis_data is not None:
+                try:
+                    from sqlalchemy import update as sql_update
+                    await session.execute(
+                        sql_update(Summary)
+                        .where(Summary.id == summary_id)
+                        .values(visual_analysis=_visual_analysis_data)
+                    )
+                    await session.commit()
+                    logger.info(
+                        "👁️ [VISUAL_V2.1] persisted to Summary.visual_analysis (id=%s)",
+                        summary_id,
+                    )
+                except Exception as _vpe:
+                    logger.warning("👁️ [VISUAL_V2.1] persist failed (graceful): %s", _vpe)
+                    await session.rollback()
 
             # 🆕 v4.0: Index structuré
             await _save_structured_index(
@@ -3689,6 +3763,7 @@ async def get_summary(
             category=summary.category,
             reliability_score=summary.reliability_score,
             tags=summary.tags,
+            visual_analysis=summary.visual_analysis,
         )
 
     # Format complet (défaut)

--- a/backend/src/videos/schemas.py
+++ b/backend/src/videos/schemas.py
@@ -667,6 +667,12 @@ class ExtensionSummary(BaseModel):
     video_title: str = Field(..., description="Titre de la vidéo")
     full_analysis_url: str = Field(..., description="URL vers l'analyse complète")
 
+    # 👁️ Visual analysis (Phase 2) — dict sérialisé d'une VisualAnalysis ou None.
+    # NULL = pas analysé visuellement (legacy avant Phase 2 plumbing, flag OFF,
+    # quota dépassé, ou Mistral fail). Permet à l'extension de skip /api/videos/{id}
+    # quand format=extension et avoir le visual_analysis directement.
+    visual_analysis: Optional[Dict[str, Any]] = None
+
 
 class ExtensionSummaryResponse(BaseModel):
     """Réponse condensée pour l'extension Chrome (format=extension)."""

--- a/backend/src/videos/summary_extractor.py
+++ b/backend/src/videos/summary_extractor.py
@@ -197,6 +197,7 @@ def extract_extension_summary(
     category: str = "general",
     reliability_score: Optional[float] = None,
     tags: Optional[str] = None,
+    visual_analysis: Optional[Dict[str, Any]] = None,
 ) -> ExtensionSummaryResponse:
     """
     Extrait un résumé condensé pour l'extension Chrome à partir du markdown complet.
@@ -254,5 +255,6 @@ def extract_extension_summary(
             tags=extracted_tags,
             video_title=title,
             full_analysis_url=full_analysis_url,
+            visual_analysis=visual_analysis,
         )
     )

--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -244,6 +244,78 @@ async def maybe_enrich_with_visual(
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# 🔌 HELPER UNIFIÉ — wraps maybe_enrich + format pour V1/V2/V2.1
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def enrich_and_capture_visual(
+    db: AsyncSession,
+    user_id: int,
+    url: str,
+    *,
+    transcript_excerpt: str,
+    web_context: str,
+    flag_enabled: bool,
+    log_tag: str,
+) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """
+    Helper unifié appelé par V1, V2, V2.1 pour appliquer le hook visual.
+
+    Flow :
+    1. Check flag VISUAL_ANALYSIS_ENABLED
+    2. Fetch user (pour quota check)
+    3. Run maybe_enrich_with_visual (extraction storyboards + Mistral Vision)
+    4. Si OK : append visual block à web_context + capture le dict
+    5. Si KO : log + retourne web_context inchangé, visual_analysis_data=None
+
+    Renvoie (updated_web_context, visual_analysis_data).
+    Le caller persist `visual_analysis_data` sur Summary.visual_analysis
+    après save_summary().
+
+    Best-effort — toute exception est attrapée et loggée (graceful degradation).
+    """
+    if not flag_enabled:
+        return web_context, None
+
+    try:
+        _user_q = await db.execute(select(User).where(User.id == user_id))
+        _user_row = _user_q.scalar_one_or_none()
+        if not _user_row:
+            return web_context, None
+
+        _visual = await maybe_enrich_with_visual(
+            db=db,
+            user=_user_row,
+            url=url,
+            transcript_excerpt=(transcript_excerpt or "")[:8000],
+            flag_enabled=True,
+        )
+        if _visual.get("status") != STATUS_OK:
+            logger.info("👁️ [%s] visual skipped: status=%s", log_tag, _visual.get("status"))
+            return web_context, None
+
+        _visual_block = format_visual_context_for_prompt(_visual)
+        new_web_context = web_context or ""
+        if _visual_block:
+            new_web_context = (
+                (new_web_context + "\n\n" + _visual_block) if new_web_context else _visual_block
+            )
+
+        logger.info(
+            "👁️ [%s] visual enrichment OK: frames=%d model=%s elapsed=%.1fs",
+            log_tag,
+            _visual.get("frame_count", 0),
+            _visual.get("model_used"),
+            _visual.get("elapsed_s", 0.0),
+        )
+        return new_web_context, _visual.get("analysis")
+    except Exception as e:
+        # Graceful — pas de raise. L'analyse de base continue sans la couche visuelle.
+        logger.warning("👁️ [%s] visual enrichment raised (graceful): %s", log_tag, e)
+        return web_context, None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # 📝 FORMAT POUR INJECTION DANS LE PROMPT
 # ═══════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- Cleanup des TODOs post-#397 : `entrypoint.sh heads` plural, helper unifié visual, hook V2/V2.1, ExtensionSummary champ
- V1 inchangé (zéro régression)

## Changes
- `backend/entrypoint.sh` : `alembic upgrade head` → `heads` (plural)
- `backend/src/videos/visual_integration.py` : nouveau helper `enrich_and_capture_visual()` 
- `backend/src/videos/router.py` : V2 + V2.1 backgrounds wirent le hook visual + persistent post-save
- `backend/src/videos/schemas.py` : `ExtensionSummary.visual_analysis: Optional[Dict]`
- `backend/src/videos/summary_extractor.py` : `extract_extension_summary()` propage visual_analysis

## Test plan
- [x] Python syntax check (py_compile) sur tous les fichiers
- [ ] CI backend pytest pass
- [ ] Post-deploy : V2 et V2.1 endpoints incluent désormais visual_analysis dans Summary persist
- [ ] `/api/videos/{id}?format=extension` retourne `extension_summary.visual_analysis` non-null pour analyses Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)