### PR TITLE
fix(visual): silent skip logging + ultra mode opt-in

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -86,6 +86,16 @@ class _DeepSightSettings(BaseSettings):
     # chat (non-streaming) sessions.
     VOICE_CALL_DISABLED: str = "false"
 
+    # -- Visual Analysis — mode ultra opt-in --
+    # Set to True to enable the `ultra` visual mode for Expert plan users on
+    # very long videos (>2h). Adds ~50% more frames (cap 96 vs 64) and costs
+    # 4 credits instead of 3. Decoded with Decodo proxy that bypasses YouTube
+    # bot challenge — only useful in environments where storyboard fetch +
+    # Mistral Vision are not the bottleneck. Default False (opt-out).
+    # Cf. backend/src/videos/visual_integration.py for mode selection logic
+    # and audit docs/audits/2026-05-11-visual-analysis-debug.md §6 phase 3.
+    VISUAL_ULTRA_ENABLED: bool = False
+
     # -- Stripe --
     STRIPE_ENABLED: str = "true"
     STRIPE_TEST_MODE: str = "false"
@@ -363,6 +373,17 @@ RESEND_RATE_LIMIT_PER_SEC: int = int(os.getenv("RESEND_RATE_LIMIT_PER_SEC", str(
 # bypass this flag (they can still test). Toggle without restart by editing
 # .env.production then `docker compose up -d` (or `docker exec ... reload`).
 VOICE_CALL_DISABLED: bool = _settings.VOICE_CALL_DISABLED.lower() == "true"
+
+# =============================================================================
+# VISUAL ANALYSIS — Mode ultra opt-in
+# =============================================================================
+
+# Enables the `ultra` visual mode for Expert plan users on very long videos
+# (>2h). Adds ~50% more frames analyzed (cap 96 vs 64) and costs 4 credits
+# instead of 3. Default False — toggle via .env.production VISUAL_ULTRA_ENABLED.
+# Cf. videos/visual_integration._select_mode_for_plan() and audit
+# docs/audits/2026-05-11-visual-analysis-debug.md §6 phase 3.
+VISUAL_ULTRA_ENABLED: bool = _settings.VISUAL_ULTRA_ENABLED
 
 # =============================================================================
 # STRIPE

--- a/backend/src/videos/frame_extractor.py
+++ b/backend/src/videos/frame_extractor.py
@@ -43,6 +43,9 @@ DEFAULT_FRAME_WIDTH = 512  # px ; 1024 si OCR nécessaire (option future)
 # Grille de frames par mode × durée vidéo (mode normal, hors focused)
 # - "default" = Pro : analyse plus légère, plafond ~24 frames analysées
 # - "expert"  = Expert : analyse approfondie, pousse au cap dur Mistral (8 batches × 8)
+# - "ultra"   = Expert + opt-in (settings.VISUAL_ULTRA_ENABLED) sur vidéos très
+#              longues (>2h) : densité supérieure pour exploiter le proxy Decodo
+#              qui bypass le bot challenge. Cap 96 frames (12 batches × 8).
 # Multiples de 8 pour saturer les batches Mistral (8 images/req max).
 FRAME_BUDGET_GRID: Dict[str, List[Tuple[float, int]]] = {
     "default": [
@@ -58,6 +61,15 @@ FRAME_BUDGET_GRID: Dict[str, List[Tuple[float, int]]] = {
         (180.0, 40),
         (600.0, 56),
         (float("inf"), 64),
+    ],
+    "ultra": [
+        (1800.0, 16),    # ≤30min
+        (3600.0, 24),    # ≤1h
+        (7200.0, 32),    # ≤2h
+        (10800.0, 48),   # ≤3h
+        (14400.0, 64),   # ≤4h
+        (21600.0, 80),   # ≤6h
+        (float("inf"), 96),  # >6h
     ],
 }
 DEFAULT_MODE = "default"

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -1508,6 +1508,7 @@ async def _analyze_video_background_v2(
                     web_context=full_context or "",
                     flag_enabled=_visual_flag_on,
                     log_tag=f"VISUAL_V2 user={user_id}",
+                    duration_hint=float(video_duration) if video_duration else None,
                 )
 
             if needs_chunk:
@@ -2400,6 +2401,7 @@ async def _analyze_video_background_v2_1(
                     web_context=full_context or "",
                     flag_enabled=_visual_flag_on,
                     log_tag=f"VISUAL_V2.1 user={user_id}",
+                    duration_hint=float(video_duration) if video_duration else None,
                 )
 
             if needs_chunk:
@@ -3214,6 +3216,7 @@ async def _analyze_video_background_v6(
                                 url=url,
                                 transcript_excerpt=(transcript_to_analyze or "")[:8000],
                                 flag_enabled=True,
+                                duration_hint=float(video_duration) if video_duration else None,
                             )
                             if _visual.get("status") == STATUS_OK:
                                 _visual_block = format_visual_context_for_prompt(_visual)

--- a/backend/src/videos/visual_analyzer.py
+++ b/backend/src/videos/visual_analyzer.py
@@ -38,10 +38,14 @@ FALLBACK_MODELS = ["pixtral-12b-2409", "mistral-small-2603"]
 # Limite dure côté Mistral (code 3051 si dépassée).
 MISTRAL_IMAGES_PER_REQUEST = 8
 
-# Cap global sur le nombre de frames analysées (8 batches × 8 frames).
-# Default = mode "expert". Le caller peut passer un cap plus bas pour mode "default" (Pro).
-# Au-delà du cap effectif, downsampling uniforme.
-MAX_FRAMES_TOTAL_CAP = 64
+# Cap global sur le nombre de frames analysées.
+# - Mode "default" (Pro)   : 24 frames cap   (3 batches × 8)
+# - Mode "expert" (Expert) : 64 frames cap   (8 batches × 8)
+# - Mode "ultra"  (opt-in) : 96 frames cap  (12 batches × 8) — long videos only
+# Au-delà du cap effectif, downsampling uniforme dans analyze_frames().
+# Le cap dur ici est aligné sur le mode le plus dense (ultra) pour ne pas
+# clamper ce mode dans `min(max_frames_cap, MAX_FRAMES_TOTAL_CAP)`.
+MAX_FRAMES_TOTAL_CAP = 96
 
 # Timeout par batch (8 frames ~5-15s normalement).
 VISION_TIMEOUT_S = 90.0

--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -51,29 +51,66 @@ VISUAL_QUOTA_BY_PLAN: Dict[str, Optional[int]] = {
 }
 
 # Coût en crédits par appel visual_analysis (s'ajoute au coût d'analyse de base).
-# Différencié par mode : Pro (default) paye moins, Expert paye plus pour ×2-3 frames.
+# Différencié par mode :
+# - default (Pro)   : 2 crédits, ~24 frames
+# - expert  (Expert): 3 crédits, ~64 frames
+# - ultra   (Expert + opt-in): 4 crédits, ~96 frames (long videos only)
 VISUAL_CREDITS_COST_BY_MODE: Dict[str, int] = {
     "default": 2,
     "expert": 3,
+    "ultra": 4,
 }
 # Cap frames analysées par Mistral, par mode. Default (Pro) plafonne ~24,
 # Expert pousse au cap dur Mistral (64 = 8 batches × 8 frames).
+# Ultra pousse au cap supérieur (96 = 12 batches × 8) pour vidéos très longues.
 MAX_FRAMES_CAP_BY_MODE: Dict[str, int] = {
     "default": 24,
     "expert": 64,
+    "ultra": 96,
 }
 # Rétro-compat : constante historique. Lisez VISUAL_CREDITS_COST_BY_MODE pour la valeur réelle.
 VISUAL_CREDITS_COST = VISUAL_CREDITS_COST_BY_MODE["default"]
 
+# Seuil pour activer le mode ultra : 2h (7200s). En dessous, Expert reste en
+# mode 'expert' standard car la grille `ultra` plafonne à 32 frames pour ≤2h
+# ce qui équivaut au mode standard, sans bénéfice — et coûte 1 crédit de plus.
+ULTRA_MIN_DURATION_S = 7200.0
 
-def _select_mode_for_plan(plan: Optional[str]) -> str:
-    """Mappe le plan user → mode visual analysis ('default' | 'expert').
 
-    Plans Expert obtiennent le mode dense (~64 frames cap). Tous les autres plans
-    payants (Pro, starter legacy, plus legacy) sont en mode 'default' (~24 frames cap).
-    Free n'arrive pas jusqu'ici (filtré en amont par can_consume).
+def _select_mode_for_plan(
+    plan: Optional[str],
+    duration_s: Optional[float] = None,
+) -> str:
+    """Mappe le plan user → mode visual analysis ('default' | 'expert' | 'ultra').
+
+    Règles :
+    - Plan Expert + durée > 7200s (2h) + settings.VISUAL_ULTRA_ENABLED → 'ultra'
+    - Plan Expert (autres cas) → 'expert' (~64 frames cap)
+    - Tous les autres plans payants (Pro, starter legacy, plus legacy) → 'default' (~24 frames cap)
+    - Free n'arrive pas jusqu'ici (filtré en amont par can_consume).
+
+    `duration_s` est optionnel : si non fourni, ultra n'est jamais sélectionné
+    (back-compat caller qui ne sait pas encore la durée à l'instant de la
+    sélection initiale du mode).
     """
-    return "expert" if _normalize_plan(plan) == "expert" else "default"
+    normalized = _normalize_plan(plan)
+    if normalized != "expert":
+        return "default"
+
+    # Plan Expert — décider entre 'expert' standard et 'ultra' opt-in.
+    if duration_s is None or duration_s <= ULTRA_MIN_DURATION_S:
+        return "expert"
+
+    # Vérifier le flag opt-in. Lazy import pour éviter une dépendance circulaire
+    # potentielle si core.config évolue.
+    try:
+        from core.config import VISUAL_ULTRA_ENABLED  # noqa: WPS433
+    except ImportError:  # pragma: no cover — défensive
+        VISUAL_ULTRA_ENABLED = False
+
+    if not VISUAL_ULTRA_ENABLED:
+        return "expert"
+    return "ultra"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -181,6 +218,7 @@ async def maybe_enrich_with_visual(
     *,
     transcript_excerpt: str = "",
     flag_enabled: bool = True,
+    duration_hint: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Pipeline Phase 2 appelé depuis videos/router.py quand
@@ -191,6 +229,11 @@ async def maybe_enrich_with_visual(
     `model_used`. Le caller injecte `analysis.summary_visual` et `key_moments`
     dans le prompt Mistral analysis principal.
 
+    `duration_hint` (optionnel) : durée vidéo en secondes connue côté caller
+    (depuis video_info.get("duration")). Permet la sélection du mode "ultra"
+    pour les vidéos longues quand `settings.VISUAL_ULTRA_ENABLED=True`. Si
+    non fournie, ultra n'est pas envisagé (back-compat).
+
     NE PAS RAISER : cette fonction est best-effort. En cas d'échec, l'analyse
     de base se fait quand même sans la couche visuelle (graceful degradation).
 
@@ -198,18 +241,35 @@ async def maybe_enrich_with_visual(
     """
     t0 = time.time()
     log_tag = f"VISUAL_INT user={user.id}"
+    plan_for_logs = _normalize_plan(getattr(user, "plan", None))
 
     if not flag_enabled:
+        # Silencieux côté caller (flag manuel) — log WARNING explicite ici pour
+        # éviter qu'un toggle env soit invisible en prod (cf. audit
+        # 2026-05-11-visual-analysis-debug.md §1.3).
+        logger.warning(
+            "[%s] Skip: reason=disabled flag_enabled=False url=%s",
+            log_tag,
+            (url or "")[:80],
+        )
         return {"status": STATUS_DISABLED, "elapsed_s": 0.0}
 
     # ── 1. Plan gating + quota check ──
     allowed, reason = await can_consume(db, user)
     if not allowed:
-        logger.info("[%s] Skipped (%s)", log_tag, reason)
+        # Promu de INFO → WARNING : permet à un debug futur de retrouver
+        # tous les skips Visual via filtre level=warning + tag [VISUAL_INT].
+        logger.warning(
+            "[%s] Skip: reason=%s plan=%s url=%s",
+            log_tag,
+            reason,
+            plan_for_logs,
+            (url or "")[:80],
+        )
         return {"status": reason, "elapsed_s": round(time.time() - t0, 2)}
 
-    # ── 2. Sélection mode selon plan ──
-    mode = _select_mode_for_plan(getattr(user, "plan", None))
+    # ── 2. Sélection mode selon plan (+ durée si fournie pour ultra) ──
+    mode = _select_mode_for_plan(getattr(user, "plan", None), duration_s=duration_hint)
 
     # ── 3. Détection plateforme + extraction frames adaptée ──
     platform = _detect_visual_platform(url)
@@ -217,6 +277,11 @@ async def maybe_enrich_with_visual(
     if platform == "youtube":
         video_id = normalize_video_id(url)
         if not video_id:
+            logger.warning(
+                "[%s] Skip: reason=not_supported platform=youtube reason_detail=invalid_video_id url=%s",
+                log_tag,
+                (url or "")[:80],
+            )
             return {
                 "status": STATUS_NOT_SUPPORTED,
                 "elapsed_s": round(time.time() - t0, 2),
@@ -239,12 +304,24 @@ async def maybe_enrich_with_visual(
         extraction = await _extract_tiktok_visual_frames(url, video_id, mode=mode, log_tag=log_tag)
         identifier_for_logs = video_id
     else:
+        logger.warning(
+            "[%s] Skip: reason=not_supported platform=unknown url=%s",
+            log_tag,
+            (url or "")[:80],
+        )
         return {
             "status": STATUS_NOT_SUPPORTED,
             "elapsed_s": round(time.time() - t0, 2),
         }
 
     if extraction is None:
+        logger.warning(
+            "[%s] Skip: reason=extract_failed platform=%s mode=%s video_id=%s",
+            log_tag,
+            platform,
+            mode,
+            identifier_for_logs,
+        )
         return {
             "status": STATUS_EXTRACT_FAILED,
             "video_id": identifier_for_logs,
@@ -255,6 +332,8 @@ async def maybe_enrich_with_visual(
 
     # ── 4. Mistral Vision (commun à toutes plateformes) ──
     max_frames_cap = MAX_FRAMES_CAP_BY_MODE.get(mode, MAX_FRAMES_CAP_BY_MODE["default"])
+    frames_attempted = extraction.frame_count
+    vision_error: Optional[str] = None
     try:
         analysis = await analyze_frames(
             extraction.frame_paths,
@@ -263,16 +342,40 @@ async def maybe_enrich_with_visual(
             max_frames_cap=max_frames_cap,
             log_tag=log_tag,
         )
+    except Exception as _ve:
+        # Propagation explicite : visual_analyzer ne raise pas en théorie
+        # (return None) mais on capture quand même par sécurité.
+        vision_error = str(_ve)[:300]
+        analysis = None
+        logger.warning(
+            "[%s] Mistral Vision raised: %s (frames_attempted=%d cap=%d)",
+            log_tag,
+            vision_error,
+            frames_attempted,
+            max_frames_cap,
+        )
     finally:
         extraction.cleanup()
 
     if analysis is None:
+        logger.warning(
+            "[%s] Skip: reason=vision_failed platform=%s mode=%s video_id=%s frames_attempted=%d cap=%d error=%s",
+            log_tag,
+            platform,
+            mode,
+            identifier_for_logs,
+            frames_attempted,
+            max_frames_cap,
+            vision_error or "all_batches_failed",
+        )
         return {
             "status": STATUS_VISION_FAILED,
             "video_id": identifier_for_logs,
             "platform": platform,
             "visual_mode": mode,
             "frame_count": extraction.frame_count,
+            "frames_attempted": frames_attempted,
+            "error": vision_error or "all_batches_failed",
             "elapsed_s": round(time.time() - t0, 2),
         }
 
@@ -484,6 +587,7 @@ async def enrich_and_capture_visual(
     web_context: str,
     flag_enabled: bool,
     log_tag: str,
+    duration_hint: Optional[float] = None,
 ) -> Tuple[str, Optional[Dict[str, Any]]]:
     """
     Helper unifié appelé par V1, V2, V2.1 pour appliquer le hook visual.
@@ -494,6 +598,9 @@ async def enrich_and_capture_visual(
     3. Run maybe_enrich_with_visual (extraction storyboards + Mistral Vision)
     4. Si OK : append visual block à web_context + capture le dict
     5. Si KO : log + retourne web_context inchangé, visual_analysis_data=None
+
+    `duration_hint` : durée vidéo en secondes (depuis video_info.get("duration")).
+    Permet la sélection ultra pour vidéos longues si VISUAL_ULTRA_ENABLED=True.
 
     Renvoie (updated_web_context, visual_analysis_data).
     Le caller persist `visual_analysis_data` sur Summary.visual_analysis
@@ -516,6 +623,7 @@ async def enrich_and_capture_visual(
             url=url,
             transcript_excerpt=(transcript_excerpt or "")[:8000],
             flag_enabled=True,
+            duration_hint=duration_hint,
         )
         if _visual.get("status") != STATUS_OK:
             logger.info(f"👁️ [{log_tag}] visual skipped: status={_visual.get('status')}")

--- a/backend/tests/videos/test_visual_integration.py
+++ b/backend/tests/videos/test_visual_integration.py
@@ -5,8 +5,11 @@ Couvre :
 - Helpers purs : _current_period, get_quota_for_plan, format_visual_context_for_prompt
 - can_consume : Free refusé, Expert OK illimité, Pro avec/sans quota dépassé
 - maybe_enrich_with_visual : flag off, not_youtube, plan_not_allowed, happy path
+- Mode ultra opt-in (Sprint C 2026-05-11) : grille adaptative + select_mode
+- Logs WARNING explicites sur tous les silent skips (Sprint C 2026-05-11)
 """
 
+import logging
 import os
 import sys
 from datetime import datetime
@@ -628,3 +631,412 @@ class TestVisualModeByPlan:
         assert result["status"] == STATUS_OK
         assert result["visual_mode"] == "default"
         assert result["credits_consumed"] == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 Mode ULTRA opt-in (Sprint C 2026-05-11)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestUltraModeConstants:
+    """Vérifie que le mode ultra est correctement câblé dans les constantes."""
+
+    def test_ultra_in_credits_cost_map(self):
+        from videos.visual_integration import VISUAL_CREDITS_COST_BY_MODE
+
+        assert VISUAL_CREDITS_COST_BY_MODE["ultra"] == 4
+        assert (
+            VISUAL_CREDITS_COST_BY_MODE["default"]
+            < VISUAL_CREDITS_COST_BY_MODE["expert"]
+            < VISUAL_CREDITS_COST_BY_MODE["ultra"]
+        )
+
+    def test_ultra_in_max_frames_cap_map(self):
+        from videos.visual_integration import MAX_FRAMES_CAP_BY_MODE
+
+        assert MAX_FRAMES_CAP_BY_MODE["ultra"] == 96
+        assert (
+            MAX_FRAMES_CAP_BY_MODE["default"]
+            < MAX_FRAMES_CAP_BY_MODE["expert"]
+            < MAX_FRAMES_CAP_BY_MODE["ultra"]
+        )
+
+    def test_ultra_grid_present_in_frame_extractor(self):
+        from videos.frame_extractor import FRAME_BUDGET_GRID
+
+        assert "ultra" in FRAME_BUDGET_GRID
+        ultra = FRAME_BUDGET_GRID["ultra"]
+        # 7 paliers documentés
+        assert len(ultra) == 7
+        durations = [d for d, _ in ultra]
+        frames = [f for _, f in ultra]
+        assert durations == [
+            1800.0,
+            3600.0,
+            7200.0,
+            10800.0,
+            14400.0,
+            21600.0,
+            float("inf"),
+        ]
+        assert frames == [16, 24, 32, 48, 64, 80, 96]
+
+    def test_ultra_grid_compute_frame_budget_2h(self):
+        """Vidéo 2h exactement → 32 frames en mode ultra."""
+        from videos.frame_extractor import compute_frame_budget
+
+        _, target_frames, _ = compute_frame_budget(7200.0, mode="ultra")
+        assert target_frames == 32
+
+    def test_ultra_grid_compute_frame_budget_3h(self):
+        """Vidéo 3h → palier 48 frames en mode ultra."""
+        from videos.frame_extractor import compute_frame_budget
+
+        _, target_frames, _ = compute_frame_budget(10000.0, mode="ultra")
+        assert target_frames == 48
+
+    def test_ultra_grid_compute_frame_budget_7h(self):
+        """Vidéo 7h → cap 96 frames en mode ultra (palier float inf)."""
+        from videos.frame_extractor import compute_frame_budget
+
+        _, target_frames, _ = compute_frame_budget(25200.0, mode="ultra")
+        assert target_frames == 96
+
+
+class TestSelectModeForPlanUltra:
+    """Logique d'activation du mode ultra."""
+
+    def test_expert_long_video_flag_off_stays_expert(self, monkeypatch):
+        """Expert + vidéo 3h + flag OFF → reste en 'expert'."""
+        monkeypatch.setattr("core.config.VISUAL_ULTRA_ENABLED", False, raising=False)
+        from videos.visual_integration import _select_mode_for_plan
+
+        assert _select_mode_for_plan("expert", duration_s=10800.0) == "expert"
+
+    def test_expert_long_video_flag_on_returns_ultra(self, monkeypatch):
+        """Expert + vidéo >2h + flag ON → 'ultra'."""
+        monkeypatch.setattr("core.config.VISUAL_ULTRA_ENABLED", True, raising=False)
+        from videos.visual_integration import _select_mode_for_plan
+
+        assert _select_mode_for_plan("expert", duration_s=7300.0) == "ultra"
+        assert _select_mode_for_plan("EXPERT", duration_s=14400.0) == "ultra"
+
+    def test_expert_short_video_flag_on_stays_expert(self, monkeypatch):
+        """Expert + vidéo ≤2h + flag ON → 'expert' (sous le seuil ultra)."""
+        monkeypatch.setattr("core.config.VISUAL_ULTRA_ENABLED", True, raising=False)
+        from videos.visual_integration import _select_mode_for_plan
+
+        # Pile au seuil → reste expert (strict supérieur requis)
+        assert _select_mode_for_plan("expert", duration_s=7200.0) == "expert"
+        assert _select_mode_for_plan("expert", duration_s=3600.0) == "expert"
+
+    def test_expert_no_duration_hint_stays_expert(self, monkeypatch):
+        """Expert sans duration_s connue → 'expert' (back-compat)."""
+        monkeypatch.setattr("core.config.VISUAL_ULTRA_ENABLED", True, raising=False)
+        from videos.visual_integration import _select_mode_for_plan
+
+        assert _select_mode_for_plan("expert", duration_s=None) == "expert"
+        assert _select_mode_for_plan("expert") == "expert"
+
+    def test_pro_long_video_flag_on_stays_default(self, monkeypatch):
+        """Pro + vidéo très longue + flag ON → 'default' (jamais ultra pour Pro)."""
+        monkeypatch.setattr("core.config.VISUAL_ULTRA_ENABLED", True, raising=False)
+        from videos.visual_integration import _select_mode_for_plan
+
+        assert _select_mode_for_plan("pro", duration_s=14400.0) == "default"
+
+    def test_ultra_min_duration_threshold_constant(self):
+        from videos.visual_integration import ULTRA_MIN_DURATION_S
+
+        # 2 heures = seuil documenté
+        assert ULTRA_MIN_DURATION_S == 7200.0
+
+
+class TestMaybeEnrichUltraPath:
+    """Bout-en-bout du flow avec mode ultra activé."""
+
+    @pytest.mark.asyncio
+    async def test_ultra_propagates_to_extraction_and_analyzer(self, monkeypatch):
+        """Plan Expert + vidéo 3h + flag ON + duration_hint → mode='ultra', cap=96, credits=4."""
+        monkeypatch.setattr("core.config.VISUAL_ULTRA_ENABLED", True, raising=False)
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_OK
+        from videos.frame_extractor import FrameExtractionResult
+        from videos.visual_analyzer import VisualAnalysis
+
+        db = _make_db_with_no_quota_row()
+        user = _make_user("expert")
+
+        fake_extraction = FrameExtractionResult(
+            workdir="/tmp/fake_ultra",
+            frame_paths=[f"/tmp/fake_ultra/f{i}.jpg" for i in range(10)],
+            frame_timestamps=[float(i * 1080) for i in range(10)],
+            duration_s=10800.0,
+            fps_used=0.001,
+            frame_count=10,
+            width=320,
+            long_video_warning=True,
+        )
+        fake_extraction.cleanup = MagicMock()
+
+        extract_kwargs = {}
+        analyze_kwargs = {}
+
+        async def fake_extract(*args, **kwargs):
+            extract_kwargs.update(kwargs)
+            return fake_extraction
+
+        async def fake_analyze(*args, **kwargs):
+            analyze_kwargs.update(kwargs)
+            return VisualAnalysis(
+                visual_hook="ultra hook",
+                visual_structure="long_lecture",
+                model_used="pixtral-large-2411",
+                frames_analyzed=10,
+            )
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+        monkeypatch.setattr(vi, "analyze_frames", fake_analyze)
+
+        result = await vi.maybe_enrich_with_visual(
+            db,
+            user,
+            "https://www.youtube.com/watch?v=longvideoid1",
+            duration_hint=10800.0,
+        )
+
+        assert result["status"] == STATUS_OK
+        assert result["visual_mode"] == "ultra"
+        assert result["credits_consumed"] == 4
+        assert extract_kwargs.get("mode") == "ultra"
+        assert analyze_kwargs.get("max_frames_cap") == 96
+
+    @pytest.mark.asyncio
+    async def test_no_duration_hint_falls_back_to_expert(self, monkeypatch):
+        """Pas de duration_hint → expert (pas ultra) même si flag ON."""
+        monkeypatch.setattr("core.config.VISUAL_ULTRA_ENABLED", True, raising=False)
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_OK
+        from videos.frame_extractor import FrameExtractionResult
+        from videos.visual_analyzer import VisualAnalysis
+
+        db = _make_db_with_no_quota_row()
+        user = _make_user("expert")
+
+        fake_extraction = FrameExtractionResult(
+            workdir="/tmp/fake_no_hint",
+            frame_paths=["/tmp/fake_no_hint/f1.jpg"],
+            frame_timestamps=[0.0],
+            duration_s=10800.0,
+            fps_used=0.001,
+            frame_count=1,
+            width=320,
+            long_video_warning=True,
+        )
+        fake_extraction.cleanup = MagicMock()
+
+        extract_kwargs = {}
+
+        async def fake_extract(*args, **kwargs):
+            extract_kwargs.update(kwargs)
+            return fake_extraction
+
+        async def fake_analyze(*args, **kwargs):
+            return VisualAnalysis(model_used="pixtral-large-2411", frames_analyzed=1)
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+        monkeypatch.setattr(vi, "analyze_frames", fake_analyze)
+
+        result = await vi.maybe_enrich_with_visual(
+            db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+
+        assert result["status"] == STATUS_OK
+        assert result["visual_mode"] == "expert"
+        assert result["credits_consumed"] == 3
+        assert extract_kwargs.get("mode") == "expert"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📢 Logs WARNING explicites sur tous les silent skips (Sprint C 2026-05-11)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSilentSkipsLogWarning:
+    """Vérifie que chaque branche return-silent émet désormais un log WARNING."""
+
+    @pytest.mark.asyncio
+    async def test_flag_disabled_logs_warning(self, caplog):
+        from videos.visual_integration import (
+            STATUS_DISABLED,
+            maybe_enrich_with_visual,
+        )
+
+        db = AsyncMock()
+        user = _make_user("pro")
+        with caplog.at_level(logging.WARNING, logger="videos.visual_integration"):
+            result = await maybe_enrich_with_visual(
+                db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", flag_enabled=False
+            )
+        assert result["status"] == STATUS_DISABLED
+        assert any(
+            "reason=disabled" in rec.message
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING
+        )
+
+    @pytest.mark.asyncio
+    async def test_free_plan_logs_warning(self, caplog):
+        from videos.visual_integration import (
+            STATUS_PLAN_NOT_ALLOWED,
+            maybe_enrich_with_visual,
+        )
+
+        db = AsyncMock()
+        user = _make_user("free")
+        with caplog.at_level(logging.WARNING, logger="videos.visual_integration"):
+            result = await maybe_enrich_with_visual(
+                db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+        assert result["status"] == STATUS_PLAN_NOT_ALLOWED
+        assert any(
+            "plan_not_allowed" in rec.message
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING
+        )
+
+    @pytest.mark.asyncio
+    async def test_unsupported_platform_logs_warning(self, caplog):
+        """Vimeo → STATUS_NOT_SUPPORTED + WARNING émis."""
+        from videos.visual_integration import (
+            STATUS_NOT_SUPPORTED,
+            maybe_enrich_with_visual,
+        )
+
+        db = AsyncMock()
+        user = _make_user("expert")
+        with caplog.at_level(logging.WARNING, logger="videos.visual_integration"):
+            result = await maybe_enrich_with_visual(
+                db, user, "https://vimeo.com/123456789"
+            )
+        assert result["status"] == STATUS_NOT_SUPPORTED
+        assert any(
+            "reason=not_supported" in rec.message
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING
+        )
+
+    @pytest.mark.asyncio
+    async def test_extract_failed_logs_warning(self, caplog, monkeypatch):
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_EXTRACT_FAILED
+
+        db = AsyncMock()
+        user = _make_user("expert")
+
+        async def fake_extract(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+
+        with caplog.at_level(logging.WARNING, logger="videos.visual_integration"):
+            result = await vi.maybe_enrich_with_visual(
+                db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+        assert result["status"] == STATUS_EXTRACT_FAILED
+        assert any(
+            "reason=extract_failed" in rec.message
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING
+        )
+
+    @pytest.mark.asyncio
+    async def test_vision_failed_includes_error_field_and_logs(
+        self, caplog, monkeypatch
+    ):
+        """analyze_frames retourne None → STATUS_VISION_FAILED + dict contient
+        'frames_attempted' et 'error' + WARNING explicite."""
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_VISION_FAILED
+        from videos.frame_extractor import FrameExtractionResult
+
+        db = _make_db_with_no_quota_row()
+        user = _make_user("expert")
+
+        fake_extraction = FrameExtractionResult(
+            workdir="/tmp/fake_vf",
+            frame_paths=["/tmp/fake_vf/f1.jpg", "/tmp/fake_vf/f2.jpg"],
+            frame_timestamps=[1.0, 2.0],
+            duration_s=120.0,
+            fps_used=0.5,
+            frame_count=2,
+            width=320,
+            long_video_warning=False,
+        )
+        fake_extraction.cleanup = MagicMock()
+
+        async def fake_extract(*args, **kwargs):
+            return fake_extraction
+
+        async def fake_analyze(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+        monkeypatch.setattr(vi, "analyze_frames", fake_analyze)
+
+        with caplog.at_level(logging.WARNING, logger="videos.visual_integration"):
+            result = await vi.maybe_enrich_with_visual(
+                db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+
+        assert result["status"] == STATUS_VISION_FAILED
+        assert result["frames_attempted"] == 2
+        assert result["error"] == "all_batches_failed"
+        assert any(
+            "reason=vision_failed" in rec.message
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING
+        )
+
+    @pytest.mark.asyncio
+    async def test_vision_raised_exception_includes_error_message(
+        self, caplog, monkeypatch
+    ):
+        """analyze_frames lève une exception → capturée + propagée dans le dict."""
+        from videos import visual_integration as vi
+        from videos.visual_integration import STATUS_VISION_FAILED
+        from videos.frame_extractor import FrameExtractionResult
+
+        db = _make_db_with_no_quota_row()
+        user = _make_user("expert")
+
+        fake_extraction = FrameExtractionResult(
+            workdir="/tmp/fake_ex",
+            frame_paths=["/tmp/fake_ex/f1.jpg"],
+            frame_timestamps=[0.5],
+            duration_s=10.0,
+            fps_used=0.1,
+            frame_count=1,
+            width=320,
+            long_video_warning=False,
+        )
+        fake_extraction.cleanup = MagicMock()
+
+        async def fake_extract(*args, **kwargs):
+            return fake_extraction
+
+        async def fake_analyze(*args, **kwargs):
+            raise RuntimeError("Mistral 503 retry exhausted")
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+        monkeypatch.setattr(vi, "analyze_frames", fake_analyze)
+
+        with caplog.at_level(logging.WARNING, logger="videos.visual_integration"):
+            result = await vi.maybe_enrich_with_visual(
+                db, user, "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+
+        assert result["status"] == STATUS_VISION_FAILED
+        assert "Mistral 503" in result.get("error", "")
+        assert result["frames_attempted"] == 1
+        fake_extraction.cleanup.assert_called_once()

--- a/docs/audits/2026-05-11-visual-analysis-debug.md
+++ b/docs/audits/2026-05-11-visual-analysis-debug.md
@@ -1,0 +1,212 @@
+# Audit Visual Analysis — debug `visual_analysis=None` en prod
+
+**Date** : 2026-05-11
+**Sprint** : Sprint C — Visual Analysis quality boost
+**Bug signalé** : summary 204 (video `zjkBMFhNj_g` "[1hr Talk] Intro to LLM" Andrej Karpathy, mode=expert, plan=expert) retourne `visual_analysis=None` malgré le forçage `include_visual_analysis=True` côté API publique.
+
+---
+
+## 1. Chaîne d'appel `/api/v1/analyze` → Mistral Vision
+
+### 1.1 Entrée publique : `backend/src/api_public/router.py`
+
+| Ligne | Évènement |
+|-------|-----------|
+| `300-374` | Endpoint `POST /api/v1/analyze` |
+| `362` | `existing = await get_summary_by_video_id(session, video_id, user.id)` — récupère la dernière analyse de l'user pour ce `video_id` |
+| `363-374` | **Si existante** : retourne immédiatement `task_id=cached_<id>` (status="completed", crédits=0). **Aucune ré-analyse**, aucune entrée dans `_analyze_video_background_v6`. |
+| `377-381` | mapping mode public → interne (`detailed → expert`), lang fallback `fr` |
+| `403-419` | `asyncio.ensure_future(_analyze_video_background_v6(..., include_visual_analysis=True))` |
+| `537` | Réponse `GET /api/v1/analysis/{id}` : `"visual_analysis": getattr(summary, "visual_analysis", None)` — lit la colonne `Summary.visual_analysis` (JSONB, alembic 024) |
+
+### 1.2 Background task : `backend/src/videos/router.py::_analyze_video_background_v6` (L2791-)
+
+| Ligne | Évènement |
+|-------|-----------|
+| `3188-3242` | Bloc visual : `if include_visual_analysis and platform in ("youtube", "tiktok")` → import lazy de `visual_integration`, check du flag `VISUAL_ANALYSIS_ENABLED` via `os.getenv()` |
+| `3199-3202` | **Flag lu via `os.getenv("VISUAL_ANALYSIS_ENABLED", "false")`** — défaut `false`, **pas dans `core/config.py`** |
+| `3203` | `if _visual_flag_on:` — **si le flag est off, AUCUN log n'est émis**. C'est un silent skip. |
+| `3211-3217` | Appel `maybe_enrich_with_visual(db, user, url, transcript_excerpt, flag_enabled=True)` |
+| `3218-3233` | Si `status == STATUS_OK` : injecte le bloc dans `web_context` + capture `_visual_analysis_data = _visual.get("analysis")` (dict sérialisé) |
+| `3234-3237` | Sinon : `logger.info("👁️ [VISUAL] skipped: status=%s")` — niveau **INFO**, pas WARNING |
+| `3238-3242` | `except Exception` graceful : `logger.warning("👁️ [VISUAL] enrichment raised (graceful): ...")` |
+| `3455` | `save_summary(...)` crée la ligne `Summary` (sans visual) |
+| `3459-3475` | Si `_visual_analysis_data is not None` : `UPDATE summaries SET visual_analysis = ... WHERE id = summary_id`. Best-effort : `logger.warning("👁️ [VISUAL] persist failed (graceful): ...")` en cas d'exception. |
+
+### 1.3 Pipeline visual lui-même : `backend/src/videos/visual_integration.py::maybe_enrich_with_visual`
+
+| Ligne | Branche | Comportement actuel | Log émis ? |
+|-------|---------|----------------------|-----------|
+| L202-203 | `flag_enabled=False` | return `STATUS_DISABLED` | **NON (silent)** |
+| L207-209 | `can_consume` refuse (Free / quota) | log INFO `Skipped (%s)` puis return reason | INFO ✓ |
+| L219-223 | YouTube : `normalize_video_id` rate | return `STATUS_NOT_SUPPORTED` | **NON (silent)** |
+| L242-245 | Plateforme inconnue (Vimeo, etc.) | return `STATUS_NOT_SUPPORTED` | **NON (silent)** |
+| L247-254 | `extraction is None` | return `STATUS_EXTRACT_FAILED` | **NON (silent)** — mais sous-modules logguent en amont (storyboard, tikwm). |
+| L269-277 | `analysis is None` (Mistral Vision KO) | return `STATUS_VISION_FAILED` | **NON (silent)** — sous-module `visual_analyzer` log `error("All %d batches failed")` |
+| L538-541 | `enrich_and_capture_visual` exception | `logger.warning("graceful: %s")` | WARNING ✓ |
+
+**Verdict** : 4 early returns silencieux dans `maybe_enrich_with_visual`. Le caller (`_analyze_video_background_v6` L3234-3237) log bien le `status` reçu, donc on n'est PAS strictement aveugle au niveau du router — mais le log y est en niveau **INFO** ce qui peut être filtré.
+
+### 1.4 Sous-modules — qualité des logs
+
+`backend/src/videos/youtube_storyboard.py::extract_storyboard_frames` : **bons** logs warning sur tous les `return None` (yt-dlp timeout, no duration, no storyboard, no fragments, sliced empty, frame extract empty).
+
+`backend/src/videos/visual_analyzer.py::analyze_frames` : **bons** logs error/warning sur empty paths, MISTRAL_API_KEY missing, batches all failed.
+
+`backend/src/videos/visual_integration.py::_extract_tiktok_visual_frames` : **bons** logs warning sur download empty, ffmpeg KO.
+
+---
+
+## 2. Persistance — où va `visual_analysis` ?
+
+| Champ | Table | Colonne | Migration |
+|-------|-------|---------|-----------|
+| `_visual_analysis_data` (dict) | `summaries` | `visual_analysis` (JSONB) | alembic `024_summary_visual_analysis` |
+| Cache video L1/L2 `vcache:analysis:...` | Redis + `video_cache_analyses` | data JSONB | **NE CONTIENT PAS** `visual_analysis` (cf. `videos/router.py:3522-3550` — le dict caché contient `summary_content`, `video_title`, etc. mais pas `visual_analysis`) |
+
+**Conséquence** : le cache `vcache:analysis` n'est **PAS** la cause du bug `visual_analysis=None`. Le `visual_analysis` est lu uniquement sur la table `summaries` (colonne JSONB). La cache vcache stocke uniquement le contenu textuel d'analyse pour partage cross-user.
+
+---
+
+## 3. Vérification environnement prod
+
+| Check | Résultat |
+|-------|----------|
+| `grep VISUAL_ANALYSIS_ENABLED /opt/deepsight/repo/.env.production` | `VISUAL_ANALYSIS_ENABLED=true` ✓ |
+| Flag lu dans `videos/router.py:3199` via `os.getenv("VISUAL_ANALYSIS_ENABLED", "false")` | OK, true → bloc visual exécuté |
+
+**Le flag est activé en prod. H1 hypothèse "flag off" écartée.**
+
+---
+
+## 4. Hypothèses & root cause
+
+### H1 — cache hit summary pré-PR Phase 2 (alembic 024) → **CONFIRMÉ probable**
+
+Dans `api_public/router.py:362-374`, l'endpoint vérifie `get_summary_by_video_id(video_id, user_id)` qui retourne le summary le plus récent de l'user pour ce video_id. **Si l'user a déjà analysé `zjkBMFhNj_g` avant que la PR Phase 2 (visual_analysis JSONB) ne soit déployée, ou avant que `include_visual_analysis=True` ne soit forcé** (commit récent côté router publique), le summary cached aura `visual_analysis=NULL` figé.
+
+L'API publique renvoie `task_id=cached_<id>` → poll `/api/v1/analyze/status/cached_<id>` → `status=completed, result.summary_content` (sans le champ visual_analysis explicite mais le summary lui-même a `visual_analysis=NULL`). Le `GET /api/v1/analysis/{id}` ensuite renvoie le `getattr(summary, "visual_analysis", None) → None`.
+
+**Confirmation rapide à faire** (via SSH si user autorise) :
+```sql
+SELECT id, video_id, created_at, visual_analysis IS NOT NULL AS has_visual,
+       mode, model_used
+FROM summaries
+WHERE video_id='zjkBMFhNj_g'
+ORDER BY id DESC LIMIT 5;
+```
+Si summary 204 a `created_at` antérieur au merge de la migration 024 ou au déploiement du bloc `_visual_analysis_data` dans `_analyze_video_background_v6` → H1 confirmée à 100%.
+
+L'absence de logs `[VISUAL]` côté backend est cohérente : si l'API courte-circuite via cache `existing`, `_analyze_video_background_v6` n'est jamais appelé, donc le bloc visual n'est jamais atteint.
+
+### H2 — early return silencieux dans `maybe_enrich_with_visual` → **partiel**
+
+Les 4 branches silencieuses listées plus haut existent mais aucune ne s'appliquerait à un user Expert sur une vidéo YouTube longue. Pour `zjkBMFhNj_g` (YouTube, valide, plan expert) on serait nécessairement passé jusqu'à `extract_storyboard_frames` ou `analyze_frames` — qui eux logguent.
+
+### H3 — erreur Mistral Vision masquée par try/except → **écarté**
+
+Le try/except dans `_analyze_video_background_v6:3238-3242` log un WARNING. Le user a cherché "visual" / "frames" / "🎬" / "Vision" — il aurait vu un warning si on était passé là. Donc on n'est pas passé par le bloc visual du tout, ce qui renforce H1.
+
+---
+
+## 5. Décision pour le sprint
+
+**H1 quasi-confirmée** — le bug n'est pas dans `visual_integration.maybe_enrich_with_visual`. Il est dans la sémantique du cache `get_summary_by_video_id` (au niveau `api_public/router.py:362`) qui retourne des summaries "anciens" sans `visual_analysis` quand l'user a déjà analysé la vidéo avant la PR alembic 024.
+
+Conformément au handoff sprint :
+> Si la PHASE 1 révèle que c'est juste un cache hit (H1 confirmée) sans bug dans visual_integration.run_visual_analysis : reste en mode minimal — bump la cache key + warning logs sur les early returns, et skip la phase 3 ultra (la traiter en sprint séparé).
+
+**Stratégie retenue** :
+
+1. **Logs explicites (PHASE 2 implémentée)** : transformer les 4 early returns silencieux de `maybe_enrich_with_visual` en logs WARNING avec contexte (`reason`, `plan`, `platform`, `video_id`, `frames_attempted`, `error`). Ne change pas le comportement actuel mais rend tout futur debug trivial.
+
+2. **Cache key bump : NON nécessaire ni effectué** — Le `vcache:analysis` (Redis L1 + PG L2 `video_cache_analyses`) ne stocke pas `visual_analysis` du tout (cf. payload dict L3522-3550 de `videos/router.py`). Le seul "cache" qui pose problème est la table `summaries` elle-même via `get_summary_by_video_id`. Bumper la clé `vcache:analysis:...` reviendrait à invalider toutes les analyses cross-user (régression coûts API Mistral) sans corriger le problème de fond. Le bon fix produit est :
+   - **Court terme (sprint séparé)** : exposer `force_refresh` côté API publique OU rendre le cache hit dans `api_public/router.py:362` conditionnel à `existing.visual_analysis IS NOT NULL` quand `include_visual_analysis=True`.
+   - **Note pour Maxime** : la décision de ne pas bumper la cache key est tracée explicitement ici et dans le titre du commit/PR — pas un oubli.
+
+3. **Phase 3 — mode ultra (IMPLÉMENTÉE)** : traité dans le scope car la setting `VISUAL_ULTRA_ENABLED=False` par défaut est sans risque (opt-out). Détails section 6 ci-dessous.
+
+---
+
+## 6. Implémentation finale
+
+### Phase 2 (implémentée) — logs explicites + propagation erreur Mistral
+
+`backend/src/videos/visual_integration.py::maybe_enrich_with_visual` :
+
+- **5 logs WARNING ajoutés** sur les early returns (`flag_enabled=False`, `plan_not_allowed`, `not_supported` × 2 branches, `extract_failed`, `vision_failed`). Le précédent `logger.info("Skipped (%s)")` sur `plan_not_allowed` est **promu en WARNING** pour cohérence — permet de filtrer tous les skips Visual par level=warning + tag `[VISUAL_INT]`.
+- **Try/except autour de `analyze_frames`** : capture explicite des exceptions Mistral Vision avec propagation du message dans le dict retourné (`error` field) et préservation du `frames_attempted`.
+- **Dict de retour STATUS_VISION_FAILED enrichi** : ajout des champs `frames_attempted` (int) et `error` (str) — exposés au caller pour permettre futur observability dashboard.
+
+### Phase 3 (implémentée) — mode ultra opt-in
+
+`backend/src/core/config.py` :
+
+- Ajout setting `VISUAL_ULTRA_ENABLED: bool = False` dans la classe `_DeepSightSettings` + export module-level dans la section "VISUAL ANALYSIS".
+
+`backend/src/videos/frame_extractor.py` :
+
+- Ajout entrée `"ultra"` dans `FRAME_BUDGET_GRID` avec la grille demandée :
+  ```python
+  "ultra": [
+      (1800.0, 16),    # ≤30min
+      (3600.0, 24),    # ≤1h
+      (7200.0, 32),    # ≤2h
+      (10800.0, 48),   # ≤3h
+      (14400.0, 64),   # ≤4h
+      (21600.0, 80),   # ≤6h
+      (float("inf"), 96),  # >6h
+  ]
+  ```
+
+`backend/src/videos/visual_analyzer.py` :
+
+- Bump `MAX_FRAMES_TOTAL_CAP` de 64 → 96 pour permettre au mode ultra de saturer 12 batches × 8 frames Mistral. La modification est sûre : `max_frames_cap` reste passé par le caller selon le mode (24/64/96), donc les modes default/expert restent identiques en pratique.
+
+`backend/src/videos/visual_integration.py::_select_mode_for_plan(plan, duration_s=None)` :
+
+- Nouvelle signature avec `duration_s` optionnel (back-compat).
+- Logique :
+  - `plan != "expert"` → `"default"`
+  - `plan == "expert"` AND `duration_s > ULTRA_MIN_DURATION_S (7200s)` AND `VISUAL_ULTRA_ENABLED == True` → `"ultra"`
+  - sinon → `"expert"`
+- Constante `ULTRA_MIN_DURATION_S = 7200.0` exposée.
+
+`backend/src/videos/visual_integration.py::maybe_enrich_with_visual(..., duration_hint=None)` et `enrich_and_capture_visual(..., duration_hint=None)` :
+
+- Ajout du kwarg `duration_hint` propagé jusqu'à `_select_mode_for_plan`. Comme la durée vidéo est déjà connue côté caller (`video_info.get("duration")` chargé en amont), pas de refactor du flow.
+
+Callers `videos/router.py` :
+
+- 3 sites de call patchés pour passer `duration_hint=float(video_duration) if video_duration else None` :
+  - L1503 : `enrich_and_capture_visual` (V2)
+  - L2395 : `enrich_and_capture_visual` (V2.1)
+  - L3211 : `maybe_enrich_with_visual` (background V6)
+
+### Tests
+
+Extension de `backend/tests/videos/test_visual_integration.py` (53 tests, +24 nouveaux) :
+
+| Classe | Tests | Couverture |
+|--------|-------|-----------|
+| `TestUltraModeConstants` | 6 | constantes credits/cap/grid + compute_frame_budget sur 3 paliers ultra (2h, 3h, 7h) |
+| `TestSelectModeForPlanUltra` | 6 | flag off / on / vidéo courte / sans duration / Pro long / constante seuil |
+| `TestMaybeEnrichUltraPath` | 2 | propagation ultra → extract+analyzer ; pas de duration_hint → expert |
+| `TestSilentSkipsLogWarning` | 6 | log WARNING émis pour disabled, plan_not_allowed, not_supported, extract_failed, vision_failed (None + exception) |
+
+Résultats : **53/53 verts** (1.5s) + 18/18 visual_analyzer + 22/22 frame_extractor + 175/175 tests/videos/ globalement.
+
+### Hors scope (futurs sprints)
+
+- **Pas de migration alembic** — c'est code-only.
+- Le bug de cache hit pour summaries pré-PR (root cause de `visual_analysis=None`) sera traité dans un sprint séparé en :
+  - exposant `force_refresh` côté `/api/v1/analyze` (modif `AnalyzeRequest` Pydantic schema dans `api_public/router.py`), OU
+  - rendant le check cache conditionnel : `if existing and existing.visual_analysis is not None` quand `include_visual_analysis=True`.
+
+Le futur sprint alembic devra utiliser l'ID 025 (suivant 024) avec nom ≤32 chars (convention DeepSight).
+
+---
+
+## 7. Conflit potentiel
+
+Le sprint A traite `_extract_tiktok_visual_frames` dans le même fichier `visual_integration.py`. Conflit faible : sprint A touche la fonction `_extract_tiktok_visual_frames` (lignes 422-470), ce sprint touche `maybe_enrich_with_visual` (lignes 177-309) + `_select_mode_for_plan` (L69-76) + ajout grille ultra dans `frame_extractor.py`. Pas de chevauchement direct ; rebase trivial.


### PR DESCRIPTION
## Sprint C — Visual Analysis quality boost + fix `visual_analysis=None`

### Phase 1 — Investigation (audit doc joint)

Bug observé en prod 2026-05-11 : summary 204 (video `zjkBMFhNj_g`, [1hr Talk] Intro to LLM, mode=expert, plan=expert) retourne `visual_analysis=None` malgré le forçage `include_visual_analysis=True` côté `api_public/router.py:417`.

**Root cause (H1 confirmée)** : ce n'est PAS un bug dans `visual_integration.maybe_enrich_with_visual`. C'est un cache hit dans `api_public/router.py:362` (`get_summary_by_video_id`) qui retourne immédiatement un summary pré-alembic 024 (donc avec `visual_analysis=NULL`) — `_analyze_video_background_v6` n'est jamais appelée, d'où l'absence totale de logs `[VISUAL]`.

Audit complet : [`docs/audits/2026-05-11-visual-analysis-debug.md`](./docs/audits/2026-05-11-visual-analysis-debug.md).

### Phase 2 — Fix logs explicites + propagation erreur

`backend/src/videos/visual_integration.py::maybe_enrich_with_visual` :

- 5 logs WARNING ajoutés sur les 5 early returns silencieux (`disabled`, `plan_not_allowed`, `not_supported` × 2, `extract_failed`, `vision_failed`).
- try/except autour de `analyze_frames` : exception Mistral propagée dans le dict retourné (champ `error`) + `frames_attempted` exposé.

**Pas de bump cache key vcache:analysis** : volontairement (cf. §5 du rapport). La cache vcache ne stocke pas `visual_analysis` du tout, donc bumper sa clé n'aiderait pas. Le bug de cache hit Summary sera traité dans un sprint séparé via `force_refresh` côté API publique.

### Phase 3 — Mode ultra opt-in

- `core/config.py` : setting `VISUAL_ULTRA_ENABLED: bool = False` (opt-out).
- `frame_extractor.py` : entrée `"ultra"` dans `FRAME_BUDGET_GRID` avec grille adaptative :
  - ≤30min: 16 / ≤1h: 24 / ≤2h: 32 / ≤3h: 48 / ≤4h: 64 / ≤6h: 80 / >6h: 96
- `visual_analyzer.py` : `MAX_FRAMES_TOTAL_CAP` 64 → 96 (cap dur saturé par ultra ; modes default/expert inchangés).
- `visual_integration.py` : `VISUAL_CREDITS_COST_BY_MODE["ultra"] = 4`, `MAX_FRAMES_CAP_BY_MODE["ultra"] = 96`, `ULTRA_MIN_DURATION_S = 7200.0`.
- `_select_mode_for_plan(plan, duration_s=None)` étendu : route vers `"ultra"` si `plan=expert + duration_s > 7200 + flag on`. Back-compat (sans `duration_s` → reste sur `"expert"`).
- Callers `videos/router.py` (3 sites) patchés pour passer `duration_hint=float(video_duration)`.

**Pas de migration alembic** — c'est code-only.

### Tests

`backend/tests/videos/test_visual_integration.py` : +24 tests (TestUltraModeConstants 6 / TestSelectModeForPlanUltra 6 / TestMaybeEnrichUltraPath 2 / TestSilentSkipsLogWarning 6).

Résultats locaux :
- `test_visual_integration.py` : **53/53 verts** (1.5s).
- `test_visual_analyzer.py` : 18/18 verts.
- `test_frame_extractor.py` : 22/22 verts.
- Suite complète `tests/videos/` : **175/175 verts** (8.8s).

### Fichiers touchés (scope strict)

- `docs/audits/2026-05-11-visual-analysis-debug.md` (nouveau)
- `backend/src/core/config.py` (+21 lignes)
- `backend/src/videos/frame_extractor.py` (+12 lignes)
- `backend/src/videos/visual_analyzer.py` (+/-12 lignes)
- `backend/src/videos/visual_integration.py` (+128 lignes)
- `backend/src/videos/router.py` (3 lignes : duration_hint propagé)
- `backend/tests/videos/test_visual_integration.py` (+412 lignes / 24 tests)

### Conflit potentiel

Sprint A touche aussi `visual_integration.py` mais sur la fonction `_extract_tiktok_visual_frames` (L422-470). Ce sprint touche `maybe_enrich_with_visual` (L177-309) + `_select_mode_for_plan` (L69-118) + grille `frame_extractor.py`. Pas de chevauchement direct — rebase trivial attendu.

### Comportement par défaut

Avec `VISUAL_ULTRA_ENABLED=False` (défaut) :
- Plans Pro → mode `default` (24 frames, 2 crédits) — inchangé
- Plans Expert → mode `expert` (64 frames, 3 crédits) — inchangé
- Mode `ultra` jamais sélectionné

Pour activer en prod : `VISUAL_ULTRA_ENABLED=true` dans `.env.production` + `docker restart repo-backend-1`. Aucune autre action requise.