### PR TITLE
feat(billing): track acquisition_channel in Stripe metadata

### DIFF
--- a/backend/src/billing/router.py
+++ b/backend/src/billing/router.py
@@ -142,7 +142,63 @@ def init_stripe():
     return False
 
 
-async def get_or_create_stripe_customer(user: User, session: AsyncSession, force_recreate: bool = False) -> str:
+# ─────────────────────────────────────────────────────────────────────────────
+# 🎯 Acquisition channel — vocabulaire SSOT aligné avec PostHog signup_source
+# ─────────────────────────────────────────────────────────────────────────────
+ALLOWED_ACQUISITION_CHANNELS: frozenset[str] = frozenset({
+    "product_hunt",
+    "twitter",
+    "reddit",
+    "linkedin",
+    "indiehackers",
+    "hackernews",
+    "karim_inmail",
+    "mobile_deeplink",
+    "test",
+    "direct",
+})
+
+_ACQUISITION_CHANNEL_ALIASES: dict[str, str] = {
+    "ph": "product_hunt",
+    "producthunt": "product_hunt",
+    "x": "twitter",
+    "ih": "indiehackers",
+    "indie": "indiehackers",
+    "hn": "hackernews",
+    "y_combinator": "hackernews",
+    "ycombinator": "hackernews",
+    "li": "linkedin",
+    "linked_in": "linkedin",
+}
+
+
+def normalize_acquisition_channel(raw: Optional[str]) -> str:
+    """Normalise et valide une valeur acquisition_channel.
+
+    Returns "direct" si la valeur est invalide ou absente. Ne raise jamais
+    pour ne pas bloquer un checkout sur un mauvais tracking côté client.
+    """
+    if not raw or not isinstance(raw, str):
+        return "direct"
+    norm = raw.strip().lower().replace("-", "_").replace(" ", "_")
+    if not norm:
+        return "direct"
+    norm = _ACQUISITION_CHANNEL_ALIASES.get(norm, norm)
+    if norm not in ALLOWED_ACQUISITION_CHANNELS:
+        logger.warning(
+            "Unknown acquisition_channel '%s' (normalized '%s'), defaulting to direct",
+            raw, norm,
+        )
+        return "direct"
+    return norm
+
+
+async def get_or_create_stripe_customer(
+    user: User,
+    session: AsyncSession,
+    force_recreate: bool = False,
+    acquisition_channel: Optional[str] = None,
+) -> str:
     """
     🔧 Récupère ou crée un client Stripe.
     Gère le cas où le client existe en mode test mais pas en mode live.
@@ -151,17 +207,31 @@ async def get_or_create_stripe_customer(user: User, session: AsyncSession, force
         user: L'utilisateur
         session: Session DB
         force_recreate: Force la recréation du client
+        acquisition_channel: Canal d'acquisition (premier-touch immutable —
+            si le Customer existe déjà avec une metadata acquisition_channel,
+            la valeur EXISTANTE est préservée. Backfill défensif uniquement
+            si le champ est absent).
 
     Returns:
         L'ID du client Stripe
     """
+    channel = normalize_acquisition_channel(acquisition_channel)
+    base_metadata = {
+        "user_id": str(user.id),
+        "acquisition_channel": channel,
+        "first_checkout_at": datetime.now(timezone.utc).isoformat(),
+    }
+
     # Si pas d'ID existant ou force_recreate, créer directement
     if not user.stripe_customer_id or force_recreate:
-        logger.info(f"Creating new Stripe customer for user {user.id}")
+        logger.info(
+            "Creating new Stripe customer for user %s (channel=%s)",
+            user.id, channel,
+        )
         customer = stripe.Customer.create(
             email=user.email,
             name=user.username or user.email,
-            metadata={"user_id": str(user.id)},
+            metadata=base_metadata,
         )
         user.stripe_customer_id = customer.id
         await session.commit()
