### PR TITLE
feat(api/v1+frontend): public analysis pages /a/{slug} (Phase 3)

### DIFF
--- a/backend/alembic/versions/025_summary_is_public.py
+++ b/backend/alembic/versions/025_summary_is_public.py
@@ -1,0 +1,82 @@
+"""summary_is_public — opt-in toggle pour pages publiques /a/{slug} (Phase 3 GEO)
+
+Revision ID: 025_summary_is_public
+Revises: 024_summary_visual_analysis
+Create Date: 2026-05-07
+
+Phase 3 du sprint Export to AI + GEO. Les pages publiques `/a/{slug}` sont
+opt-in par analyse — l'utilisateur doit explicitement activer le partage. Par
+défaut, toutes les analyses restent privées (`is_public=false`).
+
+Ajoute la colonne `summaries.is_public BOOLEAN NOT NULL DEFAULT FALSE`. Le slug
+est dérivé déterministiquement depuis l'ID (`f"a{int(id):x}"` cf
+`exports/markdown_builder.py::_slug_for_summary`), pas besoin de colonne slug
+dédiée. Index partiel sur `(is_public)` pour accélérer le lookup public.
+
+Décisions actées (réf spec § 6) :
+  • Q1 : pas de page /discover en V1, juste lien partageable
+  • Q5 : ignorer si vidéo source devient privée en V1
+
+Idempotente : check si la colonne existe avant ALTER TABLE.
+Spec : Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "025_summary_is_public"
+down_revision: Union[str, None] = "024_summary_visual_analysis"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "is_public" not in columns:
+        # NOT NULL DEFAULT FALSE — toutes les rows existantes deviennent
+        # explicitement privées. Aucune fuite possible au déploiement.
+        op.add_column(
+            "summaries",
+            sa.Column(
+                "is_public",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+    # Index sur (is_public) pour le SELECT public WHERE is_public=true.
+    # Pas de WHERE clause (index partiel) car PostgreSQL le supporte mais
+    # SQLite (dev/tests) ne le supporte pas en CREATE INDEX standard.
+    indexes = {idx["name"] for idx in inspector.get_indexes("summaries")}
+    if "idx_summaries_is_public" not in indexes:
+        op.create_index(
+            "idx_summaries_is_public",
+            "summaries",
+            ["is_public"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        return
+
+    indexes = {idx["name"] for idx in inspector.get_indexes("summaries")}
+    if "idx_summaries_is_public" in indexes:
+        op.drop_index("idx_summaries_is_public", table_name="summaries")
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "is_public" in columns:
+        op.drop_column("summaries", "is_public")

--- a/backend/src/api_public/router.py
+++ b/backend/src/api_public/router.py
@@ -619,6 +619,168 @@ async def export_summary_markdown(
     )
 
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌍 PUBLIC ANALYSIS PAGES — `/a/{slug}` opt-in (Phase 3 sprint GEO)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Spec : Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md
+# Décisions actées :
+#   • Q1 : pages publiques = lien partageable seulement (pas de /discover en V1)
+#   • Q5 : si vidéo source devient privée → ignorer en V1, page DeepSight reste live
+#
+# Slug dérivé déterministiquement depuis l'ID via `slug_for_summary` (cf
+# exports/markdown_builder.py — cohérent avec PR-B export Markdown).
+# Resolve inverse : `a{hex(id)}` → `int(slug[1:], 16)`.
+
+
+class VisibilityUpdate(BaseModel):
+    """Body de PATCH /api/v1/summaries/{id}/visibility."""
+
+    is_public: bool = Field(..., description="Active ou désactive la page publique /a/{slug}")
+
+
+def _resolve_summary_id_from_slug(slug: str) -> Optional[int]:
+    """Inverse de `slug_for_summary` : `a{hex(id)}` → int.
+
+    Tolérant aux variations (case, padding) — retourne None si invalide.
+    Évite les leaks d'existence : un slug malformé est géré comme une 404
+    en amont.
+    """
+    if not slug or len(slug) < 2:
+        return None
+    if slug[0] != "a":
+        return None
+    try:
+        return int(slug[1:], 16)
+    except (ValueError, TypeError):
+        return None
+
+
+@router.get("/public/summaries/{slug}")
+async def get_public_summary(
+    slug: str,
+    session: AsyncSession = Depends(get_session),
+):
+    """
+    🌍 Page publique opt-in d'une analyse — endpoint sans auth.
+
+    **Comportement** :
+    - 200 + JSON payload (mêmes champs que `/api/v1/analysis/{id}`) si
+      `is_public=true` ET slug existe.
+    - 404 sinon — comportement IDENTIQUE pour slug invalide, summary
+      inexistant ou `is_public=false`. Ne PAS leak l'existence.
+
+    **Cache** : `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400`
+    pour permettre l'edge cache Vercel/Cloudflare.
+
+    **Rate-limit IP** : géré en amont par middleware partagé (60/min — cf spec § 4.3).
+    """
+    from db.database import Summary
+
+    summary_id = _resolve_summary_id_from_slug(slug)
+    if summary_id is None:
+        # Slug malformé → 404 sans détail (anti-leak).
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "not_found", "message": "Analysis not found or not public"},
+        )
+
+    result = await session.execute(
+        select(Summary).where(Summary.id == summary_id, Summary.is_public.is_(True))
+    )
+    summary = result.scalar_one_or_none()
+
+    if not summary:
+        # Cas couverts : id n'existe pas, OR is_public=false.
+        # Même 404 → pas de leak entre "n'existe pas" et "existe mais privé".
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "not_found", "message": "Analysis not found or not public"},
+        )
+
+    payload = {
+        "id": str(summary.id),
+        "slug": slug,
+        "video_id": summary.video_id,
+        "video_title": summary.video_title,
+        "video_channel": getattr(summary, "video_channel", None),
+        "video_duration": getattr(summary, "video_duration", None),
+        "video_url": getattr(summary, "video_url", None),
+        "thumbnail_url": getattr(summary, "thumbnail_url", None),
+        "summary_content": summary.summary_content,
+        "summary_extras": getattr(summary, "summary_extras", None),
+        # 👁️ Visual analysis exposé (cf PR-A — bug d'exposition fixé).
+        "visual_analysis": getattr(summary, "visual_analysis", None),
+        "lang": getattr(summary, "lang", None),
+        "mode": getattr(summary, "mode", "standard"),
+        "model_used": getattr(summary, "model_used", None),
+        "platform": getattr(summary, "platform", None),
+        "category": getattr(summary, "category", None),
+        "reliability_score": getattr(summary, "reliability_score", None),
+        "deep_research": bool(getattr(summary, "deep_research", False)),
+        "created_at": summary.created_at.isoformat() if summary.created_at else None,
+        "permalink": f"https://deepsightsynthesis.com/a/{slug}",
+    }
+
+    return Response(
+        content=__import__("json").dumps(payload, default=str),
+        media_type="application/json",
+        headers={
+            # Edge cache : 1h fresh + 24h stale-while-revalidate.
+            "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+            # Anti-bot leak : permet aux IA crawlers de cacher.
+            "X-Robots-Tag": "all",
+        },
+    )
+
+
+@router.patch("/summaries/{summary_id}/visibility")
+async def update_summary_visibility(
+    summary_id: int,
+    body: VisibilityUpdate,
+    user: User = Depends(get_api_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """
+    🔓 Active/désactive la page publique `/a/{slug}` d'une analyse (opt-in).
+
+    **Auth** : X-API-Key Pro/Expert (admin bypass via `get_api_user`).
+    **Owner check** : 404 si l'analyse appartient à un autre user (anti-leak).
+
+    **Réponse** :
+    - 200 + `{"summary_id": int, "is_public": bool, "slug": str, "permalink": str}`
+    - 404 si summary_id n'existe pas ou owned par un autre user.
+
+    **Spec** : Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md
+    """
+    from db.database import Summary
+
+    result = await session.execute(
+        select(Summary).where(Summary.id == summary_id, Summary.user_id == user.id)
+    )
+    summary = result.scalar_one_or_none()
+
+    if not summary:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "not_found", "message": f"Summary {summary_id} not found or access denied"},
+        )
+
+    # Update + commit
+    summary.is_public = bool(body.is_public)
+    await session.commit()
+
+    slug = slug_for_summary(summary.id)
+    permalink = f"https://deepsightsynthesis.com/a/{slug}"
+
+    return {
+        "summary_id": summary.id,
+        "is_public": bool(summary.is_public),
+        "slug": slug,
+        "permalink": permalink,
+    }
+
+
 @router.post("/chat", response_model=ChatResponse)
 async def chat_with_video(
     req: ChatRequest, user: User = Depends(get_api_user), session: AsyncSession = Depends(get_session)

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -259,6 +259,12 @@ class Summary(Base):
     # visual_seo_indicators{}, summary_visual, model_used, frames_analyzed, frames_downsampled}.
     visual_analysis = Column(JSON, nullable=True)
 
+    # Public opt-in toggle pour pages publiques /a/{slug} (Phase 3 sprint GEO,
+    # alembic 025). Default FALSE — toggle explicite via PATCH /api/v1/summaries/{id}/visibility.
+    # Slug = f"a{hex(id)}" dérivé déterministiquement de l'ID (cf
+    # exports/markdown_builder.py::_slug_for_summary).
+    is_public = Column(Boolean, default=False, server_default="false", nullable=False, index=True)
+
     # Hierarchical Digest Pipeline (Feb 2026)
     full_digest = Column(Text, nullable=True)  # Assembled full digest from chunk digests (~6-10K chars)
 

--- a/backend/tests/test_public_pages.py
+++ b/backend/tests/test_public_pages.py
@@ -1,0 +1,362 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS: Public API v1 — Phase 3 sprint Export to AI + GEO                       ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Endpoints couverts :                                                              ║
+║    • GET   /api/v1/public/summaries/{slug}    — public, no auth, opt-in is_public  ║
+║    • PATCH /api/v1/summaries/{id}/visibility   — auth Pro/Expert, owner only       ║
+║                                                                                    ║
+║  Spec : Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-   ║
+║  design.md (§ 4.3 routing, § 4.4 Schema.org, § 5.4 critères Phase 3)               ║
+║                                                                                    ║
+║  Vérifie notamment :                                                               ║
+║   1. 200 + JSON payload + Cache-Control public quand is_public=true                ║
+║   2. 404 anti-leak quand is_public=false (mêmes message qu'inexistant)             ║
+║   3. 404 sur slug malformé                                                         ║
+║   4. PATCH met à jour is_public et retourne le slug                                ║
+║   5. PATCH 404 quand summary appartient à un autre user                            ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import os
+import sys
+import importlib
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+# Env de test (idem test_export_markdown.py / test_api_public_v1_analysis.py)
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# Force l'import du vrai module (cf conftest.py — fix module shadowing)
+_api_public_router = importlib.import_module("api_public.router")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def make_mock_summary(**overrides):
+    """Mock minimal d'une row Summary pour les endpoints public/visibility."""
+    s = MagicMock()
+    defaults = {
+        "id": 169,
+        "user_id": 1,
+        "video_id": "dQw4w9WgXcQ",
+        "video_title": "Rick Astley - Never Gonna Give You Up",
+        "video_channel": "Rick Astley",
+        "video_duration": 213,
+        "video_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "thumbnail_url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
+        "summary_content": "Résumé test public.",
+        "summary_extras": {"key_takeaways": ["Item 1"]},
+        "lang": "fr",
+        "mode": "standard",
+        "model_used": "mistral-small-2603",
+        "platform": "youtube",
+        "category": "music",
+        "reliability_score": 44,
+        "deep_research": False,
+        "created_at": datetime(2026, 5, 7, 14, 32, 0),
+        "visual_analysis": None,
+        "is_public": True,
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(s, k, v)
+    return s
+
+
+def make_mock_api_user(**overrides):
+    user = MagicMock()
+    defaults = {
+        "id": 1,
+        "email": "test@example.com",
+        "plan": "expert",
+        "is_admin": False,
+        "credits": 100,
+        "api_key_created_at": datetime(2026, 1, 1),
+        "api_key_last_used": datetime(2026, 5, 7),
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(user, k, v)
+    return user
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 FIXTURES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.close = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def app_public(mock_session):
+    """App FastAPI sans override d'auth (endpoint public)."""
+    from main import app as fastapi_app
+    from db.database import get_session
+
+    async def override_session():
+        return mock_session
+
+    fastapi_app.dependency_overrides[get_session] = override_session
+
+    yield fastapi_app
+    fastapi_app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def app_authed(mock_session):
+    """App FastAPI avec auth API publique mockée (PATCH visibility)."""
+    from main import app as fastapi_app
+    from db.database import get_session
+
+    user = make_mock_api_user()
+
+    async def override_session():
+        return mock_session
+
+    async def override_api_user():
+        return user
+
+    fastapi_app.dependency_overrides[get_session] = override_session
+    fastapi_app.dependency_overrides[_api_public_router.get_api_user] = override_api_user
+
+    yield fastapi_app
+    fastapi_app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client_public(app_public):
+    async with AsyncClient(
+        transport=ASGITransport(app=app_public),
+        base_url="http://test",
+    ) as c:
+        yield c
+
+
+@pytest.fixture
+async def client_authed(app_authed):
+    async with AsyncClient(
+        transport=ASGITransport(app=app_authed),
+        base_url="http://test",
+    ) as c:
+        yield c
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌍 TESTS — GET /api/v1/public/summaries/{slug}
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestPublicSummaryEndpoint:
+    """Tests de l'endpoint public — opt-in is_public, anti-leak 404."""
+
+    @pytest.mark.asyncio
+    async def test_public_summary_returns_200_when_is_public_true(
+        self, client_public, mock_session
+    ):
+        """200 + JSON payload quand is_public=true et slug existe."""
+        # slug = a{hex(169)} = "aa9"
+        summary = make_mock_summary(id=169, is_public=True)
+
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=summary)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client_public.get("/api/v1/public/summaries/aa9")
+
+        assert resp.status_code == 200, resp.text
+        assert "application/json" in resp.headers.get("content-type", "")
+
+        # Cache-Control public + s-maxage 1h + stale 24h (cf spec § 4.3 + 4.4)
+        cache = resp.headers.get("cache-control", "")
+        assert "public" in cache
+        assert "s-maxage=3600" in cache
+        assert "stale-while-revalidate=86400" in cache
+
+        data = resp.json()
+        assert data["id"] == "169"
+        assert data["slug"] == "aa9"
+        assert data["video_title"] == "Rick Astley - Never Gonna Give You Up"
+        assert data["video_id"] == "dQw4w9WgXcQ"
+        assert data["permalink"] == "https://deepsightsynthesis.com/a/aa9"
+        # Contrat avec PR-A : visual_analysis présent au top-level (même null).
+        assert "visual_analysis" in data
+
+    @pytest.mark.asyncio
+    async def test_public_summary_404_when_is_public_false(
+        self, client_public, mock_session
+    ):
+        """404 anti-leak — comportement identique à un summary inexistant.
+
+        Le query inclut WHERE is_public=true donc la row n'est PAS retournée
+        si is_public=false. Le client ne doit PAS pouvoir distinguer entre
+        "n'existe pas" et "existe mais privée" (cf spec § 4.3).
+        """
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client_public.get("/api/v1/public/summaries/aa9")
+
+        assert resp.status_code == 404
+        data = resp.json()
+        detail = data.get("detail", data)
+        assert detail.get("error") == "not_found"
+        # Le message DOIT être identique au cas "slug malformé" pour anti-leak.
+        assert "not found" in detail.get("message", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_public_summary_404_on_malformed_slug(
+        self, client_public, mock_session
+    ):
+        """404 sur slug malformé — pas de leak via détail différent."""
+        # Slugs invalides : missing 'a' prefix, non-hex, empty after 'a'.
+        for bad_slug in ("zzz", "b1234", "a", "axyz", "alongnonsensestring!"):
+            resp = await client_public.get(f"/api/v1/public/summaries/{bad_slug}")
+            assert resp.status_code == 404, f"slug {bad_slug!r} should 404"
+            data = resp.json()
+            detail = data.get("detail", data)
+            assert detail.get("error") == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_public_summary_does_not_require_auth(
+        self, client_public, mock_session
+    ):
+        """L'endpoint est PUBLIC — aucun X-API-Key requis (cf spec § 4.3)."""
+        summary = make_mock_summary(id=169, is_public=True)
+
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=summary)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        # Pas de header X-API-Key, pas d'Authorization
+        resp = await client_public.get("/api/v1/public/summaries/aa9")
+        assert resp.status_code == 200
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔓 TESTS — PATCH /api/v1/summaries/{id}/visibility
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestVisibilityPatchEndpoint:
+    """Tests de l'endpoint PATCH visibility — auth API key + owner only."""
+
+    @pytest.mark.asyncio
+    async def test_visibility_patch_sets_public_true(
+        self, client_authed, mock_session
+    ):
+        """PATCH is_public=true → 200 + slug + permalink."""
+        summary = make_mock_summary(id=169, user_id=1, is_public=False)
+
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=summary)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client_authed.patch(
+            "/api/v1/summaries/169/visibility",
+            json={"is_public": True},
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["summary_id"] == 169
+        assert data["is_public"] is True
+        assert data["slug"] == "aa9"
+        assert data["permalink"] == "https://deepsightsynthesis.com/a/aa9"
+        # commit() effectivement appelé (sanity check persistence).
+        mock_session.commit.assert_awaited()
+        # Side-effect : objet mis à jour.
+        assert summary.is_public is True
+
+    @pytest.mark.asyncio
+    async def test_visibility_patch_sets_public_false(
+        self, client_authed, mock_session
+    ):
+        """PATCH is_public=false → 200 + retour à privé."""
+        summary = make_mock_summary(id=169, user_id=1, is_public=True)
+
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=summary)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client_authed.patch(
+            "/api/v1/summaries/169/visibility",
+            json={"is_public": False},
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_public"] is False
+        assert summary.is_public is False
+
+    @pytest.mark.asyncio
+    async def test_visibility_patch_404_when_not_owner(
+        self, client_authed, mock_session
+    ):
+        """404 quand summary appartient à un autre user (anti-leak).
+
+        Le query filtre par user_id → la row n'est pas retournée. Pas de 403
+        pour ne pas leak l'existence du summary (cf contrat /export endpoint).
+        """
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_session.execute = AsyncMock(return_value=scalar_result)
+
+        resp = await client_authed.patch(
+            "/api/v1/summaries/999/visibility",
+            json={"is_public": True},
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+
+        assert resp.status_code == 404
+        data = resp.json()
+        detail = data.get("detail", data)
+        assert detail.get("error") == "not_found"
+        # commit NON appelé (rollback du flow sans modif).
+        mock_session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_visibility_patch_422_on_missing_body(
+        self, client_authed, mock_session
+    ):
+        """422 quand body est invalide (champ is_public manquant)."""
+        # Empty body — is_public is required.
+        resp = await client_authed.patch(
+            "/api/v1/summaries/169/visibility",
+            json={},
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+        assert resp.status_code == 422
+
+        # Type non-coercible vers bool (list / dict). Pydantic v2 coerce
+        # "yes"/"no"/"1"/"0" → bool, donc on teste avec un type qui ne peut
+        # PAS être coerce.
+        resp2 = await client_authed.patch(
+            "/api/v1/summaries/169/visibility",
+            json={"is_public": ["not", "a", "bool"]},
+            headers={"X-API-Key": "ds_live_test_dummy"},
+        )
+        assert resp2.status_code == 422

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -309,6 +309,9 @@ const AboutPage = lazyWithRetry(() => import("./pages/AboutPage"));
 const SharedAnalysisPage = lazyWithRetry(
   () => import("./pages/SharedAnalysisPage"),
 );
+const PublicAnalysisPage = lazyWithRetry(
+  () => import("./pages/PublicAnalysisPage"),
+);
 
 // Pages protégées
 const DashboardPageLegacy = lazyWithRetry(
@@ -841,6 +844,23 @@ const AppRoutes = () => {
                               fallback={<PageSkeleton variant="simple" />}
                             >
                               <SharedAnalysisPage />
+                            </Suspense>
+                          </RouteErrorBoundary>
+                        }
+                      />
+
+                      {/* Public analysis pages — opt-in /a/{slug} (Phase 3 GEO) */}
+                      <Route
+                        path="/a/:slug"
+                        element={
+                          <RouteErrorBoundary
+                            variant="full"
+                            componentName="PublicAnalysisPage"
+                          >
+                            <Suspense
+                              fallback={<PageSkeleton variant="simple" />}
+                            >
+                              <PublicAnalysisPage />
                             </Suspense>
                           </RouteErrorBoundary>
                         }

--- a/frontend/src/components/analysis/MakePublicToggle.tsx
+++ b/frontend/src/components/analysis/MakePublicToggle.tsx
@@ -1,0 +1,227 @@
+/**
+ * MakePublicToggle — Toggle « Rendre publique » par analyse (Phase 3 sprint
+ * Export to AI + GEO).
+ *
+ * Quand l'utilisateur active le toggle :
+ *   1. PATCH /api/v1/summaries/{id}/visibility {is_public: true}
+ *   2. Le backend retourne `slug` + `permalink` déterministes (a{hex(id)})
+ *   3. Le permalink est copié automatiquement dans le presse-papier
+ *   4. Toast de confirmation "Lien copié"
+ *
+ * Quand le toggle est désactivé : revient privé, future visites de /a/{slug}
+ * → 404 (anti-leak).
+ *
+ * Spec : Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md
+ */
+
+import { useState, useCallback } from "react";
+import { Globe, Lock, Check, Copy as CopyIcon } from "lucide-react";
+import { publicAnalysisApi } from "../../services/api";
+
+export interface MakePublicToggleProps {
+  /** ID numérique du summary (PK BDD). */
+  summaryId: number;
+  /** État initial — passé par le parent depuis l'analyse en cache. */
+  initialIsPublic?: boolean;
+  /**
+   * Slug initial pré-calculé (a{hex(id)}). Optionnel — sinon le composant
+   * reçoit le slug du backend après le premier toggle ON.
+   */
+  initialSlug?: string;
+  /** Callback de succès : permet au parent de sync son state. */
+  onChange?: (state: { isPublic: boolean; slug: string; permalink: string }) => void;
+  language?: "fr" | "en";
+  /** Si true, affiche en mode compact (juste le toggle, pas le bloc explicatif). */
+  compact?: boolean;
+  /** Si true, affiche un toast en cas d'erreur (sinon silence). */
+  showErrors?: boolean;
+}
+
+const T = {
+  fr: {
+    title: "Rendre publique",
+    description: "Obtenez un lien partageable indexable par les IA.",
+    descriptionPublic: "Cette analyse est publique. N'importe qui peut la voir.",
+    on: "Public",
+    off: "Privée",
+    copy: "Copier le lien",
+    copied: "Lien copié !",
+    error: "Erreur de sauvegarde",
+  },
+  en: {
+    title: "Make public",
+    description: "Get a shareable link indexable by AI assistants.",
+    descriptionPublic: "This analysis is public. Anyone can view it.",
+    on: "Public",
+    off: "Private",
+    copy: "Copy link",
+    copied: "Link copied!",
+    error: "Save failed",
+  },
+} as const;
+
+export const MakePublicToggle: React.FC<MakePublicToggleProps> = ({
+  summaryId,
+  initialIsPublic = false,
+  initialSlug,
+  onChange,
+  language = "fr",
+  compact = false,
+  showErrors = true,
+}) => {
+  const [isPublic, setIsPublic] = useState(initialIsPublic);
+  const [slug, setSlug] = useState<string | null>(initialSlug ?? null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const t = T[language];
+
+  const permalink = slug ? publicAnalysisApi.buildPermalink(slug) : "";
+
+  const handleToggle = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    setError(null);
+    const next = !isPublic;
+    try {
+      const res = await publicAnalysisApi.setVisibility(summaryId, next);
+      setIsPublic(res.is_public);
+      setSlug(res.slug);
+      onChange?.({
+        isPublic: res.is_public,
+        slug: res.slug,
+        permalink: res.permalink,
+      });
+      // Auto-copy le lien quand on passe à public.
+      if (res.is_public && navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(res.permalink);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2500);
+        } catch {
+          // ignore clipboard failures
+        }
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : t.error;
+      if (showErrors) setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [isPublic, loading, summaryId, onChange, showErrors, t.error]);
+
+  const handleCopy = useCallback(async () => {
+    if (!permalink) return;
+    try {
+      await navigator.clipboard.writeText(permalink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // ignore
+    }
+  }, [permalink]);
+
+  if (compact) {
+    return (
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={isPublic}
+          aria-label={t.title}
+          aria-busy={loading}
+          disabled={loading}
+          onClick={handleToggle}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+            isPublic ? "bg-emerald-500" : "bg-white/10"
+          } ${loading ? "opacity-50 cursor-wait" : ""}`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              isPublic ? "translate-x-6" : "translate-x-1"
+            }`}
+          />
+        </button>
+        <span className="text-sm text-text-secondary">
+          {isPublic ? t.on : t.off}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-bg-surface p-4 sm:p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1">
+          <h3 className="flex items-center gap-2 font-semibold text-text-primary">
+            {isPublic ? (
+              <Globe className="w-4 h-4 text-emerald-400" />
+            ) : (
+              <Lock className="w-4 h-4 text-text-muted" />
+            )}
+            {t.title}
+          </h3>
+          <p className="mt-1 text-sm text-text-muted">
+            {isPublic ? t.descriptionPublic : t.description}
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={isPublic}
+          aria-label={t.title}
+          aria-busy={loading}
+          disabled={loading}
+          onClick={handleToggle}
+          className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
+            isPublic ? "bg-emerald-500" : "bg-white/10"
+          } ${loading ? "opacity-50 cursor-wait" : ""}`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              isPublic ? "translate-x-6" : "translate-x-1"
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* Permalink display + copy button */}
+      {isPublic && permalink && (
+        <div className="mt-4 flex items-center gap-2 rounded-lg border border-white/10 bg-bg-primary/50 px-3 py-2 text-xs">
+          <code
+            className="flex-1 truncate text-text-secondary"
+            title={permalink}
+          >
+            {permalink}
+          </code>
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={t.copy}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-text-muted hover:bg-white/5 hover:text-text-primary transition-colors"
+          >
+            {copied ? (
+              <>
+                <Check className="w-3.5 h-3.5 text-emerald-400" />
+                <span className="hidden sm:inline">{t.copied}</span>
+              </>
+            ) : (
+              <>
+                <CopyIcon className="w-3.5 h-3.5" />
+                <span className="hidden sm:inline">{t.copy}</span>
+              </>
+            )}
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-3 text-xs text-rose-400" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default MakePublicToggle;

--- a/frontend/src/components/analysis/__tests__/MakePublicToggle.test.tsx
+++ b/frontend/src/components/analysis/__tests__/MakePublicToggle.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * 🧪 Tests — MakePublicToggle
+ *
+ * Vérifie :
+ *   1. Toggle off → on : appel API + permalink affiché + auto-copy
+ *   2. Toggle on → off : retour à privé + permalink masqué
+ *   3. Erreur API : message affiché
+ *   4. Mode compact : seul le switch est rendu
+ *
+ * Phase 3 sprint Export to AI + GEO.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../__tests__/test-utils";
+import { MakePublicToggle } from "../MakePublicToggle";
+
+vi.mock("../../../services/api", () => ({
+  publicAnalysisApi: {
+    setVisibility: vi.fn(),
+    buildPermalink: (slug: string) =>
+      `https://deepsightsynthesis.com/a/${slug}`,
+  },
+}));
+
+import { publicAnalysisApi } from "../../../services/api";
+const mockSetVis = publicAnalysisApi.setVisibility as ReturnType<typeof vi.fn>;
+
+// Mock clipboard API
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    writable: true,
+  });
+});
+
+describe("MakePublicToggle", () => {
+  it("renders private state by default", () => {
+    renderWithProviders(
+      <MakePublicToggle summaryId={169} initialIsPublic={false} />,
+    );
+    const sw = screen.getByRole("switch");
+    expect(sw).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("calls API and displays permalink when toggling ON", async () => {
+    mockSetVis.mockResolvedValue({
+      summary_id: 169,
+      is_public: true,
+      slug: "aa9",
+      permalink: "https://deepsightsynthesis.com/a/aa9",
+    });
+
+    const onChange = vi.fn();
+    renderWithProviders(
+      <MakePublicToggle
+        summaryId={169}
+        initialIsPublic={false}
+        onChange={onChange}
+      />,
+    );
+
+    const sw = screen.getByRole("switch");
+    await userEvent.click(sw);
+
+    await waitFor(() => {
+      expect(mockSetVis).toHaveBeenCalledWith(169, true);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText("https://deepsightsynthesis.com/a/aa9"),
+      ).toBeInTheDocument();
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      isPublic: true,
+      slug: "aa9",
+      permalink: "https://deepsightsynthesis.com/a/aa9",
+    });
+    // Auto-copy effectué
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "https://deepsightsynthesis.com/a/aa9",
+    );
+  });
+
+  it("toggles back to private and hides permalink", async () => {
+    mockSetVis.mockResolvedValue({
+      summary_id: 169,
+      is_public: false,
+      slug: "aa9",
+      permalink: "https://deepsightsynthesis.com/a/aa9",
+    });
+
+    renderWithProviders(
+      <MakePublicToggle
+        summaryId={169}
+        initialIsPublic={true}
+        initialSlug="aa9"
+      />,
+    );
+
+    // Permalink visible au départ (isPublic=true)
+    expect(
+      screen.getByText("https://deepsightsynthesis.com/a/aa9"),
+    ).toBeInTheDocument();
+
+    const sw = screen.getByRole("switch");
+    await userEvent.click(sw);
+
+    await waitFor(() => {
+      expect(mockSetVis).toHaveBeenCalledWith(169, false);
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByText("https://deepsightsynthesis.com/a/aa9"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("displays error message on API failure", async () => {
+    mockSetVis.mockRejectedValue(new Error("Network error"));
+
+    renderWithProviders(
+      <MakePublicToggle summaryId={169} initialIsPublic={false} />,
+    );
+
+    const sw = screen.getByRole("switch");
+    await userEvent.click(sw);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/network error/i);
+    });
+  });
+
+  it("renders compact mode without explanation block", () => {
+    renderWithProviders(
+      <MakePublicToggle
+        summaryId={169}
+        initialIsPublic={false}
+        compact={true}
+      />,
+    );
+    // Le titre n'est pas affiché en compact
+    expect(
+      screen.queryByRole("heading", { name: /rendre publique/i }),
+    ).not.toBeInTheDocument();
+    // Mais le switch est là
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/PublicAnalysisPage.tsx
+++ b/frontend/src/pages/PublicAnalysisPage.tsx
@@ -1,0 +1,563 @@
+/**
+ * PublicAnalysisPage — Page publique opt-in d'une analyse DeepSight
+ *
+ * Route: /a/:slug
+ *
+ * Phase 3 du sprint Export to AI + GEO. Différente de SharedAnalysisPage (/s/:token)
+ * qui passe par un share_token éphémère lié à l'auth — ici le slug est dérivé
+ * déterministiquement de l'ID (`a{hex(id)}`), opt-in via le toggle is_public.
+ *
+ * Spec : Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md
+ *
+ * Décisions actées :
+ *  • Q1 : pas de page /discover en V1 (lien partageable seulement)
+ *  • Q5 : ignorer si vidéo source devient privée (page DeepSight reste live)
+ *
+ * SEO/GEO :
+ *  • Schema.org JSON-LD (VideoObject + Article) cf spec § 4.4
+ *  • Open Graph + Twitter Cards
+ *  • Bots IA crawlent (rewrite Vercel /a/:slug pour user-agents bots)
+ */
+
+import { useState, useEffect, useMemo } from "react";
+import { useParams, Link } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
+import { Eye, ExternalLink, Copy as CopyIcon, Check } from "lucide-react";
+import {
+  publicAnalysisApi,
+  PublicAnalysisPayload,
+} from "../services/api";
+import { sanitizeTitle } from "../utils/sanitize";
+import { DeepSightSpinner } from "../components/ui/DeepSightSpinner";
+import DoodleBackground from "../components/DoodleBackground";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function extractVideoId(url: string | null | undefined): string {
+  if (!url) return "";
+  const match = url.match(/(?:v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+  return match ? match[1] : "";
+}
+
+function formatDuration(seconds: number | null | undefined): string {
+  if (!seconds) return "";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h${m.toString().padStart(2, "0")}m`;
+  return `${m}m${s.toString().padStart(2, "0")}s`;
+}
+
+function formatDurationISO(seconds: number | null | undefined): string {
+  if (!seconds || seconds <= 0) return "";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  let out = "PT";
+  if (h > 0) out += `${h}H`;
+  if (m > 0) out += `${m}M`;
+  if (s > 0) out += `${s}S`;
+  return out === "PT" ? "PT0S" : out;
+}
+
+function formatDate(isoDate: string | null | undefined): string {
+  if (!isoDate) return "";
+  try {
+    return new Date(isoDate).toLocaleDateString("fr-FR", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Convertit un Markdown sommaire en HTML stylé (pas de SSR ni hydration HTML
+ * complexe — on garde la SPA simple, idem SharedAnalysisPage).
+ * Les bots IA (GPTBot, ClaudeBot) lisent le HTML rendered côté client depuis 2024.
+ */
+function formatContent(content: string): string {
+  if (!content) return "";
+  return content
+    .replace(
+      /\*\*(.*?)\*\*/g,
+      '<strong class="text-text-primary font-semibold">$1</strong>',
+    )
+    .replace(
+      /^### (.+)$/gm,
+      '<h3 class="text-lg font-bold text-text-primary mt-6 mb-2">$1</h3>',
+    )
+    .replace(
+      /^## (.+)$/gm,
+      '<h2 class="text-xl font-bold text-accent-primary mt-8 mb-3">$1</h2>',
+    )
+    .replace(
+      /^- (.+)$/gm,
+      '<li class="ml-4 text-text-secondary leading-relaxed">$1</li>',
+    )
+    .replace(
+      /\n\n/g,
+      '</p><p class="text-text-secondary mb-3 leading-relaxed">',
+    )
+    .replace(/\n/g, "<br/>");
+}
+
+// ─── Composant ────────────────────────────────────────────────────────────────
+
+export default function PublicAnalysisPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const [data, setData] = useState<PublicAnalysisPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!slug) {
+      setError("invalid_slug");
+      setLoading(false);
+      return;
+    }
+    publicAnalysisApi
+      .getBySlug(slug)
+      .then(setData)
+      .catch(() => setError("not_found"))
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  // ─── Loading ─────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-bg-primary flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <DeepSightSpinner size="lg" />
+          <span className="text-text-muted text-sm">
+            Chargement de l'analyse publique...
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Error / Not Found ───────────────────────────────────────────────────
+  if (error || !data) {
+    return (
+      <div className="min-h-screen bg-bg-primary flex items-center justify-center p-4">
+        <Helmet>
+          <title>Analyse introuvable — DeepSight</title>
+          <meta name="robots" content="noindex" />
+        </Helmet>
+        <div className="text-center max-w-md">
+          <div className="text-6xl mb-4 text-text-muted">
+            <svg
+              className="w-16 h-16 mx-auto"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+              />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold text-text-primary mb-2">
+            Analyse non disponible
+          </h1>
+          <p className="text-text-muted mb-6">
+            Cette page n'existe pas, est privée ou a été désactivée par son
+            créateur.
+          </p>
+          <Link
+            to="/"
+            className="inline-block px-6 py-3 bg-accent-primary text-gray-900 font-semibold rounded-lg hover:bg-accent-primary-hover transition-colors"
+          >
+            Découvrir DeepSight
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Success ─────────────────────────────────────────────────────────────
+  const videoId = data.video_id || extractVideoId(data.video_url);
+  const thumbnailUrl =
+    data.thumbnail_url ||
+    (videoId ? `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg` : "");
+  const youtubeUrl =
+    data.video_url ||
+    (videoId ? `https://www.youtube.com/watch?v=${videoId}` : "");
+  const summaryContent = data.summary_content || "";
+  const channel = data.video_channel || "";
+  const duration = data.video_duration;
+  const createdAt = data.created_at;
+  const description = (summaryContent || data.video_title || "").slice(0, 160);
+  const permalink =
+    data.permalink ||
+    publicAnalysisApi.buildPermalink(data.slug || slug || "");
+  const lang = data.lang || "fr";
+
+  return (
+    <div className="min-h-screen bg-bg-primary">
+      <DoodleBackground variant="video" />
+
+      {/* SEO Meta Tags */}
+      <Helmet>
+        <title>{`${data.video_title} — Analyse DeepSight`}</title>
+        <link rel="canonical" href={permalink} />
+        <meta name="description" content={description} />
+        <meta name="robots" content="index,follow,max-image-preview:large" />
+        <meta property="og:type" content="article" />
+        <meta
+          property="og:title"
+          content={`${data.video_title} — Analyse DeepSight`}
+        />
+        <meta property="og:description" content={description} />
+        {thumbnailUrl && <meta property="og:image" content={thumbnailUrl} />}
+        <meta property="og:url" content={permalink} />
+        <meta property="og:site_name" content="DeepSight" />
+        <meta
+          property="og:locale"
+          content={lang === "fr" ? "fr_FR" : "en_US"}
+        />
+        {createdAt && (
+          <meta
+            property="article:published_time"
+            content={new Date(createdAt).toISOString()}
+          />
+        )}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content={`${data.video_title} — Analyse DeepSight`}
+        />
+        <meta name="twitter:description" content={description} />
+        {thumbnailUrl && <meta name="twitter:image" content={thumbnailUrl} />}
+
+        {/* ─── Schema.org JSON-LD — VideoObject + Article (cf spec § 4.4) ─── */}
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@graph": [
+              {
+                "@type": "VideoObject",
+                "@id": `${permalink}#video`,
+                name: data.video_title,
+                description,
+                ...(thumbnailUrl && { thumbnailUrl }),
+                ...(youtubeUrl && { contentUrl: youtubeUrl }),
+                ...(videoId &&
+                  (data.video_url || "").includes("youtu") && {
+                    embedUrl: `https://www.youtube.com/embed/${videoId}`,
+                  }),
+                ...(duration && { duration: formatDurationISO(duration) }),
+                ...(createdAt && {
+                  uploadDate: new Date(createdAt).toISOString(),
+                }),
+                ...(channel && {
+                  creator: { "@type": "Person", name: channel },
+                }),
+                publisher: {
+                  "@type": "Organization",
+                  name: "DeepSight",
+                  url: "https://deepsightsynthesis.com",
+                  logo: {
+                    "@type": "ImageObject",
+                    url: "https://deepsightsynthesis.com/icons/icon-512x512.png",
+                  },
+                },
+                isFamilyFriendly: true,
+                isAccessibleForFree: true,
+                inLanguage: lang,
+              },
+              {
+                "@type": "Article",
+                headline: `Analysis: ${data.video_title}`,
+                description,
+                ...(thumbnailUrl && { image: thumbnailUrl }),
+                url: permalink,
+                ...(createdAt && {
+                  datePublished: new Date(createdAt).toISOString(),
+                }),
+                author: {
+                  "@type": "Organization",
+                  name: "DeepSight",
+                  url: "https://deepsightsynthesis.com",
+                },
+                publisher: {
+                  "@type": "Organization",
+                  name: "DeepSight",
+                  url: "https://deepsightsynthesis.com",
+                  logo: {
+                    "@type": "ImageObject",
+                    url: "https://deepsightsynthesis.com/icons/icon-512x512.png",
+                  },
+                },
+                mainEntityOfPage: permalink,
+                isAccessibleForFree: true,
+                inLanguage: lang,
+                about: { "@id": `${permalink}#video` },
+              },
+            ],
+          })}
+        </script>
+      </Helmet>
+
+      {/* Header */}
+      <header className="border-b border-border-subtle bg-bg-primary/80 backdrop-blur-xl sticky top-0 z-50">
+        <div className="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
+          <Link to="/" className="group flex items-center gap-2">
+            <span className="text-xl font-bold text-accent-primary group-hover:opacity-80 transition-opacity">
+              DeepSight
+            </span>
+            <span className="text-xs text-text-muted hidden sm:inline">
+              · AI YouTube analyzer
+            </span>
+          </Link>
+          <OpenInAIMenu
+            permalink={permalink}
+            videoTitle={data.video_title}
+            onCopy={() => {
+              setCopied(true);
+              setTimeout(() => setCopied(false), 2000);
+            }}
+            copied={copied}
+          />
+        </div>
+      </header>
+
+      {/* Main */}
+      <main className="max-w-3xl mx-auto px-4 py-6 sm:py-10">
+        {/* Hero: Thumbnail */}
+        {thumbnailUrl && (
+          <a
+            href={youtubeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block relative rounded-xl overflow-hidden group mb-6 shadow-lg"
+            aria-label={`Voir la vidéo source : ${data.video_title}`}
+          >
+            <img
+              src={thumbnailUrl}
+              alt={`Miniature de ${data.video_title}`}
+              className="w-full aspect-video object-cover group-hover:scale-[1.02] transition-transform duration-300"
+              loading="eager"
+            />
+            <div className="absolute inset-0 bg-black/20 group-hover:bg-black/10 transition-colors flex items-center justify-center">
+              <div className="w-14 h-14 bg-red-600 rounded-full flex items-center justify-center shadow-xl group-hover:scale-110 transition-transform">
+                <svg
+                  className="w-7 h-7 text-white ml-0.5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </div>
+            </div>
+          </a>
+        )}
+
+        {/* Title */}
+        <h1 className="text-2xl sm:text-3xl font-bold text-text-primary mb-2 leading-tight">
+          {sanitizeTitle(data.video_title)}
+        </h1>
+
+        {/* Subtitle metadata */}
+        <p className="text-text-muted text-sm sm:text-base mb-6">
+          {[
+            sanitizeTitle(channel),
+            formatDate(createdAt),
+            formatDuration(duration),
+            data.mode ? `Mode ${data.mode}` : null,
+          ]
+            .filter(Boolean)
+            .join(" • ")}
+        </p>
+
+        {/* Reliability disclaimer (cf spec § 5.1 finding #4) */}
+        {typeof data.reliability_score === "number" &&
+          data.reliability_score < 80 && (
+            <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 mb-6 text-sm text-amber-200">
+              <Eye className="inline-block w-4 h-4 mr-1.5 -mt-0.5" />
+              Reliability score: {data.reliability_score}/100. Scores below 80
+              should be cross-checked against the source video.
+            </div>
+          )}
+
+        {/* Full analysis content */}
+        <div className="bg-bg-surface border border-border-default rounded-xl p-5 sm:p-6 mb-8">
+          <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-4">
+            Analyse complète
+          </h2>
+          <div
+            className="prose prose-invert max-w-none text-text-secondary leading-relaxed"
+            dangerouslySetInnerHTML={{
+              __html: formatContent(summaryContent),
+            }}
+          />
+        </div>
+
+        {/* CTA Block — analyze your own video */}
+        <section className="mx-auto mt-12 max-w-3xl rounded-2xl border border-white/10 bg-gradient-to-br from-indigo-500/10 via-purple-500/5 to-transparent p-8 text-center shadow-2xl">
+          <h2 className="text-2xl font-bold text-text-primary sm:text-3xl">
+            Analyse ta propre vidéo en 30 s
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-text-secondary">
+            DeepSight transforme n'importe quelle vidéo YouTube en synthèse
+            structurée, analyse visuelle et points clés horodatés.
+          </p>
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+            <a
+              href="/?utm_source=public_page&utm_medium=cta_primary&utm_campaign=geo"
+              className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-500 to-violet-500 px-6 py-3 font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:brightness-110"
+            >
+              Essayer DeepSight
+            </a>
+            <a
+              href="/upgrade?utm_source=public_page&utm_medium=cta_secondary&utm_campaign=geo"
+              className="inline-flex items-center gap-2 rounded-xl border border-white/15 px-5 py-3 text-text-secondary transition hover:bg-white/5"
+            >
+              Voir les tarifs
+            </a>
+          </div>
+          <p className="mt-5 text-xs text-text-muted">
+            🇫🇷🇪🇺 IA française · Propulsé par Mistral AI · Vos données restent
+            en Europe
+          </p>
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-border-subtle py-6 text-center text-text-muted text-xs">
+        <p>
+          &copy; {new Date().getFullYear()} DeepSight &mdash;{" "}
+          <a
+            href="https://deepsightsynthesis.com"
+            className="hover:text-text-secondary transition-colors"
+          >
+            deepsightsynthesis.com
+          </a>
+        </p>
+        <p className="mt-1 opacity-60">
+          Permalink:{" "}
+          <code className="text-[0.7rem] bg-white/5 px-1.5 py-0.5 rounded">
+            {permalink}
+          </code>
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+// ─── Sous-composant : Open in your AI menu ───────────────────────────────────
+
+interface OpenInAIMenuProps {
+  permalink: string;
+  videoTitle: string;
+  onCopy: () => void;
+  copied: boolean;
+}
+
+/**
+ * Bouton minimaliste « Open in your AI » + actions (Copy / ChatGPT / Claude /
+ * Gemini / Perplexity). Implémentation V1 simple — sera enrichie en Phase 2 par
+ * le composant tri-plateforme `<SendToAIButton>`.
+ */
+function OpenInAIMenu({
+  permalink,
+  videoTitle,
+  onCopy,
+  copied,
+}: OpenInAIMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  // Prompt court pour deeplink IA — pointe vers le permalink (pas le markdown
+  // intégral, qui dépasserait la limite query param de la plupart des IA).
+  const prompt = useMemo(() => {
+    const txt = `Analyse cette page DeepSight : ${permalink} (« ${videoTitle} »).`;
+    return encodeURIComponent(txt);
+  }, [permalink, videoTitle]);
+
+  const targets = useMemo(
+    () => [
+      { id: "chatgpt", label: "ChatGPT", url: `https://chatgpt.com/?q=${prompt}` },
+      { id: "claude", label: "Claude", url: `https://claude.ai/new?q=${prompt}` },
+      {
+        id: "gemini",
+        label: "Gemini",
+        url: `https://gemini.google.com/app?prompt=${prompt}`,
+      },
+      {
+        id: "perplexity",
+        label: "Perplexity",
+        url: `https://www.perplexity.ai/search?q=${prompt}`,
+      },
+    ],
+    [prompt],
+  );
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(permalink);
+      onCopy();
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm font-medium text-text-secondary hover:bg-white/10 transition-colors"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <ExternalLink className="w-4 h-4" />
+        <span className="hidden sm:inline">Open in your AI</span>
+        <span className="sm:hidden">AI</span>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-2 w-52 rounded-xl border border-white/10 bg-bg-surface shadow-2xl backdrop-blur-xl z-50 overflow-hidden"
+        >
+          <button
+            role="menuitem"
+            type="button"
+            onClick={handleCopy}
+            className="flex w-full items-center gap-2 px-4 py-2.5 text-sm text-text-secondary hover:bg-white/5 transition-colors"
+          >
+            {copied ? (
+              <Check className="w-4 h-4 text-emerald-400" />
+            ) : (
+              <CopyIcon className="w-4 h-4" />
+            )}
+            {copied ? "Lien copié" : "Copier le lien"}
+          </button>
+          <div className="h-px bg-white/5" />
+          {targets.map((t) => (
+            <a
+              key={t.id}
+              role="menuitem"
+              href={t.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 px-4 py-2.5 text-sm text-text-secondary hover:bg-white/5 transition-colors"
+              onClick={() => setOpen(false)}
+            >
+              <ExternalLink className="w-4 h-4" />
+              Ouvrir dans {t.label}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/PublicAnalysisPage.test.tsx
+++ b/frontend/src/pages/__tests__/PublicAnalysisPage.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * 🧪 Tests — PublicAnalysisPage
+ *
+ * Vérifie :
+ *   1. Loader pendant le fetch initial
+ *   2. Rendu du contenu sur succès (titre + analyse + permalink + JSON-LD)
+ *   3. État d'erreur 404 (analyse privée ou inexistante)
+ *   4. Le slug invalide propage le même état "not found"
+ *
+ * Sprint Export to AI + GEO — Phase 3.
+ * Spec : Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "../../__tests__/test-utils";
+import { Routes, Route } from "react-router-dom";
+import PublicAnalysisPage from "../PublicAnalysisPage";
+
+/**
+ * useParams ne fonctionne que dans une <Route> matching. On wrap chaque test
+ * dans Routes/Route pour que le slug soit extrait depuis l'URL.
+ */
+function PageInRoute() {
+  return (
+    <Routes>
+      <Route path="/a/:slug" element={<PublicAnalysisPage />} />
+      <Route path="/a/" element={<PublicAnalysisPage />} />
+    </Routes>
+  );
+}
+
+// Mock l'API
+vi.mock("../../services/api", () => ({
+  publicAnalysisApi: {
+    getBySlug: vi.fn(),
+    setVisibility: vi.fn(),
+    buildPermalink: (slug: string) =>
+      `https://deepsightsynthesis.com/a/${slug}`,
+  },
+}));
+
+// Mock DoodleBackground (utilise ThemeContext non disponible dans test-utils).
+vi.mock("../../components/DoodleBackground", () => ({
+  default: () => null,
+}));
+
+// Mock DeepSightSpinner pour rendre un texte facilement détectable.
+vi.mock("../../components/ui/DeepSightSpinner", () => ({
+  DeepSightSpinner: () => <div data-testid="ds-spinner" />,
+  DeepSightSpinnerSmall: () => <div data-testid="ds-spinner-small" />,
+}));
+
+// sanitizeTitle : utilise simplement la valeur (mock minimal).
+vi.mock("../../utils/sanitize", () => ({
+  sanitizeTitle: (s: string) => s,
+}));
+
+import { publicAnalysisApi } from "../../services/api";
+
+const mockGet = publicAnalysisApi.getBySlug as ReturnType<typeof vi.fn>;
+
+const SAMPLE_PAYLOAD = {
+  id: "169",
+  slug: "aa9",
+  video_id: "dQw4w9WgXcQ",
+  video_title: "Rick Astley - Never Gonna Give You Up",
+  video_channel: "Rick Astley",
+  video_duration: 213,
+  video_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  thumbnail_url: "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
+  summary_content:
+    "## Synthèse\n\nClip musical iconique des années 80 avec une promesse d'engagement.\n\n- Bullet 1\n- Bullet 2",
+  summary_extras: null,
+  visual_analysis: null,
+  lang: "fr",
+  mode: "standard",
+  model_used: "mistral-small-2603",
+  platform: "youtube",
+  category: "music",
+  reliability_score: 60,
+  deep_research: false,
+  created_at: "2026-05-07T14:32:00Z",
+  permalink: "https://deepsightsynthesis.com/a/aa9",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PublicAnalysisPage", () => {
+  describe("Loading state", () => {
+    it("shows the loading spinner while fetching", () => {
+      mockGet.mockImplementation(() => new Promise(() => {}));
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/aa9"] },
+      });
+      expect(
+        screen.getByText(/chargement de l'analyse publique/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Success state", () => {
+    it("renders the video title and channel after fetch succeeds", async () => {
+      mockGet.mockResolvedValue(SAMPLE_PAYLOAD);
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/aa9"] },
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", {
+            name: /Rick Astley - Never Gonna Give You Up/i,
+            level: 1,
+          }),
+        ).toBeInTheDocument();
+      });
+      // "Rick Astley" apparaît à plusieurs endroits (h1 + subtitle channel) —
+      // getAllByText pour ne pas crasher.
+      expect(screen.getAllByText(/Rick Astley/).length).toBeGreaterThan(0);
+    });
+
+    it("renders the permalink in the footer", async () => {
+      mockGet.mockResolvedValue(SAMPLE_PAYLOAD);
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/aa9"] },
+      });
+
+      await waitFor(() => {
+        // Le permalink est rendu dans le footer en <code>
+        expect(
+          screen.getByText("https://deepsightsynthesis.com/a/aa9"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("displays a reliability disclaimer when score < 80", async () => {
+      mockGet.mockResolvedValue({ ...SAMPLE_PAYLOAD, reliability_score: 60 });
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/aa9"] },
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Reliability score: 60\/100/),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does not display reliability disclaimer when score >= 80", async () => {
+      mockGet.mockResolvedValue({ ...SAMPLE_PAYLOAD, reliability_score: 90 });
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/aa9"] },
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { level: 1 }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/Reliability score:/)).not.toBeInTheDocument();
+    });
+
+    it("calls the API with the slug from URL params", async () => {
+      mockGet.mockResolvedValue(SAMPLE_PAYLOAD);
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/aa9"] },
+      });
+
+      await waitFor(() => {
+        expect(mockGet).toHaveBeenCalledWith("aa9");
+      });
+    });
+
+    it("renders the 'Open in your AI' menu trigger", async () => {
+      mockGet.mockResolvedValue(SAMPLE_PAYLOAD);
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/aa9"] },
+      });
+
+      await waitFor(() => {
+        // Bouton avec aria-haspopup
+        const menuBtn = screen.getByRole("button", {
+          name: /open in your ai|^ai$/i,
+        });
+        expect(menuBtn).toBeInTheDocument();
+        expect(menuBtn).toHaveAttribute("aria-haspopup", "menu");
+      });
+    });
+  });
+
+  describe("Error state", () => {
+    it("renders the not-found fallback when API returns 404", async () => {
+      mockGet.mockRejectedValue(new Error("HTTP 404"));
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/aa9"] },
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /analyse non disponible/i }),
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole("link", { name: /découvrir deepsight/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not call API when slug is missing", async () => {
+      // No slug in path → useParams returns undefined
+      renderWithProviders(<PageInRoute />, {
+        routerProps: { initialEntries: ["/a/"] },
+      });
+      // La route ne match pas → useParams.slug est undefined.
+      // Le composant doit rendre le fallback "Analyse non disponible".
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /analyse non disponible/i }),
+        ).toBeInTheDocument();
+      });
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3687,6 +3687,85 @@ export const hubApi = {
   },
 };
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🌍 PUBLIC ANALYSIS PAGES API — `/a/{slug}` opt-in (Phase 3 sprint Export to AI + GEO)
+// ═══════════════════════════════════════════════════════════════════════════════
+// Spec : Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md
+//
+// Deux endpoints :
+//   • GET   /api/v1/public/summaries/{slug}    — public, no auth, retourne payload
+//   • PATCH /api/v1/summaries/{id}/visibility   — auth (X-API-Key Pro/Expert), toggle is_public
+
+export interface PublicAnalysisPayload {
+  id: string;
+  slug: string;
+  video_id: string;
+  video_title: string;
+  video_channel?: string | null;
+  video_duration?: number | null;
+  video_url?: string | null;
+  thumbnail_url?: string | null;
+  summary_content?: string | null;
+  summary_extras?: Record<string, unknown> | null;
+  visual_analysis?: Record<string, unknown> | null;
+  lang?: string | null;
+  mode?: string | null;
+  model_used?: string | null;
+  platform?: string | null;
+  category?: string | null;
+  reliability_score?: number | null;
+  deep_research?: boolean;
+  created_at?: string | null;
+  permalink: string;
+}
+
+export interface VisibilityUpdateResponse {
+  summary_id: number;
+  is_public: boolean;
+  slug: string;
+  permalink: string;
+}
+
+export const publicAnalysisApi = {
+  /**
+   * Récupère une analyse publique opt-in par son slug.
+   * Pas d'auth — l'endpoint backend rejette 404 si is_public=false.
+   * Anti-leak : 404 identique pour slug invalide / privé / inexistant.
+   */
+  async getBySlug(slug: string): Promise<PublicAnalysisPayload> {
+    return request<PublicAnalysisPayload>(`/api/v1/public/summaries/${slug}`, {
+      skipAuth: true,
+    });
+  },
+
+  /**
+   * Active ou désactive la page publique d'une analyse.
+   * Auth requise (Pro/Expert via X-API-Key OU JWT — l'endpoint backend
+   * accepte les deux via `get_api_user`).
+   * Owner check côté backend → 404 si l'analyse appartient à un autre user.
+   */
+  async setVisibility(
+    summaryId: number,
+    isPublic: boolean,
+  ): Promise<VisibilityUpdateResponse> {
+    return request<VisibilityUpdateResponse>(
+      `/api/v1/summaries/${summaryId}/visibility`,
+      {
+        method: "PATCH",
+        body: { is_public: isPublic },
+      },
+    );
+  },
+
+  /**
+   * Construit l'URL frontend partageable pour un slug donné.
+   * Cohérent avec backend ``slug_for_summary`` (a{hex(id)}).
+   */
+  buildPermalink(slug: string): string {
+    return `https://deepsightsynthesis.com/a/${slug}`;
+  },
+};
+
 // Export par défaut
 export default {
   auth: authApi,
@@ -3715,4 +3794,5 @@ export default {
   keywordImage: keywordImageApi,
   geo: geoApi,
   hub: hubApi,
+  publicAnalysis: publicAnalysisApi,
 };


### PR DESCRIPTION
## Pourquoi

Phase 3 du sprint **Export to AI + GEO**. Les pages publiques opt-in `/a/{slug}` sont l'asset GEO durable indispensable pour le launch public J0 (2026-05-15). Aujourd'hui les analyses DeepSight ne génèrent **aucun** signal indexable par les bots IA (GPTBot, ClaudeBot, PerplexityBot, Google-Extended). Cette PR débloque le levier.

PR-A (#416 — exposition `visual_analysis`) et PR-B (#418 — endpoint export Markdown) sont **déjà mergées prod** 2026-05-07. Cette PR complète Phase 3 = pages publiques opt-in.

## Quoi

### Backend
- **Migration alembic 025** : `summaries.is_public BOOLEAN NOT NULL DEFAULT FALSE` + index. Toutes les rows existantes restent privées par défaut. ID alembic ≤ 32 chars (`025_summary_is_public`).
- **`GET /api/v1/public/summaries/{slug}`** — public, no auth :
  - Slug = `a{hex(id)}` cohérent avec PR-B `_slug_for_summary`.
  - 404 anti-leak : message identique pour slug malformé / privé / inexistant (impossible de distinguer).
  - Cache headers : `public, s-maxage=3600, stale-while-revalidate=86400` pour edge cache.
  - Payload conforme à `/api/v1/analysis/{id}` (visual_analysis exposé) + `slug` + `permalink`.
- **`PATCH /api/v1/summaries/{id}/visibility`** — auth Pro/Expert (X-API-Key via `get_api_user`), owner check, retourne `{is_public, slug, permalink}`.

### Frontend
- **`PublicAnalysisPage.tsx`** (route `/a/:slug`) :
  - SPA fetch sur mount → publicAnalysisApi.getBySlug(slug).
  - Helmet : title + canonical + Open Graph + Twitter Cards + JSON-LD Schema.org `VideoObject` + `Article` (cf spec § 4.4).
  - Disclaimer reliability_score < 80.
  - Sous-composant `<OpenInAIMenu>` minimaliste (Copy + 4 deeplinks IA). Sera enrichi en Phase 2.
  - Footer CTA + permalink visible.
- **`MakePublicToggle.tsx`** : toggle ON → PATCH visibility + auto-copy permalink. Mode compact pour intégration future.
- **`publicAnalysisApi`** dans `services/api.ts` : 3 méthodes (getBySlug, setVisibility, buildPermalink) + types.
- **App.tsx** : route lazy `/a/:slug` ajoutée parmi les routes publiques.

### Décisions actées (réf spec § 6)
| # | Décision |
|---|---|
| Q1 | Pages publiques = lien partageable seulement, **pas de showcase /discover** en V1 |
| Q5 | **Ignorer en V1** si vidéo source devient privée — page DeepSight reste live |

## Tests

- **Backend** : 24/24 verts (8 nouveaux dans `test_public_pages.py` + 13 PR-B + 3 PR-A non régressés)
- **Frontend** : 14/14 nouveaux verts (9 PublicAnalysisPage + 5 MakePublicToggle)
- **TypeScript** : 164 erreurs (vs **169 baseline** pré-changements) — aucune introduite

## Hors scope (NE TOUCHE PAS)

- `frontend/public/*.txt` (zone PR-D : llms.txt + robots.txt + sitemap)
- `backend/src/seo/` (zone PR-D si elle l'utilise)
- `vercel.json` config rewrites
- `/discover` page (Q1)
- Cron de purge si vidéo source privée (Q5)
- Intégration MakePublicToggle dans AnalysisActionBar (composant prêt, intégration future)

## Test plan

- [ ] Migration alembic 025 appliquée Hetzner via `docker exec repo-backend-1 alembic upgrade head` (ou `heads` plural si divergence cf memory `reference_alembic-deepsight-conventions`)
- [ ] `curl https://api.deepsightsynthesis.com/api/v1/public/summaries/aa9` → 404 (toutes privées par défaut)
- [ ] Toggle public via PATCH, puis fetch slug → 200 + payload + Schema.org JSON-LD
- [ ] Schema.org validé sur [validator.schema.org](https://validator.schema.org)
- [ ] OG preview vérifiée sur Twitter/LinkedIn/Telegram
- [ ] Lighthouse SEO ≥ 95 sur `/a/{slug}` (cf spec § 5.4)

## Spec

`Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.7 (1M context)