### PR TITLE
fix(proxy_telemetry): cast :provider to text to avoid asyncpg AmbiguousParameterError

### DIFF
--- a/backend/src/middleware/proxy_telemetry.py
+++ b/backend/src/middleware/proxy_telemetry.py
@@ -266,7 +266,7 @@ async def _upsert_usage(
                     :bytes_in,
                     :bytes_out,
                     1,
-                    jsonb_build_object(:provider, 1)
+                    jsonb_build_object(CAST(:provider AS text), 1)
                 )
                 ON CONFLICT (date) DO UPDATE SET
                     bytes_in = proxy_usage_daily.bytes_in + EXCLUDED.bytes_in,
@@ -274,10 +274,10 @@ async def _upsert_usage(
                     requests_total = proxy_usage_daily.requests_total + 1,
                     requests_by_provider = jsonb_set(
                         COALESCE(proxy_usage_daily.requests_by_provider, '{}'::jsonb),
-                        ARRAY[:provider],
+                        ARRAY[CAST(:provider AS text)],
                         to_jsonb(
                             COALESCE(
-                                (proxy_usage_daily.requests_by_provider->>:provider)::int,
+                                (proxy_usage_daily.requests_by_provider->>CAST(:provider AS text))::int,
                                 0
                             ) + 1
                         ),


### PR DESCRIPTION
## Summary
- Cast `:provider` to text 3x in `_upsert_usage` (jsonb_build_object, ARRAY[...], jsonb->>) to satisfy asyncpg type inference
- Bug present since PR #466 (2026-05-11): `proxy_usage_daily` table at 0 rows for 6 days because every insert silently failed with `AmbiguousParameterError`
- Validated inline against prod PG via SSH before push

## Test plan
- [ ] Merge → wait Hetzner auto-deploy
- [ ] Trigger an analysis using Decodo proxy (any TikTok video)
- [ ] SSH check: `SELECT * FROM proxy_usage_daily WHERE provider = 'decodo'` returns rows
- [ ] Verify AdminProxyStatsTab (next PR) reads correctly