### PR TITLE
fix(debate): render markdown in chat bubbles via EnrichedMarkdown

### DIFF
--- a/frontend/src/components/debate/DebateChat.tsx
+++ b/frontend/src/components/debate/DebateChat.tsx
@@ -10,6 +10,7 @@ import { debateApi } from "../../services/api";
 import type { DebateChatMessage } from "../../services/api";
 import { DeepSightSpinnerMicro } from "../ui/DeepSightSpinner";
 import { CopyMessageButton } from "../CopyMessageButton";
+import { EnrichedMarkdown } from "../EnrichedMarkdown";
 
 interface DebateChatProps {
   debateId: number;
@@ -170,7 +171,17 @@ export const DebateChat: React.FC<DebateChatProps> = ({
                       : "bg-white/5 border-white/10 text-white/80"
                   }`}
                 >
-                  <div>{msg.content}</div>
+                  {msg.role === "user" ? (
+                    <div className="whitespace-pre-wrap break-words">
+                      {msg.content}
+                    </div>
+                  ) : (
+                    <div className="chat-bubble-markdown break-words">
+                      <EnrichedMarkdown language="fr">
+                        {msg.content}
+                      </EnrichedMarkdown>
+                    </div>
+                  )}
                   <div
                     className={`mt-1.5 flex opacity-0 group-hover:opacity-100 transition-opacity ${
                       msg.role === "user" ? "justify-end" : "justify-start"


### PR DESCRIPTION
## Summary
Mistral returns rich markdown but `DebateChat.tsx` rendered raw text — users saw \`**bold**\`, \`### titre\`, table pipes \`|...|\`.

## Change
- Use \`EnrichedMarkdown\` (already used in ChatPopup, ChatPanel, FloatingChatWindow) for assistant bubbles
- User bubbles stay plain text with \`whitespace-pre-wrap\` to preserve line breaks

## Test plan
- [ ] After merge, send a chat message on \`/debate?id=18\` → assistant bubble shows formatted markdown (titles, lists, tables, bold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)