### PR TITLE
feat(mobile/audio): mix with Spotify/Apple Music au boot, focus exclusif au play

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -17,6 +17,7 @@ import { ErrorProvider } from "../src/contexts/ErrorContext";
 import { OfflineProvider } from "../src/contexts/OfflineContext";
 import { BackgroundAnalysisProvider } from "../src/contexts/BackgroundAnalysisContext";
 import { ElevenLabsProvider } from "@elevenlabs/react-native";
+import { setAudioModeAsync } from "expo-audio";
 import { createQueryClient } from "../src/utils/queryClient";
 import { darkColors } from "../src/theme/colors";
 import { useShareIntent } from "../src/hooks/useShareIntent";
@@ -120,6 +121,19 @@ export default function RootLayout() {
         // Silent fail — non-blocking
       }
     })();
+  }, []);
+
+  // Audio session : mix with others au boot pour ne pas couper Spotify /
+  // Apple Music / Deezer. Les hooks audio (useTTS, useVoiceChat) basculent
+  // ensuite vers doNotMix quand l'user lance volontairement un son DeepSight.
+  useEffect(() => {
+    setAudioModeAsync({
+      playsInSilentMode: true,
+      interruptionMode: "mixWithOthers",
+    }).catch(() => {
+      // Silent fail — l'audio externe survivra quand même si l'app
+      // n'acquiert pas de focus de toute façon.
+    });
   }, []);
 
   if (!fontsLoaded) {

--- a/mobile/src/components/voice/useVoiceChat.ts
+++ b/mobile/src/components/voice/useVoiceChat.ts
@@ -17,7 +17,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import { AppState, type AppStateStatus } from "react-native";
-import { Audio } from "expo-av";
+import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from "expo-av";
 import * as Haptics from "expo-haptics";
 import { useConversation } from "@elevenlabs/react-native";
 import { voiceApi } from "../../services/api";
@@ -319,11 +319,17 @@ export function useVoiceChat(
           return;
         }
 
-        // Configurer le mode audio pour l'enregistrement + lecture simultanée
+        // Configurer le mode audio pour l'enregistrement + lecture simultanée.
+        // Acquiert le focus audio exclusif → coupe Spotify/Apple Music
+        // pendant la session voice agent (le user vient de lancer un appel,
+        // il veut entendre l'agent sans bruit de fond).
         await Audio.setAudioModeAsync({
           allowsRecordingIOS: true,
           playsInSilentModeIOS: true,
           staysActiveInBackground: false,
+          interruptionModeIOS: InterruptionModeIOS.DoNotMix,
+          interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
+          shouldDuckAndroid: false,
         });
       } catch {
         reportError(ERROR_MESSAGES.MICROPHONE_GENERIC);
@@ -528,9 +534,14 @@ export function useVoiceChat(
       isActiveRef.current = false;
       stopTimer();
 
-      // Réinitialiser le mode audio
+      // Réinitialiser le mode audio + relâcher le focus exclusif →
+      // Spotify/Apple Music reprend après l'appel voice.
       Audio.setAudioModeAsync({
         allowsRecordingIOS: false,
+        playsInSilentModeIOS: true,
+        interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
+        interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+        shouldDuckAndroid: true,
       }).catch(() => {
         // Ignorer les erreurs de cleanup audio
       });

--- a/mobile/src/contexts/TTSContext.tsx
+++ b/mobile/src/contexts/TTSContext.tsx
@@ -167,6 +167,15 @@ export const TTSProvider: React.FC<{ children: React.ReactNode }> = ({
       } catch {}
       tempFileRef.current = null;
     }
+    // Relâche le focus audio → Spotify/Apple Music reprend.
+    try {
+      await setAudioModeAsync({
+        playsInSilentMode: true,
+        interruptionMode: "mixWithOthers",
+      });
+    } catch {
+      // Ignore
+    }
   }, [player]);
 
   const stopPlaying = useCallback(() => {
@@ -191,9 +200,13 @@ export const TTSProvider: React.FC<{ children: React.ReactNode }> = ({
       setIsLoading(true);
 
       try {
-        // Configure for silent mode playback
+        // Configure for silent mode playback + acquiert le focus audio.
+        // Coupe Spotify/Apple Music pendant la lecture TTS DeepSight.
         try {
-          await setAudioModeAsync({ playsInSilentMode: true });
+          await setAudioModeAsync({
+            playsInSilentMode: true,
+            interruptionMode: "doNotMix",
+          });
         } catch {
           // Ignore
         }

--- a/mobile/src/hooks/useTTS.ts
+++ b/mobile/src/hooks/useTTS.ts
@@ -51,6 +51,15 @@ export function useTTS(options?: UseTTSOptions): UseTTSReturn {
       }
       tempFileRef.current = null;
     }
+    // Relâche le focus audio → Spotify/Apple Music reprend.
+    try {
+      await setAudioModeAsync({
+        playsInSilentMode: true,
+        interruptionMode: "mixWithOthers",
+      });
+    } catch {
+      // Ignore
+    }
   }, [player]);
 
   const stop = useCallback(() => {
@@ -70,7 +79,12 @@ export function useTTS(options?: UseTTSOptions): UseTTSReturn {
 
       try {
         try {
-          await setAudioModeAsync({ playsInSilentMode: true });
+          // Acquiert le focus audio → coupe Spotify/Apple Music
+          // pendant la lecture TTS DeepSight.
+          await setAudioModeAsync({
+            playsInSilentMode: true,
+            interruptionMode: "doNotMix",
+          });
         } catch {
           // Ignore
         }


### PR DESCRIPTION
## Bug

À l'ouverture de l'app DeepSight sur iOS et Android, l'audio en cours dans Spotify / Apple Music / Deezer est coupé même si l'user n'a pas encore lancé un audio DeepSight. Source : la session AVAudioSession est activée par défaut en mode \`Playback\` exclusif au boot.

## Comportement attendu (validé)

| Moment | Audio externe |
|---|---|
| Boot de l'app | continue |
| Lecture TTS DeepSight (audio summary) | coupé puis reprend au stop |
| Voice agent ElevenLabs | coupé puis reprend en fin d'appel |
| YouTube embed dans une analyse | coupé (comportement WebView natif) |

## Changements (4 fichiers, 58 lignes)

### \`mobile/app/_layout.tsx\` — boot mixWithOthers
Ajoute un \`useEffect\` au mount du \`RootLayout\` :
\`\`\`ts
setAudioModeAsync({ playsInSilentMode: true, interruptionMode: \"mixWithOthers\" })
\`\`\`
Configure la session iOS en mode ambient au démarrage. Sur Android, neutre (Android ne demande le focus qu'au moment de jouer).

### \`mobile/src/hooks/useTTS.ts\` + \`mobile/src/contexts/TTSContext.tsx\`
- \`play()\` / \`playText()\` : \`interruptionMode: \"doNotMix\"\` → acquiert le focus quand TTS commence.
- \`cleanup()\` : reset à \`mixWithOthers\` → Spotify reprend au stop.

### \`mobile/src/components/voice/useVoiceChat.ts\`
- Import \`InterruptionModeIOS\` + \`InterruptionModeAndroid\` depuis \`expo-av\` (le voice agent ElevenLabs utilise cette lib, pas \`expo-audio\`).
- \`start()\` : ajoute \`interruptionModeIOS: DoNotMix, interruptionModeAndroid: DoNotMix, shouldDuckAndroid: false\` → focus exclusif pendant l'appel.
- Cleanup au unmount : reset à \`MixWithOthers\` / \`DuckOthers\` + \`shouldDuckAndroid: true\` → Spotify reprend après l'appel.

## Hors scope

- **YouTube embed** : c'est un \`<WebView>\` (ou \`react-native-youtube-iframe\` qui wrap un webview). iOS isole automatiquement la session audio du webview, qui prend le focus à la lecture. Pas de modif nécessaire.
- **Frontend web** : non concerné.
- **Extension Chrome** : non concerné.

## Test plan (à faire post-deploy)

- [ ] **iOS** : Spotify joue une chanson → ouvrir DeepSight → chanson continue
- [ ] **iOS** : depuis DeepSight, lancer un audio summary TTS → Spotify pause → fin TTS → Spotify reprend
- [ ] **iOS** : lancer voice agent ElevenLabs → Spotify pause → fin appel → Spotify reprend
- [ ] **iOS** : jouer la vidéo YouTube embed dans une analyse → Spotify pause (WebView natif)
- [ ] **Android** : tests miroir (Spotify continue au boot, pause sur TTS/voice/YouTube, reprend au stop)

## Déploiement

Pure JS/TS → **EAS update OTA** suffit, pas de rebuild natif requis. Une fois mergé, lancer \`eas update --auto\` ou similaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)