### PR TITLE
fix(hub+backend): analysis flow swap + global background panel + logger fix

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3898,7 +3898,7 @@ async def _autogen_summary_extras(user_id: int, summary_id: int) -> None:
             summary = result.scalar_one_or_none()
             if summary is None:
                 logger.warning(
-                    "[AUTOGEN-EXTRAS] Summary %s not found for user %s — skip", summary_id, user_id
+                    f"[AUTOGEN-EXTRAS] Summary {summary_id} not found for user {user_id} — skip"
                 )
                 return
             if getattr(summary, "summary_extras", None):
@@ -3908,24 +3908,22 @@ async def _autogen_summary_extras(user_id: int, summary_id: int) -> None:
             extras = await generate_summary_extras(summary)
             if extras is None:
                 logger.warning(
-                    "[AUTOGEN-EXTRAS] Generation returned None for summary %s — best-effort skip",
-                    summary_id,
+                    f"[AUTOGEN-EXTRAS] Generation returned None for summary {summary_id} — best-effort skip"
                 )
                 return
 
             summary.summary_extras = extras
             await bg_session.commit()
+            synthesis = "yes" if extras.get("synthesis") else "no"
+            q = len(extras.get("key_quotes", []))
+            t = len(extras.get("key_takeaways", []))
+            th = len(extras.get("chapter_themes", []))
             logger.info(
-                "[AUTOGEN-EXTRAS] OK summary=%s (synthesis=%s, q=%d, t=%d, th=%d)",
-                summary_id,
-                "yes" if extras.get("synthesis") else "no",
-                len(extras.get("key_quotes", [])),
-                len(extras.get("key_takeaways", [])),
-                len(extras.get("chapter_themes", [])),
+                f"[AUTOGEN-EXTRAS] OK summary={summary_id} (synthesis={synthesis}, q={q}, t={t}, th={th})"
             )
     except Exception as exc:  # noqa: BLE001 — best-effort, on log et on quitte
         logger.warning(
-            "[AUTOGEN-EXTRAS] Unexpected error summary=%s: %s", summary_id, exc
+            f"[AUTOGEN-EXTRAS] Unexpected error summary={summary_id}: {exc}"
         )
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,8 @@ import { CookieBanner } from "./components/CookieBanner";
 import { UpgradeModal } from "./components/UpgradeModal";
 import { VoicePrefsStagingProvider } from "./components/voice/staging/VoicePrefsStagingProvider";
 import { StagedPrefsToolbar } from "./components/voice/staging/StagedPrefsToolbar";
+import { BackgroundAnalysisProvider } from "./contexts/BackgroundAnalysisContext";
+import { BackgroundAnalysisPanel } from "./components/BackgroundAnalysisPanel";
 import { OnboardingFlow } from "./components/onboarding/OnboardingFlow";
 import { Tutor } from "./components/Tutor";
 import { analytics } from "./services/analytics";
