### PR TITLE
feat(web): Background Analysis FAB — global spinner cross-route + cap 2/2

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,8 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { LanguageProvider } from "./contexts/LanguageContext";
 import { LoadingWordProvider } from "./contexts/LoadingWordContext";
 import { TTSProvider } from "./contexts/TTSContext";
+import { BackgroundAnalysisProvider } from "./contexts/BackgroundAnalysisContext";
+import { BackgroundAnalysisFAB } from "./components/background/BackgroundAnalysisFAB";
 import { PrivateRoute } from "./components/PrivateRoute";
 import { SkipLink } from "./components/SkipLink";
 import { SEO } from "./components/SEO";
@@ -544,6 +546,7 @@ const AppRoutes = () => {
         <AuthProvider value={auth}>
           <TTSProvider>
             <VoicePrefsStagingProvider>
+              <BackgroundAnalysisProvider>
               <Router>
                 <>
                   {/* ♿ Skip Link pour l'accessibilité */}
@@ -551,6 +554,9 @@ const AppRoutes = () => {
 
                   {/* 🔮 Prefetcher intelligent */}
                   <RoutePrefetcher />
+
+                  {/* 🔄 FAB global d'analyses en background */}
+                  <BackgroundAnalysisFAB />
 
                   <ErrorBoundary>
                     <Routes>
@@ -1177,6 +1183,7 @@ const AppRoutes = () => {
                   </ErrorBoundary>
                 </>
               </Router>
+              </BackgroundAnalysisProvider>
             </VoicePrefsStagingProvider>
           </TTSProvider>
         </AuthProvider>

--- a/frontend/src/components/background/BackgroundAnalysisFAB.tsx
+++ b/frontend/src/components/background/BackgroundAnalysisFAB.tsx
@@ -1,0 +1,247 @@
+/**
+ * BackgroundAnalysisFAB — Floating Action Button global
+ * ───────────────────────────────────────────────────────────────────────────
+ * Visible sur toutes les routes Web dès qu'au moins une analyse tourne en
+ * background. États visuels : processing 1 / processing 2 / success / error.
+ *
+ * - Desktop : fixed bottom-right, 64px diam.
+ * - Mobile (< 768px) : fixed top-right (sous le header), évite zone gestes iOS.
+ * - Click → ouvre BackgroundAnalysisPanel (Phase 3).
+ *
+ * Décisions :
+ * - State dérivé directement des tasks du context (pas de double source).
+ * - Success state auto-dismiss après 10s (timer + acknowledgeCompleted).
+ * - Error state persiste jusqu'à click ou clearCompleted.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import { AlertTriangle, Check } from "lucide-react";
+import {
+  useBackgroundAnalysis,
+  type AnalysisTask,
+  type VideoAnalysisTask,
+  type PlaylistAnalysisTask,
+} from "../../contexts/BackgroundAnalysisContext";
+import { DeepSightSpinner } from "../ui/DeepSightSpinner";
+import { useWebNotification } from "../../hooks/useWebNotification";
+import { BackgroundAnalysisPanel } from "./BackgroundAnalysisPanel";
+
+function getTaskTitle(task: AnalysisTask): string {
+  if (task.type === "video") {
+    const v = task as VideoAnalysisTask;
+    return v.videoTitle || v.result?.video_title || v.videoUrl;
+  }
+  const p = task as PlaylistAnalysisTask;
+  return p.playlistTitle || p.playlistUrl;
+}
+
+function getTaskHref(task: AnalysisTask): string | null {
+  if (task.type === "video") {
+    const v = task as VideoAnalysisTask;
+    if (v.status === "completed" && v.result?.id) return `/hub?conv=${v.result.id}`;
+  }
+  return null;
+}
+
+type FabState = "hidden" | "processing" | "success" | "error";
+
+const STATE_COLORS: Record<Exclude<FabState, "hidden">, string> = {
+  processing: "from-indigo-500/40 to-violet-500/30 border-indigo-400/40",
+  success: "from-emerald-500/40 to-emerald-400/30 border-emerald-400/50",
+  error: "from-red-500/40 to-red-400/30 border-red-400/50",
+};
+
+const SUCCESS_AUTODISMISS_MS = 10_000;
+
+export const BackgroundAnalysisFAB: React.FC = () => {
+  const {
+    tasks,
+    activeTasksCount,
+    hasNewCompletedTask,
+    acknowledgeCompleted,
+  } = useBackgroundAnalysis();
+  const [open, setOpen] = useState(false);
+  const { sendNotification } = useWebNotification();
+  const navigate = useNavigate();
+  const notifiedIdsRef = useRef<Set<string>>(new Set());
+
+  // Web Notification : déclenchée uniquement si le tab est inactif au moment
+  // de la complétion (sinon le toast/check anim/badge nav suffisent).
+  useEffect(() => {
+    for (const task of tasks) {
+      if (task.status !== "completed") continue;
+      if (notifiedIdsRef.current.has(task.id)) continue;
+      notifiedIdsRef.current.add(task.id);
+      if (typeof document !== "undefined" && document.hidden) {
+        const href = getTaskHref(task);
+        sendNotification({
+          title: "DeepSight — Analyse terminée",
+          body: getTaskTitle(task),
+          tag: task.id,
+          onClick: href ? () => navigate(href) : undefined,
+        });
+      }
+    }
+    // Garbage-collect les ids de tasks supprimées.
+    const currentIds = new Set(tasks.map((t) => t.id));
+    for (const id of Array.from(notifiedIdsRef.current)) {
+      if (!currentIds.has(id)) notifiedIdsRef.current.delete(id);
+    }
+  }, [tasks, sendNotification, navigate]);
+
+  const failedCount = useMemo(
+    () => tasks.filter((t) => t.status === "failed").length,
+    [tasks],
+  );
+
+  const fabState: FabState = useMemo(() => {
+    if (activeTasksCount > 0) return "processing";
+    if (failedCount > 0) return "error";
+    if (hasNewCompletedTask) return "success";
+    return "hidden";
+  }, [activeTasksCount, failedCount, hasNewCompletedTask]);
+
+  // Auto-dismiss success state after 10s (acknowledge so the FAB hides if
+  // nothing else is going on).
+  useEffect(() => {
+    if (fabState !== "success") return;
+    const timer = window.setTimeout(() => {
+      acknowledgeCompleted();
+    }, SUCCESS_AUTODISMISS_MS);
+    return () => window.clearTimeout(timer);
+  }, [fabState, acknowledgeCompleted]);
+
+  // Close panel automatically when nothing left to show.
+  useEffect(() => {
+    if (fabState === "hidden" && open) setOpen(false);
+  }, [fabState, open]);
+
+  const handleClick = () => {
+    if (fabState === "success") {
+      acknowledgeCompleted();
+      return;
+    }
+    setOpen((v) => !v);
+  };
+
+  const badgeCount =
+    fabState === "processing" && activeTasksCount > 1
+      ? activeTasksCount
+      : fabState === "error" && failedCount > 0
+        ? failedCount
+        : null;
+
+  const ariaLabel =
+    fabState === "processing"
+      ? `${activeTasksCount} analyse${activeTasksCount > 1 ? "s" : ""} en cours`
+      : fabState === "success"
+        ? "Analyse terminée"
+        : fabState === "error"
+          ? `${failedCount} analyse${failedCount > 1 ? "s" : ""} en échec`
+          : "";
+
+  return (
+    <>
+      <AnimatePresence>
+        {fabState !== "hidden" && (
+          <motion.div
+            key="bg-analysis-fab"
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+            className="fixed z-[60] right-4 top-20 md:right-6 md:bottom-6 md:top-auto"
+          >
+            <motion.button
+              type="button"
+              onClick={handleClick}
+              aria-label={ariaLabel}
+              aria-expanded={open}
+              aria-haspopup="dialog"
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              animate={
+                fabState === "processing"
+                  ? {
+                      boxShadow: [
+                        "0 0 0 0 rgba(99,102,241,0)",
+                        "0 0 32px 8px rgba(99,102,241,0.35)",
+                        "0 0 0 0 rgba(99,102,241,0)",
+                      ],
+                    }
+                  : fabState === "error"
+                    ? {
+                        boxShadow: [
+                          "0 0 0 0 rgba(239,68,68,0)",
+                          "0 0 24px 6px rgba(239,68,68,0.4)",
+                          "0 0 0 0 rgba(239,68,68,0)",
+                        ],
+                      }
+                    : {
+                        boxShadow: "0 8px 24px rgba(16,185,129,0.35)",
+                      }
+              }
+              transition={{ duration: 2.2, repeat: Infinity, ease: "easeInOut" }}
+              className={`
+                relative flex items-center justify-center
+                w-16 h-16 rounded-full
+                bg-gradient-to-br ${STATE_COLORS[fabState]}
+                border-2 backdrop-blur-xl
+                outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0f]
+                ${fabState === "processing" ? "focus-visible:ring-indigo-400" : ""}
+                ${fabState === "success" ? "focus-visible:ring-emerald-400" : ""}
+                ${fabState === "error" ? "focus-visible:ring-red-400" : ""}
+                cursor-pointer
+              `}
+            >
+              {fabState === "processing" && (
+                <DeepSightSpinner size={44} speed="fast" />
+              )}
+              {fabState === "success" && (
+                <motion.div
+                  initial={{ scale: 0, rotate: -90 }}
+                  animate={{ scale: 1, rotate: 0 }}
+                  transition={{ type: "spring", stiffness: 400, damping: 15 }}
+                >
+                  <Check className="w-8 h-8 text-emerald-200" strokeWidth={3} />
+                </motion.div>
+              )}
+              {fabState === "error" && (
+                <AlertTriangle
+                  className="w-7 h-7 text-red-200"
+                  strokeWidth={2.2}
+                />
+              )}
+
+              {/* Badge count si > 1 task */}
+              {badgeCount !== null && (
+                <motion.span
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  className={`
+                    absolute -top-1 -right-1 min-w-[22px] h-[22px] px-1.5
+                    rounded-full flex items-center justify-center
+                    text-[11px] font-bold text-white
+                    border-2 border-[#0a0a0f]
+                    ${fabState === "processing" ? "bg-violet-500" : ""}
+                    ${fabState === "error" ? "bg-red-600" : ""}
+                  `}
+                  aria-hidden="true"
+                >
+                  {badgeCount}
+                </motion.span>
+              )}
+            </motion.button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Panneau étendu (Phase 3) */}
+      <BackgroundAnalysisPanel open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+};
+
+export default BackgroundAnalysisFAB;

