### PR TITLE
chore(debug): surface real error behind SDK_LOAD_FAILED

### DIFF
--- a/frontend/src/components/voice/useVoiceChat.ts
+++ b/frontend/src/components/voice/useVoiceChat.ts
@@ -661,9 +661,18 @@ export function useVoiceChat({
             return next;
           });
         }, 1000);
-      } catch {
+      } catch (err) {
+        // Surface the real cause — SDK import vs startSession() vs unknown.
+        // Without this the user only sees "SDK_LOAD_FAILED" and we lose all
+        // diagnostic signal (Sentry is disabled in prod).
+        // eslint-disable-next-line no-console
+        console.error("[useVoiceChat] startSession failed:", err);
         releaseMediaStream();
-        reportError(ERROR_MESSAGES.SDK_LOAD_FAILED);
+        const message =
+          err instanceof Error
+            ? `${ERROR_MESSAGES.SDK_LOAD_FAILED} (${err.name}: ${err.message})`
+            : ERROR_MESSAGES.SDK_LOAD_FAILED;
+        reportError(message);
       }
     } finally {
       isStartingRef.current = false;


### PR DESCRIPTION
Sentry disabled in prod → silent catch in useVoiceChat hides the real failure (404 on @elevenlabs/client chunk? signedUrl rejected by ElevenLabs? network?). Logs the actual error to console + appends `(name: message)` to the visible string. Revert after root cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)