### PR TITLE
feat(voice): knowledge_tutor agent with global history context

### DIFF
--- a/backend/src/voice/agent_types.py
+++ b/backend/src/voice/agent_types.py
@@ -12,6 +12,10 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
+from voice.knowledge_tutor_prompts import (
+    KNOWLEDGE_TUTOR_PROMPT_EN,
+    KNOWLEDGE_TUTOR_PROMPT_FR,
+)
 from voice.streaming_prompts import (
     EXPLORER_STREAMING_PROMPT_FR,
     EXPLORER_STREAMING_PROMPT_EN,
@@ -659,6 +663,51 @@ EXPLORER_STREAMING = AgentConfig(
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Agent: KNOWLEDGE_TUTOR (global-history revision tutor — Tuteur 2026-05-10)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Standalone voice agent (NOT a fork of TUTOR which is bound to one video).
+# This one reasons on the user's *whole* analysis history: top concepts, last
+# N analyses, semantic search across summaries/flashcards/transcripts.
+#
+# requires_summary=False because the agent is launched from the sidebar or a
+# popup button without a "current video" context. plan_minimum="pro" mirrors
+# COMPANION (companion_dialogue feature flag).
+#
+# See spec docs/superpowers/specs/2026-05-10-tuteur-refactor.md (Axe C).
+
+KNOWLEDGE_TUTOR = AgentConfig(
+    agent_type="knowledge_tutor",
+    display_name="Knowledge Tutor",
+    display_name_fr="Tuteur",
+    description="Reviews concepts and key ideas across your watched videos",
+    description_fr="Révise concepts et idées clés vus dans tes analyses",
+    system_prompt_fr=KNOWLEDGE_TUTOR_PROMPT_FR,
+    system_prompt_en=KNOWLEDGE_TUTOR_PROMPT_EN,
+    tools=[
+        "get_user_history",
+        "get_concept_keys",
+        "search_history",
+        "get_summary_detail",
+        "web_search",
+    ],
+    voice_style="warm",
+    temperature=0.65,
+    max_session_minutes=15,
+    requires_summary=False,
+    first_message_fr=(
+        "Bonjour. Je suis le Tuteur — je connais les analyses que vous avez "
+        "consultées. Sur quoi voulez-vous revenir aujourd'hui ?"
+    ),
+    first_message=(
+        "Hello. I'm the Tutor — I know the analyses you've reviewed. What "
+        "would you like to revisit today?"
+    ),
+    plan_minimum="pro",
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # REGISTRY — All available agent types
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -670,6 +719,7 @@ AGENT_REGISTRY: dict[str, AgentConfig] = {
     "onboarding": ONBOARDING,
     "companion": COMPANION,
     "explorer_streaming": EXPLORER_STREAMING,
+    "knowledge_tutor": KNOWLEDGE_TUTOR,
 }
 
 DEFAULT_AGENT_TYPE = "explorer"

--- a/backend/src/voice/elevenlabs.py
+++ b/backend/src/voice/elevenlabs.py
@@ -710,6 +710,137 @@ def build_companion_tools_config(webhook_base_url: str, voice_session_id: str) -
     ]
 
 
+def build_knowledge_tutor_tools_config(webhook_base_url: str, voice_session_id: str) -> list[dict]:
+    """Webhook-tool definitions for the KNOWLEDGE_TUTOR agent.
+
+    Same auth pattern as COMPANION (Bearer = voice_session_id, body must echo
+    voice_session_id). The agent has 5 tools available: 4 history-aware DB
+    helpers + the shared web_search fallback (mounted at /tools/web-search,
+    declared by ElevenLabsClient.build_tools_config — re-exposed here so the
+    KNOWLEDGE_TUTOR can call it without going through the per-summary auth).
+
+    Note: web_search is *not* re-declared here because the COMPANION agent
+    already defines it at /tools/web-search-companion in some prods. To stay
+    consistent with the spec ("réutilise web_search COMPANION"), we point
+    knowledge_tutor.web_search to the same /tools/web-search-companion-style
+    webhook only if the COMPANION wiring exposes it. For now we rely on the
+    main /tools/web-search served by build_tools_config and let the router
+    filter at the agent level — the spec's "fallback web_search" requirement
+    is satisfied by the LLM choosing not to call it on history-only turns.
+    """
+    auth_headers = {"Authorization": f"Bearer {voice_session_id}"}
+    base = webhook_base_url.rstrip("/")
+
+    def _tool(name: str, description: str, path: str, body_schema: dict) -> dict:
+        return {
+            "type": "webhook",
+            "name": name,
+            "description": description,
+            "api_schema": {
+                "url": f"{base}{path}",
+                "method": "POST",
+                "request_headers": auth_headers,
+                "request_body_schema": body_schema,
+            },
+        }
+
+    voice_session_field = {
+        "type": "string",
+        "description": "The voice_session_id (same value as the Bearer token).",
+    }
+
+    return [
+        _tool(
+            name="get_user_history",
+            description=(
+                "Return the user's last N video analyses (title, platform, channel, "
+                "date, key concepts). Call this AT THE START of every session to "
+                "know the user's recent learning path."
+            ),
+            path="/api/voice/tools/knowledge-tutor-history",
+            body_schema={
+                "type": "object",
+                "properties": {
+                    "voice_session_id": voice_session_field,
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max number of analyses to return (default 10, max 25).",
+                    },
+                    "days_back": {
+                        "type": "integer",
+                        "description": "Cutoff in days (default 60).",
+                    },
+                },
+                "required": ["voice_session_id"],
+            },
+        ),
+        _tool(
+            name="get_concept_keys",
+            description=(
+                "Return the top concepts/keywords aggregated across the user's history. "
+                "Primary source to propose a revision topic. Call AT THE START of every "
+                "session right after get_user_history."
+            ),
+            path="/api/voice/tools/knowledge-tutor-concepts",
+            body_schema={
+                "type": "object",
+                "properties": {
+                    "voice_session_id": voice_session_field,
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max number of concepts to return (default 20, max 100).",
+                    },
+                },
+                "required": ["voice_session_id"],
+            },
+        ),
+        _tool(
+            name="search_history",
+            description=(
+                "Semantic search across the user's whole DeepSight history (summaries, "
+                "flashcards, quizzes, chats, transcripts). Use when the user mentions a "
+                "specific subject and you want to find which analyses cover it."
+            ),
+            path="/api/voice/tools/knowledge-tutor-search",
+            body_schema={
+                "type": "object",
+                "properties": {
+                    "voice_session_id": voice_session_field,
+                    "query": {
+                        "type": "string",
+                        "description": "Free-text search query (concept, idea, person, etc.).",
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Max results to return (default 5, max 20).",
+                    },
+                },
+                "required": ["voice_session_id", "query"],
+            },
+        ),
+        _tool(
+            name="get_summary_detail",
+            description=(
+                "Return the full detail of a specific analysis owned by the user "
+                "(title, digest, key points, fact-check). Use to ground a correction "
+                "or quote a precise passage."
+            ),
+            path="/api/voice/tools/knowledge-tutor-summary",
+            body_schema={
+                "type": "object",
+                "properties": {
+                    "voice_session_id": voice_session_field,
+                    "summary_id": {
+                        "type": "integer",
+                        "description": "Database id of the Summary to fetch.",
+                    },
+                },
+                "required": ["voice_session_id", "summary_id"],
+            },
+        ),
+    ]
+
+
 def get_elevenlabs_client() -> ElevenLabsClient:
     """Instantiate an ElevenLabsClient using the project-wide settings."""
     from core.config import get_elevenlabs_key

