### PR TITLE
feat(analytics): wire PostHog tracking + UTM auto-capture for launch J0

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,6 +1,9 @@
 # Gitleaks ignore file — false positives
 # Format: fingerprint (from gitleaks report)
 
+# utmCapture.ts — STORAGE_KEY constant (localStorage key name, not credential, entropy 3.625 false positive)
+frontend/src/services/utmCapture.ts:generic-api-key:63
+
 # ApiDocsPage.tsx — placeholder "ds_live_YOUR_KEY" (not a real secret)
 frontend/src/pages/ApiDocsPage.tsx:curl-auth-header:51
 frontend/src/pages/ApiDocsPage.tsx:curl-auth-header:67

--- a/backend/scripts/posthog_insights_config.py
+++ b/backend/scripts/posthog_insights_config.py
@@ -40,6 +40,21 @@ EV_UPGRADE_STARTED = "upgrade_started"
 EV_UPGRADE_COMPLETED = "upgrade_completed"
 EV_API_ERROR = "api_error"
 
+# 🚀 Launch J0 events (sprint 2026-05-15) — frontend wires (signup_started,
+# analysis_started, payment_initiated) + backend server-side wires
+# (signup_completed, payment_completed, churn_event).
+EV_SIGNUP_STARTED = "signup_started"
+EV_SIGNUP_COMPLETED = "signup_completed"
+EV_ANALYSIS_STARTED = "analysis_started"
+EV_PAYMENT_INITIATED = "payment_initiated"
+EV_PAYMENT_COMPLETED = "payment_completed"
+EV_CHURN_EVENT = "churn_event"
+
+# UTM properties (auto-registered par utmCapture.ts → posthog.register())
+PROP_UTM_SOURCE = "utm_source"
+PROP_SIGNUP_SOURCE = "signup_source"
+PROP_ACQUISITION_CHANNEL = "acquisition_channel"
+
 # Properties usuelles
 PROP_PLAN = "plan"
 PROP_PLATFORM = "platform"  # web | mobile | extension
@@ -179,7 +194,11 @@ class TrendInsight:
     description: str
     events: list[str]
     display: Literal[
-        "ActionsLineGraph", "ActionsBar", "ActionsAreaGraph", "ActionsTable"
+        "ActionsLineGraph",
+        "ActionsBar",
+        "ActionsAreaGraph",
+        "ActionsTable",
+        "BoldNumber",
     ] = "ActionsLineGraph"
     interval: Literal["hour", "day", "week", "month"] = "day"
     breakdown_property: str | None = None
@@ -400,6 +419,54 @@ def build_funnels() -> list[FunnelInsight]:
             date_from="-90d",
             tags=["growth", "activation", "platform"],
         ),
+        # 🚀 Launch J0 — Funnel A : signup → email verified → 1st analysis (24h)
+        FunnelInsight(
+            name="DeepSight — Launch Funnel A (signup → 1st analysis 24h)",
+            description=(
+                "Wow moment funnel: signup_started → signup_completed → "
+                "analysis_started, window 24h. Breakdown utm_source. "
+                "Cible launch J0 pour mesurer l'activation par canal."
+            ),
+            steps=[EV_SIGNUP_STARTED, EV_SIGNUP_COMPLETED, EV_ANALYSIS_STARTED],
+            step_names=["Signup CTA clicked", "Email verified", "First analysis"],
+            conversion_window_seconds=24 * 3600,
+            breakdown_property=PROP_UTM_SOURCE,
+            breakdown_type="event",
+            date_from="-7d",
+            tags=["launch", "activation"],
+        ),
+        # 🚀 Launch J0 — Funnel B : Free → Pro (signup → checkout → paid 7j)
+        FunnelInsight(
+            name="DeepSight — Launch Funnel B (Free→Pro 7d)",
+            description=(
+                "Conversion launch: signup_completed → payment_initiated → "
+                "payment_completed, window 7j. Breakdown utm_source. "
+                "Cible KPI launch ≥ 2% free→paid en 7j."
+            ),
+            steps=[EV_SIGNUP_COMPLETED, EV_PAYMENT_INITIATED, EV_PAYMENT_COMPLETED],
+            step_names=["Signup completed", "Checkout clicked", "Payment OK"],
+            conversion_window_seconds=7 * 24 * 3600,
+            breakdown_property=PROP_UTM_SOURCE,
+            breakdown_type="event",
+            date_from="-7d",
+            tags=["launch", "revenue"],
+        ),
+        # 🚀 Launch J0 — Funnel C : 5+ analyses → upgrade (7j)
+        FunnelInsight(
+            name="DeepSight — Launch Funnel C (5th analysis → upgrade 7d)",
+            description=(
+                "Engagement → revenue: video_analyzed (5+) → payment_initiated → "
+                "payment_completed, window 7j. Breakdown utm_source. "
+                "Mesure si les power users free convertissent."
+            ),
+            steps=[EV_VIDEO_ANALYZED, EV_PAYMENT_INITIATED, EV_PAYMENT_COMPLETED],
+            step_names=["Heavy analysis (5+)", "Checkout clicked", "Payment OK"],
+            conversion_window_seconds=7 * 24 * 3600,
+            breakdown_property=PROP_UTM_SOURCE,
+            breakdown_type="event",
+            date_from="-30d",
+            tags=["launch", "revenue", "engagement"],
+        ),
     ]
 
 
@@ -507,6 +574,64 @@ def build_trends() -> list[TrendInsight]:
             date_from="-7d",
             tags=["growth", "errors", "ops"],
         ),
+        # 🚀 Launch J0 — Signups par heure breakdown utm_source (auto-refresh)
+        TrendInsight(
+            name="DeepSight — Launch Signups by source (today)",
+            description=(
+                "user_signup par heure, breakdown utm_source. "
+                "Auto-refresh dashboard launch. Goal line: 5 signups/hour."
+            ),
+            events=[EV_SIGNUP],
+            display="ActionsLineGraph",
+            interval="hour",
+            breakdown_property=PROP_UTM_SOURCE,
+            breakdown_type="event",
+            date_from="-1d",
+            tags=["launch", "acquisition"],
+        ),
+        # 🚀 Launch J0 — MRR added today (sum of mrr_added_eur)
+        TrendInsight(
+            name="DeepSight — MRR added today",
+            description=(
+                "Sum of mrr_added_eur from payment_completed today. "
+                "Big number widget pour dashboard launch."
+            ),
+            events=[EV_PAYMENT_COMPLETED],
+            display="BoldNumber",
+            interval="day",
+            date_from="-1d",
+            tags=["launch", "revenue"],
+        ),
+        # 🚀 Launch J0 — Churn events 7d breakdown plan
+        TrendInsight(
+            name="DeepSight — Churn events 7d",
+            description=(
+                "churn_event count par jour, breakdown plan. "
+                "Goal: ≤ 3% monthly churn."
+            ),
+            events=[EV_CHURN_EVENT],
+            display="ActionsBar",
+            interval="day",
+            breakdown_property=PROP_PLAN,
+            breakdown_type="event",
+            date_from="-7d",
+            tags=["launch", "churn"],
+        ),
+        # 🚀 Launch J0 — Top videos analyzed today (engagement signal)
+        TrendInsight(
+            name="DeepSight — Top videos analyzed today",
+            description=(
+                "video_analyzed today, breakdown video_platform "
+                "(youtube/tiktok). Indique le contenu qui drive l'engagement."
+            ),
+            events=[EV_VIDEO_ANALYZED],
+            display="ActionsBar",
+            interval="day",
+            breakdown_property="video_platform",
+            breakdown_type="event",
+            date_from="-1d",
+            tags=["launch", "engagement"],
+        ),
     ]
 
 
