### PR TITLE
feat(tutor): adaptive memory snapshot for knowledge_tutor agent

### DIFF
--- a/backend/src/voice/agent_types.py
+++ b/backend/src/voice/agent_types.py
@@ -685,6 +685,7 @@ KNOWLEDGE_TUTOR = AgentConfig(
     system_prompt_fr=KNOWLEDGE_TUTOR_PROMPT_FR,
     system_prompt_en=KNOWLEDGE_TUTOR_PROMPT_EN,
     tools=[
+        "get_tutor_memory_snapshot",
         "get_user_history",
         "get_concept_keys",
         "search_history",

--- a/backend/src/voice/elevenlabs.py
+++ b/backend/src/voice/elevenlabs.py
@@ -714,10 +714,21 @@ def build_knowledge_tutor_tools_config(webhook_base_url: str, voice_session_id: 
     """Webhook-tool definitions for the KNOWLEDGE_TUTOR agent.
 
     Same auth pattern as COMPANION (Bearer = voice_session_id, body must echo
-    voice_session_id). The agent has 5 tools available: 4 history-aware DB
-    helpers + the shared web_search fallback (mounted at /tools/web-search,
-    declared by ElevenLabsClient.build_tools_config — re-exposed here so the
-    KNOWLEDGE_TUTOR can call it without going through the per-summary auth).
+    voice_session_id). The agent has 5 history-aware DB helpers + the shared
+    web_search fallback (mounted at /tools/web-search, declared by
+    ElevenLabsClient.build_tools_config — re-exposed here so the
+    KNOWLEDGE_TUTOR can call it without going through the per-summary auth):
+
+        1. get_tutor_memory_snapshot — adaptive mind-map. PRIMARY orientation
+           tool, called first at session start (replaces get_user_history +
+           get_concept_keys for the initial pivot).
+        2. get_user_history — last N analyses (richer per-item shape, includes
+           ``key_topics`` extracted from ``## ``-headings).
+        3. get_concept_keys — top concepts aggregated across history.
+        4. search_history — semantic search across summaries / flashcards /
+           quizzes / chats / transcripts.
+        5. get_summary_detail — full detail of one analysis to ground a
+           correction or quote a precise passage.
 
     Note: web_search is *not* re-declared here because the COMPANION agent
     already defines it at /tools/web-search-companion in some prods. To stay
@@ -750,6 +761,25 @@ def build_knowledge_tutor_tools_config(webhook_base_url: str, voice_session_id: 
     }
 
     return [
+        _tool(
+            name="get_tutor_memory_snapshot",
+            description=(
+                "Return an adaptive mind-map of the user's whole analysis history "
+                "(top categories, top concepts, and a slice of recent analyses with "
+                "their key topics). Compression scales automatically with the total "
+                "analysis count. CALL THIS FIRST at the start of every session to "
+                "orient yourself — replaces the legacy "
+                "get_concept_keys + get_user_history startup pair."
+            ),
+            path="/api/voice/tools/knowledge-tutor-memory",
+            body_schema={
+                "type": "object",
+                "properties": {
+                    "voice_session_id": voice_session_field,
+                },
+                "required": ["voice_session_id"],
+            },
+        ),
         _tool(
             name="get_user_history",
             description=(

--- a/backend/src/voice/knowledge_tutor_prompts.py
+++ b/backend/src/voice/knowledge_tutor_prompts.py
@@ -6,8 +6,9 @@ analyses du user (tous les concepts/idées rencontrés, pas une vidéo en partic
 Persona "sobre, vouvoiement adulte neutre, pas de gimmick" :
 - Méthode socratique : pose une question ouverte, écoute, corrige avec
   bienveillance, propose un sujet adjacent.
-- Doit appeler systématiquement get_concept_keys + get_user_history en début
-  de session pour orienter l'échange.
+- Doit appeler systématiquement get_tutor_memory_snapshot en début de session
+  pour orienter l'échange (adaptive memory : long / medium / short / ultra
+  selon le volume d'analyses).
 - Cadre : 15 min max.
 - Fallback web_search si concept non couvert par l'historique.
 
@@ -36,10 +37,16 @@ pour ancrer la réponse.
 Démarche socratique en quatre temps :
 
 1. **Orientation initiale** — DÈS LE DÉBUT de la session, appelez \
-SYSTÉMATIQUEMENT `get_concept_keys` (top concepts récents) puis \
-`get_user_history` (10 dernières analyses). Cela vous donne le terrain de jeu.
-2. **Question ouverte** — Choisissez un concept ou une idée parmi ceux remontés \
-et posez une question d'ouverture qui invite à l'explication libre \
+SYSTÉMATIQUEMENT `get_tutor_memory_snapshot`. Cette « carte mentale » \
+adaptive vous donne en un seul appel : le total d'analyses, les grandes \
+catégories, les top concepts agrégés, et un échantillon récent d'analyses \
+avec leurs `key_topics` (les grands axes extraits des sections principales \
+de chaque analyse). Plus le user a d'analyses, plus le snapshot est compressé \
+(`long` ≤ 10, `medium` 11-30, `short` 31-100, `ultra` > 100). Cela suffit pour \
+choisir un sujet de relance — n'appelez `get_user_history` ou `get_concept_keys` \
+en complément que si le snapshot ne couvre pas une partie précise qui vous intéresse.
+2. **Question ouverte** — Choisissez un concept ou un `key_topic` parmi ceux \
+remontés et posez une question d'ouverture qui invite à l'explication libre \
 (« Pouvez-vous me résumer ce que vous avez retenu de X ? »).
 3. **Écoute + corrections bienveillantes** — Évaluez la réponse \
 (juste / partielle / approximative). Corrigez sans condescendance, donnez \
@@ -50,11 +57,18 @@ concept proche dans son historique pour étendre le lien.
 
 # Tools disponibles
 
+- `get_tutor_memory_snapshot()` : carte mentale adaptive du parcours \
+complet. PREMIER appel obligatoire. Retourne `{total_analyses, level, \
+top_categories[], top_concepts[], recent_analyses[]}`. Chaque analyse \
+récente expose ses `key_topics` (grands axes — sections principales \
+extraites du markdown) et ses `key_concepts` ([[markers]]). Sur ces axes \
+vous appuyez vos questions de relance.
 - `get_user_history(limit, days_back)` : derniers résumés du user (titres, \
-plateforme, date, concepts clés). À appeler en début de session pour \
-connaître son parcours récent.
+plateforme, date, key_topics, concepts clés). À appeler en complément du \
+snapshot si vous voulez sortir du sous-ensemble des `recent_analyses` ou \
+remonter plus loin dans le temps.
 - `get_concept_keys(limit)` : top concepts/keywords agrégés sur l'historique. \
-Source primaire pour proposer un sujet de révision.
+Complément quand vous voulez plus de concepts que les 20 du snapshot.
 - `search_history(query, top_k)` : recherche sémantique cross-source dans \
 l'historique du user (résumés, flashcards, transcripts). À appeler quand \
 l'utilisateur évoque un sujet précis et que vous voulez retrouver les \
@@ -107,11 +121,17 @@ single video, but their whole learning path.
 Socratic flow in four beats:
 
 1. **Initial orientation** — AT THE START of the session, ALWAYS call \
-`get_concept_keys` (top recent concepts) then `get_user_history` (last 10 \
-analyses). This gives you the playing field.
-2. **Open question** — Pick a concept or an idea from what surfaced and \
-ask an opening question that invites a free explanation \
-("Can you summarize what stuck with you from X?").
+`get_tutor_memory_snapshot`. This adaptive "mind map" gives you in a single \
+call: total analysis count, top categories, top aggregated concepts, and a \
+recent sample of analyses with their `key_topics` (the macro-axes extracted \
+from each analysis' section headings). Compression scales with the analysis \
+count (`long` ≤ 10, `medium` 11-30, `short` 31-100, `ultra` > 100). That is \
+enough to pick a revision topic — only call `get_user_history` or \
+`get_concept_keys` afterwards if the snapshot doesn't cover a precise area \
+you want to explore.
+2. **Open question** — Pick a concept or a `key_topic` from what surfaced \
+and ask an opening question that invites a free explanation ("Can you \
+summarize what stuck with you from X?").
 3. **Listen + gentle corrections** — Evaluate the answer (right / \
 partial / fuzzy). Correct without being condescending, give the right \
 angle, cite the source when possible ("According to your analysis of Y, the \
@@ -121,11 +141,19 @@ close concept from their history to broaden the link.
 
 # Available tools
 
+- `get_tutor_memory_snapshot()`: adaptive mind-map of the user's entire \
+learning path. MANDATORY first call. Returns `{total_analyses, level, \
+top_categories[], top_concepts[], recent_analyses[]}`. Each recent analysis \
+exposes its `key_topics` (macro-axes — main headings extracted from the \
+markdown) and `key_concepts` ([[markers]]). Build your follow-up questions \
+on those axes.
 - `get_user_history(limit, days_back)`: user's most recent summaries \
-(title, platform, date, key concepts). Call at session start to know \
-their recent path.
+(title, platform, date, key_topics, key concepts). Call in complement to \
+the snapshot when you want to step outside the snapshot's recent slice or \
+reach further back in time.
 - `get_concept_keys(limit)`: top concepts/keywords aggregated across \
-history. Primary source for proposing a revision topic.
+history. Complement when you need more than the 20 concepts surfaced in \
+the snapshot.
 - `search_history(query, top_k)`: cross-source semantic search across the \
 user's history (summaries, flashcards, transcripts). Call when the user \
 mentions a specific subject and you want to find the relevant analyses.

--- a/backend/src/voice/knowledge_tutor_tools.py
+++ b/backend/src/voice/knowledge_tutor_tools.py
@@ -1,13 +1,18 @@
 """Backend tools exposed to the KNOWLEDGE_TUTOR voice agent.
 
 The KNOWLEDGE_TUTOR agent reasons over the *user's whole history* of video
-analyses (not a single video). These four async tools let it pull just enough
+analyses (not a single video). These async tools let it pull just enough
 context per turn:
 
-    - get_user_history    : last N analyses (title / platform / date / concepts)
-    - get_concept_keys    : top concepts/keywords aggregated across history
-    - search_history      : semantic search over the user's corpus (V1, PR #292)
-    - get_summary_detail  : full details of a precise analysis
+    - get_tutor_memory_snapshot : adaptive mind-map of the user's whole path
+                                  (compression scales with analysis count).
+                                  PRIMARY entry point — call this FIRST.
+    - get_user_history          : last N analyses (title / platform / date /
+                                  key_topics / concepts).
+    - get_concept_keys          : top concepts/keywords aggregated across history.
+    - search_history            : semantic search over the user's corpus
+                                  (V1, PR #292).
+    - get_summary_detail        : full details of a precise analysis.
 
 All tools take a `user: User` parameter so they cannot leak across users — they
 are bound to the session's authenticated user, never to a free-text user_id.
@@ -36,6 +41,39 @@ logger = logging.getLogger(__name__)
 # Same regex as history_router.py — matches Obsidian-style [[concept]] or
 # [[concept|alias]] markers embedded in summary_content by Mistral.
 _CONCEPT_PATTERN = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+?)?\]\]")
+
+# Level-2 markdown heading: ``## Some title``. Used to extract the macro-axes
+# (sections) of an analysis as "key_topics" for the tuteur memory snapshot.
+_HEADING_PATTERN = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _summary_key_topics(summary: Summary, limit: int = 5) -> list[str]:
+    """Extract the macro-axes (``## ``-level headings) of a Summary.
+
+    Returns up to ``limit`` strings, normalised (stripped + leading
+    decorations dropped) and deduplicated case-insensitively. Empty when the
+    summary has no markdown structure.
+    """
+    if limit <= 0 or not summary.summary_content:
+        return []
+
+    seen: set[str] = set()
+    topics: list[str] = []
+    for match in _HEADING_PATTERN.findall(summary.summary_content):
+        topic = match.strip().lstrip("#").strip()
+        if not topic:
+            continue
+        topic = topic.lstrip("-*0123456789. ").strip()
+        if not topic or len(topic) < 2:
+            continue
+        tl = topic.lower()
+        if tl in seen:
+            continue
+        seen.add(tl)
+        topics.append(topic)
+        if len(topics) >= limit:
+            break
+    return topics
 
 
 def _summary_concept_keys(summary: Summary, limit: int = 5) -> list[str]:
@@ -127,6 +165,7 @@ async def get_user_history(
                 "channel": s.video_channel or "",
                 "category": s.category or "",
                 "created_at": s.created_at.isoformat() if s.created_at else None,
+                "key_topics": _summary_key_topics(s, limit=5),
                 "key_concepts": _summary_concept_keys(s, limit=5),
             }
         )
