### PR TITLE
fix(plans): add EXPERT key to legacy PLAN_LIMITS shim

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -527,12 +527,19 @@ LEGAL_CONFIG = {
 
 
 def _build_legacy_plan_limits() -> Dict[str, Dict[str, Any]]:
-    """Construit PLAN_LIMITS à partir du SSOT plan_config pour rétrocompatibilité."""
+    """Construit PLAN_LIMITS à partir du SSOT plan_config pour rétrocompatibilité.
+
+    ⚠️ Sprint 2026-05-12 — `PlanId.EXPERT` ajouté à l'itération. Avant ce fix,
+    la clé `expert` n'existait pas dans le dict legacy → tous les users plan=expert
+    (depuis migration v2 Alembic 012 2026-04-30) tombaient sur `PLAN_LIMITS["free"]`
+    par fallback → modèle `mistral-small-2603` au lieu de `mistral-large-2512`,
+    `deep_research_enabled=False`, etc. Cf. Summary 208/209/210 model_used cassé.
+    """
     try:
         from billing.plan_config import PLANS, PlanId
 
         legacy = {}
-        for plan_id in [PlanId.FREE, PlanId.PLUS, PlanId.PRO]:
+        for plan_id in [PlanId.FREE, PlanId.PLUS, PlanId.PRO, PlanId.EXPERT]:
             plan = PLANS[plan_id]
             limits = plan["limits"]
             key = plan_id.value
@@ -556,7 +563,7 @@ def _build_legacy_plan_limits() -> Dict[str, Dict[str, Any]]:
                 "voice_monthly_minutes": limits.get("voice_monthly_minutes", 0),
                 "blocked_features": (
                     []
-                    if key == "pro"
+                    if key in ("pro", "expert")
                     else ["playlists", "deep_research", "voice_chat", "tts"]
                     if key == "plus"
                     else [
@@ -572,25 +579,31 @@ def _build_legacy_plan_limits() -> Dict[str, Dict[str, Any]]:
                 ),
                 "upgrade_prompt": {
                     "fr": (
-                        "Vous avez le plan Pro, toutes les fonctionnalités sont débloquées !"
+                        "Vous avez le plan Expert, toutes les fonctionnalités sont débloquées !"
+                        if key == "expert"
+                        else "Passez à Expert pour débloquer Deep Research, recherche académique illimitée et le modèle Mistral Large !"
                         if key == "pro"
-                        else "Passez à Plus pour débloquer mind maps, exports et recherche web !"
+                        else "Passez à Pro pour débloquer mind maps, exports et recherche web !"
                         if key == "free"
                         else "Passez à Pro pour débloquer playlists, Deep Research et chat vocal !"
                     ),
                     "en": (
-                        "You have the Pro plan, all features are unlocked!"
+                        "You have the Expert plan, all features are unlocked!"
+                        if key == "expert"
+                        else "Upgrade to Expert to unlock Deep Research, unlimited academic search and the Mistral Large model!"
                         if key == "pro"
-                        else "Upgrade to Plus to unlock mind maps, exports and web search!"
+                        else "Upgrade to Pro to unlock mind maps, exports and web search!"
                         if key == "free"
                         else "Upgrade to Pro to unlock playlists, Deep Research and voice chat!"
                     ),
                 },
             }
-        # Admin "unlimited" — copie pro avec limites levées (défense en profondeur)
-        if "pro" in legacy:
-            pro_copy = dict(legacy["pro"])
-            pro_copy.update(
+        # Admin "unlimited" — copie expert (tier top en v2) avec limites levées.
+        # Auparavant copiait `pro` ; en v2 `pro` est l'intermédiaire et
+        # `expert` est le top — l'admin doit avoir le modèle large, pas medium.
+        if "expert" in legacy:
+            expert_copy = dict(legacy["expert"])
+            expert_copy.update(
                 {
                     "monthly_credits": 999999,
                     "daily_analyses": -1,
@@ -606,7 +619,7 @@ def _build_legacy_plan_limits() -> Dict[str, Dict[str, Any]]:
                     "blocked_features": [],
                 }
             )
-            legacy["unlimited"] = pro_copy
+            legacy["unlimited"] = expert_copy
 
         return legacy
     except Exception:
@@ -627,11 +640,21 @@ def _build_legacy_plan_limits() -> Dict[str, Dict[str, Any]]:
                 "default_model": "mistral-medium-2508",
             },
             "pro": {
+                "monthly_credits": 7500,
+                "daily_analyses": 30,
+                "blocked_features": [],
+                "models": ["mistral-small-2603", "mistral-medium-2508"],
+                "default_model": "mistral-medium-2508",
+            },
+            "expert": {
                 "monthly_credits": 15000,
                 "daily_analyses": 100,
                 "blocked_features": [],
                 "models": ["mistral-small-2603", "mistral-medium-2508", "mistral-large-2512"],
                 "default_model": "mistral-large-2512",
+                "deep_research_enabled": True,
+                "voice_chat_enabled": True,
+                "web_search_enabled": True,
             },
             "unlimited": {
                 "monthly_credits": 999999,

--- a/backend/tests/core/test_plan_limits_legacy_shim.py
+++ b/backend/tests/core/test_plan_limits_legacy_shim.py
@@ -1,0 +1,113 @@
+"""
+Tests for the legacy `PLAN_LIMITS` shim in `core/config.py`.
+
+Sprint 2026-05-12 — `_build_legacy_plan_limits()` was missing `PlanId.EXPERT`
+in its iteration, so `PLAN_LIMITS["expert"]` didn't exist. All call sites
+doing `PLAN_LIMITS.get(plan, PLAN_LIMITS["free"])` with `plan="expert"`
+fell back to FREE limits — wrong model, blocked features, low credits.
+
+Observable impact : Summaries 208/209/210 (post-migration v2) all had
+`model_used = "mistral-small-2603"` (Free model) instead of
+`"mistral-large-2512"` (Expert model). These tests lock the fix.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+class TestPlanLimitsExpertKey:
+    """The key v2 plan `expert` must exist with proper Expert-tier limits."""
+
+    def test_expert_key_present(self):
+        from core.config import PLAN_LIMITS
+        assert "expert" in PLAN_LIMITS, (
+            "PLAN_LIMITS missing 'expert' key. Users on plan=expert (v2) "
+            "fall back to FREE limits, causing model_used=mistral-small-2603 "
+            "and blocked features. Cf. _build_legacy_plan_limits() iteration."
+        )
+
+    def test_expert_default_model_is_large(self):
+        from core.config import PLAN_LIMITS
+        assert PLAN_LIMITS["expert"]["default_model"] == "mistral-large-2512"
+
+    def test_expert_models_include_all_tiers(self):
+        from core.config import PLAN_LIMITS
+        models = PLAN_LIMITS["expert"]["models"]
+        assert "mistral-large-2512" in models
+        assert "mistral-medium-2508" in models
+        assert "mistral-small-2603" in models
+
+    def test_expert_no_blocked_features(self):
+        from core.config import PLAN_LIMITS
+        assert PLAN_LIMITS["expert"]["blocked_features"] == []
+
+    def test_expert_deep_research_enabled(self):
+        from core.config import PLAN_LIMITS
+        assert PLAN_LIMITS["expert"]["deep_research_enabled"] is True
+
+    def test_expert_web_search_enabled(self):
+        from core.config import PLAN_LIMITS
+        assert PLAN_LIMITS["expert"]["web_search_enabled"] is True
+
+    def test_expert_voice_chat_enabled(self):
+        from core.config import PLAN_LIMITS
+        assert PLAN_LIMITS["expert"]["voice_chat_enabled"] is True
+
+
+class TestPlanLimitsRegressionGuard:
+    """Other plans must remain intact (no regression on legacy semantics)."""
+
+    def test_free_present(self):
+        from core.config import PLAN_LIMITS
+        assert "free" in PLAN_LIMITS
+        assert PLAN_LIMITS["free"]["default_model"] == "mistral-small-2603"
+
+    def test_pro_v2_default_model_is_medium(self):
+        """v2 PRO is the intermediate tier (8.99€/mo) — medium model."""
+        from core.config import PLAN_LIMITS
+        assert "pro" in PLAN_LIMITS
+        # v2 pro = intermediate ; medium-2508 is the default per plan_config.py
+        assert PLAN_LIMITS["pro"]["default_model"] == "mistral-medium-2508"
+
+    def test_unlimited_admin_uses_large_model(self):
+        """Admin 'unlimited' must use the TOP model (large), not medium.
+        Sprint 2026-05-12 : was copying `pro` (medium in v2) — now copies
+        `expert` (large) so admin always has the most capable model."""
+        from core.config import PLAN_LIMITS
+        assert "unlimited" in PLAN_LIMITS
+        assert PLAN_LIMITS["unlimited"]["default_model"] == "mistral-large-2512"
+        assert PLAN_LIMITS["unlimited"]["blocked_features"] == []
+
+    def test_plus_legacy_still_present(self):
+        """Grandfathered users on `plus` (v0) must still resolve."""
+        from core.config import PLAN_LIMITS
+        assert "plus" in PLAN_LIMITS
+
+
+class TestRouterModelSelectionForExpert:
+    """End-to-end regression : `videos/router.py:877` pattern resolves
+    Expert user → large-2512, not small-2603."""
+
+    def test_expert_resolves_to_large_via_legacy_pattern(self):
+        """Mirrors the pattern at videos/router.py:877 + similar lines."""
+        from core.config import PLAN_LIMITS
+
+        # Simulate request.model = None (MCP / no explicit model)
+        request_model = None
+        user_plan = "expert"
+
+        plan_limits = PLAN_LIMITS.get(user_plan, PLAN_LIMITS["free"])
+        model = request_model or plan_limits.get("default_model", "mistral-small-2603")
+        allowed_models = plan_limits.get("models", ["mistral-small-2603"])
+        if model not in allowed_models:
+            model = allowed_models[0]
+
+        assert model == "mistral-large-2512", (
+            f"Expert user should resolve to mistral-large-2512, got {model!r}. "
+            f"Bug : PLAN_LIMITS.get('expert', ...) fell back to FREE limits "
+            f"because the 'expert' key was missing."
+        )


### PR DESCRIPTION
## Summary

Critical bug : depuis la migration v2 (Alembic 012, 2026-04-30) tous les users `plan=expert` tombaient sur `PLAN_LIMITS["free"]` car `_build_legacy_plan_limits()` n'itérait pas sur `PlanId.EXPERT`. Observable sur Summaries 208/209/210 — `model_used = mistral-small-2603` au lieu de `mistral-large-2512` (Expert default).

## Root cause

`backend/src/core/config.py:491` :
```python
for plan_id in [PlanId.FREE, PlanId.PLUS, PlanId.PRO]:  # ⬅️ EXPERT manquant
```

Résultat : `PLAN_LIMITS` legacy dict n'avait pas la clé `"expert"`. Tous les `~40 call sites` faisant `PLAN_LIMITS.get(plan, PLAN_LIMITS["free"])` (15 fichiers) avec `plan="expert"` fallback sur FREE.

Le path moderne `billing.plan_config.get_limits(plan)` était OK (a `PlanId.EXPERT`), donc la majorité du feature-gating fonctionnait. Seul le model selection dans `videos/router.py:877+1149+1891+...` était dégradé.

## Impact observable

Pour les users plan=expert (au moins maximeleparc3@gmail.com) :
- `default_model = mistral-small-2603` au lieu de `mistral-large-2512` — toutes analyses dégradées
- `deep_research_enabled = False` — feature bloquée silencieusement
- `web_search_enabled = False` — idem
- `blocked_features = [playlists, deep_research, voice_chat, mindmap, ...]` — beaucoup bloqué

## Fix

1. **L491** : Ajoute `PlanId.EXPERT` à la liste d'itération
2. **L513-528** : `blocked_features` ternary inclut `expert` → `[]` (comme `pro`)
3. **L529-543** : `upgrade_prompt` distingue `expert` ("all unlocked") vs `pro` ("upgrade to Expert")
4. **L547** : Admin `unlimited` copie `expert` (large model) au lieu de `pro` (medium model). Défensive.
5. **L570-603** : Fallback exception-path inclut `expert` (utilisé si plan_config.py n'est pas importable, e.g. tests isolés)

## Tests

12 nouveaux locks dans `tests/core/test_plan_limits_legacy_shim.py` :
- `TestPlanLimitsExpertKey` (×7) : expert key present, large model, all features enabled, no blocks
- `TestPlanLimitsRegressionGuard` (×4) : free/pro/plus inchangés ; unlimited admin → large
- `TestRouterModelSelectionForExpert` (×1) : pattern exact de `videos/router.py:877` resolves expert → large-2512

**Anti-régression** : 43/43 tests existants `tests/core/test_plan_limits.py` + `tests/test_plan_gates.py` verts.

## Follow-up

Sprint séparé : migrer ~40 call sites de `PLAN_LIMITS.get(plan, PLAN_LIMITS["free"])` vers `from billing.plan_config import get_limits` (SSOT moderne). 15 fichiers concernés. Cf. memory `project_sprint-decodo-wave1-2026-05-12.md` post-sprint section.

## Test plan

- [x] 12/12 nouveaux tests verts
- [x] 43/43 tests existants plan_limits+plan_gates verts
- [ ] Backend deploy Hetzner success après merge
- [ ] E2E : nouvelle analyse expert plan → `Summary.model_used == "mistral-large-2512"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)