### PR TITLE
fix(visual): logger.warning takes only 1 positional arg

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -1673,11 +1673,10 @@ async def _analyze_video_background_v2(
                     )
                     await session.commit()
                     logger.info(
-                        "👁️ [VISUAL_V2] persisted to Summary.visual_analysis (id=%s)",
-                        summary_id,
+                        f"👁️ [VISUAL_V2] persisted to Summary.visual_analysis (id={summary_id})"
                     )
                 except Exception as _vpe:
-                    logger.warning("👁️ [VISUAL_V2] persist failed (graceful): %s", _vpe)
+                    logger.warning(f"👁️ [VISUAL_V2] persist failed (graceful): {_vpe}")
                     await session.rollback()
 
             _task_store[task_id]["progress"] = 97
@@ -2577,11 +2576,10 @@ async def _analyze_video_background_v2_1(
                     )
                     await session.commit()
                     logger.info(
-                        "👁️ [VISUAL_V2.1] persisted to Summary.visual_analysis (id=%s)",
-                        summary_id,
+                        f"👁️ [VISUAL_V2.1] persisted to Summary.visual_analysis (id={summary_id})"
                     )
                 except Exception as _vpe:
-                    logger.warning("👁️ [VISUAL_V2.1] persist failed (graceful): %s", _vpe)
+                    logger.warning(f"👁️ [VISUAL_V2.1] persist failed (graceful): {_vpe}")
                     await session.rollback()
 
             # 🆕 v4.0: Index structuré
@@ -3194,20 +3192,19 @@ async def _analyze_video_background_v6(
                                 # après save_summary() (alembic 024).
                                 _visual_analysis_data = _visual.get("analysis")
                                 logger.info(
-                                    "👁️ [VISUAL] enrichment OK: frames=%d model=%s elapsed=%.1fs",
-                                    _visual.get("frame_count", 0),
-                                    _visual.get("model_used"),
-                                    _visual.get("elapsed_s", 0.0),
+                                    f"👁️ [VISUAL] enrichment OK: "
+                                    f"frames={_visual.get('frame_count', 0)} "
+                                    f"model={_visual.get('model_used')} "
+                                    f"elapsed={_visual.get('elapsed_s', 0.0):.1f}s"
                                 )
                             else:
                                 logger.info(
-                                    "👁️ [VISUAL] skipped: status=%s",
-                                    _visual.get("status"),
+                                    f"👁️ [VISUAL] skipped: status={_visual.get('status')}"
                                 )
                 except Exception as _ve:
                     # Graceful degradation : aucune erreur visuelle ne bloque l'analyse
                     logger.warning(
-                        "👁️ [VISUAL] enrichment raised (graceful): %s", _ve
+                        f"👁️ [VISUAL] enrichment raised (graceful): {_ve}"
                     )
 
             if needs_chunk:
@@ -3435,12 +3432,11 @@ async def _analyze_video_background_v6(
                     )
                     await session.commit()
                     logger.info(
-                        "👁️ [VISUAL] persisted to Summary.visual_analysis (id=%s)",
-                        summary_id,
+                        f"👁️ [VISUAL] persisted to Summary.visual_analysis (id={summary_id})"
                     )
                 except Exception as _vpe:
                     logger.warning(
-                        "👁️ [VISUAL] persist failed (graceful): %s", _vpe
+                        f"👁️ [VISUAL] persist failed (graceful): {_vpe}"
                     )
                     await session.rollback()
 

--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -291,7 +291,7 @@ async def enrich_and_capture_visual(
             flag_enabled=True,
         )
         if _visual.get("status") != STATUS_OK:
-            logger.info("👁️ [%s] visual skipped: status=%s", log_tag, _visual.get("status"))
+            logger.info(f"👁️ [{log_tag}] visual skipped: status={_visual.get('status')}")
             return web_context, None
 
         _visual_block = format_visual_context_for_prompt(_visual)
@@ -302,16 +302,15 @@ async def enrich_and_capture_visual(
             )
 
         logger.info(
-            "👁️ [%s] visual enrichment OK: frames=%d model=%s elapsed=%.1fs",
-            log_tag,
-            _visual.get("frame_count", 0),
-            _visual.get("model_used"),
-            _visual.get("elapsed_s", 0.0),
+            f"👁️ [{log_tag}] visual enrichment OK: "
+            f"frames={_visual.get('frame_count', 0)} "
+            f"model={_visual.get('model_used')} "
+            f"elapsed={_visual.get('elapsed_s', 0.0):.1f}s"
         )
         return new_web_context, _visual.get("analysis")
     except Exception as e:
         # Graceful — pas de raise. L'analyse de base continue sans la couche visuelle.
-        logger.warning("👁️ [%s] visual enrichment raised (graceful): %s", log_tag, e)
+        logger.warning(f"👁️ [{log_tag}] visual enrichment raised (graceful): {e}")
         return web_context, None
 
 


### PR DESCRIPTION
Hotfix urgent — DeepSightLogger.warning() custom ne supporte pas lazy %s formatting. Plante à progress=50 sur POST /analyze. F-strings partout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)