### PR TITLE
fix(deploy): align docker-compose cookies mount with deploy-backend.yml

### DIFF
--- a/deploy/hetzner/docker-compose.yml
+++ b/deploy/hetzner/docker-compose.yml
@@ -91,10 +91,13 @@ services:
     networks:
       - repo_deepsight
     volumes:
-      # TikTok cookies for yt-dlp auth (TIKTOK_COOKIES_PATH=/app/tiktok_cookies.txt).
-      # Source file on host: /opt/deepsight/repo/tiktok_cookies.txt (sprint 2026-05-11,
-      # uploaded via scp). Read-only mount — backend never writes back to host.
-      - ../../tiktok_cookies.txt:/app/tiktok_cookies.txt:ro
+      # YouTube + TikTok cookies for yt-dlp auth (paths match deploy-backend.yml
+      # workflow convention — files live OUTSIDE the git repo dir for safety).
+      # YOUTUBE_COOKIES_PATH=/app/cookies.txt, TIKTOK_COOKIES_PATH=/app/tiktok_cookies.txt.
+      # Source files on host: /opt/deepsight/{cookies,tiktok_cookies}.txt (uploaded via scp).
+      # Read-only mount — backend never writes back. Empty files OK (auth no-op).
+      - /opt/deepsight/cookies.txt:/app/cookies.txt:ro
+      - /opt/deepsight/tiktok_cookies.txt:/app/tiktok_cookies.txt:ro
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Follow-up to PR #480 — fixes a path mismatch discovered post-merge:

- PR #480 used relative path `../../tiktok_cookies.txt` resolving to `/opt/deepsight/repo/tiktok_cookies.txt`
- The auto-deploy workflow (`.github/workflows/deploy-backend.yml`) already mounts cookies from `/opt/deepsight/{cookies,tiktok_cookies}.txt` (OUTSIDE the repo dir, safer)
- Files moved to that location in the same maintenance window (2026-05-12 11:30 UTC)

This PR aligns docker-compose.yml with the existing convention.

## Changes
- Switch both cookies mounts to absolute host paths (`/opt/deepsight/...txt`)
- Add `cookies.txt` (YouTube) mount that PR #480 missed (parity with deploy-backend.yml)
- Update comment block to reflect both convention + file locations

## Test plan
- [x] Backend container already running with both mounts (verified `/app/tiktok_cookies.txt` 45 KB)
- [x] Health check 200 OK post-restart
- [ ] After merge: future `docker compose -f deploy/hetzner/docker-compose.yml up -d backend` deploys use absolute paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)