### PR TITLE
chore(config): remove dead get_plan_limits compat wrapper

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -858,13 +858,6 @@ def is_semantic_search_v1_enabled() -> bool:
     return SEMANTIC_SEARCH_V1_ENABLED and bool(MISTRAL_API_KEY)
 
 
-def get_plan_limits(plan: str) -> Dict[str, Any]:
-    """Deprecated wrapper kept for binary compatibility. Use billing.plan_config.get_limits."""
-    from billing.plan_config import get_limits
-
-    return get_limits(plan)
-
-
 def get_groq_key() -> Optional[str]:
     return _settings.GROQ_API_KEY or None
 


### PR DESCRIPTION
## Summary
- Removes the 5-line `get_plan_limits()` compat wrapper in `backend/src/core/config.py`.
- All callers migrated to `billing.plan_config.get_limits` in PR #482 (`426ba2db`). Grep confirms zero remaining callers in backend/src and backend/tests.
- Flagged as dead code by reviewer Opus 4.7 during #482 review (out-of-scope at the time).

## Test plan
- [x] `grep -rn "get_plan_limits" backend/src/ backend/tests/` — only the auth/router.py FastAPI route remains (different function).
- [x] `pytest tests/ -k "plan_limits or get_limits or plan_config"` — green.
- [ ] Verify CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)