### PR TITLE
fix(storyboard): enable proxy for yt-dlp metadata fetch in extract_storyboard_frames

### DIFF
--- a/backend/src/videos/youtube_storyboard.py
+++ b/backend/src/videos/youtube_storyboard.py
@@ -115,9 +115,17 @@ def normalize_video_id(value: str) -> Optional[str]:
 def _ytdlp_info_sync(video_id: str, log_tag: str) -> Optional[Dict[str, Any]]:
     """Lance yt-dlp -j --skip-download (sync, à appeler dans un executor).
 
-    `include_proxy=False` : le metadata fetch YouTube (storyboards inclus)
-    fonctionne en direct depuis le backend Hetzner — le proxy Webshare
-    datacenter renvoie 407 et casse cet appel inutilement.
+    Sprint 2026-05-12 follow-up à PR #469 : passe `include_proxy=True` (défaut)
+    pour que ce metadata fetch parte via le proxy résidentiel Decodo. Sans
+    proxy, yt-dlp est bot-challenged depuis l'IP Hetzner et retourne None →
+    `extract_storyboard_frames` exit early L298 AVANT que les 4 fallbacks
+    duration + le 5e fallback duration_hint (PR #468) puissent fire. C'était
+    la racine cachée de Summary 209 visual_analysis=null sur zjkBMFhNj_g
+    (Karpathy 1h LLM intro) : metadata duration OK via #469 mais storyboards
+    inaccessibles ici sans proxy.
+
+    L'ancien commentaire mentionnait "le proxy Webshare datacenter renvoie 407" —
+    obsolète depuis la migration sur Decodo résidentiel (gate.decodo.com:7000).
 
     `--ignore-no-formats-error` : yt-dlp 2024+ refuse de produire le JSON quand
     aucun format vidéo "downloadable" (mp4/webm) n'est exposé, même avec
@@ -128,7 +136,7 @@ def _ytdlp_info_sync(video_id: str, log_tag: str) -> Optional[Dict[str, Any]]:
     url = f"https://www.youtube.com/watch?v={video_id}"
     cmd = [
         "yt-dlp",
-        *_yt_dlp_extra_args(include_proxy=False),
+        *_yt_dlp_extra_args(),  # include_proxy=True par défaut — Decodo résidentiel
         "-j",
         "--skip-download",
         "--ignore-no-formats-error",

--- a/backend/tests/videos/test_youtube_storyboard_proxy.py
+++ b/backend/tests/videos/test_youtube_storyboard_proxy.py
@@ -1,0 +1,138 @@
+"""
+Tests for --proxy injection in `videos/youtube_storyboard._ytdlp_info_sync`.
+
+Sprint 2026-05-12 follow-up to PR #469. Prior to this fix, `_ytdlp_info_sync`
+explicitly passed `include_proxy=False` to `_yt_dlp_extra_args`, causing the
+yt-dlp metadata fetch to bot-challenge from Hetzner. When the call returned
+None, `extract_storyboard_frames` exited early at L298 — BEFORE any of the
+4 duration fallbacks (yt-dlp top-level / sb fragments / Supadata / transcript
+timestamps) or the 5th `duration_hint` fallback added by PR #468 could fire.
+
+This was the hidden root cause of Summary 209 `visual_analysis=null` for
+zjkBMFhNj_g (Karpathy 1h LLM intro) — PR #469 fixed video_duration metadata,
+but storyboards stayed inaccessible here without the proxy.
+
+Tests :
+1. proxy injected when YOUTUBE_PROXY is set
+2. no proxy injected when YOUTUBE_PROXY is empty
+3. source-level smoke : no `include_proxy=False` left in the file
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+PROXY_URL = "http://sp9fsc9l2p:Hj046a=vHnDabt8fUj@gate.decodo.com:7000"
+
+
+def _make_fake_run(stdout: str = "{}", returncode: int = 0):
+    """Capture subprocess.run cmd and return canned output."""
+    captured = {"cmd": None}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = stdout
+        result.stderr = ""
+        return result
+
+    return fake_run, captured
+
+
+class TestYtdlpInfoSyncProxy:
+    def test_proxy_injected_when_set(self, monkeypatch):
+        """`include_proxy=True` (default) routes yt-dlp -j via Decodo."""
+        from videos import youtube_storyboard as yts
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run()
+        monkeypatch.setattr(yts.subprocess, "run", fake_run)
+        # _yt_dlp_extra_args reads from audio_utils.get_youtube_proxy()
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        yts._ytdlp_info_sync("zjkBMFhNj_g", "TEST")
+
+        cmd = captured["cmd"]
+        assert cmd is not None, "subprocess.run was not called"
+        assert "--proxy" in cmd, f"--proxy missing from cmd. Got: {cmd}"
+        idx = cmd.index("--proxy")
+        assert cmd[idx + 1] == PROXY_URL
+
+    def test_no_proxy_when_unset(self, monkeypatch):
+        """When YOUTUBE_PROXY is empty, cmd has no --proxy (no regression)."""
+        from videos import youtube_storyboard as yts
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run()
+        monkeypatch.setattr(yts.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        yts._ytdlp_info_sync("zjkBMFhNj_g", "TEST")
+
+        cmd = captured["cmd"]
+        assert cmd is not None
+        assert "--proxy" not in cmd
+
+    def test_should_bypass_proxy_skips_injection(self, monkeypatch):
+        """When `should_bypass_proxy()` is True (hard-stop > 950MB MTD or
+        PROXY_DISABLED=true), no --proxy is injected even with YOUTUBE_PROXY set.
+        Locks the budget guard behaviour preserved through this fix."""
+        from videos import youtube_storyboard as yts
+        from transcripts import audio_utils
+        from middleware import proxy_telemetry
+
+        fake_run, captured = _make_fake_run()
+        monkeypatch.setattr(yts.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+        monkeypatch.setattr(proxy_telemetry, "should_bypass_proxy", lambda: True)
+
+        yts._ytdlp_info_sync("zjkBMFhNj_g", "TEST")
+
+        cmd = captured["cmd"]
+        assert cmd is not None
+        assert "--proxy" not in cmd
+
+    def test_cmd_structure_preserved(self, monkeypatch):
+        """Other flags (-j, --skip-download, --ignore-no-formats-error,
+        --no-warnings, --no-playlist) must still be present."""
+        from videos import youtube_storyboard as yts
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run()
+        monkeypatch.setattr(yts.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        yts._ytdlp_info_sync("dQw4w9WgXcQ", "TEST")
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "yt-dlp"
+        for flag in ("-j", "--skip-download", "--ignore-no-formats-error",
+                     "--no-warnings", "--no-playlist"):
+            assert flag in cmd, f"{flag} missing from cmd"
+        assert cmd[-1] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+class TestSourceLevelLock:
+    """Source-level smoke : ensure include_proxy=False doesn't sneak back in."""
+
+    def test_no_include_proxy_false_in_youtube_storyboard(self):
+        import inspect
+
+        from videos import youtube_storyboard
+
+        src = inspect.getsource(youtube_storyboard)
+        assert "include_proxy=False" not in src, (
+            "include_proxy=False has reappeared in youtube_storyboard.py — "
+            "this caused Summary 209 visual_analysis=null. The yt-dlp -j call "
+            "MUST go through Decodo proxy from Hetzner."
+        )


### PR DESCRIPTION
## Summary

Hidden root cause of Summary 209 `visual_analysis=null` on `zjkBMFhNj_g` (Karpathy 1h LLM intro) — discovered post-PR #469 E2E re-test.

`videos/youtube_storyboard._ytdlp_info_sync` explicitly passed `include_proxy=False`, an artifact from the Webshare datacenter era (proxy returned 407). With Decodo residential proxy, that optimization is now harmful : yt-dlp -j gets bot-challenged from Hetzner, returns None, and `extract_storyboard_frames` exits early at L298 **BEFORE** any duration fallback can fire.

## The PR chain leading here

| PR | What it did | Why it wasn't enough |
|----|------------|---------------------|
| #460 | propage `duration_hint` router → maybe_enrich | ne couvrait pas extract_storyboard_frames |
| #468 | 5e fallback `duration_hint` dans extract_storyboard_frames | dormant si `_ytdlp_info_sync` retourne None — info=None bail avant les fallbacks |
| #469 | fix metadata `get_video_info_ytdlp` via proxy | video_duration=3588 ✓ mais storyboards toujours inaccessibles |
| **#470 (this)** | fix `_ytdlp_info_sync` via proxy | enfin le storyboard fetch peut succéder |

## Without this fix

PR #468's `duration_hint` safety net is dead code : it only fires when `info` is not None, i.e. when yt-dlp -j already succeeded. The visual_analysis path was broken on every video where Hetzner gets bot-challenged.

## Tests

- 5 new tests in `tests/videos/test_youtube_storyboard_proxy.py`
  - proxy injected when YOUTUBE_PROXY set
  - no proxy when unset
  - `should_bypass_proxy()` hard-stop respected (MTD > 950MB)
  - other yt-dlp flags preserved (-j, --skip-download, --ignore-no-formats-error, --no-warnings, --no-playlist)
  - **source-level lock** : assert no `include_proxy=False` reappears in future refactors
- 80/80 existing tests (test_youtube_storyboard.py + test_visual_integration.py + test_visual_integration_duration_hint.py) still green

## E2E plan post-merge

1. Push merge → Hetzner auto-deploy
2. `ds_analyze` sur `zjkBMFhNj_g`
3. Vérifier `Summary.visual_analysis` non-null
4. Mémoriser : sprints "ajouter fallback" doivent vérifier que le **bail-early** code path n'écrase pas le fallback

## Test plan

- [x] 5 nouveaux tests verts
- [x] 80 tests existants storyboard/visual_integration verts
- [ ] Backend deploy success Hetzner après merge
- [ ] E2E `ds_analyze zjkBMFhNj_g` → `visual_analysis` non-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)