### PR TITLE
feat(deploy): mount tiktok_cookies.txt into backend container

### DIFF
--- a/deploy/hetzner/docker-compose.yml
+++ b/deploy/hetzner/docker-compose.yml
@@ -90,6 +90,11 @@ services:
     restart: unless-stopped
     networks:
       - repo_deepsight
+    volumes:
+      # TikTok cookies for yt-dlp auth (TIKTOK_COOKIES_PATH=/app/tiktok_cookies.txt).
+      # Source file on host: /opt/deepsight/repo/tiktok_cookies.txt (sprint 2026-05-11,
+      # uploaded via scp). Read-only mount — backend never writes back to host.
+      - ../../tiktok_cookies.txt:/app/tiktok_cookies.txt:ro
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Add read-only bind mount for `tiktok_cookies.txt` in the backend service
- Source: `/opt/deepsight/repo/tiktok_cookies.txt` on host (uploaded 2026-05-12 via scp)
- Target: `/app/tiktok_cookies.txt` in container (matches existing `TIKTOK_COOKIES_PATH` env convention)

Resolves the "cookies uploaded host but NOT MOUNTED in container" gap discovered post-upload in Task #1 of the Decodo sprint reprise session.

## Test plan
- [ ] After merge: SSH Hetzner → `cd /opt/deepsight/repo && git pull`
- [ ] `docker compose -f deploy/hetzner/docker-compose.yml up -d --force-recreate backend`
- [ ] Verify: `docker exec repo-backend-1 ls -la /app/tiktok_cookies.txt` → should show 45 KB file
- [ ] Verify backend reads it: `docker logs repo-backend-1 --tail 50 | grep -i 'tiktok\|cookies'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)