### PR TITLE
fix(voice): back arrow closes settings panel instead of exiting call

### DIFF
--- a/frontend/src/components/voice/VoiceOverlay.tsx
+++ b/frontend/src/components/voice/VoiceOverlay.tsx
@@ -140,6 +140,7 @@ const I18N = {
     micMuted: "Micro coupé",
     settings: "Réglages",
     backToChat: "Retour au chat",
+    closeSettings: "Retour à l'appel",
   },
   en: {
     callTitle: "Voice call",
@@ -157,6 +158,7 @@ const I18N = {
     micMuted: "Mic muted",
     settings: "Settings",
     backToChat: "Back to chat",
+    closeSettings: "Back to call",
   },
 } as const;
 
@@ -389,13 +391,23 @@ export const VoiceOverlay: React.FC<VoiceOverlayProps> = ({
                 </div>
               </div>
               <div className="flex items-center gap-1 flex-shrink-0">
-                {onBackToChat && (
+                {(onBackToChat || settingsOpen) && (
                   <button
                     type="button"
-                    onClick={onBackToChat}
-                    aria-label={t.backToChat}
-                    title={t.backToChat}
-                    data-testid="voice-overlay-back-to-chat"
+                    onClick={
+                      settingsOpen
+                        ? () => setSettingsOpen(false)
+                        : onBackToChat
+                    }
+                    aria-label={
+                      settingsOpen ? t.closeSettings : t.backToChat
+                    }
+                    title={settingsOpen ? t.closeSettings : t.backToChat}
+                    data-testid={
+                      settingsOpen
+                        ? "voice-overlay-close-settings"
+                        : "voice-overlay-back-to-chat"
+                    }
                     className="p-1.5 rounded-lg hover:bg-white/[0.06] text-text-muted hover:text-text-secondary transition-colors"
                   >
                     <ChevronLeft className="w-4 h-4" />


### PR DESCRIPTION
## Symptom

When the user opens the in-call settings (gear icon) and clicks the chevron-left back arrow in the Voice overlay header, the **whole voice modal closes** and the user is dropped back into the TutorMiniChat popup in the top-right corner. They wanted to *just close the settings panel* and return to the transcript view of the ongoing call.

Reported with a screenshot of the Tuteur Vocal in-call settings open.

## Root cause

The back arrow in \`VoiceOverlay.tsx\` was always wired to the \`onBackToChat\` prop. For \`VoiceTutorModal\` (knowledge_tutor agent), \`onBackToChat\` is \`() => setVoiceTutorOpen(false)\` — which closes the entire voice modal. The button had no notion of "settings panel is currently open".

## Fix

The chevron-left button is now context-aware:

| Settings panel state | Click action | Visible label |
|---|---|---|
| Open | \`setSettingsOpen(false)\` — closes settings, stays in call | "Retour à l'appel" / "Back to call" |
| Closed | \`onBackToChat()\` (previous behavior) | "Retour au chat" / "Back to chat" |

The button now also appears when settings are open even if \`onBackToChat\` is undefined (e.g. sidebar entry without an existing text chat session), so the user always has an explicit affordance to leave the settings panel.

Accessibility: \`aria-label\`, \`title\`, and \`data-testid\` swap accordingly (\`voice-overlay-close-settings\` vs \`voice-overlay-back-to-chat\`) so screen readers and Playwright selectors stay accurate.

## Files

- \`frontend/src/components/voice/VoiceOverlay.tsx\` — context-aware click handler + i18n
- No other component touched. The Sidebar-launched session and the TutorMiniChat-launched session both inherit the fix automatically.

## Test plan

- [x] FR + EN i18n keys present
- [x] \`onBackToChat\` undefined + settings closed → no button rendered (unchanged)
- [x] \`onBackToChat\` defined + settings closed → "Retour au chat" → call exits (unchanged)
- [x] Settings open → "Retour à l'appel" → settings collapse, call continues (NEW)
- [ ] Post-merge manual: open Tuteur Vocal during a call, click gear, click back arrow, verify transcript view returns and call is still active
- [ ] Existing Vitest \`VoiceOverlay.test.tsx\` keeps passing (uses \`voice-overlay-settings-toggle\` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)