### PR TITLE
fix(debate): /chat returns DebateChatMessage (fixes empty assistant bubbles)

### DIFF
--- a/backend/src/debate/router.py
+++ b/backend/src/debate/router.py
@@ -49,7 +49,6 @@ from .schemas import (
     AddPerspectiveRequest,
     DebateChatMessageResponse,
     DebateChatRequest,
-    DebateChatResponse,
     DebateCreateRequest,
     DebateCreateResponse,
     DebateHistoryResponse,
@@ -1971,7 +1970,7 @@ async def generate_miro_board(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-@router.post("/chat", response_model=DebateChatResponse)
+@router.post("/chat", response_model=DebateChatMessageResponse)
 async def debate_chat(
     request: DebateChatRequest,
     current_user: User = Depends(get_current_user),
@@ -2070,8 +2069,15 @@ async def debate_chat(
     db.add(user_msg)
     db.add(assistant_msg)
     await db.commit()
+    await db.refresh(assistant_msg)
 
-    return DebateChatResponse(response=response_text, sources=[])
+    return DebateChatMessageResponse(
+        id=assistant_msg.id,
+        debate_id=assistant_msg.debate_id,
+        role="assistant",
+        content=response_text,
+        created_at=assistant_msg.created_at or datetime.utcnow(),
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/frontend/src/components/debate/DebateChat.tsx
+++ b/frontend/src/components/debate/DebateChat.tsx
@@ -78,11 +78,21 @@ export const DebateChat: React.FC<DebateChatProps> = ({
     setMessages((prev) => [...prev, optimisticMsg]);
 
     try {
-      const response = await debateApi.sendChat({
+      const raw = (await debateApi.sendChat({
         debate_id: debateId,
         message: trimmed,
-      });
-      setMessages((prev) => [...prev, response]);
+      })) as DebateChatMessage & { response?: string };
+      const assistantMsg: DebateChatMessage =
+        raw.content !== undefined
+          ? raw
+          : {
+              id: Date.now() + 1,
+              debate_id: debateId,
+              role: "assistant",
+              content: raw.response ?? "",
+              created_at: new Date().toISOString(),
+            };
+      setMessages((prev) => [...prev, assistantMsg]);
     } catch {
       setError("Erreur lors de l'envoi. Cliquez pour réessayer.");
     } finally {


### PR DESCRIPTION
## Summary
- Backend `/api/debate/chat` returned `DebateChatResponse {response, sources}` while frontend `sendChat` expected `DebateChatMessage {id, debate_id, role, content, created_at}`.
- Result in prod: assistant bubbles rendered empty after sending a message — confirmed on `/debate?id=18` (POST 200 OK / 7.8 KB but UI blank).
- Aligns POST `/chat` schema with the existing GET `/chat/history/{id}` schema (already returns `DebateChatMessageResponse`).

## Changes
- `backend/src/debate/router.py`: response_model + return statement now use `DebateChatMessageResponse`. Added `await db.refresh(assistant_msg)` to expose the DB id. Removed unused `DebateChatResponse` import.
- `frontend/src/components/debate/DebateChat.tsx`: resilient runtime mapping — if backend ever returns a `{response}` legacy payload, map to `DebateChatMessage` client-side. No-op when backend serves the new schema.

## Test plan
- [ ] CI green (frontend typecheck + backend pytest)
- [ ] After merge + Hetzner rebuild, send a chat message on `/debate?id=18` → assistant bubble shows the response
- [ ] `GET /api/debate/chat/history/{id}` still returns the same shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)