### PR TITLE
fix(api): resolve model dynamically from user plan in /api/v1/analyze

### DIFF
--- a/backend/src/api_public/router.py
+++ b/backend/src/api_public/router.py
@@ -439,6 +439,17 @@ async def analyze_video_api(
         },
     )
 
+    # Résolution du modèle Mistral selon le plan utilisateur (SSOT moderne).
+    # Sprint 2026-05-12 : avant ce fix, le modèle Free tier était hardcodé ici,
+    # forçant TOUTES les analyses MCP (`ds_analyze`) sur small même pour les
+    # users Expert. Observable sur Summary 211 (model_used=small malgré
+    # plan=expert). PR #473 a corrigé la voie `/api/videos/analyze` (frontend) ;
+    # cette PR-ci corrige la voie `/api/v1/analyze` (public API + MCP).
+    from billing.plan_config import get_limits
+
+    _plan_limits = get_limits(user.plan)
+    _resolved_model = _plan_limits.get("default_model", "mistral-small-2603")
+
     # Lancer l'analyse en background
     asyncio.ensure_future(
         _analyze_video_background_v6(
@@ -448,7 +459,7 @@ async def analyze_video_api(
             mode=internal_mode,
             category="auto",
             lang=lang,
-            model="mistral-small-2603",
+            model=_resolved_model,
             user_id=user.id,
             user_plan=user.plan,
             credit_cost=credits_cost,

--- a/backend/tests/test_api_public_model_resolution.py
+++ b/backend/tests/test_api_public_model_resolution.py
@@ -1,0 +1,112 @@
+"""
+Tests for model resolution in `api_public/router.py::analyze_video_api`.
+
+Sprint 2026-05-12 — before this fix, the public API `/api/v1/analyze` (used
+by the DeepSight MCP `ds_analyze` tool) hardcoded `model="mistral-small-2603"`
+when calling `_analyze_video_background_v6`. Result : ALL MCP-driven analyses
+ran on the Free-tier model regardless of `user.plan`.
+
+Observable : Summary 208/209/210/211 all had `model_used = "mistral-small-2603"`
+despite `user.plan = "expert"` (which should resolve to `mistral-large-2512`).
+
+PR #473 had already fixed the frontend path (`/api/videos/analyze`) by adding
+the missing `EXPERT` key to the legacy `PLAN_LIMITS` shim. This PR closes
+the parallel hole in the public API.
+
+These tests verify :
+1. The hardcoded `model="mistral-small-2603"` literal is GONE.
+2. The endpoint now resolves the model via `billing.plan_config.get_limits`.
+3. `get_limits("expert").default_model == "mistral-large-2512"`.
+4. `get_limits("pro").default_model == "mistral-medium-2508"`.
+5. `get_limits("free").default_model == "mistral-small-2603"`.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+class TestApiPublicModelResolution:
+    """Source-level locks : `analyze_video_api` resolves model dynamically."""
+
+    def test_no_hardcoded_small_model_in_analyze(self):
+        """The literal `model="mistral-small-2603"` must NOT appear in the
+        analyze endpoint anymore. Regression guard against future copies."""
+        import inspect
+
+        from api_public import router as api_public_router
+
+        src = inspect.getsource(api_public_router)
+        # Find the analyze_video_api function body
+        idx = src.index("async def analyze_video_api")
+        end_idx = src.index("\n@router.", idx) if "\n@router." in src[idx:] else len(src)
+        analyze_body = src[idx:end_idx]
+
+        assert 'model="mistral-small-2603"' not in analyze_body, (
+            "analyze_video_api still hardcodes model='mistral-small-2603'. "
+            "This forces Expert users onto the Free-tier model when calling "
+            "via MCP (`ds_analyze`). Use get_limits(user.plan).default_model "
+            "instead."
+        )
+
+    def test_get_limits_imported_in_analyze(self):
+        """Verify the dynamic-resolution path is wired up."""
+        import inspect
+
+        from api_public import router as api_public_router
+
+        src = inspect.getsource(api_public_router)
+        # The fix imports `get_limits` inline before _analyze_video_background_v6
+        # OR at module level. Either is acceptable.
+        assert "get_limits" in src, (
+            "api_public/router.py should call get_limits() to resolve the "
+            "Mistral model from the user's plan instead of hardcoding."
+        )
+
+    def test_resolved_model_passed_to_background_task(self):
+        """The kwarg `model=...` must reference a resolved variable, not a
+        literal string."""
+        import inspect
+
+        from api_public import router as api_public_router
+
+        src = inspect.getsource(api_public_router)
+        idx = src.index("async def analyze_video_api")
+        end_idx = src.index("\n@router.", idx) if "\n@router." in src[idx:] else len(src)
+        analyze_body = src[idx:end_idx]
+
+        # The fix uses `model=_resolved_model` (variable, not literal)
+        assert "_resolved_model" in analyze_body or "default_model" in analyze_body, (
+            "analyze_video_api should compute a resolved model variable from "
+            "the plan limits and pass it as model=<variable>, not a literal."
+        )
+
+
+class TestPlanLimitsReturnShape:
+    """Sanity check that get_limits returns the expected shape for our use case."""
+
+    def test_free_default_model(self):
+        from billing.plan_config import get_limits
+
+        assert get_limits("free")["default_model"] == "mistral-small-2603"
+
+    def test_pro_default_model(self):
+        from billing.plan_config import get_limits
+
+        # v2 PRO is intermediate tier (8.99€) → medium model
+        assert get_limits("pro")["default_model"] == "mistral-medium-2508"
+
+    def test_expert_default_model(self):
+        from billing.plan_config import get_limits
+
+        # v2 EXPERT is top tier (19.99€) → large model
+        assert get_limits("expert")["default_model"] == "mistral-large-2512"
+
+    def test_unknown_plan_falls_back_safely(self):
+        from billing.plan_config import get_limits
+
+        # Unknown / null-plan users should not crash ; get_limits should
+        # return a sensible default (typically free).
+        limits = get_limits("nonexistent_plan_xyz")
+        assert "default_model" in limits


### PR DESCRIPTION
## Summary

Suite à PR #473 (qui a fixé le legacy `PLAN_LIMITS` shim avec la clé `expert`), l'E2E test post-deploy a révélé qu'une autre voie d'analyse ignorait toujours le plan utilisateur : **le endpoint public `/api/v1/analyze` (utilisé par le MCP `ds_analyze`) hardcodait le modèle Free-tier**.

## Root cause

`backend/src/api_public/router.py:451` hardcodait :
```python
asyncio.ensure_future(
    _analyze_video_background_v6(
        ...
        model="mistral-small-2603",  # ❌ ignore user.plan
        ...
    )
)
```

Résultat : Summary 211 (Karpathy "Let's reproduce GPT-2", lancé via MCP post-PR #473) a toujours `model_used = "mistral-small-2603"` malgré `user.plan = "expert"`.

PR #473 a corrigé `videos/router.py` (la voie frontend `/api/videos/analyze`) ; **cette PR-ci corrige la voie publique `/api/v1/analyze`** qui était parallèle et n'utilisait même pas le legacy shim.

## Fix

Résolution via le SSOT moderne (`billing.plan_config.get_limits`) :
```python
from billing.plan_config import get_limits

_plan_limits = get_limits(user.plan)
_resolved_model = _plan_limits.get("default_model", "mistral-small-2603")

asyncio.ensure_future(
    _analyze_video_background_v6(
        ...
        model=_resolved_model,
        ...
    )
)
```

Import inline pour ne pas toucher les imports module-level (déjà nombreux).

## Tests

7 nouveaux dans `tests/test_api_public_model_resolution.py` :
- **TestApiPublicModelResolution** (×3) : source-level locks
  - no literal `model="mistral-small-2603"` as kwarg
  - `get_limits` est référencé
  - `model=` reçoit une variable, pas un literal
- **TestPlanLimitsReturnShape** (×4) : sanity shape
  - free → small, pro → medium, expert → large
  - unknown plan ne crash pas

Plus 12 tests `test_plan_limits_legacy_shim.py` de PR #473 toujours verts. **19/19 green**.

## E2E plan post-merge

1. Push merge → Hetzner auto-deploy
2. `ds_analyze` sur une vidéo fresh (pas cachée)
3. Vérifier `Summary.model_used == "mistral-large-2512"` (au lieu de small)

## Test plan

- [x] 7 nouveaux tests + 12 existants verts (19/19)
- [ ] Backend deploy Hetzner success après merge
- [ ] E2E : ds_analyze sur nouvelle vidéo → `model_used = large-2512`

## Related

- PR #473 : EXPERT key fix legacy PLAN_LIMITS shim (frontend path) — `514f4fbc`
- Task #16 : Phase 1B refactor `PLAN_LIMITS` → `get_limits` (15 fichiers) — bigger sprint, separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)