### PR TITLE
fix(voice): unbreak voice/session — column name + rollback + logger

### DIFF
--- a/backend/src/voice/debate_context.py
+++ b/backend/src/voice/debate_context.py
@@ -569,7 +569,7 @@ async def _load_perspectives_safe(
         result = await db.execute(
             text(
                 "SELECT id, position, video_id, platform, video_title, "
-                "video_channel, thesis, arguments_json, relation_type, "
+                "video_channel, thesis, arguments, relation_type, "
                 "audience_level, channel_quality_score "
                 "FROM debate_perspectives "
                 "WHERE debate_id = :id "
@@ -594,7 +594,7 @@ async def _load_perspectives_safe(
                     "video_title": row[4],
                     "video_channel": row[5],
                     "thesis": row[6],
-                    "arguments_json": row[7],
+                    "arguments": row[7],
                     "relation_type": row[8],
                     "audience_level": row[9] if len(row) > 9 else "unknown",
                     "channel_quality_score": row[10] if len(row) > 10 else 0.0,
@@ -603,6 +603,13 @@ async def _load_perspectives_safe(
         return perspectives
     except Exception as exc:
         # Table absente, ou colonnes manquantes, ou autre erreur SQL — fallback v1.
+        # Rollback obligatoire pour libérer la transaction Postgres : sans ça,
+        # toute query DB ultérieure dans la même session lèverait
+        # `InFailedSQLTransactionError` (cf. incident voice/session 500 mai 2026).
+        try:
+            await db.rollback()
+        except Exception:  # noqa: BLE001 — best-effort
+            pass
         logger.info(
             "debate_context: perspectives table unavailable, fallback v1 (debate_id=%s, exc=%s)",
             debate_id,
@@ -646,7 +653,7 @@ def _build_perspective_from_v2(row: dict) -> PerspectiveCtx:
         video_channel=row.get("video_channel") or "",
         platform=row.get("platform") or "youtube",
         thesis=row.get("thesis") or "",
-        arguments=_safe_json_list(row.get("arguments_json")),
+        arguments=_safe_json_list(row.get("arguments")),
         transcript="",
         audience_level=row.get("audience_level") or "unknown",
         channel_quality_score=float(row.get("channel_quality_score") or 0.0),

--- a/backend/src/voice/prompt_session.py
+++ b/backend/src/voice/prompt_session.py
@@ -213,7 +213,7 @@ async def _fetch_total_analyses(*, db: AsyncSession, user_id: int) -> Optional[i
         )
         return int(result.scalar() or 0)
     except Exception as exc:  # noqa: BLE001 — section optionnelle
-        logger.warning("prompt_session.total_analyses failed: %s", exc)
+        logger.warning("prompt_session.total_analyses failed", error=str(exc))
         return None
 
 
@@ -230,7 +230,7 @@ async def _fetch_recent_summaries(
         )
         return list(result.scalars().all())
     except Exception as exc:  # noqa: BLE001 — section optionnelle
-        logger.warning("prompt_session.recent_summaries failed: %s", exc)
+        logger.warning("prompt_session.recent_summaries failed", error=str(exc))
         return []
 
 
@@ -258,7 +258,7 @@ async def _fetch_flashcards_due_today(
         count = int(result.scalar() or 0)
         return count if count > 0 else None
     except Exception as exc:  # noqa: BLE001 — section optionnelle
-        logger.warning("prompt_session.flashcards_due failed: %s", exc)
+        logger.warning("prompt_session.flashcards_due failed", error=str(exc))
         return None
 
 
@@ -277,7 +277,7 @@ async def _fetch_themes(*, db: AsyncSession, user_id: int) -> list[str]:
         themes = await extract_top3_themes(user_id=user_id, db=adapter, llm_client=None)
         return list(themes or [])[:3]
     except Exception as exc:  # noqa: BLE001 — section optionnelle
-        logger.warning("prompt_session.themes failed: %s", exc)
+        logger.warning("prompt_session.themes failed", error=str(exc))
         return []
 
 


### PR DESCRIPTION
## Symptom
\`POST /api/voice/session\` always 500'd for debate sessions ("Erreur réseau" in UI when clicking Voice on \`/debate?id=18\`).

## Root cause (1)
\`voice/debate_context._load_perspectives_safe\` selected \`debate_perspectives.arguments_json\` but the actual column on the model and in the DB is \`arguments\` (text, JSON list). Postgres raised \`column "arguments_json" does not exist\` → transaction marked aborted → every subsequent query in the same SQLAlchemy session blew up with \`InFailedSQLTransactionError\` (transcript cache, all \`_build_session_block\` helpers, \`get_user_voice_preferences\`, \`db.commit()\`). 100% reproducible on prod.

## Defensive (2)
Added \`await db.rollback()\` in the except branch of \`_load_perspectives_safe\` so a future SQL bug here can't take down the whole request.

## Logging hygiene (3)
\`voice/prompt_session._fetch_*\` helpers used the legacy stdlib pattern \`logger.warning("foo: %s", exc)\`. \`DeepSightLogger.warning\` takes \`(message, **kwargs)\` only → every except raised \`TypeError\`, hiding the real DB error behind \`"DeepSightLogger.warning() takes 2 positional arguments but 3 were given"\` in the structured logs. Switched to \`error=str(exc)\`.

## Files
- \`backend/src/voice/debate_context.py\` — \`arguments_json\` → \`arguments\` (3 sites) + rollback in except
- \`backend/src/voice/prompt_session.py\` — 4 helpers, kwargs-style warning

## Test plan
- [ ] After merge + Hetzner rebuild, click "Appel vocal" on \`/debate?id=18\` → ElevenLabs session starts (no "Erreur réseau")
- [ ] Backend logs no longer show \`InFailedSQLTransactionError\` on \`/api/voice/session\`
- [ ] \`session_block\` warnings (if any) now contain the real DB error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)