### PR TITLE
feat(tutor): voice entry points (sidebar + popup button)

### DIFF
--- a/frontend/src/components/Tutor/Tutor.tsx
+++ b/frontend/src/components/Tutor/Tutor.tsx
@@ -9,6 +9,8 @@ import { TutorPrompting } from "./TutorPrompting";
 import { TutorMiniChat } from "./TutorMiniChat";
 import { TutorMinimized } from "./TutorMinimized";
 import { LS_TUTOR_HIDDEN, LS_TUTOR_MINIMIZED } from "./tutorConstants";
+import { useVoiceEnabled } from "../voice/hooks/useVoiceEnabled";
+import { VoiceTutorModal } from "../voice/VoiceTutorModal";
 
 function readBoolLS(key: string): boolean {
   try {
@@ -35,6 +37,12 @@ export const Tutor: React.FC = () => {
   const { currentWord } = useLoadingWord();
   const { language } = useLanguage();
   const tutor = useTutor();
+  const { voiceEnabled } = useVoiceEnabled();
+
+  // Voice Tutor modal — opened from the TutorMiniChat header button.
+  // Carries the current concept as a primer so the agent can pick up
+  // the topic immediately on connection.
+  const [voiceTutorOpen, setVoiceTutorOpen] = useState(false);
 
   // Persistance close (hidden) + minimize entre rechargements page.
   // hidden : reset uniquement quand un nouveau concept arrive (changement
@@ -99,50 +107,78 @@ export const Tutor: React.FC = () => {
   if (!isAuthenticated || !currentWord) return null;
   if (hidden) return null;
 
+  // Voice Tutor modal element — rendered alongside the phase UI so it can
+  // stay open even when the tutor mini-chat is closed/minimized. Renders
+  // via portal inside VoiceOverlay so it does not interfere with layout.
+  const voiceTutorEl = (
+    <VoiceTutorModal
+      isOpen={voiceTutorOpen}
+      onClose={() => setVoiceTutorOpen(false)}
+      language={language === "fr" ? "fr" : "en"}
+      initialContext={
+        tutor.conceptTerm
+          ? {
+              conceptTerm: tutor.conceptTerm,
+              conceptDef: tutor.conceptDef,
+              summaryId: tutor.summaryId,
+            }
+          : null
+      }
+    />
+  );
+
   // Si minimisé, peu importe la phase : on rend la pastille.
   if (minimized) {
     return (
-      <AnimatePresence mode="wait">
-        <TutorMinimized
-          key="minimized"
-          onRestore={handleRestore}
-          onClose={handleClose}
-        />
-      </AnimatePresence>
+      <>
+        <AnimatePresence mode="wait">
+          <TutorMinimized
+            key="minimized"
+            onRestore={handleRestore}
+            onClose={handleClose}
+          />
+        </AnimatePresence>
+        {voiceTutorEl}
+      </>
     );
   }
 
   return (
-    <AnimatePresence mode="wait">
-      {tutor.phase === "idle" && (
-        <TutorIdle
-          key="idle"
-          onClick={tutor.openPrompting}
-          onMinimize={handleMinimize}
-          onClose={handleClose}
-        />
-      )}
-      {tutor.phase === "prompting" && (
-        <TutorPrompting
-          key="prompting"
-          onStart={handleStart}
-          onCancel={tutor.cancelPrompting}
-          onMinimize={handleMinimize}
-          onClose={handleClose}
-        />
-      )}
-      {tutor.phase === "mini-chat" && tutor.conceptTerm && (
-        <TutorMiniChat
-          key="mini-chat"
-          conceptTerm={tutor.conceptTerm}
-          messages={tutor.messages}
-          loading={tutor.loading}
-          onSubmit={tutor.submitTextTurn}
-          onMinimize={handleMinimize}
-          onClose={handleClose}
-        />
-      )}
-    </AnimatePresence>
+    <>
+      <AnimatePresence mode="wait">
+        {tutor.phase === "idle" && (
+          <TutorIdle
+            key="idle"
+            onClick={tutor.openPrompting}
+            onMinimize={handleMinimize}
+            onClose={handleClose}
+          />
+        )}
+        {tutor.phase === "prompting" && (
+          <TutorPrompting
+            key="prompting"
+            onStart={handleStart}
+            onCancel={tutor.cancelPrompting}
+            onMinimize={handleMinimize}
+            onClose={handleClose}
+          />
+        )}
+        {tutor.phase === "mini-chat" && tutor.conceptTerm && (
+          <TutorMiniChat
+            key="mini-chat"
+            conceptTerm={tutor.conceptTerm}
+            messages={tutor.messages}
+            loading={tutor.loading}
+            onSubmit={tutor.submitTextTurn}
+            onMinimize={handleMinimize}
+            onClose={handleClose}
+            voiceTutorEnabled={voiceEnabled}
+            onOpenVoiceTutor={() => setVoiceTutorOpen(true)}
+          />
+        )}
+      </AnimatePresence>
+      {voiceTutorEl}
+    </>
   );
 };
 

--- a/frontend/src/components/Tutor/TutorMiniChat.tsx
+++ b/frontend/src/components/Tutor/TutorMiniChat.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
-import { Minus, X, Send } from "lucide-react";
+import { Minus, X, Send, Mic } from "lucide-react";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { useTranslation } from "../../hooks/useTranslation";
 import { DraggableTutorWindow } from "./DraggableTutorWindow";
@@ -14,6 +14,16 @@ interface TutorMiniChatProps {
   onSubmit: (input: string) => void;
   onMinimize: () => void;
   onClose: () => void;
+  /**
+   * Optional callback to launch the Voice Tutor modal with the current
+   * concept as a primer. When undefined, the voice button is hidden.
+   */
+  onOpenVoiceTutor?: () => void;
+  /**
+   * Whether the user can access voice features (voiceChatEnabled OR admin).
+   * Falsy → hide the voice button. Spec D: gate behind voiceChatEnabled.
+   */
+  voiceTutorEnabled?: boolean;
 }
 
 const stopPropagation = (e: React.PointerEvent | React.MouseEvent) => {
@@ -27,6 +37,8 @@ export const TutorMiniChat: React.FC<TutorMiniChatProps> = ({
   onSubmit,
   onMinimize,
   onClose,
+  onOpenVoiceTutor,
+  voiceTutorEnabled = false,
 }) => {
   const { language } = useLanguage();
   const { t } = useTranslation();
@@ -36,6 +48,8 @@ export const TutorMiniChat: React.FC<TutorMiniChatProps> = ({
   const tt = t.tutor;
   const minimizeLabel =
     tt.mini_chat.minimize ?? (language === "fr" ? "Réduire" : "Minimize");
+  const voiceTutorLabel =
+    language === "fr" ? "Tuteur Vocal" : "Voice Tutor";
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -75,6 +89,18 @@ export const TutorMiniChat: React.FC<TutorMiniChatProps> = ({
             {conceptTerm}
           </div>
           <div className="flex items-center gap-1">
+            {onOpenVoiceTutor && voiceTutorEnabled && (
+              <button
+                type="button"
+                onPointerDown={stopPropagation}
+                onClick={onOpenVoiceTutor}
+                className="text-accent-primary hover:text-accent-primary-hover p-1 transition-colors"
+                aria-label={voiceTutorLabel}
+                title={voiceTutorLabel}
+              >
+                <Mic className="w-3.5 h-3.5" />
+              </button>
+            )}
             <button
               type="button"
               onPointerDown={stopPropagation}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
   GraduationCap,
   LayoutGrid,
   Menu,
+  Mic,
 } from "lucide-react";
 import { useAuth } from "../../hooks/useAuth";
 import { useTranslation } from "../../hooks/useTranslation";
@@ -37,8 +38,10 @@ import {
   getMinPlanForFeature,
   PLANS_INFO,
   PLAN_HIERARCHY,
+  PLAN_LIMITS,
 } from "../../config/planPrivileges";
 import type { PlanId } from "../../config/planPrivileges";
+import { VoiceTutorModal } from "../voice/VoiceTutorModal";
 
 // === Logo ===
 const Logo: React.FC<{ collapsed?: boolean; onClick?: () => void }> = ({
@@ -173,6 +176,63 @@ const NavItem: React.FC<NavItemProps> = ({
         </>
       )}
     </NavLink>
+  );
+};
+
+// === Sidebar Action Item (button, not link) ===
+// Same visual language as NavItem but for actions (e.g. opens a modal).
+// Reused by the "Tuteur Vocal" sidebar entry which launches a voice modal
+// instead of navigating to a route. The Sidebar test suite forbids legacy
+// /chat or /voice-call NavLinks so we must use a button here.
+interface SidebarActionItemProps {
+  icon: React.ElementType;
+  label: string;
+  onClick: () => void;
+  collapsed?: boolean;
+  badge?: string;
+  badgeClassName?: string;
+}
+
+const SidebarActionItem: React.FC<SidebarActionItemProps> = ({
+  icon: Icon,
+  label,
+  onClick,
+  collapsed,
+  badge,
+  badgeClassName,
+}) => {
+  const baseClasses =
+    "w-full flex items-center gap-2.5 px-2.5 py-2 rounded-md transition-all text-[0.8125rem] font-medium relative text-text-secondary hover:text-text-primary hover:bg-bg-hover";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={baseClasses}
+      title={collapsed ? label : undefined}
+    >
+      <Icon className="w-[18px] h-[18px] flex-shrink-0" />
+      <AnimatePresence>
+        {!collapsed && (
+          <motion.div
+            initial={{ opacity: 0, width: 0 }}
+            animate={{ opacity: 1, width: "auto" }}
+            exit={{ opacity: 0, width: 0 }}
+            transition={{ duration: 0.15 }}
+            className="flex items-center flex-1 min-w-0 gap-2"
+          >
+            <span className="flex-1 truncate text-left">{label}</span>
+            {badge && (
+              <span
+                className={`px-1.5 py-0.5 rounded-full text-[0.625rem] font-medium ${badgeClassName || "bg-accent-secondary-muted text-accent-secondary"}`}
+              >
+                {badge}
+              </span>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </button>
   );
 };
 
@@ -334,6 +394,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
     onMobileCloseProp?.();
   };
 
+  // Voice Tutor modal — knowledge_tutor agent (sidebar global entry).
+  const [voiceTutorOpen, setVoiceTutorOpen] = useState(false);
+
   const userPlan = normalizePlanId(user?.plan);
 
   // Badges dynamiques — getMinPlanForFeature comme source unique de vérité
@@ -345,6 +408,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const minPlanPlaylists = getMinPlanForFeature("playlistsEnabled");
   const minPlanStudy = getMinPlanForFeature("flashcardsEnabled");
   const minPlanHub: PlanId = "pro"; // Hub (chat + voix) bloque les free users
+  const minPlanVoiceTutor: PlanId = getMinPlanForFeature("voiceChatEnabled"); // Tuteur Vocal — Pro+
   const getBadge = (minPlan: PlanId) => {
     const userIdx = PLAN_HIERARCHY.indexOf(userPlan);
     const minIdx = PLAN_HIERARCHY.indexOf(minPlan);
@@ -357,6 +421,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const ADMIN_EMAIL = "maximeleparc3@gmail.com";
   const isUserAdmin =
     user?.is_admin || user?.email?.toLowerCase() === ADMIN_EMAIL.toLowerCase();
+
+  // Voice Tutor — gated voiceChatEnabled (Pro+). Admin bypass.
+  const voiceTutorAllowed =
+    isUserAdmin || (PLAN_LIMITS[userPlan]?.voiceChatEnabled ?? false);
 
   // Hub Workspaces — gated Expert (cohérent avec ConversationsDrawer).
   // Admin bypass : voir l'item même hors plan Expert pour debug/preview.
@@ -489,6 +557,23 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 collapsed={collapsed}
               />
             )}
+            <div data-tour-step="voice-tutor-nav">
+              <SidebarActionItem
+                icon={Mic}
+                label={language === "fr" ? "Tuteur Vocal" : "Voice Tutor"}
+                onClick={() => {
+                  if (!voiceTutorAllowed) {
+                    navigate("/upgrade");
+                    closeMobile();
+                    return;
+                  }
+                  setVoiceTutorOpen(true);
+                  closeMobile();
+                }}
+                collapsed={collapsed}
+                {...getBadge(minPlanVoiceTutor)}
+              />
+            </div>
             <div data-tour-step="study-nav">
               <NavItem
                 to="/study"
@@ -569,6 +654,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
           <UserCard collapsed={collapsed} />
         </div>
       </aside>
+
+      {/* Voice Tutor modal — knowledge_tutor agent ConvAI session.
+          Rendered via portal inside VoiceOverlay → does not impact sidebar
+          layout. Auto-starts on open and stops on close. */}
+      <VoiceTutorModal
+        isOpen={voiceTutorOpen}
+        onClose={() => setVoiceTutorOpen(false)}
+        language={language === "fr" ? "fr" : "en"}
+      />
     </>
   );
 };

--- a/frontend/src/components/voice/VoiceOverlay.tsx
+++ b/frontend/src/components/voice/VoiceOverlay.tsx
@@ -74,6 +74,7 @@ export interface VoiceOverlayProps {
     | "explorer"
     | "companion"
     | "tutor"
+    | "knowledge_tutor"
     | "debate_moderator"
     | "quiz_coach";
   /** Language used by the agent. */

--- a/frontend/src/components/voice/VoiceTutorModal.tsx
+++ b/frontend/src/components/voice/VoiceTutorModal.tsx
@@ -1,0 +1,117 @@
+/**
+ * VoiceTutorModal — Knowledge Tutor voice session entry point.
+ *
+ * Thin wrapper around `VoiceOverlay` specialized for the `knowledge_tutor`
+ * agent. Used by:
+ *   - Sidebar "Tuteur Vocal" item (no concept context)
+ *   - TutorMiniChat header button "Tuteur Vocal" (concept context as primer)
+ *
+ * The agent does NOT require a summary (`requires_summary=False` in
+ * backend/src/voice/agent_types.py KNOWLEDGE_TUTOR). When a concept is
+ * provided, we inject it via `sendUserMessage` shortly after onConnect so the
+ * agent can pick up the topic immediately. When no concept is provided, the
+ * agent begins with its default first message and queries the user's history
+ * via its tools (get_concept_keys, get_user_history).
+ *
+ * Floating presentation (380×600 bottom-right) is reused from VoiceOverlay
+ * for consistency with COMPANION mode launched from the chat page.
+ */
+
+import React, { useEffect, useRef } from "react";
+import {
+  VoiceOverlay,
+  type VoiceOverlayController,
+} from "./VoiceOverlay";
+
+export interface VoiceTutorModalProps {
+  /** Whether the modal is visible. */
+  isOpen: boolean;
+  /** Close callback — also stops the voice session. */
+  onClose: () => void;
+  /** Optional UI language. Defaults to "fr". */
+  language?: "fr" | "en";
+  /**
+   * Optional concept context passed as a primer to the agent.
+   * When provided, the modal injects a `[CONTEXT]` block via
+   * `sendUserMessage` shortly after the call connects so the agent
+   * immediately knows what concept the user is reviewing.
+   */
+  initialContext?: {
+    conceptTerm: string;
+    /** Optional Summary id — gives the agent a deeper hook. */
+    summaryId?: number | null;
+    /** Optional brief definition to inline. */
+    conceptDef?: string | null;
+  } | null;
+}
+
+const TITLE_FR = "Tuteur Vocal";
+const TITLE_EN = "Voice Tutor";
+const SUBTITLE_FR = "Révisez vos analyses à voix haute";
+const SUBTITLE_EN = "Review your analyses out loud";
+
+export const VoiceTutorModal: React.FC<VoiceTutorModalProps> = ({
+  isOpen,
+  onClose,
+  language = "fr",
+  initialContext,
+}) => {
+  const controllerRef = useRef<VoiceOverlayController | null>(null);
+  const primerSentRef = useRef(false);
+
+  // Reset the primer flag when the modal closes so it fires again on reopen.
+  useEffect(() => {
+    if (!isOpen) {
+      primerSentRef.current = false;
+    }
+  }, [isOpen]);
+
+  // When the call becomes active and a concept primer is configured, inject
+  // a [CONTEXT] block exactly once. The agent's system prompt instructs it
+  // to honor [CONTEXT] blocks as orienting hints.
+  useEffect(() => {
+    if (!isOpen || !initialContext || primerSentRef.current) return;
+    const controller = controllerRef.current;
+    if (!controller || !controller.isActive) return;
+
+    const term = initialContext.conceptTerm.trim();
+    if (!term) return;
+
+    const def = initialContext.conceptDef?.trim();
+    const summaryRef =
+      initialContext.summaryId != null
+        ? language === "fr"
+          ? `\nAnalyse associée: #${initialContext.summaryId}`
+          : `\nLinked analysis: #${initialContext.summaryId}`
+        : "";
+
+    const primer =
+      language === "fr"
+        ? `[CONTEXT] L'utilisateur souhaite revenir sur le concept: « ${term} »${
+            def ? `\nDéfinition courte: ${def}` : ""
+          }${summaryRef}\nAttaque directement avec une question ouverte sur ce concept.`
+        : `[CONTEXT] The user wants to revisit the concept: "${term}"${
+            def ? `\nShort definition: ${def}` : ""
+          }${summaryRef}\nOpen with a direct question about this concept.`;
+
+    controller.sendUserMessage(primer);
+    primerSentRef.current = true;
+  });
+
+  return (
+    <VoiceOverlay
+      isOpen={isOpen}
+      onClose={onClose}
+      title={language === "fr" ? TITLE_FR : TITLE_EN}
+      subtitle={language === "fr" ? SUBTITLE_FR : SUBTITLE_EN}
+      summaryId={null}
+      agentType="knowledge_tutor"
+      language={language}
+      controllerRef={controllerRef}
+      autoStart
+      presentationMode="floating"
+    />
+  );
+};
+
+export default VoiceTutorModal;

--- a/frontend/src/components/voice/useVoiceChat.ts
+++ b/frontend/src/components/voice/useVoiceChat.ts
@@ -30,10 +30,10 @@ interface UseVoiceChatOptions {
     | "explorer"
     | "companion"
     | "tutor"
+    | "knowledge_tutor"
     | "debate_moderator"
     | "quiz_coach"
-    | "onboarding"
-    | "companion";
+    | "onboarding";
   language?: "fr" | "en";
   onError?: (error: string) => void;
   /**


### PR DESCRIPTION
## Summary

Phase 4 (Axe D) du sprint Tuteur 2026-05-10 — frontend voice entry points.
Branche depuis main à jour, post-merge PR #439 (backend `knowledge_tutor`) + PR #440 (popup refactor).

- **Sidebar** : nouvel item 'Tuteur Vocal' (icône `Mic`), gating `voiceChatEnabled` (Pro+) avec bypass admin, ouvre `VoiceTutorModal` via state local. Implémenté en `<button>` (pas `NavLink`) car la suite de tests Sidebar interdit toute référence aux routes legacy `/chat` ou `/voice-call`.
- **Popup `TutorMiniChat`** : bouton header `Mic` (couleur accent), apparaît seulement si le parent fournit `onOpenVoiceTutor` + `voiceTutorEnabled`. Wired dans `Tutor.tsx` via `useVoiceEnabled` ; forwarde le concept courant comme amorce `initialContext` (terme, def, summary_id).
- **`VoiceTutorModal.tsx`** (nouveau) : wrapper thin sur `VoiceOverlay` qui force `agentType=\"knowledge_tutor\"`, sans `summary_id` requis. Si un `initialContext.conceptTerm` est fourni, le wrapper injecte un bloc `[CONTEXT]` via `sendUserMessage` juste après la connexion ConvAI — l'agent attaque ainsi directement le sujet.
- Extension des unions de types `agentType` dans `useVoiceChat.ts` et `VoiceOverlay.tsx` pour inclure `\"knowledge_tutor\"`.

Les deux points d'entrée partagent le même `VoiceTutorModal` ; le modal Tutor est rendu en sibling du popup (pas dans `AnimatePresence mode=\"wait\"`) pour ne pas démonter le mini-chat texte quand l'overlay voice s'ouvre.

## Décisions verrouillées (rappel)

- Agent backend `knowledge_tutor`, `requires_summary=False`, `plan_minimum=\"pro\"`
- Sidebar entry = global (pas de concept) ; popup button = avec concept comme amorce
- Pattern COMPANION : réutilisation de `VoiceOverlay` (380×600 floating) + `useVoiceChat`
- Web only V1 (mobile/extension hors scope)

## Notes d'implémentation

- Le spec mentionnait `canAccess(plan, \"companion_dialogue\", \"web\")` mais cette fonction n'existe pas dans `frontend/src/config/planPrivileges.ts`. J'ai utilisé le pattern standard du codebase : `isAdmin || PLAN_LIMITS[plan].voiceChatEnabled` (cf `useVoiceEnabled`, `AnalysisActionBar`, `History`, `DebatePage`).
- Le spec mentionnait `initial_context: { concept_term, summary_id? }` côté API ; le backend `/api/voice/session` n'expose pas ce champ aujourd'hui. Le pattern \"primer via `[CONTEXT]` block injecté après connexion\" est conforme à la note du spec (\"l'agent reçoit le concept comme amorce dans son `first_message_fr` ou via injection `[CONTEXT]` block\"). L'agent `knowledge_tutor` honorera ce bloc selon son system prompt.

## Fichiers modifiés

- **Nouveau** : `frontend/src/components/voice/VoiceTutorModal.tsx` (110 lignes)
- `frontend/src/components/voice/useVoiceChat.ts` — agentType union + `\"knowledge_tutor\"`
- `frontend/src/components/voice/VoiceOverlay.tsx` — agentType union + `\"knowledge_tutor\"`
- `frontend/src/components/layout/Sidebar.tsx` — `SidebarActionItem` (button-style nav item) + Tuteur Vocal item + state + modal render
- `frontend/src/components/Tutor/TutorMiniChat.tsx` — props `onOpenVoiceTutor` + `voiceTutorEnabled` + bouton header `Mic`
- `frontend/src/components/Tutor/Tutor.tsx` — `useVoiceEnabled` hook + state `voiceTutorOpen` + wiring + render `VoiceTutorModal` en sibling

## Test plan

- [x] `npm run typecheck` — aucune nouvelle erreur dans les fichiers modifiés (vérifié vs main, mêmes erreurs pre-existantes uniquement)
- [x] `npm test -- --run Sidebar Tutor` — Sidebar 7/7 + Tutor 27/27 passent (tests existants intacts)
- [x] `npx eslint <fichiers modifiés>` — VoiceTutorModal clean ; les autres fichiers ont les mêmes warnings/error pre-existants que sur main (zéro nouveau)
- [ ] QA manuelle Web : item sidebar ouvre le modal ; bouton popup ouvre le modal avec `[CONTEXT]` injecté ; gating Pro+ effectif ; admin bypass OK
- [ ] QA Free user : clic sidebar redirige vers `/upgrade`

## Refs

- Spec : `docs/superpowers/specs/2026-05-10-tuteur-refactor.md` (Axe D)
- Backend : PR #439 (knowledge_tutor agent)
- Popup refactor : PR #440 (text-only + windowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)