### PR TITLE
fix(api-public): name collision get_task_status caused 500 on /api/v1/analyze/status

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3674,10 +3674,20 @@ async def cancel_task(
 
 
 @router.get("/status/{task_id}", response_model=TaskStatusResponse)
-async def get_task_status(
+async def get_task_status_endpoint(
     task_id: str, current_user: User = Depends(get_current_user), session: AsyncSession = Depends(get_session)
 ):
-    """Récupère le status d'une tâche d'analyse"""
+    """Récupère le status d'une tâche d'analyse.
+
+    NOTE 2026-05-07 : renommé `get_task_status` → `get_task_status_endpoint`
+    pour éliminer la collision avec le helper `get_task_status(task_id)` défini
+    plus haut (ligne 252). Sans ce renommage, l'import `from videos.router
+    import get_task_status` (utilisé par `api_public/router.py`) résolvait vers
+    le route handler à cause de Python's last-definition-wins, qui exigeait des
+    Depends non-résolus → AttributeError 'Depends' object has no attribute 'id'.
+    Le décorateur `@router.get(...)` enregistre la route par URL, le nom de la
+    fonction est purement identitaire — pas de breaking change pour le client.
+    """
 
     # Gérer les task_id de cache (format: cached_<summary_id>)
     if task_id.startswith("cached_"):


### PR DESCRIPTION
## Summary

- Bug 500 sur \`GET /api/v1/analyze/status/{task_id}\` → bloquait totalement le polling de tout client de l'API publique.
- Cause : 2 fonctions \`get_task_status\` dans \`videos/router.py\` (helper ligne 252 + route handler ligne 3676), Python's last-wins faisait que \`api_public/router.py\` importait le route handler avec ses \`Depends\` non-résolus → \`AttributeError: 'Depends' object has no attribute 'id'\`.
- Fix : rename la route en \`get_task_status_endpoint\`, le décorateur \`@router.get(...)\` continue de routter par URL — pas de breaking change client.

## Repro

\`\`\`bash
curl -H \"X-API-Key: ds_live_xxx\" -X POST https://api.deepsightsynthesis.com/api/v1/analyze \
  -d '{\"url\":\"https://www.youtube.com/watch?v=jNQXAC9IVRw\"}'
# → {\"task_id\":\"api_xxx\",\"status\":\"pending\"}
curl -H \"X-API-Key: ds_live_xxx\" https://api.deepsightsynthesis.com/api/v1/analyze/status/api_xxx
# → 500 \"'Depends' object has no attribute 'id'\"  ← BUG
\`\`\`

Stack trace (prod, error_id \`a6290df6\`) — voir commit body.

## Test plan

- [ ] Apres deploy : POST /api/v1/analyze → 200 task_id
- [ ] Poll /api/v1/analyze/status/{task_id} → 200 (était 500)
- [ ] Status terminal renvoie summary_id
- [ ] L'endpoint web \`/api/videos/status/{task_id}\` reste fonctionnel (déco @router.get inchangé)

## Pre-requisites

Aucun. Pas de migration. Compatible 100% backward avec clients existants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)