@@ -548,7 +550,7 @@ const AppRoutes = () => {
           <TTSProvider>
             <VoicePrefsStagingProvider>
               <Router>
-                <>
+                <BackgroundAnalysisProvider>
                   {/* ♿ Skip Link pour l'accessibilité */}
                   <SkipLink targetId="main-content" />
 
@@ -1195,7 +1197,12 @@ const AppRoutes = () => {
                   <ErrorBoundary fallback={null}>
                     <StagedPrefsToolbar />
                   </ErrorBoundary>
-                </>
+
+                  {/* ⏳ Toast bottom-right : analyses vidéo en arrière-plan */}
+                  <ErrorBoundary fallback={null}>
+                    <BackgroundAnalysisPanel />
+                  </ErrorBoundary>
+                </BackgroundAnalysisProvider>
               </Router>
             </VoicePrefsStagingProvider>
           </TTSProvider>

--- a/frontend/src/components/BackgroundAnalysisPanel.tsx
+++ b/frontend/src/components/BackgroundAnalysisPanel.tsx
@@ -1,0 +1,257 @@
+/**
+ * BackgroundAnalysisPanel — toast flottant bottom-right qui affiche en temps réel
+ * la progression de chaque analyse vidéo en cours, peu importe la page.
+ *
+ * Source de vérité : useBackgroundAnalysis() (contexte React).
+ * Rendu globalement dans App.tsx → suit l'utilisateur sur toute l'app.
+ *
+ * Comportement :
+ * - 1 carte par tâche active OU récemment complétée
+ * - Click sur carte completed → navigate /hub?conv=<summaryId>
+ * - Auto-dismiss completed après 12s (sauf si user n'a pas cliqué)
+ * - Failed tasks → bouton "Fermer" pour les retirer manuellement
+ */
+import React, { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useNavigate } from "react-router-dom";
+import { CheckCircle2, AlertCircle, X, ArrowRight } from "lucide-react";
+import {
+  useBackgroundAnalysis,
+  VideoAnalysisTask,
+  PlaylistAnalysisTask,
+} from "../contexts/BackgroundAnalysisContext";
+import { DeepSightSpinnerSmall } from "./ui/DeepSightSpinner";
+
+const AUTO_DISMISS_MS = 12_000;
+
+const sanitizeTitle = (raw?: string): string => {
+  if (!raw) return "Analyse en cours";
+  return raw.length > 48 ? `${raw.slice(0, 45)}…` : raw;
+};
+
+const VideoTaskCard: React.FC<{ task: VideoAnalysisTask }> = ({ task }) => {
+  const { removeTask } = useBackgroundAnalysis();
+  const navigate = useNavigate();
+
+  // Auto-dismiss completed tasks after AUTO_DISMISS_MS — user can still click
+  // before the timer fires.
+  useEffect(() => {
+    if (task.status !== "completed") return;
+    const timer = setTimeout(() => removeTask(task.id), AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [task.id, task.status, removeTask]);
+
+  const isCompleted = task.status === "completed";
+  const isFailed = task.status === "failed";
+  const progressPct = Math.max(5, Math.min(task.progress || 5, 100));
+
+  const handleClick = () => {
+    if (isCompleted && task.summaryId !== undefined) {
+      navigate(`/hub?conv=${task.summaryId}`);
+      removeTask(task.id);
+    }
+  };
+
+  const title = sanitizeTitle(task.videoTitle);
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, x: 24, scale: 0.95 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={{ opacity: 0, x: 24, scale: 0.95 }}
+      transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
+      className={[
+        "relative w-[300px] rounded-xl",
+        "bg-[#0c0c14]/95 backdrop-blur-xl",
+        "border border-white/10",
+        "shadow-[0_12px_36px_rgba(0,0,0,0.5)]",
+        "overflow-hidden",
+        isCompleted && task.summaryId !== undefined ? "cursor-pointer" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      onClick={handleClick}
+      role={isCompleted ? "button" : "status"}
+      aria-label={
+        isCompleted
+          ? `Analyse terminée : ${title}. Cliquer pour ouvrir.`
+          : `Analyse en cours : ${title}`
+      }
+    >
+      {/* Close button — top-right */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          removeTask(task.id);
+        }}
+        aria-label="Fermer"
+        className="absolute top-2 right-2 w-6 h-6 grid place-items-center rounded-md text-white/40 hover:text-white/80 hover:bg-white/[0.08] transition"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+
+      <div className="px-4 py-3 flex items-start gap-3">
+        {/* Spinner / status icon */}
+        <div className="flex-shrink-0 mt-0.5">
+          {isCompleted ? (
+            <div className="w-9 h-9 grid place-items-center rounded-full bg-emerald-500/15 border border-emerald-500/30">
+              <CheckCircle2 className="w-4 h-4 text-emerald-400" />
+            </div>
+          ) : isFailed ? (
+            <div className="w-9 h-9 grid place-items-center rounded-full bg-red-500/15 border border-red-500/30">
+              <AlertCircle className="w-4 h-4 text-red-400" />
+            </div>
+          ) : (
+            <DeepSightSpinnerSmall />
+          )}
+        </div>
+
+        {/* Right column : title + message + progress */}
+        <div className="flex-1 min-w-0 pr-5">
+          <div className="text-[12px] font-medium text-white/90 truncate leading-tight">
+            {title}
+          </div>
+          <div className="mt-0.5 text-[11px] text-white/55 truncate">
+            {isCompleted
+              ? "Analyse terminée — cliquer pour ouvrir"
+              : isFailed
+                ? task.error || "Échec de l'analyse"
+                : task.message || "Analyse en cours…"}
+          </div>
+
+          {/* Progress bar — hidden when completed/failed */}
+          {!isCompleted && !isFailed && (
+            <div className="mt-2 h-1 bg-white/[0.06] rounded-full overflow-hidden">
+              <motion.div
+                className="h-full bg-gradient-to-r from-indigo-500 via-violet-500 to-cyan-400"
+                initial={{ width: 0 }}
+                animate={{ width: `${Math.min(progressPct, 95)}%` }}
+                transition={{ duration: 0.4, ease: "easeOut" }}
+              />
+            </div>
+          )}
+
+          {/* CTA arrow when completed */}
+          {isCompleted && task.summaryId !== undefined && (
+            <div className="mt-1.5 inline-flex items-center gap-1 text-[11px] text-indigo-300 font-medium">
+              <span>Ouvrir la conversation</span>
+              <ArrowRight className="w-3 h-3" />
+            </div>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+const PlaylistTaskCard: React.FC<{ task: PlaylistAnalysisTask }> = ({
+  task,
+}) => {
+  const { removeTask } = useBackgroundAnalysis();
+
+  useEffect(() => {
+    if (task.status !== "completed") return;
+    const timer = setTimeout(() => removeTask(task.id), AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [task.id, task.status, removeTask]);
+
+  const isCompleted = task.status === "completed";
+  const isFailed = task.status === "failed";
+  const progressPct = Math.max(5, Math.min(task.progress || 5, 100));
+  const title = sanitizeTitle(task.playlistTitle || task.playlistUrl);
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, x: 24, scale: 0.95 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={{ opacity: 0, x: 24, scale: 0.95 }}
+      transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
+      className="relative w-[300px] rounded-xl bg-[#0c0c14]/95 backdrop-blur-xl border border-white/10 shadow-[0_12px_36px_rgba(0,0,0,0.5)] overflow-hidden"
+      role="status"
+    >
+      <button
+        type="button"
+        onClick={() => removeTask(task.id)}
+        aria-label="Fermer"
+        className="absolute top-2 right-2 w-6 h-6 grid place-items-center rounded-md text-white/40 hover:text-white/80 hover:bg-white/[0.08] transition"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+
+      <div className="px-4 py-3 flex items-start gap-3">
+        <div className="flex-shrink-0 mt-0.5">
+          {isCompleted ? (
+            <div className="w-9 h-9 grid place-items-center rounded-full bg-emerald-500/15 border border-emerald-500/30">
+              <CheckCircle2 className="w-4 h-4 text-emerald-400" />
+            </div>
+          ) : isFailed ? (
+            <div className="w-9 h-9 grid place-items-center rounded-full bg-red-500/15 border border-red-500/30">
+              <AlertCircle className="w-4 h-4 text-red-400" />
+            </div>
+          ) : (
+            <DeepSightSpinnerSmall />
+          )}
+        </div>
+
+        <div className="flex-1 min-w-0 pr-5">
+          <div className="text-[12px] font-medium text-white/90 truncate leading-tight">
+            Playlist · {title}
+          </div>
+          <div className="mt-0.5 text-[11px] text-white/55 truncate">
+            {isCompleted
+              ? `Terminé · ${task.completedVideos ?? 0}/${task.totalVideos ?? "?"} vidéos`
+              : isFailed
+                ? task.error || "Échec de l'analyse playlist"
+                : task.message || "Analyse en cours…"}
+          </div>
+          {!isCompleted && !isFailed && (
+            <div className="mt-2 h-1 bg-white/[0.06] rounded-full overflow-hidden">
+              <motion.div
+                className="h-full bg-gradient-to-r from-indigo-500 via-violet-500 to-cyan-400"
+                initial={{ width: 0 }}
+                animate={{ width: `${Math.min(progressPct, 95)}%` }}
+                transition={{ duration: 0.4, ease: "easeOut" }}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export const BackgroundAnalysisPanel: React.FC = () => {
+  const { tasks } = useBackgroundAnalysis();
+
+  // Tasks sorted most-recent-first so the newest analysis sits on top.
+  const visibleTasks = [...tasks].sort(
+    (a, b) => b.startedAt.getTime() - a.startedAt.getTime(),
+  );
+
+  if (visibleTasks.length === 0) return null;
+
+  return (
+    <div
+      className="fixed bottom-6 right-6 z-40 flex flex-col gap-2 pointer-events-none"
+      aria-live="polite"
+      aria-atomic="false"
+    >
+      <AnimatePresence initial={false}>
+        {visibleTasks.map((task) => (
+          <div key={task.id} className="pointer-events-auto">
+            {task.type === "video" ? (
+              <VideoTaskCard task={task} />
+            ) : (
+              <PlaylistTaskCard task={task} />
+            )}
+          </div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default BackgroundAnalysisPanel;

--- a/frontend/src/components/hub/NewConversationModal.tsx
+++ b/frontend/src/components/hub/NewConversationModal.tsx
@@ -3,22 +3,20 @@
  * dans le Hub. L'utilisateur colle un lien YouTube ou TikTok et clique
  * "Analyser".
  *
- * Refactor 2026-04-30 (Task 4) : la logique analyze + polling a été extraite
- * dans le hook réutilisable `useAnalyzeAndOpenHub` (frontend/src/hooks/), mais
- * la modal continue à utiliser son propre pipeline avec `onSuccess(summaryId)`
- * au lieu de naviguer directement, parce que `HubPage` veut re-fetch ses
- * conversations + setActiveConv (le hook par défaut navigue, ce qui force un
- * remount complet de HubPage et un fetch — comportement OK pour la home, mais
- * inutilement coûteux quand on est déjà dans le Hub).
+ * Refactor 2026-05-09 : la modal ne poll plus localement. Elle délègue
+ * `videoApi.analyze` au `BackgroundAnalysisContext` global, ferme l'UI
+ * immédiatement, et reçoit le `summary_id` via le callback `onComplete`. Le
+ * toast bottom-right (`BackgroundAnalysisPanel`) prend le relais visuel
+ * pendant l'analyse (~75 s sur Short typique). Plus besoin de garder la
+ * modal ouverte pour suivre la progression.
  *
- * Donc cette modal garde sa propre boucle, alignée sur le hook (mêmes
- * statuses, même timeout 5min). Si dans le futur on veut tout uniformiser,
- * extraire un sous-hook `useAnalyzeWithCustomCompletion` (TODO).
+ * `onSuccess` reste appelé par HubPage pour rafraîchir la liste des
+ * conversations + activer la nouvelle.
  */
-import React, { useState, useCallback, useRef, useEffect } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Loader2, AlertCircle } from "lucide-react";
-import { videoApi } from "../../services/api";
+import { useBackgroundAnalysis } from "../../contexts/BackgroundAnalysisContext";
 
 interface Props {
   open: boolean;
@@ -31,46 +29,25 @@ interface Props {
 const URL_PATTERN =
   /^https?:\/\/((www\.)?(youtube\.com|youtu\.be|tiktok\.com|vm\.tiktok\.com)|m\.tiktok\.com)\//i;
 
-const POLL_INTERVAL_MS = 2000;
-const POLL_MAX_DURATION_MS = 5 * 60 * 1000; // 5 min
-
 export const NewConversationModal: React.FC<Props> = ({
   open,
   onClose,
   onSuccess,
   language = "fr",
 }) => {
+  const { startVideoAnalysis } = useBackgroundAnalysis();
   const [url, setUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [analyzing, setAnalyzing] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const [progressMsg, setProgressMsg] = useState("");
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollStartRef = useRef<number>(0);
-  const progressRef = useRef(0);
-
-  const cleanup = useCallback(() => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-  }, []);
-
-  // Cleanup at unmount.
-  useEffect(() => () => cleanup(), [cleanup]);
+  const [submitting, setSubmitting] = useState(false);
 
   // Reset internal state when the modal closes.
   useEffect(() => {
     if (!open) {
       setUrl("");
       setError(null);
-      setAnalyzing(false);
-      setProgress(0);
-      setProgressMsg("");
-      progressRef.current = 0;
-      cleanup();
+      setSubmitting(false);
     }
-  }, [open, cleanup]);
+  }, [open]);
 
   const handleAnalyze = useCallback(async () => {
     setError(null);
@@ -78,73 +55,27 @@ export const NewConversationModal: React.FC<Props> = ({
       setError("URL invalide. Collez un lien YouTube ou TikTok.");
       return;
     }
-    setAnalyzing(true);
-    setProgress(5);
-    progressRef.current = 5;
-    setProgressMsg("Démarrage de l'analyse…");
+    setSubmitting(true);
 
     try {
-      const resp = await videoApi.analyze(
-        url.trim(),
-        "auto",
-        "standard",
-        undefined,
-        false,
+      await startVideoAnalysis({
+        videoUrl: url.trim(),
         language,
-      );
-      // Cache hit immédiat: l'analyse retourne déjà un summary_id.
-      if (resp.result?.summary_id) {
-        onSuccess(resp.result.summary_id);
-        onClose();
-        return;
-      }
-      const taskId = resp.task_id;
-      pollStartRef.current = Date.now();
-
-      pollRef.current = setInterval(async () => {
-        try {
-          if (Date.now() - pollStartRef.current > POLL_MAX_DURATION_MS) {
-            cleanup();
-            setAnalyzing(false);
-            setError("L'analyse prend trop de temps. Réessayez plus tard.");
-            return;
-          }
-          const status = await videoApi.getTaskStatus(taskId);
-          if (typeof status.progress === "number") {
-            const next = Math.max(progressRef.current, status.progress);
-            progressRef.current = next;
-            setProgress(next);
-          }
-          if (status.message) setProgressMsg(status.message);
-
-          if (status.status === "completed" && status.result?.summary_id) {
-            cleanup();
-            setAnalyzing(false);
-            onSuccess(status.result.summary_id);
-            onClose();
-          } else if (
-            status.status === "failed" ||
-            status.status === "cancelled"
-          ) {
-            cleanup();
-            setAnalyzing(false);
-            setError(status.error || "L'analyse a échoué. Veuillez réessayer.");
-          }
-        } catch (err) {
-          cleanup();
-          setAnalyzing(false);
-          setError(
-            err instanceof Error ? err.message : "Erreur lors du polling.",
-          );
-        }
-      }, POLL_INTERVAL_MS);
+        onComplete: (summaryId) => {
+          // Fired by the global background context once the analysis
+          // pipeline reports `completed`. HubPage uses this to re-fetch
+          // conversations + activate the new one.
+          onSuccess(summaryId);
+        },
+      });
+      // Analyse démarrée — on ferme la modal, le toast prend le relais.
+      setSubmitting(false);
+      onClose();
     } catch (err) {
-      setAnalyzing(false);
-      setError(
-        err instanceof Error ? err.message : "Erreur lors de l'analyse.",
-      );
+      setSubmitting(false);
+      setError(err instanceof Error ? err.message : "Erreur lors de l'analyse.");
     }
-  }, [url, language, onSuccess, onClose, cleanup]);
+  }, [url, language, startVideoAnalysis, onSuccess, onClose]);
 
   if (!open) return null;
 
@@ -156,7 +87,7 @@ export const NewConversationModal: React.FC<Props> = ({
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         className="fixed inset-0 bg-black/70 backdrop-blur-md z-50"
-        onClick={analyzing ? undefined : onClose}
+        onClick={submitting ? undefined : onClose}
       />
       <motion.div
         key="newconv-modal"
@@ -176,7 +107,7 @@ export const NewConversationModal: React.FC<Props> = ({
             type="button"
             aria-label="Fermer"
             onClick={onClose}
-            disabled={analyzing}
+            disabled={submitting}
             className="w-7 h-7 grid place-items-center rounded-lg hover:bg-white/[0.06] text-white/55 disabled:opacity-30"
           >
             <X className="w-4 h-4" />
@@ -186,18 +117,19 @@ export const NewConversationModal: React.FC<Props> = ({
         <div className="px-5 py-4 flex flex-col gap-3">
           <p className="text-[13px] text-white/60 leading-relaxed">
             Collez un lien YouTube ou TikTok pour lancer une analyse et démarrer
-            une nouvelle conversation.
+            une nouvelle conversation. Vous pourrez suivre la progression dans
+            la carte qui apparaîtra en bas à droite.
           </p>
 
           <input
             type="url"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            disabled={analyzing}
+            disabled={submitting}
             placeholder="https://youtube.com/watch?v=… ou https://tiktok.com/…"
             className="w-full bg-white/[0.04] border border-white/10 rounded-lg px-3 py-2.5 text-[13px] text-white placeholder-white/30 outline-none focus:border-indigo-500/40 disabled:opacity-50"
             onKeyDown={(e) => {
-              if (e.key === "Enter" && !analyzing) handleAnalyze();
+              if (e.key === "Enter" && !submitting) handleAnalyze();
             }}
           />
 
@@ -207,30 +139,13 @@ export const NewConversationModal: React.FC<Props> = ({
               <span>{error}</span>
             </div>
           )}
-
-          {analyzing && (
-            <div className="flex flex-col gap-2 px-3 py-2.5 rounded-lg bg-indigo-500/10 border border-indigo-500/20">
-              <div className="flex items-center gap-2 text-[12px] text-indigo-300">
-                <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                <span>{progressMsg || "Analyse en cours…"}</span>
-              </div>
-              <div className="h-1.5 bg-white/[0.06] rounded-full overflow-hidden">
-                <motion.div
-                  className="h-full bg-indigo-500"
-                  initial={{ width: 0 }}
-                  animate={{ width: `${Math.min(progress, 95)}%` }}
-                  transition={{ duration: 0.4 }}
-                />
-              </div>
-            </div>
-          )}
         </div>
 
         <div className="px-5 py-4 border-t border-white/10 flex items-center justify-end gap-2">
           <button
             type="button"
             onClick={onClose}
-            disabled={analyzing}
+            disabled={submitting}
             className="px-3.5 py-1.5 rounded-lg text-[13px] text-white/65 hover:bg-white/[0.04] disabled:opacity-30"
           >
             Annuler
@@ -238,10 +153,11 @@ export const NewConversationModal: React.FC<Props> = ({
           <button
             type="button"
             onClick={handleAnalyze}
-            disabled={analyzing || !url.trim()}
-            className="px-4 py-1.5 rounded-lg bg-indigo-500 text-white text-[13px] font-medium hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed"
+            disabled={submitting || !url.trim()}
+            className="px-4 py-1.5 rounded-lg bg-indigo-500 text-white text-[13px] font-medium hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
           >
-            {analyzing ? "Analyse…" : "Analyser"}
+            {submitting && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+            <span>{submitting ? "Démarrage…" : "Analyser"}</span>
           </button>
         </div>
       </motion.div>

--- a/frontend/src/components/hub/__tests__/NewConversationModal.test.tsx
+++ b/frontend/src/components/hub/__tests__/NewConversationModal.test.tsx
@@ -1,24 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NewConversationModal } from "../NewConversationModal";
-import { videoApi } from "../../../services/api";
 
-vi.mock("../../../services/api", () => ({
-  videoApi: {
-    analyze: vi.fn(),
-    getTaskStatus: vi.fn(),
-    getSummary: vi.fn(),
-  },
+const mockStartVideoAnalysis = vi.fn();
+
+vi.mock("../../../contexts/BackgroundAnalysisContext", () => ({
+  useBackgroundAnalysis: () => ({
+    startVideoAnalysis: mockStartVideoAnalysis,
+  }),
 }));
-
-const mockAnalyze = videoApi.analyze as unknown as ReturnType<typeof vi.fn>;
-const mockGetTaskStatus = videoApi.getTaskStatus as unknown as ReturnType<
-  typeof vi.fn
->;
 
 describe("NewConversationModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockStartVideoAnalysis.mockReset();
   });
 
   it("validates URL: rejects non-YouTube/TikTok URL", () => {
@@ -30,27 +25,17 @@ describe("NewConversationModal", () => {
     fireEvent.change(input, { target: { value: "https://example.com/foo" } });
     fireEvent.click(screen.getByRole("button", { name: /analyser/i }));
     expect(screen.getByText(/url invalide/i)).toBeInTheDocument();
-    expect(mockAnalyze).not.toHaveBeenCalled();
+    expect(mockStartVideoAnalysis).not.toHaveBeenCalled();
   });
 
-  it("calls videoApi.analyze with valid YouTube URL and polls until summary_id available", async () => {
+  it("delegates to background context with valid YouTube URL and propagates onComplete to onSuccess", async () => {
     const onSuccess = vi.fn();
     const onClose = vi.fn();
-    mockAnalyze.mockResolvedValue({
-      task_id: "t-123",
-      status: "pending",
+    mockStartVideoAnalysis.mockImplementation(async (params) => {
+      // Simulate the context firing onComplete after the polling resolves.
+      setTimeout(() => params.onComplete?.(42, "Test"), 5);
+      return "video-1";
     });
-    mockGetTaskStatus
-      .mockResolvedValueOnce({
-        task_id: "t-123",
-        status: "processing",
-        progress: 50,
-      })
-      .mockResolvedValueOnce({
-        task_id: "t-123",
-        status: "completed",
-        result: { summary_id: 42 },
-      });
 
     render(
       <NewConversationModal open onClose={onClose} onSuccess={onSuccess} />,
@@ -62,40 +47,33 @@ describe("NewConversationModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /analyser/i }));
 
     await waitFor(() =>
-      expect(mockAnalyze).toHaveBeenCalledWith(
-        url,
-        "auto",
-        "standard",
-        undefined,
-        false,
-        expect.any(String),
+      expect(mockStartVideoAnalysis).toHaveBeenCalledWith(
+        expect.objectContaining({
+          videoUrl: url,
+          onComplete: expect.any(Function),
+        }),
       ),
     );
     await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(42), {
-      timeout: 8000,
+      timeout: 5000,
     });
+    // Modal should close as soon as startVideoAnalysis resolves.
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it("displays progress message during polling", async () => {
-    mockAnalyze.mockResolvedValue({
-      task_id: "t-1",
-      status: "pending",
-    });
-    mockGetTaskStatus.mockResolvedValue({
-      task_id: "t-1",
-      status: "processing",
-      progress: 30,
-      message: "Extraction transcript",
-    });
-    render(<NewConversationModal open onClose={vi.fn()} onSuccess={vi.fn()} />);
+  it("displays an error and keeps the modal open when startVideoAnalysis throws", async () => {
+    const onClose = vi.fn();
+    mockStartVideoAnalysis.mockRejectedValue(new Error("Network down"));
+
+    render(<NewConversationModal open onClose={onClose} onSuccess={vi.fn()} />);
     fireEvent.change(screen.getByPlaceholderText(/youtube|tiktok/i), {
       target: { value: "https://www.youtube.com/watch?v=abc12345678" },
     });
     fireEvent.click(screen.getByRole("button", { name: /analyser/i }));
-    await waitFor(
-      () =>
-        expect(screen.getByText(/extraction transcript/i)).toBeInTheDocument(),
-      { timeout: 5000 },
+
+    await waitFor(() =>
+      expect(screen.getByText(/network down/i)).toBeInTheDocument(),
     );
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/contexts/BackgroundAnalysisContext.tsx
+++ b/frontend/src/contexts/BackgroundAnalysisContext.tsx
@@ -19,15 +19,22 @@ import React, {
   useRef,
   useEffect,
 } from "react";
-import { videoApi, playlistApi, Summary } from "../services/api";
+import { videoApi, playlistApi } from "../services/api";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // 📊 TYPES
 // ═══════════════════════════════════════════════════════════════════════════════
 
+/** Callback fired exactly once when an analysis transitions to `completed`. */
+export type VideoAnalysisCompleteCallback = (
+  summaryId: number,
+  videoTitle: string,
+) => void;
+
 export interface VideoAnalysisTask {
   id: string;
   type: "video";
+  /** Backend task_id returned by /api/videos/analyze. Empty string while pending. */
   taskId: string;
   videoUrl: string;
   videoTitle?: string;
@@ -35,7 +42,8 @@ export interface VideoAnalysisTask {
   status: "pending" | "processing" | "completed" | "failed";
   progress: number;
   message: string;
-  result?: Summary;
+  /** Set once polling reports `status === "completed"`. */
+  summaryId?: number;
   error?: string;
   startedAt: Date;
   completedAt?: Date;
@@ -67,8 +75,12 @@ interface BackgroundAnalysisContextType {
   // Actions vidéo
   startVideoAnalysis: (params: {
     videoUrl: string;
-    mode: string;
-    category: string;
+    mode?: string;
+    category?: string;
+    language?: "fr" | "en";
+    forceRefresh?: boolean;
+    /** Fires exactly once on success. Used by call-sites to navigate or refresh state. */
+    onComplete?: VideoAnalysisCompleteCallback;
   }) => Promise<string>; // Retourne l'ID de la tâche
 
   // Actions playlist
@@ -223,8 +235,11 @@ export const BackgroundAnalysisProvider: React.FC<{
   const startVideoAnalysis = useCallback(
     async (params: {
       videoUrl: string;
-      mode: string;
-      category: string;
+      mode?: string;
+      category?: string;
+      language?: "fr" | "en";
+      forceRefresh?: boolean;
+      onComplete?: VideoAnalysisCompleteCallback;
     }): Promise<string> => {
       const taskId = `video-${Date.now()}`;
 
@@ -244,11 +259,48 @@ export const BackgroundAnalysisProvider: React.FC<{
 
       try {
         // Lancer l'analyse
+        const category = params.category && params.category !== "auto" ? params.category : "auto";
+        const mode = params.mode || "standard";
+        const lang = params.language || "fr";
         const response = await videoApi.analyze(
           params.videoUrl,
-          params.mode,
-          params.category === "auto" ? undefined : params.category,
+          category,
+          mode,
+          undefined,
+          false,
+          lang,
+          params.forceRefresh ? { forceRefresh: true } : undefined,
         );
+
+        // Cache hit : le backend renvoie déjà un summary_id → on court-circuite le polling
+        // pour fire le callback immédiatement et marquer la task completed.
+        if (response.result?.summary_id) {
+          const summaryId = response.result.summary_id;
+          setTasks((prev) =>
+            prev.map((t) =>
+              t.id === taskId
+                ? {
+                    ...t,
+                    taskId: response.task_id,
+                    status: "completed" as const,
+                    progress: 100,
+                    message: "Analyse retrouvée en cache",
+                    summaryId,
+                    completedAt: new Date(),
+                  }
+                : t,
+            ),
+          );
+          setHasNewCompletedTask(true);
+          if (params.onComplete) {
+            try {
+              params.onComplete(summaryId, "");
+            } catch {
+              /* user callback failure — ignore */
+            }
+          }
+          return taskId;
+        }
 
         // Mettre à jour avec l'ID de tâche
         setTasks((prev) =>
@@ -264,8 +316,8 @@ export const BackgroundAnalysisProvider: React.FC<{
           ),
         );
 
-        // Démarrer le polling
-        startPolling(taskId, response.task_id, "video");
+        // Démarrer le polling avec le callback en closure
+        startPolling(taskId, response.task_id, "video", params.onComplete);
 
         return taskId;
       } catch (error: any) {
@@ -367,11 +419,26 @@ export const BackgroundAnalysisProvider: React.FC<{
   // ═══════════════════════════════════════════════════════════════════════════════
 
   const startPolling = useCallback(
-    (localId: string, apiTaskId: string, type: "video" | "playlist") => {
+    (
+      localId: string,
+      apiTaskId: string,
+      type: "video" | "playlist",
+      onComplete?: VideoAnalysisCompleteCallback,
+    ) => {
+      let firedComplete = false;
       const interval = setInterval(async () => {
         try {
           if (type === "video") {
             const status = await videoApi.getTaskStatus(apiTaskId);
+            // The backend `task_status.result` is a flat object:
+            // { summary_id, video_id, video_title, thumbnail_url, ... }
+            const result = status.result as
+              | {
+                  summary_id?: number;
+                  video_title?: string;
+                  thumbnail_url?: string;
+                }
+              | undefined;
 
             setTasks((prev) =>
               prev.map((t) => {
@@ -379,23 +446,34 @@ export const BackgroundAnalysisProvider: React.FC<{
 
                 const videoTask = t as VideoAnalysisTask;
 
-                if (status.status === "completed" && status.result) {
+                if (
+                  status.status === "completed" &&
+                  result?.summary_id !== undefined
+                ) {
                   clearInterval(interval);
                   pollingIntervals.current.delete(localId);
                   setHasNewCompletedTask(true);
+
+                  if (!firedComplete && onComplete) {
+                    firedComplete = true;
+                    try {
+                      onComplete(
+                        result.summary_id,
+                        result.video_title || videoTask.videoTitle || "",
+                      );
+                    } catch {
+                      /* user callback failure — ignore */
+                    }
+                  }
 
                   return {
                     ...videoTask,
                     status: "completed" as const,
                     progress: 100,
                     message: "Analyse terminée !",
-                    result: status.result?.summary,
-                    videoTitle:
-                      status.result?.summary?.video_title ||
-                      videoTask.videoTitle,
-                    thumbnail:
-                      status.result?.summary?.thumbnail_url ||
-                      videoTask.thumbnail,
+                    summaryId: result.summary_id,
+                    videoTitle: result.video_title || videoTask.videoTitle,
+                    thumbnail: result.thumbnail_url || videoTask.thumbnail,
                     completedAt: new Date(),
                   };
                 } else if (status.status === "failed") {
@@ -410,7 +488,7 @@ export const BackgroundAnalysisProvider: React.FC<{
                 } else {
                   return {
                     ...videoTask,
-                    progress: status.progress || videoTask.progress,
+                    progress: status.progress ?? videoTask.progress,
                     message: status.message || videoTask.message,
                   };
                 }

--- a/frontend/src/hooks/__tests__/useAnalyzeAndOpenHub.test.tsx
+++ b/frontend/src/hooks/__tests__/useAnalyzeAndOpenHub.test.tsx
@@ -3,9 +3,9 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import React from "react";
 import { useAnalyzeAndOpenHub } from "../useAnalyzeAndOpenHub";
-import { videoApi } from "../../services/api";
 
 const mockNavigate = vi.fn();
+const mockStartVideoAnalysis = vi.fn();
 
 vi.mock("react-router-dom", async () => {
   const actual =
@@ -18,21 +18,15 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
-vi.mock("../../services/api", () => ({
-  videoApi: {
-    analyze: vi.fn(),
-    getTaskStatus: vi.fn(),
-  },
+vi.mock("../../contexts/BackgroundAnalysisContext", () => ({
+  useBackgroundAnalysis: () => ({
+    startVideoAnalysis: mockStartVideoAnalysis,
+  }),
 }));
 
 vi.mock("../useTranslation", () => ({
   useTranslation: () => ({ language: "fr", t: {}, setLanguage: vi.fn() }),
 }));
-
-const mockAnalyze = videoApi.analyze as unknown as ReturnType<typeof vi.fn>;
-const mockGetTaskStatus = videoApi.getTaskStatus as unknown as ReturnType<
-  typeof vi.fn
->;
 
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <MemoryRouter>{children}</MemoryRouter>
@@ -42,21 +36,15 @@ describe("useAnalyzeAndOpenHub", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockNavigate.mockClear();
+    mockStartVideoAnalysis.mockReset();
   });
 
-  it("navigates to /hub?conv=<id> on completed status with summary_id", async () => {
-    mockAnalyze.mockResolvedValue({ task_id: "t-1", status: "pending" });
-    mockGetTaskStatus
-      .mockResolvedValueOnce({
-        task_id: "t-1",
-        status: "processing",
-        progress: 50,
-      })
-      .mockResolvedValueOnce({
-        task_id: "t-1",
-        status: "completed",
-        result: { summary_id: 99 },
-      });
+  it("navigates to /hub?conv=<id> when the background context fires onComplete", async () => {
+    // Simulate the context firing onComplete asynchronously (typical polling case)
+    mockStartVideoAnalysis.mockImplementation(async (params) => {
+      setTimeout(() => params.onComplete?.(99, "Test video"), 5);
+      return "video-1";
+    });
 
     const { result } = renderHook(() => useAnalyzeAndOpenHub(), { wrapper });
 
@@ -66,17 +54,17 @@ describe("useAnalyzeAndOpenHub", () => {
 
     await waitFor(
       () => expect(mockNavigate).toHaveBeenCalledWith("/hub?conv=99"),
-      { timeout: 8000 },
+      { timeout: 5000 },
     );
     expect(result.current.analyzing).toBe(false);
     expect(result.current.error).toBeNull();
   });
 
-  it("shortcuts navigation when analyze returns summary_id immediately (cache hit)", async () => {
-    mockAnalyze.mockResolvedValue({
-      task_id: "t-2",
-      status: "completed",
-      result: { summary_id: 7 },
+  it("navigates immediately when the context fires onComplete synchronously (cache hit)", async () => {
+    // Simulate cache-hit path : onComplete is fired before startVideoAnalysis resolves
+    mockStartVideoAnalysis.mockImplementation(async (params) => {
+      params.onComplete?.(7, "Cached video");
+      return "video-2";
     });
 
     const { result } = renderHook(() => useAnalyzeAndOpenHub(), { wrapper });
@@ -86,17 +74,11 @@ describe("useAnalyzeAndOpenHub", () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith("/hub?conv=7");
-    expect(mockGetTaskStatus).not.toHaveBeenCalled();
     expect(result.current.analyzing).toBe(false);
   });
 
-  it("sets error state when status returns failed", async () => {
-    mockAnalyze.mockResolvedValue({ task_id: "t-3", status: "pending" });
-    mockGetTaskStatus.mockResolvedValueOnce({
-      task_id: "t-3",
-      status: "failed",
-      error: "Transcription failed",
-    });
+  it("sets error state when startVideoAnalysis throws", async () => {
+    mockStartVideoAnalysis.mockRejectedValue(new Error("Transcription failed"));
 
     const { result } = renderHook(() => useAnalyzeAndOpenHub(), { wrapper });
 
@@ -104,10 +86,7 @@ describe("useAnalyzeAndOpenHub", () => {
       await result.current.analyze("https://www.youtube.com/watch?v=fail123");
     });
 
-    await waitFor(
-      () => expect(result.current.error).toBe("Transcription failed"),
-      { timeout: 5000 },
-    );
+    expect(result.current.error).toBe("Transcription failed");
     expect(result.current.analyzing).toBe(false);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
@@ -120,6 +99,6 @@ describe("useAnalyzeAndOpenHub", () => {
     });
 
     expect(result.current.error).toMatch(/URL invalide/i);
-    expect(mockAnalyze).not.toHaveBeenCalled();
+    expect(mockStartVideoAnalysis).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useAnalyzeAndOpenHub.ts
+++ b/frontend/src/hooks/useAnalyzeAndOpenHub.ts
@@ -1,34 +1,36 @@
 /**
- * useAnalyzeAndOpenHub — hook réutilisable qui encapsule le démarrage d'une
- * analyse vidéo (`videoApi.analyze`) et **navigue immédiatement** vers le Hub.
+ * useAnalyzeAndOpenHub — hook réutilisable qui démarre une analyse vidéo via
+ * `BackgroundAnalysisContext` et navigue vers la conversation correspondante
+ * dès que l'analyse termine.
  *
  * Comportement :
- *   - Cache hit (le backend retourne déjà `summary_id`) → navigate `/hub?conv=<id>`.
- *   - Sinon → navigate `/hub?analyzing=<task_id>`. Le polling
- *     `videoApi.getTaskStatus(taskId)` est ensuite repris par `HubPage`, qui
- *     affiche un état "Analyse en cours" et bascule sur la conversation
- *     finale dès que `summary_id` est disponible.
- *
- * Avantage : feedback visuel **immédiat** (la home n'attend pas la fin de
- * l'analyse, l'utilisateur voit déjà le Hub avec le placeholder loading).
+ *   - L'analyse est immédiatement enregistrée dans le contexte d'arrière-plan
+ *     → le panneau bottom-right (`BackgroundAnalysisPanel`) prend le relais
+ *     pour afficher la progression sur toutes les pages.
+ *   - Cache hit (le backend retourne `summary_id` immédiatement) → navigate
+ *     `/hub?conv=<id>` aussitôt.
+ *   - Pas de cache hit → l'utilisateur reste sur la page courante. Quand le
+ *     polling termine, le hook reçoit le `onComplete` et navigate vers la
+ *     nouvelle conversation.
  *
  * Utilisé par :
  *   - `DashboardPageMinimal` (home minimale : input URL + Tournesol cards)
  *   - `ConversationsDrawer` (barre input directe dans le drawer Hub)
+ *   - `HubPage` (re-export comme `triggerAnalyze`)
  */
 import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { videoApi } from "../services/api";
+import { useBackgroundAnalysis } from "../contexts/BackgroundAnalysisContext";
 import { useTranslation } from "./useTranslation";
 
 export interface AnalyzeState {
-  /** True pendant l'appel `videoApi.analyze` (avant le navigate). */
+  /** True pendant le call `startVideoAnalysis` (avant que le panneau prenne le relais). */
   analyzing: boolean;
   error: string | null;
 }
 
 export interface UseAnalyzeAndOpenHubReturn extends AnalyzeState {
-  /** Lance l'analyse et navigue immédiatement vers `/hub`. */
+  /** Lance l'analyse en arrière-plan et navigue vers la conv quand terminée. */
   analyze: (url: string) => Promise<void>;
   /** Reset manuel de l'erreur (utile entre deux essais). */
   resetError: () => void;
@@ -37,6 +39,7 @@ export interface UseAnalyzeAndOpenHubReturn extends AnalyzeState {
 export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
   const navigate = useNavigate();
   const { language } = useTranslation();
+  const { startVideoAnalysis } = useBackgroundAnalysis();
   const [state, setState] = useState<AnalyzeState>({
     analyzing: false,
     error: null,
@@ -63,26 +66,14 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
       setState({ analyzing: true, error: null });
 
       try {
-        const resp = await videoApi.analyze(
-          trimmed,
-          "auto",
-          "standard",
-          undefined,
-          false,
-          language,
-        );
-        // Cache hit : l'analyse retourne déjà un `summary_id`. Navigate sur
-        // la conversation directement.
-        if (resp.result?.summary_id) {
-          setState({ analyzing: false, error: null });
-          navigate(`/hub?conv=${resp.result.summary_id}`);
-          return;
-        }
-        // Cas standard : on a un `task_id`. On navigue vers le Hub avec
-        // `?analyzing=<taskId>` ; HubPage prend le relais pour le polling et
-        // affiche le placeholder loading.
+        await startVideoAnalysis({
+          videoUrl: trimmed,
+          language: (language === "en" ? "en" : "fr") as "fr" | "en",
+          onComplete: (summaryId) => {
+            navigate(`/hub?conv=${summaryId}`);
+          },
+        });
         setState({ analyzing: false, error: null });
-        navigate(`/hub?analyzing=${resp.task_id}`);
       } catch (err) {
         setState({
           analyzing: false,
@@ -95,7 +86,7 @@ export const useAnalyzeAndOpenHub = (): UseAnalyzeAndOpenHubReturn => {
         });
       }
     },
-    [language, navigate],
+    [language, navigate, startVideoAnalysis],
   );
 
   return { ...state, analyze, resetError };

--- a/frontend/src/pages/DashboardPageMinimal.tsx
+++ b/frontend/src/pages/DashboardPageMinimal.tsx
@@ -39,8 +39,7 @@ const DashboardPageMinimal: React.FC = () => {
   const { user } = useAuth();
   const { language } = useTranslation();
   const navigate = useNavigate();
-  const { analyzing, progress, message, error, analyze } =
-    useAnalyzeAndOpenHub();
+  const { analyzing, error, analyze } = useAnalyzeAndOpenHub();
 
   const [smartInput, setSmartInput] = useState<SmartInputValue>({
     mode: "search",
@@ -116,20 +115,13 @@ const DashboardPageMinimal: React.FC = () => {
           />
 
           {analyzing && (
-            <div className="mt-4 px-4 py-3 rounded-xl bg-indigo-500/10 border border-indigo-500/20 flex flex-col gap-2">
-              <div className="flex items-center gap-2 text-[13px] text-indigo-300">
-                <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                <span>
-                  {message ||
-                    (language === "fr" ? "Analyse en cours…" : "Analyzing…")}
-                </span>
-              </div>
-              <div className="h-1.5 bg-white/[0.06] rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-indigo-500 transition-all duration-300"
-                  style={{ width: `${Math.min(progress, 95)}%` }}
-                />
-              </div>
+            <div className="mt-4 px-4 py-3 rounded-xl bg-indigo-500/10 border border-indigo-500/20 flex items-center gap-2 text-[13px] text-indigo-300">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              <span>
+                {language === "fr"
+                  ? "Démarrage de l'analyse… suivez la progression en bas à droite."
+                  : "Starting analysis… progress shown bottom-right."}
+              </span>
             </div>
           )}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -259,11 +259,26 @@ export interface TaskStatus {
   result?: {
     summary_id?: number;
     summary?: Summary;
+    // Flat fields returned by /api/videos/status/{task_id} for completed tasks
+    video_id?: string;
+    video_title?: string;
+    video_channel?: string;
+    thumbnail_url?: string;
+    word_count?: number;
+    category?: string;
+    reliability_score?: number;
+    mode?: string;
+    lang?: string;
+    platform?: string;
+    enrichment?: {
+      level?: string;
+      sources_count?: number;
+      badge?: string;
+    };
     // Screenshot redirect fields
     redirected_to_video?: boolean;
     new_task_id?: string;
     video_url?: string;
-    platform?: string;
     content_type?: "video" | "short" | "tiktok_slideshow" | string;
     search_query?: string;
   };


### PR DESCRIPTION
## Bug initial
Maxime signale qu'une nouvelle analyse depuis le Hub renvoie l'utilisateur sur la **dernière** analyse au lieu de la nouvelle. Reproduction sur YouTube Short (Ld5bC06zCR0 — M6 Info CBD), backend prod 2026-05-09 17:09 UTC.

## Diagnostic

**Backend OK** ✅ : task `b169a41b-…` completed à 100 %, `result.summary_id = 182` (nouveau). Pas de cache HIT.

**Bug frontend** : 3 call-sites différents avaient chacun leur propre polling local (`useAnalyzeAndOpenHub`, `NewConversationModal`, `HubPage`). Quand l'utilisateur ferme/quitte le Hub avant la fin du polling (~75 s), le callback de navigation est perdu et il reste sur l'ancienne conv.

**Bug 2 (bonus)** : `_autogen_summary_extras` plante systématiquement avec `TypeError: DeepSightLogger.warning() takes 2 positional arguments but 4 were given` (router.py:3900-3927). Le custom logger DeepSight n'accepte pas le format stdlib (positional args).

**Bug 3 (latent)** : `BackgroundAnalysisContext` existait depuis longtemps avec persistance localStorage + polling reprise au refresh, mais n'était wired nulle part — orphelin. Plus son polling lisait `status.result.summary.video_title` (forme non retournée par le backend) → la task ne passait jamais à `completed`.

## Solution

3 commits atomiques :

1. **`fix(backend)`** — convertit les 4 appels logger.warning/info en f-string. Plus de TypeError au moindre summary réussi.

2. **`feat(frontend)`** — wire le `BackgroundAnalysisContext` au-dessus des routes + nouveau composant **`BackgroundAnalysisPanel`** :
   - Toast flottant bottom-right (300 px, glassmorphism dark, DeepSightSpinner)
   - 1 carte par tâche en cours OU récemment complétée
   - Click sur carte completed → navigate `/hub?conv=<summaryId>`
   - Auto-dismiss après 12 s
   - Multi-tâches empilées
   - **Survit à la navigation** : l'utilisateur peut quitter la page d'origine, le polling continue côté contexte, le toast reste visible.

3. **`refactor(frontend)`** — `useAnalyzeAndOpenHub` + `NewConversationModal` + `DashboardPageMinimal` passent tous par `startVideoAnalysis(...)` du contexte avec callback `onComplete(summaryId)`. Plus aucun polling local. Tests mis à jour.

## Fichiers

| Fichier | Δ |
|---|---|
| `backend/src/videos/router.py` | -10 / +8 |
| `frontend/src/contexts/BackgroundAnalysisContext.tsx` | shape + onComplete |
| `frontend/src/components/BackgroundAnalysisPanel.tsx` | **nouveau** |
| `frontend/src/App.tsx` | wrap + render panel |
| `frontend/src/services/api.ts` | TaskStatus.result flat fields |
| `frontend/src/hooks/useAnalyzeAndOpenHub.ts` | refactor → context |
| `frontend/src/components/hub/NewConversationModal.tsx` | -80 lignes polling local |
| `frontend/src/pages/DashboardPageMinimal.tsx` | retire bloc progress inline |
| Tests | mocks → useBackgroundAnalysis |

## Test plan

- [ ] Web prod (Vercel preview) : depuis `/dashboard`, coller une URL YouTube → toast bottom-right apparaît avec spinner DeepSight + progress bar, navigation auto vers `/hub?conv=<id>` quand fini.
- [ ] Web prod : depuis Hub avec une conv ouverte, cliquer "+ Nouvelle conversation" → modal ferme dès "Démarrage" → toast continue → bascule auto sur la nouvelle conv quand fini.
- [ ] Web prod : pendant l'analyse, naviguer vers Tournesol/History → toast suit, click ouvre la conv.
- [ ] Web prod : plusieurs analyses en parallèle → cartes empilées bottom-right.
- [ ] Backend Hetzner : après deploy, observer logs `docker logs repo-backend-1` → plus de `TypeError: DeepSightLogger.warning() takes 2 positional arguments`.
- [ ] Backend : nouvelle analyse → `[AUTOGEN-EXTRAS] OK summary=<id>` apparaît proprement (extras générés).

## Hors scope

- ~50 erreurs TS pré-existantes dans la codebase (signalées non-corrigées, conformément au CLAUDE.md scope rule).
- HubPage `?analyzing=<task>` polling local devient mort code — laissé en place pour minimiser le diff (peut être nettoyé dans une PR follow-up).
- Mobile/Extension : ce sprint cible uniquement le web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)