### PR TITLE
fix(visual): 5th fallback duration_hint from upstream Supadata metadata

### DIFF
--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -239,6 +239,12 @@ async def maybe_enrich_with_visual(
     de base se fait quand même sans la couche visuelle (graceful degradation).
 
     Aucun commit DB n'est fait ici — le caller commit en fin de flow.
+
+    `duration_hint` (Option C, sprint 2026-05-12) : durée vidéo connue côté
+    caller (`video_info.get("duration")` issu de Supadata metadata HTTP).
+    Propagée à `extract_storyboard_frames` comme 5ème fallback ; évite le
+    skip silencieux observé prod sur les vidéos où yt-dlp + fragments +
+    Supadata get_video_info + transcript timestamps échouent en cascade.
     """
     t0 = time.time()
     log_tag = f"VISUAL_INT user={user.id}"
@@ -291,10 +297,13 @@ async def maybe_enrich_with_visual(
         # et contient les timestamps Supadata `[mm:ss]` — utilisé en
         # fallback ultime dans extract_storyboard_frames si yt-dlp +
         # sb fragments + Supadata get_video_info échouent à donner duration.
+        # duration_hint (Option C) est le 5ème fallback : durée connue
+        # upstream depuis Supadata metadata HTTP, fiable, JAMAIS prioritaire.
         extraction = await extract_storyboard_frames(
             video_id,
             mode=mode,
             transcript_hint=transcript_excerpt or None,
+            duration_hint=duration_hint,
             log_tag=log_tag,
         )
         identifier_for_logs = video_id
@@ -682,6 +691,9 @@ async def enrich_and_capture_visual(
     après save_summary().
 
     Best-effort — toute exception est attrapée et loggée (graceful degradation).
+
+    `duration_hint` (Option C) propagé depuis `video_info["duration"]` côté
+    router pour servir de 5ème fallback dans `extract_storyboard_frames`.
     """
     if not flag_enabled:
         return web_context, None

--- a/backend/src/videos/youtube_storyboard.py
+++ b/backend/src/videos/youtube_storyboard.py
@@ -263,6 +263,7 @@ async def extract_storyboard_frames(
     max_frames_override: Optional[int] = None,
     mode: str = DEFAULT_MODE,
     transcript_hint: Optional[str] = None,
+    duration_hint: Optional[float] = None,
     log_tag: str = "STORYBOARD",
 ) -> Optional[FrameExtractionResult]:
     """
@@ -277,6 +278,13 @@ async def extract_storyboard_frames(
 
     Renvoie None à toute étape qui échoue. Workdir est nettoyé automatiquement
     en cas d'échec.
+
+    `duration_hint` (Option C) : 5ème fallback de durée fourni par le caller
+    depuis `video_info["duration"]` (Supadata metadata HTTP, fiable). N'est
+    consulté qu'après les 4 fallbacks classiques (yt-dlp top-level, fragments
+    sb*, Supadata get_video_info, transcript timestamps regex). Évite le skip
+    silencieux observé prod 2026-05-11 sur les vidéos où les 4 fallbacks
+    classiques échouent en cascade.
     """
     video_id = normalize_video_id(video_id_or_url)
     if not video_id:
@@ -354,9 +362,23 @@ async def extract_storyboard_frames(
                     duration_s,
                 )
 
+        # ── Fallback 4 (Option C): duration_hint propagé par le caller ──
+        # Provient de `video_info["duration"]` côté router (Supadata metadata
+        # HTTP, fiable). Active quand le transcript Supadata est en plain text
+        # (bug endpoint unifié, cf. transcripts/youtube.py:913 / :940) — la
+        # regex `[mm:ss]` ne matche rien et les 3 fallbacks précédents ont
+        # tous échoué. C'est le filet de sécurité prod, JAMAIS prioritaire.
+        if duration_s <= 0 and duration_hint and duration_hint > 0:
+            duration_s = float(duration_hint)
+            logger.info(
+                "[%s] Duration from upstream duration_hint fallback: %.1fs",
+                log_tag,
+                duration_s,
+            )
+
         if duration_s <= 0:
             logger.warning(
-                "[%s] No duration found (yt-dlp + fragments + Supadata + transcript all failed)",
+                "[%s] No duration found (yt-dlp + fragments + Supadata + transcript + hint all failed)",
                 log_tag,
             )
             shutil.rmtree(workdir, ignore_errors=True)

--- a/backend/tests/videos/test_visual_integration_duration_hint.py
+++ b/backend/tests/videos/test_visual_integration_duration_hint.py
@@ -1,0 +1,367 @@
+"""
+Tests pour la propagation de `duration_hint` (Option C).
+
+Bug originel (prod 2026-05-11) :
+- `videos/visual_integration.py::maybe_enrich_with_visual` skip silencieusement
+  quand `extract_storyboard_frames` ne trouve pas de duration, alors que
+  `video_info["duration"]` est dispo en amont (Supadata metadata l'a déjà
+  fetched).
+- Les 4 fallbacks actuels (yt-dlp top-level, fragments sb*, Supadata
+  get_video_info, transcript timestamps regex) échouent en cascade sur
+  certaines vidéos (vieilles/lockées + transcript Supadata = plain text
+  sans `[mm:ss]` à cause du bug endpoint unifié).
+
+Fix Option C :
+- Propager `duration_hint=int(video_info.get("duration") or 0)` depuis
+  `videos/router.py` (call sites V1/V2/V2.1).
+- `maybe_enrich_with_visual` accepte ce param et le passe à
+  `extract_storyboard_frames`.
+- `extract_storyboard_frames` l'utilise comme 5ème fallback APRÈS les 4
+  existants (le plus fiable car Supadata metadata HTTP est solide).
+
+Ces tests verrouillent le contrat :
+1. `extract_storyboard_frames(duration_hint=3600)` utilise bien le hint quand
+   les 4 fallbacks classiques retournent rien.
+2. `maybe_enrich_with_visual(duration_hint=3600)` propage bien le hint
+   jusqu'à `extract_storyboard_frames`.
+3. Sans `duration_hint`, le comportement legacy reste intact (None retourné).
+"""
+
+import io
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image
+
+_src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_test_sheet(width: int = 320, height: int = 180) -> bytes:
+    """Crée un mini-JPEG factice pour les tests."""
+    img = Image.new("RGB", (width, height), color=(128, 128, 128))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _make_user(plan: str, user_id: int = 1):
+    user = MagicMock()
+    user.id = user_id
+    user.plan = plan
+    return user
+
+
+# yt-dlp info SANS duration top-level, fragments sans duration, et pas de
+# Supadata duration → simule le cas réel buggué prod.
+INFO_NO_DURATION = {
+    "duration": None,  # ❌ Top-level absent
+    "title": "Locked Old Video",
+    "formats": [
+        {
+            "format_id": "sb1",
+            "width": 320,
+            "height": 180,
+            "columns": 2,
+            "rows": 2,
+            "fragments": [
+                # ❌ Fragments sans `duration`
+                {"url": "https://i.ytimg.com/sb/test/M0.jpg"},
+                {"url": "https://i.ytimg.com/sb/test/M1.jpg"},
+            ],
+        },
+    ],
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎬 extract_storyboard_frames — duration_hint comme 5ème fallback
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExtractStoryboardFramesDurationHint:
+    @pytest.mark.asyncio
+    async def test_duration_hint_used_when_all_fallbacks_fail(
+        self, tmp_path, monkeypatch
+    ):
+        """
+        Reproduit le bug prod : tous les fallbacks fail mais on a duration_hint.
+        - yt-dlp top-level: None
+        - fragments sb*: pas de duration
+        - Supadata get_video_info: simulé None
+        - transcript_hint: plain text sans timestamps
+        - duration_hint=3600 (1h, fourni par caller depuis Supadata metadata)
+
+        Attendu : extraction réussit en utilisant duration_hint.
+        """
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: INFO_NO_DURATION,
+        )
+
+        # Supadata get_video_info mocké pour ne pas fournir de duration
+        async def fake_get_video_info(_video_id):
+            return {"title": "x", "duration": None}
+
+        # On patche le module dynamique `transcripts` qui contient get_video_info
+        import transcripts
+
+        monkeypatch.setattr(
+            transcripts, "get_video_info", fake_get_video_info, raising=False
+        )
+
+        sheet_bytes = _make_test_sheet()
+
+        async def fake_download(client, url, log_tag):
+            return sheet_bytes
+
+        monkeypatch.setattr(youtube_storyboard, "_download_sheet", fake_download)
+
+        result = await youtube_storyboard.extract_storyboard_frames(
+            "dQw4w9WgXcQ",
+            transcript_hint="Plain text without any timestamps at all",
+            duration_hint=3600.0,
+        )
+
+        assert result is not None, (
+            "extract_storyboard_frames should succeed using duration_hint "
+            "when all 4 prior fallbacks fail"
+        )
+        assert result.duration_s == 3600.0
+        assert result.frame_count > 0
+        result.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_no_duration_hint_falls_back_to_legacy_behavior(
+        self, tmp_path, monkeypatch
+    ):
+        """
+        Sans duration_hint, comportement legacy : si tous les 4 fallbacks
+        fail → return None (pas de régression).
+        """
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: INFO_NO_DURATION,
+        )
+
+        async def fake_get_video_info(_video_id):
+            return {"title": "x", "duration": None}
+
+        import transcripts
+
+        monkeypatch.setattr(
+            transcripts, "get_video_info", fake_get_video_info, raising=False
+        )
+
+        result = await youtube_storyboard.extract_storyboard_frames(
+            "dQw4w9WgXcQ",
+            transcript_hint="Plain text without timestamps",
+            # ⚠️ Pas de duration_hint
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_duration_hint_zero_treated_as_absent(self, tmp_path, monkeypatch):
+        """duration_hint=0 ou None doivent être traités identiquement."""
+        from videos import youtube_storyboard
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: INFO_NO_DURATION,
+        )
+
+        async def fake_get_video_info(_video_id):
+            return {"title": "x", "duration": None}
+
+        import transcripts
+
+        monkeypatch.setattr(
+            transcripts, "get_video_info", fake_get_video_info, raising=False
+        )
+
+        result = await youtube_storyboard.extract_storyboard_frames(
+            "dQw4w9WgXcQ",
+            duration_hint=0.0,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_yt_dlp_duration_takes_priority_over_hint(
+        self, tmp_path, monkeypatch
+    ):
+        """Si yt-dlp donne déjà duration, on l'utilise — duration_hint ignoré."""
+        from videos import youtube_storyboard
+
+        info_with_duration = {
+            "duration": 30.0,  # ✅ yt-dlp top-level
+            "title": "Fake Video",
+            "formats": [
+                {
+                    "format_id": "sb1",
+                    "width": 320,
+                    "height": 180,
+                    "columns": 2,
+                    "rows": 2,
+                    "fragments": [
+                        {"url": "https://i.ytimg.com/sb/test/M0.jpg", "duration": 15.0},
+                        {"url": "https://i.ytimg.com/sb/test/M1.jpg", "duration": 15.0},
+                    ],
+                },
+            ],
+        }
+
+        monkeypatch.setattr(youtube_storyboard, "FRAMES_BASE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            youtube_storyboard,
+            "_ytdlp_info_sync",
+            lambda video_id, log_tag: info_with_duration,
+        )
+
+        sheet_bytes = _make_test_sheet()
+
+        async def fake_download(client, url, log_tag):
+            return sheet_bytes
+
+        monkeypatch.setattr(youtube_storyboard, "_download_sheet", fake_download)
+
+        result = await youtube_storyboard.extract_storyboard_frames(
+            "dQw4w9WgXcQ", duration_hint=99999.0
+        )
+        assert result is not None
+        # yt-dlp duration (30s) wins, pas le hint (99999s)
+        assert result.duration_s == 30.0
+        result.cleanup()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔌 maybe_enrich_with_visual — propagation duration_hint
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMaybeEnrichWithVisualDurationHint:
+    @pytest.mark.asyncio
+    async def test_duration_hint_propagated_to_extract(self, monkeypatch):
+        """
+        Vérifie que maybe_enrich_with_visual passe bien duration_hint
+        à extract_storyboard_frames.
+        """
+        from videos import visual_integration as vi
+
+        db = AsyncMock()
+        user = _make_user("expert")  # Bypass quota
+
+        captured_kwargs = {}
+
+        async def fake_extract(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return None  # On veut juste vérifier la propagation
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+
+        await vi.maybe_enrich_with_visual(
+            db,
+            user,
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            transcript_excerpt="hello",
+            duration_hint=3600.0,
+        )
+
+        assert "duration_hint" in captured_kwargs, (
+            "maybe_enrich_with_visual must forward duration_hint kwarg "
+            "to extract_storyboard_frames"
+        )
+        assert captured_kwargs["duration_hint"] == 3600.0
+
+    @pytest.mark.asyncio
+    async def test_no_duration_hint_passes_none(self, monkeypatch):
+        """Sans duration_hint → forwarded as None (pas d'effet de bord)."""
+        from videos import visual_integration as vi
+
+        db = AsyncMock()
+        user = _make_user("expert")
+
+        captured_kwargs = {}
+
+        async def fake_extract(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return None
+
+        monkeypatch.setattr(vi, "extract_storyboard_frames", fake_extract)
+
+        await vi.maybe_enrich_with_visual(
+            db,
+            user,
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            transcript_excerpt="hello",
+        )
+
+        # duration_hint forwarded comme None ou absent
+        assert captured_kwargs.get("duration_hint") in (None, 0, 0.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔌 enrich_and_capture_visual — propagation duration_hint
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestEnrichAndCaptureVisualDurationHint:
+    @pytest.mark.asyncio
+    async def test_duration_hint_propagated_via_helper(self, monkeypatch):
+        """
+        Vérifie que enrich_and_capture_visual (wrapper appelé par V2/V2.1)
+        forward bien duration_hint vers maybe_enrich_with_visual.
+        """
+        from videos import visual_integration as vi
+
+        # Mock select() pour ne pas hit la DB pour User
+        from unittest.mock import MagicMock as _MM
+
+        db = AsyncMock()
+        user_row = _make_user("expert")
+
+        async def fake_execute(_q):
+            r = _MM()
+            r.scalar_one_or_none = _MM(return_value=user_row)
+            return r
+
+        db.execute = fake_execute
+
+        captured_kwargs = {}
+
+        async def fake_maybe_enrich(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"status": "extract_failed"}  # peu importe pour ce test
+
+        monkeypatch.setattr(vi, "maybe_enrich_with_visual", fake_maybe_enrich)
+
+        await vi.enrich_and_capture_visual(
+            db=db,
+            user_id=1,
+            url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            transcript_excerpt="hello",
+            web_context="ctx",
+            flag_enabled=True,
+            log_tag="TEST",
+            duration_hint=7200.0,
+        )
+
+        assert captured_kwargs.get("duration_hint") == 7200.0


### PR DESCRIPTION
## Root cause (prod 2026-05-11)

`videos/visual_integration.py::maybe_enrich_with_visual` skip silencieusement quand `extract_storyboard_frames` ne trouve pas de duration, alors que `video_info["duration"]` est dispo en amont (Supadata metadata HTTP l'a deja fetched).

Les 4 fallbacks existants echouent en cascade pour certaines videos :
1. **yt-dlp top-level** : `info["duration"]` absent (videos anciennes/lockees)
2. **fragments sb*** : pas de `duration` dans le JSON
3. **Supadata `get_video_info`** : retourne sans field `duration`
4. **transcript timestamps regex** : `transcript_timestamped` est en fait du plain text — bug Supadata endpoint unifie (`transcripts/youtube.py:913` et `:940` retournent `content.strip(), content.strip()`), donc la regex `\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]` ne matche rien.

Resultat prod : `STATUS_EXTRACT_FAILED` silencieux, visual analysis jamais lancee, alors qu'on connait deja la duration en amont.

## Fix Option C — la plus simple (~10 lignes effectives)

Propager `duration_hint=float(video_info.get("duration") or 0) or None` du router jusqu'a `extract_storyboard_frames`, et l'utiliser comme **5eme fallback APRES les 4 existants** (jamais prioritaire — Supadata metadata HTTP est juste le filet de securite ultime).

### Fichiers modifies

| Fichier | Lignes | Changement |
|---|---|---|
| `backend/src/videos/youtube_storyboard.py` | +24 | Ajoute kwarg `duration_hint` + bloc fallback 5 |
| `backend/src/videos/visual_integration.py` | +15 | `maybe_enrich_with_visual` + `enrich_and_capture_visual` acceptent et forward |
| `backend/src/videos/router.py` | +3 | 3 call sites (V1 ligne 1503, V2.1 ligne 2395, V3 ligne 3211) passent `duration_hint=float(video_duration or 0) or None` |
| `backend/tests/videos/test_visual_integration_duration_hint.py` | +366 (nouveau) | 7 tests TDD verrouillent le contrat |

### Tests TDD

7 tests ecrits **avant** l'implementation :
- `test_duration_hint_used_when_all_fallbacks_fail` : reproduit le bug prod, hint=3600 sauve l'extraction.
- `test_no_duration_hint_falls_back_to_legacy_behavior` : sans hint, comportement legacy preserve (None retourne).
- `test_duration_hint_zero_treated_as_absent` : hint=0 traite comme None.
- `test_yt_dlp_duration_takes_priority_over_hint` : yt-dlp duration (30s) gagne contre hint (99999s).
- `test_duration_hint_propagated_to_extract` : `maybe_enrich_with_visual` forward le kwarg.
- `test_no_duration_hint_passes_none` : sans param, forwarded comme None.
- `test_duration_hint_propagated_via_helper` : `enrich_and_capture_visual` forward via wrapper V2/V2.1.

### Resultats

- **Test fichier** : 7/7 verts.
- **Suite videos complete** (`backend/tests/videos/`) : 162/162 verts, 0 regression.
- **Sprints recents** (`test_proxy_telemetry.py`, `test_api_public_v1_analysis.py`) : 23/23 verts (1 skip alembic attendu).

## Follow-ups (hors scope cette PR)

- **Option A** : fix `transcripts/youtube.py:913` et `:940` pour faire respecter le contrat du `transcript_timestamped` (timestamps `[mm:ss]` reels au lieu de plain text duplique).
- **Option B** : ajouter un 5eme fallback independant via Supadata `segments` endpoint (separate de `duration_hint`, pour le cas ou le caller ne connait pas la duration).

## Test plan

- [x] `pytest backend/tests/videos/test_visual_integration_duration_hint.py -v` -> 7/7 verts
- [x] `pytest backend/tests/videos/ -v` -> 162/162 verts
- [x] `pytest backend/tests/test_proxy_telemetry.py backend/tests/test_api_public_v1_analysis.py -v` -> 23/23 verts (1 skip attendu)
- [ ] Verification prod post-merge : sur une video avec duration mais sans yt-dlp/sb/Supadata/transcript timestamps, log `Duration from upstream duration_hint fallback: %.1fs` doit apparaitre.