### PR TITLE
feat(proxy): tiered resilience with sticky/geo/legacy fallback

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -68,7 +68,22 @@ class _DeepSightSettings(BaseSettings):
     MIRO_API_TOKEN: str = ""
 
     # -- YouTube Proxy (pour contourner le blocage IP YouTube sur VPS) --
+    # Tier 1 — proxy par defaut (rotating Decodo Pay-As-You-Go : nouvelle IP chaque request)
     YOUTUBE_PROXY: str = ""  # ex: socks5://user:pass@host:port ou http://user:pass@host:port
+    # Tier 2 — sticky session Decodo (port 10001-10010, IP fixe ~10 min)
+    # Utilise pour cohérence cookies session, swap automatique si default cumule trop d'erreurs.
+    YOUTUBE_PROXY_STICKY: Optional[str] = None
+    # Tier 3 — geo-targeted Decodo (username suffix `-country-XX`)
+    YOUTUBE_PROXY_GEO_US: Optional[str] = None
+    YOUTUBE_PROXY_GEO_FR: Optional[str] = None
+    # Tier 4 — fallback multi-provider (Webshare ou autre), totalement indépendant de Decodo.
+    YOUTUBE_PROXY_LEGACY: Optional[str] = None
+    # -- Proxy Circuit Breaker (Sprint D — Proxy V2 resilience) --
+    # Bascule de tier après N erreurs dans une fenetre glissante de Y secondes ;
+    # reset complet apres Z secondes sans erreur. Tunable sans deploy via .env.
+    PROXY_CIRCUIT_BREAKER_THRESHOLD: int = 5
+    PROXY_CIRCUIT_BREAKER_WINDOW_S: int = 60
+    PROXY_CIRCUIT_BREAKER_RESET_S: int = 300
 
     # -- Email --
     EMAIL_ENABLED: str = "true"
@@ -316,6 +331,14 @@ FAL_API_KEY = _settings.FAL_API_KEY
 TOGETHER_API_KEY = _settings.TOGETHER_API_KEY
 MISTRAL_IMAGE_AGENT_ID = _settings.MISTRAL_IMAGE_AGENT_ID
 YOUTUBE_PROXY = _settings.YOUTUBE_PROXY
+# Sprint D — Proxy V2 advanced (geo + sticky + multi-provider fallback)
+YOUTUBE_PROXY_STICKY = _settings.YOUTUBE_PROXY_STICKY
+YOUTUBE_PROXY_GEO_US = _settings.YOUTUBE_PROXY_GEO_US
+YOUTUBE_PROXY_GEO_FR = _settings.YOUTUBE_PROXY_GEO_FR
+YOUTUBE_PROXY_LEGACY = _settings.YOUTUBE_PROXY_LEGACY
+PROXY_CIRCUIT_BREAKER_THRESHOLD: int = _settings.PROXY_CIRCUIT_BREAKER_THRESHOLD
+PROXY_CIRCUIT_BREAKER_WINDOW_S: int = _settings.PROXY_CIRCUIT_BREAKER_WINDOW_S
+PROXY_CIRCUIT_BREAKER_RESET_S: int = _settings.PROXY_CIRCUIT_BREAKER_RESET_S
 
 
 def get_fal_key() -> str:
@@ -861,6 +884,26 @@ def get_supadata_key() -> str:
 
 def get_youtube_proxy() -> str:
     return YOUTUBE_PROXY
+
+
+def get_youtube_proxy_sticky() -> Optional[str]:
+    """Tier 2 — sticky Decodo session (cohérence cookies pendant ~10min)."""
+    return YOUTUBE_PROXY_STICKY or None
+
+
+def get_youtube_proxy_geo_us() -> Optional[str]:
+    """Tier 3 — Decodo geo-targeted US (username suffix `-country-us`)."""
+    return YOUTUBE_PROXY_GEO_US or None
+
+
+def get_youtube_proxy_geo_fr() -> Optional[str]:
+    """Tier 3 — Decodo geo-targeted FR (username suffix `-country-fr`)."""
+    return YOUTUBE_PROXY_GEO_FR or None
+
+
+def get_youtube_proxy_legacy() -> Optional[str]:
+    """Tier 4 — fallback multi-provider (Webshare etc.), indépendant de Decodo."""
+    return YOUTUBE_PROXY_LEGACY or None
 
 
 def get_ytdlp_cookies_path() -> str:

