### PR TITLE
feat(analysis): expose MakePublicToggle in AnalysisActionBar (Phase 2 visibility)

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3869,6 +3869,7 @@ async def get_summary(
         # Visual analysis (Phase 2 plumbing 2026-05-06) — null pour analyses
         # legacy avant Phase 2, flag OFF, quota dépassé, ou Mistral fail.
         visual_analysis=getattr(summary, "visual_analysis", None),
+        is_public=getattr(summary, "is_public", False),
     )
 
 

--- a/backend/src/videos/schemas.py
+++ b/backend/src/videos/schemas.py
@@ -301,6 +301,8 @@ class SummaryResponse(BaseModel):
     # quota dépassé, ou Mistral fail).
     visual_analysis: Optional[Dict[str, Any]] = None
 
+    is_public: bool = False
+
     class Config:
         from_attributes = True
 

--- a/frontend/src/components/analysis/AnalysisActionBar.tsx
+++ b/frontend/src/components/analysis/AnalysisActionBar.tsx
@@ -34,6 +34,7 @@ import { PLAN_LIMITS, normalizePlanId } from "../../config/planPrivileges";
 import { videoApi, shareApi } from "../../services/api";
 import { useToast } from "../Toast";
 import { AudioSummaryButton } from "../AudioSummaryButton";
+import { MakePublicToggle } from "./MakePublicToggle";
 import { sanitizeTitle } from "../../utils/sanitize";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -47,6 +48,7 @@ interface AnalysisActionBarProps {
     video_title: string;
     video_channel?: string;
     summary_content?: string;
+    is_public?: boolean;
   };
   language: "fr" | "en";
   onOpenVoice?: () => void;
@@ -528,6 +530,18 @@ export const AnalysisActionBar: React.FC<AnalysisActionBarProps> = ({
                 showChevron
                 active={showExportMenu}
               />
+
+              {/* Rendre publique (Phase 3 — pages /a/{slug} indexables IA) */}
+              {(isAdmin || plan === "pro" || plan === "expert") && (
+                <div className="flex-shrink-0">
+                  <MakePublicToggle
+                    summaryId={summary.id}
+                    initialIsPublic={summary.is_public ?? false}
+                    compact
+                    language={language}
+                  />
+                </div>
+              )}
 
               {/* Audio Synthèse */}
               <div className="flex-shrink-0">


### PR DESCRIPTION
## Contexte

Le composant `MakePublicToggle` livré par #422 (Phase 3 sprint Export to AI + GEO) était **orphelin** — créé mais monté dans aucune page côté propriétaire d'analyse. Conséquence : invisible en prod, impossible pour un Pro/Expert de rendre une analyse publique.

Cette PR active la **visibilité minimale du sprint précédent** en intégrant le toggle dans `AnalysisActionBar`, la barre d'actions standard utilisée par `SynthesisTab` (Hub), `History` et `DashboardPageLegacy`. Le toggle apparaît donc partout où un user consulte une de ses analyses.

Pas de Phase 2 UI complète (`<SendToAIButton>` tri-plateforme) ici — c'est différé post-J0 par décision Q7 « discret » (cf spec). Cette PR est le minimum pour rendre le travail backend/Phase 3 découvrable côté UI.

## Changements

### Backend (2 lignes)

- `backend/src/videos/schemas.py` : `is_public: bool = False` ajouté à `SummaryResponse`.
- `backend/src/videos/router.py` : `is_public=getattr(summary, "is_public", False)` passé lors de la construction de `GET /api/videos/summary/{id}`.

### Frontend (14 lignes)

- `frontend/src/components/analysis/AnalysisActionBar.tsx` :
  - import `MakePublicToggle`
  - étend `AnalysisActionBarProps.summary` avec `is_public?: boolean` (backward compat — les 3 callers passent le payload complet, pas besoin de modifier).
  - insère `<MakePublicToggle compact />` entre Export et AudioSummaryButton, gated `isAdmin || plan === "pro" || plan === "expert"` (cohérent avec PATCH `/visibility` qui exige Pro/Expert).

## Pas modifié

- `services/api.ts` — `publicAnalysisApi` existe déjà (#422).
- 3 callers (`SynthesisTab`, `History`, `DashboardPageLegacy`) — l'extension d'interface est rétrocompatible.
- `PublicAnalysisPage.tsx` (route `/a/:slug`) — déjà déployée par #422.

## Test plan

- [ ] **Prod web** : ouvrir une analyse depuis le Hub → toggle visible dans la barre, à côté d'Export.
- [ ] Toggle ON → permalink auto-copié + analyse accessible sur `https://www.deepsightsynthesis.com/a/{slug}`.
- [ ] Toggle OFF → `/a/{slug}` retourne 404 (anti-leak).
- [ ] Free user → toggle absent.
- [ ] Reload de l'analyse → état `is_public` correct (backend payload incluant `is_public`).

## Notes

- Mode `compact` du toggle : pas de feedback visible quand le permalink est copié (le composant le copie en silence). Follow-up éventuel : ajouter un toast `Lien copié` au niveau de la barre. Hors scope MVP.
- **Backend déploy** : auto via push to main → SSH Hetzner → docker rebuild. Pas de migration alembic (la colonne `is_public` est déjà appliquée par #422).
- **Frontend déploy** : auto Vercel.

Spec : `Vault/01-Projects/DeepSight/Specs/2026-05-07-deepsight-export-to-ai-geo-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)