### PR TITLE
fix(visual-analysis): skip --proxy on YouTube metadata fetch (storyboard)

### DIFF
--- a/backend/src/transcripts/audio_utils.py
+++ b/backend/src/transcripts/audio_utils.py
@@ -24,16 +24,23 @@ from core.config import get_groq_key, get_youtube_proxy, get_ytdlp_cookies_path
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def _yt_dlp_extra_args() -> list:
+def _yt_dlp_extra_args(*, include_proxy: bool = True) -> list:
     """Common yt-dlp flags for IP-banned environments: proxy + cookies.
 
     Both are no-ops when their env vars are unset, so this is safe to call
     from every yt-dlp wrapper unconditionally (YouTube ET TikTok).
+
+    `include_proxy=False` permet de skipper l'injection `--proxy` pour les
+    appels qui ne font que du metadata fetch (`yt-dlp -j --skip-download`) :
+    le CDN i.ytimg.com et l'API watch?v= acceptent les requêtes directes depuis
+    l'IP du backend, et un proxy datacenter mal configuré ferait échouer la
+    requête (407 Proxy Authentication Required) alors qu'elle marcherait sans.
     """
     extra = []
-    proxy = get_youtube_proxy()
-    if proxy:
-        extra.extend(["--proxy", proxy])
+    if include_proxy:
+        proxy = get_youtube_proxy()
+        if proxy:
+            extra.extend(["--proxy", proxy])
     cookies = get_ytdlp_cookies_path()
     if cookies and os.path.exists(cookies):
         extra.extend(["--cookies", cookies])

--- a/backend/src/videos/youtube_storyboard.py
+++ b/backend/src/videos/youtube_storyboard.py
@@ -81,11 +81,16 @@ def normalize_video_id(value: str) -> Optional[str]:
 
 
 def _ytdlp_info_sync(video_id: str, log_tag: str) -> Optional[Dict[str, Any]]:
-    """Lance yt-dlp -j --skip-download (sync, à appeler dans un executor)."""
+    """Lance yt-dlp -j --skip-download (sync, à appeler dans un executor).
+
+    `include_proxy=False` : le metadata fetch YouTube (storyboards inclus)
+    fonctionne en direct depuis le backend Hetzner — le proxy Webshare
+    datacenter renvoie 407 et casse cet appel inutilement.
+    """
     url = f"https://www.youtube.com/watch?v={video_id}"
     cmd = [
         "yt-dlp",
-        *_yt_dlp_extra_args(),
+        *_yt_dlp_extra_args(include_proxy=False),
         "-j",
         "--skip-download",
         "--no-warnings",


### PR DESCRIPTION
## Symptôme

Depuis quelque temps, l''hook visual analysis YouTube en prod tombe systématiquement en `STATUS_EXTRACT_FAILED`. Logs container backend :

```
[VISUAL_INT user=1] yt-dlp -j failed: ERROR: [youtube] Q0l9fZPFJXY:
Unable to download API page: (''Unable to connect to proxy'',
OSError(''Tunnel connection failed: 407 Proxy Authentication Required''))
```

## Diagnostic

Test SSH sur le container :
- `yt-dlp -j --skip-download` **sans proxy** → ✅ JSON storyboards complet
- `yt-dlp -j --skip-download` **avec `--proxy $YOUTUBE_PROXY`** → ❌ 407 Proxy Auth Required

Root cause : `_yt_dlp_extra_args()` injecte `--proxy` inconditionnellement. Or le metadata fetch + le CDN storyboard (`i.ytimg.com`) acceptent les requêtes directes depuis l''IP Hetzner — le proxy Webshare datacenter (creds expirées ou rotation côté Webshare) renvoie 407 et casse tout.

Le proxy reste utile pour les vrais downloads (audio extraction, etc.) qui passent par les CDN googlevideo.com bot-challengés. Mais pas pour metadata.

## Fix

- `_yt_dlp_extra_args(*, include_proxy: bool = True)` — nouveau kwarg keyword-only
- `youtube_storyboard._ytdlp_info_sync` passe `include_proxy=False`
- Tous les autres callers gardent le comportement par défaut (proxy injecté)

## Impact

- Visual Analysis YouTube revient en green E2E (testé manuellement, sera revérifié post-merge sur prod)
- Aucun changement de comportement pour audio download, transcript fallback yt-dlp, ou n''importe quel autre caller
- 55/55 tests backend visual restent verts

## Test plan

- [ ] CI Pytest passe
- [ ] Post-merge prod : analyser une vidéo YouTube fresh (`ds_analyze`) → `visual_analysis.visual_mode` = "expert" pour mon compte
- [ ] Logs container : voir `[VISUAL_INT] OK in Xs (platform=youtube mode=expert ...)` au lieu du `extract_failed` actuel

## Follow-up (out of scope)

- **TikTok blocker externe** : tikwm.com renvoie "Url parsing failed" sur toutes les requêtes et son homepage est en 403 — service tiers dégradé. À mitiger via fallback chain (snaptik/ssstik/etc.) dans un sprint séparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)