### PR TITLE
feat(visual-analysis): default/expert mode tied to plan, frames adapt to duration

### DIFF
--- a/backend/src/videos/frame_extractor.py
+++ b/backend/src/videos/frame_extractor.py
@@ -24,7 +24,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from transcripts.audio_utils import _yt_dlp_extra_args
 
@@ -39,6 +39,28 @@ logger = logging.getLogger(__name__)
 MAX_FRAMES = 100
 MAX_FPS = 2.0
 DEFAULT_FRAME_WIDTH = 512  # px ; 1024 si OCR nécessaire (option future)
+
+# Grille de frames par mode × durée vidéo (mode normal, hors focused)
+# - "default" = Pro : analyse plus légère, plafond ~24 frames analysées
+# - "expert"  = Expert : analyse approfondie, pousse au cap dur Mistral (8 batches × 8)
+# Multiples de 8 pour saturer les batches Mistral (8 images/req max).
+FRAME_BUDGET_GRID: Dict[str, List[Tuple[float, int]]] = {
+    "default": [
+        (30.0, 8),
+        (60.0, 12),
+        (180.0, 16),
+        (600.0, 20),
+        (float("inf"), 24),
+    ],
+    "expert": [
+        (30.0, 16),
+        (60.0, 24),
+        (180.0, 40),
+        (600.0, 56),
+        (float("inf"), 64),
+    ],
+}
+DEFAULT_MODE = "default"
 
 # Timeouts
 DOWNLOAD_TIMEOUT_S = 300  # 5 min max pour télécharger
@@ -96,18 +118,17 @@ def compute_frame_budget(
     duration_s: float,
     focused_start: Optional[float] = None,
     focused_end: Optional[float] = None,
+    *,
+    mode: str = DEFAULT_MODE,
 ) -> Tuple[float, int, bool]:
     """
-    Calcule (fps, max_frames, long_video_warning) selon la durée.
+    Calcule (fps, max_frames, long_video_warning) selon la durée et le mode.
 
-    Mode normal (full video) :
-    - ≤30s   → fps adaptatif (cap 2), 30 frames max
-    - 30-60s → 40 frames
-    - 1-3min → 60 frames
-    - 3-10min → 80 frames
-    - >10min → 100 frames sparse (warning)
+    Mode normal (full video) — grille adaptative par durée, par mode :
+    - "default" (Pro)   : 8 → 24 frames selon durée
+    - "expert"  (Expert): 16 → 64 frames selon durée
 
-    Mode focused (start/end fournis) : densité plus élevée.
+    Mode focused (start/end fournis) : densité plus élevée, indépendant du mode.
 
     Le caller est libre de bypass via override (--max-frames N).
     """
