### PR TITLE
chore(debug): public sourcemaps to trace voice/debate React #300

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -38,8 +38,9 @@ export default defineConfig({
   },
 
   build: {
-    // Source maps for Sentry — uploaded then deleted by the plugin
-    sourcemap: "hidden",
+    // Public source maps + non-mangled names for production debugging.
+    // TEMPORARY: revert once React #300 in voice/debate is resolved.
+    sourcemap: true,
 
     // Taille minimale pour le code splitting
     chunkSizeWarningLimit: 500,


### PR DESCRIPTION
Sentry disabled in prod → no resolved stack for the React #300 (Rendered fewer hooks than expected) crash on voice debate. Public sourcemaps temporarily enabled so DevTools resolves vendor-react-*.js frames to real component names. Will revert once the bug is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)