### PR TITLE
feat(tiktok): enrichir channel context avec scrape HTML profil

### DIFF
--- a/backend/src/transcripts/tiktok.py
+++ b/backend/src/transcripts/tiktok.py
@@ -1148,6 +1148,95 @@ def extract_tiktok_username_from_video_metadata(metadata: Dict[str, Any]) -> Opt
     return None
 
 
+# ── Regex utilisés pour extraire les méta du compte depuis la page HTML TikTok.
+# yt-dlp `--flat-playlist` retourne les entries (titres, view_count) mais en prod
+# les champs `channel`, `uploader`, `channel_follower_count`, `playlist_count`,
+# `description` reviennent à None — d'où ce fallback HTML scrape.
+_HTML_FOLLOWER_RE = re.compile(r'"followerCount":\s*(\d+)')
+_HTML_VIDEO_COUNT_RE = re.compile(r'"videoCount":\s*(\d+)')
+_HTML_NICKNAME_RE = re.compile(r'"nickname":"((?:[^"\\]|\\.)*)"')
+_HTML_SIGNATURE_RE = re.compile(r'"signature":"((?:[^"\\]|\\.)*)"')
+_HTML_VERIFIED_RE = re.compile(r'"verified":\s*(true|false)')
+
+_HTML_META_TIMEOUT_S = 10.0
+_HTML_META_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+def _decode_html_unicode_escapes(value: str) -> str:
+    """Décode les escapes JSON style \\u00e9 et \\\" dans une chaîne extraite de HTML."""
+    if not value:
+        return value
+    try:
+        return json.loads(f'"{value}"')
+    except (json.JSONDecodeError, ValueError):
+        return value
+
+
+async def _fetch_tiktok_account_meta_from_html(username: str) -> Optional[Dict[str, Any]]:
+    """Scrape la page utilisateur TikTok pour les méta du compte.
+
+    Renvoie un dict avec les clés présentes parmi
+    {nickname, signature, follower_count, video_count, verified} ou None
+    si le fetch ou le parse échoue. Best-effort, jamais raise.
+    """
+    if not username:
+        return None
+    url = f"https://www.tiktok.com/@{username}"
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=_HTML_META_TIMEOUT_S,
+            headers=_HTML_META_HEADERS,
+            follow_redirects=True,
+        ) as client:
+            resp = await client.get(url)
+        if resp.status_code != 200:
+            logger.info(
+                f"[TIKTOK] HTML meta fetch HTTP {resp.status_code} for @{username}"
+            )
+            return None
+        html = resp.text
+    except Exception as e:
+        logger.info(f"[TIKTOK] HTML meta fetch error for @{username}: {e}")
+        return None
+
+    if not html or len(html) < 1000:
+        return None
+
+    meta: Dict[str, Any] = {}
+    if (m := _HTML_NICKNAME_RE.search(html)):
+        meta["nickname"] = _decode_html_unicode_escapes(m.group(1))[:200]
+    if (m := _HTML_SIGNATURE_RE.search(html)):
+        meta["signature"] = _decode_html_unicode_escapes(m.group(1))[:2000]
+    if (m := _HTML_FOLLOWER_RE.search(html)):
+        try:
+            meta["follower_count"] = int(m.group(1))
+        except (TypeError, ValueError):
+            pass
+    if (m := _HTML_VIDEO_COUNT_RE.search(html)):
+        try:
+            meta["video_count"] = int(m.group(1))
+        except (TypeError, ValueError):
+            pass
+    if (m := _HTML_VERIFIED_RE.search(html)):
+        meta["verified"] = m.group(1) == "true"
+
+    if not meta:
+        return None
+
+    logger.info(
+        f"[TIKTOK] HTML meta @{username}: name={meta.get('nickname')!r}, "
+        f"followers={meta.get('follower_count')}, videos={meta.get('video_count')}, "
+        f"verified={meta.get('verified')}"
+    )
+    return meta
+
+
 async def get_tiktok_account_context(username: str, limit: int = 50) -> Optional[Dict[str, Any]]:
     """
     Récupère le contexte d'un compte TikTok : métadonnées + N derniers posts.
@@ -1194,58 +1283,78 @@ async def get_tiktok_account_context(username: str, limit: int = 50) -> Optional
 
     logger.info(f"[TIKTOK] Fetching account context for @{normalized_username} (limit={safe_limit})")
 
-    try:
-        loop = asyncio.get_event_loop()
+    loop = asyncio.get_event_loop()
 
-        def _fetch_account():
-            cmd = [
-                "yt-dlp",
-                *_yt_dlp_extra_args(),
-                "--flat-playlist",
-                "--dump-single-json",
-                "--playlist-items",
-                f"1:{safe_limit}",
-                "--no-warnings",
-                "--skip-download",
-                account_url,
-            ]
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-            if result.returncode != 0:
-                stderr = (result.stderr or "")[:300]
-                logger.warning(
-                    f"[TIKTOK] yt-dlp account fetch failed for @{normalized_username}: {stderr}"
-                )
-                return None
-            try:
-                return json.loads(result.stdout)
-            except json.JSONDecodeError as e:
-                logger.warning(f"[TIKTOK] yt-dlp account JSON parse error: {e}")
-                return None
+    def _fetch_account():
+        cmd = [
+            "yt-dlp",
+            *_yt_dlp_extra_args(),
+            "--flat-playlist",
+            "--dump-single-json",
+            "--playlist-items",
+            f"1:{safe_limit}",
+            "--no-warnings",
+            "--skip-download",
+            account_url,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        if result.returncode != 0:
+            stderr = (result.stderr or "")[:300]
+            logger.warning(
+                f"[TIKTOK] yt-dlp account fetch failed for @{normalized_username}: {stderr}"
+            )
+            return None
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            logger.warning(f"[TIKTOK] yt-dlp account JSON parse error: {e}")
+            return None
 
-        data = await asyncio.wait_for(
-            loop.run_in_executor(audio_executor, _fetch_account),
-            timeout=60,
-        )
-    except asyncio.TimeoutError:
-        logger.warning(f"[TIKTOK] Account fetch timeout for @{normalized_username}")
-        return None
-    except Exception as e:
-        logger.error(f"[TIKTOK] Account fetch error for @{normalized_username}: {e}")
-        return None
+    async def _fetch_yt_dlp():
+        try:
+            return await asyncio.wait_for(
+                loop.run_in_executor(audio_executor, _fetch_account),
+                timeout=60,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(f"[TIKTOK] yt-dlp account fetch timeout for @{normalized_username}")
+            return None
+        except Exception as e:
+            logger.error(f"[TIKTOK] yt-dlp account fetch error for @{normalized_username}: {e}")
+            return None
+
+    # Lance yt-dlp (entries) ET HTML scrape (méta du compte) en parallèle.
+    # En prod yt-dlp `--flat-playlist` ne renvoie pas channel/follower_count/playlist_count
+    # → seul le HTML scrape les fournit. Tests CI : si HTML fail, on retombe sur yt-dlp seul.
+    data, html_meta = await asyncio.gather(
+        _fetch_yt_dlp(),
+        _fetch_tiktok_account_meta_from_html(normalized_username),
+        return_exceptions=False,
+    )
 
     if not data or not isinstance(data, dict):
+        # yt-dlp est la source d'autorité pour exister/pas-exister (private,
+        # banned, suspended, etc.) — pas de fallback HTML-seul ici.
         return None
 
-    # Métadonnées du compte (champs yt-dlp pour une page de compte TikTok)
+    html_meta = html_meta if isinstance(html_meta, dict) else {}
+
+    # Métadonnées du compte — HTML scrape prioritaire (yt-dlp les retourne None en prod)
     display_name = (
-        data.get("channel")
+        html_meta.get("nickname")
+        or data.get("channel")
         or data.get("uploader")
         or data.get("title")
         or normalized_username
     )
-    description = data.get("description", "") or ""
+    description = (
+        html_meta.get("signature")
+        or data.get("description")
+        or ""
+    )
     subscriber_count = (
-        data.get("channel_follower_count")
+        html_meta.get("follower_count")
+        or data.get("channel_follower_count")
         or data.get("uploader_follower_count")
         or data.get("follower_count")
     )
@@ -1302,8 +1411,12 @@ async def get_tiktok_account_context(username: str, limit: int = 50) -> Optional
             }
         )
 
-    # video_count : on prend playlist_count si dispo, sinon le nombre d'entries
-    raw_video_count = data.get("playlist_count") or data.get("video_count")
+    # video_count : HTML scrape > playlist_count yt-dlp > nombre d'entries
+    raw_video_count = (
+        html_meta.get("video_count")
+        or data.get("playlist_count")
+        or data.get("video_count")
+    )
     if raw_video_count is not None:
         try:
             video_count = int(raw_video_count)

--- a/backend/tests/transcripts/test_tiktok_account.py
+++ b/backend/tests/transcripts/test_tiktok_account.py
@@ -66,6 +66,26 @@ def _make_entry(
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture(autouse=True)
+def _stub_html_meta_fetch(monkeypatch):
+    """Désactive le scrape HTML par défaut pour ne tester que la branche yt-dlp.
+
+    Les tests qui ciblent l'enrichissement HTML monkeypatchent eux-mêmes la
+    fonction avec leur propre stub.
+    """
+    from transcripts import tiktok
+
+    async def _stub(_username):
+        return None
+
+    monkeypatch.setattr(tiktok, "_fetch_tiktok_account_meta_from_html", _stub)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # get_tiktok_account_context()
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -398,3 +418,197 @@ class TestExtractTiktokUsernameFromMetadata:
 
         metadata = {"uploader_id": "user.name_42"}
         assert extract_tiktok_username_from_video_metadata(metadata) == "user.name_42"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HTML meta enrichment (_fetch_tiktok_account_meta_from_html + merging)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestTiktokHtmlMetaRegex:
+    """Tests des regex de parse HTML pour extraire follower_count, nickname, etc."""
+
+    def test_regex_extracts_follower_count(self):
+        from transcripts.tiktok import _HTML_FOLLOWER_RE
+
+        html = '...other stuff..."followerCount": 161200000,"otherField"...'
+        m = _HTML_FOLLOWER_RE.search(html)
+        assert m is not None
+        assert m.group(1) == "161200000"
+
+    def test_regex_extracts_video_count(self):
+        from transcripts.tiktok import _HTML_VIDEO_COUNT_RE
+
+        html = '..."videoCount":1322,...'
+        m = _HTML_VIDEO_COUNT_RE.search(html)
+        assert m is not None
+        assert m.group(1) == "1322"
+
+    def test_regex_extracts_nickname(self):
+        from transcripts.tiktok import _HTML_NICKNAME_RE
+
+        html = '..."nickname":"Khabane lame","other":...'
+        m = _HTML_NICKNAME_RE.search(html)
+        assert m is not None
+        assert m.group(1) == "Khabane lame"
+
+    def test_regex_extracts_signature_with_unicode_escapes(self):
+        from transcripts.tiktok import _HTML_SIGNATURE_RE, _decode_html_unicode_escapes
+
+        html = '..."signature":"Bio with caf\\u00e9 emoji","stat":...'
+        m = _HTML_SIGNATURE_RE.search(html)
+        assert m is not None
+        decoded = _decode_html_unicode_escapes(m.group(1))
+        assert decoded == "Bio with café emoji"
+
+    def test_regex_extracts_verified(self):
+        from transcripts.tiktok import _HTML_VERIFIED_RE
+
+        html_true = '..."verified":true,...'
+        html_false = '..."verified":false,...'
+        m_true = _HTML_VERIFIED_RE.search(html_true)
+        m_false = _HTML_VERIFIED_RE.search(html_false)
+        assert m_true is not None and m_true.group(1) == "true"
+        assert m_false is not None and m_false.group(1) == "false"
+
+    def test_decode_unicode_escapes_handles_quotes(self):
+        from transcripts.tiktok import _decode_html_unicode_escapes
+
+        # Backslash-escaped quote inside JSON-like string
+        assert _decode_html_unicode_escapes(r'foo \"bar\" baz') == 'foo "bar" baz'
+
+    def test_decode_unicode_escapes_returns_value_on_invalid(self):
+        from transcripts.tiktok import _decode_html_unicode_escapes
+
+        # Stray backslash that isn't a valid JSON escape — fall back to raw
+        weird = "foo \\Z bar"
+        assert _decode_html_unicode_escapes(weird) == weird
+
+
+class TestTiktokAccountContextHtmlMerging:
+    """Tests du merging HTML meta + yt-dlp dans get_tiktok_account_context()."""
+
+    @pytest.mark.asyncio
+    async def test_html_meta_overrides_yt_dlp_when_present(self, monkeypatch):
+        """yt-dlp renvoie meta=None (cas prod) → HTML meta remplit name/desc/subs/video_count."""
+        from transcripts import tiktok
+
+        async def _html_stub(_username):
+            return {
+                "nickname": "Khabane lame",
+                "signature": "Se vuoi ridere sei nel posto giusto",
+                "follower_count": 161200000,
+                "video_count": 1322,
+                "verified": True,
+            }
+
+        monkeypatch.setattr(tiktok, "_fetch_tiktok_account_meta_from_html", _html_stub)
+
+        # yt-dlp renvoie entries OK mais channel/uploader/follower=None (cas réel prod)
+        prod_payload = {
+            "channel": None,
+            "uploader": None,
+            "channel_follower_count": None,
+            "playlist_count": None,
+            "description": None,
+            "entries": [_make_entry(title="A test post #fyp")],
+        }
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(prod_payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("khaby.lame", limit=5)
+
+        assert ctx is not None
+        assert ctx["name"] == "Khabane lame"
+        assert ctx["description"] == "Se vuoi ridere sei nel posto giusto"
+        assert ctx["subscriber_count"] == 161200000
+        assert ctx["video_count"] == 1322
+        # last_videos toujours rempli depuis yt-dlp entries
+        assert len(ctx["last_videos"]) == 1
+        assert "fyp" in ctx["last_videos"][0]["tags"]
+
+    @pytest.mark.asyncio
+    async def test_html_meta_priority_over_yt_dlp_meta(self, monkeypatch):
+        """Quand yt-dlp et HTML donnent tous deux des méta → HTML gagne (plus fiable en prod)."""
+        from transcripts import tiktok
+
+        async def _html_stub(_username):
+            return {
+                "nickname": "From HTML",
+                "follower_count": 999_999,
+                "video_count": 50,
+            }
+
+        monkeypatch.setattr(tiktok, "_fetch_tiktok_account_meta_from_html", _html_stub)
+
+        yt_dlp_payload = _make_account_payload(
+            "user1",
+            [_make_entry()],
+            channel="From yt-dlp",
+            channel_follower_count=100,
+            playlist_count=10,
+        )
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(yt_dlp_payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("user1")
+
+        assert ctx is not None
+        assert ctx["name"] == "From HTML"
+        assert ctx["subscriber_count"] == 999_999
+        assert ctx["video_count"] == 50
+
+    @pytest.mark.asyncio
+    async def test_yt_dlp_failure_returns_none_even_with_html_meta(self, monkeypatch):
+        """Si yt-dlp fail (compte privé/banned) → return None, peu importe HTML.
+
+        Le HTML d'un compte privé peut renvoyer un 200 avec stub, on ne veut pas
+        retourner un faux 'partial dict' qui leurrerait le caller.
+        """
+        from transcripts import tiktok
+
+        async def _html_stub(_username):
+            return {"nickname": "Stub", "follower_count": 1}
+
+        monkeypatch.setattr(tiktok, "_fetch_tiktok_account_meta_from_html", _html_stub)
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(
+                1, stdout="", stderr="ERROR: account is private"
+            ),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("private_user")
+
+        assert ctx is None
+
+    @pytest.mark.asyncio
+    async def test_html_meta_none_falls_back_to_yt_dlp(self, monkeypatch):
+        """Si HTML scrape KO mais yt-dlp OK → fallback aux meta yt-dlp (legacy behavior)."""
+        from transcripts import tiktok
+
+        async def _html_none(_username):
+            return None
+
+        monkeypatch.setattr(tiktok, "_fetch_tiktok_account_meta_from_html", _html_none)
+
+        yt_dlp_payload = _make_account_payload(
+            "user1",
+            [_make_entry()],
+            channel="yt-dlp name",
+            channel_follower_count=42,
+        )
+
+        with patch.object(
+            tiktok.subprocess, "run",
+            return_value=_make_completed_process(0, stdout=json.dumps(yt_dlp_payload)),
+        ):
+            ctx = await tiktok.get_tiktok_account_context("user1")
+
+        assert ctx is not None
+        assert ctx["name"] == "yt-dlp name"
+        assert ctx["subscriber_count"] == 42


### PR DESCRIPTION
## Problème

`get_tiktok_account_context()` (alimente le hook `[CHANNEL-CTX]` de l'analyse vidéo TikTok) retournait des méta de compte vides en prod :

```json
{
  "channel_id": "khaby.lame",
  "name": "khaby.lame",        // ← devrait être "Khabane lame"
  "description": "",            // ← devrait être la bio
  "subscriber_count": null,    // ← devrait être 161 200 000
  "video_count": 3              // ← devrait être 1 322 (pris sur len(entries))
}
```

Cause root : `yt-dlp --flat-playlist --dump-single-json` depuis Hetzner ramène les `entries` (titres + view_count) mais TOUS les champs méta du compte (`channel`, `uploader`, `channel_follower_count`, `playlist_count`, `description`) reviennent `null`. Vérifié manuellement via SSH Hetzner sur `@khaby.lame`.

## Fix

Fetch en parallèle la page `https://www.tiktok.com/@<username>` (HTML SSR rendu serveur, ~280 KB) et extrait par regex :

| Champ HTML | Champ shape | Valeur exemple |
|------------|-------------|----------------|
| `\"nickname\":\"...\"` | `name` | "Khabane lame" |
| `\"signature\":\"...\"` | `description` | "Se vuoi ridere..." |
| `\"followerCount\":N` | `subscriber_count` | 161200000 |
| `\"videoCount\":N` | `video_count` | 1322 |
| `\"verified\":bool` | (logged only) | true |

Merge HTML > yt-dlp (HTML est plus fiable en prod). yt-dlp reste source d'autorité pour exister/pas-exister (compte privé/banned → return None, peu importe HTML).

## Tests

- Fixture `autouse` stub le HTML fetch → tests existants inchangés (zéro régression).
- 7 tests regex parsing (`TestTiktokHtmlMetaRegex`) : follower_count, video_count, nickname, signature avec unicode escapes, verified, decode `\u00e9` → `é`, fallback sur escape invalide.
- 4 tests merging (`TestTiktokAccountContextHtmlMerging`) : HTML override yt-dlp meta=None (cas prod), HTML > yt-dlp meta présentes, yt-dlp KO bloque même si HTML OK (compte privé), HTML KO fallback yt-dlp (legacy).

## Validation manuelle (SSH Hetzner backend container)

```python
ctx = await get_tiktok_account_context("khaby.lame", limit=3)
# Avant : name="khaby.lame", description="", subscriber_count=None, video_count=3
# Après : name="Khabane lame", description="Se vuoi ridere...", subscriber_count=161200000, video_count=1322
```

## Test plan

- [ ] CI tests backend verts
- [ ] Auto-deploy Hetzner OK (push to main)
- [ ] Test prod : analyser vidéo TikTok via `/api/videos/analyze` → vérifier logs `[CHANNEL-CTX] Fetched context for tiktok/<user>: name='Khabane lame', N recent videos`
- [ ] Vérifier qu'une analyse TikTok mentionne maintenant la chaîne dans son contexte

🤖 Generated with [Claude Code](https://claude.com/claude-code)