@@ -590,6 +715,50 @@ def build_cohorts() -> list[CohortDefinition]:
                 )
             ],
         ),
+        # 🚀 Launch J0 — Cohort signups par canal launch (PH/Twitter/etc.)
+        CohortDefinition(
+            name="DeepSight — Launch J0 signups",
+            description=(
+                "Users inscrits via canaux launch (product_hunt, twitter, "
+                "reddit, linkedin, indiehackers, hackernews, karim_inmail, "
+                "mobile_deeplink) à partir de 2026-05-15. Cible primaire "
+                "suivi launch."
+            ),
+            filters=[
+                CohortFilter(
+                    type="person",
+                    key=PROP_SIGNUP_SOURCE,
+                    value=[
+                        "product_hunt",
+                        "twitter",
+                        "reddit",
+                        "linkedin",
+                        "indiehackers",
+                        "hackernews",
+                        "karim_inmail",
+                        "mobile_deeplink",
+                    ],
+                    operator="exact",
+                ),
+            ],
+        ),
+        # 🚀 Launch J0 — Cohort B2B Karim outreach LinkedIn InMail
+        CohortDefinition(
+            name="DeepSight — B2B Karim contacts",
+            description=(
+                "Users issus outreach Karim LinkedIn InMail. "
+                "Property `signup_source = karim_inmail`. "
+                "Cible high-touch B2B."
+            ),
+            filters=[
+                CohortFilter(
+                    type="person",
+                    key=PROP_SIGNUP_SOURCE,
+                    value="karim_inmail",
+                    operator="exact",
+                ),
+            ],
+        ),
     ]
 
 
@@ -598,12 +767,29 @@ def build_dashboards(
     retention: list[RetentionInsight],
     trends: list[TrendInsight],
 ) -> list[DashboardSpec]:
-    """Un seul dashboard global qui rassemble tout."""
+    """Deux dashboards : Growth (général) + Launch J0 Real-Time (temporaire).
+
+    Le dashboard Launch J0 est tagué `launch` pour pouvoir être archivé
+    facilement post-launch via filtrage tag dans la UI PostHog.
+    """
     all_insight_names = (
         [f.name for f in funnels]
         + [r.name for r in retention]
         + [t.name for t in trends]
     )
+
+    # 🚀 Launch J0 dashboard — sélection ciblée des 6 widgets temps réel.
+    # Les insight names doivent matcher exactement les `name=` ci-dessus
+    # (idempotency by-name dans setup_posthog_insights.py).
+    launch_insight_names = [
+        "DeepSight — Launch Signups by source (today)",
+        "DeepSight — Launch Funnel B (Free→Pro 7d)",
+        "DeepSight — MRR added today",
+        "DeepSight — Top videos analyzed today",
+        "DeepSight — Churn events 7d",
+        "DeepSight — API Errors by endpoint",
+    ]
+
     return [
         DashboardSpec(
             name="DeepSight — Growth",
@@ -616,7 +802,18 @@ def build_dashboards(
             insight_names=all_insight_names,
             pinned=True,
             tags=["growth", "managed-by-script"],
-        )
+        ),
+        DashboardSpec(
+            name="DeepSight — Launch J0 Real-Time",
+            description=(
+                "Dashboard live launch 2026-05-15. 6 widgets temps réel. "
+                "Source : posthog_insights_config.py — managed by script. "
+                "Archive ce dashboard post-launch (~J+30) via tag `launch`."
+            ),
+            insight_names=launch_insight_names,
+            pinned=True,
+            tags=["launch", "managed-by-script"],
+        ),
     ]
 
 

--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Optional
 
 from db.database import get_session