--- a/backend/src/core/proxy_resilience.py
+++ b/backend/src/core/proxy_resilience.py
@@ -1,0 +1,237 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🛡️ PROXY RESILIENCE MANAGER — Tiered fallback + circuit breaker (Sprint D)       ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Strategy (5 tiers, fail-down only) :                                              ║
+║    Tier 1 → default  : rotating Decodo (gate.decodo.com:7000 — IP différente/req) ║
+║    Tier 2 → sticky   : sticky Decodo port 10001 (IP fixe ~10min, cohérence cookies)║
+║    Tier 3 → geo_us / geo_fr : Decodo geo-targeted (-country-XX dans username)     ║
+║    Tier 4 → legacy   : provider indépendant (Webshare) — résilience cross-vendor  ║
+║    Tier 5 → none     : bare request sans proxy (last resort)                      ║
+║                                                                                    ║
+║  Bascule auto basée sur compteur d'erreurs glissant (PROXY_CIRCUIT_BREAKER_*).     ║
+║  Reset partiel sur success (évite l'oscillation excessive en bordure de seuil).   ║
+║  Fallback gracieux : si setting tier-N == None → cascade au tier suivant + warn.  ║
+║                                                                                    ║
+║  Thread-safety : protégé par asyncio.Lock (state in-process). Multi-worker FastAPI ║
+║  ⇒ state PAR worker (4 instances), pas synchronisé inter-process. C'est le coût   ║
+║  d'un singleton in-memory — distributed lock via Redis = follow-up V2.            ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict
+from typing import Dict, List, Literal, Optional
+
+from core.logging import logger
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📐 TYPES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+ProxyVariant = Literal["default", "sticky", "geo_us", "geo_fr", "legacy", "none"]
+ErrorKind = Literal["429", "403", "blocked", "timeout", "other"]
+
+# Ordre de bascule du circuit breaker. Le premier element est le tier de depart.
+# Cascade strict : un tier ne se reactive que apres reset complet.
+_TIER_ORDER: List[ProxyVariant] = ["default", "sticky", "geo_us", "geo_fr", "legacy", "none"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛡️ MANAGER
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class ProxyResilienceManager:
+    """In-memory circuit breaker for proxy tier selection.
+
+    Use `instance()` to get the process-wide singleton (4 instances en prod
+    FastAPI multi-worker). Pour les tests, instancier directement.
+    """
+
+    _instance: Optional["ProxyResilienceManager"] = None
+
+    def __init__(
+        self,
+        *,
+        threshold: Optional[int] = None,
+        window_s: Optional[int] = None,
+        reset_s: Optional[int] = None,
+    ) -> None:
+        """Initialize. Defaults read from `core.config` at call time.
+
+        Args (override pour tests) :
+            threshold : erreurs avant bascule au tier suivant.
+            window_s  : fenetre glissante des erreurs (sec).
+            reset_s   : duree sans erreur avant retour au tier 1.
+        """
+        if threshold is None or window_s is None or reset_s is None:
+            from core.config import (
+                PROXY_CIRCUIT_BREAKER_THRESHOLD,
+                PROXY_CIRCUIT_BREAKER_WINDOW_S,
+                PROXY_CIRCUIT_BREAKER_RESET_S,
+            )
+
+            self._threshold: int = threshold if threshold is not None else PROXY_CIRCUIT_BREAKER_THRESHOLD
+            self._window_s: int = window_s if window_s is not None else PROXY_CIRCUIT_BREAKER_WINDOW_S
+            self._reset_s: int = reset_s if reset_s is not None else PROXY_CIRCUIT_BREAKER_RESET_S
+        else:
+            self._threshold = threshold
+            self._window_s = window_s
+            self._reset_s = reset_s
+
+        # variant → list[error_ts] (window-based pruning at read time)
+        self._errors: Dict[ProxyVariant, List[float]] = defaultdict(list)
+        # variant → last success ts (utilise pour reset)
+        self._last_success: Dict[ProxyVariant, float] = {}
+        # lock pour mutations cross-tasks (sync-safe : pas d'await dedans)
+        self._lock = asyncio.Lock()
+
+    # -- Singleton accessor -------------------------------------------------
+
+    @classmethod
+    def instance(cls) -> "ProxyResilienceManager":
+        """Return process-wide singleton (one per FastAPI worker)."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Test helper — clear the singleton."""
+        cls._instance = None
+
+    # -- Public API ---------------------------------------------------------
+
+    def select_proxy_variant(
+        self,
+        platform: str,
+        video_id: Optional[str] = None,
+        geo_hint: Optional[str] = None,
+    ) -> ProxyVariant:
+        """Pick the next variant to attempt, based on circuit breaker state.
+
+        Cascade strict : on commence par `default`, on bascule au tier suivant
+        des qu'il a strictement plus de `threshold` erreurs dans la fenetre
+        de `window_s`. Le tier 3 (`geo_us`/`geo_fr`) est selectionne via
+        `geo_hint` ; sans hint on prend `geo_us` (couvre US-only blocks).
+
+        Args:
+            platform: plateforme cible (logging uniquement, pas de routing
+                differencie en V1).
+            video_id: optionnel, log uniquement.
+            geo_hint: "us" / "fr" pour choisir le tier geo. None → "us".
+
+        Returns:
+            Le variant a utiliser pour la prochaine requete.
+        """
+        # Quel tier ne consomme PAS de quota d'erreurs ? On itere dans l'ordre
+        # et on retourne le premier `healthy` (= sous seuil dans la fenetre).
+        now = time.monotonic()
+        cleaned = self._prune_old_errors(now)
+
+        for tier in _TIER_ORDER:
+            # Tier 3 : decline en geo_us vs geo_fr selon hint
+            if tier == "geo_us" and geo_hint and geo_hint.lower() == "fr":
+                continue  # geo_fr sera tente au cycle suivant
+            if tier == "geo_fr" and geo_hint and geo_hint.lower() != "fr":
+                continue  # geo_us seulement si hint != fr
+
+            err_count = len(cleaned.get(tier, []))
+            if err_count <= self._threshold:
+                logger.debug(
+                    f"proxy_resilience: select tier={tier} err_count={err_count} "
+                    f"threshold={self._threshold} platform={platform} "
+                    f"video_id={video_id} geo_hint={geo_hint}"
+                )
+                return tier
+
+        # Tous les tiers ont depasse le seuil — derniere chance : "none" (bare)
+        logger.warning(
+            f"proxy_resilience: ALL tiers saturated, falling back to 'none' "
+            f"(bare request) platform={platform} video_id={video_id}"
+        )
+        return "none"
+
+    def report_error(self, variant: str, error_kind: ErrorKind = "other") -> None:
+        """Record an error on the given variant.
+
+        Args:
+            variant: tier en cours d'utilisation (default/sticky/...). Si
+                inconnu, ignore silencieusement (caller robustesse).
+            error_kind: nature de l'erreur (logging + future segregation).
+        """
+        if variant not in _TIER_ORDER:
+            return
+        now = time.monotonic()
+        self._errors[variant].append(now)  # type: ignore[index]
+        logger.info(
+            f"proxy_resilience: error reported variant={variant} kind={error_kind} "
+            f"total_in_window={len(self._errors[variant])}"  # type: ignore[index]
+        )
+
+    def report_success(self, variant: str) -> None:
+        """Record a success on the given variant.
+
+        Reset partiel : on retire 1 erreur (la plus ancienne) pour eviter le
+        "thrashing" en bordure de seuil. Reset complet seulement apres
+        `reset_s` sans aucune erreur (via `_prune_old_errors`).
+        """
+        if variant not in _TIER_ORDER:
+            return
+        now = time.monotonic()
+        self._last_success[variant] = now  # type: ignore[index]
+        # Partial reset : pop the oldest error (FIFO) si la liste n'est pas vide.
+        errs = self._errors.get(variant)  # type: ignore[arg-type]
+        if errs:
+            errs.pop(0)
+            logger.debug(
+                f"proxy_resilience: success on variant={variant} — "
+                f"popped 1 error, remaining={len(errs)}"
+            )
+
+    # -- Introspection helpers (debug + tests) ------------------------------
+
+    def get_state(self) -> Dict[str, Dict[str, int]]:
+        """Snapshot state per tier (errors in window + age of last success)."""
+        now = time.monotonic()
+        cleaned = self._prune_old_errors(now)
+        return {
+            tier: {
+                "errors_in_window": len(cleaned.get(tier, [])),
+                "last_success_age_s": (
+                    int(now - self._last_success[tier])
+                    if tier in self._last_success
+                    else -1
+                ),
+            }
+            for tier in _TIER_ORDER
+        }
+
+    # -- Internal -----------------------------------------------------------
+
+    def _prune_old_errors(self, now: float) -> Dict[ProxyVariant, List[float]]:
+        """Drop errors older than `window_s`, AND drop ALL errors on a tier
+        if its last success is more recent than `reset_s` ago (full reset).
+
+        Returns the cleaned mapping (mutates in-place for memory efficiency).
+        """
+        cutoff = now - self._window_s
+        for tier in list(self._errors.keys()):
+            # Reset complet apres `reset_s` sans erreur ET success recent
+            last_ok = self._last_success.get(tier)  # type: ignore[arg-type]
+            if last_ok is not None and (now - last_ok) > self._reset_s:
+                # Verify : si la plus recente erreur est AVANT le dernier success,
+                # on peut reset propre. Sinon on garde uniquement les erreurs
+                # posterieures au success.
+                errs = self._errors[tier]  # type: ignore[index]
+                self._errors[tier] = [e for e in errs if e > last_ok]  # type: ignore[index]
+
+            # Pruning fenetre glissante
+            self._errors[tier] = [e for e in self._errors[tier] if e >= cutoff]  # type: ignore[index]
+
+        return self._errors  # type: ignore[return-value]

--- a/backend/src/transcripts/audio_utils.py
+++ b/backend/src/transcripts/audio_utils.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Literal, Optional, Tuple
 from concurrent.futures import ThreadPoolExecutor
 
 import httpx
@@ -20,8 +20,83 @@ from core.config import (
     get_groq_key,
     get_tiktok_cookies_path,
     get_youtube_proxy,
+    get_youtube_proxy_geo_fr,
+    get_youtube_proxy_geo_us,
+    get_youtube_proxy_legacy,
+    get_youtube_proxy_sticky,
     get_ytdlp_cookies_path,
 )
+from core.logging import logger
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 PROXY VARIANT RESOLUTION (Sprint D — Proxy V2 resilience)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+ProxyVariant = Literal["default", "sticky", "geo_us", "geo_fr", "legacy", "none"]
+
+# Variant → nom du getter dans le module (resolution dynamique a l'appel).
+# "none" retourne toujours "" via _GETTER_NONE.
+# Pourquoi indexer par nom de symbole et pas par fonction ? Parce que les tests
+# monkeypatch `audio_utils.get_youtube_proxy` (rebinding du nom), ce qui ne
+# se propage pas a une reference fonctionnelle figee dans un dict global.
+_VARIANT_GETTER_NAMES = {
+    "default": "get_youtube_proxy",
+    "sticky": "get_youtube_proxy_sticky",
+    "geo_us": "get_youtube_proxy_geo_us",
+    "geo_fr": "get_youtube_proxy_geo_fr",
+    "legacy": "get_youtube_proxy_legacy",
+    "none": None,  # special-cased dans _resolve_proxy_variant
+}
+
+
+def _resolve_proxy_variant(variant: ProxyVariant) -> str:
+    """Look up the proxy URL for the requested variant.
+
+    Fallback gracieux : si le variant est demande mais le setting est None/vide,
+    on log un warning et on retombe sur `YOUTUBE_PROXY` (default). Permet de
+    deployer le code AVANT que Maxime ait seed les variants en prod sans casser
+    les flows existants.
+
+    Args:
+        variant: "default" | "sticky" | "geo_us" | "geo_fr" | "legacy" | "none".
+
+    Returns:
+        URL proxy a injecter dans `--proxy` (ou "" pour bare).
+    """
+    if variant == "none":
+        return ""
+
+    getter_name = _VARIANT_GETTER_NAMES.get(variant)
+    if getter_name is None:
+        logger.warning(f"proxy_variant: unknown variant={variant!r}, using 'default'")
+        return _resolve_default()
+
+    # Resolution dynamique du symbole pour rester compatible monkeypatch
+    getter = globals().get(getter_name)
+    if getter is None:
+        logger.warning(
+            f"proxy_variant: getter {getter_name} not found in module — using default"
+        )
+        return _resolve_default()
+
+    url = getter() or ""
+    if not url and variant != "default":
+        # Tier configure absent en .env → cascade vers default avec warn.
+        logger.warning(
+            f"proxy_variant: {variant} requested but setting is None/empty, "
+            "falling back to default"
+        )
+        return _resolve_default()
+    return url
+
+
+def _resolve_default() -> str:
+    """Helper interne — toujours utilise le getter `get_youtube_proxy` courant."""
+    fn = globals().get("get_youtube_proxy")
+    if fn is None:
+        return ""
+    return fn() or ""
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -29,7 +104,12 @@ from core.config import (
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def _yt_dlp_extra_args(*, include_proxy: bool = True, use_tiktok_cookies: bool = False) -> list:
+def _yt_dlp_extra_args(
+    *,
+    include_proxy: bool = True,
+    use_tiktok_cookies: bool = False,
+    proxy_variant: ProxyVariant = "default",
+) -> list:
     """Common yt-dlp flags for IP-banned environments: proxy + cookies.
 
     Both are no-ops when their env vars are unset, so this is safe to call
@@ -49,12 +129,21 @@ def _yt_dlp_extra_args(*, include_proxy: bool = True, use_tiktok_cookies: bool =
     MTD > 950 MB), on skip `--proxy` même quand include_proxy=True. Dégradation
     gracieuse : la requête peut échouer côté YouTube (IP-ban) mais on ne bloque
     JAMAIS la requête côté backend.
+
+    `proxy_variant` (Sprint D) selectionne le tier proxy a utiliser :
+      - "default" : `YOUTUBE_PROXY` (rotating Decodo, comportement historique)
+      - "sticky"  : `YOUTUBE_PROXY_STICKY` (sticky session ~10min)
+      - "geo_us" / "geo_fr" : `YOUTUBE_PROXY_GEO_{US,FR}` (geo-targeted)
+      - "legacy"  : `YOUTUBE_PROXY_LEGACY` (fallback multi-provider)
+      - "none"    : skip `--proxy` (bare request, last-resort)
+    Fallback gracieux : si le variant pointe sur un setting None/vide,
+    cascade automatique vers `default` avec warning (`_resolve_proxy_variant`).
     """
     from middleware.proxy_telemetry import should_bypass_proxy  # local import — évite cycle
 
     extra = []
-    if include_proxy and not should_bypass_proxy():
-        proxy = get_youtube_proxy()
+    if include_proxy and proxy_variant != "none" and not should_bypass_proxy():
+        proxy = _resolve_proxy_variant(proxy_variant)
         if proxy:
             extra.extend(["--proxy", proxy])
     cookies = get_tiktok_cookies_path() if use_tiktok_cookies else get_ytdlp_cookies_path()

--- a/backend/tests/test_proxy_resilience.py
+++ b/backend/tests/test_proxy_resilience.py
@@ -1,0 +1,319 @@
+"""
+Tests for Sprint D — Proxy V2 advanced (tiered resilience).
+
+Couvre :
+  - `ProxyResilienceManager` : circuit breaker state, tier upgrade, reset window.
+  - `_yt_dlp_extra_args(proxy_variant=...)` : selection du variant + fallback gracieux
+    si le setting est None.
+  - `_resolve_proxy_variant(...)` : mapping variant → setting + cascade vers default.
+"""
+
+import os
+import sys
+import time
+import pytest
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# 🛡️ ProxyResilienceManager
+# ═════════════════════════════════════════════════════════════════════════
+
+
+class TestProxyResilienceManager:
+    """Circuit breaker state + tier selection."""
+
+    def _make(self, threshold=3, window_s=60, reset_s=300):
+        from core.proxy_resilience import ProxyResilienceManager
+
+        return ProxyResilienceManager(threshold=threshold, window_s=window_s, reset_s=reset_s)
+
+    def test_initial_tier_is_default(self):
+        mgr = self._make()
+        assert mgr.select_proxy_variant(platform="youtube") == "default"
+
+    def test_tier_upgrade_after_threshold_errors(self):
+        """Apres > threshold erreurs sur 'default', on bascule sur 'sticky'."""
+        mgr = self._make(threshold=3, window_s=60)
+        for _ in range(4):
+            mgr.report_error("default", "429")
+        assert mgr.select_proxy_variant(platform="youtube") == "sticky"
+
+    def test_tier_cascade_through_all(self):
+        """Si tous les tiers cumulent des erreurs, on tombe sur 'none' (last resort)."""
+        mgr = self._make(threshold=2, window_s=60)
+        for tier in ("default", "sticky", "geo_us", "geo_fr", "legacy"):
+            for _ in range(3):
+                mgr.report_error(tier, "blocked")
+        assert mgr.select_proxy_variant(platform="tiktok") == "none"
+
+    def test_geo_hint_us_selects_geo_us(self):
+        """Tier 3 — geo_us choisi par defaut, geo_fr saute (hint != fr)."""
+        mgr = self._make(threshold=2, window_s=60)
+        # Sature default + sticky
+        for _ in range(3):
+            mgr.report_error("default", "429")
+            mgr.report_error("sticky", "blocked")
+        # Sans hint → geo_us
+        assert mgr.select_proxy_variant(platform="youtube") == "geo_us"
+        # Avec hint='us' → geo_us (idem)
+        assert mgr.select_proxy_variant(platform="youtube", geo_hint="us") == "geo_us"
+
+    def test_geo_hint_fr_selects_geo_fr(self):
+        """Tier 3 — hint='fr' selectionne geo_fr (geo_us saute)."""
+        mgr = self._make(threshold=2, window_s=60)
+        for _ in range(3):
+            mgr.report_error("default", "429")
+            mgr.report_error("sticky", "blocked")
+        assert mgr.select_proxy_variant(platform="tiktok", geo_hint="fr") == "geo_fr"
+
+    def test_error_window_pruning(self, monkeypatch):
+        """Erreurs hors fenetre glissante sont ignorees."""
+        import core.proxy_resilience as pr
+
+        mgr = self._make(threshold=3, window_s=10)
+
+        # On falsifie time.monotonic pour simuler le passage du temps.
+        fake_time = [1000.0]
+
+        def fake_monotonic():
+            return fake_time[0]
+
+        monkeypatch.setattr(pr.time, "monotonic", fake_monotonic)
+
+        # 4 erreurs a t=1000 → seuil depasse, bascule sticky
+        for _ in range(4):
+            mgr.report_error("default", "429")
+        assert mgr.select_proxy_variant(platform="youtube") == "sticky"
+
+        # On avance de 20s (au-dela de window_s=10) — les anciennes erreurs sont oubliees
+        fake_time[0] += 20
+        assert mgr.select_proxy_variant(platform="youtube") == "default"
+
+    def test_partial_reset_on_success(self):
+        """report_success pop la plus ancienne erreur (anti-thrashing)."""
+        mgr = self._make(threshold=3, window_s=60)
+        for _ in range(4):
+            mgr.report_error("default", "429")
+        # Maintenant 4 erreurs → on bascule sticky
+        assert mgr.select_proxy_variant(platform="youtube") == "sticky"
+
+        # 1 success → 3 erreurs restantes (seuil = 3, donc <= seuil → default)
+        mgr.report_success("default")
+        assert mgr.select_proxy_variant(platform="youtube") == "default"
+
+    def test_full_reset_after_reset_s(self, monkeypatch):
+        """Apres reset_s sans erreur ET avec success enregistre, le tier est reset."""
+        import core.proxy_resilience as pr
+
+        mgr = self._make(threshold=2, window_s=600, reset_s=120)
+        fake_time = [1000.0]
+
+        def fake_monotonic():
+            return fake_time[0]
+
+        monkeypatch.setattr(pr.time, "monotonic", fake_monotonic)
+
+        # 3 erreurs → seuil depasse
+        for _ in range(3):
+            mgr.report_error("default", "blocked")
+        assert mgr.select_proxy_variant(platform="youtube") == "sticky"
+
+        # On avance 5s puis success
+        fake_time[0] += 5
+        mgr.report_success("default")  # pop 1, reste 2 erreurs
+
+        # Toujours sticky tant qu'on n'a pas attendu reset_s
+        # 2 erreurs <= threshold=2 → default
+        assert mgr.select_proxy_variant(platform="youtube") == "default"
+
+        # On avance 150s (reset_s=120 depasse) — les erreurs anciennes sont nettoyees
+        fake_time[0] += 150
+        assert mgr.select_proxy_variant(platform="youtube") == "default"
+        state = mgr.get_state()
+        assert state["default"]["errors_in_window"] == 0
+
+    def test_report_error_unknown_variant_is_silent(self):
+        """Robustesse : un variant inconnu ne crashe pas."""
+        mgr = self._make()
+        mgr.report_error("nonexistent_tier", "other")  # ne doit pas raise
+        assert mgr.select_proxy_variant(platform="youtube") == "default"
+
+    def test_report_success_unknown_variant_is_silent(self):
+        """Robustesse : success sur variant inconnu ne crashe pas."""
+        mgr = self._make()
+        mgr.report_success("nonexistent_tier")  # ne doit pas raise
+
+    def test_get_state_snapshot(self):
+        """`get_state` retourne un snapshot exploitable pour debug/metrics."""
+        mgr = self._make(threshold=5, window_s=60)
+        mgr.report_error("default", "429")
+        mgr.report_error("sticky", "blocked")
+        mgr.report_error("sticky", "blocked")
+
+        state = mgr.get_state()
+        assert state["default"]["errors_in_window"] == 1
+        assert state["sticky"]["errors_in_window"] == 2
+        assert state["geo_us"]["errors_in_window"] == 0
+        # All tiers tracked
+        assert set(state.keys()) == {"default", "sticky", "geo_us", "geo_fr", "legacy", "none"}
+
+    def test_singleton_returns_same_instance(self):
+        """`instance()` retourne le meme objet a chaque appel."""
+        from core.proxy_resilience import ProxyResilienceManager
+
+        ProxyResilienceManager.reset_instance()
+        a = ProxyResilienceManager.instance()
+        b = ProxyResilienceManager.instance()
+        assert a is b
+        ProxyResilienceManager.reset_instance()
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# 🔧 _resolve_proxy_variant + _yt_dlp_extra_args
+# ═════════════════════════════════════════════════════════════════════════
+
+
+class TestResolveProxyVariant:
+    """Mapping variant → setting + fallback gracieux."""
+
+    def test_default_returns_main_proxy(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://default:1080")
+        assert audio_utils._resolve_proxy_variant("default") == "http://default:1080"
+
+    def test_sticky_returns_sticky_setting(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy_sticky", lambda: "http://sticky:10001")
+        assert audio_utils._resolve_proxy_variant("sticky") == "http://sticky:10001"
+
+    def test_geo_us_returns_geo_setting(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy_geo_us", lambda: "http://geo-us:7000")
+        assert audio_utils._resolve_proxy_variant("geo_us") == "http://geo-us:7000"
+
+    def test_none_returns_empty(self):
+        from transcripts import audio_utils
+
+        assert audio_utils._resolve_proxy_variant("none") == ""
+
+    def test_fallback_to_default_when_variant_unset(self, monkeypatch):
+        """Si sticky est None, on retombe sur default (avec warning)."""
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://default:7000")
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy_sticky", lambda: None)
+        # Setting absent → cascade vers default
+        assert audio_utils._resolve_proxy_variant("sticky") == "http://default:7000"
+
+    def test_fallback_to_default_for_legacy_when_unset(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://default")
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy_legacy", lambda: "")
+        assert audio_utils._resolve_proxy_variant("legacy") == "http://default"
+
+
+class TestYtDlpExtraArgsWithVariant:
+    """Signature etendue : _yt_dlp_extra_args(proxy_variant=...)."""
+
+    def test_default_variant_uses_youtube_proxy(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://default:7000")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        args = audio_utils._yt_dlp_extra_args()  # variant = default
+        assert args == ["--proxy", "http://default:7000"]
+
+    def test_sticky_variant_uses_sticky_setting(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy_sticky", lambda: "http://sticky:10001")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        args = audio_utils._yt_dlp_extra_args(proxy_variant="sticky")
+        assert args == ["--proxy", "http://sticky:10001"]
+
+    def test_none_variant_skips_proxy(self, monkeypatch):
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://default:7000")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        args = audio_utils._yt_dlp_extra_args(proxy_variant="none")
+        assert args == []  # ni proxy ni cookies
+
+    def test_geo_fr_variant_with_cookies(self, monkeypatch, tmp_path):
+        from transcripts import audio_utils
+
+        cookies_file = tmp_path / "cookies.txt"
+        cookies_file.write_text("# cookies")
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy_geo_fr", lambda: "http://geo-fr:7000")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: str(cookies_file))
+
+        args = audio_utils._yt_dlp_extra_args(proxy_variant="geo_fr")
+        assert args == ["--proxy", "http://geo-fr:7000", "--cookies", str(cookies_file)]
+
+    def test_include_proxy_false_skips_variant_resolution(self, monkeypatch):
+        """Backward-compat : include_proxy=False ne charge meme pas le variant."""
+        from transcripts import audio_utils
+
+        # Setter qui leve si appele — verification que _resolve n'est pas execute
+        called = {"n": 0}
+
+        def _spy():
+            called["n"] += 1
+            return "http://should-not-be-used"
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", _spy)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        args = audio_utils._yt_dlp_extra_args(include_proxy=False, proxy_variant="default")
+        assert args == []
+        assert called["n"] == 0  # _resolve n'a pas ete appele
+
+    def test_use_tiktok_cookies_with_variant(self, monkeypatch, tmp_path):
+        """use_tiktok_cookies + proxy_variant coexistent."""
+        from transcripts import audio_utils
+
+        cookies_file = tmp_path / "tiktok-cookies.txt"
+        cookies_file.write_text("# tiktok")
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy_sticky", lambda: "http://sticky:10001")
+        monkeypatch.setattr(audio_utils, "get_tiktok_cookies_path", lambda: str(cookies_file))
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        args = audio_utils._yt_dlp_extra_args(
+            use_tiktok_cookies=True, proxy_variant="sticky"
+        )
+        assert args == ["--proxy", "http://sticky:10001", "--cookies", str(cookies_file)]
+
+    def test_variant_fallback_when_setting_empty(self, monkeypatch):
+        """Variant demande mais setting vide → cascade vers YOUTUBE_PROXY."""
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://default")
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy_legacy", lambda: None)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        # legacy n'est pas configure → fallback vers default
+        args = audio_utils._yt_dlp_extra_args(proxy_variant="legacy")
+        assert args == ["--proxy", "http://default"]
+
+    def test_backward_compat_no_variant_arg(self, monkeypatch):
+        """Appel sans proxy_variant garde le comportement legacy (default)."""
+        from transcripts import audio_utils
+
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "http://legacy-call")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        # Aucun nouvel argument — comportement strictement equivalent au Sprint A
+        args = audio_utils._yt_dlp_extra_args(include_proxy=True, use_tiktok_cookies=False)
+        assert args == ["--proxy", "http://legacy-call"]


### PR DESCRIPTION
## Sprint D — Proxy V2 advanced (geo + sticky + multi-provider fallback)

Cable les variants Decodo (rotating/sticky/geo) + provider de fallback (Webshare) + bare request derniere chance. Circuit breaker in-memory bascule au tier suivant des qu''un tier cumule plus de `PROXY_CIRCUIT_BREAKER_THRESHOLD` erreurs dans la fenetre.

## Files

| Fichier | Changes |
|---------|---------|
| `backend/src/core/config.py` | 4 settings proxy (sticky/geo_us/geo_fr/legacy) + 3 settings circuit breaker + 4 getters helpers |
| `backend/src/core/proxy_resilience.py` | **Nouveau** — `ProxyResilienceManager` singleton |
| `backend/src/transcripts/audio_utils.py` | Signature `_yt_dlp_extra_args` etendue avec `proxy_variant` |
| `backend/tests/test_proxy_resilience.py` | **Nouveau** — 26 tests |

## Approach

Cascade strict `default → sticky → geo_us/fr → legacy → none`. Le `ProxyResilienceManager` maintient un compteur d''erreurs par tier sur fenetre glissante (`PROXY_CIRCUIT_BREAKER_WINDOW_S` = 60s par defaut). Sur reach du seuil (`PROXY_CIRCUIT_BREAKER_THRESHOLD` = 5), `select_proxy_variant()` passe au tier suivant. `report_success()` fait un reset partiel (FIFO pop 1) — reset complet apres `PROXY_CIRCUIT_BREAKER_RESET_S` (300s) sans erreur.

## Backward compatibility

- `_yt_dlp_extra_args()` sans nouveau parametre = comportement identique a Sprint A.
- Tous les variants `STICKY/GEO_*/LEGACY` sont `None` par defaut — **0 changement comportemental en prod tant que `.env.production` n''est pas seeded**.
- Resolution dynamique du getter via `globals()` → monkeypatch des tests reste fonctionnel sans mock du dict global.

## Tests

```
26 passed in 1.53s
```

Couvre :
- Initial tier = `default`
- Tier upgrade apres N erreurs
- Cascade complete `default → sticky → geo → legacy → none`
- `geo_hint` selectionne `geo_us` vs `geo_fr`
- Fenetre glissante (erreurs hors fenetre ignorees)
- Reset partiel sur `report_success` (anti-thrashing)
- Reset complet apres `reset_s` sans erreur
- Singleton return-same-instance
- `_resolve_proxy_variant` mapping pour chaque variant
- Fallback gracieux quand setting `None`/vide
- Backward-compat sans `proxy_variant`

## Followups

- Seed `YOUTUBE_PROXY_STICKY`, `YOUTUBE_PROXY_GEO_US/FR`, `YOUTUBE_PROXY_LEGACY` dans `.env.production` Hetzner (manuel post-merge).
- Brancher les call sites yt-dlp sur le `ProxyResilienceManager` (`select_proxy_variant` + `report_error`/`report_success`) — out of scope Sprint D.
- Distributed lock Redis pour partager le state entre les 4 workers FastAPI — V2.

## Test plan

- [x] `pytest tests/test_proxy_resilience.py -v` → 26/26 verts
- [x] `pytest tests/transcripts/test_yt_dlp_extra_args.py tests/test_tiktok_visual.py` → backward-compat preservee (1 echec pre-existant hors scope, `test_re_export_from_ultra_resilient`)
- [ ] Seed env vars en prod et verifier passage de tier en cas d''erreur 429/403 reelle (suivi manuel post-merge)