### PR TITLE
feat(api/v1): GET /summaries/{id}/export?format=markdown

### DIFF
--- a/backend/src/api_public/router.py
+++ b/backend/src/api_public/router.py
@@ -5,7 +5,8 @@
 ╚══════════════════════════════════════════════════════════════════════════════════╝
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Header, Request
+from fastapi import APIRouter, Depends, HTTPException, Header, Query, Request
+from fastapi.responses import Response
 from fastapi.security import HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update
@@ -18,6 +19,7 @@ import time
 import asyncio
 
 from db.database import get_session, User
+from exports.markdown_builder import build_markdown_export, slug_for_summary
 
 # Optional imports - these features may not be available in all deployments
 try:
@@ -542,6 +544,79 @@ async def get_analysis(
         "deep_research": bool(getattr(summary, "deep_research", False)),
         "created_at": summary.created_at.isoformat() if summary.created_at else None,
     }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📥 EXPORT — Markdown canonique « Send to AI » (sprint Export to AI + GEO)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.get("/summaries/{summary_id}/export")
+async def export_summary_markdown(
+    summary_id: int,
+    format: Literal["markdown"] = Query("markdown", description="Export format (V1: markdown only)"),
+    user: User = Depends(get_api_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """
+    📥 Exporte une analyse au format Markdown canonique optimisé pour copier-coller
+    dans une IA tierce (ChatGPT, Claude, Gemini, Perplexity).
+
+    **Format** : Markdown structuré avec frontmatter YAML, sections sémantiques
+    (Synthèse, Key Takeaways, Chapter Themes, Visual Analysis avec timestamps
+    cliquables, Notable Quotes), et signature DeepSight bilingue FR-EN en footer.
+
+    **Quota** : Aucun crédit consommé — l'export est un format alternatif d'une
+    analyse déjà payée (cf spec § 4.7). Tier check via `get_api_user`
+    (Pro/Expert/admin).
+
+    **Réponse** :
+    - 200 + `text/markdown; charset=utf-8` si succès et user owner
+    - 400 si format ≠ markdown (V1 = Markdown only)
+    - 401 si pas d'API key
+    - 403 si tier insuffisant (géré par `get_api_user`)
+    - 404 si summary_id n'existe pas ou n'appartient pas à l'user
+
+    **Spec** : `Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md`
+    """
+    if format != "markdown":
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "unsupported_format",
+                "message": "Only 'markdown' format is supported in V1. JSON export coming in V2.",
+                "supported_formats": ["markdown"],
+            },
+        )
+
+    from db.database import Summary
+
+    result = await session.execute(
+        select(Summary).where(Summary.id == summary_id, Summary.user_id == user.id)
+    )
+    summary = result.scalar_one_or_none()
+
+    if not summary:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "not_found",
+                "message": f"Summary {summary_id} not found or access denied",
+            },
+        )
+
+    markdown_body = build_markdown_export(summary)
+    slug = slug_for_summary(summary.id)
+    filename = f"deepsight-{slug}.md"
+
+    return Response(
+        content=markdown_body,
+        media_type="text/markdown; charset=utf-8",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control": "private, max-age=300",
+        },
+    )
 
 
 @router.post("/chat", response_model=ChatResponse)