@@ -357,6 +396,52 @@ async def get_summary_detail(
         "reliability_score": summary.reliability_score,
         "key_concepts": _summary_concept_keys(summary, limit=10),
     }
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tool 5 : get_tutor_memory_snapshot (adaptive mind-map)
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def get_tutor_memory_snapshot(
+    user: User,
+    db: AsyncSession,
+    redis: Optional[Any] = None,
+) -> dict[str, Any]:
+    """Return an adaptive carte-mentale of the user's whole analysis history.
+
+    Thin wrapper around :func:`voice.tutor_memory.build_tutor_memory`. This
+    helper is the primary orientation tool for the KNOWLEDGE_TUTOR agent —
+    one call replaces the legacy "get_concept_keys + get_user_history" startup
+    sequence.
+
+    See :func:`voice.tutor_memory.build_tutor_memory` for the result shape and
+    the four compression levels (``long`` / ``medium`` / ``short`` / ``ultra``).
+    """
+    logger.info(
+        "knowledge_tutor.get_tutor_memory_snapshot",
+        extra={"user_id": user.id},
+    )
+
+    # Local import avoids circular dependencies at module import time
+    # (tutor_memory.py lives in the same package).
+    from voice.tutor_memory import build_tutor_memory
+
+    try:
+        return await build_tutor_memory(user=user, db=db, redis=redis)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("get_tutor_memory_snapshot failed: %s", exc, exc_info=True)
+        # Degrade gracefully — the agent will see an empty snapshot and fall
+        # back on the older history/concepts tools.
+        return {
+            "total_analyses": 0,
+            "level": "long",
+            "top_categories": [],
+            "top_concepts": [],
+            "recent_analyses": [],
+            "snapshot_at": None,
+            "error": "snapshot_failed",
+        }
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/backend/src/voice/router.py
+++ b/backend/src/voice/router.py
@@ -3389,6 +3389,29 @@ async def tool_knowledge_tutor_summary(request: Request, db: AsyncSession = Depe
     return {"result": detail}
 
 
+@router.post("/tools/knowledge-tutor-memory")
+async def tool_knowledge_tutor_memory(request: Request, db: AsyncSession = Depends(get_session)):
+    """KNOWLEDGE_TUTOR webhook: adaptive memory snapshot (mind-map) of the user.
+
+    Primary orientation tool — replaces the legacy "get_user_history +
+    get_concept_keys" startup pair when the agent picks up on a session.
+    Compression scales with the user's total analysis count (long / medium /
+    short / ultra). Result is cached server-side (30 min TTL).
+    """
+    from voice.knowledge_tutor_tools import get_tutor_memory_snapshot
+
+    voice_session, _body = await verify_companion_tool_request(request, db)
+    user = await _load_voice_session_user(voice_session, db)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "user_not_found", "message": "User not found."},
+        )
+
+    snapshot = await get_tutor_memory_snapshot(user=user, db=db)
+    return {"result": snapshot}
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # POST /tools/debate-* — Debate moderator agent tools (public, bearer=debate_id)
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/src/voice/tutor_memory.py
+++ b/backend/src/voice/tutor_memory.py
@@ -1,0 +1,409 @@
+"""Adaptive memory snapshot of the user's analysis history for KNOWLEDGE_TUTOR.
+
+The KNOWLEDGE_TUTOR voice agent needs a *carte mentale* (mind map) of the
+user's whole learning path before it can pick a revision topic. The existing
+helpers (``get_user_history`` + ``get_concept_keys``) return raw lists, but when
+the user owns 30+ analyses the agent gets overwhelmed and fails to pick a
+direction.
+
+This module builds a **compressed snapshot** whose shape depends on the total
+analysis count:
+
+    ≤ 10  → long    : full per-analysis detail (title + 3-5 key_topics + concepts)
+    11-30 → medium  : per-analysis with fewer key_topics (1-2 per item)
+    31-100 → short  : aggregated (top categories + top concepts + 10 recent items)
+    > 100 → ultra   : aggregated + 5 most recent items only
+
+The "key_topics" of each analysis are extracted directly from the markdown
+``## `` section headings in ``summary.summary_content`` — no extra Mistral
+call required for V1.
+
+Result is cached for 30 minutes in Redis under ``tutor:memory:{user_id}`` so
+repeated calls during the same voice session reuse the same snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import Summary, User
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Constants — compression levels
+# ─────────────────────────────────────────────────────────────────────
+
+LEVEL_LONG = "long"
+LEVEL_MEDIUM = "medium"
+LEVEL_SHORT = "short"
+LEVEL_ULTRA = "ultra"
+
+# Cap on the number of summaries we scan when aggregating categories / concepts.
+# Beyond this the snapshot becomes too costly without adding signal — the agent
+# only needs the dominant themes, not exhaustive coverage.
+_MAX_SCAN_ROWS = 200
+
+# Cache TTL (seconds). 30 min is enough to cover the longest voice session
+# (15 min) plus the user resuming a session a few minutes later.
+CACHE_TTL_SECONDS = 30 * 60
+
+# Same regex as knowledge_tutor_tools.py — Obsidian-style [[concept]] markers.
+_CONCEPT_PATTERN = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+?)?\]\]")
+
+# Markdown heading pattern: only ``## `` (level-2) at the start of a line.
+# Avoids capturing ``### `` (level-3) — too noisy and not what the agent needs
+# as macro-axes.
+_HEADING_PATTERN = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers — extraction
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _extract_key_topics(content: Optional[str], limit: int) -> list[str]:
+    """Extract macro-axes (``## `` section headings) from a markdown summary.
+
+    Heading text is stripped, deduplicated case-insensitively, and capped at
+    ``limit``. Returns an empty list when ``content`` is empty.
+
+    Examples:
+        >>> _extract_key_topics("## Résumé\\nblah\\n## Points clés\\nfoo", 5)
+        ['Résumé', 'Points clés']
+    """
+    if not content or not content.strip() or limit <= 0:
+        return []
+
+    seen: set[str] = set()
+    topics: list[str] = []
+    for match in _HEADING_PATTERN.findall(content):
+        topic = match.strip().lstrip("#").strip()
+        if not topic:
+            continue
+        # Drop leading bullets / decorations like "- " or "1. " that sometimes
+        # creep into markdown headings.
+        topic = topic.lstrip("-*0123456789. ").strip()
+        if not topic or len(topic) < 2:
+            continue
+        tl = topic.lower()
+        if tl in seen:
+            continue
+        seen.add(tl)
+        topics.append(topic)
+        if len(topics) >= limit:
+            break
+    return topics
+
+
+def _extract_concepts(content: Optional[str], tags: Optional[str], limit: int) -> list[str]:
+    """Extract ``[[concept]]`` markers + tag fallback (same logic as
+    ``knowledge_tutor_tools._summary_concept_keys``). Returned terms are
+    deduplicated case-insensitively and capped at ``limit``."""
+    if limit <= 0:
+        return []
+    seen: set[str] = set()
+    keys: list[str] = []
+
+    if content:
+        for match in _CONCEPT_PATTERN.findall(content):
+            term = match.strip()
+            if not term or len(term) < 2:
+                continue
+            tl = term.lower()
+            if tl in seen:
+                continue
+            seen.add(tl)
+            keys.append(term)
+            if len(keys) >= limit:
+                return keys
+
+    if tags:
+        for raw in tags.split(","):
+            term = raw.strip()
+            if not term or len(term) < 2:
+                continue
+            tl = term.lower()
+            if tl in seen:
+                continue
+            seen.add(tl)
+            keys.append(term)
+            if len(keys) >= limit:
+                break
+
+    return keys
+
+
+def _compression_level(count: int) -> str:
+    """Map a total analysis count to a compression level."""
+    if count <= 10:
+        return LEVEL_LONG
+    if count <= 30:
+        return LEVEL_MEDIUM
+    if count <= 100:
+        return LEVEL_SHORT
+    return LEVEL_ULTRA
+
+
+def _topics_per_item(level: str) -> int:
+    """Max number of ``key_topics`` to surface per analysis at this level."""
+    if level == LEVEL_LONG:
+        return 5
+    if level == LEVEL_MEDIUM:
+        return 2
+    # short / ultra: aggregated view, recent items only carry a couple of axes.
+    return 2
+
+
+def _concepts_per_item(level: str) -> int:
+    """Max number of ``key_concepts`` to surface per analysis at this level."""
+    if level == LEVEL_LONG:
+        return 5
+    if level == LEVEL_MEDIUM:
+        return 3
+    return 3
+
+
+def _recent_count(level: str) -> int:
+    """How many of the most recent analyses to surface verbatim."""
+    if level == LEVEL_LONG:
+        # All of them (up to 10 — that's the LEVEL_LONG ceiling).
+        return 10
+    if level == LEVEL_MEDIUM:
+        # All of them (up to 30 — that's the LEVEL_MEDIUM ceiling).
+        return 30
+    if level == LEVEL_SHORT:
+        return 10
+    return 5  # LEVEL_ULTRA
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Cache helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _cache_key(user_id: int) -> str:
+    return f"tutor:memory:{user_id}"
+
+
+async def _read_from_redis(redis, key: str) -> Optional[dict[str, Any]]:
+    """Fetch a JSON payload from a redis client. Returns None on miss / error."""
+    if redis is None:
+        return None
+    try:
+        raw = await redis.get(key)
+        if raw is None:
+            return None
+        # decode_responses=True is the project default (core.cache) → strings
+        # come back as str. Be defensive for raw clients passed by tests.
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("tutor_memory: redis GET failed: %s", exc)
+        return None
+
+
+async def _write_to_redis(redis, key: str, payload: dict[str, Any]) -> None:
+    """Set the payload in redis with TTL. Best-effort — failures are swallowed."""
+    if redis is None:
+        return
+    try:
+        serialized = json.dumps(payload, ensure_ascii=False, default=str)
+        # redis.asyncio exposes setex(name, time, value).
+        await redis.setex(key, CACHE_TTL_SECONDS, serialized)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("tutor_memory: redis SETEX failed: %s", exc)
+
+
+async def _read_from_cache_service(key: str) -> Optional[dict[str, Any]]:
+    """Fallback cache read via the project-wide ``cache_service`` singleton.
+
+    Used when no explicit ``redis`` client is passed — keeps the snapshot warm
+    even in dev (in-memory cachetools) or when the route doesn't have a
+    request-scoped redis client.
+    """
+    try:
+        from core.cache import cache_service
+
+        return await cache_service.get(key)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("tutor_memory: cache_service GET failed: %s", exc)
+        return None
+
+
+async def _write_to_cache_service(key: str, payload: dict[str, Any]) -> None:
+    """Best-effort write via the project-wide ``cache_service`` singleton."""
+    try:
+        from core.cache import cache_service
+
+        await cache_service.set(key, payload, ttl=CACHE_TTL_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("tutor_memory: cache_service SET failed: %s", exc)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Main entry point
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def build_tutor_memory(
+    user: User,
+    db: AsyncSession,
+    redis: Optional[Any] = None,
+) -> dict[str, Any]:
+    """Build an adaptive memory snapshot of the user's analysis history.
+
+    Compression level adapts to total analysis count:
+        ≤ 10   → ``long``   per-analysis: title + up to 5 key_topics + concepts
+        11-30  → ``medium`` per-analysis: title + up to 2 key_topics + concepts
+        31-100 → ``short``  top 10 categories + top 20 concepts + 10 recent items
+        > 100  → ``ultra``  same as ``short`` but only 5 most recent items
+
+    Args:
+        user: the authenticated User (snapshot is strictly scoped to this user).
+        db: async DB session.
+        redis: optional explicit redis client. When None, falls back to the
+            project ``cache_service`` singleton (Redis when prod, in-memory
+            elsewhere).
+
+    Returns:
+        A JSON-friendly dict with the shape::
+
+            {
+                "total_analyses": int,
+                "level": "long" | "medium" | "short" | "ultra",
+                "top_categories": [{"category": str, "count": int}, ...],
+                "top_concepts":   [{"term": str, "count": int,
+                                    "latest_summary_id": int}, ...],
+                "recent_analyses": [
+                    {
+                        "id": int,
+                        "title": str,
+                        "platform": str,
+                        "created_at": iso-str | None,
+                        "category": str,
+                        "key_topics": [str, ...],
+                        "key_concepts": [str, ...],
+                    },
+                    ...
+                ],
+                "snapshot_at": iso-str,
+            }
+    """
+    cache_key = _cache_key(user.id)
+
+    # ── Cache hit? ───────────────────────────────────────────────────
+    cached: Optional[dict[str, Any]] = None
+    if redis is not None:
+        cached = await _read_from_redis(redis, cache_key)
+    if cached is None:
+        cached = await _read_from_cache_service(cache_key)
+    if cached is not None:
+        logger.info(
+            "tutor_memory.cache_hit",
+            extra={"user_id": user.id, "level": cached.get("level")},
+        )
+        return cached
+
+    # ── Cache miss → rebuild ─────────────────────────────────────────
+    logger.info("tutor_memory.cache_miss", extra={"user_id": user.id})
+
+    try:
+        stmt = (
+            select(Summary)
+            .where(Summary.user_id == user.id)
+            .order_by(Summary.created_at.desc())
+            .limit(_MAX_SCAN_ROWS)
+        )
+        result = await db.execute(stmt)
+        rows = list(result.scalars().all())
+    except Exception as exc:  # noqa: BLE001
+        logger.error("tutor_memory: DB select failed: %s", exc, exc_info=True)
+        rows = []
+
+    total = len(rows)
+    level = _compression_level(total)
+    topics_limit = _topics_per_item(level)
+    concepts_limit = _concepts_per_item(level)
+    recent_n = _recent_count(level)
+
+    # ── Aggregate top categories + top concepts across the scan ───────
+    category_counts: dict[str, int] = {}
+    # term lower → {"term": original_case, "count": int, "latest_summary_id": int}
+    concept_index: dict[str, dict[str, Any]] = {}
+
+    for s in rows:
+        cat = (s.category or "").strip()
+        if cat:
+            category_counts[cat] = category_counts.get(cat, 0) + 1
+
+        # Concept terms from [[markers]] + tag fallback, scanned with a wide
+        # per-row cap (10) so the global aggregate has good coverage.
+        for term in _extract_concepts(s.summary_content, s.tags, limit=10):
+            tl = term.lower()
+            entry = concept_index.get(tl)
+            if entry is None:
+                concept_index[tl] = {
+                    "term": term,
+                    "count": 1,
+                    "latest_summary_id": s.id,
+                }
+            else:
+                entry["count"] += 1
+                # rows are ordered DESC → first occurrence has the latest id.
+
+    top_categories = sorted(
+        ({"category": k, "count": v} for k, v in category_counts.items()),
+        key=lambda x: x["count"],
+        reverse=True,
+    )[:10]
+
+    top_concepts_limit = 20 if level in (LEVEL_SHORT, LEVEL_ULTRA) else 20
+    top_concepts = sorted(
+        concept_index.values(),
+        key=lambda x: x["count"],
+        reverse=True,
+    )[:top_concepts_limit]
+
+    # ── Recent analyses verbatim slice ────────────────────────────────
+    recent_rows = rows[:recent_n]
+    recent_analyses: list[dict[str, Any]] = []
+    for s in recent_rows:
+        recent_analyses.append(
+            {
+                "id": s.id,
+                "title": s.video_title or "",
+                "platform": s.platform or "youtube",
+                "created_at": s.created_at.isoformat() if s.created_at else None,
+                "category": s.category or "",
+                "key_topics": _extract_key_topics(s.summary_content, topics_limit),
+                "key_concepts": _extract_concepts(
+                    s.summary_content, s.tags, limit=concepts_limit
+                ),
+            }
+        )
+
+    snapshot: dict[str, Any] = {
+        "total_analyses": total,
+        "level": level,
+        "top_categories": top_categories,
+        "top_concepts": top_concepts,
+        "recent_analyses": recent_analyses,
+        "snapshot_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # ── Cache write (best-effort) ────────────────────────────────────
+    if redis is not None:
+        await _write_to_redis(redis, cache_key, snapshot)
+    await _write_to_cache_service(cache_key, snapshot)
+
+    return snapshot

--- a/backend/tests/voice/test_knowledge_tutor.py
+++ b/backend/tests/voice/test_knowledge_tutor.py
@@ -51,12 +51,20 @@ def test_knowledge_tutor_tools_listed():
     cfg = get_agent_config("knowledge_tutor")
     tool_names = set(cfg.tools)
     assert {
+        "get_tutor_memory_snapshot",
         "get_user_history",
         "get_concept_keys",
         "search_history",
         "get_summary_detail",
         "web_search",
     }.issubset(tool_names)
+
+
+def test_knowledge_tutor_memory_snapshot_is_first_tool():
+    """The adaptive snapshot must be the agent's primary orientation tool —
+    the prompt instructs the model to call it FIRST at session start."""
+    cfg = get_agent_config("knowledge_tutor")
+    assert cfg.tools[0] == "get_tutor_memory_snapshot"
 
 
 def test_knowledge_tutor_in_list_agent_types():
@@ -68,16 +76,18 @@ def test_knowledge_tutor_in_list_agent_types():
 
 
 def test_knowledge_tutor_prompts_socratic():
-    """System prompts must mention the four-step socratic flow + the two
-    mandatory startup tools (get_concept_keys, get_user_history)."""
+    """System prompts must mention the four-step socratic flow + the mandatory
+    startup tool (get_tutor_memory_snapshot) + the legacy fallback tools."""
     cfg = get_agent_config("knowledge_tutor")
     # FR
+    assert "get_tutor_memory_snapshot" in cfg.system_prompt_fr
     assert "get_concept_keys" in cfg.system_prompt_fr
     assert "get_user_history" in cfg.system_prompt_fr
     assert "search_history" in cfg.system_prompt_fr
     assert "get_summary_detail" in cfg.system_prompt_fr
     assert "Socratique" in cfg.system_prompt_fr or "socratique" in cfg.system_prompt_fr
     # EN
+    assert "get_tutor_memory_snapshot" in cfg.system_prompt_en
     assert "get_concept_keys" in cfg.system_prompt_en
     assert "get_user_history" in cfg.system_prompt_en
     assert "Socratic" in cfg.system_prompt_en or "socratic" in cfg.system_prompt_en
@@ -95,6 +105,7 @@ def test_build_knowledge_tutor_tools_config_shape():
     )
     names = [t["name"] for t in tools]
     assert names == [
+        "get_tutor_memory_snapshot",
         "get_user_history",
         "get_concept_keys",
         "search_history",
@@ -110,6 +121,18 @@ def test_build_knowledge_tutor_tools_config_shape():
         assert body["type"] == "object"
         assert "voice_session_id" in body["properties"]
         assert "voice_session_id" in body["required"]
+
+
+def test_memory_snapshot_tool_has_no_extra_required_fields():
+    """The snapshot tool should only require voice_session_id (no params)."""
+    tools = build_knowledge_tutor_tools_config(
+        webhook_base_url="https://api.example.com",
+        voice_session_id="vs_abc",
+    )
+    snap = next(t for t in tools if t["name"] == "get_tutor_memory_snapshot")
+    body = snap["api_schema"]["request_body_schema"]
+    assert body["required"] == ["voice_session_id"]
+    assert snap["api_schema"]["url"].endswith("/knowledge-tutor-memory")
 
 
 def test_search_history_tool_requires_query():
@@ -218,15 +241,27 @@ async def test_get_user_history_returns_recent_summaries(
     items = await get_user_history(user=kt_user, db=async_db_session, limit=10)
     assert len(items) == 3
     for item in items:
-        assert {"id", "title", "video_id", "platform", "channel", "category", "created_at", "key_concepts"}.issubset(
-            item.keys()
-        )
+        assert {
+            "id",
+            "title",
+            "video_id",
+            "platform",
+            "channel",
+            "category",
+            "created_at",
+            "key_topics",
+            "key_concepts",
+        }.issubset(item.keys())
     titles = {item["title"] for item in items}
     assert "L'éthique de l'IA générative" in titles
     assert "Introduction aux LLM" in titles
     # First summary has Obsidian-style concepts → should appear in key_concepts.
     eth = next(item for item in items if item["video_id"] == "vid_001")
     assert "alignment" in eth["key_concepts"]
+    # And its markdown headings should surface as key_topics.
+    topics_lower = [t.lower() for t in eth["key_topics"]]
+    assert "résumé" in topics_lower or "resume" in topics_lower
+    assert any("points clés" in t or "points cles" in t for t in topics_lower)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/voice/test_tutor_memory.py
+++ b/backend/tests/voice/test_tutor_memory.py
@@ -1,0 +1,510 @@
+"""Tests for the adaptive Tuteur memory snapshot (V2 / 2026-05-11).
+
+Coverage:
+    - Four compression levels driven by analysis count (long/medium/short/ultra)
+    - `key_topics` extraction from markdown ``## `` headings
+    - `top_concepts` aggregation from `[[concept]]` markers across history
+    - `top_categories` aggregation
+    - Recent slice capped per level (5 items at ultra)
+    - Redis cache hit/miss path
+    - Strict user isolation (no cross-user leak)
+
+Tests use the local SQLite in-memory async DB provided by conftest.py
+(``async_db_session`` + ``kt_user`` style fixtures).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import Summary, User
+from voice.tutor_memory import (
+    LEVEL_LONG,
+    LEVEL_MEDIUM,
+    LEVEL_SHORT,
+    LEVEL_ULTRA,
+    _cache_key,
+    _compression_level,
+    _extract_key_topics,
+    build_tutor_memory,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _isolate_cache_service():
+    """Reset the project-wide ``cache_service`` between tests.
+
+    ``cache_service`` is a process-wide singleton; without isolation a snapshot
+    written by test N leaks into test N+1 and we get cache_hit false positives.
+    The autouse fixture clears the in-memory backend before each test runs.
+    """
+    try:
+        from core.cache import cache_service
+
+        backend = cache_service.backend
+        # In-memory backend stores its data in `_cache` + `_expiry`. We reach
+        # into the internal state because the public API has no flush helper.
+        if hasattr(backend, "_cache"):
+            backend._cache.clear()
+        if hasattr(backend, "_expiry"):
+            backend._expiry.clear()
+    except Exception:  # pragma: no cover - defensive
+        pass
+    yield
+
+
+@pytest_asyncio.fixture
+async def tutor_user(async_db_session: AsyncSession) -> User:
+    user = User(
+        username="tutor_mem",
+        email="tutor_mem@test.fr",
+        password_hash="x",
+        plan="pro",
+        email_verified=True,
+    )
+    async_db_session.add(user)
+    await async_db_session.commit()
+    await async_db_session.refresh(user)
+    return user
+
+
+def _summary(
+    user_id: int,
+    idx: int,
+    *,
+    category: str = "ai",
+    concepts: list[str] | None = None,
+    sections: list[str] | None = None,
+    tags: str | None = None,
+) -> Summary:
+    """Build an in-memory Summary with predictable content for tests."""
+    if sections is None:
+        sections = ["Résumé", "Points clés", "Conclusion"]
+    if concepts is None:
+        concepts = []
+
+    content_parts: list[str] = []
+    for s in sections:
+        content_parts.append(f"## {s}\nSection {s} body content.\n")
+    if concepts:
+        content_parts.append(
+            "Mentions : " + ", ".join(f"[[{c}]]" for c in concepts) + ".\n"
+        )
+
+    return Summary(
+        user_id=user_id,
+        video_id=f"vid_{idx:03d}",
+        video_title=f"Analyse #{idx}",
+        video_channel="Test Channel",
+        platform="youtube",
+        lang="fr",
+        category=category,
+        summary_content="\n".join(content_parts),
+        tags=tags,
+    )
+
+
+async def _persist_n_summaries(
+    db: AsyncSession,
+    user: User,
+    n: int,
+    *,
+    categories: list[str] | None = None,
+    shared_concepts: list[str] | None = None,
+) -> list[Summary]:
+    """Create n summaries owned by ``user`` and persist them."""
+    rows: list[Summary] = []
+    cats = categories or ["ai", "science", "philo"]
+    shared = shared_concepts or ["alignment", "transformer"]
+    for i in range(n):
+        rows.append(
+            _summary(
+                user.id,
+                idx=i,
+                category=cats[i % len(cats)],
+                concepts=[shared[0]] if i % 2 == 0 else [shared[1]],
+                sections=["Résumé", f"Axe {i}", "Conclusion"],
+                tags="t1, t2",
+            )
+        )
+    for r in rows:
+        db.add(r)
+    await db.commit()
+    for r in rows:
+        await db.refresh(r)
+    return rows
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Compression levels
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "count,expected",
+    [
+        (0, LEVEL_LONG),
+        (1, LEVEL_LONG),
+        (10, LEVEL_LONG),
+        (11, LEVEL_MEDIUM),
+        (30, LEVEL_MEDIUM),
+        (31, LEVEL_SHORT),
+        (100, LEVEL_SHORT),
+        (101, LEVEL_ULTRA),
+        (150, LEVEL_ULTRA),
+        (500, LEVEL_ULTRA),
+    ],
+)
+def test_compression_level_thresholds(count: int, expected: str):
+    assert _compression_level(count) == expected
+
+
+@pytest.mark.asyncio
+async def test_snapshot_long_level_with_5_analyses(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    await _persist_n_summaries(async_db_session, tutor_user, 5)
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    assert snap["total_analyses"] == 5
+    assert snap["level"] == LEVEL_LONG
+    assert len(snap["recent_analyses"]) == 5
+    # Each recent item must carry key_topics (since sections exist).
+    for item in snap["recent_analyses"]:
+        assert "key_topics" in item
+        assert isinstance(item["key_topics"], list)
+        # Sections "Résumé", "Axe N", "Conclusion" → at least one non-empty.
+        assert len(item["key_topics"]) >= 1
+        assert "key_concepts" in item
+    # Categories aggregated.
+    assert snap["top_categories"]
+    # Concepts aggregated from [[alignment]] / [[transformer]] markers.
+    concept_terms = {c["term"].lower() for c in snap["top_concepts"]}
+    assert {"alignment", "transformer"}.issubset(concept_terms)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_medium_level_with_25_analyses(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    await _persist_n_summaries(async_db_session, tutor_user, 25)
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    assert snap["total_analyses"] == 25
+    assert snap["level"] == LEVEL_MEDIUM
+    # At medium level the recent slice covers all 25 items (ceiling = 30).
+    assert len(snap["recent_analyses"]) == 25
+    # Each item only carries 1-2 key_topics at medium (cap = 2).
+    for item in snap["recent_analyses"]:
+        assert len(item["key_topics"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_snapshot_short_level_with_60_analyses(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    await _persist_n_summaries(async_db_session, tutor_user, 60)
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    assert snap["total_analyses"] == 60
+    assert snap["level"] == LEVEL_SHORT
+    # At short level we cap the recent slice to 10.
+    assert len(snap["recent_analyses"]) == 10
+    # Categories surfaced.
+    assert snap["top_categories"]
+    # Each item key_topics capped at 2.
+    for item in snap["recent_analyses"]:
+        assert len(item["key_topics"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_snapshot_ultra_level_with_150_analyses(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    # We only scan up to 200 rows (MAX_SCAN). For total_analyses we expose
+    # whatever the scan returned — for 150 that's still 150.
+    await _persist_n_summaries(async_db_session, tutor_user, 150)
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    assert snap["total_analyses"] == 150
+    assert snap["level"] == LEVEL_ULTRA
+    # At ultra level we cap recent_analyses to 5.
+    assert len(snap["recent_analyses"]) == 5
+
+
+# ─────────────────────────────────────────────────────────────────────
+# key_topics extraction
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_extract_key_topics_from_markdown():
+    content = (
+        "## Résumé\nblah\n"
+        "## Points clés\n"
+        "- point un\n"
+        "## Analyse critique\nmore\n"
+        "### Sous-section ignored\n"
+        "## Conclusion\nfin\n"
+    )
+    topics = _extract_key_topics(content, limit=10)
+    # Level-2 headings only.
+    assert topics == ["Résumé", "Points clés", "Analyse critique", "Conclusion"]
+
+
+def test_extract_key_topics_respects_limit():
+    content = (
+        "## Alpha section\nx\n"
+        "## Beta section\ny\n"
+        "## Gamma section\nz\n"
+        "## Delta section\nw\n"
+    )
+    topics = _extract_key_topics(content, limit=2)
+    assert topics == ["Alpha section", "Beta section"]
+
+
+def test_extract_key_topics_dedup_case_insensitive():
+    content = "## Sujet\nfirst\n## sujet\nduplicate\n## SUJET\nstill dup\n## Autre\nz\n"
+    topics = _extract_key_topics(content, limit=10)
+    # "Sujet" deduplicated despite case variations.
+    assert len(topics) == 2
+    assert topics[0].lower() == "sujet"
+    assert topics[1] == "Autre"
+
+
+def test_extract_key_topics_handles_empty_or_zero():
+    assert _extract_key_topics(None, limit=5) == []
+    assert _extract_key_topics("", limit=5) == []
+    assert _extract_key_topics("## Title", limit=0) == []
+    assert _extract_key_topics("No headings here", limit=5) == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Concept aggregation
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_top_concepts_aggregates_repeated_markers(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    """`[[alignment]]` appearing in 4 different summaries should rank above
+    `[[gradient descent]]` appearing only in 1."""
+    rows = [
+        _summary(tutor_user.id, idx=1, concepts=["alignment", "rlhf"]),
+        _summary(tutor_user.id, idx=2, concepts=["alignment"]),
+        _summary(tutor_user.id, idx=3, concepts=["alignment", "rlhf"]),
+        _summary(tutor_user.id, idx=4, concepts=["alignment"]),
+        _summary(tutor_user.id, idx=5, concepts=["gradient descent"]),
+    ]
+    for r in rows:
+        async_db_session.add(r)
+    await async_db_session.commit()
+
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    by_term = {c["term"].lower(): c for c in snap["top_concepts"]}
+    assert by_term["alignment"]["count"] == 4
+    assert by_term["rlhf"]["count"] == 2
+    assert by_term["gradient descent"]["count"] == 1
+    # alignment should rank first.
+    assert snap["top_concepts"][0]["term"].lower() == "alignment"
+
+
+@pytest.mark.asyncio
+async def test_top_concepts_capped_at_20(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    """When the corpus has > 20 distinct concepts, the snapshot keeps the top 20."""
+    # 25 distinct concepts, one per summary.
+    rows: list[Summary] = []
+    for i in range(25):
+        rows.append(
+            _summary(tutor_user.id, idx=i, concepts=[f"concept_{i:02d}"])
+        )
+    for r in rows:
+        async_db_session.add(r)
+    await async_db_session.commit()
+
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    assert len(snap["top_concepts"]) <= 20
+
+
+@pytest.mark.asyncio
+async def test_top_categories_aggregated_with_counts(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    rows = [
+        _summary(tutor_user.id, idx=1, category="ai"),
+        _summary(tutor_user.id, idx=2, category="ai"),
+        _summary(tutor_user.id, idx=3, category="ai"),
+        _summary(tutor_user.id, idx=4, category="philo"),
+        _summary(tutor_user.id, idx=5, category="science"),
+    ]
+    for r in rows:
+        async_db_session.add(r)
+    await async_db_session.commit()
+
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    cats = {c["category"]: c["count"] for c in snap["top_categories"]}
+    assert cats["ai"] == 3
+    assert cats["philo"] == 1
+    assert cats["science"] == 1
+    # AI should rank first.
+    assert snap["top_categories"][0]["category"] == "ai"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Empty corpus
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_snapshot_empty_corpus(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    assert snap["total_analyses"] == 0
+    assert snap["level"] == LEVEL_LONG
+    assert snap["top_categories"] == []
+    assert snap["top_concepts"] == []
+    assert snap["recent_analyses"] == []
+    assert snap["snapshot_at"] is not None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# User isolation
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_snapshot_isolated_per_user(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    """A second user must not see the first user's analyses in the snapshot."""
+    await _persist_n_summaries(async_db_session, tutor_user, 3)
+
+    other = User(
+        username="other_mem",
+        email="other_mem@test.fr",
+        password_hash="x",
+        plan="pro",
+        email_verified=True,
+    )
+    async_db_session.add(other)
+    await async_db_session.commit()
+    await async_db_session.refresh(other)
+
+    snap_other = await build_tutor_memory(user=other, db=async_db_session)
+    assert snap_other["total_analyses"] == 0
+    assert snap_other["recent_analyses"] == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Redis cache path
+# ─────────────────────────────────────────────────────────────────────
+
+
+class _FakeRedis:
+    """Tiny async stub matching the subset of redis.asyncio used by the snapshot."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.get_calls: int = 0
+        self.setex_calls: int = 0
+
+    async def get(self, key: str) -> str | None:
+        self.get_calls += 1
+        return self.store.get(key)
+
+    async def setex(self, key: str, ttl: int, value: str) -> None:
+        self.setex_calls += 1
+        self.store[key] = value
+
+
+@pytest.mark.asyncio
+async def test_snapshot_writes_to_redis(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    await _persist_n_summaries(async_db_session, tutor_user, 3)
+    fake = _FakeRedis()
+
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session, redis=fake)
+    assert snap["total_analyses"] == 3
+    # Snapshot was persisted.
+    assert fake.setex_calls == 1
+    key = _cache_key(tutor_user.id)
+    assert key in fake.store
+    # And the payload is JSON-serializable.
+    decoded = json.loads(fake.store[key])
+    assert decoded["total_analyses"] == 3
+
+
+@pytest.mark.asyncio
+async def test_snapshot_reads_from_redis_cache(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    """A pre-populated Redis cache should short-circuit the DB scan."""
+    fake = _FakeRedis()
+    # Insert a fake snapshot directly.
+    cached_payload: dict[str, Any] = {
+        "total_analyses": 99,
+        "level": "short",
+        "top_categories": [{"category": "ai", "count": 99}],
+        "top_concepts": [],
+        "recent_analyses": [],
+        "snapshot_at": "2026-05-11T00:00:00+00:00",
+    }
+    fake.store[_cache_key(tutor_user.id)] = json.dumps(cached_payload)
+
+    # Even though no Summary exists in DB, the cache hit returns the stub.
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session, redis=fake)
+    assert snap["total_analyses"] == 99
+    assert snap["level"] == "short"
+    # SETEX must NOT have been called on a hit.
+    assert fake.setex_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_snapshot_redis_error_falls_through_to_db(
+    async_db_session: AsyncSession, tutor_user: User, monkeypatch: pytest.MonkeyPatch
+):
+    """A Redis read failure must not break the snapshot — the DB path runs."""
+    await _persist_n_summaries(async_db_session, tutor_user, 2)
+
+    class _BoomRedis:
+        async def get(self, *_args, **_kwargs):
+            raise RuntimeError("redis is dead")
+
+        async def setex(self, *_args, **_kwargs):
+            raise RuntimeError("still dead")
+
+    snap = await build_tutor_memory(
+        user=tutor_user, db=async_db_session, redis=_BoomRedis()
+    )
+    assert snap["total_analyses"] == 2
+    assert snap["level"] == LEVEL_LONG
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Recent slice ordering (most recent first)
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recent_analyses_ordered_desc(
+    async_db_session: AsyncSession, tutor_user: User
+):
+    """The recent slice must follow ``created_at DESC`` (most recent first)."""
+    rows = await _persist_n_summaries(async_db_session, tutor_user, 7)
+    snap = await build_tutor_memory(user=tutor_user, db=async_db_session)
+    # The DB default applies func.now() — all rows share the same timestamp at
+    # the second resolution. We can still verify the slice contains the right
+    # set of ids.
+    snap_ids = {item["id"] for item in snap["recent_analyses"]}
+    persisted_ids = {r.id for r in rows}
+    assert snap_ids == persisted_ids


### PR DESCRIPTION
## Summary
- Nouveau service `tutor_memory.py` qui agrège une carte mentale adaptive du parcours utilisateur (4 niveaux de compression selon volume d'analyses)
- Extension `knowledge_tutor_tools.py` : nouveau tool `get_tutor_memory_snapshot` + champ `key_topics` dans `get_user_history`
- Cache Redis 30min sur le snapshot
- Mise à jour prompt agent pour appeler le snapshot en premier (remplace get_concept_keys+get_user_history en orientation)

## Compression levels
- ≤10 analyses : long (3-5 key_topics par item)
- 11-30 : medium (1-2 key_topics par item)
- 31-100 : short (catégories + top concepts + 10 recent)
- >100 : ultra (catégories + top concepts + 5 recent)

## Test plan
- [x] backend/tests/voice/test_tutor_memory.py — 4 niveaux + extraction key_topics
- [x] backend/tests/voice/test_knowledge_tutor.py — zéro régression

Spec : docs/superpowers/specs/2026-05-10-tuteur-refactor.md (axe C étendu)