### PR TITLE
fix(tutor): user bubble visible + history preserved on text→voice toggle

### DIFF
--- a/frontend/src/components/Tutor/TutorHub.tsx
+++ b/frontend/src/components/Tutor/TutorHub.tsx
@@ -391,7 +391,11 @@ export const TutorHub: React.FC<TutorHubProps> = ({
       voicePrimerSentRef.current = false;
       if (tutorPhase === "mini-chat") {
         try {
-          await endSession();
+          // Keep the local transcript so the user still sees what they
+          // discussed in text mode. The backend Redis session is torn down
+          // (concept may change for the voice agent), but the visible
+          // timeline remains — that's the whole point of the unified hub.
+          await endSession({ keepMessages: true });
         } catch {
           /* ignore */
         }

--- a/frontend/src/components/Tutor/__tests__/TutorHub.test.tsx
+++ b/frontend/src/components/Tutor/__tests__/TutorHub.test.tsx
@@ -254,6 +254,35 @@ describe("TutorHub", () => {
       concept_def: "",
       mode: "text",
     });
+    // The user's own message must appear in the transcript alongside the
+    // agent's first_prompt (otherwise the user can't see what they sent).
+    await waitFor(() => {
+      expect(screen.getByText("Première question")).toBeInTheDocument();
+      expect(screen.getByText("Premier message agent.")).toBeInTheDocument();
+    });
+  });
+
+  it("text → voice (with confirm OK) keeps the prior transcript visible in the unified timeline", async () => {
+    vi.spyOn(window, "confirm").mockImplementation(() => true);
+    render(<TutorHub isOpen onClose={vi.fn()} />);
+    await useTutorStore.getState().startSession({
+      concept_term: "Concept X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Concept X")).toBeInTheDocument();
+      expect(screen.getByText("Premier message agent.")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("tutor-hub-mode-voice"));
+    // Switched to voice pane AND sessionEnd was called (Redis torn down)…
+    await waitFor(() => {
+      expect(screen.getByTestId("tutor-hub-voice-pane")).toBeInTheDocument();
+      expect(tutorApiMock.sessionEnd).toHaveBeenCalled();
+    });
+    // …but the user can still see what they discussed in text mode.
+    expect(screen.getByText("Concept X")).toBeInTheDocument();
+    expect(screen.getByText("Premier message agent.")).toBeInTheDocument();
   });
 
   it("close button calls onClose AND ends the text session if active", async () => {

--- a/frontend/src/store/__tests__/tutorStore.test.ts
+++ b/frontend/src/store/__tests__/tutorStore.test.ts
@@ -50,7 +50,7 @@ describe("tutorStore", () => {
     expect(useTutorStore.getState().phase).toBe("idle");
   });
 
-  it("startSession populates state and appends first assistant message", async () => {
+  it("startSession pushes the user's concept_term as the first turn, then the agent's first_prompt", async () => {
     await useTutorStore.getState().startSession({
       concept_term: "Rasoir d'Occam",
       concept_def: "Principe de parcimonie",
@@ -61,12 +61,17 @@ describe("tutorStore", () => {
     expect(s.sessionId).toBe("tutor-test123");
     expect(s.conceptTerm).toBe("Rasoir d'Occam");
     expect(s.conceptDef).toBe("Principe de parcimonie");
-    expect(s.messages).toHaveLength(1);
-    expect(s.messages[0].role).toBe("assistant");
+    expect(s.messages).toHaveLength(2);
+    expect(s.messages[0].role).toBe("user");
+    expect(s.messages[0].content).toBe("Rasoir d'Occam");
+    expect(s.messages[1].role).toBe("assistant");
+    expect(s.messages[1].content).toBe(
+      "Comment expliqueriez-vous ce concept ?",
+    );
     expect(s.loading).toBe(false);
   });
 
-  it("submitTextTurn pushes user then assistant messages", async () => {
+  it("submitTextTurn appends user + assistant turns after the opening pair", async () => {
     await useTutorStore.getState().startSession({
       concept_term: "X",
       concept_def: "Y",
@@ -74,10 +79,14 @@ describe("tutorStore", () => {
     });
     await useTutorStore.getState().submitTextTurn("Mon idée");
     const s = useTutorStore.getState();
-    expect(s.messages).toHaveLength(3);
-    expect(s.messages[1].role).toBe("user");
-    expect(s.messages[1].content).toBe("Mon idée");
-    expect(s.messages[2].role).toBe("assistant");
+    // Opening: user "X" + assistant first_prompt. Turn: user "Mon idée" + assistant.
+    expect(s.messages).toHaveLength(4);
+    expect(s.messages[0].role).toBe("user");
+    expect(s.messages[0].content).toBe("X");
+    expect(s.messages[1].role).toBe("assistant");
+    expect(s.messages[2].role).toBe("user");
+    expect(s.messages[2].content).toBe("Mon idée");
+    expect(s.messages[3].role).toBe("assistant");
   });
 
   it("submitTextTurn is no-op without a session", async () => {
@@ -126,6 +135,25 @@ describe("tutorStore", () => {
     expect(s.error).toBe("boom");
     expect(s.loading).toBe(false);
     expect(s.phase).toBe("idle");
+    // Optimistic user turn is rolled back so the empty-state UI returns.
+    expect(s.messages).toEqual([]);
+  });
+
+  it("endSession({ keepMessages: true }) tears down the Redis session but keeps the local transcript", async () => {
+    await useTutorStore.getState().startSession({
+      concept_term: "X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    await useTutorStore.getState().endSession({ keepMessages: true });
+    const s = useTutorStore.getState();
+    expect(s.phase).toBe("idle");
+    expect(s.sessionId).toBeNull();
+    expect(s.conceptTerm).toBeNull();
+    // Transcript stays visible — that's the contract of the unified hub.
+    expect(s.messages).toHaveLength(2);
+    expect(s.messages[0].role).toBe("user");
+    expect(s.messages[1].role).toBe("assistant");
   });
 
   it("reset clears state immediately", async () => {

--- a/frontend/src/store/tutorStore.ts
+++ b/frontend/src/store/tutorStore.ts
@@ -42,7 +42,16 @@ export interface TutorState {
   cancelPrompting: () => void;
   startSession: (opts: StartSessionOpts) => Promise<void>;
   submitTextTurn: (input: string) => Promise<void>;
-  endSession: () => Promise<void>;
+  /**
+   * End the backend Redis session.
+   *
+   * - `{ keepMessages: true }` keeps the local transcript visible (used when
+   *   toggling text → voice inside the unified TutorHub timeline — Redis is
+   *   torn down but the user still sees their text history).
+   * - Default (`undefined` / `{ keepMessages: false }`) wipes the whole store
+   *   back to INITIAL (used on hub close / explicit reset).
+   */
+  endSession: (opts?: { keepMessages?: boolean }) => Promise<void>;
   setFullscreen: (v: boolean) => void;
   reset: () => void;
 }
@@ -91,10 +100,21 @@ export const useTutorStore = create<TutorState>()(
 
     startSession: async (opts) => {
       const lang: TutorLang = opts.lang ?? "fr";
+      // Optimistically push the user's input (concept_term) as the first
+      // visible turn. Without this, the transcript only shows the agent's
+      // first_prompt and the user can't tell what they just submitted.
+      const userTurnTs = Date.now();
       set((s) => {
         s.lang = lang;
         s.loading = true;
         s.error = null;
+        s.messages = [
+          {
+            role: "user",
+            content: opts.concept_term,
+            timestamp_ms: userTurnTs,
+          },
+        ];
       });
       try {
         const resp = await tutorApi.sessionStart({
@@ -112,17 +132,17 @@ export const useTutorStore = create<TutorState>()(
           s.conceptDef = opts.concept_def;
           s.summaryId = opts.summary_id ?? null;
           s.sourceVideoTitle = opts.source_video_title ?? null;
-          s.messages = [
-            {
-              role: "assistant",
-              content: resp.first_prompt,
-              timestamp_ms: Date.now(),
-            },
-          ];
+          s.messages.push({
+            role: "assistant",
+            content: resp.first_prompt,
+            timestamp_ms: Date.now(),
+          });
           s.loading = false;
         });
       } catch (err) {
         set((s) => {
+          // Roll back the optimistic user turn so the empty-state UI returns.
+          s.messages = [];
           s.error = (err as Error).message;
           s.loading = false;
         });
@@ -160,7 +180,7 @@ export const useTutorStore = create<TutorState>()(
       }
     },
 
-    endSession: async () => {
+    endSession: async (opts) => {
       const sessionId = get().sessionId;
       if (sessionId) {
         try {
@@ -171,7 +191,13 @@ export const useTutorStore = create<TutorState>()(
         }
       }
       set((s) => {
-        Object.assign(s, INITIAL);
+        if (opts?.keepMessages) {
+          const savedMessages = s.messages;
+          Object.assign(s, INITIAL);
+          s.messages = savedMessages;
+        } else {
+          Object.assign(s, INITIAL);
+        }
       });
     },
 


### PR DESCRIPTION
## Summary

Suite à #465 (unified text+voice timeline), deux régressions observées en prod via test E2E ce matin (`https://www.deepsightsynthesis.com`, plan Expert) :

| # | Bug | Root cause |
|---|-----|------------|
| **B2** | Mode Texte : bulle user invisible après envoi 1er message | `tutorStore.startSession()` posait `messages = [first_prompt]` mais n'ajoutait jamais l'input user dans le fil (l'input devient `concept_term` côté backend). |
| **B3** | Toggle Texte→Vocal wipe le fil chat | `endSession()` fait `Object.assign(s, INITIAL)` → reset `messages = []`. Contredit la spec « timeline unifiée partagée entre les deux modes ». |

Le 3e bug observé (`useVoiceChat startSession → Failed to fetch dynamically imported module: lib.modern-CRAQVYS6.js`) reste à diagnostiquer — chunk OK côté serveur (HTTP 200, MIME bon, CSP autorise `self`, hash entry correct). Un 2e tour CinC avec DevTools Network ouvert est prévu pour capter la requête réelle (transient network vs runtime SDK error).

## Fix

### `tutorStore.startSession()`

- Push optimiste de `concept_term` comme tour user AVANT l'appel API
- `push` (au lieu de `=`) du `first_prompt` assistant à la réponse — on accumule au lieu de remplacer
- Rollback à `[]` si l'API échoue (error path)

### `tutorStore.endSession({ keepMessages?: boolean })`

Nouveau flag :
- `{ keepMessages: true }` → tear down Redis session + reset state SAUF `messages` (utilisé sur text→voice)
- Default (`undefined` / `false`) → wipe complet (utilisé sur close du hub)

### `TutorHub.handleModeChange("voice")`

Appelle `endSession({ keepMessages: true })` au lieu de `endSession()` quand on bascule en vocal avec une conv texte en cours.

## Tests

- ✅ 11/11 tutorStore vitest (+1 nouveau pour `endSession({ keepMessages: true })`, 2 modifiés pour la nouvelle shape `[user, assistant]`)
- ✅ 14/14 TutorHub vitest (+1 nouveau pour le toggle texte→vocal qui preserve le transcript, 1 étendu pour vérifier que la bulle user apparaît)
- ✅ `tsc --noEmit` → 0 erreur

## Test plan (manuel post-deploy)

- [ ] Sidebar « Tuteur » → tape « Bonjour » → envoie → bulle bleue user visible + réponse agent en dessous
- [ ] Toggle « Vocal » (confirm OK) → fil texte reste visible, pane voice apparaît
- [ ] Toggle « Texte » pendant l'appel → transcript vocal + texte tous deux visibles
- [ ] Plus de régression sur les 13 scénarios couverts par PR #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)