### PR TITLE
fix(deps): pin mistralai to v1.12.4 GitHub tarball (PyPI quarantine)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -86,7 +86,11 @@ Pillow>=10.0.0           # Image processing (thumbnail WebP conversion)
 # ─────────────────────────────────────────────────────────────────────────────────
 # 🤖 AI MODELS
 # ─────────────────────────────────────────────────────────────────────────────────
-mistralai>=1.0.0
+# 2026-05-12 — `mistralai` package quarantined on PyPI (versions: []), pin to a
+# known-good v1.x tag via GitHub tarball until PyPI restores. The DeepSight
+# code uses `from mistralai.client import Mistral` (v1.x API), so we stay on
+# v1.12.4 (last v1 release) rather than v2.x which restructured imports.
+mistralai @ https://github.com/mistralai/client-python/archive/refs/tags/v1.12.4.tar.gz
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # 🎙️ AUDIO TRANSCRIPTION (optional - for Whisper fallback)


### PR DESCRIPTION
## Summary
- PyPI a mis le package \`mistralai\` en quarantine entre 06:58 UTC (dernier deploy main réussi) et 07:47 UTC (deploy échoué après merge PR #478)
- L'API PyPI renvoie \`versions: []\`, \`project-status: quarantined\` → tous les futurs rebuilds Hetzner échouent
- Le runtime actuel n'est PAS impacté (container 49 min healthy), mais aucun rebuild ne passera tant que ce blocker n'est pas levé
- Fix : installer depuis GitHub tarball pinné \`v1.12.4\` (dernière release v1.x, garde l'API \`from mistralai.client import Mistral\` utilisée par 6 modules backend)

## Test plan
- [x] PyPI status check : \`curl https://pypi.org/simple/mistralai/\` → \`versions: []\` confirmé
- [x] v2.x dropping \`mistralai.client\` module → resterait à réécrire 6 fichiers (demo, images, videos.chunking, videos.raw_text_enhance, voice.context_digest)
- [x] v1.12.4 git tarball : URL HTTP testée, structure src/mistralai/client.py présente
- [ ] CI Backend doit redevenir vert (Tests + Deploy Backend)
- [ ] Smoke prod après deploy : \`curl https://api.deepsightsynthesis.com/health\`

## Rollback
Si PyPI restaure le package : `git revert` ce commit ou remplacer la ligne par `mistralai>=1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)