@@ -173,6 +243,23 @@ async def get_or_create_stripe_customer(user: User, session: AsyncSession, force
         customer = stripe.Customer.retrieve(user.stripe_customer_id)
         if customer.get("deleted"):
             raise stripe.error.InvalidRequestError("Customer deleted", None)
+        # 🎯 Backfill défensif : Customer existant créé avant ce sprint
+        # n'a pas acquisition_channel. On ajoute SANS écraser autre metadata.
+        # Premier-touch wins : si déjà présent, on ne touche RIEN.
+        existing_meta = customer.get("metadata") or {}
+        if "acquisition_channel" not in existing_meta:
+            try:
+                merged = {**existing_meta, **base_metadata}
+                stripe.Customer.modify(
+                    user.stripe_customer_id,
+                    metadata=merged,
+                )
+                logger.info(
+                    "Backfilled acquisition_channel=%s on existing customer %s",
+                    channel, user.stripe_customer_id,
+                )
+            except stripe.error.StripeError as e:
+                logger.warning("Backfill metadata failed: %s", e)
         logger.info(f"Found existing Stripe customer: {user.stripe_customer_id}")
         return user.stripe_customer_id
     except stripe.error.InvalidRequestError as e:
@@ -183,7 +270,7 @@ async def get_or_create_stripe_customer(user: User, session: AsyncSession, force
         customer = stripe.Customer.create(
             email=user.email,
             name=user.username or user.email,
-            metadata={"user_id": str(user.id)},
+            metadata=base_metadata,
         )
         user.stripe_customer_id = customer.id
         await session.commit()
@@ -719,6 +806,10 @@ class CreateCheckoutByPlanId(BaseModel):
     plan: Optional[str] = None    # "pro" | "expert"
     cycle: str = "monthly"         # "monthly" | "yearly"
     plan_id: Optional[str] = None  # legacy alias of plan
+    # 🎯 Attribution launch J0 — premier-touch immutable.
+    # Vocabulaire SSOT (cf. ALLOWED_ACQUISITION_CHANNELS).
+    # Valeur invalide ou absente → "direct" (jamais 4xx).
+    acquisition_channel: Optional[str] = None
 
 
 @router.post("/create-checkout")
@@ -767,18 +858,18 @@ async def create_checkout_by_plan_id(
             detail=f"Plan {plan} ({request.cycle}) price not configured",
         )
 
-    # Créer ou récupérer le client Stripe
-    if current_user.stripe_customer_id:
-        customer_id = current_user.stripe_customer_id
-    else:
-        customer = stripe.Customer.create(
-            email=current_user.email,
-            name=current_user.username or current_user.email,
-            metadata={"user_id": str(current_user.id)},
-        )
-        customer_id = customer.id
-        current_user.stripe_customer_id = customer_id
-        await session.commit()
+    # 🎯 Acquisition channel — normalisé en amont, partagé entre Customer
+    # metadata (premier-touch immutable côté Stripe) et Session metadata
+    # (lu par le webhook handler sans round-trip Stripe).
+    acquisition_channel = normalize_acquisition_channel(request.acquisition_channel)
+
+    # Créer ou récupérer le client Stripe via helper centralisé
+    # (gère premier-touch immutable + backfill défensif).
+    customer_id = await get_or_create_stripe_customer(
+        current_user,
+        session,
+        acquisition_channel=request.acquisition_channel,
+    )
 
     # URLs de retour (avec plan + cycle pour affichage immédiat)
     success_url = (
@@ -805,6 +896,8 @@ async def create_checkout_by_plan_id(
                 "user_id": str(current_user.id),
                 "plan": plan,
                 "cycle": request.cycle,
+                # 🎯 Propagé pour webhook (évite round-trip Customer.retrieve)
+                "acquisition_channel": acquisition_channel,
             },
         )
 
@@ -1780,6 +1873,21 @@ async def handle_checkout_completed(session: AsyncSession, data: dict):
     """Gère la complétion d'un checkout"""
     metadata = data.get("metadata", {})
 
+    # 🎯 Attribution channel — log AVANT le routing voice/credit/subscription
+    # pour avoir un signal cohérent peu importe le type de paiement.
+    # Source : Session.metadata propagé depuis create_checkout_by_plan_id.
+    # Pour les voice packs / credit packs, le helper get_or_create_stripe_customer
+    # n'est pas appelé avec un canal côté inline (legacy) → "direct" par défaut.
+    acquisition_channel = metadata.get("acquisition_channel", "direct")
+    customer_id = data.get("customer")
+    logger.info(
+        "ATTRIBUTION checkout.completed channel=%s customer=%s session=%s kind=%s",
+        acquisition_channel,
+        customer_id,
+        data.get("id"),
+        metadata.get("kind") or metadata.get("type") or "subscription",
+    )
+
     # ── Voice pack top-up (NEW system, migration 011) ─────────────────
     # Prioritized BEFORE legacy voice_addon so the new flow always wins
     # if both flags are present (defensive: should never happen in practice).
@@ -1858,6 +1966,47 @@ async def handle_checkout_completed(session: AsyncSession, data: dict):
 
     await session.commit()
     logger.info("User %s upgraded to %s, +%d credits", user_id, plan, credits_to_add)
+
+    # 🎯 Audit log RGPD — channel d'acquisition pour cohorte launch
+    try:
+        await log_audit(
+            session,
+            action="payment.completed",
+            user_id=user.id,
+            details={
+                "plan": plan,
+                "channel": acquisition_channel,
+                "stripe_session_id": data.get("id"),
+                "subscription_id": subscription_id,
+                "amount_cents": data.get("amount_total") or 0,
+                "currency": data.get("currency", "eur"),
+            },
+        )
+        await session.commit()
+    except Exception as e:
+        logger.info("audit_log payment.completed failed: %s", e)
+
+    # 🎯 PostHog event server-side (best-effort, non-bloquant).
+    # Le service est créé par le sub-agent P PostHog dans une PR concurrente.
+    # try/except ImportError → no-op si pas encore mergé.
+    try:
+        from services.posthog_service import capture_event  # type: ignore
+        await capture_event(
+            distinct_id=str(user.id),
+            event="payment_completed",
+            properties={
+                "plan": plan,
+                "acquisition_channel": acquisition_channel,
+                "stripe_customer_id": customer_id,
+                "amount_cents": data.get("amount_total") or 0,
+                "currency": data.get("currency", "eur"),
+            },
+        )
+    except ImportError:
+        # posthog_service pas encore mergé (sub-agent P PR). Silencieux.
+        pass
+    except Exception as e:
+        logger.info("PostHog payment_completed capture failed: %s", e)
 
     # 📧 Send payment success email
     try:

--- a/backend/tests/billing/test_acquisition_channel.py
+++ b/backend/tests/billing/test_acquisition_channel.py
@@ -1,0 +1,277 @@
+"""Tests pour `acquisition_channel` Stripe metadata (launch J0 attribution).
+
+Couvre :
+  * `normalize_acquisition_channel()` — vocabulaire SSOT + aliases + invalides
+  * Schéma Pydantic `CreateCheckoutByPlanId` accepte le champ optionnel
+  * `get_or_create_stripe_customer()` :
+    - pose `acquisition_channel` sur Customer.create
+    - premier-touch immutable : ne SURCHARGE PAS si déjà présent
+    - backfill défensif : ajoute si Customer existant n'a pas le champ
+    - resilient si stripe.Customer.modify() raise StripeError
+
+Vocabulaire SSOT (mêmes 10 valeurs côté frontend/mobile/PostHog) :
+    product_hunt | twitter | reddit | linkedin | indiehackers | hackernews
+    | karim_inmail | mobile_deeplink | test | direct
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import stripe
+
+from billing.router import (
+    ALLOWED_ACQUISITION_CHANNELS,
+    CreateCheckoutByPlanId,
+    get_or_create_stripe_customer,
+    normalize_acquisition_channel,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Section 1 — `normalize_acquisition_channel` (parametrize matrice 14 cas)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Cas vides / défaut
+        (None, "direct"),
+        ("", "direct"),
+        ("   ", "direct"),
+        # Valeurs SSOT directes
+        ("product_hunt", "product_hunt"),
+        ("twitter", "twitter"),
+        ("reddit", "reddit"),
+        ("karim_inmail", "karim_inmail"),
+        ("mobile_deeplink", "mobile_deeplink"),
+        ("test", "test"),
+        ("direct", "direct"),
+        # Aliases courants
+        ("ph", "product_hunt"),
+        ("PH", "product_hunt"),
+        ("ProductHunt", "product_hunt"),
+        ("Product Hunt", "product_hunt"),
+        ("Product-Hunt", "product_hunt"),
+        ("x", "twitter"),
+        ("X", "twitter"),
+        ("ih", "indiehackers"),
+        ("indie", "indiehackers"),
+        ("hn", "hackernews"),
+        ("Y_Combinator", "hackernews"),
+        ("ycombinator", "hackernews"),
+        ("li", "linkedin"),
+        ("LinkedIn", "linkedin"),
+        # Casing & normalisation
+        ("LINKEDIN", "linkedin"),
+        ("  twitter  ", "twitter"),
+        # Valeurs inconnues → fallback "direct" (pas de raise)
+        ("tiktokk", "direct"),
+        ("facebook", "direct"),
+        ("unknown_source", "direct"),
+        ("rick-roll", "direct"),
+        # Type invalide → fallback "direct"
+        (123, "direct"),
+        ([], "direct"),
+    ],
+)
+def test_normalize_acquisition_channel(raw, expected):
+    """Vocabulaire SSOT : valid → mapped, invalid → 'direct' (jamais raise)."""
+    assert normalize_acquisition_channel(raw) == expected
+
+
+def test_allowed_channels_contains_ssot_vocabulary():
+    """Garde-fou : la liste des channels reste alignée avec PostHog signup_source.
+
+    Toute modif ici doit être coordonnée avec sub-agent P (PostHog tracking).
+    """
+    assert ALLOWED_ACQUISITION_CHANNELS == frozenset({
+        "product_hunt",
+        "twitter",
+        "reddit",
+        "linkedin",
+        "indiehackers",
+        "hackernews",
+        "karim_inmail",
+        "mobile_deeplink",
+        "test",
+        "direct",
+    })
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Section 2 — Pydantic schema accepte le champ optionnel
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_schema_acquisition_channel_optional():
+    """Le champ est optionnel (default None) — pas de breaking change pour clients legacy."""
+    req = CreateCheckoutByPlanId(plan="pro", cycle="monthly")
+    assert req.acquisition_channel is None
+
+
+def test_schema_acquisition_channel_provided():
+    req = CreateCheckoutByPlanId(
+        plan="pro", cycle="monthly", acquisition_channel="product_hunt"
+    )
+    assert req.acquisition_channel == "product_hunt"
+
+
+def test_schema_acquisition_channel_passthrough_invalid():
+    """Le schema NE valide PAS la valeur — c'est `normalize_acquisition_channel`
+    qui gère le fallback. Permet de logger les valeurs raw avant normalisation
+    pour analyse debug du tracking côté client."""
+    req = CreateCheckoutByPlanId(
+        plan="pro", cycle="monthly", acquisition_channel="tiktokk"
+    )
+    assert req.acquisition_channel == "tiktokk"  # raw, non-normalisé au schema
+    # Mais après normalize, devient "direct"
+    assert normalize_acquisition_channel(req.acquisition_channel) == "direct"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Section 3 — `get_or_create_stripe_customer` premier-touch + backfill
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_user(stripe_customer_id=None):
+    user = MagicMock()
+    user.id = 42
+    user.email = "test@example.com"
+    user.username = "alice"
+    user.stripe_customer_id = stripe_customer_id
+    return user
+
+
+@pytest.fixture
+def mock_session():
+    session = MagicMock()
+    session.commit = AsyncMock(return_value=None)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_create_customer_pose_acquisition_channel(mock_session):
+    """Nouveau Customer → metadata['acquisition_channel'] = canal normalisé."""
+    user = _make_user(stripe_customer_id=None)
+
+    fake_customer = MagicMock(id="cus_NEW_123")
+    with patch.object(stripe.Customer, "create", return_value=fake_customer) as mock_create:
+        cid = await get_or_create_stripe_customer(
+            user, mock_session, acquisition_channel="product_hunt"
+        )
+
+    assert cid == "cus_NEW_123"
+    assert mock_create.call_count == 1
+    metadata = mock_create.call_args.kwargs["metadata"]
+    assert metadata["acquisition_channel"] == "product_hunt"
+    assert metadata["user_id"] == "42"
+    assert "first_checkout_at" in metadata
+
+
+@pytest.mark.asyncio
+async def test_create_customer_invalid_channel_falls_back_direct(mock_session):
+    """Canal invalide passé → normalisé en 'direct' avant pose Stripe."""
+    user = _make_user(stripe_customer_id=None)
+
+    fake_customer = MagicMock(id="cus_NEW_456")
+    with patch.object(stripe.Customer, "create", return_value=fake_customer) as mock_create:
+        await get_or_create_stripe_customer(
+            user, mock_session, acquisition_channel="tiktokk"
+        )
+
+    metadata = mock_create.call_args.kwargs["metadata"]
+    assert metadata["acquisition_channel"] == "direct"
+
+
+@pytest.mark.asyncio
+async def test_existing_customer_first_touch_immutable(mock_session):
+    """Customer existant AVEC acquisition_channel='product_hunt' déjà posé.
+
+    Un nouveau checkout depuis Twitter NE DOIT PAS écraser le canal originel.
+    """
+    user = _make_user(stripe_customer_id="cus_EXISTING_PH")
+
+    existing_customer = MagicMock()
+    existing_customer.get = lambda key, default=None: {
+        "deleted": False,
+        "metadata": {
+            "user_id": "42",
+            "acquisition_channel": "product_hunt",
+            "first_checkout_at": "2026-04-01T10:00:00+00:00",
+        },
+    }.get(key, default)
+
+    with (
+        patch.object(stripe.Customer, "retrieve", return_value=existing_customer),
+        patch.object(stripe.Customer, "modify") as mock_modify,
+    ):
+        cid = await get_or_create_stripe_customer(
+            user, mock_session, acquisition_channel="twitter"
+        )
+
+    assert cid == "cus_EXISTING_PH"
+    # Premier-touch immutable : modify() n'est PAS appelé puisque le champ existe.
+    assert mock_modify.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_existing_customer_backfill_when_missing(mock_session):
+    """Customer existant SANS acquisition_channel (legacy pre-sprint).
+
+    Doit être backfillé avec le canal courant SANS écraser autre metadata.
+    """
+    user = _make_user(stripe_customer_id="cus_LEGACY_NO_CHANNEL")
+
+    legacy_customer = MagicMock()
+    legacy_customer.get = lambda key, default=None: {
+        "deleted": False,
+        "metadata": {
+            "user_id": "42",
+            "some_other_key": "preserve_me",
+        },
+    }.get(key, default)
+
+    with (
+        patch.object(stripe.Customer, "retrieve", return_value=legacy_customer),
+        patch.object(stripe.Customer, "modify") as mock_modify,
+    ):
+        cid = await get_or_create_stripe_customer(
+            user, mock_session, acquisition_channel="reddit"
+        )
+
+    assert cid == "cus_LEGACY_NO_CHANNEL"
+    assert mock_modify.call_count == 1
+    backfilled_metadata = mock_modify.call_args.kwargs["metadata"]
+    assert backfilled_metadata["acquisition_channel"] == "reddit"
+    # Préservation des autres metadata existantes
+    assert backfilled_metadata["some_other_key"] == "preserve_me"
+    assert backfilled_metadata["user_id"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_backfill_resilient_to_stripe_error(mock_session):
+    """Si stripe.Customer.modify() raise, on continue (audit non-bloquant)."""
+    user = _make_user(stripe_customer_id="cus_LEGACY_FAIL_MODIFY")
+
+    legacy_customer = MagicMock()
+    legacy_customer.get = lambda key, default=None: {
+        "deleted": False,
+        "metadata": {"user_id": "42"},
+    }.get(key, default)
+
+    with (
+        patch.object(stripe.Customer, "retrieve", return_value=legacy_customer),
+        patch.object(
+            stripe.Customer,
+            "modify",
+            side_effect=stripe.error.StripeError("simulated API failure"),
+        ),
+    ):
+        # Ne raise PAS — la fonction retourne le customer_id existant
+        cid = await get_or_create_stripe_customer(
+            user, mock_session, acquisition_channel="reddit"
+        )
+
+    assert cid == "cus_LEGACY_FAIL_MODIFY"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1935,19 +1935,97 @@ export interface ApiBillingMyPlan {
   };
 }
 
+// 🎯 Acquisition channel — vocabulaire SSOT aligné avec backend
+//    (`backend/src/billing/router.py::ALLOWED_ACQUISITION_CHANNELS`) ET
+//    PostHog signup_source (sub-agent P).
+const ALLOWED_ACQUISITION_CHANNELS: ReadonlySet<string> = new Set([
+  "product_hunt",
+  "twitter",
+  "reddit",
+  "linkedin",
+  "indiehackers",
+  "hackernews",
+  "karim_inmail",
+  "mobile_deeplink",
+  "test",
+  "direct",
+]);
+
+const ACQUISITION_CHANNEL_ALIASES: Readonly<Record<string, string>> = {
+  ph: "product_hunt",
+  producthunt: "product_hunt",
+  x: "twitter",
+  ih: "indiehackers",
+  indie: "indiehackers",
+  hn: "hackernews",
+  y_combinator: "hackernews",
+  ycombinator: "hackernews",
+  li: "linkedin",
+  linked_in: "linkedin",
+};
+
+function normalizeAcquisitionChannel(raw: string | null | undefined): string {
+  if (!raw) return "direct";
+  const norm = raw.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  if (!norm) return "direct";
+  const resolved = ACQUISITION_CHANNEL_ALIASES[norm] ?? norm;
+  return ALLOWED_ACQUISITION_CHANNELS.has(resolved) ? resolved : "direct";
+}
+
+/**
+ * 🎯 Infère le canal d'acquisition.
+ * Lookup order : localStorage.acquisition_channel → utm_source → referrer → "direct".
+ * Aligné avec PostHog signup_source (sub-agent P) — premier-touch immutable côté backend.
+ * Toute valeur invalide est silencieusement remappée sur "direct".
+ */
+export function inferAcquisitionChannel(): string {
+  if (typeof window === "undefined") return "direct";
+  try {
+    const explicit = window.localStorage.getItem("acquisition_channel");
+    if (explicit) return normalizeAcquisitionChannel(explicit);
+
+    const utmSource = window.localStorage.getItem("utm_source");
+    if (utmSource) return normalizeAcquisitionChannel(utmSource);
+
+    const ref = (typeof document !== "undefined" && document.referrer) || "";
+    if (!ref) return "direct";
+    let host: string;
+    try {
+      host = new URL(ref).hostname.toLowerCase();
+    } catch {
+      return "direct";
+    }
+    if (host.includes("producthunt.com")) return "product_hunt";
+    if (host.includes("twitter.com") || host.includes("x.com")) return "twitter";
+    if (host.includes("reddit.com")) return "reddit";
+    if (host.includes("linkedin.com")) return "linkedin";
+    if (host.includes("indiehackers.com")) return "indiehackers";
+    if (host.includes("news.ycombinator.com")) return "hackernews";
+    return "direct";
+  } catch {
+    return "direct";
+  }
+}
+
 export const billingApi = {
   /**
    * 🆕 Pricing v2 — Crée une session Stripe Checkout (plan + cycle).
    * @param plan "pro" | "expert"
    * @param cycle "monthly" | "yearly" (default monthly)
+   * @param acquisitionChannel — optionnel. Si absent, dérivé de
+   *   `inferAcquisitionChannel()` (localStorage.utm_source / referrer).
+   *   ⚠️ Backend ignore ce champ si le Customer existe déjà avec une
+   *   acquisition_channel posée (premier-touch immutable).
    */
   async createCheckout(
     plan: ApiPlanIdV2 | string,
     cycle: BillingCycle = "monthly",
+    acquisitionChannel?: string,
   ): Promise<{ checkout_url: string; session_id: string }> {
+    const channel = acquisitionChannel ?? inferAcquisitionChannel();
     return request("/api/billing/create-checkout", {
       method: "POST",
-      body: { plan, cycle },
+      body: { plan, cycle, acquisition_channel: channel },
     });
   },
 

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -1570,17 +1570,28 @@ export const billingApi = {
    *
    * @param plan "pro" | "expert"
    * @param cycle "monthly" | "yearly" (default monthly)
+   * @param acquisitionChannel — optionnel. Default `"mobile_deeplink"` (le
+   *   contexte mobile n'a ni `localStorage.utm_source` ni referrer DOM).
+   *   Pass explicite si install via campagne deep-linkée (ex : "twitter").
+   *   ⚠️ Backend ignore ce champ si Customer déjà posé (premier-touch immutable).
    */
   async createCheckout(
     plan: ApiPlanIdV2 | string,
     cycle: BillingCycle = "monthly",
+    acquisitionChannel?: string,
   ): Promise<{ url: string; session_id: string }> {
+    const channel = acquisitionChannel ?? "mobile_deeplink";
     const response = await request<{
       checkout_url: string;
       session_id: string;
     }>("/api/billing/create-checkout", {
       method: "POST",
-      body: { plan, cycle, plan_id: plan },
+      body: {
+        plan,
+        cycle,
+        plan_id: plan,
+        acquisition_channel: channel,
+      },
     });
     return { url: response.checkout_url, session_id: response.session_id };
   },


### PR DESCRIPTION
## Summary

Persistent **acquisition channel attribution** for every Stripe Customer + Checkout Session, enabling MRR-by-source segmentation in Stripe Dashboard / Sigma SQL / PostHog `payment_completed` events for the J0 launch (2026-05-15).

- New `acquisition_channel` field on `CreateCheckoutByPlanId` Pydantic schema (Optional, no breaking change)
- Backend helper `normalize_acquisition_channel()` + frozenset `ALLOWED_ACQUISITION_CHANNELS` (10 values)
- `get_or_create_stripe_customer()` refactored: now accepts `acquisition_channel`, posts to `Customer.metadata`, and **defends premier-touch immutability** (never overwrites an existing channel ; backfills only if missing)
- Inline `stripe.Customer.create(...)` path in `create_checkout_by_plan_id` migrated to the centralized helper (techdebt cleanup)
- Webhook `handle_checkout_completed` logs `ATTRIBUTION` line + posts `payment.completed` to `audit_logs` with channel
- Best-effort PostHog backend `payment_completed` event via `try/except ImportError` (no-op if sub-agent P PR not yet merged)
- Frontend exports `inferAcquisitionChannel()` (`localStorage.acquisition_channel` -> `localStorage.utm_source` -> `document.referrer` mapping -> `"direct"`)
- Mobile defaults to `"mobile_deeplink"` (no DOM referrer/localStorage)
- 41 parametrized tests covering normalization (24 cases) + schema (3) + helper paths (5) + Stripe error resilience

## Why now

J0 = 9 days. Without channel tracking on day-1, the launch retrospective MRR-by-source breakdown is impossible to reconstruct after the fact. First-touch wins is non-negotiable to keep cohort analytics honest.

## Coordination

- Vocabulary SSOT (10 values) **must** stay aligned with sub-agent P PostHog `signup_source` capture PR — touching this list requires sync.
- Independent of PR #382 (Trust Center) — touches different files (PR #382 = trust pages, this PR = billing layer).
- The `posthog_service.py` import is wrapped in `try/except ImportError` so this PR can land before the PostHog sub-agent PR without breaking webhook handler.

## Test plan

- [x] Backend unit tests: `python -m pytest tests/billing/test_acquisition_channel.py -v` -> **41 passed**
- [x] Backend regression: `python -m pytest tests/test_billing.py tests/billing/ -v` -> **129 passed** (no regression)
- [x] Frontend typecheck: no new errors in `frontend/src/services/api.ts` (pre-existing errors elsewhere unaffected)
- [x] Mobile typecheck: no new errors in `mobile/src/services/api.ts`
- [ ] Stripe CLI smoke (test mode) post-merge: `stripe trigger checkout.session.completed --add ...metadata.acquisition_channel=product_hunt`
- [ ] Smoke prod J-6: 1 live-mode checkout via `?utm_source=product_hunt`, verify `acquisition_channel=product_hunt` on Stripe Dashboard Customer metadata

## Risks

- **First-touch immutability**: an existing user upgrading after a campaign keeps their original channel. This is a feature, not a bug — but to be communicated for post-launch reporting.
- **Backfill on legacy customers**: customers created before this PR will get `acquisition_channel = "direct"` (or the value at first checkout) on their next checkout. No retroactive backfill script in this PR — Maxime to decide pre-J0 if mass-assigning `legacy` makes sense.
- **`posthog_service.py` not yet merged**: webhook posts a debug log instead of an event until the sub-agent P PR lands — non-blocking.

Runbook: `Vault/01-Projects/DeepSight/Sessions/2026-05-07-stripe-acquisition-channel-J-8.md`