### PR TITLE
feat(hub): drawer ouvert + auto-open dernière analyse + fix scroll historique

### DIFF
--- a/frontend/src/components/hub/ConversationsDrawer.tsx
+++ b/frontend/src/components/hub/ConversationsDrawer.tsx
@@ -287,7 +287,7 @@ export const ConversationsDrawer: React.FC<Props> = ({
       >
         {/* ─── Header ─────────────────────────────────────────────── */}
         {isSelectMode ? (
-          <div className="flex items-center gap-2 px-3 py-3 border-b border-white/10 bg-indigo-500/[0.06]">
+          <div className="flex-shrink-0 flex items-center gap-2 px-3 py-3 border-b border-white/10 bg-indigo-500/[0.06]">
             <span className="flex-1 text-[13px] font-medium text-white">
               {selectedCount} / {MAX_SELECTION} sélectionnée
               {selectedCount > 1 ? "s" : ""}
@@ -309,7 +309,7 @@ export const ConversationsDrawer: React.FC<Props> = ({
             </button>
           </div>
         ) : (
-          <div className="flex items-center gap-3 px-4 py-3 border-b border-white/10">
+          <div className="flex-shrink-0 flex items-center gap-3 px-4 py-3 border-b border-white/10">
             <button
               type="button"
               aria-label="fermer"
@@ -346,7 +346,7 @@ export const ConversationsDrawer: React.FC<Props> = ({
         )}
 
         {!isSelectMode && onAnalyze && (
-          <div className="px-3 pt-3 pb-1">
+          <div className="flex-shrink-0 px-3 pt-3 pb-1">
             <form onSubmit={handleAnalyzeSubmit} className="relative">
               <Sparkles className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-indigo-400 pointer-events-none" />
               <input
@@ -373,7 +373,7 @@ export const ConversationsDrawer: React.FC<Props> = ({
         )}
 
         {isSelectMode && (
-          <div className="px-3 pt-2 pb-1">
+          <div className="flex-shrink-0 px-3 pt-2 pb-1">
             <p className="text-[11px] text-white/55 leading-relaxed">
               Sélectionnez {MIN_SELECTION} à {MAX_SELECTION} analyses pour créer
               un workspace Miro.
@@ -381,7 +381,7 @@ export const ConversationsDrawer: React.FC<Props> = ({
           </div>
         )}
 
-        <div className="px-3 pt-2 pb-2 relative">
+        <div className="flex-shrink-0 px-3 pt-2 pb-2 relative">
           <Search className="absolute left-5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
           <input
             type="text"
@@ -391,7 +391,7 @@ export const ConversationsDrawer: React.FC<Props> = ({
             className="w-full pl-7 pr-3 py-2 rounded-lg bg-white/[0.04] border border-white/10 text-[13px] text-white outline-none focus:border-white/20"
           />
         </div>
-        <div className="flex-1 overflow-y-auto px-2 pb-4">
+        <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-4">
           {renderGroup("Aujourd'hui", grouped.today)}
           {renderGroup("Hier", grouped.yesterday)}
           {renderGroup("Cette semaine", grouped.week)}

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -326,16 +326,30 @@ const HubPage: React.FC = () => {
           }),
         );
         setConversations(convs);
-        // Auto-select if URL has ?conv=<id> or ?summary[Id]=<id>.
-        const target =
+        // Auto-select priority:
+        //   1. URL ?conv=<id> or ?summary[Id]=<id> (explicit deeplink)
+        //   2. fallback to most recent conversation from history (lands user
+        //      directly on the latest analysis synthesis, drawer pre-opened).
+        const explicitTarget =
           urlConvId !== null
             ? Number(urlConvId)
             : urlSummaryId !== null
               ? Number(urlSummaryId)
               : null;
+        const target = explicitTarget ?? convs[0]?.id ?? null;
         if (!target) return;
         if (convs.find((c) => c.id === target)) {
           setActiveConv(target);
+          // When we auto-selected (no explicit URL deeplink), surface the
+          // conv in the URL and force tab=synthesis so the synthesis tab
+          // wins over the "chat if messages exist" default. `replace: true`
+          // avoids polluting history.
+          if (explicitTarget === null) {
+            setSearchParams(
+              { conv: String(target), tab: "synthesis" },
+              { replace: true },
+            );
+          }
           return;
         }
         // Conv not in user's history (legitimate case when arriving from

--- a/frontend/src/store/hubStore.ts
+++ b/frontend/src/store/hubStore.ts
@@ -97,7 +97,7 @@ const INITIAL: Pick<
   concepts: [],
   reliability: null,
   reliabilityLoading: false,
-  drawerOpen: false,
+  drawerOpen: true,
   summaryExpanded: false,
   pipExpanded: false,
   voiceCallOpen: false,


### PR DESCRIPTION
## Summary

Trois changements UX pour l'arrivée sur `/hub` (web) :

- **Drawer Conversations ouvert par défaut** (`hubStore.ts:100`) — `drawerOpen: false` → `true`. L'historique est visible dès l'arrivée, plus besoin de cliquer le burger.
- **Auto-open dernière analyse** (`HubPage.tsx:328-352`) — sans deeplink (`?conv=`/`?summary=`), la conv la plus récente est auto-sélectionnée et `tab=synthesis` est forcé via `setSearchParams({replace:true})`. Avant : `NoConvPlaceholder`. Maintenant : la synthèse de la dernière analyse s'ouvre directement.
- **Fix scroll historique tronqué** (`ConversationsDrawer.tsx`) — `flex-shrink-0` sur les 4 blocs en-tête + `min-h-0` sur le scroll container. Cause : le `motion.aside` avait 5 children en flux ; le `flex-1 overflow-y-auto` ne calculait pas la bonne hauteur résiduelle → "Cette semaine" + "Plus ancien" tombaient sous le viewport.

## Test plan

- [ ] Login sur https://www.deepsightsynthesis.com après deploy Vercel
- [ ] `/hub` s'ouvre directement sur la dernière analyse, onglet Synthèse, drawer Conversations visible à gauche
- [ ] Le drawer scrolle jusqu'au bout de l'historique (toutes les sections : Aujourd'hui, Hier, Cette semaine, Plus ancien sont accessibles)
- [ ] Deeplink `/hub?conv=<id>` continue à fonctionner (cible explicite prime sur le fallback)
- [ ] Pas de boucle infinie de re-fetch (le `setSearchParams` ne fire que la première fois grâce au check `explicitTarget === null`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)