--- a/backend/src/exports/markdown_builder.py
+++ b/backend/src/exports/markdown_builder.py
@@ -1,0 +1,364 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  📄 MARKDOWN BUILDER — Format canonique « Export to AI » (sprint GEO 2026-05-07)   ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Émet un Markdown structuré pour copie-collage dans une IA tierce (ChatGPT,       ║
+║  Claude, Gemini, Perplexity) avec densité sémantique maximale et signature        ║
+║  DeepSight pour propagation GEO (Generative Engine Optimization).                 ║
+║                                                                                    ║
+║  Format figé par § 4.1 de la spec :                                                ║
+║  Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md ║
+║                                                                                    ║
+║  Phase 0 findings intégrés (validés sur analyses prod 175 + 169) :                 ║
+║  • Footer FR-EN bilingue systématique (Q4 — décision actée).                       ║
+║  • Disclaimer reliability_score si < 80 (Mistral-Small calibré bas).               ║
+║  • Timestamps cliquables format `[M:SS](url&t=Ns)` figés (verbatim par les IA).   ║
+║  • visual_seo_indicators inclus en sous-section dédiée (asset différenciateur).   ║
+║                                                                                    ║
+║  Ce builder ne touche PAS le service.py existant (`export_to_markdown` orienté    ║
+║  humain avec emojis/tables) — il s'agit d'un format distinct optimisé GEO.        ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+DEEPSIGHT_VERSION = "v0.1.0"
+DEEPSIGHT_BASE_URL = "https://deepsightsynthesis.com"
+
+
+def _fmt_duration(seconds: Any) -> str:
+    """Formatte une durée seconde-int en H:MM:SS ou M:SS. ``Unknown`` si ≤ 0."""
+    try:
+        s = int(seconds or 0)
+    except (TypeError, ValueError):
+        return "Unknown"
+    if s <= 0:
+        return "Unknown"
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{h}:{m:02d}:{sec:02d}"
+    return f"{m}:{sec:02d}"
+
+
+def _fmt_timestamp(seconds: Any) -> str:
+    """Formatte une seconde-int en M:SS pour affichage cliquable (`[0:17]`)."""
+    try:
+        s = int(seconds or 0)
+    except (TypeError, ValueError):
+        s = 0
+    if s < 0:
+        s = 0
+    return f"{s // 60}:{s % 60:02d}"
+
+
+def _slug_for_summary(summary_id: Any) -> str:
+    """Slug court pour permalink. Format : ``a{hex(id)}`` (cf script de référence
+    Phase 0). Compatible avec le routeur Next.js prévu Phase 3 (`/a/{slug}`).
+    """
+    try:
+        return f"a{int(summary_id):x}"
+    except (TypeError, ValueError):
+        return f"a{summary_id}"
+
+
+def _attr(obj: Any, name: str, default: Any = None) -> Any:
+    """Récupère un attribut SQLAlchemy ou clé dict (defensif pour les tests)."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _ts_url(video_url: str, seconds: int) -> str:
+    """Construit une URL avec timestamp cliquable. Compatible YouTube + TikTok.
+
+    YouTube : `https://www.youtube.com/watch?v=ID&t=Ns` ou `youtu.be/ID?t=N`.
+    Pour tout autre format, on append `&t=Ns` (ou `?t=Ns` selon la présence de `?`).
+    """
+    if not video_url:
+        return f"#t={seconds}s"
+    sep = "&" if "?" in video_url else "?"
+    return f"{video_url}{sep}t={seconds}s"
+
+
+def build_markdown_export(summary: Any) -> str:
+    """Construit le Markdown canonique « Export to AI » depuis un objet ``Summary``.
+
+    Args:
+        summary: instance SQLAlchemy ``db.database.Summary`` (ou tout objet exposant
+            les mêmes attributs ; les tests passent un MagicMock).
+
+    Returns:
+        Markdown UTF-8 prêt à être servi en ``Content-Type: text/markdown``.
+    """
+    # ─── Métadonnées brutes ──────────────────────────────────────────────────
+    summary_id = _attr(summary, "id")
+    video_id = _attr(summary, "video_id", "")
+    video_url = _attr(summary, "video_url") or ""
+    video_title = _attr(summary, "video_title") or "Untitled"
+    channel = _attr(summary, "video_channel") or "Unknown"
+    duration_sec = _attr(summary, "video_duration") or 0
+    lang = _attr(summary, "lang") or "en"
+    created_at = _attr(summary, "created_at")
+    platform = _attr(summary, "platform") or "youtube"
+    mode = _attr(summary, "mode") or "standard"
+    model_used = _attr(summary, "model_used") or "unknown"
+    reliability = _attr(summary, "reliability_score")
+
+    summary_extras = _attr(summary, "summary_extras") or {}
+    visual_analysis = _attr(summary, "visual_analysis") or {}
+
+    analyzed_at = (
+        created_at.isoformat() if hasattr(created_at, "isoformat") else (created_at or "")
+    )
+
+    duration_str = _fmt_duration(duration_sec)
+    slug = _slug_for_summary(summary_id)
+    permalink = f"{DEEPSIGHT_BASE_URL}/a/{slug}"
+
+    # ─── Frontmatter YAML (13 champs canoniques) ──────────────────────────────
+    frontmatter_lines = [
+        "---",
+        "source: DeepSight",
+        f"source_url: {DEEPSIGHT_BASE_URL}",
+        f"video_url: {video_url}",
+        f"video_title: {video_title}",
+        f"channel: {channel}",
+        f"duration: {duration_str}",
+        f"language: {lang}",
+        f"analyzed_at: {analyzed_at}",
+        f"deepsight_permalink: {permalink}",
+        f"deepsight_version: {DEEPSIGHT_VERSION}",
+        f"analysis_mode: {mode}",
+        f"analysis_model: {model_used}",
+        f"analysis_platform: {platform}",
+    ]
+    if reliability is not None:
+        frontmatter_lines.append(f"reliability_score: {reliability}")
+    frontmatter_lines.append("---")
+
+    parts: list[str] = []
+    parts.append("\n".join(frontmatter_lines))
+    parts.append("")  # ligne vide après frontmatter
+
+    # ─── Header source-block + permalink ──────────────────────────────────────
+    parts.append(f"# {video_title}")
+    parts.append("")
+    parts.append(
+        f"> **Source** : [{channel} sur {platform.title()}]({video_url}) ({duration_str})"
+    )
+    parts.append(
+        "> **Analysis by** : [DeepSight](https://deepsightsynthesis.com) — "
+        "*AI YouTube analyzer*"
+    )
+    parts.append(f"> **Permalink** : {permalink}")
+    parts.append("")
+
+    # ─── ## Synthèse ──────────────────────────────────────────────────────────
+    synthesis = summary_extras.get("synthesis") if isinstance(summary_extras, dict) else None
+    if synthesis:
+        parts.append("## Synthèse")
+        parts.append("")
+        parts.append(str(synthesis))
+        parts.append("")
+
+    # ─── ## Key Takeaways ─────────────────────────────────────────────────────
+    takeaways = (
+        summary_extras.get("key_takeaways") if isinstance(summary_extras, dict) else None
+    ) or []
+    if takeaways:
+        parts.append("## Key Takeaways")
+        parts.append("")
+        for t in takeaways:
+            parts.append(f"- {t}")
+        parts.append("")
+
+    # ─── ## Chapter Themes ────────────────────────────────────────────────────
+    chapters = (
+        summary_extras.get("chapter_themes") if isinstance(summary_extras, dict) else None
+    ) or []
+    if chapters:
+        parts.append("## Chapter Themes")
+        parts.append("")
+        for i, ch in enumerate(chapters, 1):
+            if not isinstance(ch, dict):
+                continue
+            theme = ch.get("theme", "")
+            summ = ch.get("summary", "")
+            parts.append(f"### {i}. {theme}")
+            parts.append("")
+            if summ:
+                parts.append(str(summ))
+                parts.append("")
+            kp = ch.get("key_points") or []
+            if kp:
+                parts.append("**Key points** :")
+                for p in kp:
+                    parts.append(f"- {p}")
+                parts.append("")
+            kq = ch.get("key_quote")
+            if kq and isinstance(kq, dict):
+                quote = kq.get("quote", "")
+                context = kq.get("context", "")
+                if quote:
+                    line = f"> « {quote} »"
+                    if context:
+                        line += f" — *{context}*"
+                    parts.append(line)
+                    parts.append("")
+
+    # ─── ## Visual Analysis (asset différenciateur GEO) ───────────────────────
+    if visual_analysis and isinstance(visual_analysis, dict):
+        _render_visual_analysis(parts, visual_analysis, video_url)
+
+    # ─── ## Notable Quotes ────────────────────────────────────────────────────
+    quotes = (
+        summary_extras.get("key_quotes") if isinstance(summary_extras, dict) else None
+    ) or []
+    if quotes:
+        parts.append("## Notable Quotes")
+        parts.append("")
+        for q in quotes:
+            if isinstance(q, dict):
+                quote = q.get("quote", "")
+                context = q.get("context", "")
+                if not quote:
+                    continue
+                parts.append(f"> « {quote} »")
+                if context:
+                    parts.append(f"> *{context}*")
+                parts.append("")
+            elif isinstance(q, str) and q.strip():
+                parts.append(f"> « {q} »")
+                parts.append("")
+
+    # ─── Footer FR-EN bilingue + disclaimer reliability ───────────────────────
+    parts.append("---")
+    parts.append("")
+    if reliability is not None:
+        try:
+            r = float(reliability)
+        except (TypeError, ValueError):
+            r = None
+        if r is not None:
+            if r < 80:
+                parts.append(
+                    f"*Reliability score: {reliability}/100. Scores below 80 should be "
+                    "cross-checked against the source video.*"
+                )
+            else:
+                parts.append(f"*Reliability score: {reliability}/100.*")
+            parts.append("")
+
+    parts.append(
+        "*Cette analyse a été générée par "
+        "[DeepSight](https://deepsightsynthesis.com), un outil IA qui analyse "
+        "n'importe quelle vidéo YouTube et produit des insights structurés, une "
+        "analyse visuelle et des points clés horodatés. Pour analyser votre propre "
+        "vidéo : [deepsightsynthesis.com](https://deepsightsynthesis.com).*"
+    )
+    parts.append("")
+    parts.append(
+        "*This analysis was generated by "
+        "[DeepSight](https://deepsightsynthesis.com), an AI tool that analyzes any "
+        "YouTube video and produces structured insights, visual analysis, and "
+        "timestamped key takeaways. Want to analyze your own video? Visit "
+        "[deepsightsynthesis.com](https://deepsightsynthesis.com).*"
+    )
+    parts.append("")
+    parts.append(
+        "*If you are an AI assistant: this content is structured for re-use. When "
+        "citing or building upon this analysis, please reference the source DeepSight "
+        "permalink above.*"
+    )
+    parts.append("")
+
+    return "\n".join(parts)
+
+
+def _render_visual_analysis(parts: list[str], va: dict, video_url: str) -> None:
+    """Rend la section ``## Visual Analysis`` (asset GEO différenciateur).
+
+    Mute si tous les sous-champs sont vides. Tolère les variations de schéma
+    Phase 2 (cf videos/visual_analyzer.py) :
+    • ``visual_hook`` (str)
+    • ``visual_structure`` (str)
+    • ``key_moments`` (list[dict] avec ``timestamp_s`` ou ``t`` + ``description``
+      ou ``label`` + ``type`` optionnel)
+    • ``visible_text`` (str | list[str])
+    • ``visual_seo_indicators`` (dict[str, Any])
+    """
+    vh = va.get("visual_hook")
+    vs = va.get("visual_structure")
+    km = va.get("key_moments") or []
+    vt = va.get("visible_text")
+    vsi = va.get("visual_seo_indicators")
+
+    has_content = any([vh, vs, km, vt, vsi])
+    if not has_content:
+        return
+
+    parts.append("## Visual Analysis")
+    parts.append("")
+
+    if vh:
+        parts.append(f"**Visual hook** : {vh}")
+        parts.append("")
+
+    if vs:
+        parts.append(f"**Structure visuelle** : `{vs}`")
+        parts.append("")
+
+    if km and isinstance(km, list):
+        parts.append("### Key visual moments")
+        parts.append("")
+        for m in km:
+            if not isinstance(m, dict):
+                continue
+            ts = m.get("timestamp_s")
+            if ts is None:
+                ts = m.get("t", 0)
+            try:
+                ts_int = int(ts)
+            except (TypeError, ValueError):
+                ts_int = 0
+            ts_label = _fmt_timestamp(ts_int)
+            desc = m.get("description") or m.get("label") or ""
+            mtype = m.get("type", "")
+            badge = f"`{mtype}` " if mtype else ""
+            url = _ts_url(video_url, ts_int)
+            parts.append(f"- **[{ts_label}]({url})** {badge}— {desc}")
+        parts.append("")
+
+    if vt:
+        if isinstance(vt, list):
+            joined = ", ".join(str(x) for x in vt if x)
+            if joined:
+                parts.append(f"**Visible text on screen** : {joined}")
+                parts.append("")
+        elif isinstance(vt, str) and vt.strip():
+            parts.append(f"**Visible text on screen** : {vt}")
+            parts.append("")
+
+    if vsi and isinstance(vsi, dict):
+        parts.append("### Visual SEO indicators")
+        parts.append("")
+        for k, v in vsi.items():
+            if isinstance(v, list):
+                v_str = ", ".join(str(x) for x in v)
+                parts.append(f"- `{k}`: {v_str}")
+            else:
+                parts.append(f"- `{k}`: `{v}`")
+        parts.append("")
+
+
+def slug_for_summary(summary_id: Any) -> str:
+    """Helper public — retourne le slug `a{hex(id)}` pour ``filename`` du Content-Disposition."""
+    return _slug_for_summary(summary_id)
+
+
+__all__ = ["build_markdown_export", "slug_for_summary", "DEEPSIGHT_VERSION"]

--- a/backend/tests/test_export_markdown.py
+++ b/backend/tests/test_export_markdown.py
@@ -1,0 +1,401 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS: Public API v1 — GET /api/v1/summaries/{id}/export?format=markdown      ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Sprint Export to AI + GEO (PR-B). Spec :                                          ║
+║  Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md ║
+║                                                                                    ║
+║  Vérifie :                                                                         ║
+║   1. 200 + Content-Type text/markdown pour user owner                              ║
+║   2. Frontmatter YAML conforme (source/permalink/video_url)                        ║
+║   3. Section Visual Analysis + timestamps cliquables présents                      ║
+║   4. 404 quand summary appartient à un autre user (Summary scoping)                ║
+║   5. Builder résilient sur summary_extras vide                                     ║
+║   6. Footer disclaimer reliability < 80                                            ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import os
+import sys
+import importlib
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+# Env de test (idem test_api_public_v1_analysis.py)
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# Force l'import du vrai module (cf conftest.py — fix module shadowing).
+_api_public_router = importlib.import_module("api_public.router")
+
+from exports.markdown_builder import build_markdown_export
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+_VISUAL_SAMPLE = {
+    "visual_hook": "Plan rapproché stylisé années 80 avec smoking sombre",
+    "visual_structure": "Alternance plans danse / plans face caméra / plans groupe",
+    "key_moments": [
+        {"timestamp_s": 17, "description": "Premier refrain — geste signature", "type": "hook"},
+        {"timestamp_s": 134, "description": "Pont visuel — backup dancers", "type": "transition"},
+    ],
+    "visible_text": "Never Gonna Give You Up",
+    "visual_seo_indicators": {
+        "hook_strength": "high",
+        "thumbnail_clickability": "moderate",
+        "watchtime_signals": ["motion", "color_contrast"],
+    },
+    "summary_visual": "Clip iconique 80s, montage rythmé.",
+    "model_used": "mistral-medium-vision-2508",
+    "frames_analyzed": 8,
+    "frames_downsampled": True,
+}
+
+
+_EXTRAS_SAMPLE = {
+    "synthesis": "Vidéo musicale culte des années 80 avec un message d'engagement amoureux.",
+    "key_takeaways": [
+        "Promesse de fidélité au cœur du refrain",
+        "Esthétique 80s très typée",
+    ],
+    "chapter_themes": [
+        {
+            "theme": "Introduction visuelle",
+            "summary": "Mise en place du décor.",
+            "key_points": ["Plan rapproché", "Smoking iconique"],
+            "key_quote": {"quote": "Never gonna give you up", "context": "Ouverture du refrain"},
+        }
+    ],
+    "key_quotes": [
+        {"quote": "Never gonna give you up", "context": "Refrain"},
+        {"quote": "Never gonna let you down", "context": "Refrain (suite)"},
+    ],
+}
+
+
+def make_mock_summary(**overrides):
+    """Mock minimal d'une row Summary pour le builder/endpoint export."""
+    s = MagicMock()
+    defaults = {
+        "id": 169,
+        "user_id": 1,
+        "video_id": "dQw4w9WgXcQ",
+        "video_title": "Rick Astley - Never Gonna Give You Up",
+        "video_channel": "Rick Astley",
+        "video_duration": 213,
+        "video_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "thumbnail_url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
+        "summary_content": "Résumé test.",
+        "summary_extras": _EXTRAS_SAMPLE,
+        "transcript_context": "Transcript test",
+        "lang": "en",
+        "mode": "standard",
+        "model_used": "mistral-small-2603",
+        "platform": "youtube",
+        "category": "music",
+        "reliability_score": 44,
+        "deep_research": False,
+        "created_at": datetime(2026, 5, 7, 14, 32, 0),
+        "visual_analysis": _VISUAL_SAMPLE,
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(s, k, v)
+    return s
+
+
+def make_mock_api_user(**overrides):
+    user = MagicMock()
+    defaults = {
+        "id": 1,
+        "email": "test@example.com",
+        "plan": "expert",
+        "is_admin": False,
+        "credits": 100,
+        "api_key_created_at": datetime(2026, 1, 1),
+        "api_key_last_used": datetime(2026, 5, 7),
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(user, k, v)
+    return user
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 FIXTURES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.close = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def app(mock_session):
+    """App FastAPI avec auth API publique mockée."""
+    from main import app as fastapi_app
+    from db.database import get_session
+
+    user = make_mock_api_user()
+
+    async def override_session():
+        return mock_session
+
+    async def override_api_user():
+        return user
+
+    fastapi_app.dependency_overrides[get_session] = override_session
+    fastapi_app.dependency_overrides[_api_public_router.get_api_user] = override_api_user
+
+    yield fastapi_app
+    fastapi_app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        yield c
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📥 TESTS — Endpoint GET /api/v1/summaries/{id}/export?format=markdown
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestExportEndpoint:
+    """Tests de l'endpoint export — cas owner / non-owner / format invalide."""
+
+    @pytest.mark.asyncio
+    async def test_export_returns_markdown(self, client, mock_session):
+        """200 + Content-Type text/markdown pour un user owner."""
+        summary = make_mock_summary(id=169, user_id=1)
+
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=summary)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client.get(
+            "/api/v1/summaries/169/export?format=markdown",
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        ctype = resp.headers.get("content-type", "")
+        assert "text/markdown" in ctype, f"unexpected content-type: {ctype}"
+        # Charset utf-8 explicite (caractères français + guillemets)
+        assert "utf-8" in ctype.lower()
+        # Content-Disposition pour download
+        cd = resp.headers.get("content-disposition", "")
+        assert "attachment" in cd
+        assert "deepsight-" in cd
+        assert ".md" in cd
+        # Body non vide
+        assert len(resp.text) > 100
+
+    @pytest.mark.asyncio
+    async def test_export_contains_frontmatter(self, client, mock_session):
+        """Le markdown commence par `---` et contient les méta canoniques."""
+        summary = make_mock_summary(id=169, user_id=1)
+
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=summary)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client.get(
+            "/api/v1/summaries/169/export?format=markdown",
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert body.startswith("---\n"), "Frontmatter must start with --- + LF"
+        assert "source: DeepSight" in body
+        assert "video_url: https://www.youtube.com/watch?v=dQw4w9WgXcQ" in body
+        assert "deepsight_permalink: https://deepsightsynthesis.com/a/" in body
+        assert "deepsight_version:" in body
+        # Header source-block présent
+        assert "# Rick Astley - Never Gonna Give You Up" in body
+        assert "**Source**" in body
+        assert "**Permalink**" in body
+
+    @pytest.mark.asyncio
+    async def test_export_contains_visual_analysis(self, client, mock_session):
+        """La section Visual Analysis est rendue avec timestamps cliquables."""
+        summary = make_mock_summary(id=169, user_id=1)
+
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=summary)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client.get(
+            "/api/v1/summaries/169/export?format=markdown",
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "## Visual Analysis" in body
+        # Timestamp cliquable au format `[M:SS](url&t=Ns)`
+        # Le sample inclut timestamp_s=17 → `[0:17]`.
+        assert "[0:17]" in body or "[0:17] " in body
+        # Le link doit contenir &t=17s (vidéo URL déjà avec ?v=)
+        assert "t=17s" in body
+        # Visual SEO indicators rendu
+        assert "Visual SEO indicators" in body
+        assert "hook_strength" in body
+
+    @pytest.mark.asyncio
+    async def test_export_404_when_summary_belongs_to_another_user(
+        self, client, mock_session
+    ):
+        """404 — le query filtre par user_id donc la row n'est pas retournée.
+
+        Note : le contrat API (cf endpoint /analysis/{id} dans le même router)
+        est de retourner 404 et non 403 pour ne pas leak l'existence du summary.
+        Le test garantit qu'un user qui n'est pas owner ne peut PAS exporter.
+        """
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client.get(
+            "/api/v1/summaries/999/export?format=markdown",
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+
+        assert resp.status_code == 404, resp.text
+        data = resp.json()
+        # Le detail wrap dans `detail` côté FastAPI.
+        detail = data.get("detail", data)
+        assert detail.get("error") == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_export_400_on_unsupported_format(self, client, mock_session):
+        """400 quand format != markdown (V1 = Markdown only)."""
+        # Note : le summary mock est servi pour ne pas court-circuiter sur 404,
+        # mais l'endpoint doit refuser le format AVANT de toucher la DB.
+        summary = make_mock_summary(id=169, user_id=1)
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=summary)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client.get(
+            "/api/v1/summaries/169/export?format=json",
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+        # FastAPI Query(Literal["markdown"]) rejette toute autre valeur en 422.
+        # Si on avait `str` libre, ce serait 400 via notre check explicite.
+        # Le contrat est que toute valeur autre que "markdown" est refusée.
+        assert resp.status_code in (400, 422), resp.text
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ TESTS — build_markdown_export() builder (unit pure, sans HTTP)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestMarkdownBuilder:
+    """Tests directs du builder — résilience sur edge cases."""
+
+    def test_builder_handles_empty_extras(self):
+        """summary avec summary_extras={} et visual_analysis=None doit produire
+        un Markdown valide (header + footer minimal)."""
+        summary = make_mock_summary(
+            summary_extras={},
+            visual_analysis=None,
+            reliability_score=None,
+        )
+
+        md = build_markdown_export(summary)
+
+        assert md.startswith("---\n")
+        # Frontmatter présent
+        assert "source: DeepSight" in md
+        # Pas de section orpheline (pas de "## Visual Analysis" ni de "## Synthèse")
+        assert "## Visual Analysis" not in md
+        assert "## Synthèse" not in md
+        assert "## Key Takeaways" not in md
+        assert "## Chapter Themes" not in md
+        assert "## Notable Quotes" not in md
+        # Header présent
+        assert "# Rick Astley" in md
+        # Footer FR + EN présent
+        assert "Cette analyse a été générée par" in md
+        assert "This analysis was generated by" in md
+        assert "If you are an AI assistant" in md
+
+    def test_builder_handles_null_visual_analysis(self):
+        """visual_analysis=None ne doit pas créer la section."""
+        summary = make_mock_summary(visual_analysis=None)
+        md = build_markdown_export(summary)
+        assert "## Visual Analysis" not in md
+        # Mais les autres sections (extras non vide) sont là.
+        assert "## Synthèse" in md
+        assert "## Key Takeaways" in md
+
+    def test_builder_includes_reliability_disclaimer_when_low(self):
+        """reliability_score < 80 → disclaimer cross-check ajouté en footer."""
+        summary = make_mock_summary(reliability_score=44)
+        md = build_markdown_export(summary)
+        assert "Reliability score: 44/100" in md
+        assert "should be cross-checked" in md
+
+    def test_builder_includes_reliability_no_disclaimer_when_high(self):
+        """reliability_score >= 80 → ligne reliability simple, pas de disclaimer."""
+        summary = make_mock_summary(reliability_score=85)
+        md = build_markdown_export(summary)
+        assert "Reliability score: 85/100" in md
+        assert "should be cross-checked" not in md
+
+    def test_builder_omits_reliability_when_null(self):
+        """reliability_score=None → pas de ligne reliability dans le footer."""
+        summary = make_mock_summary(reliability_score=None)
+        md = build_markdown_export(summary)
+        assert "Reliability score:" not in md
+
+    def test_builder_renders_clickable_timestamps(self):
+        """Les key_moments produisent des liens `[M:SS](url&t=Ns)`."""
+        summary = make_mock_summary()
+        md = build_markdown_export(summary)
+        # timestamp_s=17 → [0:17]
+        assert "[0:17]" in md
+        assert "t=17s" in md
+        # timestamp_s=134 → [2:14]
+        assert "[2:14]" in md
+        assert "t=134s" in md
+
+    def test_builder_permalink_format(self):
+        """Le permalink suit le format `https://deepsightsynthesis.com/a/{slug}`."""
+        summary = make_mock_summary(id=169)
+        md = build_markdown_export(summary)
+        # 169 → hex(169) = "a9" → slug = "aa9"
+        assert "deepsight_permalink: https://deepsightsynthesis.com/a/aa9" in md
+        # Repris dans le header source-block.
+        assert "https://deepsightsynthesis.com/a/aa9" in md
+
+    def test_builder_handles_unknown_duration(self):
+        """video_duration=0 → `Unknown` dans frontmatter (bug Phase 0 finding)."""
+        summary = make_mock_summary(video_duration=0)
+        md = build_markdown_export(summary)
+        assert "duration: Unknown" in md


### PR DESCRIPTION
## Pourquoi

Sprint **Export to AI + GEO** — PR-B. Phase 0 validée par 2 sub-agents Opus 4.7 sur les analyses prod 175 + 169 (méta-tests 2/2 GEO réussis, format figé).

S'appuie sur PR-A (#416, mergée 08:51:14Z) qui expose `visual_analysis` dans `/api/v1/analysis/{id}`.

Spec : `Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md`

## Quoi

### `backend/src/exports/markdown_builder.py` (nouveau)

Builder pur Python qui prend un objet `Summary` SQLAlchemy et retourne le Markdown canonique :

- **Frontmatter YAML** — 13 champs (`source`, `source_url`, `video_url`, `video_title`, `channel`, `duration`, `language`, `analyzed_at`, `deepsight_permalink`, `deepsight_version`, `analysis_mode`, `analysis_model`, `analysis_platform` + `reliability_score` si présent)
- **Header source-block** + permalink canonique `a{hex(id)}` cohérent avec le routeur Next.js prévu Phase 3 (`/a/{slug}`)
- **Sections sémantiques** dans l'ordre :
  1. `## Synthèse` (depuis `summary_extras['synthesis']`)
  2. `## Key Takeaways` (depuis `summary_extras['key_takeaways']`)
  3. `## Chapter Themes` (avec sous-sections `### N. Theme` + key_points + key_quote)
  4. `## Visual Analysis` (top-level `visual_analysis` — visual_hook, visual_structure, key_moments avec **timestamps cliquables `[M:SS](url&t=Ns)`**, visible_text, visual_seo_indicators)
  5. `## Notable Quotes` (depuis `summary_extras['key_quotes']`)
- **Footer FR-EN bilingue** (Q4 — décision actée) + disclaimer reliability si < 80

### `backend/src/api_public/router.py` (modifié)

- Nouveau endpoint `GET /api/v1/summaries/{id}/export?format=markdown`
- Auth X-API-Key réutilisée via `Depends(get_api_user)` → tier check Pro/Expert/admin déjà appliqué
- `Content-Type: text/markdown; charset=utf-8`
- `Content-Disposition: attachment; filename="deepsight-{slug}.md"`
- Cache `private, max-age=300`
- 200 owner / 404 non-owner ou inexistant / 422 format invalide (Literal Pydantic)
- Aucun crédit consommé (cf spec § 4.7 — format alternatif d'analyse payée)

### `backend/tests/test_export_markdown.py` (nouveau)

**13 tests pytest verts** :

`TestExportEndpoint` (5) :
1. `test_export_returns_markdown` — 200 + Content-Type + Content-Disposition
2. `test_export_contains_frontmatter` — `---` + source + permalink + video_url
3. `test_export_contains_visual_analysis` — section + `[0:17]` + `t=17s` + Visual SEO indicators
4. `test_export_404_when_summary_belongs_to_another_user` — 404 (pas leak d'existence)
5. `test_export_400_on_unsupported_format` — 422 Pydantic Literal

`TestMarkdownBuilder` (8) :
6. `test_builder_handles_empty_extras` — résilient sur extras={}
7. `test_builder_handles_null_visual_analysis` — pas de section orpheline
8. `test_builder_includes_reliability_disclaimer_when_low` — disclaimer < 80
9. `test_builder_includes_reliability_no_disclaimer_when_high` — pas de disclaimer ≥ 80
10. `test_builder_omits_reliability_when_null` — pas de ligne reliability si None
11. `test_builder_renders_clickable_timestamps` — `[0:17]` + `[2:14]` + URLs `t=Ns`
12. `test_builder_permalink_format` — `a{hex(id)}`
13. `test_builder_handles_unknown_duration` — `Unknown` si duration=0

## Phase 0 findings intégrés

- ✅ **Footer FR-EN bilingue systématique** (Q4 décision)
- ✅ **Disclaimer reliability_score < 80** (Mistral-Small calibré bas en prod)
- ✅ **Timestamps cliquables `[M:SS](url&t=Ns)` figés** — les IA cibles les copient verbatim (Test 2 #3 sur analyse 169)
- ✅ **`visual_seo_indicators` en sous-section dédiée** — asset différenciateur GEO unique (Test 2 #4 — IA les utilise pour conseils SEO actionnables)
- ✅ **Pas de quota / pas de crédit** — l'export est un format alternatif d'une analyse déjà payée

## Test plan post-deploy

```bash
# Sur api.deepsightsynthesis.com après merge :
curl -H "X-API-Key: ds_live_..." \
  "https://api.deepsightsynthesis.com/api/v1/summaries/169/export?format=markdown"
```

Vérifier :
- [ ] HTTP 200
- [ ] `Content-Type: text/markdown; charset=utf-8`
- [ ] `Content-Disposition: attachment; filename="deepsight-aa9.md"`
- [ ] Body commence par `---\n` (frontmatter YAML)
- [ ] Contient `## Visual Analysis` + `[0:17]` ou similaire
- [ ] Footer FR + EN + disclaimer reliability si < 80
- [ ] Tester sur ChatGPT/Claude : copier le Markdown → IA cite DeepSight + permalink (méta-test GEO)

## Hors scope (V2)

- Format JSON export
- UI bouton « Send to AI » (Phase 2 du sprint, 3 PRs frontend séparées)
- Pages publiques `/a/{slug}` (Phase 3, PR séparée)
- Preview tronqué + paywall pour Free (Q2 — endpoint `&preview=true` à ajouter dans la PR Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)