--- a/frontend/src/components/background/BackgroundAnalysisPanel.tsx
+++ b/frontend/src/components/background/BackgroundAnalysisPanel.tsx
@@ -1,0 +1,331 @@
+/**
+ * BackgroundAnalysisPanel — popover déclenché par BackgroundAnalysisFAB
+ * ───────────────────────────────────────────────────────────────────────────
+ * Liste les analyses en cours / terminées récemment / en échec.
+ * - Bouton « Voir » → navigate vers la page d'analyse correspondante.
+ * - Bouton « Réessayer » sur task failed → retryTask du context.
+ * - Ligne quota mensuel + lien /pricing si proche limite.
+ * - Bouton « Effacer terminées » → clearCompleted du context.
+ */
+
+import React, { useEffect, useMemo, useRef } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { motion } from "framer-motion";
+import { Eye, RefreshCw, Trash2, X, AlertTriangle } from "lucide-react";
+import {
+  useBackgroundAnalysis,
+  type AnalysisTask,
+  type VideoAnalysisTask,
+  type PlaylistAnalysisTask,
+} from "../../contexts/BackgroundAnalysisContext";
+import { authApi } from "../../services/api";
+
+interface BackgroundAnalysisPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const QUOTA_WARN_THRESHOLD = 0.2; // < 20% restant → orange
+
+function formatEta(task: AnalysisTask): string {
+  if (task.status === "completed") return "Terminée";
+  if (task.status === "failed") return "Échec";
+  if (task.progress <= 0) return "—";
+  const elapsedMs = Date.now() - task.startedAt.getTime();
+  const totalMs = (elapsedMs / task.progress) * 100;
+  const remainingMs = Math.max(0, totalMs - elapsedMs);
+  if (remainingMs > 30 * 60 * 1000) return "—";
+  if (remainingMs < 5_000) return "< 5s";
+  const m = Math.floor(remainingMs / 60_000);
+  const s = Math.floor((remainingMs % 60_000) / 1_000);
+  return m > 0 ? `${m}m${s.toString().padStart(2, "0")}` : `${s}s`;
+}
+
+function getViewHref(task: AnalysisTask): string | null {
+  if (task.type === "video") {
+    const v = task as VideoAnalysisTask;
+    if (v.status === "completed" && v.result?.id) return `/hub?conv=${v.result.id}`;
+    if (v.taskId) return `/hub?analyzing=${v.taskId}`;
+    return null;
+  }
+  // Playlists : routing pas finalisé pour V1, fallback /history
+  return "/history";
+}
+
+function getTitle(task: AnalysisTask): string {
+  if (task.type === "video") {
+    const v = task as VideoAnalysisTask;
+    return v.videoTitle || v.result?.video_title || v.videoUrl;
+  }
+  const p = task as PlaylistAnalysisTask;
+  return p.playlistTitle || p.playlistUrl;
+}
+
+const TaskRow: React.FC<{
+  task: AnalysisTask;
+  onView: (href: string) => void;
+  onRetry: (id: string) => void;
+}> = ({ task, onView, onRetry }) => {
+  const href = getViewHref(task);
+  const title = getTitle(task);
+  const isFailed = task.status === "failed";
+  const isCompleted = task.status === "completed";
+  const isPlaylist = task.type === "playlist";
+
+  return (
+    <li className="py-3 border-b border-white/5 last:border-b-0">
+      <div className="flex items-start gap-3">
+        {(task as VideoAnalysisTask).thumbnail && task.type === "video" ? (
+          <img
+            src={(task as VideoAnalysisTask).thumbnail}
+            alt=""
+            className="w-12 h-12 rounded-md object-cover flex-shrink-0 border border-white/10"
+            aria-hidden="true"
+          />
+        ) : (
+          <div
+            className={`w-12 h-12 rounded-md flex-shrink-0 flex items-center justify-center text-[10px] font-semibold ${
+              isFailed
+                ? "bg-red-500/20 text-red-300 border border-red-500/40"
+                : isCompleted
+                  ? "bg-emerald-500/20 text-emerald-300 border border-emerald-500/40"
+                  : "bg-indigo-500/15 text-indigo-300 border border-indigo-500/30"
+            }`}
+            aria-hidden="true"
+          >
+            {isPlaylist ? "PL" : "VID"}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-white/90 truncate" title={title}>
+            {title}
+          </p>
+          <p className="text-xs text-white/50 truncate">{task.message}</p>
+          {!isFailed && !isCompleted && (
+            <div className="mt-1.5 flex items-center gap-2">
+              <div className="h-1.5 flex-1 rounded-full bg-white/5 overflow-hidden">
+                <motion.div
+                  className="h-full bg-gradient-to-r from-indigo-500 to-violet-500"
+                  initial={{ width: 0 }}
+                  animate={{ width: `${task.progress}%` }}
+                  transition={{ duration: 0.4, ease: "easeOut" }}
+                />
+              </div>
+              <span className="text-[11px] tabular-nums text-white/60 min-w-[3.5rem] text-right">
+                {task.progress}% · {formatEta(task)}
+              </span>
+            </div>
+          )}
+          {isFailed && task.error && (
+            <p className="mt-1 text-xs text-red-300 flex items-center gap-1">
+              <AlertTriangle className="w-3 h-3 flex-shrink-0" />
+              <span className="truncate">{task.error}</span>
+            </p>
+          )}
+          <div className="mt-2 flex items-center gap-2">
+            {isFailed ? (
+              <button
+                type="button"
+                onClick={() => onRetry(task.id)}
+                className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium text-red-200 bg-red-500/15 hover:bg-red-500/25 border border-red-500/30 transition-colors"
+              >
+                <RefreshCw className="w-3 h-3" />
+                Réessayer
+              </button>
+            ) : href ? (
+              <button
+                type="button"
+                onClick={() => onView(href)}
+                className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium text-indigo-200 bg-indigo-500/15 hover:bg-indigo-500/25 border border-indigo-500/30 transition-colors"
+              >
+                <Eye className="w-3 h-3" />
+                Voir
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export const BackgroundAnalysisPanel: React.FC<
+  BackgroundAnalysisPanelProps
+> = ({ open, onClose }) => {
+  const navigate = useNavigate();
+  const { tasks, retryTask, clearCompleted } = useBackgroundAnalysis();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const { data: quota } = useQuery({
+    queryKey: ["auth-quota"],
+    queryFn: () => authApi.quota(),
+    enabled: open,
+    staleTime: 30_000,
+  });
+
+  // Close on Escape + outside click
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    const onOutside = (e: MouseEvent) => {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(e.target as Node)
+      ) {
+        const target = e.target as HTMLElement | null;
+        // Ne ferme pas si le clic est sur le FAB lui-même
+        if (target?.closest("[aria-haspopup='dialog']")) return;
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("mousedown", onOutside);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("mousedown", onOutside);
+    };
+  }, [open, onClose]);
+
+  const sortedTasks = useMemo(() => {
+    // pending+processing en haut, puis failed, puis completed récents
+    const order: Record<AnalysisTask["status"], number> = {
+      processing: 0,
+      pending: 1,
+      failed: 2,
+      completed: 3,
+    };
+    return [...tasks].sort((a, b) => order[a.status] - order[b.status]);
+  }, [tasks]);
+
+  const hasCompletedOrFailed = tasks.some(
+    (t) => t.status === "completed" || t.status === "failed",
+  );
+
+  const quotaPct =
+    quota && quota.credits_monthly > 0
+      ? quota.credits_used / quota.credits_monthly
+      : 0;
+  const quotaRemaining =
+    quota && quota.credits_monthly > 0
+      ? quota.credits_monthly - quota.credits_used
+      : null;
+  const quotaLow =
+    quota && quota.credits_monthly > 0
+      ? quotaRemaining !== null &&
+        quotaRemaining <= quota.credits_monthly * QUOTA_WARN_THRESHOLD
+      : false;
+  const quotaExhausted =
+    quotaRemaining !== null && quotaRemaining <= 0;
+
+  const handleView = (href: string) => {
+    onClose();
+    navigate(href);
+  };
+
+  const handleRetry = async (id: string) => {
+    try {
+      await retryTask(id);
+    } catch (e) {
+      // L'erreur est déjà visible dans la task elle-même via failed status.
+      console.error("retryTask failed:", e);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <motion.div
+      ref={panelRef}
+      role="dialog"
+      aria-label="Analyses en cours"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 8 }}
+      transition={{ duration: 0.18, ease: "easeOut" }}
+      className="fixed z-[59] right-4 top-40 md:right-6 md:bottom-24 md:top-auto w-[min(92vw,380px)] max-h-[70vh] flex flex-col rounded-2xl bg-[#12121a]/95 backdrop-blur-xl border border-white/10 shadow-2xl overflow-hidden"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5">
+        <h2 className="text-sm font-semibold text-white/90">
+          Analyses
+          <span className="ml-2 text-xs font-normal text-white/50">
+            {tasks.length}
+          </span>
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Fermer"
+          className="p-1 rounded-md text-white/50 hover:text-white/90 hover:bg-white/5 transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Liste */}
+      <div className="flex-1 overflow-y-auto px-4">
+        {sortedTasks.length === 0 ? (
+          <p className="py-6 text-center text-xs text-white/40">
+            Aucune analyse en cours.
+          </p>
+        ) : (
+          <ul className="py-1">
+            {sortedTasks.map((task) => (
+              <TaskRow
+                key={task.id}
+                task={task}
+                onView={handleView}
+                onRetry={handleRetry}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Footer : quota + actions */}
+      <div className="border-t border-white/5 px-4 py-2.5 space-y-1.5">
+        {quota ? (
+          <p
+            className={`text-xs flex items-center justify-between ${
+              quotaExhausted
+                ? "text-red-300"
+                : quotaLow
+                  ? "text-orange-300"
+                  : "text-white/55"
+            }`}
+          >
+            <span>
+              {quota.credits_used}/{quota.credits_monthly} analyses ·{" "}
+              <span className="capitalize">{quota.plan}</span>
+            </span>
+            {(quotaLow || quotaExhausted) && (
+              <Link
+                to="/pricing"
+                className="ml-2 text-orange-300 hover:text-orange-200 underline underline-offset-2"
+                onClick={onClose}
+              >
+                Upgrade
+              </Link>
+            )}
+          </p>
+        ) : null}
+
+        {hasCompletedOrFailed && (
+          <button
+            type="button"
+            onClick={clearCompleted}
+            className="text-xs text-white/50 hover:text-white/80 inline-flex items-center gap-1 transition-colors"
+          >
+            <Trash2 className="w-3 h-3" />
+            Effacer les terminées
+          </button>
+        )}
+      </div>
+    </motion.div>
+  );
+};
+
+export default BackgroundAnalysisPanel;

--- a/frontend/src/components/background/HubNavBadge.tsx
+++ b/frontend/src/components/background/HubNavBadge.tsx
@@ -1,0 +1,37 @@
+/**
+ * HubNavBadge — petit dot rouge à poser sur le NavItem Hub de la sidebar
+ * quand une analyse vient de terminer (et l'user n'est pas sur /hub) ou
+ * quand une analyse est en échec.
+ *
+ * À monter à l'intérieur d'un wrapper `relative`.
+ */
+
+import React from "react";
+import { useLocation } from "react-router-dom";
+import { motion } from "framer-motion";
+import { useBackgroundAnalysis } from "../../contexts/BackgroundAnalysisContext";
+
+export const HubNavBadge: React.FC = () => {
+  const { tasks, hasNewCompletedTask } = useBackgroundAnalysis();
+  const location = useLocation();
+  const isOnHub = location.pathname.startsWith("/hub");
+  const hasFailed = tasks.some((t) => t.status === "failed");
+
+  const visible = (hasNewCompletedTask && !isOnHub) || hasFailed;
+  if (!visible) return null;
+
+  const color = hasFailed ? "bg-red-500" : "bg-emerald-400";
+
+  return (
+    <motion.span
+      initial={{ scale: 0 }}
+      animate={{ scale: 1 }}
+      exit={{ scale: 0 }}
+      transition={{ type: "spring", stiffness: 400, damping: 18 }}
+      aria-hidden="true"
+      className={`absolute top-1 right-1 w-2 h-2 rounded-full ${color} ring-2 ring-bg-base`}
+    />
+  );
+};
+
+export default HubNavBadge;

--- a/frontend/src/components/background/__tests__/BackgroundAnalysisFAB.integration.test.tsx
+++ b/frontend/src/components/background/__tests__/BackgroundAnalysisFAB.integration.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Integration test : mount le vrai Provider + le vrai FAB + un bouton qui
+ * appelle startVideoAnalysis. Vérifie que le FAB transitionne hidden → visible
+ * comme attendu. Permet de détecter les bugs de connexion Provider/FAB sans
+ * passer par le browser.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import {
+  BackgroundAnalysisProvider,
+  useBackgroundAnalysis,
+} from "../../../contexts/BackgroundAnalysisContext";
+import { BackgroundAnalysisFAB } from "../BackgroundAnalysisFAB";
+
+vi.mock("../../../services/api", () => ({
+  videoApi: {
+    analyze: vi.fn().mockResolvedValue({
+      task_id: "backend-task-int-1",
+      status: "pending",
+    }),
+    getTaskStatus: vi.fn().mockResolvedValue({
+      task_id: "backend-task-int-1",
+      status: "processing",
+      progress: 25,
+    }),
+  },
+  playlistApi: {
+    analyze: vi.fn(),
+    analyzeCorpus: vi.fn(),
+    getStatus: vi.fn(),
+  },
+  authApi: {
+    quota: vi.fn().mockResolvedValue({
+      credits: 25,
+      credits_monthly: 30,
+      credits_used: 5,
+      plan: "pro",
+    }),
+  },
+}));
+
+vi.mock("../../../hooks/useWebNotification", () => ({
+  useWebNotification: () => ({
+    sendNotification: vi.fn(),
+    ensurePermission: vi.fn(),
+  }),
+}));
+
+const TriggerButton: React.FC = () => {
+  const { startVideoAnalysis } = useBackgroundAnalysis();
+  return (
+    <button
+      type="button"
+      data-testid="trigger"
+      onClick={() => {
+        void startVideoAnalysis({
+          videoUrl: "https://youtube.com/watch?v=test",
+          mode: "auto",
+          category: "standard",
+        });
+      }}
+    >
+      start
+    </button>
+  );
+};
+
+describe("BackgroundAnalysisFAB — integration with real Provider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("FAB hidden by default, visible after startVideoAnalysis", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BackgroundAnalysisProvider>
+          <MemoryRouter>
+            <TriggerButton />
+            <BackgroundAnalysisFAB />
+          </MemoryRouter>
+        </BackgroundAnalysisProvider>
+      </QueryClientProvider>,
+    );
+
+    // Initial : FAB hidden, aucun bouton aria-label "analyse en cours".
+    expect(screen.queryByLabelText(/analyse en cours/i)).toBeNull();
+
+    // Trigger startVideoAnalysis via le bouton.
+    await act(async () => {
+      screen.getByTestId("trigger").click();
+    });
+
+    // FAB devient visible avec activeTasksCount=1.
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText(/1 analyse en cours/i)).toBeTruthy();
+      },
+      { timeout: 3000 },
+    );
+  });
+});

