### PR TITLE
feat(visual): brancher Phase 2 visual analysis sur TikTok

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -1469,7 +1469,7 @@ async def _analyze_video_background_v2(
 
             # 👁️ Phase 2 visual hook (V2) — enrich full_context + capture pour persist post-save
             _visual_analysis_data: Optional[Dict[str, Any]] = None
-            if options.get("include_visual_analysis", True) and platform == "youtube":
+            if options.get("include_visual_analysis", True) and platform in ("youtube", "tiktok"):
                 from .visual_integration import enrich_and_capture_visual
 
                 _visual_flag_on = (
@@ -2361,7 +2361,7 @@ async def _analyze_video_background_v2_1(
 
             # 👁️ Phase 2 visual hook (V2.1) — enrich full_context + capture pour persist post-save
             _visual_analysis_data: Optional[Dict[str, Any]] = None
-            if options.get("include_visual_analysis", True) and platform == "youtube":
+            if options.get("include_visual_analysis", True) and platform in ("youtube", "tiktok"):
                 from .visual_integration import enrich_and_capture_visual
 
                 _visual_flag_on = (
@@ -3162,7 +3162,7 @@ async def _analyze_video_background_v6(
             # Best-effort : si échec, on continue sans la couche visuelle.
             # ═══════════════════════════════════════════════════════════════════
             _visual_analysis_data: Optional[Dict[str, Any]] = None
-            if include_visual_analysis and platform == "youtube":
+            if include_visual_analysis and platform in ("youtube", "tiktok"):
                 try:
                     from .visual_integration import (
                         STATUS_OK,

--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -5,8 +5,10 @@
 ║  Orchestre l'enrichissement visuel multimodal (Phase 2) :                         ║
 ║  1. Plan gating : Pro/Expert seulement (Free → upsell, jamais incrémenté)         ║
 ║  2. Quota mensuel : Pro=30, Expert=illimité (table visual_analysis_quota)         ║
-║  3. Extraction video_id YouTube (Phase 2 = YouTube uniquement)                    ║
-║  4. Pipeline Pivot 5 : extract_storyboard_frames + analyze_frames                 ║
+║  3. Extraction frames selon plateforme :                                          ║
+║     • YouTube → Pivot 5 storyboards (i.ytimg.com, no download)                    ║
+║     • TikTok  → download via tikwm fallback + ffmpeg frames (extract_frames_from_local)║
+║  4. Mistral Vision (analyze_frames, agnostic)                                     ║
 ║  5. Format visual context pour injection dans le prompt Mistral analysis          ║
 ║                                                                                    ║
 ║  Source de vérité quotas : core.plan_limits (DRY) ; ce module ne hardcode pas.    ║
@@ -15,8 +17,12 @@
 """
 
 import logging
+import re
+import tempfile
 import time
+import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from sqlalchemy import select
@@ -24,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.database import User, VisualAnalysisQuota
 
+from .frame_extractor import FrameExtractionResult, extract_frames_from_local
 from .visual_analyzer import analyze_frames
 from .youtube_storyboard import extract_storyboard_frames, normalize_video_id
 
@@ -56,7 +63,8 @@ STATUS_OK = "ok"
 STATUS_DISABLED = "disabled"  # flag VISUAL_ANALYSIS_ENABLED pas activé
 STATUS_PLAN_NOT_ALLOWED = "plan_not_allowed"  # Free
 STATUS_QUOTA_EXCEEDED = "quota_exceeded"
-STATUS_NOT_YOUTUBE = "not_youtube"  # URL TikTok/Vimeo, etc. — Phase 2 = YouTube uniquement
+STATUS_NOT_SUPPORTED = "not_supported"  # plateforme inconnue (Vimeo, etc.)
+STATUS_NOT_YOUTUBE = "not_youtube"  # rétro-compat — synonyme de not_supported pour callers existants
 STATUS_EXTRACT_FAILED = "extract_failed"
 STATUS_VISION_FAILED = "vision_failed"
 
@@ -178,25 +186,39 @@ async def maybe_enrich_with_visual(
         logger.info("[%s] Skipped (%s)", log_tag, reason)
         return {"status": reason, "elapsed_s": round(time.time() - t0, 2)}
 
-    # ── 2. URL → video_id YouTube ──
-    video_id = normalize_video_id(url)
-    if not video_id:
-        # Pas une URL/ID YouTube → Phase 2 ne couvre pas TikTok/Vimeo
+    # ── 2. Détection plateforme + extraction frames adaptée ──
+    platform = _detect_visual_platform(url)
+
+    if platform == "youtube":
+        video_id = normalize_video_id(url)
+        if not video_id:
+            return {
+                "status": STATUS_NOT_SUPPORTED,
+                "elapsed_s": round(time.time() - t0, 2),
+            }
+        extraction = await extract_storyboard_frames(video_id, log_tag=log_tag)
+        identifier_for_logs = video_id
+    elif platform == "tiktok":
+        # TikTok : download via tikwm fallback (IP Hetzner ban yt-dlp direct)
+        # → extract_frames_from_local → cleanup
+        video_id = _extract_tiktok_id_or_fallback(url)
+        extraction = await _extract_tiktok_visual_frames(url, video_id, log_tag=log_tag)
+        identifier_for_logs = video_id
+    else:
         return {
-            "status": STATUS_NOT_YOUTUBE,
+            "status": STATUS_NOT_SUPPORTED,
             "elapsed_s": round(time.time() - t0, 2),
         }
 
-    # ── 3. Extraction storyboards (Pivot 5) ──
-    extraction = await extract_storyboard_frames(video_id, log_tag=log_tag)
     if extraction is None:
         return {
             "status": STATUS_EXTRACT_FAILED,
-            "video_id": video_id,
+            "video_id": identifier_for_logs,
+            "platform": platform,
             "elapsed_s": round(time.time() - t0, 2),
         }
 
-    # ── 4. Mistral Vision ──
+    # ── 3. Mistral Vision (commun à toutes plateformes) ──
     try:
         analysis = await analyze_frames(
             extraction.frame_paths,
@@ -210,19 +232,21 @@ async def maybe_enrich_with_visual(
     if analysis is None:
         return {
             "status": STATUS_VISION_FAILED,
-            "video_id": video_id,
+            "video_id": identifier_for_logs,
+            "platform": platform,
             "frame_count": extraction.frame_count,
             "elapsed_s": round(time.time() - t0, 2),
         }
 
-    # ── 5. Quota incrément (succès uniquement) ──
+    # ── 4. Quota incrément (succès uniquement) ──
     new_count = await increment_quota(db, user.id)
 
     elapsed = round(time.time() - t0, 2)
     logger.info(
-        "[%s] OK in %.1fs (frames=%d model=%s quota_count=%d)",
+        "[%s] OK in %.1fs (platform=%s frames=%d model=%s quota_count=%d)",
         log_tag,
         elapsed,
+        platform,
         extraction.frame_count,
         analysis.model_used,
         new_count,
@@ -230,7 +254,8 @@ async def maybe_enrich_with_visual(
 
     return {
         "status": STATUS_OK,
-        "video_id": video_id,
+        "video_id": identifier_for_logs,
+        "platform": platform,
         "frame_count": extraction.frame_count,
         "duration_s": round(extraction.duration_s, 2),
         "model_used": analysis.model_used,
@@ -240,6 +265,96 @@ async def maybe_enrich_with_visual(
         "quota_count_after": new_count,
         "elapsed_s": elapsed,
     }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎬 EXTRACTION FRAMES PAR PLATEFORME
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+_TIKTOK_HOSTS_RE = re.compile(r"(?:^|\.)(?:tiktok\.com|vm\.tiktok\.com)", re.IGNORECASE)
+
+
+def _detect_visual_platform(url: str) -> str:
+    """Détecte la plateforme à partir de l'URL.
+
+    Returns:
+        "youtube" | "tiktok" | "unknown"
+    """
+    if not url:
+        return "unknown"
+    if _TIKTOK_HOSTS_RE.search(url):
+        return "tiktok"
+    if normalize_video_id(url):
+        return "youtube"
+    # Fallback : pas de match URL mais peut-être une chaîne d'ID YouTube brut
+    return "unknown"
+
+
+def _extract_tiktok_id_or_fallback(url: str) -> str:
+    """Extrait l'ID vidéo TikTok ou retourne 'tiktok_<rand>' en fallback (logs only)."""
+    try:
+        from transcripts.tiktok import extract_tiktok_video_id
+
+        vid = extract_tiktok_video_id(url)
+        if vid:
+            return vid
+    except Exception:
+        pass
+    return f"tiktok_{uuid.uuid4().hex[:8]}"
+
+
+async def _extract_tiktok_visual_frames(
+    url: str, video_id: str, *, log_tag: str
+) -> Optional[FrameExtractionResult]:
+    """Pipeline TikTok : download bytes → /tmp file → extract_frames_from_local.
+
+    L'IP Hetzner est ban TikTok pour `yt-dlp <video_url>` direct, donc on
+    réutilise `_download_video_bytes()` qui a un fallback tikwm.com éprouvé
+    en prod (utilisé par Phase 5 Visual OCR du transcript).
+    """
+    # Lazy import : évite cycle transcripts → videos → transcripts
+    try:
+        from transcripts.tiktok import _download_video_bytes
+    except Exception as e:
+        logger.warning("[%s] _download_video_bytes import failed: %s", log_tag, e)
+        return None
+
+    t0 = time.time()
+    try:
+        video_data = await _download_video_bytes(url, video_id)
+    except Exception as e:
+        logger.warning("[%s] TikTok download raised: %s", log_tag, e)
+        return None
+
+    if not video_data:
+        logger.warning("[%s] TikTok download returned empty for %s", log_tag, video_id)
+        return None
+
+    logger.info(
+        "[%s] TikTok download OK in %.1fs (%.0f KB)",
+        log_tag,
+        time.time() - t0,
+        len(video_data) / 1024,
+    )
+
+    # Sauvegarde fichier temporaire — extract_frames_from_local lira ffprobe + ffmpeg
+    tmp_path = Path(tempfile.gettempdir()) / f"tk_visual_{video_id}_{uuid.uuid4().hex[:8]}.mp4"
+    try:
+        tmp_path.write_bytes(video_data)
+    except OSError as e:
+        logger.warning("[%s] Failed to write tmp file %s: %s", log_tag, tmp_path, e)
+        return None
+
+    try:
+        result = await extract_frames_from_local(str(tmp_path), log_tag=f"{log_tag} TIKTOK")
+    finally:
+        # Le mp4 source n'est plus utile une fois les frames extraites — peu importe le résultat
+        tmp_path.unlink(missing_ok=True)
+
+    if result is None:
+        logger.warning("[%s] TikTok ffmpeg extraction returned None for %s", log_tag, video_id)
+    return result
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/tests/videos/test_visual_integration.py
+++ b/backend/tests/videos/test_visual_integration.py
@@ -239,16 +239,17 @@ class TestMaybeEnrichWithVisual:
         assert result["status"] == STATUS_PLAN_NOT_ALLOWED
 
     @pytest.mark.asyncio
-    async def test_non_youtube_url_returns_not_youtube(self, monkeypatch):
+    async def test_unsupported_platform_returns_not_supported(self, monkeypatch):
+        """Vimeo (et tout host non YouTube/TikTok) → STATUS_NOT_SUPPORTED."""
         from videos import visual_integration as vi
-        from videos.visual_integration import STATUS_NOT_YOUTUBE
+        from videos.visual_integration import STATUS_NOT_SUPPORTED
 
         db = AsyncMock()
         user = _make_user("expert")  # Bypass quota
         result = await vi.maybe_enrich_with_visual(
-            db, user, "https://www.tiktok.com/@user/video/123"
+            db, user, "https://vimeo.com/123456789"
         )
-        assert result["status"] == STATUS_NOT_YOUTUBE
+        assert result["status"] == STATUS_NOT_SUPPORTED
 
     @pytest.mark.asyncio
     async def test_quota_exceeded(self):
@@ -335,6 +336,7 @@ class TestMaybeEnrichWithVisual:
 
         assert result["status"] == STATUS_OK
         assert result["video_id"] == "dQw4w9WgXcQ"
+        assert result["platform"] == "youtube"
         assert result["frame_count"] == 2
         assert result["model_used"] == "pixtral-large-2411"
         assert result["credits_consumed"] == 2
@@ -342,3 +344,151 @@ class TestMaybeEnrichWithVisual:
         assert "elapsed_s" in result
         # cleanup a été appelé pour purger les frames
         fake_extraction.cleanup.assert_called_once()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔍 _detect_visual_platform — routing par URL
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDetectVisualPlatform:
+    def test_youtube_watch_url(self):
+        from videos.visual_integration import _detect_visual_platform
+
+        assert _detect_visual_platform("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == "youtube"
+
+    def test_youtube_short_url(self):
+        from videos.visual_integration import _detect_visual_platform
+
+        assert _detect_visual_platform("https://youtu.be/dQw4w9WgXcQ") == "youtube"
+
+    def test_youtube_shorts_url(self):
+        from videos.visual_integration import _detect_visual_platform
+
+        assert _detect_visual_platform("https://www.youtube.com/shorts/dQw4w9WgXcQ") == "youtube"
+
+    def test_tiktok_canonical_url(self):
+        from videos.visual_integration import _detect_visual_platform
+
+        assert _detect_visual_platform("https://www.tiktok.com/@user/video/12345") == "tiktok"
+
+    def test_tiktok_short_url(self):
+        from videos.visual_integration import _detect_visual_platform
+
+        assert _detect_visual_platform("https://vm.tiktok.com/ABCDE/") == "tiktok"
+
+    def test_vimeo_returns_unknown(self):
+        from videos.visual_integration import _detect_visual_platform
+
+        assert _detect_visual_platform("https://vimeo.com/123456") == "unknown"
+
+    def test_empty_url_returns_unknown(self):
+        from videos.visual_integration import _detect_visual_platform
+
+        assert _detect_visual_platform("") == "unknown"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎵 maybe_enrich_with_visual — branche TikTok
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMaybeEnrichWithVisualTiktok:
+    @pytest.mark.asyncio
+    async def test_tiktok_extract_failed(self, monkeypatch):
+        """Si _extract_tiktok_visual_frames retourne None (download/ffmpeg KO) → EXTRACT_FAILED."""
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_EXTRACT_FAILED
+
+        db = AsyncMock()
+        user = _make_user("expert")
+
+        async def fake_tiktok_extract(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(vi, "_extract_tiktok_visual_frames", fake_tiktok_extract)
+
+        result = await vi.maybe_enrich_with_visual(
+            db, user, "https://www.tiktok.com/@khaby.lame/video/7459716872551976210"
+        )
+        assert result["status"] == STATUS_EXTRACT_FAILED
+        assert result["platform"] == "tiktok"
+
+    @pytest.mark.asyncio
+    async def test_tiktok_happy_path(self, monkeypatch):
+        """TikTok download + frame extraction OK → analyse Mistral → STATUS_OK avec platform=tiktok."""
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_OK
+        from videos.frame_extractor import FrameExtractionResult
+        from videos.visual_analyzer import VisualAnalysis
+
+        db = _make_db_with_no_quota_row()
+        user = _make_user("expert")
+
+        fake_extraction = FrameExtractionResult(
+            workdir="/tmp/fake_tk",
+            frame_paths=["/tmp/fake_tk/f1.jpg", "/tmp/fake_tk/f2.jpg", "/tmp/fake_tk/f3.jpg"],
+            frame_timestamps=[0.5, 5.0, 12.0],
+            duration_s=15.0,
+            fps_used=0.2,
+            frame_count=3,
+            width=512,
+            long_video_warning=False,
+        )
+        fake_extraction.cleanup = MagicMock()
+
+        async def fake_tiktok_extract(*args, **kwargs):
+            return fake_extraction
+
+        async def fake_analyze(*args, **kwargs):
+            return VisualAnalysis(
+                visual_hook="Plan TikTok punchy",
+                visual_structure="vertical_pov",
+                key_moments=[{"timestamp_s": 0.5, "description": "Reveal", "type": "hook"}],
+                visible_text="learnfromkhaby",
+                summary_visual="Vidéo verticale comique sans dialogue",
+                model_used="pixtral-large-2411",
+                frames_analyzed=3,
+                frames_downsampled=False,
+            )
+
+        monkeypatch.setattr(vi, "_extract_tiktok_visual_frames", fake_tiktok_extract)
+        monkeypatch.setattr(vi, "analyze_frames", fake_analyze)
+
+        result = await vi.maybe_enrich_with_visual(
+            db,
+            user,
+            "https://www.tiktok.com/@khaby.lame/video/7459716872551976210",
+            transcript_excerpt="(comédie silencieuse)",
+        )
+
+        assert result["status"] == STATUS_OK
+        assert result["platform"] == "tiktok"
+        assert result["frame_count"] == 3
+        assert result["model_used"] == "pixtral-large-2411"
+        assert result["analysis"]["visual_structure"] == "vertical_pov"
+        fake_extraction.cleanup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tiktok_extract_uses_id_from_url(self, monkeypatch):
+        """Vérifie que l'extraction reçoit bien l'ID vidéo TikTok depuis l'URL."""
+        from videos import visual_integration as vi
+
+        db = AsyncMock()
+        user = _make_user("expert")
+
+        captured = {}
+
+        async def fake_tiktok_extract(url, video_id, *, log_tag=""):
+            captured["url"] = url
+            captured["video_id"] = video_id
+            return None  # Trigger EXTRACT_FAILED, peu importe ici
+
+        monkeypatch.setattr(vi, "_extract_tiktok_visual_frames", fake_tiktok_extract)
+
+        await vi.maybe_enrich_with_visual(
+            db, user, "https://www.tiktok.com/@khaby.lame/video/7459716872551976210"
+        )
+
+        assert captured["url"] == "https://www.tiktok.com/@khaby.lame/video/7459716872551976210"
+        assert captured["video_id"] == "7459716872551976210"


### PR DESCRIPTION
## Problème

Phase 2 visual analysis (mergée 2026-05-06) ne couvrait que YouTube. Les analyses TikTok n'avaient pas de hook visual → tab Visuel toujours vide pour les vidéos TikTok.

Cause root : `if include_visual_analysis and platform == \"youtube\"` aux 3 hooks (V1/V2/V2.1) du router, et `maybe_enrich_with_visual()` retournait `STATUS_NOT_YOUTUBE` pour toute URL non-YouTube.

Blocage technique sur le port YouTube → TikTok : l'IP Hetzner est bannie par TikTok pour `yt-dlp <video_url>` (\"Your IP address is blocked from accessing this post\" — testé manuellement). Donc le path \"yt-dlp video → ffmpeg\" ne marche pas tel quel.

## Solution

Réutiliser `_download_video_bytes()` de `transcripts/tiktok.py` qui a déjà un fallback `tikwm.com` éprouvé en prod (utilisé par Phase 5 Visual OCR du transcript depuis avril). Une fois le mp4 en bytes → écrit dans /tmp → `extract_frames_from_local()` (helper existant dans `frame_extractor.py`) qui fait ffprobe + ffmpeg + budget frames + cleanup.

## Modifications

### `videos/visual_integration.py`
- `_detect_visual_platform(url)` — route URL → \"youtube\" | \"tiktok\" | \"unknown\"
- `_extract_tiktok_visual_frames(url, vid, log_tag)` — download bytes (tikwm fallback) → tmp .mp4 → `extract_frames_from_local` → cleanup mp4
- `maybe_enrich_with_visual` : branching par plateforme pour l'extraction. Pipeline `analyze_frames` (Mistral Vision) reste agnostic.
- Nouveau status `STATUS_NOT_SUPPORTED` pour Vimeo/inconnu. `STATUS_NOT_YOUTUBE` conservé en alias rétro-compat.
- Ajoute champ `platform` dans tous les returns (non-breaking, downstream callers ne le lisent pas).

### `videos/router.py` (3 hooks)
- V1 ligne 3163, V2 ligne 1472, V2.1 ligne 2362 : `platform == \"youtube\"` → `platform in (\"youtube\", \"tiktok\")`

### Tests
- Adapte `test_non_youtube_url_returns_not_youtube` → utilise URL Vimeo, asserte `STATUS_NOT_SUPPORTED`
- Nouveau `TestDetectVisualPlatform` : 7 tests (yt watch/short/shorts, tk canonical/vm, vimeo, empty)
- Nouveau `TestMaybeEnrichWithVisualTiktok` : extract_failed (status + platform=tiktok), happy_path (vertical_pov, frame_count=3, cleanup), id-from-url (capture le video_id passé à l'extract)

## Plan d'abonnement / quotas

Aucun changement. Quota Phase 2 partagé YouTube + TikTok dans la même table `visual_analysis_quota` :
- Free 0/mois, Pro 30/mois, Expert illimité.
- Crédit 2 par appel succès (inchangé).

## Validation manuelle

```bash
# Confirmé que yt-dlp direct TikTok est bloqué depuis Hetzner :
ssh root@89.167.23.214 docker exec repo-backend-1 yt-dlp -f \"best[ext=mp4]/best\" \
    \"https://www.tiktok.com/@khaby.lame/video/7459716872551976210\"
# → ERROR: [TikTok] ... Your IP address is blocked from accessing this post

# ffmpeg dispo dans le container :
# → ffmpeg version 7.1.3-0+deb13u1
```

`_download_video_bytes()` est déjà utilisé en prod par Phase 5 OCR transcript via le même flow tikwm.com → bytes → ffmpeg, donc le pattern est validé.

## Test plan

- [ ] CI tests backend verts
- [ ] Auto-deploy Hetzner OK (push to main)
- [ ] Test prod : analyser une vidéo TikTok via `/api/videos/analyze` → vérifier que `summaries.visual_analysis` est non-NULL et que la tab Visuel se remplit dans frontend / mobile / extension
- [ ] Surveiller logs `[VISUAL_INT] OK in N.Ns (platform=tiktok frames=K ...)` dans backend container

🤖 Generated with [Claude Code](https://claude.com/claude-code)