### PR TITLE
feat(tutor): V2 popup resize + fullscreen Hub view + voice back-to-chat

### DIFF
--- a/frontend/src/components/Tutor/DraggableTutorWindow.tsx
+++ b/frontend/src/components/Tutor/DraggableTutorWindow.tsx
@@ -1,7 +1,13 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion, type PanInfo } from "framer-motion";
-import { TUTOR_SNAP_MARGIN, type TutorCorner } from "./tutorConstants";
 import {
+  TUTOR_MAX_SIZE,
+  TUTOR_MIN_SIZE,
+  TUTOR_SNAP_MARGIN,
+  type TutorCorner,
+} from "./tutorConstants";
+import {
+  clampSize,
   cornerToPosition,
   nearestCorner,
   readSavedCorner,
@@ -13,11 +19,26 @@ interface DraggableTutorWindowProps {
   className?: string;
   ariaLabel?: string;
   role?: string;
+  /**
+   * V2 — Active les 8 resize handles (4 bords + 4 coins). Défaut `false`
+   * pour préserver le comportement legacy de TutorIdle / TutorPrompting
+   * (taille fixe). TutorMiniChat passe `true`.
+   */
+  resizable?: boolean;
+  /**
+   * V2 — Callback déclenché à chaque tick du resize. Le parent doit clamp
+   * et persister (ex. localStorage `LS_TUTOR_SIZE`). Sans `onResize`, les
+   * handles sont quand même rendus si `resizable` est `true` mais le parent
+   * ne sera jamais notifié — utile pour smoke-tests.
+   */
+  onResize?: (size: { width: number; height: number }) => void;
   children: React.ReactNode;
 }
 
+type ResizeDir = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
 /**
- * Wrapper draggable pour le Tuteur web (Phase 2 — mai 2026).
+ * Wrapper draggable pour le Tuteur web (Phase 2 — mai 2026, étendu V2).
  *
  * Comportement :
  * - Drag libre via Framer Motion : toute la fenêtre est draggable
@@ -28,6 +49,9 @@ interface DraggableTutorWindowProps {
  * - Position persistée en localStorage (clé `ds-tutor-corner`)
  * - Recalcul automatique à chaque resize fenêtre (depuis le coin sauvé,
  *   pas une position absolue x/y → robuste au resize)
+ * - V2 : si `resizable`, 8 handles (4 bords + 4 coins) permettent de
+ *   redimensionner la fenêtre dans les limites TUTOR_MIN_SIZE/MAX_SIZE.
+ *   Le coin actuel est conservé après resize (snap recalculé).
  *
  * Le wrapper porte le `position: fixed` ; les enfants ne doivent PAS définir
  * leur propre positionnement absolu.
@@ -37,6 +61,8 @@ export const DraggableTutorWindow: React.FC<DraggableTutorWindowProps> = ({
   className,
   ariaLabel,
   role,
+  resizable = false,
+  onResize,
   children,
 }) => {
   const [corner, setCorner] = useState<TutorCorner>(() => readSavedCorner());
@@ -46,11 +72,11 @@ export const DraggableTutorWindow: React.FC<DraggableTutorWindowProps> = ({
   }));
 
   useEffect(() => {
-    const onResize = () => {
+    const onWinResize = () => {
       setViewport({ width: window.innerWidth, height: window.innerHeight });
     };
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    window.addEventListener("resize", onWinResize);
+    return () => window.removeEventListener("resize", onWinResize);
   }, []);
 
   const position = useMemo(
@@ -89,6 +115,166 @@ export const DraggableTutorWindow: React.FC<DraggableTutorWindowProps> = ({
     ],
   );
 
+  // ── Resize state (V2) ──
+  // refs to avoid re-creating listeners on every render.
+  const resizeStateRef = useRef<{
+    dir: ResizeDir;
+    startX: number;
+    startY: number;
+    startWidth: number;
+    startHeight: number;
+  } | null>(null);
+
+  const handleResizeStart = useCallback(
+    (dir: ResizeDir, e: React.PointerEvent<HTMLDivElement>) => {
+      if (!resizable || !onResize) return;
+      e.stopPropagation();
+      e.preventDefault();
+      resizeStateRef.current = {
+        dir,
+        startX: e.clientX,
+        startY: e.clientY,
+        startWidth: size.width,
+        startHeight: size.height,
+      };
+
+      const onMove = (ev: PointerEvent) => {
+        const state = resizeStateRef.current;
+        if (!state) return;
+        const dx = ev.clientX - state.startX;
+        const dy = ev.clientY - state.startY;
+        let nextWidth = state.startWidth;
+        let nextHeight = state.startHeight;
+
+        // Each direction adjusts width/height with the appropriate sign:
+        // east/west drive width, north/south drive height. Corner handles
+        // combine both. We assume the window keeps its current anchor
+        // (snapped corner) — so dragging the WEST handle to the LEFT grows
+        // width, and to the RIGHT shrinks it; symmetric for north/south.
+        if (state.dir.includes("e")) nextWidth = state.startWidth + dx;
+        if (state.dir.includes("w")) nextWidth = state.startWidth - dx;
+        if (state.dir.includes("s")) nextHeight = state.startHeight + dy;
+        if (state.dir.includes("n")) nextHeight = state.startHeight - dy;
+
+        const clamped = clampSize({ width: nextWidth, height: nextHeight });
+        onResize(clamped);
+      };
+
+      const onUp = () => {
+        resizeStateRef.current = null;
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+      };
+
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [resizable, onResize, size.width, size.height],
+  );
+
+  // Handle props per direction (cursor, position) — pre-computed to keep
+  // the JSX tidy. 8px for edges, 12px for corners.
+  const handles: Array<{
+    dir: ResizeDir;
+    style: React.CSSProperties;
+    testId: string;
+  }> = useMemo(() => {
+    const EDGE = 8;
+    const CORNER = 12;
+    return [
+      // Edges
+      {
+        dir: "n",
+        testId: "resize-n",
+        style: {
+          top: 0,
+          left: CORNER,
+          right: CORNER,
+          height: EDGE,
+          cursor: "ns-resize",
+        },
+      },
+      {
+        dir: "s",
+        testId: "resize-s",
+        style: {
+          bottom: 0,
+          left: CORNER,
+          right: CORNER,
+          height: EDGE,
+          cursor: "ns-resize",
+        },
+      },
+      {
+        dir: "e",
+        testId: "resize-e",
+        style: {
+          top: CORNER,
+          bottom: CORNER,
+          right: 0,
+          width: EDGE,
+          cursor: "ew-resize",
+        },
+      },
+      {
+        dir: "w",
+        testId: "resize-w",
+        style: {
+          top: CORNER,
+          bottom: CORNER,
+          left: 0,
+          width: EDGE,
+          cursor: "ew-resize",
+        },
+      },
+      // Corners
+      {
+        dir: "nw",
+        testId: "resize-nw",
+        style: {
+          top: 0,
+          left: 0,
+          width: CORNER,
+          height: CORNER,
+          cursor: "nwse-resize",
+        },
+      },
+      {
+        dir: "ne",
+        testId: "resize-ne",
+        style: {
+          top: 0,
+          right: 0,
+          width: CORNER,
+          height: CORNER,
+          cursor: "nesw-resize",
+        },
+      },
+      {
+        dir: "sw",
+        testId: "resize-sw",
+        style: {
+          bottom: 0,
+          left: 0,
+          width: CORNER,
+          height: CORNER,
+          cursor: "nesw-resize",
+        },
+      },
+      {
+        dir: "se",
+        testId: "resize-se",
+        style: {
+          bottom: 0,
+          right: 0,
+          width: CORNER,
+          height: CORNER,
+          cursor: "nwse-resize",
+        },
+      },
+    ];
+  }, []);
+
   return (
     <motion.div
       drag
@@ -114,8 +300,23 @@ export const DraggableTutorWindow: React.FC<DraggableTutorWindowProps> = ({
       className={className}
     >
       {children}
+      {resizable &&
+        handles.map((h) => (
+          <div
+            key={h.dir}
+            data-testid={h.testId}
+            onPointerDown={(e) => handleResizeStart(h.dir, e)}
+            style={{
+              position: "absolute",
+              zIndex: 50,
+              ...h.style,
+            }}
+            aria-hidden="true"
+          />
+        ))}
     </motion.div>
   );
 };
 
+export { TUTOR_MAX_SIZE, TUTOR_MIN_SIZE };
 export default DraggableTutorWindow;

--- a/frontend/src/components/Tutor/Tutor.tsx
+++ b/frontend/src/components/Tutor/Tutor.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { AnimatePresence } from "framer-motion";
+import { useNavigate } from "react-router-dom";
 import { useLoadingWord } from "../../contexts/LoadingWordContext";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { useAuth } from "../../hooks/useAuth";
@@ -38,6 +39,7 @@ export const Tutor: React.FC = () => {
   const { language } = useLanguage();
   const tutor = useTutor();
   const { voiceEnabled } = useVoiceEnabled();
+  const navigate = useNavigate();
 
   // Voice Tutor modal — opened from the TutorMiniChat header button.
   // Carries the current concept as a primer so the agent can pick up
@@ -104,8 +106,29 @@ export const Tutor: React.FC = () => {
     });
   }, [currentWord, language, tutor]);
 
+  // V2 — Fullscreen: bascule la conv tuteur dans la vue plein écran du Hub
+  // (`/hub?fsChat=tutor`). La popup reste montée en arrière-plan (masquée
+  // par le HubPage qui early-return sur `fsChat`), mais la conv vit
+  // désormais dans le store Zustand global → la vue Hub lit la même
+  // session sans drop de messages.
+  const handleFullscreen = useCallback(() => {
+    tutor.setFullscreen(true);
+    navigate("/hub?fsChat=tutor");
+  }, [tutor, navigate]);
+
   if (!isAuthenticated || !currentWord) return null;
   if (hidden) return null;
+
+  // V2 — back-to-chat callback : ne s'expose au modal vocal QUE si une
+  // conv texte est déjà en cours. Sans conv (lancement sidebar sans
+  // concept), pas de "retour au chat" possible → le bouton reste masqué.
+  const voiceBackToChat =
+    tutor.phase === "mini-chat"
+      ? () => {
+          setVoiceTutorOpen(false);
+          /* La popup texte est déjà visible derrière, rien d'autre à faire. */
+        }
+      : undefined;
 
   // Voice Tutor modal element — rendered alongside the phase UI so it can
   // stay open even when the tutor mini-chat is closed/minimized. Renders
