### PR TITLE
fix(visual): Dict, Any imports manquants causes prod boot crash

### DIFF
--- a/backend/src/videos/summary_extractor.py
+++ b/backend/src/videos/summary_extractor.py
@@ -6,7 +6,7 @@
 """
 
 import re
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from .schemas import ExtensionKeyPoint, ExtensionSummary, ExtensionSummaryResponse
 


### PR DESCRIPTION
Hotfix urgent — `summary_extractor.py` plantait avec `NameError: Dict not defined`. Le param `visual_analysis: Optional[Dict[str, Any]]` ajouté en #402 utilisait Dict/Any sans les importer. Add typing.Any et Dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)