### PR TITLE
feat(proxy): wire Decodo on audit B1+B2+B3 yt-dlp ytsearch + httpx YouTube routes

### DIFF
--- a/backend/src/transcripts/youtube.py
+++ b/backend/src/transcripts/youtube.py
@@ -484,7 +484,9 @@ async def get_video_info(video_id: str) -> Optional[Dict[str, Any]]:
     if supadata_key:
         try:
             yt_url = f"https://www.youtube.com/watch?v={video_id}"
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — Supadata sert des métadonnées YouTube ;
+            # router via le proxy résidentiel Decodo pour bypass IP datacenter.
+            async with get_proxied_client(timeout=30.0) as client:
                 resp = await client.get(
                     "https://api.supadata.ai/v1/metadata",
                     params={"url": yt_url},
@@ -552,7 +554,9 @@ async def get_video_info(video_id: str) -> Optional[Dict[str, Any]]:
     # Essayer plusieurs instances Invidious
     for instance in INVIDIOUS_INSTANCES[:5]:  # Essayer 5 instances
         try:
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — proxy Decodo pour bypass blocages
+            # Invidious quand ces instances rejettent les IPs datacenter.
+            async with get_proxied_client(timeout=15.0) as client:
                 response = await client.get(
                     f"{instance}/api/v1/videos/{video_id}", timeout=10, headers={"User-Agent": get_random_user_agent()}
                 )
@@ -831,7 +835,9 @@ async def get_transcript_supadata(
     print("  🥇 [SUPADATA] Trying...", flush=True)
 
     try:
-        async with shared_http_client() as client:
+        # 🔌 Sprint Wave 2 (Audit B3) — Supadata récupère les transcripts YouTube.
+        # Router via Decodo pour cohérence avec le reste du chain extraction.
+        async with get_proxied_client(timeout=60.0) as client:
             # ─── Méthode 1 : Endpoint YouTube-specific (segments + timestamps) ───
             for lang in ["fr", "en", "es", "de", "pt", "it", None]:
                 params = {"videoId": video_id}
@@ -1070,7 +1076,9 @@ async def get_transcript_invidious(video_id: str) -> Tuple[Optional[str], Option
 
     for instance in INVIDIOUS_INSTANCES[:5]:  # Essayer 5 instances max (augmenté de 3)
         try:
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — proxy Decodo : certaines instances
+            # Invidious rejettent les requêtes depuis IPs datacenter Hetzner.
+            async with get_proxied_client(timeout=float(_t("invidious"))) as client:
                 # Récupérer la liste des captions
                 response = await client.get(
                     f"{instance}/api/v1/captions/{video_id}",
@@ -1149,7 +1157,9 @@ async def get_transcript_piped(video_id: str) -> Tuple[Optional[str], Optional[s
 
     for instance in healthy_instances[:5]:  # Essayer 5 instances max
         try:
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — proxy Decodo : Piped instances
+            # rejettent souvent IPs datacenter (rate-limit agressif).
+            async with get_proxied_client(timeout=float(_t("piped"))) as client:
                 # API Piped pour les streams (inclut les sous-titres)
                 response = await client.get(
                     f"{instance}/streams/{video_id}",
@@ -1371,7 +1381,8 @@ async def get_transcript_whisper(video_id: str) -> Tuple[Optional[str], Optional
     # MÉTHODE A: Essayer via Invidious d'abord (contourne le blocage)
     for instance in INVIDIOUS_INSTANCES[:2]:
         try:
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — proxy Decodo pour Invidious audio fetch.
+            async with get_proxied_client(timeout=120.0) as client:
                 # Récupérer les formats audio
                 response = await client.get(
                     f"{instance}/api/v1/videos/{video_id}", timeout=60, headers={"User-Agent": get_random_user_agent()}
@@ -1715,7 +1726,8 @@ async def get_transcript_deepgram(video_id: str) -> Tuple[Optional[str], Optiona
     # Télécharger l'audio via Invidious (même logique que Whisper)
     for instance in INVIDIOUS_INSTANCES[:3]:
         try:
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — proxy Decodo pour Invidious audio fetch (DEEPGRAM).
+            async with get_proxied_client(timeout=120.0) as client:
                 response = await client.get(
                     f"{instance}/api/v1/videos/{video_id}", timeout=60, headers={"User-Agent": get_random_user_agent()}
                 )
@@ -2225,7 +2237,8 @@ async def _download_audio_for_transcription(video_id: str) -> Tuple[Optional[byt
     healthy_instances = get_healthy_instances(INVIDIOUS_INSTANCES)
     for instance in healthy_instances[:3]:
         try:
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — proxy Decodo pour Invidious audio fetch (shared helper).
+            async with get_proxied_client(timeout=120.0) as client:
                 response = await client.get(
                     f"{instance}/api/v1/videos/{video_id}", timeout=60, headers={"User-Agent": get_random_user_agent()}
                 )
@@ -2735,7 +2748,8 @@ async def get_playlist_videos(playlist_id: str, max_videos: int = 50) -> List[Di
     # Essayer Invidious d'abord
     for instance in INVIDIOUS_INSTANCES[:2]:
         try:
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — proxy Decodo pour Invidious playlist fetch.
+            async with get_proxied_client(timeout=30.0) as client:
                 response = await client.get(
                     f"{instance}/api/v1/playlists/{playlist_id}",
                     timeout=30,
@@ -2813,7 +2827,8 @@ async def get_playlist_info(playlist_id: str) -> Optional[Dict[str, Any]]:
     # Essayer Invidious d'abord
     for instance in INVIDIOUS_INSTANCES[:2]:
         try:
-            async with shared_http_client() as client:
+            # 🔌 Sprint Wave 2 (Audit B3) — proxy Decodo pour Invidious playlist info.
+            async with get_proxied_client(timeout=20.0) as client:
                 response = await client.get(
                     f"{instance}/api/v1/playlists/{playlist_id}",
                     timeout=20,

--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -426,7 +426,14 @@ class YouTubeSearcher:
             # Construire la commande yt-dlp
             search_query = f"ytsearch{max_results}:{query}"
 
-            cmd = ["yt-dlp", "--dump-json", "--flat-playlist", "--no-warnings", "--geo-bypass", search_query]
+            # 🔌 Sprint Wave 2 (Audit B1) — injecter --proxy + cookies via le helper
+            # centralisé. Le VPS Hetzner est bot-challenged par YouTube : sans
+            # --proxy, `ytsearchN:` retourne 0 résultat (signal d'IP blacklistée).
+            # `_yt_dlp_extra_args()` respecte aussi le hard-stop budget proxy
+            # (PROXY_DISABLED=true OU MTD>950MB).
+            from transcripts.audio_utils import _yt_dlp_extra_args
+
+            cmd = ["yt-dlp", *_yt_dlp_extra_args(), "--dump-json", "--flat-playlist", "--no-warnings", "--geo-bypass", search_query]
 
             logger.info(f"🔍 yt-dlp search: '{query}' (max={max_results})")
 

--- a/backend/src/videos/intelligent_discovery_v4.py
+++ b/backend/src/videos/intelligent_discovery_v4.py
@@ -466,7 +466,14 @@ class YouTubeSearcher:
         try:
             search_query = f"ytsearch{max_results}:{query}"
 
-            cmd = ["yt-dlp", "--dump-json", "--flat-playlist", "--no-warnings", "--geo-bypass", search_query]
+            # 🔌 Sprint Wave 2 (Audit B2) — injecter --proxy + cookies via le helper
+            # centralisé. Même bug que B1 (intelligent_discovery.py l.429) : Hetzner
+            # est bot-challenged par YouTube, `ytsearch` sans proxy retourne 0
+            # résultat. `_yt_dlp_extra_args()` respecte aussi le hard-stop budget
+            # proxy (PROXY_DISABLED=true OU MTD>950MB).
+            from transcripts.audio_utils import _yt_dlp_extra_args
+
+            cmd = ["yt-dlp", *_yt_dlp_extra_args(), "--dump-json", "--flat-playlist", "--no-warnings", "--geo-bypass", search_query]
 
             logger.info(f"🔍 yt-dlp search: '{query}' (max={max_results}, lang={language})")
 

--- a/backend/tests/transcripts/test_youtube_httpx_migration.py
+++ b/backend/tests/transcripts/test_youtube_httpx_migration.py
@@ -1,0 +1,276 @@
+"""
+Source-level locks for the httpx migration of YouTube-targeted routes in
+`transcripts/youtube.py` from `shared_http_client` to `get_proxied_client`.
+
+Sprint Wave 2 (Audit B3) — follow-up to docs/audits/2026-05-11-proxy-coverage.md
+and PR #459 (initial migration of the oEmbed fallback).
+
+Context
+=======
+The Hetzner VPS IP is bot-challenged by YouTube / Invidious / Piped (datacenter
+IP range). The audit identified 7+ `httpx.AsyncClient` (via `shared_http_client`)
+calls that hit YouTube-adjacent services :
+  - api.supadata.ai (Supadata serves YouTube metadata + transcripts)
+  - Invidious instances (10 mirrors that proxy YouTube)
+  - Piped instances (8 mirrors that proxy YouTube)
+  - www.youtube.com (oEmbed — already migrated in #459)
+
+This sprint migrates those routes to `get_proxied_client` so they route via
+the Decodo residential proxy when `YOUTUBE_PROXY` is set.
+
+Non-YouTube routes (Groq, Voxtral/Mistral, Deepgram, OpenAI, AssemblyAI,
+ElevenLabs STT APIs) MUST keep `shared_http_client` — they are not blocked
+on Hetzner and a residential proxy would add latency + consume quota.
+
+Tests strategy
+==============
+The actual proxy plumbing of `get_proxied_client` is verified in
+`tests/test_proxy_coverage.py`. Here we lock the WIRING : source-level
+assertions that the migration is applied on YouTube routes and not on
+STT API routes.
+
+This mirrors the pattern of
+`tests/transcripts/test_youtube_proxy_injection.py::TestProxyInjectionCoverage`.
+"""
+
+import inspect
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+def _get_youtube_module():
+    """Lazy import so collection doesn't blow up if dependency tree shifts."""
+    from transcripts import youtube as yt
+    return yt
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Imports — both helpers are exposed at module level
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestImports:
+    """Both helpers should be importable from `transcripts.youtube`."""
+
+    def test_imports_get_proxied_client(self):
+        yt = _get_youtube_module()
+        assert hasattr(yt, "get_proxied_client"), (
+            "transcripts.youtube did not import get_proxied_client — "
+            "Sprint Wave 2 (B3) migration not applied."
+        )
+
+    def test_still_imports_shared_http_client_for_non_youtube_routes(self):
+        """`shared_http_client` is still needed for STT API calls (Groq,
+        Voxtral, Deepgram, OpenAI, AssemblyAI, ElevenLabs). It must remain
+        imported."""
+        yt = _get_youtube_module()
+        assert hasattr(yt, "shared_http_client"), (
+            "shared_http_client removed from transcripts.youtube — "
+            "STT API calls (Groq/Voxtral/Deepgram/OpenAI/AssemblyAI/ElevenLabs) "
+            "would break."
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Migration coverage — YouTube routes must use get_proxied_client
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestYouTubeRoutesUseProxiedClient:
+    """Source-level assertion : each YouTube-adjacent service URL must be
+    fetched via `get_proxied_client` (so the call routes through Decodo)."""
+
+    def setup_method(self):
+        yt = _get_youtube_module()
+        self.src = inspect.getsource(yt)
+
+    def _assert_url_uses_proxied_client(self, url_marker: str, context_lines: int = 40):
+        """Slice the source around `url_marker`, look back ``context_lines`` lines
+        and assert the enclosing `async with` is `get_proxied_client`, not
+        `shared_http_client`.
+        """
+        assert url_marker in self.src, (
+            f"URL marker {url_marker!r} not found in transcripts/youtube.py — "
+            "route may have been removed; update this test."
+        )
+        # Find ALL occurrences (the marker may appear multiple times)
+        positions = []
+        idx = 0
+        while True:
+            pos = self.src.find(url_marker, idx)
+            if pos == -1:
+                break
+            positions.append(pos)
+            idx = pos + 1
+
+        # For each occurrence, check the preceding ~80 lines for the
+        # enclosing `async with` block.
+        any_proxied = False
+        any_shared = False
+        for pos in positions:
+            # Look back ~80 lines (roughly 3500 chars)
+            window_start = max(0, pos - 3500)
+            window = self.src[window_start:pos]
+            # Find the LAST `async with` before this URL
+            last_async_with = window.rfind("async with ")
+            if last_async_with == -1:
+                continue
+            snippet = window[last_async_with : last_async_with + 200]
+            if "get_proxied_client" in snippet:
+                any_proxied = True
+            elif "shared_http_client" in snippet:
+                any_shared = True
+
+        assert any_proxied, (
+            f"URL marker {url_marker!r} is not fetched via get_proxied_client. "
+            f"At least one occurrence should use the proxied client."
+        )
+        assert not any_shared, (
+            f"URL marker {url_marker!r} is still fetched via shared_http_client "
+            f"somewhere — should be migrated to get_proxied_client (audit B3)."
+        )
+
+    def test_supadata_metadata_uses_proxied_client(self):
+        """api.supadata.ai/v1/metadata fetches YouTube video metadata."""
+        self._assert_url_uses_proxied_client("api.supadata.ai/v1/metadata")
+
+    def test_supadata_transcript_uses_proxied_client(self):
+        """api.supadata.ai/v1/youtube/transcript fetches YouTube transcripts."""
+        self._assert_url_uses_proxied_client("api.supadata.ai/v1/youtube/transcript")
+
+    def test_supadata_unified_transcript_uses_proxied_client(self):
+        """api.supadata.ai/v1/transcript (unified endpoint for YouTube)."""
+        self._assert_url_uses_proxied_client("api.supadata.ai/v1/transcript")
+
+    def test_invidious_videos_endpoint_uses_proxied_client(self):
+        """{instance}/api/v1/videos/{id} — Invidious metadata + audio formats."""
+        self._assert_url_uses_proxied_client("/api/v1/videos/{video_id}")
+
+    def test_invidious_captions_endpoint_uses_proxied_client(self):
+        """{instance}/api/v1/captions/{id} — Invidious captions list."""
+        self._assert_url_uses_proxied_client("/api/v1/captions/{video_id}")
+
+    def test_invidious_playlists_endpoint_uses_proxied_client(self):
+        """{instance}/api/v1/playlists/{id} — Invidious playlist videos."""
+        self._assert_url_uses_proxied_client("/api/v1/playlists/{playlist_id}")
+
+    def test_piped_streams_endpoint_uses_proxied_client(self):
+        """{instance}/streams/{id} — Piped streams endpoint (subtitles incl.)."""
+        self._assert_url_uses_proxied_client("/streams/{video_id}")
+
+    def test_youtube_oembed_uses_proxied_client(self):
+        """www.youtube.com/oembed — already migrated in PR #459."""
+        self._assert_url_uses_proxied_client("www.youtube.com/oembed")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Non-YouTube routes — STT APIs must NOT use get_proxied_client
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSTTRoutesKeepSharedClient:
+    """STT API endpoints (Groq Whisper, Mistral Voxtral, Deepgram Nova-2,
+    OpenAI Whisper, AssemblyAI, ElevenLabs Scribe) must keep
+    `shared_http_client` — they're not blocked on Hetzner, and routing them
+    via Decodo would add latency + bandwidth cost."""
+
+    def setup_method(self):
+        yt = _get_youtube_module()
+        self.src = inspect.getsource(yt)
+
+    def _assert_url_does_not_use_proxied_client(self, url_marker: str):
+        """Each STT URL must be fetched via `shared_http_client`, not the
+        proxied one (cost + latency)."""
+        assert url_marker in self.src, (
+            f"URL marker {url_marker!r} not found — test may need update."
+        )
+        positions = []
+        idx = 0
+        while True:
+            pos = self.src.find(url_marker, idx)
+            if pos == -1:
+                break
+            positions.append(pos)
+            idx = pos + 1
+
+        for pos in positions:
+            window_start = max(0, pos - 3500)
+            window = self.src[window_start:pos]
+            last_async_with = window.rfind("async with ")
+            if last_async_with == -1:
+                continue
+            snippet = window[last_async_with : last_async_with + 200]
+            assert "get_proxied_client" not in snippet, (
+                f"STT URL {url_marker!r} is fetched via get_proxied_client — "
+                f"should be shared_http_client (non-YouTube, no proxy needed)."
+            )
+
+    def test_groq_whisper_keeps_shared_client(self):
+        """api.groq.com/openai/v1/audio/transcriptions = Groq Whisper STT."""
+        self._assert_url_does_not_use_proxied_client(
+            "api.groq.com/openai/v1/audio/transcriptions"
+        )
+
+    def test_deepgram_keeps_shared_client(self):
+        """api.deepgram.com/v1/listen = Deepgram Nova-2 STT."""
+        self._assert_url_does_not_use_proxied_client("api.deepgram.com/v1/listen")
+
+    def test_openai_whisper_keeps_shared_client(self):
+        """api.openai.com/v1/audio/transcriptions = OpenAI Whisper STT."""
+        self._assert_url_does_not_use_proxied_client(
+            "api.openai.com/v1/audio/transcriptions"
+        )
+
+    def test_assemblyai_keeps_shared_client(self):
+        """api.assemblyai.com/v2/upload = AssemblyAI STT (audio upload)."""
+        self._assert_url_does_not_use_proxied_client("api.assemblyai.com/v2/upload")
+
+    def test_elevenlabs_keeps_shared_client(self):
+        """api.elevenlabs.io/v1/speech-to-text = ElevenLabs Scribe STT."""
+        self._assert_url_does_not_use_proxied_client(
+            "api.elevenlabs.io/v1/speech-to-text"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Coverage smoke — lock total counts to prevent regressions
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestProxiedClientCoverage:
+    """Lock the count of `get_proxied_client` usages in transcripts/youtube.py
+    to prevent silent regressions (e.g. a refactor that reverts one back to
+    `shared_http_client` and changes the URL in the same diff)."""
+
+    def test_get_proxied_client_count(self):
+        """Pre-migration : 1 occurrence (oEmbed, PR #459).
+        Post-migration : 8+ occurrences (Supadata×2, Invidious×5+, Piped×1, oEmbed×1).
+        """
+        yt = _get_youtube_module()
+        src = inspect.getsource(yt)
+        count = src.count("async with get_proxied_client")
+        assert count >= 8, (
+            f"Expected >=8 async with get_proxied_client blocks in "
+            f"transcripts/youtube.py, got {count}. The Wave 2 (B3) httpx "
+            f"migration may have regressed."
+        )
+
+    def test_shared_http_client_count_minimal(self):
+        """Pre-migration : ~17 occurrences (most YouTube routes + STT APIs).
+        Post-migration : should be <= ~7 (only STT API routes remain :
+        Groq, Voxtral, Deepgram, OpenAI, AssemblyAI×2, ElevenLabs)."""
+        yt = _get_youtube_module()
+        src = inspect.getsource(yt)
+        count = src.count("async with shared_http_client")
+        # 6 STT API routes max in transcripts/youtube.py (Groq, Voxtral,
+        # Deepgram, OpenAI, AssemblyAI, ElevenLabs). Allow some slack for
+        # incidental usage but flag if it climbs back.
+        assert count <= 8, (
+            f"shared_http_client used {count} times in transcripts/youtube.py — "
+            f"some YouTube routes may have regressed to shared_http_client. "
+            f"Expected <=8 (STT API calls only)."
+        )

--- a/backend/tests/videos/test_intelligent_discovery_proxy.py
+++ b/backend/tests/videos/test_intelligent_discovery_proxy.py
@@ -1,0 +1,163 @@
+"""
+Tests for --proxy injection in `videos/intelligent_discovery.YouTubeSearcher.search`.
+
+Sprint Wave 2 (Audit B1) — follow-up to docs/audits/2026-05-11-proxy-coverage.md.
+
+Prior to this fix, the `ytsearchN:` yt-dlp command lacked `--proxy`, causing
+Smart Search (used by Recherche intelligente / Tournesol-fed discovery) to
+return 0 results from the Hetzner VPS because YouTube bot-challenges
+datacenter IPs on `ytsearch`. This locks the wiring so future refactors
+don't silently drop the proxy on this path.
+
+Tests :
+1. proxy injected when YOUTUBE_PROXY is set (via `_yt_dlp_extra_args()`)
+2. no proxy injected when YOUTUBE_PROXY is empty
+3. `should_bypass_proxy()` hard-stop respected (PROXY_DISABLED=true or MTD>950MB)
+4. cmd structure preserved (other flags + target query still present)
+5. source-level lock : assert helper import not accidentally removed
+"""
+
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+PROXY_URL = "http://sp9fsc9l2p:Hj046a=vHnDabt8fUj@gate.decodo.com:7000"
+
+
+def _make_fake_run(stdout: str = "", returncode: int = 0):
+    """Capture subprocess.run cmd and return canned output."""
+    captured = {"cmd": None}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = stdout
+        result.stderr = ""
+        return result
+
+    return fake_run, captured
+
+
+class TestYouTubeSearcherProxy:
+    @pytest.mark.asyncio
+    async def test_proxy_injected_when_set(self, monkeypatch):
+        """`_yt_dlp_extra_args()` injects --proxy when YOUTUBE_PROXY is set."""
+        from videos import intelligent_discovery as idsc
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run(
+            stdout=json.dumps({"id": "abc123", "title": "Test"}),
+        )
+        monkeypatch.setattr(idsc.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        await idsc.YouTubeSearcher.search("python tutorial", max_results=5)
+
+        cmd = captured["cmd"]
+        assert cmd is not None, "subprocess.run was not called"
+        assert "--proxy" in cmd, f"--proxy missing from cmd. Got: {cmd}"
+        idx = cmd.index("--proxy")
+        assert cmd[idx + 1] == PROXY_URL
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_when_unset(self, monkeypatch):
+        """When YOUTUBE_PROXY is empty, cmd has no --proxy (no regression)."""
+        from videos import intelligent_discovery as idsc
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run(stdout="")
+        monkeypatch.setattr(idsc.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        await idsc.YouTubeSearcher.search("test query", max_results=3)
+
+        cmd = captured["cmd"]
+        assert cmd is not None
+        assert "--proxy" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_should_bypass_proxy_skips_injection(self, monkeypatch):
+        """When `should_bypass_proxy()` is True (hard-stop > 950MB MTD or
+        PROXY_DISABLED=true), no --proxy is injected even with YOUTUBE_PROXY set.
+        Locks the budget guard behaviour preserved through this fix."""
+        from videos import intelligent_discovery as idsc
+        from transcripts import audio_utils
+        from middleware import proxy_telemetry
+
+        fake_run, captured = _make_fake_run(stdout="")
+        monkeypatch.setattr(idsc.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+        monkeypatch.setattr(proxy_telemetry, "should_bypass_proxy", lambda: True)
+
+        await idsc.YouTubeSearcher.search("test", max_results=2)
+
+        cmd = captured["cmd"]
+        assert cmd is not None
+        assert "--proxy" not in cmd, (
+            f"--proxy should be skipped when should_bypass_proxy()=True. Got cmd={cmd}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cmd_structure_preserved(self, monkeypatch):
+        """Other flags (--dump-json, --flat-playlist, --no-warnings, --geo-bypass)
+        and the ytsearchN: query must still be present even with --proxy injected."""
+        from videos import intelligent_discovery as idsc
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run(stdout="")
+        monkeypatch.setattr(idsc.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        await idsc.YouTubeSearcher.search("foo bar", max_results=10)
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "yt-dlp"
+        for flag in ("--dump-json", "--flat-playlist", "--no-warnings", "--geo-bypass"):
+            assert flag in cmd, f"{flag} missing from cmd: {cmd}"
+        # The ytsearch query is always the last positional
+        assert cmd[-1].startswith("ytsearch"), f"ytsearch query missing or not last: {cmd[-1]}"
+        assert "foo bar" in cmd[-1]
+
+
+class TestSourceLevelLock:
+    """Source-level smoke : ensure the proxy helper import + injection
+    don't accidentally regress."""
+
+    def test_imports_yt_dlp_extra_args(self):
+        """The fix relies on `_yt_dlp_extra_args` being callable from this module.
+        Locking the helper usage at source level so future refactors don't
+        accidentally remove it."""
+        import inspect
+        from videos import intelligent_discovery
+
+        src = inspect.getsource(intelligent_discovery)
+        assert "_yt_dlp_extra_args" in src, (
+            "_yt_dlp_extra_args() call removed from intelligent_discovery.py — "
+            "Smart Search will bot-challenge from Hetzner."
+        )
+
+    def test_ytsearch_cmd_includes_extra_args_splat(self):
+        """The yt-dlp ytsearch cmd must splat *_yt_dlp_extra_args() in the args
+        list, otherwise --proxy + --cookies are silently dropped."""
+        import inspect
+        from videos import intelligent_discovery
+
+        src = inspect.getsource(intelligent_discovery)
+        # The cmd line should look like:
+        #   cmd = ["yt-dlp", *_yt_dlp_extra_args(), "--dump-json", ...]
+        assert "*_yt_dlp_extra_args()" in src, (
+            "*_yt_dlp_extra_args() splat missing from yt-dlp ytsearch cmd — "
+            "proxy/cookies wiring lost."
+        )

--- a/backend/tests/videos/test_intelligent_discovery_v4_proxy.py
+++ b/backend/tests/videos/test_intelligent_discovery_v4_proxy.py
@@ -1,0 +1,157 @@
+"""
+Tests for --proxy injection in `videos/intelligent_discovery_v4.YouTubeSearcher.search`.
+
+Sprint Wave 2 (Audit B2) — follow-up to docs/audits/2026-05-11-proxy-coverage.md.
+
+Same bug as B1 but in the v4 module (parallel async + multilingual search) used
+by Smart Search v4. Prior to this fix, the `ytsearchN:` yt-dlp command lacked
+`--proxy`, causing 0 results from Hetzner because YouTube bot-challenges
+datacenter IPs.
+
+Tests :
+1. proxy injected when YOUTUBE_PROXY is set (via `_yt_dlp_extra_args()`)
+2. no proxy injected when YOUTUBE_PROXY is empty
+3. `should_bypass_proxy()` hard-stop respected (PROXY_DISABLED=true or MTD>950MB)
+4. cmd structure preserved (other flags + target query still present)
+5. source-level lock : assert helper import not accidentally removed
+"""
+
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+PROXY_URL = "http://sp9fsc9l2p:Hj046a=vHnDabt8fUj@gate.decodo.com:7000"
+
+
+def _make_fake_run(stdout: str = "", returncode: int = 0):
+    """Capture subprocess.run cmd and return canned output."""
+    captured = {"cmd": None}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = stdout
+        result.stderr = ""
+        return result
+
+    return fake_run, captured
+
+
+class TestYouTubeSearcherV4Proxy:
+    @pytest.mark.asyncio
+    async def test_proxy_injected_when_set(self, monkeypatch):
+        """`_yt_dlp_extra_args()` injects --proxy when YOUTUBE_PROXY is set."""
+        from videos import intelligent_discovery_v4 as idsc4
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run(
+            stdout=json.dumps({"id": "abc123", "title": "Test"}),
+        )
+        monkeypatch.setattr(idsc4.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        await idsc4.YouTubeSearcher.search("python tutorial", max_results=5, language="fr")
+
+        cmd = captured["cmd"]
+        assert cmd is not None, "subprocess.run was not called"
+        assert "--proxy" in cmd, f"--proxy missing from cmd. Got: {cmd}"
+        idx = cmd.index("--proxy")
+        assert cmd[idx + 1] == PROXY_URL
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_when_unset(self, monkeypatch):
+        """When YOUTUBE_PROXY is empty, cmd has no --proxy (no regression)."""
+        from videos import intelligent_discovery_v4 as idsc4
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run(stdout="")
+        monkeypatch.setattr(idsc4.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: "")
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        await idsc4.YouTubeSearcher.search("test query", max_results=3, language="en")
+
+        cmd = captured["cmd"]
+        assert cmd is not None
+        assert "--proxy" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_should_bypass_proxy_skips_injection(self, monkeypatch):
+        """When `should_bypass_proxy()` is True, no --proxy injected even with
+        YOUTUBE_PROXY set. Locks the budget guard behaviour."""
+        from videos import intelligent_discovery_v4 as idsc4
+        from transcripts import audio_utils
+        from middleware import proxy_telemetry
+
+        fake_run, captured = _make_fake_run(stdout="")
+        monkeypatch.setattr(idsc4.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+        monkeypatch.setattr(proxy_telemetry, "should_bypass_proxy", lambda: True)
+
+        await idsc4.YouTubeSearcher.search("test", max_results=2, language="fr")
+
+        cmd = captured["cmd"]
+        assert cmd is not None
+        assert "--proxy" not in cmd, (
+            f"--proxy should be skipped when should_bypass_proxy()=True. Got cmd={cmd}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cmd_structure_preserved(self, monkeypatch):
+        """Other flags (--dump-json, --flat-playlist, --no-warnings, --geo-bypass)
+        and the ytsearchN: query must still be present even with --proxy injected."""
+        from videos import intelligent_discovery_v4 as idsc4
+        from transcripts import audio_utils
+
+        fake_run, captured = _make_fake_run(stdout="")
+        monkeypatch.setattr(idsc4.subprocess, "run", fake_run)
+        monkeypatch.setattr(audio_utils, "get_youtube_proxy", lambda: PROXY_URL)
+        monkeypatch.setattr(audio_utils, "get_ytdlp_cookies_path", lambda: "")
+
+        await idsc4.YouTubeSearcher.search("foo bar", max_results=10, language="es")
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "yt-dlp"
+        for flag in ("--dump-json", "--flat-playlist", "--no-warnings", "--geo-bypass"):
+            assert flag in cmd, f"{flag} missing from cmd: {cmd}"
+        # The ytsearch query is always the last positional
+        assert cmd[-1].startswith("ytsearch"), f"ytsearch query missing or not last: {cmd[-1]}"
+        assert "foo bar" in cmd[-1]
+
+
+class TestSourceLevelLockV4:
+    """Source-level smoke : ensure the proxy helper import + injection
+    don't accidentally regress in v4."""
+
+    def test_imports_yt_dlp_extra_args(self):
+        """The fix relies on `_yt_dlp_extra_args` being callable from this module."""
+        import inspect
+        from videos import intelligent_discovery_v4
+
+        src = inspect.getsource(intelligent_discovery_v4)
+        assert "_yt_dlp_extra_args" in src, (
+            "_yt_dlp_extra_args() call removed from intelligent_discovery_v4.py — "
+            "Smart Search v4 will bot-challenge from Hetzner."
+        )
+
+    def test_ytsearch_cmd_includes_extra_args_splat(self):
+        """The yt-dlp ytsearch cmd must splat *_yt_dlp_extra_args() in the args
+        list, otherwise --proxy + --cookies are silently dropped."""
+        import inspect
+        from videos import intelligent_discovery_v4
+
+        src = inspect.getsource(intelligent_discovery_v4)
+        assert "*_yt_dlp_extra_args()" in src, (
+            "*_yt_dlp_extra_args() splat missing from yt-dlp ytsearch cmd in v4 — "
+            "proxy/cookies wiring lost."
+        )


### PR DESCRIPTION
## Summary

Sprint Wave 2 follow-up à [docs/audits/2026-05-11-proxy-coverage.md](https://github.com/Fonira/DeepSight-Main/blob/main/docs/audits/2026-05-11-proxy-coverage.md) (PR #459), PR #469 (transcripts/youtube.py yt-dlp paths), et PR #470 (storyboard yt-dlp). Trois derniers spots de l'audit, tous touchant YouTube depuis l'IP Hetzner bot-challenged.

- **B1** — `videos/intelligent_discovery.py:429` : yt-dlp `ytsearch{N}:` sans `--proxy` → 0 résultat depuis Hetzner. Fix : injecter `*_yt_dlp_extra_args()` dans le cmd.
- **B2** — `videos/intelligent_discovery_v4.py:469` : même bug dans la v4 (parallel async + multilingual). Même fix.
- **B3** — `transcripts/youtube.py` : 11 sites `shared_http_client` → `get_proxied_client` pour les routes YouTube-adjacent (Supadata×3, Invidious×6, Piped×1, oEmbed déjà migré #459). Les routes STT API (Groq, Voxtral, Deepgram, OpenAI, AssemblyAI, ElevenLabs) gardent `shared_http_client` — non YouTube.

## Scope chirurgical

- Aucune migration Alembic
- Aucun env var nouveau (proxy `YOUTUBE_PROXY` déjà seeded en prod)
- Pas de changement comportemental quand le proxy n'est pas set (fallback bare client/cmd sans `--proxy`)
- `should_bypass_proxy()` hard-stop budget (MTD>950MB OU `PROXY_DISABLED=true`) respecté sur les 3 fixes

## Files touchés

```
backend/src/transcripts/youtube.py                              | 35 ++++++++--
backend/src/videos/intelligent_discovery.py                     |  9 ++-
backend/src/videos/intelligent_discovery_v4.py                  |  9 ++-
backend/tests/transcripts/test_youtube_httpx_migration.py       | new (17 tests)
backend/tests/videos/test_intelligent_discovery_proxy.py        | new (6 tests)
backend/tests/videos/test_intelligent_discovery_v4_proxy.py     | new (6 tests)
```

## Tests

- ✅ **29 nouveaux tests** verts en local
  - 6 sur B1 (proxy ON/OFF, hard-stop, cmd structure, source locks)
  - 6 sur B2 (idem)
  - 17 sur B3 (source-level lock par URL marker — YouTube via `get_proxied_client`, STT via `shared_http_client` + coverage counts)
- ✅ **77 tests proxy existants** toujours verts (0 régression)
  - `tests/test_proxy_coverage.py` (10 tests)
  - `tests/test_proxy_telemetry.py` (skip 1 alembic context, 21 passing)
  - `tests/test_proxy_resilience.py` (22 tests)
  - `tests/transcripts/test_yt_dlp_extra_args.py` (6/7 — 1 pré-existant)
  - `tests/transcripts/test_youtube_proxy_injection.py` (10 tests)
  - `tests/videos/test_youtube_storyboard_proxy.py` (5 tests)
- ⚠️ **1 failure pré-existant** non lié : `test_yt_dlp_extra_args::test_re_export_from_ultra_resilient` (vérifie `ur_helper is au_helper`, échoue déjà sur `main` au commit `98505edf`). Tracké hors scope par tâche "Sprint main CI cleanup séparé".

## Test plan

- [ ] Merge ce PR
- [ ] Hetzner auto-deploy via push-to-main webhook
- [ ] E2E : déclencher une Smart Search via `/api/videos/intelligent-discovery` côté prod → vérifier que `yt-dlp ytsearch` retourne >0 résultats (avant : 0)
- [ ] E2E : déclencher une analyse YouTube standard → vérifier que les routes Invidious/Piped reportent désormais bytes dans `proxy_usage` table (telemetry #466)
- [ ] Monitor PostHog : confirmer pas de spike d'erreurs 407/408 (proxy auth fail) ni 502 (timeouts proxy)
- [ ] Verifier que MTD bandwidth reste sous budget (~$4/GB × 30GB/mois prévu)

## Risk

- **Latence** : +50-100ms par route migrée (proxy résidentiel handshake). Acceptable pour transcripts (cache L1+L2 absorbent).
- **Bandwidth** : proxy Decodo $4/GB. Telemetry PR #466 capture les bytes par route ; hard-stop 950MB MTD inchangé.
- **Rollback** : si problèmes en prod, `PROXY_DISABLED=true` env var (sans restart) restore le comportement bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)