@@ -124,6 +147,7 @@ export const Tutor: React.FC = () => {
             }
           : null
       }
+      onBackToChat={voiceBackToChat}
     />
   );
 
@@ -174,6 +198,7 @@ export const Tutor: React.FC = () => {
             onClose={handleClose}
             voiceTutorEnabled={voiceEnabled}
             onOpenVoiceTutor={() => setVoiceTutorOpen(true)}
+            onFullscreen={handleFullscreen}
           />
         )}
       </AnimatePresence>

--- a/frontend/src/components/Tutor/TutorFullscreen.tsx
+++ b/frontend/src/components/Tutor/TutorFullscreen.tsx
@@ -1,0 +1,183 @@
+// frontend/src/components/Tutor/TutorFullscreen.tsx
+//
+// Vue plein écran de la conv Tuteur, rendue depuis HubPage quand l'URL
+// porte `?fsChat=tutor` (V2 — mai 2026). Lit le state depuis le store
+// Zustand `useTutorStore` pour partager la session avec la popup
+// flottante.
+
+import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ChevronLeft, Send, X } from "lucide-react";
+import { useTutorStore } from "../../store/tutorStore";
+import { useLanguage } from "../../contexts/LanguageContext";
+
+const stopPropagation = (e: React.PointerEvent | React.MouseEvent) => {
+  e.stopPropagation();
+};
+
+export const TutorFullscreen: React.FC = () => {
+  const navigate = useNavigate();
+  const { language } = useLanguage();
+  const phase = useTutorStore((s) => s.phase);
+  const messages = useTutorStore((s) => s.messages);
+  const conceptTerm = useTutorStore((s) => s.conceptTerm);
+  const loading = useTutorStore((s) => s.loading);
+  const submitTextTurn = useTutorStore((s) => s.submitTextTurn);
+  const endSession = useTutorStore((s) => s.endSession);
+  const setFullscreen = useTutorStore((s) => s.setFullscreen);
+
+  const [input, setInput] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({
+      top: scrollRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [messages]);
+
+  const titleLabel = conceptTerm ?? (language === "fr" ? "Le Tuteur" : "Tutor");
+  const backLabel =
+    language === "fr" ? "Retour à la popup" : "Back to popup";
+  const closeLabel = language === "fr" ? "Terminer" : "End";
+  const placeholder =
+    language === "fr" ? "Tapez votre réponse..." : "Type your answer...";
+  const emptyHint =
+    language === "fr"
+      ? "Démarrez une session depuis la popup pour discuter ici."
+      : "Start a session from the popup to chat here.";
+
+  const handleBack = () => {
+    setFullscreen(false);
+    navigate("/hub");
+  };
+
+  const handleEnd = async () => {
+    await endSession();
+    setFullscreen(false);
+    navigate("/hub");
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (input.trim() && !loading) {
+      void submitTextTurn(input.trim());
+      setInput("");
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label={titleLabel}
+      className="min-h-screen flex flex-col bg-[#0a0a0f] text-text-primary"
+      data-testid="tutor-fullscreen"
+    >
+      {/* Header */}
+      <header className="flex items-center justify-between px-4 py-3 border-b border-white/[0.06] flex-shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <button
+            type="button"
+            onClick={handleBack}
+            aria-label={backLabel}
+            title={backLabel}
+            className="p-1.5 rounded-lg hover:bg-white/[0.06] text-text-muted hover:text-text-primary transition-colors"
+            data-testid="tutor-fullscreen-back"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+          <div className="min-w-0">
+            <p className="text-base font-semibold text-text-primary truncate leading-tight">
+              {titleLabel}
+            </p>
+            <p className="text-xs text-text-muted">
+              {language === "fr" ? "Le Tuteur" : "The Tutor"}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleEnd}
+          aria-label={closeLabel}
+          title={closeLabel}
+          className="p-1.5 rounded-lg hover:bg-red-500/15 text-text-muted hover:text-red-300 transition-colors"
+          data-testid="tutor-fullscreen-end"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </header>
+
+      {/* Body */}
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-y-auto px-4 py-6 max-w-3xl mx-auto w-full"
+      >
+        {phase !== "mini-chat" || messages.length === 0 ? (
+          <div className="h-full flex items-center justify-center text-center">
+            <p className="text-sm text-text-tertiary leading-relaxed max-w-md">
+              {emptyHint}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {messages.map((msg, idx) => (
+              <li
+                key={idx}
+                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`max-w-[85%] px-4 py-3 rounded-2xl text-sm leading-relaxed ${
+                    msg.role === "assistant"
+                      ? "bg-accent-primary/10 text-text-secondary border border-accent-primary/20"
+                      : "bg-indigo-500/15 text-text-primary border border-indigo-500/25"
+                  }`}
+                >
+                  {msg.content}
+                </div>
+              </li>
+            ))}
+            {loading && (
+              <li className="flex justify-start">
+                <div className="px-4 py-3 rounded-2xl bg-accent-primary/5 text-text-tertiary text-sm italic">
+                  …
+                </div>
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+
+      {/* Footer */}
+      <form
+        onSubmit={handleSubmit}
+        onPointerDown={stopPropagation}
+        className="flex items-center gap-2 px-4 py-3 border-t border-white/[0.06] bg-[#0a0a0f]/80 max-w-3xl mx-auto w-full"
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={placeholder}
+          disabled={loading || phase !== "mini-chat"}
+          className="flex-1 bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent-primary/40"
+        />
+        <button
+          type="submit"
+          disabled={!input.trim() || loading || phase !== "mini-chat"}
+          className="p-2 rounded-lg bg-accent-primary/20 hover:bg-accent-primary/30 text-accent-primary disabled:opacity-40 disabled:cursor-not-allowed transition-colors border border-accent-primary/30"
+          aria-label={language === "fr" ? "Envoyer" : "Send"}
+        >
+          <Send className="w-4 h-4" />
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default TutorFullscreen;

--- a/frontend/src/components/Tutor/TutorMiniChat.tsx
+++ b/frontend/src/components/Tutor/TutorMiniChat.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
-import { Minus, X, Send, Mic } from "lucide-react";
+import { Maximize2, Mic, Minus, Send, X } from "lucide-react";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { useTranslation } from "../../hooks/useTranslation";
 import { DraggableTutorWindow } from "./DraggableTutorWindow";
 import { TUTOR_MINICHAT_SIZE } from "./tutorConstants";
+import { readSavedSize, saveSize } from "./snapHelpers";
 import type { TutorTurn } from "../../types/tutor";
 
 interface TutorMiniChatProps {
@@ -24,6 +25,11 @@ interface TutorMiniChatProps {
    * Falsy → hide the voice button. Spec D: gate behind voiceChatEnabled.
    */
   voiceTutorEnabled?: boolean;
+  /**
+   * V2 — Optional callback to expand the popup into the Hub fullscreen view
+   * (`/hub?fsChat=tutor`). When undefined, the fullscreen button is hidden.
+   */
+  onFullscreen?: () => void;
 }
 
 const stopPropagation = (e: React.PointerEvent | React.MouseEvent) => {
@@ -39,6 +45,7 @@ export const TutorMiniChat: React.FC<TutorMiniChatProps> = ({
   onClose,
   onOpenVoiceTutor,
   voiceTutorEnabled = false,
+  onFullscreen,
 }) => {
   const { language } = useLanguage();
   const { t } = useTranslation();
@@ -50,6 +57,20 @@ export const TutorMiniChat: React.FC<TutorMiniChatProps> = ({
     tt.mini_chat.minimize ?? (language === "fr" ? "Réduire" : "Minimize");
   const voiceTutorLabel =
     language === "fr" ? "Tuteur Vocal" : "Voice Tutor";
+  const fullscreenLabel =
+    language === "fr" ? "Plein écran" : "Fullscreen";
+
+  // V2 — Resize: la taille de TutorMiniChat est désormais persistée et
+  // ajustable via 8 handles dans DraggableTutorWindow. On lit la valeur
+  // initiale depuis localStorage avec fallback sur TUTOR_MINICHAT_SIZE.
+  const [size, setSize] = useState<{ width: number; height: number }>(() =>
+    readSavedSize(TUTOR_MINICHAT_SIZE),
+  );
+
+  const handleResize = (next: { width: number; height: number }) => {
+    setSize(next);
+    saveSize(next);
+  };
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -72,7 +93,9 @@ export const TutorMiniChat: React.FC<TutorMiniChatProps> = ({
 
   return (
     <DraggableTutorWindow
-      size={TUTOR_MINICHAT_SIZE}
+      size={size}
+      resizable
+      onResize={handleResize}
       className="z-40 cursor-grab active:cursor-grabbing"
     >
       <motion.div
@@ -99,6 +122,18 @@ export const TutorMiniChat: React.FC<TutorMiniChatProps> = ({
                 title={voiceTutorLabel}
               >
                 <Mic className="w-3.5 h-3.5" />
+              </button>
+            )}
+            {onFullscreen && (
+              <button
+                type="button"
+                onPointerDown={stopPropagation}
+                onClick={onFullscreen}
+                className="text-text-tertiary hover:text-text-primary p-1 transition-colors"
+                aria-label={fullscreenLabel}
+                title={fullscreenLabel}
+              >
+                <Maximize2 className="w-3.5 h-3.5" />
               </button>
             )}
             <button

--- a/frontend/src/components/Tutor/__tests__/DraggableTutorWindow.test.tsx
+++ b/frontend/src/components/Tutor/__tests__/DraggableTutorWindow.test.tsx
@@ -1,0 +1,151 @@
+// frontend/src/components/Tutor/__tests__/DraggableTutorWindow.test.tsx
+//
+// Tests d'intégration pour les resize handles (Phase 2 V2 — mai 2026).
+// Les helpers (cornerToPosition / nearestCorner / readSavedCorner / saveCorner /
+// clampSize / readSavedSize / saveSize) ont leurs tests unitaires dans
+// `DraggableTutorWindow.test.ts`. Ce fichier vérifie le rendu + la
+// présence/absence des 8 resize handles selon la prop `resizable`.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DraggableTutorWindow } from "../DraggableTutorWindow";
+import {
+  TUTOR_MAX_SIZE,
+  TUTOR_MIN_SIZE,
+} from "../tutorConstants";
+import { clampSize, readSavedSize, saveSize } from "../snapHelpers";
+
+const SIZE = { width: 320, height: 480 };
+
+describe("DraggableTutorWindow — resize handles", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders without resize handles by default (resizable=false)", () => {
+    render(
+      <DraggableTutorWindow size={SIZE} ariaLabel="tutor">
+        <div>content</div>
+      </DraggableTutorWindow>,
+    );
+    expect(screen.getByText("content")).toBeInTheDocument();
+    // None of the 8 handles should be present.
+    [
+      "resize-n",
+      "resize-s",
+      "resize-e",
+      "resize-w",
+      "resize-nw",
+      "resize-ne",
+      "resize-sw",
+      "resize-se",
+    ].forEach((id) => {
+      expect(screen.queryByTestId(id)).toBeNull();
+    });
+  });
+
+  it("renders all 8 resize handles when resizable=true", () => {
+    render(
+      <DraggableTutorWindow
+        size={SIZE}
+        ariaLabel="tutor"
+        resizable
+        onResize={vi.fn()}
+      >
+        <div>content</div>
+      </DraggableTutorWindow>,
+    );
+    [
+      "resize-n",
+      "resize-s",
+      "resize-e",
+      "resize-w",
+      "resize-nw",
+      "resize-ne",
+      "resize-sw",
+      "resize-se",
+    ].forEach((id) => {
+      expect(screen.getByTestId(id)).toBeInTheDocument();
+    });
+  });
+
+  it("handles have appropriate cursors (edges vs corners)", () => {
+    render(
+      <DraggableTutorWindow size={SIZE} resizable onResize={vi.fn()}>
+        <div>content</div>
+      </DraggableTutorWindow>,
+    );
+    expect((screen.getByTestId("resize-n") as HTMLElement).style.cursor).toBe(
+      "ns-resize",
+    );
+    expect((screen.getByTestId("resize-s") as HTMLElement).style.cursor).toBe(
+      "ns-resize",
+    );
+    expect((screen.getByTestId("resize-e") as HTMLElement).style.cursor).toBe(
+      "ew-resize",
+    );
+    expect((screen.getByTestId("resize-w") as HTMLElement).style.cursor).toBe(
+      "ew-resize",
+    );
+    expect((screen.getByTestId("resize-nw") as HTMLElement).style.cursor).toBe(
+      "nwse-resize",
+    );
+    expect((screen.getByTestId("resize-se") as HTMLElement).style.cursor).toBe(
+      "nwse-resize",
+    );
+    expect((screen.getByTestId("resize-ne") as HTMLElement).style.cursor).toBe(
+      "nesw-resize",
+    );
+    expect((screen.getByTestId("resize-sw") as HTMLElement).style.cursor).toBe(
+      "nesw-resize",
+    );
+  });
+});
+
+describe("snapHelpers — size persistence + clamp", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("clampSize honors TUTOR_MIN_SIZE", () => {
+    const clamped = clampSize({ width: 100, height: 50 });
+    expect(clamped.width).toBe(TUTOR_MIN_SIZE.width);
+    expect(clamped.height).toBe(TUTOR_MIN_SIZE.height);
+  });
+
+  it("clampSize honors TUTOR_MAX_SIZE", () => {
+    const clamped = clampSize({ width: 9999, height: 9999 });
+    expect(clamped.width).toBe(TUTOR_MAX_SIZE.width);
+    expect(clamped.height).toBe(TUTOR_MAX_SIZE.height);
+  });
+
+  it("clampSize rounds to integers", () => {
+    const clamped = clampSize({ width: 300.7, height: 400.2 });
+    expect(clamped.width).toBe(301);
+    expect(clamped.height).toBe(400);
+  });
+
+  it("readSavedSize returns clamped fallback when nothing is saved", () => {
+    const s = readSavedSize({ width: 280, height: 400 });
+    expect(s).toEqual({ width: 280, height: 400 });
+  });
+
+  it("saveSize + readSavedSize round-trip", () => {
+    saveSize({ width: 350, height: 500 });
+    const s = readSavedSize({ width: 280, height: 400 });
+    expect(s).toEqual({ width: 350, height: 500 });
+  });
+
+  it("readSavedSize falls back when stored value is invalid JSON", () => {
+    localStorage.setItem("ds-tutor-size", "garbage");
+    const s = readSavedSize({ width: 280, height: 400 });
+    expect(s).toEqual({ width: 280, height: 400 });
+  });
+
+  it("readSavedSize clamps stored values outside limits", () => {
+    saveSize({ width: 99999, height: 50 });
+    const s = readSavedSize({ width: 280, height: 400 });
+    expect(s.width).toBe(TUTOR_MAX_SIZE.width);
+    expect(s.height).toBe(TUTOR_MIN_SIZE.height);
+  });
+});

--- a/frontend/src/components/Tutor/__tests__/Tutor.test.tsx
+++ b/frontend/src/components/Tutor/__tests__/Tutor.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { Tutor } from "../Tutor";
+import { useTutorStore } from "../../../store/tutorStore";
 
 // jsdom n'implémente pas Element.scrollTo — TutorMiniChat utilise scrollRef.current?.scrollTo
 beforeAll(() => {
@@ -77,11 +79,17 @@ vi.mock("../../../hooks/useTranslation", () => ({
   }),
 }));
 
-const renderTutor = () => render(<Tutor />);
+const renderTutor = () =>
+  render(
+    <MemoryRouter>
+      <Tutor />
+    </MemoryRouter>,
+  );
 
 describe("Tutor (composant racine)", () => {
   beforeEach(() => {
     localStorage.clear();
+    useTutorStore.getState().reset();
   });
 
   it("renders idle state by default", () => {

--- a/frontend/src/components/Tutor/__tests__/TutorFullscreen.test.tsx
+++ b/frontend/src/components/Tutor/__tests__/TutorFullscreen.test.tsx
@@ -1,0 +1,109 @@
+// frontend/src/components/Tutor/__tests__/TutorFullscreen.test.tsx
+import React from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { TutorFullscreen } from "../TutorFullscreen";
+import { useTutorStore } from "../../../store/tutorStore";
+
+beforeAll(() => {
+  Element.prototype.scrollTo =
+    vi.fn() as unknown as typeof Element.prototype.scrollTo;
+});
+
+vi.mock("../../../contexts/LanguageContext", () => ({
+  useLanguage: () => ({ language: "fr" }),
+}));
+
+vi.mock("../../../services/api", () => ({
+  tutorApi: {
+    sessionStart: vi.fn().mockResolvedValue({
+      session_id: "tutor-fs-test",
+      first_prompt: "Comment expliqueriez-vous ?",
+      audio_url: null,
+    }),
+    sessionTurn: vi.fn().mockResolvedValue({
+      ai_response: "Bien.",
+      audio_url: null,
+      turn_count: 3,
+    }),
+    sessionEnd: vi.fn().mockResolvedValue({
+      duration_sec: 30,
+      turns_count: 3,
+      source_summary_url: null,
+      source_video_title: null,
+    }),
+  },
+}));
+
+function renderFullscreen() {
+  return render(
+    <MemoryRouter>
+      <TutorFullscreen />
+    </MemoryRouter>,
+  );
+}
+
+describe("TutorFullscreen", () => {
+  beforeEach(() => {
+    useTutorStore.getState().reset();
+  });
+
+  it("renders default title 'Le Tuteur' when no concept term in store", () => {
+    renderFullscreen();
+    // Le titre principal vaut "Le Tuteur" en l'absence de concept.
+    expect(screen.getByTestId("tutor-fullscreen")).toBeInTheDocument();
+    expect(screen.getAllByText(/Le Tuteur/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows empty hint when no session is active", () => {
+    renderFullscreen();
+    expect(
+      screen.getByText(/Démarrez une session depuis la popup/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders concept term as title when session is active", async () => {
+    await useTutorStore.getState().startSession({
+      concept_term: "Rasoir d'Occam",
+      concept_def: "Principe de parcimonie",
+      mode: "text",
+    });
+    renderFullscreen();
+    expect(screen.getByText("Rasoir d'Occam")).toBeInTheDocument();
+  });
+
+  it("renders messages from the store", async () => {
+    await useTutorStore.getState().startSession({
+      concept_term: "X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    renderFullscreen();
+    expect(screen.getByText("Comment expliqueriez-vous ?")).toBeInTheDocument();
+  });
+
+  it("has a back button (Retour à la popup) that triggers navigation", () => {
+    renderFullscreen();
+    const backBtn = screen.getByTestId("tutor-fullscreen-back");
+    expect(backBtn).toBeInTheDocument();
+    // setFullscreen should be invoked on click (clears the flag).
+    useTutorStore.getState().setFullscreen(true);
+    fireEvent.click(backBtn);
+    expect(useTutorStore.getState().fullscreen).toBe(false);
+  });
+
+  it("has an end button (X) that ends the session", async () => {
+    await useTutorStore.getState().startSession({
+      concept_term: "X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    renderFullscreen();
+    const endBtn = screen.getByTestId("tutor-fullscreen-end");
+    fireEvent.click(endBtn);
+    // endSession is async — but the test asserts the click works without
+    // throwing. State changes are verified separately in tutorStore.test.
+    expect(endBtn).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Tutor/__tests__/useTutor.test.ts
+++ b/frontend/src/components/Tutor/__tests__/useTutor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useTutor } from "../useTutor";
+import { useTutorStore } from "../../../store/tutorStore";
 
 vi.mock("../../../services/api", () => ({
   tutorApi: {
@@ -27,6 +28,7 @@ describe("useTutor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    useTutorStore.getState().reset();
   });
 
   it("starts in idle phase", () => {

--- a/frontend/src/components/Tutor/snapHelpers.ts
+++ b/frontend/src/components/Tutor/snapHelpers.ts
@@ -5,7 +5,10 @@
 
 import {
   LS_TUTOR_CORNER,
+  LS_TUTOR_SIZE,
   TUTOR_DEFAULT_CORNER,
+  TUTOR_MAX_SIZE,
+  TUTOR_MIN_SIZE,
   TUTOR_SNAP_MARGIN,
   type TutorCorner,
 } from "./tutorConstants";
@@ -79,6 +82,59 @@ export function readSavedCorner(): TutorCorner {
 export function saveCorner(corner: TutorCorner) {
   try {
     localStorage.setItem(LS_TUTOR_CORNER, corner);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Clamp une dimension entre TUTOR_MIN_SIZE et TUTOR_MAX_SIZE. */
+export function clampSize(size: {
+  width: number;
+  height: number;
+}): { width: number; height: number } {
+  return {
+    width: Math.max(
+      TUTOR_MIN_SIZE.width,
+      Math.min(TUTOR_MAX_SIZE.width, Math.round(size.width)),
+    ),
+    height: Math.max(
+      TUTOR_MIN_SIZE.height,
+      Math.min(TUTOR_MAX_SIZE.height, Math.round(size.height)),
+    ),
+  };
+}
+
+/** Lit la taille sauvée du Tuteur (TutorMiniChat) depuis localStorage. */
+export function readSavedSize(
+  fallback: { width: number; height: number },
+): { width: number; height: number } {
+  try {
+    const raw = localStorage.getItem(LS_TUTOR_SIZE);
+    if (raw) {
+      const parsed = JSON.parse(raw) as { width?: number; height?: number };
+      if (
+        parsed &&
+        typeof parsed.width === "number" &&
+        typeof parsed.height === "number" &&
+        Number.isFinite(parsed.width) &&
+        Number.isFinite(parsed.height)
+      ) {
+        return clampSize({ width: parsed.width, height: parsed.height });
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return clampSize(fallback);
+}
+
+/** Sauve la taille du Tuteur (TutorMiniChat) en localStorage. */
+export function saveSize(size: { width: number; height: number }) {
+  try {
+    localStorage.setItem(
+      LS_TUTOR_SIZE,
+      JSON.stringify(clampSize(size)),
+    );
   } catch {
     /* ignore */
   }

--- a/frontend/src/components/Tutor/tutorConstants.ts
+++ b/frontend/src/components/Tutor/tutorConstants.ts
@@ -3,16 +3,22 @@
 /**
  * localStorage keys pour le windowing du Tuteur (Phase 2 — mai 2026).
  * Le popup est draggable, snap aux 4 coins, minimisable, fermable persistant.
+ * V2 ajoute la persistance de la taille (resize handles).
  */
 export const LS_TUTOR_HIDDEN = "ds-tutor-hidden";
 export const LS_TUTOR_MINIMIZED = "ds-tutor-minimized";
 export const LS_TUTOR_CORNER = "ds-tutor-corner";
+export const LS_TUTOR_SIZE = "ds-tutor-size";
 
 /** Tailles des différentes phases (utile pour clamp/snap calculations). */
 export const TUTOR_IDLE_SIZE = { width: 200, height: 140 };
 export const TUTOR_PROMPTING_SIZE = { width: 220, height: 180 };
 export const TUTOR_MINICHAT_SIZE = { width: 280, height: 400 };
 export const TUTOR_MINIMIZED_SIZE = { width: 48, height: 48 };
+
+/** Limites du resize (V2 — TutorMiniChat uniquement). */
+export const TUTOR_MIN_SIZE = { width: 240, height: 280 };
+export const TUTOR_MAX_SIZE = { width: 600, height: 800 };
 
 /** Marge entre le bord du viewport et la fenêtre snappée. */
 export const TUTOR_SNAP_MARGIN = 12;

--- a/frontend/src/components/Tutor/useTutor.ts
+++ b/frontend/src/components/Tutor/useTutor.ts
@@ -1,207 +1,54 @@
 // frontend/src/components/Tutor/useTutor.ts
+//
+// Wrapper minimal autour de `useTutorStore` (Zustand) — Phase 2 V2 mai 2026.
+//
+// Préserve la signature historique du hook (`tutor.phase`, `tutor.messages`,
+// `tutor.startSession(...)`, etc.) pour ne pas casser les composants
+// `Tutor.tsx`, `TutorPrompting.tsx`, `TutorMiniChat.tsx`. La logique d'état
+// est désormais portée par le store global afin que la conversation soit
+// partagée entre la popup flottante et la vue plein écran dans le Hub.
 
-import { useReducer, useCallback } from "react";
-import { tutorApi } from "../../services/api";
-import type {
-  TutorPhase,
-  TutorLang,
-  TutorTurn,
-} from "../../types/tutor";
-
-interface TutorState {
-  phase: TutorPhase;
-  sessionId: string | null;
-  messages: TutorTurn[];
-  conceptTerm: string | null;
-  conceptDef: string | null;
-  summaryId: number | null;
-  sourceVideoTitle: string | null;
-  lang: TutorLang;
-  loading: boolean;
-  error: string | null;
-}
-
-type Action =
-  | { type: "OPEN_PROMPTING" }
-  | { type: "CANCEL_PROMPTING" }
-  | { type: "SESSION_STARTING"; lang: TutorLang }
-  | {
-      type: "SESSION_STARTED";
-      session_id: string;
-      first_prompt: string;
-      concept_term: string;
-      concept_def: string;
-      summary_id: number | null;
-      source_video_title: string | null;
-    }
-  | { type: "TURN_PENDING"; user_input: string }
-  | { type: "TURN_DONE"; ai_response: string }
-  | { type: "SESSION_ENDED" }
-  | { type: "ERROR"; message: string };
-
-const initialState: TutorState = {
-  phase: "idle",
-  sessionId: null,
-  messages: [],
-  conceptTerm: null,
-  conceptDef: null,
-  summaryId: null,
-  sourceVideoTitle: null,
-  lang: "fr",
-  loading: false,
-  error: null,
-};
-
-function reducer(state: TutorState, action: Action): TutorState {
-  switch (action.type) {
-    case "OPEN_PROMPTING":
-      return { ...state, phase: "prompting", error: null };
-    case "CANCEL_PROMPTING":
-      return { ...state, phase: "idle" };
-    case "SESSION_STARTING":
-      return {
-        ...state,
-        lang: action.lang,
-        loading: true,
-        error: null,
-      };
-    case "SESSION_STARTED":
-      return {
-        ...state,
-        phase: "mini-chat",
-        sessionId: action.session_id,
-        conceptTerm: action.concept_term,
-        conceptDef: action.concept_def,
-        summaryId: action.summary_id,
-        sourceVideoTitle: action.source_video_title,
-        messages: [
-          {
-            role: "assistant",
-            content: action.first_prompt,
-            timestamp_ms: Date.now(),
-          },
-        ],
-        loading: false,
-      };
-    case "TURN_PENDING":
-      return {
-        ...state,
-        messages: [
-          ...state.messages,
-          {
-            role: "user",
-            content: action.user_input,
-            timestamp_ms: Date.now(),
-          },
-        ],
-        loading: true,
-      };
-    case "TURN_DONE":
-      return {
-        ...state,
-        messages: [
-          ...state.messages,
-          {
-            role: "assistant",
-            content: action.ai_response,
-            timestamp_ms: Date.now(),
-          },
-        ],
-        loading: false,
-      };
-    case "SESSION_ENDED":
-      return initialState;
-    case "ERROR":
-      return { ...state, error: action.message, loading: false };
-    default:
-      return state;
-  }
-}
-
-interface StartSessionParams {
-  concept_term: string;
-  concept_def: string;
-  summary_id?: number;
-  source_video_title?: string;
-  mode: "text";
-  lang?: TutorLang;
-}
+import { useTutorStore, type StartSessionOpts } from "../../store/tutorStore";
 
 export function useTutor() {
-  const [state, dispatch] = useReducer(reducer, initialState);
+  const phase = useTutorStore((s) => s.phase);
+  const sessionId = useTutorStore((s) => s.sessionId);
+  const messages = useTutorStore((s) => s.messages);
+  const conceptTerm = useTutorStore((s) => s.conceptTerm);
+  const conceptDef = useTutorStore((s) => s.conceptDef);
+  const summaryId = useTutorStore((s) => s.summaryId);
+  const sourceVideoTitle = useTutorStore((s) => s.sourceVideoTitle);
+  const lang = useTutorStore((s) => s.lang);
+  const loading = useTutorStore((s) => s.loading);
+  const error = useTutorStore((s) => s.error);
+  const fullscreen = useTutorStore((s) => s.fullscreen);
 
-  const openPrompting = useCallback(
-    () => dispatch({ type: "OPEN_PROMPTING" }),
-    [],
-  );
-  const cancelPrompting = useCallback(
-    () => dispatch({ type: "CANCEL_PROMPTING" }),
-    [],
-  );
-
-  const startSession = useCallback(async (params: StartSessionParams) => {
-    const lang = params.lang ?? "fr";
-    dispatch({ type: "SESSION_STARTING", lang });
-    try {
-      const resp = await tutorApi.sessionStart({
-        concept_term: params.concept_term,
-        concept_def: params.concept_def,
-        summary_id: params.summary_id,
-        source_video_title: params.source_video_title,
-        mode: "text",
-        lang,
-      });
-      dispatch({
-        type: "SESSION_STARTED",
-        session_id: resp.session_id,
-        first_prompt: resp.first_prompt,
-        concept_term: params.concept_term,
-        concept_def: params.concept_def,
-        summary_id: params.summary_id ?? null,
-        source_video_title: params.source_video_title ?? null,
-      });
-    } catch (err) {
-      dispatch({ type: "ERROR", message: (err as Error).message });
-    }
-  }, []);
-
-  const submitTextTurn = useCallback(
-    async (user_input: string) => {
-      if (!state.sessionId) return;
-      dispatch({ type: "TURN_PENDING", user_input });
-      try {
-        const resp = await tutorApi.sessionTurn(state.sessionId, {
-          user_input,
-        });
-        dispatch({
-          type: "TURN_DONE",
-          ai_response: resp.ai_response,
-        });
-      } catch (err) {
-        dispatch({ type: "ERROR", message: (err as Error).message });
-      }
-    },
-    [state.sessionId],
-  );
-
-  const endSession = useCallback(async () => {
-    if (state.sessionId) {
-      try {
-        await tutorApi.sessionEnd(state.sessionId);
-      } catch (err) {
-        // Best effort — logger mais ne pas bloquer
-        console.error("[useTutor] endSession failed", err);
-      }
-    }
-    dispatch({ type: "SESSION_ENDED" });
-  }, [state.sessionId]);
+  const openPrompting = useTutorStore((s) => s.openPrompting);
+  const cancelPrompting = useTutorStore((s) => s.cancelPrompting);
+  const startSession = useTutorStore((s) => s.startSession);
+  const submitTextTurn = useTutorStore((s) => s.submitTextTurn);
+  const endSession = useTutorStore((s) => s.endSession);
+  const setFullscreen = useTutorStore((s) => s.setFullscreen);
 
   return {
-    ...state,
+    phase,
+    sessionId,
+    messages,
+    conceptTerm,
+    conceptDef,
+    summaryId,
+    sourceVideoTitle,
+    lang,
+    loading,
+    error,
+    fullscreen,
     openPrompting,
     cancelPrompting,
     startSession,
     submitTextTurn,
     endSession,
+    setFullscreen,
   };
 }
+
+export type { StartSessionOpts };

--- a/frontend/src/components/hub/FullscreenChatView.tsx
+++ b/frontend/src/components/hub/FullscreenChatView.tsx
@@ -1,0 +1,26 @@
+// frontend/src/components/hub/FullscreenChatView.tsx
+//
+// Vue dispatcher pour les chats plein écran rendus depuis HubPage quand
+// l'URL porte `?fsChat=<type>` (V2 — mai 2026). Architecture extensible
+// pour ajouter quickchat, debate, etc. plus tard. V1 ne supporte que
+// `tutor`.
+
+import React from "react";
+import { TutorFullscreen } from "../Tutor/TutorFullscreen";
+
+export interface FullscreenChatViewProps {
+  /** Type lu depuis l'URL `?fsChat=<type>`. */
+  chatType: string;
+}
+
+export const FullscreenChatView: React.FC<FullscreenChatViewProps> = ({
+  chatType,
+}) => {
+  if (chatType === "tutor") return <TutorFullscreen />;
+  // V1 : seul "tutor" supporté. Architecture extensible pour quickchat,
+  // debate, etc. — retourner null permet à HubPage de fallback sur le
+  // rendu hub normal si un type inconnu apparaît dans l'URL.
+  return null;
+};
+
+export default FullscreenChatView;

--- a/frontend/src/components/hub/__tests__/FullscreenChatView.test.tsx
+++ b/frontend/src/components/hub/__tests__/FullscreenChatView.test.tsx
@@ -1,0 +1,59 @@
+// frontend/src/components/hub/__tests__/FullscreenChatView.test.tsx
+import React from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { FullscreenChatView } from "../FullscreenChatView";
+import { useTutorStore } from "../../../store/tutorStore";
+
+// jsdom n'implémente pas Element.scrollTo — TutorFullscreen utilise scrollRef.current?.scrollTo
+beforeAll(() => {
+  Element.prototype.scrollTo =
+    vi.fn() as unknown as typeof Element.prototype.scrollTo;
+});
+
+vi.mock("../../../contexts/LanguageContext", () => ({
+  useLanguage: () => ({ language: "fr" }),
+}));
+
+vi.mock("../../../services/api", () => ({
+  tutorApi: {
+    sessionStart: vi.fn(),
+    sessionTurn: vi.fn(),
+    sessionEnd: vi.fn(),
+  },
+}));
+
+function renderView(chatType: string) {
+  return render(
+    <MemoryRouter>
+      <FullscreenChatView chatType={chatType} />
+    </MemoryRouter>,
+  );
+}
+
+describe("FullscreenChatView", () => {
+  beforeEach(() => {
+    useTutorStore.getState().reset();
+  });
+
+  it("renders TutorFullscreen for chatType='tutor'", () => {
+    renderView("tutor");
+    expect(screen.getByTestId("tutor-fullscreen")).toBeInTheDocument();
+  });
+
+  it("returns null for unknown chatType", () => {
+    const { container } = renderView("unknown-chat-type");
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null for empty chatType", () => {
+    const { container } = renderView("");
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null for chatType='quickchat' (V1 not supported)", () => {
+    const { container } = renderView("quickchat");
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/voice/VoiceOverlay.tsx
+++ b/frontend/src/components/voice/VoiceOverlay.tsx
@@ -36,6 +36,7 @@ import {
   PhoneOff,
   X,
   AlertCircle,
+  ChevronLeft,
   Loader2,
   Volume2,
   Settings,
@@ -96,6 +97,13 @@ export interface VoiceOverlayProps {
   autoStart?: boolean;
   /** "floating" (default — bottom-right 380×600) or "fullbleed" (occupies parent container). */
   presentationMode?: "floating" | "fullbleed";
+  /**
+   * V2 — Optional callback to navigate back to a text chat surface that
+   * triggered the voice modal (typically the Tutor popup). When defined,
+   * a `ChevronLeft` button appears in the header as the first item so the
+   * user can dismiss the voice call without losing the underlying chat.
+   */
+  onBackToChat?: () => void;
 }
 
 export interface VoiceOverlayController {
@@ -131,6 +139,7 @@ const I18N = {
     minutesLeft: "min restantes",
     micMuted: "Micro coupé",
     settings: "Réglages",
+    backToChat: "Retour au chat",
   },
   en: {
     callTitle: "Voice call",
@@ -147,6 +156,7 @@ const I18N = {
     minutesLeft: "min left",
     micMuted: "Mic muted",
     settings: "Settings",
+    backToChat: "Back to chat",
   },
 } as const;
 
@@ -166,6 +176,7 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
   controllerRef,
   autoStart = true,
   presentationMode = "floating",
+  onBackToChat,
 }) => {
   const t = I18N[language];
   const resolvedAgent: VoiceOverlayProps["agentType"] =
@@ -378,6 +389,18 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
                 </div>
               </div>
               <div className="flex items-center gap-1 flex-shrink-0">
+                {onBackToChat && (
+                  <button
+                    type="button"
+                    onClick={onBackToChat}
+                    aria-label={t.backToChat}
+                    title={t.backToChat}
+                    data-testid="voice-overlay-back-to-chat"
+                    className="p-1.5 rounded-lg hover:bg-white/[0.06] text-text-muted hover:text-text-secondary transition-colors"
+                  >
+                    <ChevronLeft className="w-4 h-4" />
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={() => setSettingsOpen((v) => !v)}

--- a/frontend/src/components/voice/VoiceTutorModal.tsx
+++ b/frontend/src/components/voice/VoiceTutorModal.tsx
@@ -43,6 +43,12 @@ export interface VoiceTutorModalProps {
     /** Optional brief definition to inline. */
     conceptDef?: string | null;
   } | null;
+  /**
+   * V2 — Optional callback to navigate back to the text chat surface that
+   * launched the voice modal (the Tutor popup). Forwarded to
+   * `VoiceOverlay.onBackToChat` which renders a back arrow in the header.
+   */
+  onBackToChat?: () => void;
 }
 
 const TITLE_FR = "Tuteur Vocal";
@@ -55,6 +61,7 @@ export const VoiceTutorModal: React.FC<VoiceTutorModalProps> = ({
   onClose,
   language = "fr",
   initialContext,
+  onBackToChat,
 }) => {
   const controllerRef = useRef<VoiceOverlayController | null>(null);
   const primerSentRef = useRef(false);
@@ -110,6 +117,7 @@ export const VoiceTutorModal: React.FC<VoiceTutorModalProps> = ({
       controllerRef={controllerRef}
       autoStart
       presentationMode="floating"
+      onBackToChat={onBackToChat}
     />
   );
 };

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -188,7 +188,14 @@
       "input_placeholder": "Type your answer...",
       "close": "Close",
       "minimize": "Minimize",
-      "expand": "Expand"
+      "expand": "Expand",
+      "fullscreen": "Fullscreen"
+    },
+    "fullscreen": {
+      "back_to_popup": "Back to popup"
+    },
+    "voice": {
+      "back_to_chat": "Back to chat"
     },
     "errors": {
       "session_failed": "Session failed — please retry",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -188,7 +188,14 @@
       "input_placeholder": "Tapez votre réponse...",
       "close": "Fermer",
       "minimize": "Réduire",
-      "expand": "Agrandir"
+      "expand": "Agrandir",
+      "fullscreen": "Plein écran"
+    },
+    "fullscreen": {
+      "back_to_popup": "Retour à la popup"
+    },
+    "voice": {
+      "back_to_chat": "Retour au chat"
     },
     "errors": {
       "session_failed": "Session impossible — réessayez",

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -33,6 +33,7 @@ import { NewConversationModal } from "../components/hub/NewConversationModal";
 import { HubAnalysisPanel } from "../components/hub/HubAnalysisPanel";
 import { HubTabBar } from "../components/hub/HubTabBar";
 import { QuickVoiceCallCTA } from "../components/hub/QuickVoiceCallCTA";
+import { FullscreenChatView } from "../components/hub/FullscreenChatView";
 import { useAnalyzeAndOpenHub } from "../hooks/useAnalyzeAndOpenHub";
 import { SemanticHighlightProvider } from "../components/highlight/SemanticHighlightProvider";
 import { HighlightNavigationBar } from "../components/highlight/HighlightNavigationBar";
@@ -166,7 +167,7 @@ const NoConvPlaceholder: React.FC<{
   </div>
 );
 
-const HubPage: React.FC = () => {
+const HubPageInner: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const urlConvId = searchParams.get("conv");
@@ -957,6 +958,21 @@ const UrlQueryBridge: React.FC<{ q: string }> = ({ q }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [q, ctx?.setQuery]);
   return null;
+};
+
+/**
+ * Top-level dispatcher for /hub. Switches between the normal Hub layout
+ * (analysis + chat + voice) and a fullscreen chat surface when the URL
+ * carries `?fsChat=<type>` (V2 — mai 2026). Each branch mounts a distinct
+ * subtree so React hook order remains stable even on URL transitions.
+ */
+const HubPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const fsChat = searchParams.get("fsChat");
+  if (fsChat) {
+    return <FullscreenChatView chatType={fsChat} />;
+  }
+  return <HubPageInner />;
 };
 
 export default HubPage;

--- a/frontend/src/store/__tests__/tutorStore.test.ts
+++ b/frontend/src/store/__tests__/tutorStore.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useTutorStore } from "../tutorStore";
+
+vi.mock("../../services/api", () => ({
+  tutorApi: {
+    sessionStart: vi.fn().mockResolvedValue({
+      session_id: "tutor-test123",
+      first_prompt: "Comment expliqueriez-vous ce concept ?",
+      audio_url: null,
+    }),
+    sessionTurn: vi.fn().mockResolvedValue({
+      ai_response: "Très bien.",
+      audio_url: null,
+      turn_count: 3,
+    }),
+    sessionEnd: vi.fn().mockResolvedValue({
+      duration_sec: 45,
+      turns_count: 3,
+      source_summary_url: null,
+      source_video_title: null,
+    }),
+  },
+}));
+
+describe("tutorStore", () => {
+  beforeEach(() => {
+    useTutorStore.getState().reset();
+  });
+
+  it("initial state has idle phase, no session, empty messages", () => {
+    const s = useTutorStore.getState();
+    expect(s.phase).toBe("idle");
+    expect(s.sessionId).toBeNull();
+    expect(s.messages).toEqual([]);
+    expect(s.conceptTerm).toBeNull();
+    expect(s.fullscreen).toBe(false);
+    expect(s.loading).toBe(false);
+    expect(s.error).toBeNull();
+  });
+
+  it("openPrompting → phase = prompting", () => {
+    useTutorStore.getState().openPrompting();
+    expect(useTutorStore.getState().phase).toBe("prompting");
+    expect(useTutorStore.getState().error).toBeNull();
+  });
+
+  it("cancelPrompting → phase = idle", () => {
+    useTutorStore.getState().openPrompting();
+    useTutorStore.getState().cancelPrompting();
+    expect(useTutorStore.getState().phase).toBe("idle");
+  });
+
+  it("startSession populates state and appends first assistant message", async () => {
+    await useTutorStore.getState().startSession({
+      concept_term: "Rasoir d'Occam",
+      concept_def: "Principe de parcimonie",
+      mode: "text",
+    });
+    const s = useTutorStore.getState();
+    expect(s.phase).toBe("mini-chat");
+    expect(s.sessionId).toBe("tutor-test123");
+    expect(s.conceptTerm).toBe("Rasoir d'Occam");
+    expect(s.conceptDef).toBe("Principe de parcimonie");
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0].role).toBe("assistant");
+    expect(s.loading).toBe(false);
+  });
+
+  it("submitTextTurn pushes user then assistant messages", async () => {
+    await useTutorStore.getState().startSession({
+      concept_term: "X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    await useTutorStore.getState().submitTextTurn("Mon idée");
+    const s = useTutorStore.getState();
+    expect(s.messages).toHaveLength(3);
+    expect(s.messages[1].role).toBe("user");
+    expect(s.messages[1].content).toBe("Mon idée");
+    expect(s.messages[2].role).toBe("assistant");
+  });
+
+  it("submitTextTurn is no-op without a session", async () => {
+    await useTutorStore.getState().submitTextTurn("Test sans session");
+    expect(useTutorStore.getState().messages).toHaveLength(0);
+  });
+
+  it("endSession resets state back to initial", async () => {
+    await useTutorStore.getState().startSession({
+      concept_term: "X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    await useTutorStore.getState().endSession();
+    const s = useTutorStore.getState();
+    expect(s.phase).toBe("idle");
+    expect(s.sessionId).toBeNull();
+    expect(s.messages).toEqual([]);
+    expect(s.conceptTerm).toBeNull();
+  });
+
+  it("setFullscreen toggles fullscreen flag", () => {
+    useTutorStore.getState().setFullscreen(true);
+    expect(useTutorStore.getState().fullscreen).toBe(true);
+    useTutorStore.getState().setFullscreen(false);
+    expect(useTutorStore.getState().fullscreen).toBe(false);
+  });
+
+  it("startSession on failure surfaces error and clears loading", async () => {
+    const api = (await import("../../services/api")) as unknown as {
+      tutorApi: {
+        sessionStart: ReturnType<typeof vi.fn>;
+        sessionTurn: ReturnType<typeof vi.fn>;
+        sessionEnd: ReturnType<typeof vi.fn>;
+      };
+    };
+    api.tutorApi.sessionStart.mockRejectedValueOnce(
+      new Error("boom"),
+    );
+    await useTutorStore.getState().startSession({
+      concept_term: "X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    const s = useTutorStore.getState();
+    expect(s.error).toBe("boom");
+    expect(s.loading).toBe(false);
+    expect(s.phase).toBe("idle");
+  });
+
+  it("reset clears state immediately", async () => {
+    await useTutorStore.getState().startSession({
+      concept_term: "X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    useTutorStore.getState().reset();
+    const s = useTutorStore.getState();
+    expect(s.phase).toBe("idle");
+    expect(s.sessionId).toBeNull();
+    expect(s.messages).toEqual([]);
+  });
+});

--- a/frontend/src/store/tutorStore.ts
+++ b/frontend/src/store/tutorStore.ts
@@ -1,0 +1,188 @@
+// frontend/src/store/tutorStore.ts
+//
+// Store Zustand pour Le Tuteur (Phase 2 V2 — mai 2026).
+//
+// Promotion du `useReducer` local (frontend/src/components/Tutor/useTutor.ts)
+// en store global. Raison : la conversation doit être partagée entre la popup
+// flottante (sidebar + concept primer) et la vue plein écran dans le Hub
+// (`/hub?fsChat=tutor`).
+//
+// Le hook `useTutor` reste exposé comme wrapper minimal autour de ce store
+// pour préserver l'API existante des composants Tutor (signature inchangée).
+
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { tutorApi } from "../services/api";
+import type { TutorLang, TutorPhase, TutorTurn } from "../types/tutor";
+
+export interface StartSessionOpts {
+  concept_term: string;
+  concept_def: string;
+  summary_id?: number;
+  source_video_title?: string;
+  mode: "text";
+  lang?: TutorLang;
+}
+
+export interface TutorState {
+  phase: TutorPhase;
+  sessionId: string | null;
+  messages: TutorTurn[];
+  conceptTerm: string | null;
+  conceptDef: string | null;
+  summaryId: number | null;
+  sourceVideoTitle: string | null;
+  lang: TutorLang;
+  loading: boolean;
+  error: string | null;
+  /** True quand la conv est rendue en vue Hub fullscreen (/hub?fsChat=tutor). */
+  fullscreen: boolean;
+
+  openPrompting: () => void;
+  cancelPrompting: () => void;
+  startSession: (opts: StartSessionOpts) => Promise<void>;
+  submitTextTurn: (input: string) => Promise<void>;
+  endSession: () => Promise<void>;
+  setFullscreen: (v: boolean) => void;
+  reset: () => void;
+}
+
+const INITIAL: Pick<
+  TutorState,
+  | "phase"
+  | "sessionId"
+  | "messages"
+  | "conceptTerm"
+  | "conceptDef"
+  | "summaryId"
+  | "sourceVideoTitle"
+  | "lang"
+  | "loading"
+  | "error"
+  | "fullscreen"
+> = {
+  phase: "idle",
+  sessionId: null,
+  messages: [],
+  conceptTerm: null,
+  conceptDef: null,
+  summaryId: null,
+  sourceVideoTitle: null,
+  lang: "fr",
+  loading: false,
+  error: null,
+  fullscreen: false,
+};
+
+export const useTutorStore = create<TutorState>()(
+  immer((set, get) => ({
+    ...INITIAL,
+
+    openPrompting: () =>
+      set((s) => {
+        s.phase = "prompting";
+        s.error = null;
+      }),
+
+    cancelPrompting: () =>
+      set((s) => {
+        s.phase = "idle";
+      }),
+
+    startSession: async (opts) => {
+      const lang: TutorLang = opts.lang ?? "fr";
+      set((s) => {
+        s.lang = lang;
+        s.loading = true;
+        s.error = null;
+      });
+      try {
+        const resp = await tutorApi.sessionStart({
+          concept_term: opts.concept_term,
+          concept_def: opts.concept_def,
+          summary_id: opts.summary_id,
+          source_video_title: opts.source_video_title,
+          mode: "text",
+          lang,
+        });
+        set((s) => {
+          s.phase = "mini-chat";
+          s.sessionId = resp.session_id;
+          s.conceptTerm = opts.concept_term;
+          s.conceptDef = opts.concept_def;
+          s.summaryId = opts.summary_id ?? null;
+          s.sourceVideoTitle = opts.source_video_title ?? null;
+          s.messages = [
+            {
+              role: "assistant",
+              content: resp.first_prompt,
+              timestamp_ms: Date.now(),
+            },
+          ];
+          s.loading = false;
+        });
+      } catch (err) {
+        set((s) => {
+          s.error = (err as Error).message;
+          s.loading = false;
+        });
+      }
+    },
+
+    submitTextTurn: async (input) => {
+      const sessionId = get().sessionId;
+      if (!sessionId) return;
+      set((s) => {
+        s.messages.push({
+          role: "user",
+          content: input,
+          timestamp_ms: Date.now(),
+        });
+        s.loading = true;
+      });
+      try {
+        const resp = await tutorApi.sessionTurn(sessionId, {
+          user_input: input,
+        });
+        set((s) => {
+          s.messages.push({
+            role: "assistant",
+            content: resp.ai_response,
+            timestamp_ms: Date.now(),
+          });
+          s.loading = false;
+        });
+      } catch (err) {
+        set((s) => {
+          s.error = (err as Error).message;
+          s.loading = false;
+        });
+      }
+    },
+
+    endSession: async () => {
+      const sessionId = get().sessionId;
+      if (sessionId) {
+        try {
+          await tutorApi.sessionEnd(sessionId);
+        } catch (err) {
+          // Best-effort — logger mais ne pas bloquer
+          console.error("[tutorStore] endSession failed", err);
+        }
+      }
+      set((s) => {
+        Object.assign(s, INITIAL);
+      });
+    },
+
+    setFullscreen: (v) =>
+      set((s) => {
+        s.fullscreen = v;
+      }),
+
+    reset: () =>
+      set((s) => {
+        Object.assign(s, INITIAL);
+      }),
+  })),
+);


### PR DESCRIPTION
## Summary
- Promotion `useTutor` (useReducer local) en store Zustand global pour partage popup ↔ Hub fullscreen (conv jamais perdue à la bascule).
- Resize handles (4 bords + 4 coins) sur `DraggableTutorWindow` + persistance `localStorage` (`ds-tutor-size`).
- Bouton "Plein écran" dans `TutorMiniChat` → navigation `/hub?fsChat=tutor`.
- Nouvelle vue plein écran chat (`HubPage` dispatcher + `FullscreenChatView` extensible quickchat/debate + `TutorFullscreen`).
- Bouton "Retour au chat" dans `VoiceOverlay` (via prop optionnelle `onBackToChat` forwardée par `VoiceTutorModal` quand une conv texte est en cours).

## Test plan
- [x] Vitest `tutorStore` (10 tests state + actions + errors + reset)
- [x] Vitest `DraggableTutorWindow.test.tsx` (10 tests resize handles + persistance + clamp) + tests unitaires existants des snap helpers (14 tests verts)
- [x] Vitest `FullscreenChatView.test.tsx` (4 tests dispatcher) + `TutorFullscreen.test.tsx` (6 tests rendu + actions store)
- [x] Vitest `Tutor.test.tsx` (8 tests) + `useTutor.test.ts` (5 tests) — wrap `MemoryRouter` ajouté pour le nouveau `useNavigate`
- [x] Typecheck — zéro erreur introduite (les 19 erreurs pré-existantes restent inchangées : HubPage L371→L372 = simple shift d'1 ligne dû à l'import ajouté)
- [x] Lint — zéro warning/error introduit
- [ ] Manuel : drag-resize sur 4 bords + 4 coins (clamp aux min/max, persist au reload), bouton fullscreen popup → vue Hub `/hub?fsChat=tutor`, retour à la popup, retour au chat depuis voice tutor.

## Architecture notes
- `HubPage` est désormais un dispatcher minimal qui early-return sur `?fsChat=`. La logique legacy vit dans `HubPageInner` (split nécessaire pour préserver l'ordre des hooks React lors des transitions d'URL — sans split, navigate de `/hub?fsChat=tutor` à `/hub` aurait violé Rules of Hooks).
- `useTutor` est conservé comme wrapper minimal pour ne pas casser la signature publique exposée à `Tutor.tsx` / `TutorPrompting.tsx` / `TutorMiniChat.tsx`.
- `FullscreenChatView` dispatcher prêt à recevoir d'autres types (`quickchat`, `debate`) plus tard.

Spec : `docs/superpowers/specs/2026-05-10-tuteur-refactor.md` (Axes A/B/C/D V2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)