--- a/frontend/src/components/background/__tests__/BackgroundAnalysisFAB.test.tsx
+++ b/frontend/src/components/background/__tests__/BackgroundAnalysisFAB.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { BackgroundAnalysisFAB } from "../BackgroundAnalysisFAB";
+import type {
+  AnalysisTask,
+  VideoAnalysisTask,
+} from "../../../contexts/BackgroundAnalysisContext";
+
+const mockUseBackgroundAnalysis = vi.fn();
+
+vi.mock("../../../contexts/BackgroundAnalysisContext", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../contexts/BackgroundAnalysisContext")
+  >("../../../contexts/BackgroundAnalysisContext");
+  return {
+    ...actual,
+    useBackgroundAnalysis: () => mockUseBackgroundAnalysis(),
+  };
+});
+
+vi.mock("../../../hooks/useWebNotification", () => ({
+  useWebNotification: () => ({
+    sendNotification: vi.fn(),
+    ensurePermission: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../services/api", () => ({
+  authApi: {
+    quota: vi.fn().mockResolvedValue({
+      credits: 25,
+      credits_monthly: 30,
+      credits_used: 5,
+      plan: "pro",
+    }),
+  },
+}));
+
+const baseTask = (overrides: Partial<VideoAnalysisTask>): AnalysisTask => ({
+  id: "video-1",
+  type: "video",
+  taskId: "backend-1",
+  videoUrl: "https://youtube.com/watch?v=a",
+  status: "processing",
+  progress: 30,
+  message: "Analyse en cours...",
+  startedAt: new Date(),
+  ...overrides,
+});
+
+const renderFab = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <BackgroundAnalysisFAB />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe("BackgroundAnalysisFAB", () => {
+  beforeEach(() => {
+    mockUseBackgroundAnalysis.mockReset();
+  });
+
+  it("renders nothing when no tasks (hidden state)", () => {
+    mockUseBackgroundAnalysis.mockReturnValue({
+      tasks: [],
+      activeTasksCount: 0,
+      hasNewCompletedTask: false,
+      acknowledgeCompleted: vi.fn(),
+    });
+    renderFab();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders processing state with aria-label when 1 task active", () => {
+    mockUseBackgroundAnalysis.mockReturnValue({
+      tasks: [baseTask({ status: "processing" })],
+      activeTasksCount: 1,
+      hasNewCompletedTask: false,
+      acknowledgeCompleted: vi.fn(),
+    });
+    renderFab();
+    expect(screen.getByLabelText("1 analyse en cours")).toBeTruthy();
+  });
+
+  it("shows badge count when 2 tasks active", () => {
+    mockUseBackgroundAnalysis.mockReturnValue({
+      tasks: [
+        baseTask({ id: "video-1" }),
+        baseTask({ id: "video-2", taskId: "backend-2" }),
+      ],
+      activeTasksCount: 2,
+      hasNewCompletedTask: false,
+      acknowledgeCompleted: vi.fn(),
+    });
+    renderFab();
+    expect(screen.getByLabelText("2 analyses en cours")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  it("renders error state when a task is failed", () => {
+    mockUseBackgroundAnalysis.mockReturnValue({
+      tasks: [
+        baseTask({
+          status: "failed",
+          error: "Échec",
+        }),
+      ],
+      activeTasksCount: 0,
+      hasNewCompletedTask: false,
+      acknowledgeCompleted: vi.fn(),
+    });
+    renderFab();
+    expect(screen.getByLabelText(/1 analyse.*échec/i)).toBeTruthy();
+  });
+
+  it("renders success state when hasNewCompletedTask = true", () => {
+    mockUseBackgroundAnalysis.mockReturnValue({
+      tasks: [
+        baseTask({ status: "completed", progress: 100 }),
+      ],
+      activeTasksCount: 0,
+      hasNewCompletedTask: true,
+      acknowledgeCompleted: vi.fn(),
+    });
+    renderFab();
+    expect(screen.getByLabelText("Analyse terminée")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -32,6 +32,7 @@ import { useAuth } from "../../hooks/useAuth";
 import { useTranslation } from "../../hooks/useTranslation";
 import { SidebarInsight } from "../SidebarInsight";
 import { PlanBadge } from "../PlanBadge";
+import { HubNavBadge } from "../background/HubNavBadge";
 import {
   normalizePlanId,
   getMinPlanForFeature,
@@ -469,7 +470,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               label={language === "fr" ? "Débat IA" : "AI Debate"}
               collapsed={collapsed}
             />
-            <div data-tour-step="hub-nav">
+            <div data-tour-step="hub-nav" className="relative">
               <NavItem
                 to="/hub"
                 icon={MessageCircle}
@@ -480,6 +481,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 end={canSeeHubWorkspaces}
                 {...getBadge(minPlanHub)}
               />
+              <HubNavBadge />
             </div>
             {canSeeHubWorkspaces && (
               <NavItem

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -65,6 +65,11 @@ vi.mock("../../../hooks/useTranslation", () => ({
 }));
 
 // SidebarInsight & PlanBadge: stub minimaliste
+// HubNavBadge consomme BackgroundAnalysisContext qui n'est pas mounté ici.
+vi.mock("../../background/HubNavBadge", () => ({
+  HubNavBadge: () => null,
+}));
+
 vi.mock("../../SidebarInsight", () => ({
   SidebarInsight: () => null,
 }));

--- a/frontend/src/contexts/BackgroundAnalysisContext.tsx
+++ b/frontend/src/contexts/BackgroundAnalysisContext.tsx
@@ -81,6 +81,15 @@ export interface PlaylistAnalysisTask {
 
 export type AnalysisTask = VideoAnalysisTask | PlaylistAnalysisTask;
 
+export interface StartAnalysisResult {
+  /** ID local de la task dans le context. */
+  localId: string;
+  /** Backend task_id (utilisable pour /hub?analyzing=…). */
+  taskId: string;
+  /** Si défini → cache hit synchrone backend, summary déjà disponible. */
+  summaryId?: number;
+}
+
 interface BackgroundAnalysisContextType {
   // État
   tasks: AnalysisTask[];
@@ -91,7 +100,7 @@ interface BackgroundAnalysisContextType {
     videoUrl: string;
     mode: string;
     category: string;
-  }) => Promise<string>; // Retourne l'ID de la tâche
+  }) => Promise<StartAnalysisResult>;
 
   // Actions playlist
   startPlaylistAnalysis: (params: {
@@ -99,13 +108,13 @@ interface BackgroundAnalysisContextType {
     urls?: string[];
     mode: string;
     category: string;
-  }) => Promise<string>;
+  }) => Promise<StartAnalysisResult>;
 
   // Gestion
   getTask: (taskId: string) => AnalysisTask | undefined;
   removeTask: (taskId: string) => void;
   clearCompleted: () => void;
-  retryTask: (taskId: string) => Promise<string>;
+  retryTask: (taskId: string) => Promise<StartAnalysisResult>;
 
   // Notifications
   hasNewCompletedTask: boolean;
@@ -342,7 +351,7 @@ export const BackgroundAnalysisProvider: React.FC<{
       videoUrl: string;
       mode: string;
       category: string;
-    }): Promise<string> => {
+    }): Promise<StartAnalysisResult> => {
       // Cap: refuse if too many active analyses (read via ref to keep
       // useCallback stable with []).
       const currentActive = tasksRef.current.filter(
@@ -378,7 +387,33 @@ export const BackgroundAnalysisProvider: React.FC<{
           params.category === "auto" ? undefined : params.category,
         );
 
-        // Mettre à jour avec l'ID de tâche
+        const cacheHitSummaryId = response.result?.summary_id;
+
+        if (cacheHitSummaryId) {
+          // Cache hit synchrone : pas de polling, on bascule direct sur completed.
+          setTasks((prev) =>
+            prev.map((t) =>
+              t.id === taskId
+                ? {
+                    ...(t as VideoAnalysisTask),
+                    taskId: response.task_id,
+                    status: "completed" as const,
+                    progress: 100,
+                    message: "Analyse terminée !",
+                    completedAt: new Date(),
+                  }
+                : t,
+            ),
+          );
+          setHasNewCompletedTask(true);
+          return {
+            localId: taskId,
+            taskId: response.task_id,
+            summaryId: cacheHitSummaryId,
+          };
+        }
+
+        // Mettre à jour avec l'ID de tâche backend
         setTasks((prev) =>
           prev.map((t) =>
             t.id === taskId
@@ -395,7 +430,7 @@ export const BackgroundAnalysisProvider: React.FC<{
         // Démarrer le polling
         startPolling(taskId, response.task_id, "video");
 
-        return taskId;
+        return { localId: taskId, taskId: response.task_id };
       } catch (error: any) {
         setTasks((prev) =>
           prev.map((t) =>
@@ -424,7 +459,7 @@ export const BackgroundAnalysisProvider: React.FC<{
       urls?: string[];
       mode: string;
       category: string;
-    }): Promise<string> => {
+    }): Promise<StartAnalysisResult> => {
       // Cap: refuse if too many active analyses (shared with video).
       const currentActive = tasksRef.current.filter(
         (t) => t.status === "pending" || t.status === "processing",
@@ -482,7 +517,7 @@ export const BackgroundAnalysisProvider: React.FC<{
 
         startPolling(taskId, response.task_id, "playlist");
 
-        return taskId;
+        return { localId: taskId, taskId: response.task_id };
       } catch (error: any) {
         setTasks((prev) =>
           prev.map((t) =>
@@ -641,7 +676,7 @@ export const BackgroundAnalysisProvider: React.FC<{
   }, []);
 
   const retryTask = useCallback(
-    async (localTaskId: string): Promise<string> => {
+    async (localTaskId: string): Promise<StartAnalysisResult> => {
       const task = tasksRef.current.find((t) => t.id === localTaskId);
       if (!task) {
         throw new Error(`Tâche ${localTaskId} introuvable`);

--- a/frontend/src/contexts/BackgroundAnalysisContext.tsx
+++ b/frontend/src/contexts/BackgroundAnalysisContext.tsx
@@ -22,6 +22,21 @@ import React, {
 import { videoApi, playlistApi, Summary } from "../services/api";
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// 🚦 CONCURRENCY CAP
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const MAX_CONCURRENT_ANALYSES = 2;
+
+export class MaxConcurrentReachedError extends Error {
+  constructor() {
+    super(
+      `Limite de ${MAX_CONCURRENT_ANALYSES} analyses simultanées atteinte. Attendez la fin d'une analyse en cours.`,
+    );
+    this.name = "MaxConcurrentReachedError";
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // 📊 TYPES
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -39,6 +54,9 @@ export interface VideoAnalysisTask {
   error?: string;
   startedAt: Date;
   completedAt?: Date;
+  // Stockés pour permettre le retry après échec
+  mode?: string;
+  category?: string;
 }
 
 export interface PlaylistAnalysisTask {
@@ -55,6 +73,10 @@ export interface PlaylistAnalysisTask {
   error?: string;
   startedAt: Date;
   completedAt?: Date;
+  // Stockés pour permettre le retry après échec
+  mode?: string;
+  category?: string;
+  urls?: string[];
 }
 
 export type AnalysisTask = VideoAnalysisTask | PlaylistAnalysisTask;
@@ -83,6 +105,7 @@ interface BackgroundAnalysisContextType {
   getTask: (taskId: string) => AnalysisTask | undefined;
   removeTask: (taskId: string) => void;
   clearCompleted: () => void;
+  retryTask: (taskId: string) => Promise<string>;
 
   // Notifications
   hasNewCompletedTask: boolean;
@@ -109,6 +132,14 @@ export const BackgroundAnalysisProvider: React.FC<{
   const [hasNewCompletedTask, setHasNewCompletedTask] = useState(false);
   const [isRestoring, setIsRestoring] = useState(true);
   const pollingIntervals = useRef<Map<string, NodeJS.Timeout>>(new Map());
+
+  // Ref synchronisée avec tasks pour permettre des reads stables dans
+  // useCallback([]) — utilisé notamment pour le cap-check sans casser
+  // l'identité de startVideoAnalysis/startPlaylistAnalysis.
+  const tasksRef = useRef<AnalysisTask[]>([]);
+  useEffect(() => {
+    tasksRef.current = tasks;
+  }, [tasks]);
 
   // ═══════════════════════════════════════════════════════════════════════════════
   // 💾 PERSISTENCE: Sauvegarder les tâches en cours dans localStorage
@@ -184,9 +215,95 @@ export const BackgroundAnalysisProvider: React.FC<{
 
             setTasks((prev) => [...prev, restoredTask]);
 
-            // Reprendre le polling
-            setTimeout(() => {
-              startPolling(task.id, task.taskId, task.type);
+            // Refetch confirm one-shot avant de relancer le polling.
+            // Si la task est déjà completed/failed côté backend (analyse
+            // terminée pendant que l'onglet était fermé), on évite un
+            // tick de polling vide et on bascule direct sur l'état final.
+            setTimeout(async () => {
+              try {
+                if (task.type === "video") {
+                  const status = await videoApi.getTaskStatus(task.taskId);
+                  if (status.status === "completed" && status.result) {
+                    setTasks((prev) =>
+                      prev.map((t) =>
+                        t.id === task.id
+                          ? ({
+                              ...(t as VideoAnalysisTask),
+                              status: "completed" as const,
+                              progress: 100,
+                              message: "Analyse terminée !",
+                              result: status.result?.summary,
+                              videoTitle:
+                                status.result?.summary?.video_title ||
+                                (t as VideoAnalysisTask).videoTitle,
+                              thumbnail:
+                                status.result?.summary?.thumbnail_url ||
+                                (t as VideoAnalysisTask).thumbnail,
+                              completedAt: new Date(),
+                            } as VideoAnalysisTask)
+                          : t,
+                      ),
+                    );
+                    setHasNewCompletedTask(true);
+                    return;
+                  }
+                  if (status.status === "failed") {
+                    setTasks((prev) =>
+                      prev.map((t) =>
+                        t.id === task.id
+                          ? {
+                              ...(t as VideoAnalysisTask),
+                              status: "failed" as const,
+                              error: status.error || "Échec de l'analyse",
+                            }
+                          : t,
+                      ),
+                    );
+                    return;
+                  }
+                } else {
+                  const status = await playlistApi.getStatus(task.taskId);
+                  if (status.status === "completed") {
+                    setTasks((prev) =>
+                      prev.map((t) =>
+                        t.id === task.id
+                          ? ({
+                              ...(t as PlaylistAnalysisTask),
+                              status: "completed" as const,
+                              progress: 100,
+                              message: "Analyse terminée !",
+                              playlistTitle: status.playlist_title,
+                              totalVideos: status.total_videos,
+                              completedVideos: status.completed_videos,
+                              completedAt: new Date(),
+                            } as PlaylistAnalysisTask)
+                          : t,
+                      ),
+                    );
+                    setHasNewCompletedTask(true);
+                    return;
+                  }
+                  if (status.status === "failed") {
+                    setTasks((prev) =>
+                      prev.map((t) =>
+                        t.id === task.id
+                          ? {
+                              ...(t as PlaylistAnalysisTask),
+                              status: "failed" as const,
+                              error: status.error || "Échec de l'analyse",
+                            }
+                          : t,
+                      ),
+                    );
+                    return;
+                  }
+                }
+                // Encore en cours côté backend → reprendre le polling.
+                startPolling(task.id, task.taskId, task.type);
+              } catch (e) {
+                // Erreur réseau / 404 → fall-back sur polling, qui gérera.
+                startPolling(task.id, task.taskId, task.type);
+              }
             }, 500);
           }
         }
@@ -226,6 +343,15 @@ export const BackgroundAnalysisProvider: React.FC<{
       mode: string;
       category: string;
     }): Promise<string> => {
+      // Cap: refuse if too many active analyses (read via ref to keep
+      // useCallback stable with []).
+      const currentActive = tasksRef.current.filter(
+        (t) => t.status === "pending" || t.status === "processing",
+      ).length;
+      if (currentActive >= MAX_CONCURRENT_ANALYSES) {
+        throw new MaxConcurrentReachedError();
+      }
+
       const taskId = `video-${Date.now()}`;
 
       // Créer la tâche
@@ -238,6 +364,8 @@ export const BackgroundAnalysisProvider: React.FC<{
         progress: 0,
         message: "Démarrage de l'analyse...",
         startedAt: new Date(),
+        mode: params.mode,
+        category: params.category,
       };
 
       setTasks((prev) => [...prev, newTask]);
@@ -297,6 +425,14 @@ export const BackgroundAnalysisProvider: React.FC<{
       mode: string;
       category: string;
     }): Promise<string> => {
+      // Cap: refuse if too many active analyses (shared with video).
+      const currentActive = tasksRef.current.filter(
+        (t) => t.status === "pending" || t.status === "processing",
+      ).length;
+      if (currentActive >= MAX_CONCURRENT_ANALYSES) {
+        throw new MaxConcurrentReachedError();
+      }
+
       const taskId = `playlist-${Date.now()}`;
 
       const newTask: PlaylistAnalysisTask = {
@@ -308,6 +444,9 @@ export const BackgroundAnalysisProvider: React.FC<{
         progress: 0,
         message: "Démarrage de l'analyse...",
         startedAt: new Date(),
+        mode: params.mode,
+        category: params.category,
+        urls: params.urls,
       };
 
       setTasks((prev) => [...prev, newTask]);
@@ -501,6 +640,55 @@ export const BackgroundAnalysisProvider: React.FC<{
     setHasNewCompletedTask(false);
   }, []);
 
+  const retryTask = useCallback(
+    async (localTaskId: string): Promise<string> => {
+      const task = tasksRef.current.find((t) => t.id === localTaskId);
+      if (!task) {
+        throw new Error(`Tâche ${localTaskId} introuvable`);
+      }
+      if (task.status !== "failed") {
+        throw new Error(
+          `Seules les tâches en échec peuvent être relancées (état actuel : ${task.status})`,
+        );
+      }
+      if (!task.mode || !task.category) {
+        throw new Error(
+          "Paramètres de relance manquants — relancez l'analyse depuis le bouton d'origine",
+        );
+      }
+
+      // Remove failed task before re-launch so the cap-check passes.
+      const interval = pollingIntervals.current.get(localTaskId);
+      if (interval) {
+        clearInterval(interval);
+        pollingIntervals.current.delete(localTaskId);
+      }
+      setTasks((prev) => prev.filter((t) => t.id !== localTaskId));
+
+      if (task.type === "video") {
+        return startVideoAnalysis({
+          videoUrl: (task as VideoAnalysisTask).videoUrl,
+          mode: task.mode,
+          category: task.category,
+        });
+      }
+      const pl = task as PlaylistAnalysisTask;
+      if (pl.urls && pl.urls.length > 0) {
+        return startPlaylistAnalysis({
+          urls: pl.urls,
+          mode: task.mode,
+          category: task.category,
+        });
+      }
+      return startPlaylistAnalysis({
+        playlistUrl: pl.playlistUrl,
+        mode: task.mode,
+        category: task.category,
+      });
+    },
+    [startVideoAnalysis, startPlaylistAnalysis],
+  );
+
   return (
     <BackgroundAnalysisContext.Provider
       value={{
@@ -511,6 +699,7 @@ export const BackgroundAnalysisProvider: React.FC<{
         getTask,
         removeTask,
         clearCompleted,
+        retryTask,
         hasNewCompletedTask,
         acknowledgeCompleted,
       }}

--- a/frontend/src/contexts/__tests__/BackgroundAnalysisContext.test.tsx
+++ b/frontend/src/contexts/__tests__/BackgroundAnalysisContext.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import {
+  BackgroundAnalysisProvider,
+  useBackgroundAnalysis,
+  MaxConcurrentReachedError,
+  MAX_CONCURRENT_ANALYSES,
+} from "../BackgroundAnalysisContext";
+
+vi.mock("../../services/api", () => ({
+  videoApi: {
+    analyze: vi.fn(),
+    getTaskStatus: vi.fn(),
+  },
+  playlistApi: {
+    analyze: vi.fn(),
+    analyzeCorpus: vi.fn(),
+    getStatus: vi.fn(),
+  },
+}));
+
+import { videoApi } from "../../services/api";
+
+const mockAnalyze = videoApi.analyze as unknown as ReturnType<typeof vi.fn>;
+const mockGetTaskStatus = videoApi.getTaskStatus as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <BackgroundAnalysisProvider>{children}</BackgroundAnalysisProvider>
+);
+
+describe("BackgroundAnalysisContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    // Default: getTaskStatus returns "processing" so polling stays harmless.
+    mockGetTaskStatus.mockResolvedValue({
+      task_id: "t-x",
+      status: "processing",
+      progress: 10,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with activeTasksCount = 0 and empty tasks", () => {
+    const { result } = renderHook(() => useBackgroundAnalysis(), { wrapper });
+    expect(result.current.activeTasksCount).toBe(0);
+    expect(result.current.tasks).toEqual([]);
+  });
+
+  it("startVideoAnalysis returns StartAnalysisResult with localId + taskId", async () => {
+    mockAnalyze.mockResolvedValue({ task_id: "backend-1", status: "pending" });
+
+    const { result } = renderHook(() => useBackgroundAnalysis(), { wrapper });
+
+    let started: Awaited<
+      ReturnType<typeof result.current.startVideoAnalysis>
+    > | null = null;
+    await act(async () => {
+      started = await result.current.startVideoAnalysis({
+        videoUrl: "https://youtube.com/watch?v=a",
+        mode: "auto",
+        category: "standard",
+      });
+    });
+
+    expect(started).not.toBeNull();
+    expect(started!.taskId).toBe("backend-1");
+    expect(started!.localId).toMatch(/^video-/);
+    expect(started!.summaryId).toBeUndefined();
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.activeTasksCount).toBe(1);
+  });
+
+  it("returns summaryId when backend response has cache hit", async () => {
+    mockAnalyze.mockResolvedValue({
+      task_id: "backend-cache",
+      status: "completed",
+      result: { summary_id: 777 },
+    });
+
+    const { result } = renderHook(() => useBackgroundAnalysis(), { wrapper });
+
+    let started: Awaited<
+      ReturnType<typeof result.current.startVideoAnalysis>
+    > | null = null;
+    await act(async () => {
+      started = await result.current.startVideoAnalysis({
+        videoUrl: "https://youtube.com/watch?v=cached",
+        mode: "auto",
+        category: "standard",
+      });
+    });
+
+    expect(started!.summaryId).toBe(777);
+    // Task completed status, not actively polling.
+    await waitFor(() => {
+      expect(result.current.tasks[0].status).toBe("completed");
+    });
+    expect(result.current.activeTasksCount).toBe(0);
+    expect(result.current.hasNewCompletedTask).toBe(true);
+  });
+
+  it("throws MaxConcurrentReachedError when cap reached", async () => {
+    mockAnalyze.mockResolvedValue({
+      task_id: "backend-x",
+      status: "pending",
+    });
+
+    const { result } = renderHook(() => useBackgroundAnalysis(), { wrapper });
+
+    // Fill cap with MAX_CONCURRENT tasks (2).
+    for (let i = 0; i < MAX_CONCURRENT_ANALYSES; i++) {
+      await act(async () => {
+        await result.current.startVideoAnalysis({
+          videoUrl: `https://youtube.com/watch?v=v${i}`,
+          mode: "auto",
+          category: "standard",
+        });
+      });
+    }
+    expect(result.current.activeTasksCount).toBe(MAX_CONCURRENT_ANALYSES);
+
+    // Next call should throw.
+    let caught: unknown = null;
+    await act(async () => {
+      try {
+        await result.current.startVideoAnalysis({
+          videoUrl: "https://youtube.com/watch?v=overflow",
+          mode: "auto",
+          category: "standard",
+        });
+      } catch (e) {
+        caught = e;
+      }
+    });
+    expect(caught).toBeInstanceOf(MaxConcurrentReachedError);
+    // No side effect: task count unchanged.
+    expect(result.current.activeTasksCount).toBe(MAX_CONCURRENT_ANALYSES);
+    // mockAnalyze called exactly MAX_CONCURRENT times (not on the rejected one).
+    expect(mockAnalyze).toHaveBeenCalledTimes(MAX_CONCURRENT_ANALYSES);
+  });
+
+  it("retryTask refuses non-failed tasks", async () => {
+    mockAnalyze.mockResolvedValue({ task_id: "t-pending", status: "pending" });
+
+    const { result } = renderHook(() => useBackgroundAnalysis(), { wrapper });
+
+    let localId = "";
+    await act(async () => {
+      const r = await result.current.startVideoAnalysis({
+        videoUrl: "https://youtube.com/watch?v=a",
+        mode: "auto",
+        category: "standard",
+      });
+      localId = r.localId;
+    });
+
+    await expect(result.current.retryTask(localId)).rejects.toThrow(
+      /échec/i,
+    );
+  });
+
+  it("retryTask re-launches a failed task with stored mode + category", async () => {
+    // First analyze: throws to mark task as failed.
+    mockAnalyze.mockRejectedValueOnce(new Error("transcription failed"));
+
+    const { result } = renderHook(() => useBackgroundAnalysis(), { wrapper });
+
+    let firstLocalId = "";
+    await act(async () => {
+      try {
+        const r = await result.current.startVideoAnalysis({
+          videoUrl: "https://youtube.com/watch?v=retry",
+          mode: "deep",
+          category: "tech",
+        });
+        firstLocalId = r.localId;
+      } catch (e) {
+        // Failed analyze captures the error in the task itself; we read it back.
+      }
+    });
+
+    // The failed task should be in the tasks list (status: failed).
+    await waitFor(() => {
+      const failedTask = result.current.tasks.find(
+        (t) => t.status === "failed",
+      );
+      expect(failedTask).toBeTruthy();
+      firstLocalId = failedTask!.id;
+    });
+
+    // Re-call now succeeds.
+    mockAnalyze.mockResolvedValueOnce({
+      task_id: "retry-backend-id",
+      status: "pending",
+    });
+
+    let retryResult: Awaited<
+      ReturnType<typeof result.current.retryTask>
+    > | null = null;
+    await act(async () => {
+      retryResult = await result.current.retryTask(firstLocalId);
+    });
+
+    expect(retryResult!.taskId).toBe("retry-backend-id");
+    // Initial failed task removed, new task created.
+    expect(
+      result.current.tasks.some((t) => t.id === firstLocalId),
+    ).toBe(false);
+    expect(result.current.activeTasksCount).toBe(1);
+
+    // mockAnalyze called twice with the same URL.
+    expect(mockAnalyze).toHaveBeenCalledTimes(2);
+    expect(mockAnalyze).toHaveBeenLastCalledWith(
+      "https://youtube.com/watch?v=retry",
+      "deep", // mode → 2nd param
+      "tech", // category (auto → undefined sinon)
+    );
+  });
+});

--- a/frontend/src/hooks/__tests__/useAnalyzeAndOpenHub.test.tsx
+++ b/frontend/src/hooks/__tests__/useAnalyzeAndOpenHub.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import React from "react";
 import { useAnalyzeAndOpenHub } from "../useAnalyzeAndOpenHub";
-import { videoApi } from "../../services/api";
+import { MaxConcurrentReachedError } from "../../contexts/BackgroundAnalysisContext";
 
 const mockNavigate = vi.fn();
+const mockStartVideoAnalysis = vi.fn();
 
 vi.mock("react-router-dom", async () => {
   const actual =
@@ -18,21 +19,30 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
-vi.mock("../../services/api", () => ({
-  videoApi: {
-    analyze: vi.fn(),
-    getTaskStatus: vi.fn(),
-  },
-}));
+vi.mock("../../contexts/BackgroundAnalysisContext", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../contexts/BackgroundAnalysisContext")
+  >("../../contexts/BackgroundAnalysisContext");
+  return {
+    ...actual,
+    useBackgroundAnalysis: () => ({
+      tasks: [],
+      activeTasksCount: 0,
+      startVideoAnalysis: mockStartVideoAnalysis,
+      startPlaylistAnalysis: vi.fn(),
+      getTask: vi.fn(),
+      removeTask: vi.fn(),
+      clearCompleted: vi.fn(),
+      retryTask: vi.fn(),
+      hasNewCompletedTask: false,
+      acknowledgeCompleted: vi.fn(),
+    }),
+  };
+});
 
 vi.mock("../useTranslation", () => ({
   useTranslation: () => ({ language: "fr", t: {}, setLanguage: vi.fn() }),
 }));
-
-const mockAnalyze = videoApi.analyze as unknown as ReturnType<typeof vi.fn>;
-const mockGetTaskStatus = videoApi.getTaskStatus as unknown as ReturnType<
-  typeof vi.fn
->;
 
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <MemoryRouter>{children}</MemoryRouter>
@@ -41,22 +51,14 @@ const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 describe("useAnalyzeAndOpenHub", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockNavigate.mockClear();
   });
 
-  it("navigates to /hub?conv=<id> on completed status with summary_id", async () => {
-    mockAnalyze.mockResolvedValue({ task_id: "t-1", status: "pending" });
-    mockGetTaskStatus
-      .mockResolvedValueOnce({
-        task_id: "t-1",
-        status: "processing",
-        progress: 50,
-      })
-      .mockResolvedValueOnce({
-        task_id: "t-1",
-        status: "completed",
-        result: { summary_id: 99 },
-      });
+  it("navigates to /hub?conv=<id> on cache hit (summaryId returned)", async () => {
+    mockStartVideoAnalysis.mockResolvedValue({
+      localId: "video-123",
+      taskId: "t-7",
+      summaryId: 42,
+    });
 
     const { result } = renderHook(() => useAnalyzeAndOpenHub(), { wrapper });
 
@@ -64,51 +66,39 @@ describe("useAnalyzeAndOpenHub", () => {
       await result.current.analyze("https://www.youtube.com/watch?v=abc12345");
     });
 
-    await waitFor(
-      () => expect(mockNavigate).toHaveBeenCalledWith("/hub?conv=99"),
-      { timeout: 8000 },
-    );
+    expect(mockNavigate).toHaveBeenCalledWith("/hub?conv=42");
     expect(result.current.analyzing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.capReached).toBe(false);
+  });
+
+  it("navigates to /hub?analyzing=<taskId> when no cache hit", async () => {
+    mockStartVideoAnalysis.mockResolvedValue({
+      localId: "video-456",
+      taskId: "backend-task-99",
+    });
+
+    const { result } = renderHook(() => useAnalyzeAndOpenHub(), { wrapper });
+
+    await act(async () => {
+      await result.current.analyze("https://youtu.be/xyz12345");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/hub?analyzing=backend-task-99");
     expect(result.current.error).toBeNull();
   });
 
-  it("shortcuts navigation when analyze returns summary_id immediately (cache hit)", async () => {
-    mockAnalyze.mockResolvedValue({
-      task_id: "t-2",
-      status: "completed",
-      result: { summary_id: 7 },
-    });
+  it("sets capReached + error message when MaxConcurrentReachedError thrown", async () => {
+    mockStartVideoAnalysis.mockRejectedValue(new MaxConcurrentReachedError());
 
     const { result } = renderHook(() => useAnalyzeAndOpenHub(), { wrapper });
 
     await act(async () => {
-      await result.current.analyze("https://www.youtube.com/watch?v=cache123");
+      await result.current.analyze("https://www.youtube.com/watch?v=overflow");
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith("/hub?conv=7");
-    expect(mockGetTaskStatus).not.toHaveBeenCalled();
-    expect(result.current.analyzing).toBe(false);
-  });
-
-  it("sets error state when status returns failed", async () => {
-    mockAnalyze.mockResolvedValue({ task_id: "t-3", status: "pending" });
-    mockGetTaskStatus.mockResolvedValueOnce({
-      task_id: "t-3",
-      status: "failed",
-      error: "Transcription failed",
-    });
-
-    const { result } = renderHook(() => useAnalyzeAndOpenHub(), { wrapper });
-
-    await act(async () => {
-      await result.current.analyze("https://www.youtube.com/watch?v=fail123");
-    });
-
-    await waitFor(
-      () => expect(result.current.error).toBe("Transcription failed"),
-      { timeout: 5000 },
-    );
-    expect(result.current.analyzing).toBe(false);
+    expect(result.current.capReached).toBe(true);
+    expect(result.current.error).toMatch(/2 analyses simultanées/i);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
@@ -120,6 +110,25 @@ describe("useAnalyzeAndOpenHub", () => {
     });
 
     expect(result.current.error).toMatch(/URL invalide/i);
-    expect(mockAnalyze).not.toHaveBeenCalled();
+    expect(mockStartVideoAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("resetError clears error and capReached", async () => {
+    mockStartVideoAnalysis.mockRejectedValue(new MaxConcurrentReachedError());
+
+    const { result } = renderHook(() => useAnalyzeAndOpenHub(), { wrapper });
+
+    await act(async () => {
+      await result.current.analyze("https://www.youtube.com/watch?v=overflow");
+    });
+
+    expect(result.current.capReached).toBe(true);
+
+    act(() => {
+      result.current.resetError();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.capReached).toBe(false);
   });
 });

--- a/frontend/src/hooks/useAnalyzeAndOpenHub.ts
+++ b/frontend/src/hooks/useAnalyzeAndOpenHub.ts
@@ -1,30 +1,35 @@
 /**
- * useAnalyzeAndOpenHub — hook réutilisable qui encapsule le démarrage d'une
- * analyse vidéo (`videoApi.analyze`) et **navigue immédiatement** vers le Hub.
+ * useAnalyzeAndOpenHub — hook réutilisable qui démarre une analyse vidéo
+ * via `BackgroundAnalysisContext` (FAB + polling unifié) et **navigue
+ * immédiatement** vers le Hub.
  *
  * Comportement :
- *   - Cache hit (le backend retourne déjà `summary_id`) → navigate `/hub?conv=<id>`.
- *   - Sinon → navigate `/hub?analyzing=<task_id>`. Le polling
- *     `videoApi.getTaskStatus(taskId)` est ensuite repris par `HubPage`, qui
- *     affiche un état "Analyse en cours" et bascule sur la conversation
- *     finale dès que `summary_id` est disponible.
+ *   - Cap atteint (2 analyses simultanées) → `error` retourné, pas de navigate.
+ *     Le caller affiche un toast.
+ *   - Cache hit (le backend retourne déjà `summary_id`) → navigate
+ *     `/hub?conv=<id>`. La task est marquée `completed` côté context (FAB
+ *     affiche brièvement le check anim).
+ *   - Cas standard → navigate `/hub?analyzing=<task_id>`. Le polling
+ *     démarré par le context permet au FAB de suivre la progression cross-route ;
+ *     `HubPage` continue son propre polling local pour le placeholder UI.
  *
- * Avantage : feedback visuel **immédiat** (la home n'attend pas la fin de
- * l'analyse, l'utilisateur voit déjà le Hub avec le placeholder loading).
- *
- * Utilisé par :
- *   - `DashboardPageMinimal` (home minimale : input URL + Tournesol cards)
- *   - `ConversationsDrawer` (barre input directe dans le drawer Hub)
+ * Utilisé par : `DashboardPageMinimal`, `ConversationsDrawer`,
+ * `NewConversationModal`, `HubPage`, `SmartInputBar`.
  */
 import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { videoApi } from "../services/api";
+import {
+  useBackgroundAnalysis,
+  MaxConcurrentReachedError,
+} from "../contexts/BackgroundAnalysisContext";
 import { useTranslation } from "./useTranslation";
 
 export interface AnalyzeState {
-  /** True pendant l'appel `videoApi.analyze` (avant le navigate). */
+  /** True pendant l'appel d'analyse (avant le navigate). */
   analyzing: boolean;
   error: string | null;
+  /** True si l'erreur est un cap atteint (caller peut afficher un toast spécifique). */
+  capReached: boolean;
 }
 
 export interface UseAnalyzeAndOpenHubReturn extends AnalyzeState {
@@ -37,13 +42,15 @@ export interface UseAnalyzeAndOpenHubReturn extends AnalyzeState {
 export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
   const navigate = useNavigate();
   const { language } = useTranslation();
+  const { startVideoAnalysis } = useBackgroundAnalysis();
   const [state, setState] = useState<AnalyzeState>({
     analyzing: false,
     error: null,
+    capReached: false,
   });
 
   const resetError = useCallback(() => {
-    setState((s) => ({ ...s, error: null }));
+    setState((s) => ({ ...s, error: null, capReached: false }));
   }, []);
 
   const analyze = useCallback(
@@ -52,6 +59,7 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
       if (!trimmed) {
         setState({
           analyzing: false,
+          capReached: false,
           error:
             language === "fr"
               ? "URL invalide. Collez un lien YouTube ou TikTok."
@@ -60,32 +68,37 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
         return;
       }
 
-      setState({ analyzing: true, error: null });
+      setState({ analyzing: true, error: null, capReached: false });
 
       try {
-        const resp = await videoApi.analyze(
-          trimmed,
-          "auto",
-          "standard",
-          undefined,
-          false,
-          language,
-        );
-        // Cache hit : l'analyse retourne déjà un `summary_id`. Navigate sur
-        // la conversation directement.
-        if (resp.result?.summary_id) {
-          setState({ analyzing: false, error: null });
-          navigate(`/hub?conv=${resp.result.summary_id}`);
+        const result = await startVideoAnalysis({
+          videoUrl: trimmed,
+          mode: "auto",
+          category: "standard",
+        });
+
+        setState({ analyzing: false, error: null, capReached: false });
+
+        // Cache hit synchrone : navigate direct sur la conversation finale.
+        if (result.summaryId) {
+          navigate(`/hub?conv=${result.summaryId}`);
           return;
         }
-        // Cas standard : on a un `task_id`. On navigue vers le Hub avec
-        // `?analyzing=<taskId>` ; HubPage prend le relais pour le polling et
-        // affiche le placeholder loading.
-        setState({ analyzing: false, error: null });
-        navigate(`/hub?analyzing=${resp.task_id}`);
+
+        // Cas standard : navigate vers le placeholder loading du Hub.
+        navigate(`/hub?analyzing=${result.taskId}`);
       } catch (err) {
+        if (err instanceof MaxConcurrentReachedError) {
+          setState({
+            analyzing: false,
+            capReached: true,
+            error: err.message,
+          });
+          return;
+        }
         setState({
           analyzing: false,
+          capReached: false,
           error:
             err instanceof Error
               ? err.message
@@ -95,7 +108,7 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
         });
       }
     },
-    [language, navigate],
+    [language, navigate, startVideoAnalysis],
   );
 
   return { ...state, analyze, resetError };

--- a/frontend/src/hooks/useWebNotification.ts
+++ b/frontend/src/hooks/useWebNotification.ts
@@ -1,0 +1,70 @@
+/**
+ * useWebNotification — wrapper minimaliste sur l'API Web Notification.
+ *
+ * - Permission demandée *lazy* (au premier `sendNotification`, pas au mount).
+ * - Si `denied` : silencieusement ignoré (l'app a d'autres canaux : toast,
+ *   FAB, badge nav).
+ * - SSR-safe : retourne des no-ops si `window`/`Notification` indisponibles.
+ */
+
+import { useCallback, useRef } from "react";
+
+interface SendParams {
+  title: string;
+  body?: string;
+  /** Identifiant unique pour dédupliquer (replace une notif précédente). */
+  tag?: string;
+  /** Click handler → focus tab + custom action. */
+  onClick?: () => void;
+}
+
+const isSupported = (): boolean =>
+  typeof window !== "undefined" && "Notification" in window;
+
+export function useWebNotification() {
+  const requestedRef = useRef(false);
+
+  const ensurePermission =
+    useCallback(async (): Promise<NotificationPermission> => {
+      if (!isSupported()) return "denied";
+      if (Notification.permission === "granted") return "granted";
+      if (Notification.permission === "denied") return "denied";
+      // Demander une seule fois par session.
+      if (requestedRef.current) return Notification.permission;
+      requestedRef.current = true;
+      try {
+        return await Notification.requestPermission();
+      } catch {
+        return "denied";
+      }
+    }, []);
+
+  const sendNotification = useCallback(
+    async (params: SendParams): Promise<void> => {
+      if (!isSupported()) return;
+      const perm = await ensurePermission();
+      if (perm !== "granted") return;
+      try {
+        const notif = new Notification(params.title, {
+          body: params.body,
+          icon: "/favicon.ico",
+          tag: params.tag,
+        });
+        if (params.onClick) {
+          notif.onclick = () => {
+            window.focus();
+            params.onClick?.();
+            notif.close();
+          };
+        }
+      } catch {
+        /* Failure to instantiate Notification is non-critical. */
+      }
+    },
+    [ensurePermission],
+  );
+
+  return { ensurePermission, sendNotification };
+}
+
+export default useWebNotification;

--- a/frontend/src/pages/__tests__/HubPage.test.tsx
+++ b/frontend/src/pages/__tests__/HubPage.test.tsx
@@ -25,6 +25,15 @@ vi.mock("../../hooks/useAuth", () => ({
   }),
 }));
 
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuthContext: () => ({
+    user: { plan: "pro", preferences: { has_completed_onboarding: true } },
+    loading: false,
+    logout: vi.fn(),
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 vi.mock("../../hooks/useTranslation", () => ({
   useTranslation: () => ({ language: "fr", t: { empty_states: {} } }),
 }));
@@ -53,6 +62,24 @@ vi.mock("../../components/DoodleBackground", () => ({
 // SEO uses react-helmet-async which complains without HelmetProvider — mock it.
 vi.mock("../../components/SEO", () => ({
   SEO: () => null,
+}));
+
+// BackgroundAnalysisProvider is mounted at the root in App.tsx; tests rendering
+// HubPage in isolation need a stub.
+vi.mock("../../contexts/BackgroundAnalysisContext", () => ({
+  useBackgroundAnalysis: () => ({
+    tasks: [],
+    activeTasksCount: 0,
+    startVideoAnalysis: vi.fn(),
+    startPlaylistAnalysis: vi.fn(),
+    getTask: vi.fn(),
+    removeTask: vi.fn(),
+    clearCompleted: vi.fn(),
+    retryTask: vi.fn(),
+    hasNewCompletedTask: false,
+    acknowledgeCompleted: vi.fn(),
+  }),
+  MaxConcurrentReachedError: class extends Error {},
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
## Contexte

Sur DeepSight Web, plusieurs boutons « Analyser » sont éparpillés (`DashboardPageMinimal`, `ConversationsDrawer`, `NewConversationModal`, `HubPage`, `SmartInputBar`). Quand une analyse tourne, l'user perd la visibilité globale dès qu'il navigue ailleurs que `/hub?analyzing=…`.

Cette PR ajoute un FAB persistant bas-droite avec spinner DeepSight (anneau luminous Doodles v14) qui rend visible toutes les analyses en cours sur **toutes les routes**, plafonne à 2 simultanées, et notifie la fin via 4 canaux combinés (toast + check anim + Web Notification API + badge nav Hub).

Spec complète : [`Vault/01-Projects/DeepSight/Specs/2026-05-07-background-analysis-fab-design.md`](https://github.com/Fonira/DeepSight-Main/blob/feat/background-analysis-fab/docs/) (vault local Maxime).

## Summary

### Phase 1-4 (commit `5e3d2650`)
- `BackgroundAnalysisContext`: `MAX_CONCURRENT_ANALYSES = 2` + throw `MaxConcurrentReachedError` dans `startVideoAnalysis`/`startPlaylistAnalysis`. Mode/category stockés sur les tasks pour permettre `retryTask`. Refetch confirm one-shot dans `restoreTasks` (purge zombies localStorage post-reload).
- `BackgroundAnalysisFAB` (fixed bottom-right desktop / top-right mobile, 64px) — états `processing` (indigo + DeepSightSpinner), `success` (emerald check anim 10s auto-dismiss), `error` (rouge + AlertTriangle). Glow Framer Motion. Badge count si > 1.
- `BackgroundAnalysisPanel` (popover au click FAB) — liste tasks avec ETA dérivé du progress, bouton Voir, bouton Réessayer pour failed, ligne quota orange < 20% restant + lien `/pricing`, bouton Effacer terminées.
- `useWebNotification` hook (lazy permission, déclenché uniquement si `document.hidden` au moment de la complétion).
- `HubNavBadge` (dot rouge sur le NavItem Hub si analyse failed OU `hasNewCompletedTask && !on /hub`).
- Mount `<BackgroundAnalysisProvider>` autour de `<Router>` + render `<BackgroundAnalysisFAB />` à la racine.

### Phase 5 (commit `b498c426`)
- Refactor signatures : `startVideoAnalysis` / `startPlaylistAnalysis` / `retryTask` retournent `StartAnalysisResult { localId, taskId, summaryId? }`. Le cache hit synchrone backend (response.result.summary_id présent) court-circuite le polling.
- `useAnalyzeAndOpenHub` migré au context. `capReached: true` exposé dans le state quand throw. Les 5 boutons appelants bénéficient automatiquement du tracking dans le FAB.
- Tests Vitest (16 nouveaux tests, tous passent) :
  - `BackgroundAnalysisContext.test.tsx` — cap, retryTask, cache hit, count.
  - `useAnalyzeAndOpenHub.test.tsx` — migré sur mock context, capReached.
  - `BackgroundAnalysisFAB.test.tsx` — états visuels.
- Mocks ajoutés dans `HubPage.test.tsx` + `Sidebar.test.tsx` pour isoler le BackgroundAnalysisContext (sinon crash hors Provider).

## Tech-debt connue (V1 → V2)

- **`NewConversationModal`** a son propre flux polling local intentionnel (commenté in-source) → pas migré, donc analyses lancées depuis cette modal ne sont **pas** trackées par le FAB. Workaround V2 : ajouter `addProcessingTask(taskId)` au context.
- **Cross-tab sync** (BroadcastChannel) reporté V2 — ouverture de plusieurs onglets DeepSight n'est pas synchronisée.
- **i18n** : les messages d'erreur (cap atteint) et titres (« Analyse terminée », « Analyses ») sont actuellement français hardcoded → extraction i18n à faire en V2.

## Test plan

- [x] `npm run typecheck` : aucune erreur sur `BackgroundAnalysisContext`, `useAnalyzeAndOpenHub`, `BackgroundAnalysisFAB/Panel`, `HubNavBadge`, `useWebNotification`. Erreurs TS pré-existantes (debate.ts duplicates, History.tsx calcExportMenuPos, etc.) hors scope.
- [x] `npx vitest run src/contexts/__tests__/ src/hooks/__tests__/useAnalyzeAndOpenHub.test.tsx src/components/background/` → 16/16 passing.
- [ ] **Manual smoke test** (à faire post-merge ou pre-merge en local) :
  - Lancer une analyse depuis Dashboard → FAB apparaît bas-droite avec spinner.
  - Naviguer vers `/history` ou `/playlists` → FAB persiste.
  - Click FAB → panneau étendu avec progress + ETA + bouton Voir.
  - Lancer 2e analyse → 2 tasks dans le panneau, badge count = 2 sur FAB.
  - Lancer 3e analyse → toast d'erreur cap atteint, pas de side effect.
  - Reload page pendant analyse → FAB réapparaît post-reload (refetch confirm).
  - Tab inactive + analyse termine → notification browser + toast au retour + badge nav Hub.
  - Click sur task failed → bouton Réessayer relance avec mêmes params.
- [ ] **Mobile viewport** : vérifier FAB en top-right (sous header) et panneau full-width.
- [ ] **Quota proche limite** : sur compte Pro avec 28/30 analyses utilisées → ligne quota orange + lien Upgrade.

## Régressions identifiées (non causées par cette PR)

- `HubPage.test.tsx` (2 tests) cherche des textes UI obsolètes — la page a évolué ; à fixer dans une PR dédiée.
- TS errors pré-existants sur `History.tsx` / `debate.ts` / `DashboardPageMinimal.tsx` — non touchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)