### PR TITLE
feat(proxy_telemetry): instrument 10 httpx call sites via record_proxied_response helper

### DIFF
--- a/backend/src/core/http_client.py
+++ b/backend/src/core/http_client.py
@@ -255,3 +255,51 @@ def is_proxy_configured() -> bool:
     YouTube partira proxifiée ou bare en prod).
     """
     return bool(_get_proxy_url())
+
+
+async def record_proxied_response(response, provider: str) -> None:
+    """Best-effort telemetry helper pour les appels via `get_proxied_client`.
+
+    Appel idiomatique après un `client.get(...)` / `client.post(...)` qui
+    consomme la réponse :
+
+        async with get_proxied_client(timeout=10.0) as client:
+            resp = await client.get(url)
+            await record_proxied_response(resp, provider="tiktok_oembed")
+            data = resp.json()
+
+    L'idée : décharger les call sites de la duplication du try/except autour
+    de `record_proxy_usage`, et standardiser le calcul de `bytes_in` (préférer
+    `num_bytes_downloaded` qui marche pour streamed + non-streamed, fallback
+    `len(content)` si nécessaire).
+
+    Args:
+        response: l'objet `httpx.Response` retourné par client.get/post/etc.
+        provider: identifiant logique du call site, alimente
+            `proxy_usage_daily.requests_by_provider` (ex: "tiktok_oembed",
+            "youtube_oembed", "tikwm", "external_page_scrape", etc.)
+
+    Skip silencieusement :
+    - Si le proxy n'est pas configuré (rien à tracker, dev local)
+    - Si bytes_in = 0 (HEAD request, redirect-only, etc.)
+    - Si l'import / record / DB plante (best-effort, jamais bloquant)
+    """
+    if not _get_proxy_url():
+        return
+    try:
+        from middleware.proxy_telemetry import record_proxy_usage
+
+        # num_bytes_downloaded couvre streamed + non-streamed (httpx ≥0.20).
+        # Fallback `len(content)` si jamais l'attribut manque (mock test, etc.).
+        bytes_in = getattr(response, "num_bytes_downloaded", None)
+        if not bytes_in:
+            try:
+                bytes_in = len(response.content)
+            except Exception:
+                bytes_in = 0
+
+        if bytes_in > 0:
+            await record_proxy_usage(provider=provider, bytes_in=bytes_in)
+    except Exception:
+        # Best-effort : jamais bloquant pour le caller.
+        pass

--- a/backend/src/transcripts/tiktok.py
+++ b/backend/src/transcripts/tiktok.py
@@ -32,7 +32,7 @@ from transcripts.audio_utils import (
     _yt_dlp_extra_args,
 )
 from core.config import get_supadata_key, get_mistral_key
-from core.http_client import get_proxied_client
+from core.http_client import get_proxied_client, record_proxied_response
 
 logger = logging.getLogger(__name__)
 
@@ -433,6 +433,7 @@ async def _resolve_short_url(url: str) -> Optional[str]:
             timeout=15.0,
         ) as client:
             resp = await client.head(url)
+            await record_proxied_response(resp, provider="tiktok_resolve_short")
             resolved = str(resp.url)
             logger.info(f"[TIKTOK] Resolved short URL → {resolved}")
             return resolved
@@ -463,6 +464,7 @@ async def _get_info_via_oembed(url: str) -> Optional[Dict[str, Any]]:
 
         async with get_proxied_client(timeout=10.0) as client:
             resp = await client.get(oembed_url)
+            await record_proxied_response(resp, provider="tiktok_oembed")
             if resp.status_code != 200:
                 logger.warning(f"[TIKTOK] oEmbed returned {resp.status_code}")
                 return None
@@ -811,6 +813,10 @@ async def _get_media_url_from_api(url: str, api_config: dict) -> Optional[str]:
                     headers={"User-Agent": "Mozilla/5.0"},
                 )
 
+            await record_proxied_response(
+                resp,
+                provider=f"tiktok_media_api_{api_config['name']}",
+            )
             if resp.status_code != 200:
                 logger.warning(f"[TIKTOK] API {api_config['name']} returned {resp.status_code}")
                 return None
@@ -837,6 +843,7 @@ async def _download_media_bytes(media_url: str, source: str) -> Optional[bytes]:
             headers={"Referer": "https://www.tiktok.com/"},
         ) as client:
             resp = await client.get(media_url)
+            await record_proxied_response(resp, provider=f"tiktok_media_cdn_{source}")
             if resp.status_code == 200 and len(resp.content) > 1000:
                 logger.info(f"[TIKTOK] Downloaded {len(resp.content) / 1024:.0f}KB from {source}")
                 return resp.content
@@ -1195,6 +1202,7 @@ async def _fetch_tiktok_account_meta_from_html(username: str) -> Optional[Dict[s
             follow_redirects=True,
         ) as client:
             resp = await client.get(url)
+            await record_proxied_response(resp, provider="tiktok_channel_html")
         if resp.status_code != 200:
             logger.info(f"[TIKTOK] HTML meta fetch HTTP {resp.status_code} for @{username}")
             return None

--- a/backend/src/transcripts/youtube.py
+++ b/backend/src/transcripts/youtube.py
@@ -62,7 +62,7 @@ from core.config import (
     get_youtube_proxy,
     TRANSCRIPT_CONFIG,
 )
-from core.http_client import shared_http_client, get_proxied_client
+from core.http_client import shared_http_client, get_proxied_client, record_proxied_response
 
 # 💾 Cache pour les transcripts (TTL 24h)
 try:
@@ -618,6 +618,7 @@ async def get_video_info(video_id: str) -> Optional[Dict[str, Any]]:
         url = f"https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v={video_id}&format=json"
         async with get_proxied_client(timeout=10.0) as client:
             response = await client.get(url, headers={"User-Agent": get_random_user_agent()})
+            await record_proxied_response(response, provider="youtube_oembed")
             if response.status_code == 200:
                 data = response.json()
                 print("  ⚠️ [OEMBED] Got title but no duration", flush=True)

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -34,7 +34,7 @@ from auth.dependencies import (
 )
 from core.config import CATEGORIES, get_mistral_key
 from billing.plan_config import get_limits
-from core.http_client import get_proxied_client, shared_http_client
+from core.http_client import get_proxied_client, shared_http_client, record_proxied_response
 from core.logging import logger
 from core.moderation_service import moderate_text
 
@@ -369,6 +369,7 @@ async def quick_chat_prepare(
         try:
             async with get_proxied_client(timeout=8.0) as client:
                 head_resp = await client.head(url)
+                await record_proxied_response(head_resp, provider="tiktok_resolve_short_quickchat")
                 if head_resp.status_code in (200, 301, 302) and "tiktok.com" in str(head_resp.url):
                     resolved_url = str(head_resp.url).split("?")[0]  # Drop tracking params
                     logger.info(f"[QUICK CHAT] Resolved short URL → {resolved_url[:80]}")
@@ -415,6 +416,7 @@ async def quick_chat_prepare(
                     "https://www.tiktok.com/oembed",
                     params={"url": resolved_url},
                 )
+                await record_proxied_response(oembed_resp, provider="tiktok_oembed_thumbnail")
                 if oembed_resp.status_code == 200:
                     oembed_data = oembed_resp.json()
                     thumbnail_url = oembed_data.get("thumbnail_url", "")

--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, Optional, Tuple
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from core.http_client import get_proxied_client
+from core.http_client import get_proxied_client, record_proxied_response
 from db.database import User, VisualAnalysisQuota
 from transcripts.audio_utils import _yt_dlp_extra_args, executor as audio_executor
 
@@ -481,6 +481,7 @@ async def _download_tiktok_video_no_watermark(url: str, *, log_tag: str) -> Opti
     try:
         async with get_proxied_client(timeout=_TIKWM_TIMEOUT_S) as client:
             resp = await client.post(_TIKWM_API_URL, data={"url": url})
+            await record_proxied_response(resp, provider="tikwm_api")
         if resp.status_code != 200:
             logger.warning("[%s] tikwm API HTTP %d for %s", log_tag, resp.status_code, url)
             return None
@@ -506,6 +507,7 @@ async def _download_tiktok_video_no_watermark(url: str, *, log_tag: str) -> Opti
             headers={"Referer": "https://www.tiktok.com/"},
         ) as client:
             r = await client.get(media_url)
+            await record_proxied_response(r, provider="tikwm_cdn_download")
         if r.status_code != 200:
             logger.warning("[%s] tikwm video CDN HTTP %d for %s", log_tag, r.status_code, media_url[:80])
             return None


### PR DESCRIPTION
## Summary
- Helper `record_proxied_response()` dans `backend/src/core/http_client.py` — centralise pattern `num_bytes_downloaded` priorité → `len(content)` fallback + try/except best-effort
- Instrumentation 10 call sites : tiktok ×5, youtube ×1, videos/router ×2, visual_integration ×2
- Observabilité passe de 2/16 → 12/16 sites trackés
- Mistral API NON tracké (intentionnel : Hetzner→Mistral direct, pas de proxy Decodo)

## Test plan
- [ ] Merger fix asyncpg PR AVANT pour que les inserts marchent
- [ ] Trigger analyse TikTok → vérifier table `proxy_usage_daily` reflète les 5 sites tiktok
- [ ] Trigger analyse YouTube → vérifier sites router + visual_integration trackés