### PR TITLE
fix(proxy): inject --proxy on 5 missing yt-dlp paths in transcripts/youtube.py

### DIFF
--- a/backend/src/transcripts/youtube.py
+++ b/backend/src/transcripts/youtube.py
@@ -662,6 +662,11 @@ async def get_video_info_ytdlp(video_id: str) -> Optional[Dict[str, Any]]:
                 "youtube:player_client=android",
                 f"https://youtube.com/watch?v={video_id}",
             ]
+            proxy = get_youtube_proxy()
+            if proxy:
+                cmd.insert(1, "--proxy")
+                cmd.insert(2, proxy)
+                print("  🔌 [YT-DLP-INFO] Using proxy", flush=True)
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
             if result.returncode == 0:
                 return json.loads(result.stdout)
@@ -1433,6 +1438,11 @@ async def get_transcript_whisper(video_id: str) -> Tuple[Optional[str], Optional
                         "youtube:player_client=android",
                         f"https://youtube.com/watch?v={video_id}",
                     ]
+                    proxy = get_youtube_proxy()
+                    if proxy:
+                        cmd.insert(1, "--proxy")
+                        cmd.insert(2, proxy)
+                        print("  🔌 [WHISPER] Using proxy", flush=True)
 
                     result = subprocess.run(cmd, capture_output=True, text=True, timeout=_t("whisper_download"))
 
@@ -1772,6 +1782,11 @@ async def get_transcript_deepgram(video_id: str) -> Tuple[Optional[str], Optiona
                         "3",
                         f"https://youtube.com/watch?v={video_id}",
                     ]
+                    proxy = get_youtube_proxy()
+                    if proxy:
+                        cmd.insert(1, "--proxy")
+                        cmd.insert(2, proxy)
+                        print("  🔌 [DEEPGRAM] Using proxy", flush=True)
 
                     result = subprocess.run(cmd, capture_output=True, text=True, timeout=_t("whisper_download"))
 
@@ -2759,6 +2774,11 @@ async def get_playlist_videos(playlist_id: str, max_videos: int = 50) -> List[Di
                 get_random_user_agent(),
                 f"https://www.youtube.com/playlist?list={playlist_id}",
             ]
+            proxy = get_youtube_proxy()
+            if proxy:
+                cmd.insert(1, "--proxy")
+                cmd.insert(2, proxy)
+                print("  🔌 [PLAYLIST] Using proxy", flush=True)
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
             if result.returncode != 0:
                 return []
@@ -2826,6 +2846,11 @@ async def get_playlist_info(playlist_id: str) -> Optional[Dict[str, Any]]:
                 get_random_user_agent(),
                 f"https://www.youtube.com/playlist?list={playlist_id}",
             ]
+            proxy = get_youtube_proxy()
+            if proxy:
+                cmd.insert(1, "--proxy")
+                cmd.insert(2, proxy)
+                print("  🔌 [PLAYLIST-INFO] Using proxy", flush=True)
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
             if result.returncode == 0:
                 return json.loads(result.stdout)

