### PR TITLE
feat(backend): auto-promote mode to expert for Expert plan users

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -859,6 +859,20 @@ async def analyze_video(
         if not video_id:
             raise HTTPException(status_code=400, detail={"code": "invalid_url", "message": "Invalid YouTube URL"})
 
+    # 🎯 Auto-promote mode based on plan
+    # Le frontend envoie `mode="standard"` par défaut quel que soit le plan. Pour
+    # aligner la profondeur d'analyse sur la promesse pricing (Expert = analyse
+    # exhaustive avec Cartographie Argumentative, Évaluation Épistémique, etc.),
+    # on auto-promote standard → expert pour les users plan=expert. Les users qui
+    # ont explicitement choisi `accessible` (mode léger) gardent leur choix.
+    # Le `mode` impacte la cache key globale donc une promote = nouvelle analyse
+    # générée avec le prompt expert (cohérent avec le plan).
+    if request.mode == "standard" and current_user.plan == "expert":
+        logger.info(
+            f"🎯 [AUTO-MODE] Promoting standard → expert for user {current_user.id} (plan=expert)"
+        )
+        request.mode = "expert"
+
     # Déterminer le modèle à utiliser
     plan_limits = PLAN_LIMITS.get(current_user.plan, PLAN_LIMITS["free"])
     model = request.model or plan_limits.get("default_model", "mistral-small-2603")


### PR DESCRIPTION
## Bug

Maxime constate que ses analyses récentes sont moins fournies qu'avant (~2100 mots vs 2900 mots historiquement). Diagnostic : son plan `expert` mais ses analyses tournent sur **mode `standard`** (prompt « Analyste Équilibré ») au lieu de **mode `expert`** (prompt « Analyste Critique Exhaustif »).

Cause : le frontend hardcode `mode="standard"` sur tous les call-sites (DashboardPageMinimal, useAnalyzeAndOpenHub, NewConversationModal). Le sélecteur de mode n'est pas exposé partout. Un user qui paye le plan Expert n'a donc jamais accès à l'analyse exhaustive promise par son tier.

## Fix

Backend auto-promote dans `/analyze` : si `request.mode == "standard"` ET `current_user.plan == "expert"` → `request.mode = "expert"`. Logger info `🎯 [AUTO-MODE] Promoting standard → expert`.

Pas de changement Free/Pro. Les users qui choisissent explicitement `accessible` gardent leur choix.

## Impact pour le user Expert

L'analyse passe du prompt « Standard – Analyste Équilibré » au prompt « Expert – Analyste Critique Exhaustif » (cf. `backend/src/videos/analysis.py:1180→1246`) :

- Sections additionnelles : Cartographie Argumentative, Évaluation Épistémique, Mise en Perspective, Questions Non Résolues, Index Temporel Complet
- Cadre épistémique formel par claim (BASE / PREUVES / VERDICT ↑↑/↑/→/↓)
- Analyse rhétorique & logique : sophismes, biais cognitifs
- Format « Synthèse Express » en tête conservé (pas de breaking UX)

## Cache global

`mode` fait partie de la cache key (vcache + summary lookup). Une nouvelle analyse en mode=expert sera générée la première fois après deploy ; les ré-analyses cross-user en mode=expert bénéficieront ensuite du cache.

## Test plan

- [ ] Re-analyser la vidéo Short M6 CBD (déjà summary 183 en mode=standard)
- [ ] Logs : `🎯 [AUTO-MODE] Promoting standard → expert for user 1 (plan=expert)`
- [ ] DB : `SELECT mode, length(summary_content) FROM summaries WHERE user_id=1 ORDER BY id DESC LIMIT 3;` → la nouvelle row a `mode=expert` et un content significativement plus long
- [ ] UI Hub : Vue d'ensemble enrichie + sections additionnelles visibles (Cartographie Argumentative, etc.)

## Hors scope (follow-ups possibles)

- UI : exposer un sélecteur de mode dans le Hub pour permettre à l'user de choisir explicitement standard/expert/accessible (le backend respecte déjà le choix explicite)
- Pro tier : envisager un auto-promote standard → standard+enrichments si ce tier doit être différencié de Free

🤖 Generated with [Claude Code](https://claude.com/claude-code)