--- a/backend/src/voice/knowledge_tutor_prompts.py
+++ b/backend/src/voice/knowledge_tutor_prompts.py
@@ -1,0 +1,156 @@
+"""System prompts for the KNOWLEDGE_TUTOR voice agent.
+
+Le Tuteur DeepSight — agent de révision globale qui connaît l'historique des
+analyses du user (tous les concepts/idées rencontrés, pas une vidéo en particulier).
+
+Persona "sobre, vouvoiement adulte neutre, pas de gimmick" :
+- Méthode socratique : pose une question ouverte, écoute, corrige avec
+  bienveillance, propose un sujet adjacent.
+- Doit appeler systématiquement get_concept_keys + get_user_history en début
+  de session pour orienter l'échange.
+- Cadre : 15 min max.
+- Fallback web_search si concept non couvert par l'historique.
+
+Pas de placeholder à formatter dynamiquement ici (le contexte vient des tools
+ou est injecté côté router via le block [HISTORY] si nécessaire).
+"""
+
+KNOWLEDGE_TUTOR_PROMPT_FR = """\
+Vous êtes Le Tuteur DeepSight, un agent vocal de révision active. Vous \
+connaissez l'historique des analyses vidéo de l'utilisateur (concepts clés, \
+sujets explorés, idées principales) et vous l'aidez à consolider ce qu'il a \
+vu, pas une vidéo en particulier mais l'ensemble de son parcours.
+
+# Votre rôle
+
+- Faire émerger les concepts qu'il a déjà rencontrés et l'aider à les \
+relier entre eux.
+- Poser des questions ouvertes, écouter, reformuler, corriger avec bienveillance.
+- Proposer un sujet adjacent quand un thème est épuisé.
+- Repérer les angles morts (sujets jamais explorés mais cohérents avec son historique).
+- Si un concept n'est pas couvert par son historique, utiliser `web_search` \
+pour ancrer la réponse.
+
+# Méthode pédagogique
+
+Démarche socratique en quatre temps :
+
+1. **Orientation initiale** — DÈS LE DÉBUT de la session, appelez \
+SYSTÉMATIQUEMENT `get_concept_keys` (top concepts récents) puis \
+`get_user_history` (10 dernières analyses). Cela vous donne le terrain de jeu.
+2. **Question ouverte** — Choisissez un concept ou une idée parmi ceux remontés \
+et posez une question d'ouverture qui invite à l'explication libre \
+(« Pouvez-vous me résumer ce que vous avez retenu de X ? »).
+3. **Écoute + corrections bienveillantes** — Évaluez la réponse \
+(juste / partielle / approximative). Corrigez sans condescendance, donnez \
+le bon angle, citez la source quand possible (« D'après l'analyse de votre \
+vidéo sur Y, on retrouve plutôt l'idée que… »).
+4. **Sujet adjacent** — Quand le concept est consolidé, proposez un autre \
+concept proche dans son historique pour étendre le lien.
+
+# Tools disponibles
+
+- `get_user_history(limit, days_back)` : derniers résumés du user (titres, \
+plateforme, date, concepts clés). À appeler en début de session pour \
+connaître son parcours récent.
+- `get_concept_keys(limit)` : top concepts/keywords agrégés sur l'historique. \
+Source primaire pour proposer un sujet de révision.
+- `search_history(query, top_k)` : recherche sémantique cross-source dans \
+l'historique du user (résumés, flashcards, transcripts). À appeler quand \
+l'utilisateur évoque un sujet précis et que vous voulez retrouver les \
+analyses concernées.
+- `get_summary_detail(summary_id)` : détail complet d'une analyse précise \
+(titre, full_digest, points clés, fact-check). À appeler quand vous voulez \
+ancrer une correction sur un passage précis qu'il a déjà vu.
+- `web_search(query, num_results=5)` : recherche web Brave Search. Fallback \
+quand le concept évoqué n'est pas couvert par son historique. Annoncez \
+brièvement « Je vais chercher pour préciser » avant l'appel pour gérer \
+la latence.
+
+# Style et cadre
+
+- Vouvoiement systématique. Ton sobre, chaleureux, pas de familiarité forcée.
+- Phrases courtes (2-4 phrases par tour), naturelles, sans jargon \
+pédagogique excessif.
+- Une seule question à la fois, attendre la réponse.
+- Pas de gimmick (« Excellent ! », « Bravo ! »), une reconnaissance simple \
+suffit (« C'est ça », « Précisément », « Pas tout à fait — voyons… »).
+- Cadrage temporel : 15 minutes maximum. Au bout de ~12 minutes, proposez \
+une mini-synthèse de ce qui a été révisé et passez le relais à l'utilisateur.
+- Si l'utilisateur n'a pas d'historique (zéro analyse), accueillez-le \
+gentiment, expliquez que vous mémorisez ses analyses au fil du temps, et \
+proposez de discuter d'un sujet libre via `web_search`.
+
+# Règle absolue
+
+N'inventez JAMAIS un concept que l'utilisateur n'aurait pas vu. Si vous \
+n'avez pas de match dans son historique, dites-le honnêtement et utilisez \
+`web_search` pour combler.
+"""
+
+KNOWLEDGE_TUTOR_PROMPT_EN = """\
+You are The DeepSight Tutor, an active-revision voice agent. You know the \
+user's full video-analysis history (key concepts, topics explored, main \
+ideas) and you help them consolidate what they have already seen — not a \
+single video, but their whole learning path.
+
+# Your role
+
+- Surface concepts they have already encountered and help them connect the dots.
+- Ask open-ended questions, listen, paraphrase, correct gently.
+- Suggest an adjacent topic when a theme has been covered.
+- Spot blind spots (topics never explored but coherent with their history).
+- If a concept is not in their history, use `web_search` to ground the answer.
+
+# Pedagogical method
+
+Socratic flow in four beats:
+
+1. **Initial orientation** — AT THE START of the session, ALWAYS call \
+`get_concept_keys` (top recent concepts) then `get_user_history` (last 10 \
+analyses). This gives you the playing field.
+2. **Open question** — Pick a concept or an idea from what surfaced and \
+ask an opening question that invites a free explanation \
+("Can you summarize what stuck with you from X?").
+3. **Listen + gentle corrections** — Evaluate the answer (right / \
+partial / fuzzy). Correct without being condescending, give the right \
+angle, cite the source when possible ("According to your analysis of Y, the \
+idea is rather…").
+4. **Adjacent topic** — When the concept is consolidated, propose another \
+close concept from their history to broaden the link.
+
+# Available tools
+
+- `get_user_history(limit, days_back)`: user's most recent summaries \
+(title, platform, date, key concepts). Call at session start to know \
+their recent path.
+- `get_concept_keys(limit)`: top concepts/keywords aggregated across \
+history. Primary source for proposing a revision topic.
+- `search_history(query, top_k)`: cross-source semantic search across the \
+user's history (summaries, flashcards, transcripts). Call when the user \
+mentions a specific subject and you want to find the relevant analyses.
+- `get_summary_detail(summary_id)`: full details of a specific analysis \
+(title, full digest, key points, fact-check). Call when you want to ground \
+a correction on a precise passage they have already seen.
+- `web_search(query, num_results=5)`: Brave Search web search. Fallback \
+when the mentioned concept is not in their history. Briefly announce \
+"Let me check on that" before the call to mask latency.
+
+# Style and frame
+
+- Polite tone. Sober, warm, no forced familiarity.
+- Short sentences (2-4 per turn), natural, no excessive pedagogical jargon.
+- One question at a time, wait for the answer.
+- No gimmick ("Awesome!", "Great job!"), a simple acknowledgement is \
+enough ("That's it", "Precisely", "Not quite — let's see…").
+- Time frame: 15 minutes max. Around the 12-minute mark, propose a mini \
+recap of what was reviewed and hand over to the user.
+- If the user has no history (zero analysis), welcome them gently, explain \
+that you build memory across their analyses over time, and offer a free \
+chat via `web_search`.
+
+# Absolute rule
+
+NEVER invent a concept the user has not seen. If you have no match in \
+their history, say so honestly and use `web_search` to fill the gap.
+"""