@@ -137,17 +158,15 @@ def compute_frame_budget(
 
         return fps, min(target_frames, MAX_FRAMES), False
 
-    # ── Mode normal : full video ──
-    if duration_s <= 30:
-        target_frames = min(30, max(10, int(duration_s * 1)))
-    elif duration_s <= 60:
-        target_frames = 40
-    elif duration_s <= 180:  # 3 min
-        target_frames = 60
-    elif duration_s <= 600:  # 10 min
-        target_frames = 80
-    else:
-        target_frames = MAX_FRAMES
+    # ── Mode normal : grille par mode ──
+    grid = FRAME_BUDGET_GRID.get(mode) or FRAME_BUDGET_GRID[DEFAULT_MODE]
+    target_frames = grid[-1][1]
+    for max_dur, frames in grid:
+        if duration_s <= max_dur:
+            target_frames = frames
+            break
+
+    if duration_s > 600:
         long_warning = True
 
     target_frames = min(target_frames, MAX_FRAMES)
@@ -307,6 +326,7 @@ async def extract_frames_from_url(
     focused_end: Optional[float] = None,
     max_frames_override: Optional[int] = None,
     width: int = DEFAULT_FRAME_WIDTH,
+    mode: str = DEFAULT_MODE,
     log_tag: str = "FRAME_EXTRACT",
 ) -> Optional[FrameExtractionResult]:
     """
@@ -315,7 +335,7 @@ async def extract_frames_from_url(
     1. Crée un workdir unique sous FRAMES_BASE_DIR
     2. Télécharge la vidéo via yt-dlp (proxy + cookies hérités)
     3. ffprobe → durée
-    4. compute_frame_budget → (fps, max_frames)
+    4. compute_frame_budget(duration, mode=mode) → (fps, max_frames)
     5. ffmpeg → extraction JPEG
     6. Renvoie FrameExtractionResult ; le caller appelle .cleanup() en fin de vie
 
@@ -348,6 +368,7 @@ async def extract_frames_from_url(
             duration_s,
             focused_start=focused_start,
             focused_end=focused_end,
+            mode=mode,
         )
         if max_frames_override is not None:
             target_frames = min(max_frames_override, MAX_FRAMES)
@@ -360,13 +381,14 @@ async def extract_frames_from_url(
             fps = min(MAX_FPS, target_frames / effective_duration)
 
         logger.info(
-            "[%s] duration=%.1fs fps=%.3f target_frames=%d long=%s focused=%s",
+            "[%s] duration=%.1fs fps=%.3f target_frames=%d long=%s focused=%s mode=%s",
             log_tag,
             duration_s,
             fps,
             target_frames,
             long_warning,
             focused_start is not None or focused_end is not None,
+            mode,
         )
 
         # ── 4. Extraction frames ──
@@ -427,6 +449,7 @@ async def extract_frames_from_local(
     focused_end: Optional[float] = None,
     max_frames_override: Optional[int] = None,
     width: int = DEFAULT_FRAME_WIDTH,
+    mode: str = DEFAULT_MODE,
     log_tag: str = "FRAME_EXTRACT",
 ) -> Optional[FrameExtractionResult]:
     """Variante pour fichier local déjà téléchargé. Skip l'étape yt-dlp."""
@@ -448,7 +471,10 @@ async def extract_frames_from_local(
             return None
 
         fps, target_frames, long_warning = compute_frame_budget(
-            duration_s, focused_start=focused_start, focused_end=focused_end
+            duration_s,
+            focused_start=focused_start,
+            focused_end=focused_end,
+            mode=mode,
         )
         if max_frames_override is not None:
             target_frames = min(max_frames_override, MAX_FRAMES)

--- a/backend/src/videos/visual_analyzer.py
+++ b/backend/src/videos/visual_analyzer.py
@@ -39,7 +39,8 @@ FALLBACK_MODELS = ["pixtral-12b-2409", "mistral-small-2603"]
 MISTRAL_IMAGES_PER_REQUEST = 8
 
 # Cap global sur le nombre de frames analysées (8 batches × 8 frames).
-# Au-delà, downsampling uniforme pour rester sous le cap.
+# Default = mode "expert". Le caller peut passer un cap plus bas pour mode "default" (Pro).
+# Au-delà du cap effectif, downsampling uniforme.
 MAX_FRAMES_TOTAL_CAP = 64
 
 # Timeout par batch (8 frames ~5-15s normalement).
@@ -336,6 +337,7 @@ async def analyze_frames(
     *,
     model: str = PRIMARY_MODEL,
     fallback_models: Optional[List[str]] = None,
+    max_frames_cap: int = MAX_FRAMES_TOTAL_CAP,
     log_tag: str = "VISUAL_ANALYZER",
 ) -> Optional[VisualAnalysis]:
     """
@@ -343,6 +345,10 @@ async def analyze_frames(
 
     Découpe les frames en batches de ≤MISTRAL_IMAGES_PER_REQUEST, lance les batches
     en parallèle, merge les résultats partiels.
+
+    `max_frames_cap` : limite haute du nombre de frames effectivement envoyées à
+    Mistral (downsampling uniforme au-delà). Default 64 (Expert) ; passer 24 pour
+    mode Pro / "default". Doit rester ≤ MAX_FRAMES_TOTAL_CAP (cap dur batches × 8).
 
     Renvoie None si :
     - Aucune clé Mistral configurée
@@ -367,17 +373,20 @@ async def analyze_frames(
 
     effective_fallbacks = fallback_models if fallback_models is not None else FALLBACK_MODELS
 
+    # Clamp le cap demandé à la limite dure (8 batches × 8 frames Mistral)
+    effective_cap = max(1, min(max_frames_cap, MAX_FRAMES_TOTAL_CAP))
+
     downsampled = False
-    if len(frame_paths) > MAX_FRAMES_TOTAL_CAP:
+    if len(frame_paths) > effective_cap:
         downsampled = True
-        sampled_paths = _downsample(frame_paths, MAX_FRAMES_TOTAL_CAP)
-        sampled_ts = _downsample(frame_timestamps, MAX_FRAMES_TOTAL_CAP)
+        sampled_paths = _downsample(frame_paths, effective_cap)
+        sampled_ts = _downsample(frame_timestamps, effective_cap)
         logger.info(
             "[%s] Downsampled %d → %d frames (cap %d)",
             log_tag,
             len(frame_paths),
             len(sampled_paths),
-            MAX_FRAMES_TOTAL_CAP,
+            effective_cap,
         )
     else:
         sampled_paths = list(frame_paths)

--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -50,8 +50,30 @@ VISUAL_QUOTA_BY_PLAN: Dict[str, Optional[int]] = {
     "plus": 30,
 }
 
-# Coût en crédits par appel visual_analysis (s'ajoute au coût d'analyse de base)
-VISUAL_CREDITS_COST = 2
+# Coût en crédits par appel visual_analysis (s'ajoute au coût d'analyse de base).
+# Différencié par mode : Pro (default) paye moins, Expert paye plus pour ×2-3 frames.
+VISUAL_CREDITS_COST_BY_MODE: Dict[str, int] = {
+    "default": 2,
+    "expert": 3,
+}
+# Cap frames analysées par Mistral, par mode. Default (Pro) plafonne ~24,
+# Expert pousse au cap dur Mistral (64 = 8 batches × 8 frames).
+MAX_FRAMES_CAP_BY_MODE: Dict[str, int] = {
+    "default": 24,
+    "expert": 64,
+}
+# Rétro-compat : constante historique. Lisez VISUAL_CREDITS_COST_BY_MODE pour la valeur réelle.
+VISUAL_CREDITS_COST = VISUAL_CREDITS_COST_BY_MODE["default"]
+
+
+def _select_mode_for_plan(plan: Optional[str]) -> str:
+    """Mappe le plan user → mode visual analysis ('default' | 'expert').
+
+    Plans Expert obtiennent le mode dense (~64 frames cap). Tous les autres plans
+    payants (Pro, starter legacy, plus legacy) sont en mode 'default' (~24 frames cap).
+    Free n'arrive pas jusqu'ici (filtré en amont par can_consume).
+    """
+    return "expert" if _normalize_plan(plan) == "expert" else "default"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -186,7 +208,10 @@ async def maybe_enrich_with_visual(
         logger.info("[%s] Skipped (%s)", log_tag, reason)
         return {"status": reason, "elapsed_s": round(time.time() - t0, 2)}
 
-    # ── 2. Détection plateforme + extraction frames adaptée ──
+    # ── 2. Sélection mode selon plan ──
+    mode = _select_mode_for_plan(getattr(user, "plan", None))
+
+    # ── 3. Détection plateforme + extraction frames adaptée ──
     platform = _detect_visual_platform(url)
 
     if platform == "youtube":
@@ -196,13 +221,13 @@ async def maybe_enrich_with_visual(
                 "status": STATUS_NOT_SUPPORTED,
                 "elapsed_s": round(time.time() - t0, 2),
             }
-        extraction = await extract_storyboard_frames(video_id, log_tag=log_tag)
+        extraction = await extract_storyboard_frames(video_id, mode=mode, log_tag=log_tag)
         identifier_for_logs = video_id
     elif platform == "tiktok":
         # TikTok : download via tikwm fallback (IP Hetzner ban yt-dlp direct)
         # → extract_frames_from_local → cleanup
         video_id = _extract_tiktok_id_or_fallback(url)
-        extraction = await _extract_tiktok_visual_frames(url, video_id, log_tag=log_tag)
+        extraction = await _extract_tiktok_visual_frames(url, video_id, mode=mode, log_tag=log_tag)
         identifier_for_logs = video_id
     else:
         return {
@@ -215,15 +240,18 @@ async def maybe_enrich_with_visual(
             "status": STATUS_EXTRACT_FAILED,
             "video_id": identifier_for_logs,
             "platform": platform,
+            "visual_mode": mode,
             "elapsed_s": round(time.time() - t0, 2),
         }
 
-    # ── 3. Mistral Vision (commun à toutes plateformes) ──
+    # ── 4. Mistral Vision (commun à toutes plateformes) ──
+    max_frames_cap = MAX_FRAMES_CAP_BY_MODE.get(mode, MAX_FRAMES_CAP_BY_MODE["default"])
     try:
         analysis = await analyze_frames(
             extraction.frame_paths,
             extraction.frame_timestamps,
             transcript_excerpt=transcript_excerpt,
+            max_frames_cap=max_frames_cap,
             log_tag=log_tag,
         )
     finally:
@@ -234,34 +262,39 @@ async def maybe_enrich_with_visual(
             "status": STATUS_VISION_FAILED,
             "video_id": identifier_for_logs,
             "platform": platform,
+            "visual_mode": mode,
             "frame_count": extraction.frame_count,
             "elapsed_s": round(time.time() - t0, 2),
         }
 
-    # ── 4. Quota incrément (succès uniquement) ──
+    # ── 5. Quota incrément (succès uniquement) ──
     new_count = await increment_quota(db, user.id)
 
     elapsed = round(time.time() - t0, 2)
+    credits_consumed = VISUAL_CREDITS_COST_BY_MODE.get(mode, VISUAL_CREDITS_COST_BY_MODE["default"])
     logger.info(
-        "[%s] OK in %.1fs (platform=%s frames=%d model=%s quota_count=%d)",
+        "[%s] OK in %.1fs (platform=%s mode=%s frames=%d model=%s quota_count=%d credits=%d)",
         log_tag,
         elapsed,
         platform,
+        mode,
         extraction.frame_count,
         analysis.model_used,
         new_count,
+        credits_consumed,
     )
 
     return {
         "status": STATUS_OK,
         "video_id": identifier_for_logs,
         "platform": platform,
+        "visual_mode": mode,
         "frame_count": extraction.frame_count,
         "duration_s": round(extraction.duration_s, 2),
         "model_used": analysis.model_used,
         "frames_downsampled": analysis.frames_downsampled,
         "analysis": analysis.to_dict(),
-        "credits_consumed": VISUAL_CREDITS_COST,
+        "credits_consumed": credits_consumed,
         "quota_count_after": new_count,
         "elapsed_s": elapsed,
     }
@@ -378,7 +411,7 @@ async def _download_tiktok_video_no_watermark(
 
 
 async def _extract_tiktok_visual_frames(
-    url: str, video_id: str, *, log_tag: str
+    url: str, video_id: str, *, mode: str = "default", log_tag: str
 ) -> Optional[FrameExtractionResult]:
     """Pipeline TikTok : tikwm `data.play` → /tmp .mp4 → extract_frames_from_local.
 
@@ -386,6 +419,8 @@ async def _extract_tiktok_visual_frames(
     expose le mp4 no-watermark dans `data.play`. On l'utilise directement ici
     plutôt que `transcripts.tiktok._download_video_bytes()` qui priorise
     `music_info.play` (audio mp3, inutilisable pour ffmpeg).
+
+    `mode` est propagé à extract_frames_from_local pour appliquer la grille frames.
     """
     t0 = time.time()
     try:
@@ -414,7 +449,9 @@ async def _extract_tiktok_visual_frames(
         return None
 
     try:
-        result = await extract_frames_from_local(str(tmp_path), log_tag=f"{log_tag} TIKTOK")
+        result = await extract_frames_from_local(
+            str(tmp_path), mode=mode, log_tag=f"{log_tag} TIKTOK"
+        )
     finally:
         # Le mp4 source n'est plus utile une fois les frames extraites — peu importe le résultat
         tmp_path.unlink(missing_ok=True)

--- a/backend/src/videos/youtube_storyboard.py
+++ b/backend/src/videos/youtube_storyboard.py
@@ -37,7 +37,13 @@ from PIL import Image
 
 from transcripts.audio_utils import _yt_dlp_extra_args
 
-from .frame_extractor import FRAMES_BASE_DIR, MAX_FRAMES, FrameExtractionResult
+from .frame_extractor import (
+    DEFAULT_MODE,
+    FRAMES_BASE_DIR,
+    MAX_FRAMES,
+    FrameExtractionResult,
+    compute_frame_budget,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +204,7 @@ async def extract_storyboard_frames(
     video_id_or_url: str,
     *,
     max_frames_override: Optional[int] = None,
+    mode: str = DEFAULT_MODE,
     log_tag: str = "STORYBOARD",
 ) -> Optional[FrameExtractionResult]:
     """
@@ -207,7 +214,7 @@ async def extract_storyboard_frames(
     3. Sélection format sb* de meilleure résolution
     4. Download tous les sheets (httpx + retries)
     5. Slice chaque sheet via Pillow
-    6. Sauvegarde frames JPEG dans workdir unique
+    6. Tronque selon le budget (mode × durée) ou max_frames_override
     7. Renvoie FrameExtractionResult drop-in pour visual_analyzer
 
     Renvoie None à toute étape qui échoue. Workdir est nettoyé automatiquement
@@ -316,10 +323,16 @@ async def extract_storyboard_frames(
             shutil.rmtree(workdir, ignore_errors=True)
             return None
 
-        # ── 5. Override max_frames ──
-        if max_frames_override and len(frame_paths) > max_frames_override:
-            step = len(frame_paths) / max_frames_override
-            keep_indices = sorted(set(int(i * step) for i in range(max_frames_override)))
+        # ── 5. Budget frames (mode × durée) ou override explicite ──
+        if max_frames_override is None:
+            _, budget_frames, _ = compute_frame_budget(duration_s, mode=mode)
+            effective_max = budget_frames
+        else:
+            effective_max = max_frames_override
+
+        if effective_max and len(frame_paths) > effective_max:
+            step = len(frame_paths) / effective_max
+            keep_indices = sorted(set(int(i * step) for i in range(effective_max)))
             kept_paths = []
             kept_ts = []
             for i, p in enumerate(frame_paths):
@@ -330,6 +343,15 @@ async def extract_storyboard_frames(
                     Path(p).unlink(missing_ok=True)
             frame_paths = kept_paths
             frame_timestamps = kept_ts
+
+        logger.info(
+            "[%s] mode=%s budget=%d kept=%d (raw=%d before tronc)",
+            log_tag,
+            mode,
+            effective_max,
+            len(frame_paths),
+            len(frame_paths) if effective_max == 0 else max(effective_max, len(frame_paths)),
+        )
 
         # ── 6. Wrap result ──
         fps_used = len(frame_paths) / duration_s if duration_s > 0 else 0.0

--- a/backend/tests/videos/test_frame_extractor.py
+++ b/backend/tests/videos/test_frame_extractor.py
@@ -30,75 +30,133 @@ _HAS_FFMPEG = shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is 
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-class TestComputeFrameBudget:
-    """Vérifie le scaling claude-video-style par durée."""
+class TestComputeFrameBudgetDefaultMode:
+    """Mode 'default' (Pro) — grille light : 8→24 frames selon durée."""
 
     def test_short_video_under_30s(self):
         from videos.frame_extractor import MAX_FPS, compute_frame_budget
 
-        fps, frames, warning = compute_frame_budget(20.0)
-        assert frames <= 30
-        assert frames >= 10
+        fps, frames, warning = compute_frame_budget(20.0, mode="default")
+        assert frames == 8
         assert fps <= MAX_FPS
         assert warning is False
 
     def test_medium_30_60s(self):
         from videos.frame_extractor import compute_frame_budget
 
-        fps, frames, warning = compute_frame_budget(45.0)
-        assert frames == 40
+        fps, frames, warning = compute_frame_budget(45.0, mode="default")
+        assert frames == 12
         assert warning is False
 
     def test_1_to_3_min(self):
         from videos.frame_extractor import compute_frame_budget
 
-        fps, frames, warning = compute_frame_budget(120.0)
-        assert frames == 60
+        fps, frames, warning = compute_frame_budget(120.0, mode="default")
+        assert frames == 16
         assert warning is False
 
     def test_3_to_10_min(self):
         from videos.frame_extractor import compute_frame_budget
 
-        fps, frames, warning = compute_frame_budget(420.0)  # 7 min
-        assert frames == 80
+        fps, frames, warning = compute_frame_budget(420.0, mode="default")
+        assert frames == 20
         assert warning is False
 
-    def test_long_video_warning(self):
-        from videos.frame_extractor import MAX_FRAMES, compute_frame_budget
+    def test_long_video_caps_at_24(self):
+        from videos.frame_extractor import compute_frame_budget
 
-        fps, frames, warning = compute_frame_budget(1800.0)  # 30 min
-        assert frames == MAX_FRAMES
+        fps, frames, warning = compute_frame_budget(1800.0, mode="default")  # 30 min
+        assert frames == 24
         assert warning is True
 
+
+class TestComputeFrameBudgetExpertMode:
+    """Mode 'expert' (Expert) — grille dense : 16→64 frames, cap dur Mistral."""
+
+    def test_short_video_under_30s(self):
+        from videos.frame_extractor import compute_frame_budget
+
+        _, frames, warning = compute_frame_budget(20.0, mode="expert")
+        assert frames == 16
+        assert warning is False
+
+    def test_medium_30_60s(self):
+        from videos.frame_extractor import compute_frame_budget
+
+        _, frames, _ = compute_frame_budget(45.0, mode="expert")
+        assert frames == 24
+
+    def test_1_to_3_min(self):
+        from videos.frame_extractor import compute_frame_budget
+
+        _, frames, _ = compute_frame_budget(120.0, mode="expert")
+        assert frames == 40
+
+    def test_3_to_10_min(self):
+        from videos.frame_extractor import compute_frame_budget
+
+        _, frames, _ = compute_frame_budget(420.0, mode="expert")
+        assert frames == 56
+
+    def test_long_video_caps_at_64(self):
+        from videos.frame_extractor import compute_frame_budget
+
+        _, frames, warning = compute_frame_budget(1800.0, mode="expert")
+        assert frames == 64
+        assert warning is True
+
+    def test_expert_strictly_denser_than_default_across_durations(self):
+        """Pour chaque tranche de durée, expert renvoie ≥ default."""
+        from videos.frame_extractor import compute_frame_budget
+
+        for dur in (20.0, 45.0, 120.0, 420.0, 1800.0):
+            _, default_frames, _ = compute_frame_budget(dur, mode="default")
+            _, expert_frames, _ = compute_frame_budget(dur, mode="expert")
+            assert expert_frames > default_frames, f"dur={dur}"
+
+
+class TestComputeFrameBudgetMisc:
+    """Fps cap, focused mode, robustesse."""
+
     def test_fps_capped_at_max(self):
-        """Sur très courte vidéo, fps ne doit jamais dépasser MAX_FPS."""
         from videos.frame_extractor import MAX_FPS, compute_frame_budget
 
         fps, _, _ = compute_frame_budget(5.0)
         assert fps <= MAX_FPS
 
-    def test_focused_mode_dense(self):
-        """Focused mode → densité plus élevée que full video."""
+    def test_unknown_mode_falls_back_to_default(self):
+        """Mode invalide → fallback silencieux sur 'default' (pas de crash)."""
         from videos.frame_extractor import compute_frame_budget
 
-        # 10s focus dans une vidéo de 600s
+        _, frames_default, _ = compute_frame_budget(45.0, mode="default")
+        _, frames_unknown, _ = compute_frame_budget(45.0, mode="bogus_mode")
+        assert frames_default == frames_unknown == 12
+
+    def test_default_mode_when_unspecified(self):
+        """Sans mode explicite → comportement 'default'."""
+        from videos.frame_extractor import compute_frame_budget
+
+        _, frames_implicit, _ = compute_frame_budget(45.0)
+        _, frames_explicit, _ = compute_frame_budget(45.0, mode="default")
+        assert frames_implicit == frames_explicit
+
+    def test_focused_mode_dense_ignores_mode(self):
+        """Focused mode garde sa densité historique indépendamment du mode."""
+        from videos.frame_extractor import compute_frame_budget
+
         fps, frames, warning = compute_frame_budget(
-            600.0, focused_start=120.0, focused_end=130.0
+            600.0, focused_start=120.0, focused_end=130.0, mode="default"
         )
-        # 10s à 2 fps cap = 20 frames max attendu
         assert frames <= 30
         assert warning is False
 
     def test_focused_mode_full_range_implicit(self):
-        """focused_start sans focused_end → end = duration."""
         from videos.frame_extractor import compute_frame_budget
 
         fps, frames, _ = compute_frame_budget(60.0, focused_start=30.0)
-        # On focus sur 30→60s, soit 30s
         assert frames > 0
 
     def test_zero_duration_safety(self):
-        """Durée 0 ne crashe pas (max() de protection)."""
         from videos.frame_extractor import compute_frame_budget
 
         fps, frames, _ = compute_frame_budget(0.5)

--- a/backend/tests/videos/test_visual_integration.py
+++ b/backend/tests/videos/test_visual_integration.py
@@ -286,15 +286,15 @@ class TestMaybeEnrichWithVisual:
 
     @pytest.mark.asyncio
     async def test_happy_path(self, monkeypatch):
+        """Expert plan → mode='expert', credits=3, max_frames_cap=64."""
         from videos import visual_integration as vi
         from videos.visual_integration import STATUS_OK
         from videos.frame_extractor import FrameExtractionResult
         from videos.visual_analyzer import VisualAnalysis
 
         db = _make_db_with_no_quota_row()
-        user = _make_user("expert")  # Pas de quota check besides initial allowed
+        user = _make_user("expert")
 
-        # Mock extraction
         fake_extraction = FrameExtractionResult(
             workdir="/tmp/fake",
             frame_paths=["/tmp/fake/f1.jpg", "/tmp/fake/f2.jpg"],
@@ -306,13 +306,18 @@ class TestMaybeEnrichWithVisual:
             long_video_warning=False,
         )
 
+        extract_kwargs = {}
+
         async def fake_extract(*args, **kwargs):
+            extract_kwargs.update(kwargs)
             return fake_extraction
 
-        # Patch cleanup pour ne pas tenter de supprimer un dossier inexistant
         fake_extraction.cleanup = MagicMock()
 
+        analyze_kwargs = {}
+
         async def fake_analyze(*args, **kwargs):
+            analyze_kwargs.update(kwargs)
             return VisualAnalysis(
                 visual_hook="hook visuel test",
                 visual_structure="talking_head",
@@ -337,12 +342,15 @@ class TestMaybeEnrichWithVisual:
         assert result["status"] == STATUS_OK
         assert result["video_id"] == "dQw4w9WgXcQ"
         assert result["platform"] == "youtube"
+        assert result["visual_mode"] == "expert"
         assert result["frame_count"] == 2
         assert result["model_used"] == "pixtral-large-2411"
-        assert result["credits_consumed"] == 2
+        assert result["credits_consumed"] == 3
         assert result["analysis"]["visual_structure"] == "talking_head"
         assert "elapsed_s" in result
-        # cleanup a été appelé pour purger les frames
+        # Mode 'expert' propagé à l'extraction storyboard et au cap analyzer
+        assert extract_kwargs.get("mode") == "expert"
+        assert analyze_kwargs.get("max_frames_cap") == 64
         fake_extraction.cleanup.assert_called_once()
 
 
@@ -479,9 +487,10 @@ class TestMaybeEnrichWithVisualTiktok:
 
         captured = {}
 
-        async def fake_tiktok_extract(url, video_id, *, log_tag=""):
+        async def fake_tiktok_extract(url, video_id, *, mode="default", log_tag=""):
             captured["url"] = url
             captured["video_id"] = video_id
+            captured["mode"] = mode
             return None  # Trigger EXTRACT_FAILED, peu importe ici
 
         monkeypatch.setattr(vi, "_extract_tiktok_visual_frames", fake_tiktok_extract)
@@ -492,3 +501,130 @@ class TestMaybeEnrichWithVisualTiktok:
 
         assert captured["url"] == "https://www.tiktok.com/@khaby.lame/video/7459716872551976210"
         assert captured["video_id"] == "7459716872551976210"
+        assert captured["mode"] == "expert"  # User Expert → mode expert propagé
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎚️ Mode par plan + crédits différenciés
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestVisualModeByPlan:
+    """Vérifie que le plan utilisateur sélectionne le bon mode + bon cap + bons crédits."""
+
+    def test_select_mode_for_plan_helper(self):
+        from videos.visual_integration import _select_mode_for_plan
+
+        assert _select_mode_for_plan("expert") == "expert"
+        assert _select_mode_for_plan("EXPERT") == "expert"
+        assert _select_mode_for_plan("pro") == "default"
+        assert _select_mode_for_plan("starter") == "default"
+        assert _select_mode_for_plan("plus") == "default"
+        assert _select_mode_for_plan(None) == "default"
+        assert _select_mode_for_plan("free") == "default"  # Free filtré en amont par can_consume
+
+    def test_constants_consistency(self):
+        from videos.visual_integration import (
+            MAX_FRAMES_CAP_BY_MODE,
+            VISUAL_CREDITS_COST,
+            VISUAL_CREDITS_COST_BY_MODE,
+        )
+
+        assert MAX_FRAMES_CAP_BY_MODE["default"] == 24
+        assert MAX_FRAMES_CAP_BY_MODE["expert"] == 64
+        assert VISUAL_CREDITS_COST_BY_MODE["default"] == 2
+        assert VISUAL_CREDITS_COST_BY_MODE["expert"] == 3
+        # Rétro-compat : VISUAL_CREDITS_COST pointe sur la valeur 'default'
+        assert VISUAL_CREDITS_COST == VISUAL_CREDITS_COST_BY_MODE["default"]
+
+    @pytest.mark.asyncio
+    async def test_pro_uses_default_mode_and_low_cap(self, monkeypatch):
+        """Pro plan → mode='default', credits=2, max_frames_cap=24."""
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_OK
+        from videos.frame_extractor import FrameExtractionResult
+        from videos.visual_analyzer import VisualAnalysis
+
+        db = _make_db_with_no_quota_row()
+        user = _make_user("pro")
+
+        fake_extraction = FrameExtractionResult(
+            workdir="/tmp/fake_pro",
+            frame_paths=["/tmp/fake_pro/f1.jpg"],
+            frame_timestamps=[0.5],
+            duration_s=60.0,
+            fps_used=0.2,
+            frame_count=1,
+            width=320,
+            long_video_warning=False,
+        )
+        fake_extraction.cleanup = MagicMock()
+
+        extract_kwargs = {}
+        analyze_kwargs = {}
+
+        async def fake_extract(*args, **kwargs):
+            extract_kwargs.update(kwargs)
+            return fake_extraction
+
+        async def fake_analyze(*args, **kwargs):
+            analyze_kwargs.update(kwargs)
+            return VisualAnalysis(
+                visual_hook="pro hook",
+                visual_structure="talking_head",
+                model_used="pixtral-large-2411",
+                frames_analyzed=1,
+            )
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+        monkeypatch.setattr(vi, "analyze_frames", fake_analyze)
+
+        result = await vi.maybe_enrich_with_visual(
+            db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+
+        assert result["status"] == STATUS_OK
+        assert result["visual_mode"] == "default"
+        assert result["credits_consumed"] == 2
+        assert extract_kwargs.get("mode") == "default"
+        assert analyze_kwargs.get("max_frames_cap") == 24
+
+    @pytest.mark.asyncio
+    async def test_legacy_starter_uses_default_mode(self, monkeypatch):
+        """Plan legacy 'starter' (pré-pricing v2) → mode='default'."""
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_OK
+        from videos.frame_extractor import FrameExtractionResult
+        from videos.visual_analyzer import VisualAnalysis
+
+        db = _make_db_with_quota(count_value=10)  # sous quota 30
+        user = _make_user("starter")
+
+        fake_extraction = FrameExtractionResult(
+            workdir="/tmp/fake_starter",
+            frame_paths=["/tmp/fake_starter/f1.jpg"],
+            frame_timestamps=[0.5],
+            duration_s=30.0,
+            fps_used=0.2,
+            frame_count=1,
+            width=320,
+            long_video_warning=False,
+        )
+        fake_extraction.cleanup = MagicMock()
+
+        async def fake_extract(*args, **kwargs):
+            return fake_extraction
+
+        async def fake_analyze(*args, **kwargs):
+            return VisualAnalysis(model_used="pixtral-large-2411", frames_analyzed=1)
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+        monkeypatch.setattr(vi, "analyze_frames", fake_analyze)
+
+        result = await vi.maybe_enrich_with_visual(
+            db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+
+        assert result["status"] == STATUS_OK
+        assert result["visual_mode"] == "default"
+        assert result["credits_consumed"] == 2


### PR DESCRIPTION
## Résumé

Différencie l''analyse visuelle Pro / Expert en deux modes appliqués automatiquement selon le plan, chaque mode restant adaptatif à la durée vidéo.

- **Pro** → mode `default` : cap 24 frames, 2 crédits/appel
- **Expert** → mode `expert` : cap 64 frames (limite Mistral 8×8), 3 crédits/appel
- **Free** : inchangé, skip silencieux (quota=0)

## Grille frames × mode × durée

| Durée vidéo | Pro (`default`) | Expert (`expert`) |
|-------------|-----------------|-------------------|
| ≤ 30 s      | 8               | 16                |
| 30-60 s     | 12              | 24                |
| 1-3 min     | 16              | 40                |
| 3-10 min    | 20              | 56                |
| > 10 min    | 24              | 64                |

Multiples de 8 pour saturer les batches Mistral (8 images/req). Expert ≈ ×2-3 frames analysées vs default → key_moments plus denses, hook plus précis, OCR `visible_text` mieux capté.

## Changements

- `frame_extractor.py` : `compute_frame_budget()` reçoit `mode`, table `FRAME_BUDGET_GRID` par mode, propagation à `extract_frames_from_url/_from_local`
- `youtube_storyboard.py` : `extract_storyboard_frames(..., mode=)` calcule `max_frames_override` via `compute_frame_budget` si non fourni
- `visual_analyzer.py` : `analyze_frames(..., max_frames_cap=)` paramétrable (clamp ≤ 64 cap dur Mistral)
- `visual_integration.py` :
  - `VISUAL_CREDITS_COST_BY_MODE = {"default": 2, "expert": 3}`
  - `MAX_FRAMES_CAP_BY_MODE = {"default": 24, "expert": 64}`
  - `_select_mode_for_plan(plan)` → "expert" si Expert, "default" sinon
  - `maybe_enrich_with_visual()` propage `mode` à l''extraction et `max_frames_cap` à l''analyzer
  - Retour ajoute `"visual_mode": mode`
  - `_extract_tiktok_visual_frames(..., mode=)` propagé à `extract_frames_from_local`

Aucune migration DB requise — `visual_mode` vit dans le dict de retour, pas dans le schéma `summaries.visual_analysis`.

## Tests

55/55 verts (14 nouveaux) :
- `TestComputeFrameBudgetDefaultMode` × 5
- `TestComputeFrameBudgetExpertMode` × 6 (dont expert ≥ default sur toutes durées)
- `TestComputeFrameBudgetMisc` × 6 (mode invalide → fallback, focused indépendant du mode)
- `TestVisualModeByPlan` × 4 (helper, constantes, Pro path, legacy starter)
- Mise à jour `test_happy_path` (Expert) et `test_tiktok_extract_uses_id_from_url`

## Test plan

- [ ] CI Pytest backend passe sur les tests modifiés
- [ ] Une fois mergé + déployé Hetzner : appel `/api/admin/visual/debug-from-youtube` avec user Expert → `visual_mode=expert` dans la réponse, `frames_analyzed` proche du cap durée
- [ ] Idem avec user Pro → `visual_mode=default`, `frames_analyzed` ≤ 24
- [ ] Vérifier coût crédits différencié dans les logs `credits=2` / `credits=3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)