### PR TITLE
fix(ui): replace generic CSS spinners with DeepSightSpinner brand

### DIFF
--- a/frontend/src/components/AudioSummaryButton.tsx
+++ b/frontend/src/components/AudioSummaryButton.tsx
@@ -12,6 +12,7 @@
 import React, { useState, useCallback } from "react";
 import { motion } from "framer-motion";
 import { AudioSummaryPlayer } from "./AudioSummaryPlayer";
+import { DeepSightSpinner } from "./ui/DeepSightSpinner";
 import api from "../services/api";
 
 interface AudioSummaryButtonProps {
@@ -85,7 +86,7 @@ export const AudioSummaryButton: React.FC<AudioSummaryButtonProps> = ({
       >
         {isLoading ? (
           <>
-            <div className="w-4 h-4 border-2 border-indigo-300/30 border-t-indigo-300 rounded-full animate-spin" />
+            <DeepSightSpinner size={16} speed="fast" />
             {!compact && <span className="text-sm">Génération...</span>}
           </>
         ) : audioData ? (

--- a/frontend/src/components/AudioSummaryPlayer.tsx
+++ b/frontend/src/components/AudioSummaryPlayer.tsx
@@ -13,6 +13,7 @@
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { DeepSightSpinner } from "./ui/DeepSightSpinner";
 
 interface AudioSummaryPlayerProps {
   audioUrl: string;
@@ -206,7 +207,7 @@ export const AudioSummaryPlayer: React.FC<AudioSummaryPlayerProps> = ({
                 className="w-10 h-10 flex items-center justify-center rounded-full bg-indigo-500 hover:bg-indigo-400 disabled:bg-white/10 transition-colors"
               >
                 {isLoading ? (
-                  <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  <DeepSightSpinner size={16} speed="fast" onLight />
                 ) : isPlaying ? (
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="white">
                     <rect x="6" y="4" width="4" height="16" />

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
+import { DeepSightSpinner } from "./ui/DeepSightSpinner";
 
 interface PrivateRouteProps {
   children: React.ReactNode;
@@ -13,7 +14,7 @@ export const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
     return (
       <div className="h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center">
         <div className="text-center">
-          <div className="w-12 h-12 border-4 border-yellow-500/20 border-t-yellow-500 rounded-full animate-spin mx-auto mb-4"></div>
+          <DeepSightSpinner size={48} speed="normal" className="mx-auto mb-4" />
           <p className="text-text-secondary">Loading...</p>
         </div>
       </div>

--- a/frontend/src/components/voice/DebateVoiceHero.tsx
+++ b/frontend/src/components/voice/DebateVoiceHero.tsx
@@ -9,6 +9,7 @@
 import React, { useEffect } from "react";
 import { motion } from "framer-motion";
 import { Mic, Sparkles, Lock } from "lucide-react";
+import { DeepSightSpinner } from "../ui/DeepSightSpinner";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Types
@@ -125,7 +126,7 @@ export const DebateVoiceHero: React.FC<DebateVoiceHeroProps> = ({
                 />
               ) : avatarStatus === "generating" ? (
                 <div className="w-full h-full flex items-center justify-center bg-[#0b0b14]/60">
-                  <div className="w-7 h-7 border-2 border-white/30 border-t-indigo-400 rounded-full animate-spin" />
+                  <DeepSightSpinner size={40} speed="normal" />
                 </div>
               ) : (
                 <span className="text-2xl font-bold text-text-primary uppercase">

--- a/frontend/src/components/voice/VoiceModal.tsx
+++ b/frontend/src/components/voice/VoiceModal.tsx
@@ -680,7 +680,7 @@ export const VoiceModal: React.FC<VoiceModalProps> = ({
                       />
                     ) : avatarStatus === "generating" ? (
                       <div className="w-full h-full flex items-center justify-center">
-                        <div className="w-5 h-5 border-2 border-white/30 border-t-white/80 rounded-full animate-spin" />
+                        <DeepSightSpinner size={20} speed="fast" />
                       </div>
                     ) : (
                       <span className="text-xs font-semibold text-text-secondary uppercase">


### PR DESCRIPTION
Five generic Tailwind `border-t-*-rounded-full-animate-spin` spinners replaced with the DeepSight gouvernail spinner so the loading states match the brand everywhere they're visible:

| Component | Old size | New |
|-----------|----------|-----|
| DebateVoiceHero avatar (generating) | 28px | 40px |
| VoiceModal modal avatar (generating) | 20px | 20px |
| AudioSummaryButton inline | 16px | 16px |
| AudioSummaryPlayer play button | 16px | 16px (onLight) |
| PrivateRoute full-page loader | 48px | 48px |

Skipped `Button.tsx.bak` (legacy backup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)