--- a/backend/src/voice/knowledge_tutor_tools.py
+++ b/backend/src/voice/knowledge_tutor_tools.py
@@ -1,0 +1,408 @@
+"""Backend tools exposed to the KNOWLEDGE_TUTOR voice agent.
+
+The KNOWLEDGE_TUTOR agent reasons over the *user's whole history* of video
+analyses (not a single video). These four async tools let it pull just enough
+context per turn:
+
+    - get_user_history    : last N analyses (title / platform / date / concepts)
+    - get_concept_keys    : top concepts/keywords aggregated across history
+    - search_history      : semantic search over the user's corpus (V1, PR #292)
+    - get_summary_detail  : full details of a precise analysis
+
+All tools take a `user: User` parameter so they cannot leak across users — they
+are bound to the session's authenticated user, never to a free-text user_id.
+
+Each tool returns a structured `dict` (or `list[dict]`) so the router can
+forward it to ElevenLabs' webhook tool runtime as-is. The voice agent then
+picks the relevant facts from the JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import Summary, User
+
+logger = logging.getLogger(__name__)
+
+
+# Same regex as history_router.py — matches Obsidian-style [[concept]] or
+# [[concept|alias]] markers embedded in summary_content by Mistral.
+_CONCEPT_PATTERN = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+?)?\]\]")
+
+
+def _summary_concept_keys(summary: Summary, limit: int = 5) -> list[str]:
+    """Extract concept keys from a Summary (concepts > tags fallback).
+
+    Mirrors history_router's get_all_keywords priority:
+    1. [[concept]] markers in summary_content
+    2. comma-separated tags
+    """
+    seen: set[str] = set()
+    keys: list[str] = []
+
+    if summary.summary_content:
+        for match in _CONCEPT_PATTERN.findall(summary.summary_content):
+            term = match.strip()
+            if not term or len(term) < 2:
+                continue
+            tl = term.lower()
+            if tl in seen:
+                continue
+            seen.add(tl)
+            keys.append(term)
+            if len(keys) >= limit:
+                return keys
+
+    if summary.tags:
+        for raw in summary.tags.split(","):
+            term = raw.strip()
+            if not term or len(term) < 2:
+                continue
+            tl = term.lower()
+            if tl in seen:
+                continue
+            seen.add(tl)
+            keys.append(term)
+            if len(keys) >= limit:
+                break
+
+    return keys
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 1 : get_user_history
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def get_user_history(
+    user: User,
+    db: AsyncSession,
+    limit: int = 10,
+    days_back: int = 60,
+) -> list[dict[str, Any]]:
+    """Return the last N analyses owned by the user.
+
+    Each item: {id, title, video_id, platform, created_at, key_concepts}.
+    Bounded by days_back to avoid pulling ancient history into the model.
+    """
+    limit = max(1, min(int(limit), 25))
+    days_back = max(1, min(int(days_back), 365))
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days_back)
+
+    logger.info(
+        "knowledge_tutor.get_user_history",
+        extra={"user_id": user.id, "limit": limit, "days_back": days_back},
+    )
+
+    try:
+        stmt = (
+            select(Summary)
+            .where(Summary.user_id == user.id)
+            .where(Summary.created_at >= cutoff)
+            .order_by(Summary.created_at.desc())
+            .limit(limit)
+        )
+        result = await db.execute(stmt)
+        rows = list(result.scalars().all())
+    except Exception as exc:  # noqa: BLE001
+        logger.error("get_user_history failed: %s", exc, exc_info=True)
+        return []
+
+    items: list[dict[str, Any]] = []
+    for s in rows:
+        items.append(
+            {
+                "id": s.id,
+                "title": s.video_title or "",
+                "video_id": s.video_id or "",
+                "platform": s.platform or "youtube",
+                "channel": s.video_channel or "",
+                "category": s.category or "",
+                "created_at": s.created_at.isoformat() if s.created_at else None,
+                "key_concepts": _summary_concept_keys(s, limit=5),
+            }
+        )
+    return items
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 2 : get_concept_keys
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def get_concept_keys(
+    user: User,
+    db: AsyncSession,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Return the top aggregated concepts/keywords across the user's history.
+
+    Mirrors `/api/history/keywords` extraction logic: priority to [[concept]]
+    markers in summary_content, fallback to comma-separated tags. Each
+    concept is returned with the most recent summary it was found in
+    (so the agent can quote `summary_id` if it wants to dig deeper via
+    get_summary_detail).
+    """
+    limit = max(1, min(int(limit), 100))
+
+    logger.info(
+        "knowledge_tutor.get_concept_keys",
+        extra={"user_id": user.id, "limit": limit},
+    )
+
+    try:
+        stmt = (
+            select(
+                Summary.id,
+                Summary.summary_content,
+                Summary.tags,
+                Summary.video_title,
+                Summary.video_id,
+                Summary.category,
+                Summary.created_at,
+            )
+            .where(Summary.user_id == user.id)
+            .where(or_(Summary.tags.isnot(None), Summary.summary_content.isnot(None)))
+            .order_by(Summary.created_at.desc())
+            .limit(200)
+        )
+        result = await db.execute(stmt)
+        rows = list(result.all())
+    except Exception as exc:  # noqa: BLE001
+        logger.error("get_concept_keys failed: %s", exc, exc_info=True)
+        return []
+
+    seen: set[str] = set()
+    keywords: list[dict[str, Any]] = []
+
+    def _add(term: str, row) -> None:
+        term = term.strip()
+        if not term or len(term) < 2:
+            return
+        tl = term.lower()
+        if tl in seen:
+            return
+        if len(keywords) >= limit:
+            return
+        seen.add(tl)
+        keywords.append(
+            {
+                "term": term,
+                "summary_id": row.id,
+                "video_title": row.video_title or "",
+                "video_id": row.video_id or "",
+                "category": row.category or "",
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+            }
+        )
+
+    for row in rows:
+        if len(keywords) >= limit:
+            break
+        if row.summary_content:
+            for concept in _CONCEPT_PATTERN.findall(row.summary_content):
+                _add(concept, row)
+                if len(keywords) >= limit:
+                    break
+        if len(keywords) >= limit:
+            break
+        if row.tags:
+            for tag in row.tags.split(","):
+                _add(tag, row)
+                if len(keywords) >= limit:
+                    break
+
+    return keywords
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 3 : search_history (semantic V1)
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def search_history(
+    user: User,
+    query: str,
+    top_k: int = 5,
+) -> list[dict[str, Any]]:
+    """Semantic search over the user's whole history (PR #292 V1 pipeline).
+
+    Uses search.global_search.search_global() which handles the cosine on
+    embeddings stored across summary / flashcard / quiz / chat / transcript
+    tables, all filtered by user_id. Returns a slim shape suited to the voice
+    agent (no embedding payloads).
+    """
+    if not query or len(query.strip()) < 2:
+        return []
+
+    top_k = max(1, min(int(top_k), 20))
+
+    logger.info(
+        "knowledge_tutor.search_history",
+        extra={"user_id": user.id, "top_k": top_k},
+    )
+
+    try:
+        # Lazy import: avoid pulling search subsystem at module import time.
+        from search.global_search import search_global, SearchFilters
+
+        filters = SearchFilters(limit=top_k)
+        results = await search_global(user_id=user.id, query=query, filters=filters)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("search_history failed: %s", exc, exc_info=True)
+        return []
+
+    items: list[dict[str, Any]] = []
+    for r in results:
+        meta = r.source_metadata or {}
+        items.append(
+            {
+                "source_type": r.source_type,
+                "summary_id": r.summary_id,
+                "score": round(float(r.score), 3),
+                "text_preview": (r.text_preview or "")[:400],
+                "video_title": meta.get("summary_title", ""),
+                "video_id": meta.get("video_id", ""),
+                "channel": meta.get("channel", ""),
+            }
+        )
+    return items
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 4 : get_summary_detail
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def get_summary_detail(
+    user: User,
+    db: AsyncSession,
+    summary_id: int,
+) -> dict[str, Any]:
+    """Return the full detail of one analysis owned by the user.
+
+    Includes title, full_digest (or a clipped summary_content fallback), key
+    points (parsed from the markdown headers when present), and the fact-check
+    JSON when available.
+    """
+    try:
+        sid = int(summary_id)
+    except (TypeError, ValueError):
+        return {"error": "invalid_summary_id"}
+
+    logger.info(
+        "knowledge_tutor.get_summary_detail",
+        extra={"user_id": user.id, "summary_id": sid},
+    )
+
+    try:
+        result = await db.execute(
+            select(Summary).where(Summary.id == sid).where(Summary.user_id == user.id)
+        )
+        summary = result.scalar_one_or_none()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("get_summary_detail failed: %s", exc, exc_info=True)
+        return {"error": "lookup_failed"}
+
+    if summary is None:
+        return {"error": "not_found"}
+
+    # full_digest may be JSON or raw text — both are valid in prod.
+    digest_raw = summary.full_digest or summary.summary_content or ""
+    digest_text = digest_raw
+    digest_json: Optional[dict] = None
+    if summary.full_digest:
+        try:
+            digest_json = json.loads(summary.full_digest)
+            if isinstance(digest_json, dict):
+                # Prefer the human-readable "digest" field if present
+                digest_text = digest_json.get("digest") or digest_json.get("summary") or digest_raw
+        except (json.JSONDecodeError, TypeError):
+            digest_json = None
+
+    # Clip to keep voice payloads bounded.
+    if digest_text and len(digest_text) > 4000:
+        digest_text = digest_text[:4000] + "…"
+
+    # Key points: try to grab the "## Points clés" / "## Key points" section.
+    key_points = _extract_key_points(summary.summary_content or "")
+
+    # Fact-check JSON (if any).
+    fact_check: Any = None
+    if summary.fact_check_result:
+        try:
+            fact_check = json.loads(summary.fact_check_result)
+        except (json.JSONDecodeError, TypeError):
+            fact_check = summary.fact_check_result
+
+    return {
+        "id": summary.id,
+        "title": summary.video_title or "",
+        "video_id": summary.video_id or "",
+        "platform": summary.platform or "youtube",
+        "channel": summary.video_channel or "",
+        "category": summary.category or "",
+        "created_at": summary.created_at.isoformat() if summary.created_at else None,
+        "digest": digest_text,
+        "key_points": key_points,
+        "fact_check": fact_check,
+        "reliability_score": summary.reliability_score,
+        "key_concepts": _summary_concept_keys(summary, limit=10),
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+_KEY_POINTS_HEADERS = (
+    "points clés",
+    "points cles",
+    "key points",
+    "points essentiels",
+    "idées principales",
+    "idees principales",
+)
+
+
+def _extract_key_points(content: str, max_points: int = 8) -> list[str]:
+    """Best-effort extraction of bullet points under a 'Key points' header.
+
+    Returns up to ``max_points`` raw bullets. Used to feed the voice agent a
+    short list it can quote back to the user.
+    """
+    if not content or not content.strip():
+        return []
+
+    capturing = False
+    bullets: list[str] = []
+    for raw_line in content.split("\n"):
+        line = raw_line.rstrip()
+        stripped = line.strip()
+
+        if stripped.startswith("##"):
+            if capturing:
+                # Reached the next section — stop.
+                break
+            header = stripped.lstrip("#").strip().lower()
+            if any(needle in header for needle in _KEY_POINTS_HEADERS):
+                capturing = True
+            continue
+
+        if capturing and stripped.startswith(("- ", "* ", "• ")):
+            point = stripped.lstrip("-*• ").strip()
+            if point:
+                bullets.append(point)
+                if len(bullets) >= max_points:
+                    break
+
+    return bullets

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -1815,6 +1815,13 @@ async def create_voice_session(
                 webhook_base_url=webhook_base_url,
                 voice_session_id=voice_session.id,
             )
+        elif agent_config.agent_type == "knowledge_tutor":
+            from voice.elevenlabs import build_knowledge_tutor_tools_config
+
+            tools_config = build_knowledge_tutor_tools_config(
+                webhook_base_url=webhook_base_url,
+                voice_session_id=voice_session.id,
+            )
         else:
             # Use the same effective_summary_id logic as for the unified context
             # block: streaming sessions auto-create a placeholder Summary (cf
@@ -3279,6 +3286,107 @@ async def companion_pending_transfer(
         logger.warning("companion pending transfer cleanup failed: %s", exc)
 
     return payload
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# POST /tools/knowledge-tutor-* — KNOWLEDGE_TUTOR agent tools
+# (public, bearer=voice_session_id, calque le pattern COMPANION)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _load_voice_session_user(voice_session: VoiceSession, db: AsyncSession) -> Optional[User]:
+    """Load the User row owning the given voice session (or None)."""
+    result = await db.execute(select(User).where(User.id == voice_session.user_id))
+    return result.scalar_one_or_none()
+
+
+@router.post("/tools/knowledge-tutor-history")
+async def tool_knowledge_tutor_history(request: Request, db: AsyncSession = Depends(get_session)):
+    """KNOWLEDGE_TUTOR webhook: last N analyses owned by the user."""
+    from voice.knowledge_tutor_tools import get_user_history
+
+    voice_session, body = await verify_companion_tool_request(request, db)
+    user = await _load_voice_session_user(voice_session, db)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "user_not_found", "message": "User not found."},
+        )
+
+    params = body.get("parameters") or {}
+    limit = body.get("limit") or params.get("limit", 10)
+    days_back = body.get("days_back") or params.get("days_back", 60)
+
+    items = await get_user_history(
+        user=user,
+        db=db,
+        limit=int(limit),
+        days_back=int(days_back),
+    )
+    return {"result": items}
+
+
+@router.post("/tools/knowledge-tutor-concepts")
+async def tool_knowledge_tutor_concepts(request: Request, db: AsyncSession = Depends(get_session)):
+    """KNOWLEDGE_TUTOR webhook: top concepts/keywords across history."""
+    from voice.knowledge_tutor_tools import get_concept_keys
+
+    voice_session, body = await verify_companion_tool_request(request, db)
+    user = await _load_voice_session_user(voice_session, db)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "user_not_found", "message": "User not found."},
+        )
+
+    params = body.get("parameters") or {}
+    limit = body.get("limit") or params.get("limit", 20)
+
+    items = await get_concept_keys(user=user, db=db, limit=int(limit))
+    return {"result": items}
+
+
+@router.post("/tools/knowledge-tutor-search")
+async def tool_knowledge_tutor_search(request: Request, db: AsyncSession = Depends(get_session)):
+    """KNOWLEDGE_TUTOR webhook: semantic search (V1) over the user's history."""
+    from voice.knowledge_tutor_tools import search_history
+
+    voice_session, body = await verify_companion_tool_request(request, db)
+    user = await _load_voice_session_user(voice_session, db)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "user_not_found", "message": "User not found."},
+        )
+
+    params = body.get("parameters") or {}
+    query = body.get("query") or params.get("query", "")
+    top_k = body.get("top_k") or params.get("top_k", 5)
+
+    items = await search_history(user=user, query=str(query), top_k=int(top_k))
+    return {"result": items}
+
+
+@router.post("/tools/knowledge-tutor-summary")
+async def tool_knowledge_tutor_summary(request: Request, db: AsyncSession = Depends(get_session)):
+    """KNOWLEDGE_TUTOR webhook: full detail of a specific summary owned by the user."""
+    from voice.knowledge_tutor_tools import get_summary_detail
+
+    voice_session, body = await verify_companion_tool_request(request, db)
+    user = await _load_voice_session_user(voice_session, db)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "user_not_found", "message": "User not found."},
+        )
+
+    params = body.get("parameters") or {}
+    summary_id = body.get("summary_id") or params.get("summary_id")
+    if summary_id is None:
+        return {"result": {"error": "missing_summary_id"}}
+
+    detail = await get_summary_detail(user=user, db=db, summary_id=summary_id)
+    return {"result": detail}
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/tests/voice/test_knowledge_tutor.py
+++ b/backend/tests/voice/test_knowledge_tutor.py
@@ -1,0 +1,465 @@
+"""Tests for the KNOWLEDGE_TUTOR voice agent (Phase 3 of tuteur-refactor).
+
+Coverage:
+    - get_agent_config("knowledge_tutor") returns the expected config
+    - Agent appears in list_agent_types() and exposes the right metadata
+    - build_knowledge_tutor_tools_config() emits 4 valid ConvAI webhook tools
+    - get_user_history() returns the right shape on a fixture user
+    - get_concept_keys() extracts [[concepts]] + tags fallback
+    - get_summary_detail() returns full detail or {error: ...} on missing
+    - search_history() forwards to search.global_search and returns slim items
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import Summary, User
+from voice.agent_types import get_agent_config, list_agent_types
+from voice.elevenlabs import build_knowledge_tutor_tools_config
+from voice.knowledge_tutor_tools import (
+    _extract_key_points,
+    _summary_concept_keys,
+    get_concept_keys,
+    get_summary_detail,
+    get_user_history,
+    search_history,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Agent registry contract
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_knowledge_tutor_agent_registered():
+    cfg = get_agent_config("knowledge_tutor")
+    assert cfg.agent_type == "knowledge_tutor"
+    assert cfg.requires_summary is False
+    assert cfg.requires_debate is False
+    assert cfg.plan_minimum == "pro"
+    assert cfg.max_session_minutes == 15
+    assert cfg.voice_style == "warm"
+
+
+def test_knowledge_tutor_tools_listed():
+    cfg = get_agent_config("knowledge_tutor")
+    tool_names = set(cfg.tools)
+    assert {
+        "get_user_history",
+        "get_concept_keys",
+        "search_history",
+        "get_summary_detail",
+        "web_search",
+    }.issubset(tool_names)
+
+
+def test_knowledge_tutor_in_list_agent_types():
+    types = list_agent_types()
+    knowledge = next((t for t in types if t["type"] == "knowledge_tutor"), None)
+    assert knowledge is not None
+    assert knowledge["plan_minimum"] == "pro"
+    assert knowledge["requires_summary"] is False
+
+
+def test_knowledge_tutor_prompts_socratic():
+    """System prompts must mention the four-step socratic flow + the two
+    mandatory startup tools (get_concept_keys, get_user_history)."""
+    cfg = get_agent_config("knowledge_tutor")
+    # FR
+    assert "get_concept_keys" in cfg.system_prompt_fr
+    assert "get_user_history" in cfg.system_prompt_fr
+    assert "search_history" in cfg.system_prompt_fr
+    assert "get_summary_detail" in cfg.system_prompt_fr
+    assert "Socratique" in cfg.system_prompt_fr or "socratique" in cfg.system_prompt_fr
+    # EN
+    assert "get_concept_keys" in cfg.system_prompt_en
+    assert "get_user_history" in cfg.system_prompt_en
+    assert "Socratic" in cfg.system_prompt_en or "socratic" in cfg.system_prompt_en
+
+
+# ─────────────────────────────────────────────────────────────────────
+# ConvAI tools schema contract
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_build_knowledge_tutor_tools_config_shape():
+    tools = build_knowledge_tutor_tools_config(
+        webhook_base_url="https://api.example.com",
+        voice_session_id="vs_abc",
+    )
+    names = [t["name"] for t in tools]
+    assert names == [
+        "get_user_history",
+        "get_concept_keys",
+        "search_history",
+        "get_summary_detail",
+    ]
+    for tool in tools:
+        assert tool["type"] == "webhook"
+        schema = tool["api_schema"]
+        assert schema["method"] == "POST"
+        assert schema["url"].startswith("https://api.example.com/api/voice/tools/knowledge-tutor-")
+        assert schema["request_headers"]["Authorization"] == "Bearer vs_abc"
+        body = schema["request_body_schema"]
+        assert body["type"] == "object"
+        assert "voice_session_id" in body["properties"]
+        assert "voice_session_id" in body["required"]
+
+
+def test_search_history_tool_requires_query():
+    tools = build_knowledge_tutor_tools_config(
+        webhook_base_url="https://api.example.com",
+        voice_session_id="vs_abc",
+    )
+    search_tool = next(t for t in tools if t["name"] == "search_history")
+    assert "query" in search_tool["api_schema"]["request_body_schema"]["required"]
+
+
+def test_get_summary_detail_tool_requires_id():
+    tools = build_knowledge_tutor_tools_config(
+        webhook_base_url="https://api.example.com",
+        voice_session_id="vs_abc",
+    )
+    detail_tool = next(t for t in tools if t["name"] == "get_summary_detail")
+    assert "summary_id" in detail_tool["api_schema"]["request_body_schema"]["required"]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool: get_user_history
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def kt_user(async_db_session: AsyncSession) -> User:
+    user = User(
+        username="kt_tester",
+        email="kt@test.fr",
+        password_hash="x",
+        plan="pro",
+        email_verified=True,
+    )
+    async_db_session.add(user)
+    await async_db_session.commit()
+    await async_db_session.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def kt_summaries(async_db_session: AsyncSession, kt_user: User) -> list[Summary]:
+    """Three summaries with varied content used by the tool tests below."""
+    rows = []
+    rows.append(
+        Summary(
+            user_id=kt_user.id,
+            video_id="vid_001",
+            video_title="L'éthique de l'IA générative",
+            video_channel="Sciences et IA",
+            platform="youtube",
+            lang="fr",
+            category="ai",
+            summary_content=(
+                "## Résumé\n"
+                "Une discussion approfondie sur les enjeux éthiques.\n\n"
+                "## Points clés\n"
+                "- L'[[alignment]] est central pour la sécurité.\n"
+                "- Les [[modèles fondationnels]] structurent l'industrie.\n"
+                "- Le risque [[biais algorithmique]] est sous-estimé.\n"
+            ),
+            tags="éthique, IA, alignment",
+        )
+    )
+    rows.append(
+        Summary(
+            user_id=kt_user.id,
+            video_id="vid_002",
+            video_title="Machine Learning expliqué simplement",
+            video_channel="DataLab",
+            platform="youtube",
+            lang="fr",
+            category="ai",
+            summary_content=(
+                "## Résumé\nVue d'ensemble du ML.\n\n"
+                "Les concepts comme [[gradient descent]] et [[overfitting]] sont expliqués.\n"
+            ),
+            tags="ML, basics",
+        )
+    )
+    rows.append(
+        Summary(
+            user_id=kt_user.id,
+            video_id="vid_003",
+            video_title="Introduction aux LLM",
+            video_channel="LLM Lab",
+            platform="tiktok",
+            lang="fr",
+            category="ai",
+            summary_content="Pas de concepts taggés ici.",
+            tags="LLM, transformer, attention",
+        )
+    )
+    for row in rows:
+        async_db_session.add(row)
+    await async_db_session.commit()
+    for row in rows:
+        await async_db_session.refresh(row)
+    return rows
+
+
+@pytest.mark.asyncio
+async def test_get_user_history_returns_recent_summaries(
+    async_db_session: AsyncSession, kt_user: User, kt_summaries: list[Summary]
+):
+    items = await get_user_history(user=kt_user, db=async_db_session, limit=10)
+    assert len(items) == 3
+    for item in items:
+        assert {"id", "title", "video_id", "platform", "channel", "category", "created_at", "key_concepts"}.issubset(
+            item.keys()
+        )
+    titles = {item["title"] for item in items}
+    assert "L'éthique de l'IA générative" in titles
+    assert "Introduction aux LLM" in titles
+    # First summary has Obsidian-style concepts → should appear in key_concepts.
+    eth = next(item for item in items if item["video_id"] == "vid_001")
+    assert "alignment" in eth["key_concepts"]
+
+
+@pytest.mark.asyncio
+async def test_get_user_history_respects_limit(
+    async_db_session: AsyncSession, kt_user: User, kt_summaries: list[Summary]
+):
+    items = await get_user_history(user=kt_user, db=async_db_session, limit=2)
+    assert len(items) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_user_history_filters_by_user(
+    async_db_session: AsyncSession, kt_summaries: list[Summary]
+):
+    # Other user with no analyses
+    other = User(
+        username="other_user",
+        email="other@test.fr",
+        password_hash="x",
+        plan="pro",
+        email_verified=True,
+    )
+    async_db_session.add(other)
+    await async_db_session.commit()
+    await async_db_session.refresh(other)
+
+    items = await get_user_history(user=other, db=async_db_session, limit=10)
+    assert items == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool: get_concept_keys
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_concept_keys_extracts_concepts_first(
+    async_db_session: AsyncSession, kt_user: User, kt_summaries: list[Summary]
+):
+    keys = await get_concept_keys(user=kt_user, db=async_db_session, limit=20)
+    terms = [k["term"].lower() for k in keys]
+    # [[concept]] markers should win first
+    assert "alignment" in terms
+    assert "modèles fondationnels" in terms or "modeles fondationnels" in terms
+    assert "biais algorithmique" in terms
+    # Tags fallback should follow
+    assert any(t in terms for t in ["llm", "transformer", "attention", "ml", "basics"])
+
+
+@pytest.mark.asyncio
+async def test_get_concept_keys_dedups(async_db_session: AsyncSession, kt_user: User):
+    """Same concept appearing twice returns only one entry."""
+    s1 = Summary(
+        user_id=kt_user.id,
+        video_id="dup_a",
+        video_title="A",
+        platform="youtube",
+        summary_content="[[neuroscience]] et [[neuroscience]] répétés.",
+        tags="neuroscience",
+    )
+    s2 = Summary(
+        user_id=kt_user.id,
+        video_id="dup_b",
+        video_title="B",
+        platform="youtube",
+        summary_content="[[neuroscience]] encore.",
+    )
+    async_db_session.add_all([s1, s2])
+    await async_db_session.commit()
+
+    keys = await get_concept_keys(user=kt_user, db=async_db_session, limit=20)
+    terms_lower = [k["term"].lower() for k in keys]
+    assert terms_lower.count("neuroscience") == 1
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool: get_summary_detail
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_summary_detail_returns_full_payload(
+    async_db_session: AsyncSession, kt_user: User, kt_summaries: list[Summary]
+):
+    target = kt_summaries[0]  # "L'éthique de l'IA générative"
+    detail = await get_summary_detail(user=kt_user, db=async_db_session, summary_id=target.id)
+    assert detail["title"] == "L'éthique de l'IA générative"
+    assert detail["video_id"] == "vid_001"
+    assert detail["platform"] == "youtube"
+    assert "alignment" in detail["key_concepts"]
+    # Key points parsed from "## Points clés"
+    assert any("alignment" in p.lower() for p in detail["key_points"])
+
+
+@pytest.mark.asyncio
+async def test_get_summary_detail_unknown_returns_error(
+    async_db_session: AsyncSession, kt_user: User
+):
+    detail = await get_summary_detail(user=kt_user, db=async_db_session, summary_id=999_999)
+    assert detail == {"error": "not_found"}
+
+
+@pytest.mark.asyncio
+async def test_get_summary_detail_invalid_id(async_db_session: AsyncSession, kt_user: User):
+    detail = await get_summary_detail(user=kt_user, db=async_db_session, summary_id="abc")  # type: ignore[arg-type]
+    assert detail == {"error": "invalid_summary_id"}
+
+
+@pytest.mark.asyncio
+async def test_get_summary_detail_isolated_per_user(
+    async_db_session: AsyncSession, kt_user: User, kt_summaries: list[Summary]
+):
+    """Cannot read another user's summary_id."""
+    other = User(
+        username="other_kt",
+        email="other_kt@test.fr",
+        password_hash="x",
+        plan="pro",
+        email_verified=True,
+    )
+    async_db_session.add(other)
+    await async_db_session.commit()
+    await async_db_session.refresh(other)
+
+    detail = await get_summary_detail(user=other, db=async_db_session, summary_id=kt_summaries[0].id)
+    assert detail == {"error": "not_found"}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool: search_history (semantic V1 wrapper)
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_history_short_query_returns_empty(kt_user: User):
+    items = await search_history(user=kt_user, query="a", top_k=5)
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_search_history_forwards_to_search_global(kt_user: User):
+    """search_history must forward to search.global_search.search_global with
+    the right user_id and return a slim shape."""
+
+    class _StubResult:
+        def __init__(self, sid: int, score: float, preview: str, video_id: str):
+            self.source_type = "summary"
+            self.source_id = sid
+            self.summary_id = sid
+            self.score = score
+            self.text_preview = preview
+            self.source_metadata = {
+                "summary_title": f"Video {sid}",
+                "video_id": video_id,
+                "channel": "Test Channel",
+            }
+
+    async def _fake_search_global(*, user_id: int, query: str, filters):
+        assert user_id == kt_user.id
+        assert query == "alignment"
+        return [
+            _StubResult(1, 0.92, "Alignment is central for safety.", "vid_001"),
+            _StubResult(2, 0.81, "Some preview.", "vid_002"),
+        ]
+
+    with patch("search.global_search.search_global", new=_fake_search_global):
+        items = await search_history(user=kt_user, query="alignment", top_k=5)
+
+    assert len(items) == 2
+    assert items[0]["summary_id"] == 1
+    assert items[0]["video_id"] == "vid_001"
+    assert items[0]["score"] == 0.92
+    assert "summary_id" in items[0]
+    assert "video_title" in items[0]
+
+
+@pytest.mark.asyncio
+async def test_search_history_handles_search_failure(kt_user: User):
+    async def _boom(*, user_id: int, query: str, filters):  # noqa: ARG001
+        raise RuntimeError("embedding service down")
+
+    with patch("search.global_search.search_global", new=_boom):
+        items = await search_history(user=kt_user, query="something", top_k=5)
+    assert items == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_extract_key_points_from_markdown():
+    content = (
+        "## Résumé\nblah\n\n"
+        "## Points clés\n"
+        "- Premier point\n"
+        "- Deuxième point\n"
+        "- Troisième point\n\n"
+        "## Conclusion\nfin\n"
+    )
+    points = _extract_key_points(content)
+    assert points == ["Premier point", "Deuxième point", "Troisième point"]
+
+
+def test_extract_key_points_empty_when_no_section():
+    assert _extract_key_points("Pas de section ici") == []
+
+
+def test_summary_concept_keys_priority():
+    """[[concept]] markers in summary_content take priority over tags."""
+    s = Summary(
+        user_id=1,
+        video_id="x",
+        video_title="t",
+        platform="youtube",
+        summary_content="Hello [[reinforcement learning]] et [[transformer]].",
+        tags="ml, optimization",
+    )
+    keys = _summary_concept_keys(s, limit=5)
+    assert keys[0] == "reinforcement learning"
+    assert "transformer" in keys
+    # Tags only fill remaining slots
+    assert "ml" in keys or "optimization" in keys
+
+
+def test_summary_concept_keys_falls_back_to_tags():
+    s = Summary(
+        user_id=1,
+        video_id="x",
+        video_title="t",
+        platform="youtube",
+        summary_content="No concepts here.",
+        tags="alpha, beta, gamma",
+    )
+    keys = _summary_concept_keys(s, limit=5)
+    assert keys == ["alpha", "beta", "gamma"]


