### PR TITLE
fix(visual): expose visual_analysis dans SummaryResponse handler

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3854,6 +3854,9 @@ async def get_summary(
         carousel_images=_carousel_images,
         # Summary extras (spike 2026-05-06) — null tant que pas généré
         summary_extras=getattr(summary, "summary_extras", None),
+        # Visual analysis (Phase 2 plumbing 2026-05-06) — null pour analyses
+        # legacy avant Phase 2, flag OFF, quota dépassé, ou Mistral fail.
+        visual_analysis=getattr(summary, "visual_analysis", None),
     )
 
 


### PR DESCRIPTION
Le handler GET oubliait `visual_analysis=getattr(summary, ...)` dans le constructeur SummaryResponse. DB a la donnée mais API retourne null. 1 ligne fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)