### PR TITLE
fix(transcripts): unify Option A return None on failure (lines 913, 940)

### DIFF
--- a/backend/src/transcripts/youtube.py
+++ b/backend/src/transcripts/youtube.py
@@ -928,8 +928,22 @@ async def get_transcript_supadata(
                         else:
                             content = ""
                     if content and isinstance(content, str) and len(content.strip()) >= 20:
-                        print(f"  ✅ [SUPADATA] Unified success: {len(content)} chars", flush=True)
-                        return content.strip(), content.strip(), detected_lang
+                        # 🔧 Option A (2026-05-12) — Endpoint unifié Supadata ne fournit
+                        # PAS de timestamps. Retourner `None` pour le canal timestamped
+                        # signale clairement aux callers (`if simple and timestamped`) que
+                        # ce résultat n'a pas d'anchors `[MM:SS]` exploitables, ce qui
+                        # déclenche la fallback vers Phase 1 (ytapi/Invidious/Piped) qui
+                        # peuvent fournir des timestamps réels. Si tous les fallbacks
+                        # échouent à fournir des timestamps, Option C (duration_hint
+                        # PR #468) prend le relais côté visual analysis. Anciennement,
+                        # le timestamped était dupliqué depuis le texte plain → la regex
+                        # de _parse_timestamps (chunker.py) matchait zéro anchor, causant
+                        # silencieusement la perte de timestamps pour visual analysis.
+                        print(
+                            f"  ✅ [SUPADATA] Unified success (plain text, no timestamps): {len(content)} chars",
+                            flush=True,
+                        )
+                        return content.strip(), None, detected_lang
 
                 elif response.status_code == 202:
                     # Async job — poll
@@ -955,8 +969,15 @@ async def get_transcript_supadata(
                                     else:
                                         content = ""
                                 if content and isinstance(content, str) and len(content.strip()) >= 20:
-                                    print(f"  ✅ [SUPADATA] Async success: {len(content)} chars", flush=True)
-                                    return content.strip(), content.strip(), detected_lang
+                                    # 🔧 Option A (2026-05-12) — voir commentaire identique
+                                    # sur l'endpoint unifié plus haut. L'endpoint async
+                                    # de Supadata retourne le même format (`content` =
+                                    # plain text), donc même contrat : timestamped=None.
+                                    print(
+                                        f"  ✅ [SUPADATA] Async success (plain text, no timestamps): {len(content)} chars",
+                                        flush=True,
+                                    )
+                                    return content.strip(), None, detected_lang
                             elif poll.status_code == 202:
                                 continue
                             else:

--- a/backend/tests/transcripts/test_supadata_option_a.py
+++ b/backend/tests/transcripts/test_supadata_option_a.py
@@ -1,0 +1,254 @@
+"""
+Tests for Option A pattern in `get_transcript_supadata`.
+
+CONTEXT (2026-05-12)
+====================
+Bug originel : les endpoints unified (`/v1/transcript`) et async (`/v1/transcript/{job_id}`)
+de Supadata ne retournent qu'un champ `content` (plain text, sans timestamps).
+Les anciennes lignes ~913/~940 de `transcripts/youtube.py` retournaient
+`(content.strip(), content.strip(), detected_lang)` — dupliquant le texte plain
+dans le canal `transcript_timestamped`. Conséquence : la regex `_parse_timestamps`
+(chunker.py) matchait zéro anchor `[MM:SS]`, et visual analysis perdait
+silencieusement ses timestamps réels (bug observé prod 2026-05-11).
+
+Fix Option A : retourner `(content, None, lang)` pour signaler au caller
+(`if simple and timestamped` dans `_get_transcript_with_timestamps_inner`) que
+ce résultat n'a pas d'anchors exploitables → fallback vers Phase 1 (ytapi,
+Invidious, Piped) qui fournissent de vrais timestamps.
+
+Le contrat vérifié ici :
+1. Endpoint unifié (200 OK) avec `content` = string → return (text, None, lang)
+2. Endpoint async (202 → polling 200) avec `content` = string → return (text, None, lang)
+3. Endpoint unifié avec `content` = liste de segments dict → toujours plain text → (text, None, lang)
+4. Caller `_get_transcript_with_timestamps_inner` rejette correctement
+   (`if simple and timestamped` est falsy) pour forcer le fallback Phase 1.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ajouter src au path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+def _get_youtube_module():
+    from transcripts import youtube as yt
+    return yt
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Source-level lock — Option A pattern visible in the code
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSourceLevelOptionAPattern:
+    """Source inspection to lock the Option A return pattern at L932/L959.
+
+    These tests catch regressions where someone reverts to
+    `return content.strip(), content.strip(), detected_lang`
+    (the buggy pre-2026-05-12 pattern).
+    """
+
+    def setup_method(self):
+        yt = _get_youtube_module()
+        self.src = inspect.getsource(yt)
+
+    def test_no_duplicated_content_return_pattern(self):
+        """The buggy pattern `content.strip(), content.strip()` MUST NOT
+        reappear in the file. This was the L913/L940 bug fixed 2026-05-12.
+        """
+        # Both lines used the exact same pattern: identical "content.strip()" duplicated
+        assert "content.strip(), content.strip()" not in self.src, (
+            "Buggy Supadata return pattern detected: "
+            "`content.strip(), content.strip(), ...` returns plain text in the "
+            "timestamped channel. This breaks visual analysis (regex matches "
+            "zero `[MM:SS]` anchors). Use `return content.strip(), None, lang` "
+            "instead (Option A pattern, fixed 2026-05-12)."
+        )
+
+    def test_unified_endpoint_returns_none_for_timestamped(self):
+        """L932 — Unified endpoint return must use `None` for timestamped."""
+        # Locate the unified success log marker and verify the return below it
+        marker = "[SUPADATA] Unified success"
+        assert marker in self.src, (
+            f"Marker {marker!r} not found — unified endpoint success path removed?"
+        )
+        pos = self.src.find(marker)
+        # Look forward for the return statement (within ~300 chars)
+        window = self.src[pos : pos + 500]
+        # Must have `content.strip(), None, detected_lang` (or similar with None)
+        assert "content.strip(), None, detected_lang" in window, (
+            "Unified endpoint should return (content, None, lang). "
+            "Found window:\n" + window
+        )
+
+    def test_async_endpoint_returns_none_for_timestamped(self):
+        """L959 — Async polling endpoint return must use `None` for timestamped."""
+        marker = "[SUPADATA] Async success"
+        assert marker in self.src, (
+            f"Marker {marker!r} not found — async polling success path removed?"
+        )
+        pos = self.src.find(marker)
+        window = self.src[pos : pos + 500]
+        assert "content.strip(), None, detected_lang" in window, (
+            "Async polling endpoint should return (content, None, lang). "
+            "Found window:\n" + window
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Behavioral tests — mocked HTTP responses
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_supadata_unified_endpoint_returns_none_for_timestamped():
+    """When Supadata unified endpoint returns plain-text `content`, the helper
+    must return `(content, None, lang)` — NOT `(content, content, lang)`.
+
+    The downstream caller `_get_transcript_with_timestamps_inner` checks
+    `if simple and timestamped`. With `None`, this evaluates falsy → fallback
+    to Phase 1 (ytapi/Invidious/Piped) which may give real timestamps.
+    """
+    yt = _get_youtube_module()
+
+    # Mock response for unified endpoint: plain text content, no segments
+    fake_response_200 = MagicMock()
+    fake_response_200.status_code = 200
+    fake_response_200.json = MagicMock(
+        return_value={
+            "content": "This is a plain text transcript without any timestamps at all here.",
+            "lang": "en",
+        }
+    )
+
+    # Mock response for YT-specific endpoint: 404 (so we fall through to unified)
+    fake_response_404 = MagicMock()
+    fake_response_404.status_code = 404
+
+    # Fake client: yt-specific returns 404 for every lang, unified returns the 200
+    call_log = []
+
+    async def fake_get(url, params=None, headers=None, timeout=None):
+        call_log.append(url)
+        # YT-specific endpoint → 404 for all langs
+        if "youtube/transcript" in url:
+            return fake_response_404
+        # Unified endpoint
+        if url.endswith("/v1/transcript"):
+            return fake_response_200
+        return fake_response_404
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+
+    # Async context manager
+    fake_ctx = MagicMock()
+    fake_ctx.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(yt, "shared_http_client", return_value=fake_ctx):
+        simple, timestamped, lang = await yt.get_transcript_supadata(
+            video_id="testvideo01", api_key="fake_key"
+        )
+
+    # Option A contract
+    assert simple is not None and len(simple) > 0, (
+        "Plain text content from unified endpoint should populate `simple`"
+    )
+    assert timestamped is None, (
+        "Option A — unified endpoint has no timestamps, must return None "
+        f"(got: {timestamped!r})"
+    )
+    assert lang == "en"
+
+
+@pytest.mark.asyncio
+async def test_supadata_async_polling_returns_none_for_timestamped():
+    """When Supadata returns 202 (async job) and polling eventually returns
+    plain-text `content`, the helper must return `(content, None, lang)`.
+    """
+    yt = _get_youtube_module()
+
+    # Mocks
+    fake_response_404 = MagicMock()
+    fake_response_404.status_code = 404
+
+    fake_response_202 = MagicMock()
+    fake_response_202.status_code = 202
+    fake_response_202.json = MagicMock(return_value={"jobId": "job_xyz"})
+
+    fake_poll_200 = MagicMock()
+    fake_poll_200.status_code = 200
+    fake_poll_200.json = MagicMock(
+        return_value={
+            "content": "Async polling result with plain text only and no timestamps.",
+            "lang": "fr",
+        }
+    )
+
+    async def fake_get(url, params=None, headers=None, timeout=None):
+        if "youtube/transcript" in url:
+            return fake_response_404
+        if url.endswith("/v1/transcript"):
+            # First call returns 202 (async job)
+            return fake_response_202
+        if "/v1/transcript/job_xyz" in url:
+            # Poll returns 200 with plain text
+            return fake_poll_200
+        return fake_response_404
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+
+    fake_ctx = MagicMock()
+    fake_ctx.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    # Patch asyncio.sleep to avoid real 5s waits in test
+    with patch.object(yt, "shared_http_client", return_value=fake_ctx), \
+         patch("asyncio.sleep", new=AsyncMock(return_value=None)):
+        simple, timestamped, lang = await yt.get_transcript_supadata(
+            video_id="testvideo02", api_key="fake_key"
+        )
+
+    assert simple is not None and "Async polling result" in simple
+    assert timestamped is None, (
+        "Option A — async polling has no timestamps, must return None "
+        f"(got: {timestamped!r})"
+    )
+    assert lang == "fr"
+
+
+@pytest.mark.asyncio
+async def test_supadata_caller_rejects_plain_text_only_result():
+    """Integration : downstream caller `_get_transcript_with_timestamps_inner`
+    must reject `(content, None, lang)` via the `if simple and timestamped`
+    guard, forcing fallback to Phase 1.
+
+    We can't easily exercise the full inner function in unit test (heavy deps),
+    but we can lock the source pattern that ensures `None` triggers rejection.
+    """
+    yt = _get_youtube_module()
+    src = inspect.getsource(yt)
+
+    # The Supadata caller in Phase 0 must check `if simple and timestamped` so
+    # that `timestamped=None` rejects the result and falls through.
+    # Locate the Phase 0 supadata call and verify the guard exists.
+    phase0_marker = "🥇 PHASE 0: Supadata API (PRIORITY)"
+    assert phase0_marker in src, "Phase 0 Supadata block removed?"
+    pos = src.find(phase0_marker)
+    window = src[pos : pos + 2000]
+
+    assert "if simple and timestamped" in window, (
+        "Phase 0 Supadata caller must guard with `if simple and timestamped` "
+        "so that `(content, None, lang)` triggers Phase 1 fallback. "
+        "Without this guard, plain-text-only Supadata results would be cached "
+        "and downstream visual analysis would lose timestamps."
+    )


### PR DESCRIPTION
## Summary

Apply **Option A** pattern to `transcripts/youtube.py::get_transcript_supadata` at lines 932 (formerly 913) and 959 (formerly 940). These two endpoints (Supadata unified `/v1/transcript` + async polling) were returning `(content.strip(), content.strip(), detected_lang)` — duplicating plain text into the `transcript_timestamped` slot without any `[MM:SS]` anchors.

The fix : return `(content.strip(), None, detected_lang)` so the downstream caller (`if simple and timestamped` in `_get_transcript_with_timestamps_inner`) correctly rejects the result and falls through to Phase 1 (ytapi / Invidious / Piped) which may provide real timestamps. If everything fails, Option C (`duration_hint`, PR #468) still kicks in on the visual analysis side.

## Context

- **PR #468** (Sprint Decodo Wave 1+2, 2026-05-12) shipped **Option C** : 5th fallback `duration_hint` propagated from Supadata metadata to `extract_storyboard_frames`. That patched the symptom (visual analysis losing timestamps on certain videos) but not the root cause.
- **Option A** documented in PR #468 diagnostic, deferred as separate tech-debt → this PR.
- The bug : `_parse_timestamps` (chunker.py L313) returns empty list when the timestamped text contains no `[MM:SS]` anchors. The two endpoints duplicating plain text were silently breaking real-timestamp extraction.

## Out of scope

- **L869** (`return segments, segments, lang`) shows a similar pattern when `segments` arrives as a string (no timestamps available). Task scope is explicit on L913/L940 only — to be handled in a follow-up if needed.
- No caller updates required : the 4 Phase 0/1/2/3 call-sites already use `if simple and timestamped` which correctly evaluates `None` as falsy.
- Function signature already `Tuple[Optional[str], Optional[str], Optional[str]]` — no type annotation change.

## Files changed

- `backend/src/transcripts/youtube.py` (+25 / -4) — two return statements + inline Option A comments + log enrichment
- `backend/tests/transcripts/test_supadata_option_a.py` (+254, new) — 6 tests
  - 3 source-level locks (regression guards)
  - 2 behavioral tests with mocked HTTP responses (unified + async polling)
  - 1 source-level lock on the caller guard

## Test plan

- [x] `pytest tests/transcripts/test_supadata_option_a.py -x -q` → 6/6 green
- [x] `pytest tests/transcripts/ -x -q` → 127/127 green (no regressions)
- [x] `pytest tests/videos/test_visual_integration_duration_hint.py -x -q` → 7/7 green (Option C still intact)
- [ ] Manual review in PR — leave for reviewer

## References

- Memory note : `~/.claude/projects/C--Users-33667/memory/project_sprint-decodo-wave1-2026-05-12.md` → Tech-debt section "Bug `transcripts/youtube.py:913+940` ... à fix séparément, Option A documentée dans diagnostic PR #468"
- Related: PR #468 (Option C duration_hint), PR #477 (httpx revert)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>