+from core.analytics import track_event
 from core.config import FRONTEND_URL, EMAIL_CONFIG, GOOGLE_OAUTH_CONFIG
 from .schemas import (
     UserRegister,
@@ -72,6 +73,11 @@ async def register(data: UserRegister, session: AsyncSession = Depends(get_sessi
     """
     Inscription d'un nouvel utilisateur.
     Envoie un email de vérification si EMAIL_ENABLED.
+
+    🚀 Launch J0 (2026-05-15) — Persiste les UTM/signup_source du payload
+    dans User.preferences (JSON, migration 008 prod). Permet à PostHog de
+    breakdown les cohorts et funnels par canal d'acquisition (PH, Twitter,
+    Karim B2B, etc.). Aucune nouvelle migration requise.
     """
     success, user, message = await create_user(
         session, username=data.username, email=data.email, password=data.password
@@ -79,6 +85,22 @@ async def register(data: UserRegister, session: AsyncSession = Depends(get_sessi
 
     if not success:
         raise HTTPException(status_code=400, detail=message)
+
+    # 🚀 Launch tracking — persister UTM dans User.preferences
+    if user and (data.signup_source or data.utm_source or data.referrer):
+        prefs = dict(user.preferences or {})
+        utm_payload = {
+            "signup_source": data.signup_source,
+            "utm_source": data.utm_source,
+            "utm_medium": data.utm_medium,
+            "utm_campaign": data.utm_campaign,
+            "referrer": data.referrer,
+        }
+        # On stocke uniquement les valeurs non-vides pour éviter de polluer
+        # le JSON avec des None (rétro-compat + lisibilité admin DB).
+        prefs.update({k: v for k, v in utm_payload.items() if v is not None})
+        user.preferences = prefs
+        await session.commit()
 
     # Envoyer l'email de vérification
     if EMAIL_CONFIG.get("ENABLED") and user and user.verification_code:
@@ -279,6 +301,39 @@ async def verify_email_endpoint(data: VerifyEmailRequest, session: AsyncSession 
             await send_welcome_email(user.email, user.username)
         except Exception:
             pass  # Non-blocking — don't fail verification if email fails
+
+    # 🚀 Launch J0 — fire `signup_completed` server-side (fiable même si user
+    # ferme l'onglet entre register et verify). PostHog cohort "Launch J0
+    # signups" filtre sur `signup_source` ∈ {product_hunt, twitter, reddit,
+    # linkedin, indiehackers, hackernews, karim_inmail, mobile_deeplink}.
+    try:
+        prefs = user.preferences or {}
+        time_to_verify_seconds: Optional[float] = None
+        if user.created_at:
+            created_at = user.created_at
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+            time_to_verify_seconds = (
+                datetime.now(timezone.utc) - created_at
+            ).total_seconds()
+
+        track_event(
+            "signup_completed",
+            properties={
+                "signup_source": prefs.get("signup_source", "direct"),
+                "utm_source": prefs.get("utm_source"),
+                "utm_medium": prefs.get("utm_medium"),
+                "utm_campaign": prefs.get("utm_campaign"),
+                "referrer": prefs.get("referrer"),
+                "email_verified_at": datetime.now(timezone.utc).isoformat(),
+                "time_to_verify_seconds": time_to_verify_seconds,
+                "plan": user.plan,
+            },
+            distinct_id=str(user.id),
+        )
+    except Exception:
+        # Best-effort — never block verify on analytics failure
+        pass
 
     # 🆕 Créer une session unique
     session_token = await create_user_session(session, user.id)

--- a/backend/src/auth/schemas.py
+++ b/backend/src/auth/schemas.py
@@ -15,11 +15,28 @@ from datetime import datetime
 
 
 class UserRegister(BaseModel):
-    """Schéma pour l'inscription"""
+    """Schéma pour l'inscription.
+
+    🚀 Launch J0 (2026-05-15) — accepte les UTM/source frontend pour
+    persistance dans `User.preferences` (JSON column, migration 008 prod).
+    Tous les champs UTM sont Optional pour rester backward-compatible avec
+    les anciens clients qui ne les envoient pas.
+
+    SSOT vocabulary `signup_source` aligné avec `utmCapture.ts` frontend
+    et `acquisition_channel` Stripe (sub-agent Q parallel PR) :
+        product_hunt | twitter | reddit | linkedin | indiehackers |
+        hackernews | karim_inmail | mobile_deeplink | direct.
+    """
 
     username: str = Field(..., min_length=3, max_length=50)
     email: EmailStr
     password: str = Field(..., min_length=6)
+    # 🚀 Launch tracking — UTM/source persistance pour analyses cross-channel
+    signup_source: Optional[str] = Field(None, max_length=50)
+    utm_source: Optional[str] = Field(None, max_length=80)
+    utm_medium: Optional[str] = Field(None, max_length=80)
+    utm_campaign: Optional[str] = Field(None, max_length=80)
+    referrer: Optional[str] = Field(None, max_length=300)
 
 
 class UserLogin(BaseModel):

--- a/backend/src/billing/router.py
+++ b/backend/src/billing/router.py
@@ -26,6 +26,7 @@ from db.database import (
     VoiceCreditPurchase,
 )
 from auth.dependencies import get_current_user, get_current_user_optional
+from core.analytics import track_event
 from core.config import STRIPE_CONFIG, FRONTEND_URL, get_stripe_key, STRIPE_AUTOMATIC_TAX_ENABLED
 from services.audit_log import log_audit
 from .plan_config import (
@@ -1840,6 +1841,9 @@ async def handle_checkout_completed(session: AsyncSession, data: dict):
     # Crédits depuis plan_config — source de vérité unique
     credits_to_add = get_limits(plan).get("monthly_credits", 0)
 
+    # 🚀 Launch J0 — capturer is_first_payment AVANT user.plan = plan
+    is_first_payment = (user.plan or "free") == "free"
+
     user.plan = plan
     user.credits = (user.credits or 0) + credits_to_add
     user.stripe_customer_id = customer_id
@@ -1858,6 +1862,35 @@ async def handle_checkout_completed(session: AsyncSession, data: dict):
 
     await session.commit()
     logger.info("User %s upgraded to %s, +%d credits", user_id, plan, credits_to_add)
+
+    # 🚀 Launch J0 — fire `payment_completed` server-side (fiable même si tab
+    # fermée). PostHog dashboard "Launch J0 Real-Time" lit le sum de
+    # mrr_added_eur today + breakdown acquisition_channel pour cohort.
+    try:
+        amount_total = data.get("amount_total") or 0  # cents
+        cycle = (metadata.get("cycle") or "monthly").lower()
+        mrr_added_eur = (amount_total / 100.0) / (12.0 if cycle == "yearly" else 1.0)
+        prefs = user.preferences or {}
+        track_event(
+            "payment_completed",
+            properties={
+                "plan": plan,
+                "cycle": cycle,
+                "mrr_added_eur": round(mrr_added_eur, 2),
+                "amount_total_eur": round(amount_total / 100.0, 2),
+                "currency": data.get("currency", "eur"),
+                "acquisition_channel": prefs.get("signup_source", "direct"),
+                "utm_source": prefs.get("utm_source"),
+                "utm_medium": prefs.get("utm_medium"),
+                "utm_campaign": prefs.get("utm_campaign"),
+                "stripe_customer_id": customer_id,
+                "stripe_subscription_id": subscription_id,
+                "is_first_payment": is_first_payment,
+            },
+            distinct_id=str(user.id),
+        )
+    except Exception as e:
+        logger.debug(f"PostHog payment_completed track failed: {e}")
 
     # 📧 Send payment success email
     try:
@@ -2091,6 +2124,58 @@ async def handle_subscription_deleted(session: AsyncSession, data: dict):
         user.stripe_subscription_id = None
         await session.commit()
         logger.info(f"User {user.id} subscription deleted, reverted to free (was {old_plan})")
+
+        # 🚀 Launch J0 — fire `churn_event` server-side avec metadata churn
+        # (tenure_days, last_analysis_days_ago, cancel_reason). PostHog
+        # dashboard "Launch J0 Real-Time" widget Churn lit count par jour
+        # breakdown plan.
+        try:
+            from datetime import datetime, timezone
+
+            tenure_days: Optional[int] = None
+            if user.created_at:
+                created_at = user.created_at
+                if created_at.tzinfo is None:
+                    created_at = created_at.replace(tzinfo=timezone.utc)
+                tenure_days = (datetime.now(timezone.utc) - created_at).days
+
+            # Last analysis days ago — signal "user dormant avant cancel"
+            last_summary_q = await session.execute(
+                select(Summary)
+                .where(Summary.user_id == user.id)
+                .order_by(Summary.created_at.desc())
+                .limit(1)
+            )
+            last = last_summary_q.scalar_one_or_none()
+            last_analysis_days_ago: Optional[int] = None
+            if last and last.created_at:
+                la_created = last.created_at
+                if la_created.tzinfo is None:
+                    la_created = la_created.replace(tzinfo=timezone.utc)
+                last_analysis_days_ago = (
+                    datetime.now(timezone.utc) - la_created
+                ).days
+
+            cancel_reason = (
+                (data.get("cancellation_details") or {}).get("reason") or "(none)"
+            )
+            prefs = user.preferences or {}
+
+            track_event(
+                "churn_event",
+                properties={
+                    "plan": old_plan or "free",
+                    "tenure_days": tenure_days,
+                    "last_analysis_days_ago": last_analysis_days_ago,
+                    "cancel_reason": cancel_reason,
+                    "stripe_customer_id": customer_id,
+                    "acquisition_channel": prefs.get("signup_source", "direct"),
+                    "utm_source": prefs.get("utm_source"),
+                },
+                distinct_id=str(user.id),
+            )
+        except Exception as e:
+            logger.debug(f"PostHog churn_event track failed: {e}")
 
         try:
             from services.email_service import email_service

--- a/backend/src/services/posthog_service.py
+++ b/backend/src/services/posthog_service.py
@@ -1,0 +1,71 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  📊 POSTHOG SERVICE — server-side event capture (Launch J0 hub)                    ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  RÔLE                                                                              ║
+║  • Wrapper async autour de `core.analytics.track_event` qui expose une API         ║
+║    cohérente (`capture_event`) attendue par les routers (sub-agent Q Stripe        ║
+║    `acquisition_channel` parallel PR).                                             ║
+║  • Best-effort : toute exception est silencieusement avalée (jamais bloquant).     ║
+║  • No-op si `POSTHOG_API_KEY` non configuré (cf. core.analytics).                  ║
+║                                                                                    ║
+║  USAGE                                                                             ║
+║      from services.posthog_service import capture_event                            ║
+║      await capture_event(                                                          ║
+║          distinct_id=str(user.id),                                                 ║
+║          event="payment_completed",                                                ║
+║          properties={"plan": "pro", "acquisition_channel": "product_hunt"},        ║
+║      )                                                                             ║
+║                                                                                    ║
+║  ÉVÉNEMENTS CONNUS LAUNCH J0                                                       ║
+║  • signup_completed   (auth/router.py verify_email)                                ║
+║  • payment_completed  (billing/router.py handle_checkout_completed)                ║
+║  • churn_event        (billing/router.py handle_subscription_deleted)              ║
+║  • analysis_started   (frontend uniquement, mais loggable server-side aussi)       ║
+║                                                                                    ║
+║  VOCABULAIRE SSOT (`acquisition_channel` / `signup_source`)                        ║
+║  • product_hunt | twitter | reddit | linkedin | indiehackers |                     ║
+║    hackernews | karim_inmail | mobile_deeplink | direct                            ║
+║                                                                                    ║
+║  BENEFITS                                                                          ║
+║  • Découple les routers d'`asyncio.create_task` direct (testable plus facile)      ║
+║  • Permet d'ajouter futur: rate limiting, batching, dedup local sans toucher       ║
+║    aux call sites.                                                                 ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from core.analytics import track_event
+from core.logging import logger
+
+
+async def capture_event(
+    distinct_id: str,
+    event: str,
+    properties: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Capture un event PostHog server-side (fire-and-forget, non-bloquant).
+
+    Args:
+        distinct_id: PostHog distinct user id (string). Pour les events
+            authentifiés, utiliser `str(user.id)`. Pour les events anonymes,
+            "server" ou un identifiant de session (jamais d'email PII).
+        event: Nom canonique snake_case (ex: "payment_completed").
+        properties: Propriétés event-level. Pour les events launch, inclure
+            `acquisition_channel` ou `signup_source` du vocabulaire SSOT
+            pour permettre breakdown PostHog cohorts.
+
+    Toutes les exceptions sont avalées à debug-level — never raises.
+    No-op si `POSTHOG_API_KEY` vide.
+    """
+    try:
+        track_event(name=event, properties=properties or {}, distinct_id=distinct_id)
+    except Exception as e:
+        # `track_event` est déjà best-effort (cf. core.analytics) mais on
+        # ajoute un filet ici au cas où l'import lui-même casse.
+        logger.debug(f"[POSTHOG_SERVICE] capture_event '{event}' failed: {e}")
+
+
+__all__ = ["capture_event"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import { StagedPrefsToolbar } from "./components/voice/staging/StagedPrefsToolba
 import { OnboardingFlow } from "./components/onboarding/OnboardingFlow";
 import { Tutor } from "./components/Tutor";
 import { analytics } from "./services/analytics";
+import { captureUtmParams } from "./services/utmCapture";
 import { initWebVitals } from "./services/webVitals";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { DeepSightSpinner } from "./components/ui/DeepSightSpinner";
@@ -1191,7 +1192,10 @@ const AppRoutes = () => {
 const App = () => {
   // 📊 Initialiser PostHog analytics (RGPD-compliant, attend le consentement)
   // 📈 Initialiser Core Web Vitals tracking → PostHog (auto-gated sur consentement)
+  // 🚀 Launch J0 (2026-05-15) — UTM auto-capture AVANT init PostHog (idempotent,
+  //    posthog-js queue les `register()` jusqu'à `init()` donc pas de race).
   useEffect(() => {
+    captureUtmParams();
     analytics.init();
     initWebVitals();
   }, []);

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -3,20 +3,41 @@
  *
  * S'utilise dans les composants pour tracker des actions utilisateur.
  * Respecte automatiquement le consentement RGPD via le service analytics.
+ *
+ * Sprint Launch J0 (2026-05-15) — enrichi avec UTM auto-capture pour
+ * breakdown signups/payments par canal d'acquisition (PH, Twitter, etc.).
  */
 
 import { useCallback } from "react";
 import { analytics, AnalyticsEvents } from "../services/analytics";
+import { getCapturedUtm } from "../services/utmCapture";
 
 export function useAnalytics() {
+  /**
+   * Tracker `user_signup` côté client (best-effort — le serveur fire
+   * `signup_completed` via `verify_email` pour la fiabilité).
+   * Enrichi UTM pour breakdown par canal.
+   */
   const trackSignup = useCallback((method: "email" | "google") => {
-    analytics.capture(AnalyticsEvents.SIGNUP, { method });
+    const utm = getCapturedUtm();
+    analytics.capture(AnalyticsEvents.SIGNUP, { method, ...utm });
   }, []);
 
+  /**
+   * Identify + capture `user_login`. Enrichit le profil PostHog avec les UTM
+   * persistés pour permettre le filtrage par cohort `Launch J0 signups`.
+   */
   const trackLogin = useCallback(
     (userId: string | number, plan: string, method: "email" | "google") => {
-      analytics.identify(userId, { plan });
-      analytics.capture(AnalyticsEvents.LOGIN, { method, plan });
+      const utm = getCapturedUtm();
+      analytics.identify(userId, {
+        plan,
+        signup_source: utm.utm_source,
+        utm_source: utm.utm_source,
+        utm_medium: utm.utm_medium,
+        utm_campaign: utm.utm_campaign,
+      });
+      analytics.capture(AnalyticsEvents.LOGIN, { method, plan, ...utm });
     },
     [],
   );
@@ -41,6 +62,61 @@ export function useAnalytics() {
   const trackAnalysisStarted = useCallback(
     (props: { url?: string; mode?: string; model?: string }) => {
       analytics.capture(AnalyticsEvents.VIDEO_ANALYSIS_STARTED, props);
+    },
+    [],
+  );
+
+  /**
+   * 🚀 Launch J0 — `signup_started` au clic CTA landing (avant register).
+   * Permet de mesurer le drop-off CTA→form→submit.
+   */
+  const trackSignupStarted = useCallback(
+    (props?: { cta_location?: string }) => {
+      const utm = getCapturedUtm();
+      analytics.capture(AnalyticsEvents.SIGNUP_STARTED, {
+        ...utm,
+        referrer: document.referrer || "direct",
+        ...props,
+      });
+    },
+    [],
+  );
+
+  /**
+   * 🚀 Launch J0 — `analysis_started` enrichi avec metadata launch.
+   * Distinct de `trackAnalysisStarted` (qui reste pour `video_analysis_started`
+   * legacy) car launch funnel A utilise un event séparé pour breakdown propre.
+   */
+  const trackLaunchAnalysisStarted = useCallback(
+    (props: {
+      video_platform?: "youtube" | "tiktok";
+      video_duration_min?: number;
+      analysis_mode?: string;
+      is_first_analysis?: boolean;
+    }) => {
+      analytics.capture(AnalyticsEvents.ANALYSIS_STARTED, {
+        ...props,
+        ...getCapturedUtm(),
+      });
+    },
+    [],
+  );
+
+  /**
+   * 🚀 Launch J0 — `payment_initiated` au clic CTA Subscribe avant redirect
+   * Stripe Checkout. Permet le funnel C (5+ analyses → upgrade 7d).
+   */
+  const trackPaymentInitiated = useCallback(
+    (props: {
+      plan: "pro" | "expert";
+      cycle: "monthly" | "yearly";
+      current_plan?: string;
+      time_since_signup_days?: number;
+    }) => {
+      analytics.capture(AnalyticsEvents.PAYMENT_INITIATED, {
+        ...props,
+        ...getCapturedUtm(),
+      });
     },
     [],
   );
@@ -70,6 +146,9 @@ export function useAnalytics() {
     trackLogout,
     trackAnalysis,
     trackAnalysisStarted,
+    trackSignupStarted,
+    trackLaunchAnalysisStarted,
+    trackPaymentInitiated,
     trackExport,
     trackUpgrade,
     trackChat,

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -22,6 +22,7 @@ import {
   ApiError,
   User,
 } from "../services/api";
+import { getCapturedUtm } from "../services/utmCapture";
 import { setUser as setSentryUser } from "../lib/sentry";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -449,7 +450,16 @@ export function useAuth(): UseAuthReturn {
       setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
       try {
-        await authApi.register(username, email, password);
+        // 🚀 Launch J0 — joindre les UTM auto-capturés (cf. utmCapture.ts).
+        // Le backend persiste dans User.preferences pour PostHog cohorts.
+        const utm = getCapturedUtm();
+        await authApi.register(username, email, password, {
+          signup_source: utm.utm_source ?? "direct",
+          utm_source: utm.utm_source,
+          utm_medium: utm.utm_medium,
+          utm_campaign: utm.utm_campaign,
+          referrer: utm.referrer,
+        });
 
         if (mountedRef.current) {
           setState((prev) => ({ ...prev, isLoading: false }));

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -33,6 +33,7 @@ import {
 import { DeepSightSpinner } from "../components/ui/DeepSightSpinner";
 import { useTranslation } from "../hooks/useTranslation";
 import { useAuth } from "../hooks/useAuth";
+import { useAnalytics } from "../hooks/useAnalytics";
 import { SEO } from "../components/SEO";
 import { demoApi } from "../services/api";
 import type { DemoAnalyzeResult } from "../services/api";
@@ -397,7 +398,15 @@ const LandingPage: React.FC = () => {
   const navigate = useNavigate();
   const { language } = useTranslation();
   const { user, isLoading } = useAuth();
+  const { trackSignupStarted } = useAnalytics();
   const lang = language as "fr" | "en";
+
+  // 🚀 Launch J0 — fire `signup_started` puis navigate vers `/login?tab=register`.
+  // Permet de mesurer le drop-off CTA→form→submit par UTM source dans funnel A.
+  const handleSignupCta = (ctaLocation: string) => {
+    trackSignupStarted({ cta_location: ctaLocation });
+    navigate("/login?tab=register");
+  };
 
   const features = getFeatures(language);
   const audiences = getAudiences(language);
@@ -641,7 +650,7 @@ const LandingPage: React.FC = () => {
               {language === "fr" ? "Se connecter" : "Sign in"}
             </button>
             <motion.button
-              onClick={() => navigate("/login?tab=register")}
+              onClick={() => handleSignupCta("header")}
               className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-accent-primary text-gray-900 text-sm font-medium hover:bg-accent-primary-hover transition-colors"
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
@@ -829,7 +838,7 @@ const LandingPage: React.FC = () => {
                   {/* Features showcase — conversation IA vocale, flashcards, etc. */}
                   <DemoFeaturesShowcase
                     language={language}
-                    onSignup={() => navigate("/login?tab=register")}
+                    onSignup={() => handleSignupCta("demo_features")}
                   />
 
                   {/* Mini chat AI */}
@@ -869,7 +878,7 @@ const LandingPage: React.FC = () => {
                             : "Analyze another video"}
                         </motion.button>
                         <motion.button
-                          onClick={() => navigate("/login?tab=register")}
+                          onClick={() => handleSignupCta("demo_footer")}
                           className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-accent-primary/10 border border-accent-primary/20 text-accent-primary text-xs font-medium hover:bg-accent-primary/20 transition-colors"
                           whileHover={{ scale: 1.02 }}
                           whileTap={{ scale: 0.98 }}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -12,6 +12,7 @@ import {
 } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { useAuth } from "../hooks/useAuth";
+import { useAnalytics } from "../hooks/useAnalytics";
 import { useTranslation } from "../hooks/useTranslation";
 import { SEO } from "../components/SEO";
 import DoodleBackground from "../components/DoodleBackground";
@@ -72,6 +73,7 @@ export const Login: React.FC = () => {
     isLoading: authLoading,
   } = useAuth();
   const { t, language } = useTranslation();
+  const { trackSignup, trackLogin } = useAnalytics();
 
   const [isRegister, setIsRegister] = useState(false);
   const [showVerification, setShowVerification] = useState(false);
@@ -161,6 +163,9 @@ export const Login: React.FC = () => {
     try {
       if (isRegister) {
         await register(email.split("@")[0], email, password);
+        // 🚀 Launch J0 — track `user_signup` côté frontend (best-effort).
+        // Le backend fire `signup_completed` au verify_email pour la fiabilité.
+        trackSignup("email");
         setVerificationEmail(email);
         setShowVerification(true);
         setSuccess(
@@ -170,6 +175,21 @@ export const Login: React.FC = () => {
         );
       } else {
         await login(email, password);
+        // `trackLogin` ne peut pas accéder au user qui vient d'être chargé
+        // dans le state useAuth — useEffect ci-dessus gère la redirection ;
+        // l'identify se fait au prochain mount via trackLogin si appelé,
+        // mais user state hydrate après login() return. Best-effort identify
+        // via le storage `cached_user` (useAuth set localStorage).
+        try {
+          const cached = localStorage.getItem("cached_user");
+          if (cached) {
+            const parsed = JSON.parse(cached);
+            const u = parsed?.user;
+            if (u?.id) trackLogin(u.id, u.plan ?? "free", "email");
+          }
+        } catch {
+          /* identify best-effort — silent fail OK */
+        }
       }
     } catch (err: any) {
       setError(err?.message || err?.detail || t.errors.generic);

--- a/frontend/src/pages/UpgradePage.tsx
+++ b/frontend/src/pages/UpgradePage.tsx
@@ -35,6 +35,7 @@ import {
 } from "lucide-react";
 
 import { useAuth } from "../hooks/useAuth";
+import { useAnalytics } from "../hooks/useAnalytics";
 import { useTranslation } from "../hooks/useTranslation";
 import { Sidebar } from "../components/layout/Sidebar";
 import DoodleBackground from "../components/DoodleBackground";
@@ -967,6 +968,7 @@ interface SubscriptionStatus {
 
 export const UpgradePage: React.FC = () => {
   const { user, refreshUser } = useAuth();
+  const { trackPaymentInitiated } = useAnalytics();
   const { language } = useTranslation();
   const lang = (language as "fr" | "en") || "fr";
 
@@ -1102,6 +1104,24 @@ export const UpgradePage: React.FC = () => {
         !currentPlan ||
         currentPlan.price_monthly_cents === 0
       ) {
+        // 🚀 Launch J0 — fire `payment_initiated` AVANT redirect Stripe.
+        // Le backend fire `payment_completed` au webhook Stripe pour la
+        // fiabilité (tab fermée, adblock, etc.). Funnel C breakdown UTM.
+        if (plan.id === "pro" || plan.id === "expert") {
+          const tenureDays =
+            user?.created_at != null
+              ? Math.floor(
+                  (Date.now() - new Date(user.created_at).getTime()) /
+                    86_400_000,
+                )
+              : undefined;
+          trackPaymentInitiated({
+            plan: plan.id,
+            cycle,
+            current_plan: user?.plan ?? "free",
+            time_since_signup_days: tenureDays,
+          });
+        }
         // Upgrade → Stripe checkout (Pricing v2 : passer le cycle)
         const result = await billingApi.createCheckout(plan.id, cycle);
         if (result.checkout_url) {

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -267,6 +267,18 @@ export const AnalyticsEvents = {
   ONBOARDING_TOUR_STARTED: "onboarding_tour_started",
   ONBOARDING_TOUR_COMPLETED: "onboarding_tour_completed",
   ONBOARDING_TOUR_SKIPPED: "onboarding_tour_skipped",
+
+  // 🚀 Launch J0 events (sprint 2026-05-15) — UTM acquisition tracking
+  // SSOT vocab : `product_hunt | twitter | reddit | linkedin | indiehackers |
+  // hackernews | karim_inmail | mobile_deeplink | direct` (cf. utmCapture.ts).
+  // Events server-side fiables (signup_completed, payment_completed,
+  // churn_event) sont fired par le backend — ne PAS dupliquer côté frontend.
+  SIGNUP_STARTED: "signup_started", // clic CTA "Sign Up" landing
+  SIGNUP_COMPLETED: "signup_completed", // email vérifié (server-side)
+  ANALYSIS_STARTED: "analysis_started", // 1ère analyse vidéo (engagement KPI)
+  PAYMENT_INITIATED: "payment_initiated", // clic "Upgrade" → checkout Stripe
+  PAYMENT_COMPLETED: "payment_completed", // checkout success (server-side)
+  CHURN_EVENT: "churn_event", // cancel sub (server-side, Stripe webhook)
 } as const;
 
 export type AnalyticsEvent =

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -762,10 +762,29 @@ export const authApi = {
     username: string,
     email: string,
     password: string,
+    utm?: {
+      signup_source?: string;
+      utm_source?: string;
+      utm_medium?: string;
+      utm_campaign?: string;
+      referrer?: string;
+    },
   ): Promise<{ success: boolean; message: string }> {
     return request("/api/auth/register", {
       method: "POST",
-      body: { username, email, password },
+      body: {
+        username,
+        email,
+        password,
+        // 🚀 Launch J0 — UTM persistance dans User.preferences (backend
+        // auth/router.py). Backward-compatible : champs ignorés si tous
+        // undefined. Backend tolère les champs absents (Pydantic Optional).
+        ...(utm?.signup_source ? { signup_source: utm.signup_source } : {}),
+        ...(utm?.utm_source ? { utm_source: utm.utm_source } : {}),
+        ...(utm?.utm_medium ? { utm_medium: utm.utm_medium } : {}),
+        ...(utm?.utm_campaign ? { utm_campaign: utm.utm_campaign } : {}),
+        ...(utm?.referrer ? { referrer: utm.referrer } : {}),
+      },
       skipAuth: true,
     });
   },

--- a/frontend/src/services/utmCapture.ts
+++ b/frontend/src/services/utmCapture.ts
@@ -1,0 +1,233 @@
+/**
+ * 🎯 UTM Auto-Capture Helper — Launch J0 (2026-05-15)
+ *
+ * Parse `window.location.search` au mount AppProvider, persiste les paramètres
+ * UTM dans `localStorage` 30 jours (RGPD-tolerable : pas de PII, expire auto),
+ * puis les attache à TOUS les events PostHog via `posthog.register()`.
+ *
+ * Sources canoniques tracked (SSOT vocab aligné avec backend Stripe metadata
+ * `acquisition_channel` côté sub-agent Q) :
+ *   `product_hunt | twitter | reddit | linkedin | indiehackers | hackernews |
+ *    karim_inmail | mobile_deeplink | direct`.
+ * Tout autre `utm_source` est conservé tel quel (debug + futurs canaux).
+ *
+ * Persistance : clé `deepsight_utm_v1` (versioned — bump version pour forcer
+ * re-capture si schema change). Cleanup auto si `capturedAt > 30j`.
+ *
+ * Idempotent : si UTM déjà capturé < 30j, ne réécrase pas.
+ *
+ * Cross-team contract :
+ * - Frontend (ce fichier) : capture URL params + referrer fallback + register.
+ * - Backend `auth/router.py` : reçoit `signup_source/utm_*` au register, les
+ *   persiste dans `User.preferences` (JSON, migration 008 prod).
+ * - Backend `posthog_service.py` : fire `signup_completed/payment_completed/
+ *   churn_event` server-side avec ces mêmes propriétés.
+ */
+import posthog from "posthog-js";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Vocabulaire SSOT pour `utm_source` (et `signup_source` côté backend).
+ * Aligné avec sub-agent Q Stripe `acquisition_channel`. Toute source non
+ * listée est conservée brute (pour debug) — ne PAS l'invalider.
+ */
+export type CanonicalUtmSource =
+  | "product_hunt"
+  | "twitter"
+  | "reddit"
+  | "linkedin"
+  | "indiehackers"
+  | "hackernews"
+  | "karim_inmail"
+  | "mobile_deeplink"
+  | "direct";
+
+export interface CapturedUtm {
+  /** Source canonique normalisée OU valeur brute si inconnue. */
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+  /** `document.referrer` au moment de la capture. */
+  referrer?: string;
+  /** `window.location.pathname` au moment de la capture. */
+  landing_page?: string;
+  /** ISO date — utilisé pour le TTL 30j. */
+  capturedAt?: string;
+}
+
+const STORAGE_KEY = "deepsight_utm_v1";
+const TTL_DAYS = 30;
+const TTL_MS = TTL_DAYS * 86400 * 1000;
+
+/**
+ * Mapping aliases bruts (URL params lower-cased OU referrer hostnames) →
+ * vocabulaire SSOT. Ordre = priorité de match dans `inferSourceFromReferrer`.
+ */
+const KNOWN_SOURCES: Record<string, CanonicalUtmSource> = {
+  // Product Hunt
+  producthunt: "product_hunt",
+  product_hunt: "product_hunt",
+  ph: "product_hunt",
+  "producthunt.com": "product_hunt",
+  // Twitter / X
+  twitter: "twitter",
+  x: "twitter",
+  "t.co": "twitter",
+  "twitter.com": "twitter",
+  "x.com": "twitter",
+  // Reddit
+  reddit: "reddit",
+  "reddit.com": "reddit",
+  "old.reddit.com": "reddit",
+  // LinkedIn
+  linkedin: "linkedin",
+  "linkedin.com": "linkedin",
+  "lnkd.in": "linkedin",
+  // Indie Hackers
+  indiehackers: "indiehackers",
+  ih: "indiehackers",
+  "indiehackers.com": "indiehackers",
+  // Hacker News
+  hackernews: "hackernews",
+  hn: "hackernews",
+  "news.ycombinator.com": "hackernews",
+  // Karim B2B InMail
+  karim: "karim_inmail",
+  karim_inmail: "karim_inmail",
+  // Mobile deeplink (extension/app → web)
+  mobile: "mobile_deeplink",
+  mobile_deeplink: "mobile_deeplink",
+  app: "mobile_deeplink",
+  extension: "mobile_deeplink",
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+function normalizeSource(raw?: string | null): string | undefined {
+  if (!raw) return undefined;
+  const lower = raw.toLowerCase().trim();
+  if (!lower) return undefined;
+  return KNOWN_SOURCES[lower] ?? raw;
+}
+
+function readStored(): CapturedUtm | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CapturedUtm;
+    if (parsed.capturedAt) {
+      const ageMs = Date.now() - new Date(parsed.capturedAt).getTime();
+      if (ageMs > TTL_MS) {
+        localStorage.removeItem(STORAGE_KEY);
+        return null;
+      }
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(utm: CapturedUtm): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(utm));
+  } catch {
+    // Safari private mode / quota exceeded — silent no-op
+  }
+}
+
+function inferSourceFromReferrer(
+  referrer: string,
+): CanonicalUtmSource | string | undefined {
+  if (!referrer) return undefined;
+  try {
+    const host = new URL(referrer).hostname.replace(/^www\./, "");
+    // Match exact hostname first
+    if (host in KNOWN_SOURCES) return KNOWN_SOURCES[host];
+    // Then partial substring match for subdomains
+    for (const [needle, label] of Object.entries(KNOWN_SOURCES)) {
+      if (host.includes(needle)) return label;
+    }
+    // Garde le hostname brut comme dernier recours (debug)
+    return host;
+  } catch {
+    return undefined;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Public API
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * À appeler une fois au mount de l'App (cf. `App.tsx` `useEffect` initial).
+ *
+ * Idempotent : si UTM déjà capturé < 30j, ne réécrase pas et register juste
+ * dans PostHog (au cas où ce serait une navigation post-init via SPA route).
+ *
+ * Safe à appeler avant `posthog.init()` — `posthog-js` queue les appels en
+ * attendant l'init, donc pas de race condition. Pas de side effect si
+ * localStorage indispo (Safari private mode → silent no-op).
+ */
+export function captureUtmParams(): CapturedUtm {
+  const existing = readStored();
+  if (existing) {
+    posthog.register(existing);
+    return existing;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const referrer = document.referrer || "";
+
+  const utm: CapturedUtm = {
+    utm_source:
+      normalizeSource(params.get("utm_source")) ??
+      inferSourceFromReferrer(referrer) ??
+      "direct",
+    utm_medium: params.get("utm_medium") ?? undefined,
+    utm_campaign: params.get("utm_campaign") ?? undefined,
+    utm_term: params.get("utm_term") ?? undefined,
+    utm_content: params.get("utm_content") ?? undefined,
+    referrer: referrer || undefined,
+    landing_page: window.location.pathname || undefined,
+    capturedAt: new Date().toISOString(),
+  };
+
+  writeStored(utm);
+
+  // Register dans PostHog : ces props seront attachées à TOUS les events
+  // futurs (pas juste signup) pour permettre breakdown sur n'importe quel
+  // event ultérieur. Persistantes au niveau session PostHog.
+  posthog.register(utm);
+
+  return utm;
+}
+
+/**
+ * Helper read-only à utiliser depuis n'importe quel composant qui veut
+ * envoyer un event avec les UTM (ex : `handleClickSignUp`,
+ * `handleSubscribe`). Retourne `{ utm_source: "direct" }` si rien capturé
+ * (fallback safe pour ne jamais émettre des events orphelins de source).
+ */
+export function getCapturedUtm(): CapturedUtm {
+  return readStored() ?? { utm_source: "direct" };
+}
+
+/**
+ * Cleanup explicite. Utile au logout pour repartir d'une page propre, ou en
+ * test/debug. Sinon le TTL 30j auto-purge.
+ */
+export function clearCapturedUtm(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* noop */
+  }
+}

--- a/frontend/src/services/utmCapture.ts
+++ b/frontend/src/services/utmCapture.ts
@@ -60,7 +60,7 @@ export interface CapturedUtm {
   capturedAt?: string;
 }
 
-const STORAGE_KEY = "deepsight_utm_v1";
+const STORAGE_KEY = "deepsight_utm_v1"; // gitleaks:allow — localStorage key name, not a credential
 const TTL_DAYS = 30;
 const TTL_MS = TTL_DAYS * 86400 * 1000;
 

--- a/frontend/src/services/utmCapture.ts
+++ b/frontend/src/services/utmCapture.ts
@@ -60,7 +60,7 @@ export interface CapturedUtm {
   capturedAt?: string;
 }
 
-const STORAGE_KEY = "deepsight_utm_v1"; // gitleaks:allow — localStorage key name, not a credential
+const STORAGE_KEY = "deepsight_utm_v1";
 const TTL_DAYS = 30;
 const TTL_MS = TTL_DAYS * 86400 * 1000;
 


### PR DESCRIPTION
## Summary
- 14 fichiers (2 new + 12 modified) brancher PostHog launch J0 (2026-05-15) end-to-end : UTM auto-capture 30j, 6 events launch (3 frontend + 3 backend server-side), 3 funnels + 2 cohorts + 1 dashboard provisioning automatise.
- Vocabulaire SSOT `signup_source/acquisition_channel` aligne avec sub-agent Q Stripe (`product_hunt/twitter/reddit/linkedin/indiehackers/hackernews/karim_inmail/mobile_deeplink/direct`).
- Backend server-side events (`signup_completed/payment_completed/churn_event`) garantissent fiabilite meme si user ferme l'onglet ou adblock.

## Why now
- J0 = launch public 2026-05-15 (~8 jours). Dashboard launch real-time KPIs (signups/h, conversion Free->Pro 7d, MRR added today, churn 7d) doit etre operationnel avant J0 pour pilotage live.
- Le hook `useAnalytics` existait mais `trackSignup/trackLogin` n'etaient appeles nulle part dans `Login.tsx` (trou de tracking confirme grep). Cette PR le branche.
- UTM source non persistee aujourd'hui (`signup_source` n'existe pas dans `auth/schemas.py`). Sans ca, impossible de breakdown cohorts par canal d'acquisition.

## How it coordinates with parallel PRs
- **PR #382 (Trust Center, `feat/trust-center`)** : aucune collision. Cette PR ne touche PAS `TrustPage.tsx`. Ajout minimal sur `api.ts` (4e param optional sur `authApi.register`, backward-compat) pour eviter merge conflict avec l'export `request` de #382.
- **`feat/stripe-acquisition-channel` (sub-agent Q)** : meme vocabulaire SSOT. Q ajoute `acquisition_channel` dans Stripe Customer/Session metadata cote backend ; cette PR ajoute les memes valeurs canoniques cote frontend `utmCapture.ts` + `signup_source` dans User.preferences. Les deux PRs sont independantes mais coherentes (PostHog cohorts breakdown sur les memes valeurs).

## Files (14)
**New (2)** :
- `frontend/src/services/utmCapture.ts` (~210 LOC type-safe)
- `backend/src/services/posthog_service.py` (async wrapper autour `core.analytics.track_event`)

**Modified frontend (8)** :
- `frontend/src/services/analytics.ts` (+12 6 nouveaux events SIGNUP_STARTED/COMPLETED/ANALYSIS_STARTED/PAYMENT_INITIATED/COMPLETED/CHURN_EVENT)
- `frontend/src/services/api.ts` (+25 4e param `utm` optional sur `authApi.register`)
- `frontend/src/App.tsx` (+3 import + call `captureUtmParams()` au mount)
- `frontend/src/hooks/useAuth.ts` (+11 forward UTM au register call)
- `frontend/src/hooks/useAnalytics.ts` (+50 trackSignupStarted/trackLaunchAnalysisStarted/trackPaymentInitiated + UTM enrichment trackLogin/trackSignup)
- `frontend/src/pages/Login.tsx` (+22 trackSignup au register success + trackLogin au login success best-effort via cached_user)
- `frontend/src/pages/LandingPage.tsx` (+10 4 CTAs signup avec cta_location)
- `frontend/src/pages/UpgradePage.tsx` (+18 trackPaymentInitiated avant Stripe redirect)

**Modified backend (4)** :
- `backend/src/auth/schemas.py` (+15 UserRegister UTM fields Optional)
- `backend/src/auth/router.py` (+45 persist UTM + signup_completed track)
- `backend/src/billing/router.py` (+95 payment_completed + churn_event tracks)
- `backend/scripts/posthog_insights_config.py` (+150 3 funnels + 4 trends + 2 cohorts + 1 dashboard launch + BoldNumber Literal)

## Test plan
- [x] **Frontend typecheck** : `cd frontend && npm run typecheck` — pas de regression liee aux modifs (erreurs pre-existantes inchangees : DashboardPageLegacy, debate.ts, HubPage, useAuth.test.ts)
- [x] **Backend pytest** : 49 auth comprehensive + 52 billing + 12 auth_flow/analytics_helper → tous verts
- [x] **Backend smoke build_config** : 3 launch funnels + 4 launch trends + 2 launch cohorts + 1 launch dashboard correctement enregistres
- [ ] **PostHog provisioning dry-run** (post-merge, manual user action) : `POSTHOG_API_KEY=... POSTHOG_PROJECT_ID=... python backend/scripts/setup_posthog_insights.py --dry-run` — vérifier diff create-only sur les 7 nouveaux objets launch
- [ ] **Smoke test E2E** (post-deploy Vercel preview) : incognito `?utm_source=product_hunt&utm_campaign=launch-j0` → signup → DevTools Network voit POST `eu.i.posthog.com/i/v0/e/` avec utm_source: "product_hunt"
- [ ] **Stripe webhook trigger** : `stripe trigger checkout.session.completed` — verifier `payment_completed` apparait dans PostHog Live Events avec mrr_added_eur

## SSOT vocabulary (canonical strings)
Ces 9 valeurs sont la source de verite cross-team (frontend utmCapture + backend Stripe metadata + PostHog cohorts) :
`product_hunt | twitter | reddit | linkedin | indiehackers | hackernews | karim_inmail | mobile_deeplink | direct`

Tout autre `utm_source` brut est conserve pour debug mais ne match pas la cohort "Launch J0 signups".

## Risks
- **Conflit potentiel api.ts** avec PR #382 : minimise — j'ajoute un 4e param optional, PR #382 modifie autre chose dans api.ts (export `request`, suppression d'options analyze). Resolution conflict triviale au merge.
- **Tests __tests__/useAuth.test.ts** ont des erreurs TS pre-existantes (vi.fn() generic) qui restent — non liees a cette PR.
- **PostHog provisioning script** : `BoldNumber` ajoute au Literal display pourrait casser un appel existant si un autre dev utilise `display=` differement — verifie : aucun usage hors fichier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)