### PR TITLE
fix(db): chat_messages.summary_id nullable — unblock knowledge_tutor + companion

### DIFF
--- a/backend/alembic/versions/026_chat_messages_summary_id_nullable.py
+++ b/backend/alembic/versions/026_chat_messages_summary_id_nullable.py
@@ -1,0 +1,87 @@
+"""chat_messages.summary_id nullable — fix knowledge_tutor + companion crash
+
+Revision ID: 026_chatmsg_summary_null
+Revises: 025_summary_is_public
+Create Date: 2026-05-11
+
+Bug Sentry PYTHON-FASTAPI-27 (28 occurrences depuis 2026-04-29) :
+`chat_messages.summary_id` est `NOT NULL` en prod alors que le model Python
+(`db/database.py:ChatMessage`) déclare `nullable=True` depuis le merge du
+spec voice unified timeline (migration 007). La migration 007 n'avait pas
+propagé le drop NOT NULL → tout INSERT sans `summary_id` crash en
+`NotNullViolationError`.
+
+Cas qui passent sans `summary_id` (et donc crashent jusqu'à ce fix) :
+  • Agent voice COMPANION (sans vidéo)
+  • Agent voice KNOWLEDGE_TUTOR (PR #439, deployed prod 2026-05-11) —
+    introspection globale de l'historique, pas de vidéo en cours
+  • Tout futur agent voice `requires_summary=False`
+
+Cascade observée : rollback async dans un context corrompu ré-émet
+`MissingGreenlet` côté SQLAlchemy, pollue le pool DB, fait timeout les
+endpoints concurrents (notamment `/api/history/videos` → "Erreur réseau"
+côté frontend).
+
+Migration idempotente : check is_nullable avant ALTER. Aucune data n'est
+modifiée, seulement la contrainte de colonne. Down-migration restaure
+NOT NULL si jamais besoin (mais data avec NULL existant après ce fix
+empêcherait le downgrade — ce qui est volontaire, NOT NULL était un
+bug).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "026_chatmsg_summary_null"
+down_revision: Union[str, None] = "025_summary_is_public"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Drop NOT NULL on chat_messages.summary_id."""
+    bind = op.get_bind()
+
+    # Idempotence : check si la colonne est déjà nullable.
+    result = bind.execute(
+        sa.text(
+            """
+            SELECT is_nullable
+            FROM information_schema.columns
+            WHERE table_name = 'chat_messages'
+              AND column_name = 'summary_id'
+            """
+        )
+    ).scalar()
+
+    if result == "YES":
+        # Déjà nullable — rien à faire.
+        return
+
+    op.alter_column(
+        "chat_messages",
+        "summary_id",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Restore NOT NULL on chat_messages.summary_id.
+
+    ⚠️ ATTENTION : ce downgrade échoue si des rows ont déjà
+    `summary_id IS NULL` (cas attendu après upgrade + utilisation
+    knowledge_tutor / companion). Pour rollback effectif, il faudrait
+    soit DELETE les rows orphelines, soit set un summary_id placeholder
+    — décision produit, donc on laisse le downgrade strict.
+    """
+    op.alter_column(
+        "chat_messages",
+        "summary_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )


### PR DESCRIPTION
## Summary

Hotfix for Sentry **[PYTHON-FASTAPI-27](https://deep-sight.sentry.io/issues/PYTHON-FASTAPI-27)** (28 occurrences since 2026-04-29, peak today after PR #439 deployed prod).

`chat_messages.summary_id` is `NOT NULL` in prod, but the Python model declares `nullable=True` since the v6.0 unified text+voice timeline (migration 007). Migration 007 forgot to propagate the drop NOT NULL to the actual DB schema.

## Visible symptoms

1. **Voice agent without video crashes**: COMPANION + KNOWLEDGE_TUTOR (new in PR #439) try to INSERT into `chat_messages` with `summary_id=NULL` → `NotNullViolationError`.
2. **Cascade DB pool corruption**: rollback in corrupted async context re-emits `MissingGreenlet`, pollutes the DB pool, makes concurrent endpoints time out.
3. **Frontend collateral damage**: `/api/history/videos` waits for a free connection and the frontend shows "Erreur réseau — Impossible de charger l'historique" on the History page (despite the user having analyses).

## Fix

Migration `026_chat_messages_summary_id_nullable.py`:
- Idempotent: checks `information_schema.columns.is_nullable` before ALTER.
- `ALTER TABLE chat_messages ALTER COLUMN summary_id DROP NOT NULL`.
- Downgrade restores NOT NULL (will fail if any NULL row exists after upgrade — voluntary, the prod state was a bug).

Auto-applied by `entrypoint.sh` (`alembic upgrade heads`) on next backend container restart, triggered by this PR's merge → push to main → Hetzner webhook → docker rebuild.

## Test plan

- [x] Migration is idempotent (re-run safe via is_nullable check)
- [x] No code change required — Python model already declares nullable=True
- [x] Existing data unaffected — only constraint relaxed
- [ ] Post-merge: verify backend container restart applied 026 (check `docker exec repo-backend-1 alembic current` shows `026_chatmsg_summary_null`)
- [ ] Post-merge: reproduce knowledge_tutor session, confirm no Sentry alert spike
- [ ] Post-merge: reload /history page, confirm loads with user's analyses

Fixes PYTHON-FASTAPI-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)