### PR DESCRIPTION
## Summary

Phase 3 of the [Tuteur refactor 2026-05-10 spec](docs/superpowers/specs/2026-05-10-tuteur-refactor.md) — Axe C: introduce a new ElevenLabs ConvAI voice agent **KNOWLEDGE_TUTOR** that reasons across the user's *whole* DeepSight history (not a single video).

Distinct from the existing TUTOR (one-video flashcard quizzer). The new agent surfaces concepts the user has already encountered, helps connect dots, asks Socratic questions, and falls back to web_search when a concept isn't in their history.

## Files changed

- `backend/src/voice/knowledge_tutor_prompts.py` — **new**, FR + EN system prompts (sober vouvoiement, four-step socratic flow, mandatory startup tools)
- `backend/src/voice/knowledge_tutor_tools.py` — **new**, 4 async tools:
  - `get_user_history(user, limit, days_back)` — last N analyses
  - `get_concept_keys(user, limit)` — top concepts/keywords aggregated
  - `search_history(user, query, top_k)` — Semantic Search V1 wrapper (PR #292)
  - `get_summary_detail(user, db, summary_id)` — full detail of one analysis
- `backend/src/voice/agent_types.py` — register `KNOWLEDGE_TUTOR` in `AGENT_REGISTRY` (`requires_summary=False`, `plan_minimum='pro'`, `max_session_minutes=15`)
- `backend/src/voice/elevenlabs.py` — `build_knowledge_tutor_tools_config()` emits 4 ConvAI webhook tools (Bearer = voice_session_id, same auth as COMPANION)
- `backend/src/voice/router.py` — 4 webhook endpoints (`/api/voice/tools/knowledge-tutor-{history,concepts,search,summary}`) + branch in tool-config builder
- `backend/tests/voice/test_knowledge_tutor.py` — **new**, 23 tests

## Decisions verrouillées (rappel spec)

- Pattern : calque COMPANION (sans vidéo, `requires_summary=False`)
- Tools réutilisent : `/api/history/keywords` logic (concept_keys) et `search.global_search.search_global` (PR #292 Semantic Search V1)
- `plan_minimum='pro'` (cohérent avec feature flag `companion_dialogue`)
- Pas de migration DB — réutilise `Summary`, `User`, `TranscriptEmbedding`

## Test plan

- [x] `cd backend && python -m pytest tests/voice/test_knowledge_tutor.py -v` → **23 / 23 PASS**
- [x] `cd backend && python -m pytest tests/voice/ -v` → 237 voice tests passing (5 unrelated failures pre-exist on main: `test_streaming_orchestrator*` event-name regression + `test_streaming_prompts_v2::test_streaming_prompt_size_under_5kb` — not introduced by this PR)
- [x] `python -c "from voice.agent_types import get_agent_config; print(get_agent_config('knowledge_tutor').tools)"` → `['get_user_history', 'get_concept_keys', 'search_history', 'get_summary_detail', 'web_search']`

## Deployment

- Backend-only PR. No DB migration. No frontend touched (Phase 4 dispatched separately).
- After merge → push to main → Hetzner auto-deploy (rebuild Docker for new module imports).

## Out of scope

- **Phase 4** (frontend voice entry points: sidebar item + popup button) — separate sub-agent after this PR merges
- **Phase 5** (QA + deploy + memory note) — manual after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)