### PR TITLE
fix(backend): trigger autogen extras after GLOBAL CACHE HIT

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -947,6 +947,16 @@ async def analyze_video(
                     logger.info(
                         f"💾 [GLOBAL CACHE HIT] {platform}/{video_id} → summary_id={_cache_summary_id} (0 credits)"
                     )
+                    # Generate Mistral extras (synthesis, key_quotes, key_takeaways,
+                    # chapter_themes) in the background. Without this, the row inherits
+                    # `summary_extras = NULL` from the freshly-saved Summary and the
+                    # frontend falls back to rendering raw markdown instead of the
+                    # structured "Vue d'ensemble / Citations marquantes" layout —
+                    # which is exactly what every other analyze code path does after
+                    # save_summary() (cf. lines 1685, 2593, 3454, 4953, 5682).
+                    asyncio.create_task(
+                        _autogen_summary_extras(current_user.id, _cache_summary_id)
+                    )
                     await _invalidate_companion_cache()
                     return TaskStatusResponse(
                         task_id=f"cached_{_cache_summary_id}",


### PR DESCRIPTION
## Bug
Maxime constate que les nouvelles analyses ont un rendu en markdown brut (« Synthèse Express » non structurée) alors que les anciennes affichent le format structuré (Vue d'ensemble + Citations marquantes + Synthèse formelle).

Cause : la nouvelle summary 183 a `summary_extras = NULL`, contrairement aux 181/182 qui ont leurs extras peuplés. Le frontend bascule sur un fallback markdown brut quand `summary_extras` est NULL.

## Diagnostic

`summary_extras` est généré en background par `_autogen_summary_extras(user_id, summary_id)` après chaque `save_summary()`. Ce fire-and-forget est lancé à 5 endroits dans `router.py` (lines 1685, 2593, 3454, 4953, 5682) **mais pas après le GLOBAL CACHE HIT** (line 919-964).

Quand un user analyse une vidéo déjà présente dans le cache cross-user (Redis L1 / PG L2), le pipeline crée la nouvelle Summary à partir de `_cached`, retourne au client, et `summary_extras` reste NULL pour toujours.

## Fix

Une ligne :

```python
asyncio.create_task(
    _autogen_summary_extras(current_user.id, _cache_summary_id)
)
```

Juste avant le `return TaskStatusResponse(...)` du GLOBAL CACHE HIT path. Aligné sur le pattern fire-and-forget existant (les 5 autres call-sites). La task utilise `async_session_maker` en session indépendante donc safe.

## Backfill manuel

La prod a déjà des Summary sans extras (ex: 183 que Maxime regarde maintenant). Pour les repeupler :

```bash
docker exec repo-backend-1 python -c "
import asyncio
from videos.router import _autogen_summary_extras
asyncio.run(_autogen_summary_extras(USER_ID, SUMMARY_ID))
"
```

Summary 183 déjà backfillée live (avant ce PR) — confirmation log : `[AUTOGEN-EXTRAS] OK summary=183 (synthesis=yes, q=2, t=5, th=3)`.

## Test plan

- [ ] Après merge + deploy backend Hetzner, re-analyser une vidéo déjà présente en cache global → log `[AUTOGEN-EXTRAS] OK summary=<id>` doit apparaître ~30s après la réponse cache hit
- [ ] Vérifier en DB : `SELECT id, summary_extras IS NOT NULL FROM summaries WHERE id = <id>` → `t`
- [ ] Frontend : la vue `/hub?conv=<id>` affiche Vue d'ensemble + Citations marquantes + Synthèse formelle (pas markdown brut)

## Hors scope

- Le `_cached` (vcache) ne stocke pas `summary_extras`. À long terme on pourrait étendre `VideoContentCache.set_analysis()` pour le persister, ce qui éviterait de regénérer Mistral extras à chaque cache hit. Pour l'instant le fire-and-forget suffit (~3 s, ~500 tokens Mistral small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)