--- a/backend/tests/transcripts/test_youtube_proxy_injection.py
+++ b/backend/tests/transcripts/test_youtube_proxy_injection.py
@@ -1,0 +1,270 @@
+"""
+Tests for --proxy injection in yt-dlp subprocess calls inside transcripts/youtube.py.
+
+Sprint 2026-05-12 follow-up to audit 2026-05-11-proxy-coverage.md : 5 yt-dlp
+subprocess calls were missing the Decodo residential proxy, causing bot
+challenges from Hetzner. This locks the wiring so future refactors don't
+silently drop --proxy on these paths.
+
+Spots covered :
+- L654 get_video_info_ytdlp (metadata dump-json — root cause Summary 208
+  visual_analysis=null, video_duration=0)
+- L1419 WHISPER STT audio fallback
+- L1756 DEEPGRAM STT audio fallback
+- L2753 get_playlist_videos (flat-playlist metadata)
+- L2820 get_playlist_info (playlist single-json metadata)
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_fake_run(stdout: str = "", returncode: int = 0):
+    """Return a fake subprocess.run that captures cmd and returns canned output."""
+    captured = {"cmd": None}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = stdout
+        result.stderr = ""
+        return result
+
+    return fake_run, captured
+
+
+def _assert_proxy_in_cmd(cmd: list, proxy_url: str):
+    """Assert --proxy <url> is in cmd (anywhere, since pattern uses insert(1,2))."""
+    assert "--proxy" in cmd, (
+        f"--proxy missing from cmd. Got: {cmd[:8]}..."
+    )
+    idx = cmd.index("--proxy")
+    assert cmd[idx + 1] == proxy_url, (
+        f"Expected proxy {proxy_url!r} after --proxy, got {cmd[idx + 1]!r}"
+    )
+
+
+def _assert_no_proxy_in_cmd(cmd: list):
+    assert "--proxy" not in cmd, f"Unexpected --proxy in cmd: {cmd[:8]}..."
+
+
+PROXY_URL = "http://sp9fsc9l2p:Hj046a=vHnDabt8fUj@gate.decodo.com:7000"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# L654 get_video_info_ytdlp — metadata dump-json
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetVideoInfoYtdlpProxy:
+    @pytest.mark.asyncio
+    async def test_proxy_injected_when_set(self, monkeypatch):
+        from transcripts import youtube as yt
+
+        fake_run, captured = _make_fake_run(
+            stdout=json.dumps({"title": "x", "duration": 3600})
+        )
+        monkeypatch.setattr(yt.subprocess, "run", fake_run)
+        monkeypatch.setattr(yt, "get_youtube_proxy", lambda: PROXY_URL)
+
+        result = await yt.get_video_info_ytdlp("zjkBMFhNj_g")
+
+        assert result is not None
+        assert result["duration"] == 3600
+        _assert_proxy_in_cmd(captured["cmd"], PROXY_URL)
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_when_unset(self, monkeypatch):
+        from transcripts import youtube as yt
+
+        fake_run, captured = _make_fake_run(stdout=json.dumps({"title": "x"}))
+        monkeypatch.setattr(yt.subprocess, "run", fake_run)
+        monkeypatch.setattr(yt, "get_youtube_proxy", lambda: "")
+
+        await yt.get_video_info_ytdlp("zjkBMFhNj_g")
+
+        _assert_no_proxy_in_cmd(captured["cmd"])
+
+    @pytest.mark.asyncio
+    async def test_cmd_target_url_preserved_with_proxy(self, monkeypatch):
+        """Regression : proxy insertion at position 1-2 doesn't break target URL."""
+        from transcripts import youtube as yt
+
+        fake_run, captured = _make_fake_run(stdout=json.dumps({}))
+        monkeypatch.setattr(yt.subprocess, "run", fake_run)
+        monkeypatch.setattr(yt, "get_youtube_proxy", lambda: PROXY_URL)
+
+        await yt.get_video_info_ytdlp("dQw4w9WgXcQ")
+
+        assert captured["cmd"][0] == "yt-dlp"
+        assert captured["cmd"][1] == "--proxy"
+        assert captured["cmd"][2] == PROXY_URL
+        # Target URL is always the last positional
+        assert captured["cmd"][-1] == "https://youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# L2753 get_playlist_videos — flat-playlist dump
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetPlaylistVideosProxy:
+    @pytest.mark.asyncio
+    async def test_proxy_injected_when_set(self, monkeypatch):
+        from transcripts import youtube as yt
+
+        fake_run, captured = _make_fake_run(
+            stdout=json.dumps({"id": "v1", "title": "T1", "duration": 10})
+        )
+        monkeypatch.setattr(yt.subprocess, "run", fake_run)
+        monkeypatch.setattr(yt, "get_youtube_proxy", lambda: PROXY_URL)
+        # Force-skip Invidious so we hit yt-dlp fallback
+        monkeypatch.setattr(yt, "INVIDIOUS_INSTANCES", [])
+
+        await yt.get_playlist_videos("PL123")
+
+        assert captured["cmd"] is not None, "yt-dlp fallback never called"
+        _assert_proxy_in_cmd(captured["cmd"], PROXY_URL)
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_when_unset(self, monkeypatch):
+        from transcripts import youtube as yt
+
+        fake_run, captured = _make_fake_run(stdout="")
+        monkeypatch.setattr(yt.subprocess, "run", fake_run)
+        monkeypatch.setattr(yt, "get_youtube_proxy", lambda: "")
+        monkeypatch.setattr(yt, "INVIDIOUS_INSTANCES", [])
+
+        await yt.get_playlist_videos("PL123")
+
+        if captured["cmd"]:
+            _assert_no_proxy_in_cmd(captured["cmd"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# L2820 get_playlist_info — playlist single-json
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetPlaylistInfoProxy:
+    @pytest.mark.asyncio
+    async def test_proxy_injected_when_set(self, monkeypatch):
+        from transcripts import youtube as yt
+
+        fake_run, captured = _make_fake_run(
+            stdout=json.dumps({"title": "Playlist", "entries": []})
+        )
+        monkeypatch.setattr(yt.subprocess, "run", fake_run)
+        monkeypatch.setattr(yt, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(yt, "INVIDIOUS_INSTANCES", [])
+
+        await yt.get_playlist_info("PL123")
+
+        assert captured["cmd"] is not None, "yt-dlp fallback never called"
+        _assert_proxy_in_cmd(captured["cmd"], PROXY_URL)
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_when_unset(self, monkeypatch):
+        from transcripts import youtube as yt
+
+        fake_run, captured = _make_fake_run(stdout=json.dumps({}))
+        monkeypatch.setattr(yt.subprocess, "run", fake_run)
+        monkeypatch.setattr(yt, "get_youtube_proxy", lambda: "")
+        monkeypatch.setattr(yt, "INVIDIOUS_INSTANCES", [])
+
+        await yt.get_playlist_info("PL123")
+
+        if captured["cmd"]:
+            _assert_no_proxy_in_cmd(captured["cmd"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# L1419 / L1756 — WHISPER + DEEPGRAM yt-dlp audio fallback
+# Source-level check (regression lock without exercising the full STT chain)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSttYtdlpProxyWiringSourceLevel:
+    """
+    Locking source-level proof that --proxy is injected for STT yt-dlp paths.
+
+    These functions (transcribe_audio_whisper, transcribe_audio_deepgram) live
+    inside long branching pipelines (Invidious → ytdlp → STT API) that are
+    hard to drive in unit tests without a full DB+Redis+API fixture. So we
+    assert the wiring at the source level — same approach as
+    `test_proxy_coverage.py::test_transcripts_youtube_imports_get_proxied_client`.
+    """
+
+    def test_whisper_ytdlp_path_injects_proxy(self):
+        import inspect
+
+        from transcripts import youtube as yt
+
+        src = inspect.getsource(yt)
+        # The WHISPER block (line ~1419-1445) must contain the proxy injection
+        # right after the cmd= [...] block.
+        whisper_anchor = '[WHISPER] yt-dlp failed'
+        assert whisper_anchor in src, "WHISPER yt-dlp block has changed"
+        # Slice 1500 chars before the WHISPER anchor to find the cmd block + proxy
+        idx = src.index(whisper_anchor)
+        whisper_block = src[max(0, idx - 1500) : idx]
+        assert "[WHISPER] Using proxy" in whisper_block, (
+            "WHISPER yt-dlp cmd is missing the proxy injection block "
+            "(cmd.insert + get_youtube_proxy)"
+        )
+        assert "cmd.insert(1, \"--proxy\")" in whisper_block
+
+    def test_deepgram_ytdlp_path_injects_proxy(self):
+        import inspect
+
+        from transcripts import youtube as yt
+
+        src = inspect.getsource(yt)
+        deepgram_anchor = '[DEEPGRAM] Audio from yt-dlp'
+        assert deepgram_anchor in src, "DEEPGRAM yt-dlp block has changed"
+        idx = src.index(deepgram_anchor)
+        deepgram_block = src[max(0, idx - 1500) : idx]
+        assert "[DEEPGRAM] Using proxy" in deepgram_block, (
+            "DEEPGRAM yt-dlp cmd is missing the proxy injection block"
+        )
+        assert "cmd.insert(1, \"--proxy\")" in deepgram_block
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Coverage smoke : count proxy injections to prevent regressions
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestProxyInjectionCoverage:
+    """Lock the total count of --proxy injections in transcripts/youtube.py.
+
+    Originally only 3 yt-dlp cmds had --proxy (transcript download paths).
+    Sprint 2026-05-12 added 5 more for metadata/STT/playlist paths.
+    Expected count post-fix : 8 inline injections.
+    """
+
+    def test_proxy_injection_count(self):
+        import inspect
+
+        from transcripts import youtube as yt
+
+        src = inspect.getsource(yt)
+        count = src.count('cmd.insert(1, "--proxy")')
+        # 3 pre-existing (ytdlp manual subs / auto subs / one more transcript path)
+        # + 5 new spots from sprint 2026-05-12
+        assert count >= 8, (
+            f"Expected ≥8 inline --proxy injections in transcripts/youtube.py, "
+            f"got {count}. A yt-dlp subprocess call may have lost proxy wiring."
+        )


### PR DESCRIPTION
## Summary

Closes the **root cause** of Summary 208 `visual_analysis=null` (re-test post-#468 confirmed 2026-05-12). `get_video_info_ytdlp` falls back from Supadata metadata HTTP without proxy, hits YouTube bot challenge from Hetzner IP, returns `duration=0` → `duration_hint=None` → PRs #460+#468 5th fallback chain dormant.

This fixes the proxy wiring on 5 yt-dlp subprocess paths that the audit `docs/audits/2026-05-11-proxy-coverage.md` (mergé via #459) classified as missing.

## Context

Audit mentioned "yt-dlp injecté manuellement (4 endroits)" — actual count was 3 with proxy, 5 without. This bridges the gap using the **exact existing inline pattern** (`cmd.insert(1, "--proxy"); cmd.insert(2, proxy)`).

## Spots fixed

| Ligne | Fonction | Path |
|------|---------|------|
| L654 | `get_video_info_ytdlp` | metadata dump-json — **root cause Summary 208** |
| L1419 | WHISPER STT audio fallback | `yt-dlp -x mp3` |
| L1756 | DEEPGRAM STT audio fallback | `yt-dlp -x mp3` |
| L2753 | `get_playlist_videos` | flat-playlist dump-json |
| L2820 | `get_playlist_info` | dump-single-json |

## Tests

10 nouveaux tests dans `tests/transcripts/test_youtube_proxy_injection.py` :
- **TestGetVideoInfoYtdlpProxy** (×3) : proxy on/off + cmd structure preservation
- **TestGetPlaylistVideosProxy** (×2) : proxy on/off
- **TestGetPlaylistInfoProxy** (×2) : proxy on/off
- **TestSttYtdlpProxyWiringSourceLevel** (×2) : source-level lock pour WHISPER + DEEPGRAM (chaîne STT trop large pour unit tests)
- **TestProxyInjectionCoverage** (×1) : assert ≥8 inline `--proxy` injections total dans le module (3 pre-existing + 5 new) — anti-regression future

Run local : `10 passed, 0 failed` (4.83s).

## E2E plan post-merge

1. Push merge → Hetzner auto-deploy
2. `ds_analyze` sur `zjkBMFhNj_g` (Karpathy 1hr LLM)
3. Vérifier `Summary.video_duration > 0` + `visual_analysis` non-null
4. Mémoriser le pattern : sprints "ajouter fallback" doivent vérifier que la SOURCE DE DONNÉES du fallback est elle-même atteignable depuis Hetzner

## Risk

- **Faible** : pattern identique aux 3 injections déjà présentes (L1253/1320/2277)
- Si `YOUTUBE_PROXY` non défini, comportement inchangé (else path)
- Hard-stop Decodo MTD > 950MB déjà géré côté `should_bypass_proxy()` dans `_yt_dlp_extra_args` — non utilisé ici (style inline conservé), donc ces 5 paths peuvent saigner légèrement plus de bande passante si proxy bypass actif. Acceptable car le bot-block est strict (rien sans proxy).

## Test plan

- [x] Tests unitaires verts (10/10)
- [ ] Backend deploy success Hetzner après merge
- [ ] E2E `ds_analyze zjkBMFhNj_g` mode detailed → `visual_analysis` non-null
- [ ] Logs prod montrent `[YT-DLP-INFO] Using proxy` pour next analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)