### PR TITLE
fix(api-key): allow Expert plan + admin bypass (was Pro-only)

### DIFF
--- a/backend/src/api_public/router.py
+++ b/backend/src/api_public/router.py
@@ -147,14 +147,15 @@ async def get_api_user(
             status_code=401, detail={"error": "invalid_api_key", "message": "Invalid or revoked API key"}
         )
 
-    # Vérifier le plan
-    if user.plan not in ["pro"]:
+    # Pro ET Expert ont accès à l'API publique. Admin bypass.
+    if not (user.is_admin or user.plan in ("pro", "expert")):
         raise HTTPException(
             status_code=403,
             detail={
                 "error": "plan_required",
-                "message": "API access requires Pro plan",
+                "message": "API access requires Pro or Expert plan",
                 "current_plan": user.plan,
+                "required_plans": ["pro", "expert"],
                 "upgrade_url": "https://www.deepsightsynthesis.com/upgrade",
             },
         )

--- a/backend/src/billing/router.py
+++ b/backend/src/billing/router.py
@@ -2430,17 +2430,17 @@ async def generate_user_api_key(
     ⚠️ IMPORTANT: La clé complète n'est affichée QU'UNE SEULE FOIS.
     Sauvegardez-la immédiatement car elle ne pourra plus être récupérée.
 
-    Disponible uniquement pour le plan Pro.
+    Disponible pour les plans Pro et Expert (admin bypass).
     """
-    # Vérifier le plan
-    if current_user.plan != "pro":
+    # Pro ET Expert ont accès à l'API publique. Admin bypass.
+    if not (current_user.is_admin or current_user.plan in ("pro", "expert")):
         raise HTTPException(
             status_code=403,
             detail={
                 "code": "plan_required",
-                "message": "API access requires Pro plan. Upgrade at /upgrade",
+                "message": "API access requires Pro or Expert plan. Upgrade at /upgrade",
                 "current_plan": current_user.plan,
-                "required_plan": "pro",
+                "required_plans": ["pro", "expert"],
             },
         )
 
@@ -2484,16 +2484,17 @@ async def regenerate_user_api_key(
     ⚠️ ATTENTION: L'ancienne clé sera immédiatement invalidée.
     Toutes les applications utilisant l'ancienne clé cesseront de fonctionner.
 
-    Disponible uniquement pour le plan Pro.
+    Disponible pour les plans Pro et Expert (admin bypass).
     """
-    # Vérifier le plan
-    if current_user.plan != "pro":
+    # Pro ET Expert ont accès à l'API publique. Admin bypass.
+    if not (current_user.is_admin or current_user.plan in ("pro", "expert")):
         raise HTTPException(
             status_code=403,
             detail={
                 "code": "plan_required",
-                "message": "API access requires Pro plan.",
+                "message": "API access requires Pro or Expert plan.",
                 "current_plan": current_user.plan,
+                "required_plans": ["pro", "expert"],
             },
         )
 

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -1914,7 +1914,9 @@ async def analyze_video_v2_1(
         logger.warning("⚠️ [v2.1] Comments analysis disabled (requires Pro)")
 
     # Analyse de propagande: Pro only (advanced feature)
-    if customization.detect_propaganda and current_user.plan not in ["pro"]:
+    if customization.detect_propaganda and not (
+        current_user.is_admin or current_user.plan in ("pro", "expert")
+    ):
         customization.detect_propaganda = False
         logger.warning("⚠️ [v2.1] Propaganda analysis disabled (requires Pro)")
 


### PR DESCRIPTION
## Summary

- Bug : check \`current_user.plan != \"pro\"\` rejetait les Expert (tier supérieur) sur 4 endpoints d'auth API key.
- Fix : \`if not (current_user.is_admin or current_user.plan in (\"pro\", \"expert\"))\` — Pro + Expert + admin acceptés.
- Débloque la génération d'API key pour les Expert et les comptes admin internes.

## Files

- \`backend/src/billing/router.py\` (lignes ~2436, ~2490)
- \`backend/src/api_public/router.py\` (ligne ~151)
- \`backend/src/videos/router.py\` (ligne ~1876, customization.detect_propaganda)

## Test plan

- [ ] Avec compte Expert : POST /api/billing/api-key/generate → 200 + ds_live_xxx
- [ ] Avec clé Expert : GET /api/v1/me → 200 (était 403 invalid_plan)
- [ ] Pro user existant garde son accès (backward-compat)
- [ ] Free user reste rejeté (403)
- [ ] Admin Free serait bypassé (defense in depth)

## Inconsistance signalée

Le test fixture local \`test_billing.py:PLAN_CONFIG\` dit \`pro.api_access=False / expert.api_access=True\` (Expert-only intent). Le fix accepte les deux pour ne pas casser les Pro avec clés déjà générées (backward-compat). Si le produit décide Expert-only à terme, retirer \"pro\" du tuple.

## Pré-requis prod

Aucun. Pas de migration, pas d'env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)