### PR TITLE
feat(academic): Google Scholar deep crawl service + 32 tests (PR 1/3)

### DIFF
--- a/backend/src/academic/scholar.py
+++ b/backend/src/academic/scholar.py
@@ -1,0 +1,608 @@
+"""
+Google Scholar Deep Crawl Client
+================================
+Scraping HTML de la SERP Scholar via proxy Decodo Residential.
+Sans API officielle — Phase 4 conditionnelle (Pro+, opt-in deep_search).
+
+Rate limit : 1 query / 5 s (Redis distributed lock + local fallback)
+Circuit breaker : 3 failures consecutives -> open 1h
+Cache : Redis L1 (TTL 7 jours, key vcache:scholar:{md5(query_normalized)})
+Telemetry : record_proxy_usage(provider="scholar_scrape", bytes_in=len(html_bytes))
+
+PR1 scope :
+- Service standalone (parse + rate-limit + CB + cache + search).
+- NO router integration, NO aggregator hook, NO DB writes.
+- scholar_paper_to_academic() ABSENT in PR1 — depends on AcademicSource.SCHOLAR
+  enum entry which is added in PR2 (schemas.py modification). The conversion
+  helper will land alongside the aggregator phase-4 wiring in PR2.
+
+Hard requirements (spec sect. 4) :
+- get_proxied_client() MANDATORY (Hetzner IP blacklisted by Google).
+- record_proxy_usage() best-effort after each successful fetch.
+- 5s rate limit (NOT 1s, NOT 3s — Scholar bans <3s patterns).
+- 3 failures -> open CB for 1h (NOT 30min, NOT 5min).
+- 7-day cache TTL (NOT 24h — Decodo budget mitigation).
+- NEVER cache an empty papers batch (poisoning anti-pattern).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import random
+import re
+import time
+from typing import List, Optional
+
+from bs4 import BeautifulSoup
+from pydantic import BaseModel, Field
+
+from core.http_client import get_proxied_client
+from middleware.proxy_telemetry import record_proxy_usage, should_bypass_proxy_async
+
+logger = logging.getLogger(__name__)
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Configuration constants
+# ───────────────────────────────────────────────────────────────────────────────
+
+SCHOLAR_BASE_URL = "https://scholar.google.com/scholar"
+SCHOLAR_RATE_INTERVAL = 5.0
+SCHOLAR_RATE_LOCK_KEY = "deepsight:scholar:rate_lock"
+SCHOLAR_CB_FAIL_KEY = "deepsight:scholar:cb_fail_count"
+SCHOLAR_CB_OPEN_KEY = "deepsight:scholar:cb_open_until"
+SCHOLAR_CB_THRESHOLD = 3
+SCHOLAR_CB_OPEN_DURATION = 3600  # 1 hour
+SCHOLAR_CACHE_KEY_PREFIX = "vcache:scholar:"
+SCHOLAR_CACHE_TTL = 7 * 24 * 3600  # 7 days
+SCHOLAR_HTTP_TIMEOUT = 15.0
+SCHOLAR_MIN_HTML_BYTES = 5000
+
+# User-Agent pool (rotation random per query — spec sect. 4.2).
+_UA_POOL: List[str] = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1",
+]
+
+# CAPTCHA / sorry-page detection markers (spec sect. 4.6).
+_CAPTCHA_PATTERNS: List[str] = [
+    "/sorry/index",
+    "<title>sorry...",
+    "unusual traffic from your computer network",
+    "captcha",
+]
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Module-level state (Redis-shared rate limit + CB, local fallback)
+# ───────────────────────────────────────────────────────────────────────────────
+
+_redis_client = None
+_last_local_request_time: float = 0.0
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Pydantic models
+# ───────────────────────────────────────────────────────────────────────────────
+
+
+class ScholarPaper(BaseModel):
+    """Single Scholar result, post-parse."""
+
+    scholar_id: Optional[str] = None
+    title: str
+    authors: List[str] = Field(default_factory=list)
+    year: Optional[int] = None
+    venue: Optional[str] = None
+    abstract: Optional[str] = None
+    url: Optional[str] = None
+    pdf_url: Optional[str] = None
+    citation_count: int = 0
+
+
+class ScholarBatch(BaseModel):
+    """Batch returned by a single SERP fetch."""
+
+    query: str
+    papers: List[ScholarPaper] = Field(default_factory=list)
+    fetched_at: float
+    raw_html_size: int
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Init / state helpers (test-only reset utilities exposed)
+# ───────────────────────────────────────────────────────────────────────────────
+
+
+async def init_scholar_redis(redis_client) -> None:
+    """Connect rate limiter + circuit breaker + cache to the shared Redis client.
+
+    Call from FastAPI startup with the shared async Redis client. If never
+    called, Scholar falls back to per-process local rate limiting and disables
+    circuit breaker + cache (best-effort fail-open).
+    """
+    global _redis_client
+    _redis_client = redis_client
+
+
+def _reset_state_for_tests() -> None:
+    """Reset module-level state. Test-only helper."""
+    global _redis_client, _last_local_request_time
+    _redis_client = None
+    _last_local_request_time = 0.0
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Rate limit (5s, Redis-backed with local fallback)
+# ───────────────────────────────────────────────────────────────────────────────
+
+
+async def _rate_limit() -> None:
+    """Enforce 5s minimum interval between consecutive Scholar queries.
+
+    Distributed via Redis (cross-worker). Falls back to per-process local
+    timer if Redis is unreachable. Spec sect. 4.5.
+    """
+    global _last_local_request_time
+
+    if _redis_client is not None:
+        try:
+            now = time.time()
+            last_raw = await _redis_client.get(SCHOLAR_RATE_LOCK_KEY)
+            if last_raw:
+                try:
+                    last = float(last_raw)
+                    elapsed = now - last
+                    if elapsed < SCHOLAR_RATE_INTERVAL:
+                        await asyncio.sleep(SCHOLAR_RATE_INTERVAL - elapsed)
+                except (ValueError, TypeError):
+                    pass
+            await _redis_client.set(SCHOLAR_RATE_LOCK_KEY, str(time.time()), ex=15)
+            return
+        except Exception as e:
+            logger.debug(f"[SCHOLAR] Redis rate limit failed, fallback local: {e}")
+
+    # Local fallback
+    elapsed = time.time() - _last_local_request_time
+    if elapsed < SCHOLAR_RATE_INTERVAL:
+        await asyncio.sleep(SCHOLAR_RATE_INTERVAL - elapsed)
+    _last_local_request_time = time.time()
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Circuit breaker (3 failures -> open 1h)
+# ───────────────────────────────────────────────────────────────────────────────
+
+
+async def is_circuit_open() -> bool:
+    """Returns True if the breaker is currently open. Fail-open if Redis down."""
+    if _redis_client is None:
+        return False
+    try:
+        open_until = await _redis_client.get(SCHOLAR_CB_OPEN_KEY)
+        if open_until:
+            try:
+                if float(open_until) > time.time():
+                    return True
+            except (ValueError, TypeError):
+                return False
+    except Exception as e:
+        logger.debug(f"[SCHOLAR] CB is_circuit_open Redis failed: {e}")
+    return False
+
+
+async def _record_failure(reason: str) -> None:
+    """Increment failure counter; open breaker if threshold reached."""
+    if _redis_client is None:
+        return
+    try:
+        count = await _redis_client.incr(SCHOLAR_CB_FAIL_KEY)
+        await _redis_client.expire(SCHOLAR_CB_FAIL_KEY, 600)
+        if int(count) >= SCHOLAR_CB_THRESHOLD:
+            open_until = time.time() + SCHOLAR_CB_OPEN_DURATION
+            await _redis_client.set(
+                SCHOLAR_CB_OPEN_KEY,
+                str(open_until),
+                ex=SCHOLAR_CB_OPEN_DURATION,
+            )
+            await _redis_client.delete(SCHOLAR_CB_FAIL_KEY)
+            logger.warning(
+                f"[SCHOLAR] Circuit OPEN for {SCHOLAR_CB_OPEN_DURATION}s "
+                f"(reason={reason}, count={count})"
+            )
+    except Exception as e:
+        logger.debug(f"[SCHOLAR] CB record_failure Redis failed: {e}")
+
+
+async def _record_success() -> None:
+    """Reset failure counter on successful fetch."""
+    if _redis_client is None:
+        return
+    try:
+        await _redis_client.delete(SCHOLAR_CB_FAIL_KEY)
+    except Exception as e:
+        logger.debug(f"[SCHOLAR] CB record_success Redis failed: {e}")
+
+
+def _is_bad_html(html: str) -> Optional[str]:
+    """Detect CAPTCHA / error pages. Returns failure reason or None."""
+    if len(html) < SCHOLAR_MIN_HTML_BYTES:
+        return f"html_too_short_{len(html)}"
+    lower = html.lower()
+    for pattern in _CAPTCHA_PATTERNS:
+        if pattern in lower:
+            return f"captcha_pattern:{pattern}"
+    return None
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Cache (Redis L1, TTL 7 days)
+# ───────────────────────────────────────────────────────────────────────────────
+
+
+def _cache_key(query: str) -> str:
+    """Build a normalized cache key from a query string."""
+    normalized = query.lower().strip()
+    h = hashlib.md5(normalized.encode("utf-8")).hexdigest()
+    return f"{SCHOLAR_CACHE_KEY_PREFIX}{h}"
+
+
+async def _cache_get(query: str) -> Optional[ScholarBatch]:
+    """Read a cached batch from Redis. Returns None on miss or any error."""
+    if _redis_client is None:
+        return None
+    try:
+        raw = await _redis_client.get(_cache_key(query))
+        if raw:
+            data = json.loads(raw)
+            return ScholarBatch.model_validate(data)
+    except Exception as e:
+        logger.debug(f"[SCHOLAR] cache get failed: {e}")
+    return None
+
+
+async def _cache_set(query: str, batch: ScholarBatch) -> None:
+    """Persist a batch in Redis (TTL 7d). NEVER stores an empty papers batch.
+
+    Empty-batch cache-poisoning protection — spec sect. 8.3. A 0-paper batch
+    is most often the result of a transient CAPTCHA / parse error and would
+    pollute the cache for a week.
+    """
+    if _redis_client is None:
+        return
+    if not batch.papers:
+        logger.debug(f"[SCHOLAR] skipping cache_set: empty batch for q='{query[:60]}'")
+        return
+    try:
+        await _redis_client.set(
+            _cache_key(query),
+            batch.model_dump_json(),
+            ex=SCHOLAR_CACHE_TTL,
+        )
+    except Exception as e:
+        logger.debug(f"[SCHOLAR] cache set failed: {e}")
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# HTML parser (BeautifulSoup, spec sect. 4.7)
+# ───────────────────────────────────────────────────────────────────────────────
+
+# Citation count patterns: EN ("Cited by 42") + FR ("Cité 13 fois").
+_CITATION_REGEX_EN = re.compile(r"Cited by (\d+)", re.IGNORECASE)
+_CITATION_REGEX_FR = re.compile(r"Cit[ée]?\s+(\d+)\s+fois", re.IGNORECASE)
+_YEAR_REGEX = re.compile(r"\b(19\d{2}|20\d{2})\b")
+_TITLE_PREFIX_REGEX = re.compile(
+    r"^\s*\[(PDF|HTML|CITATION|BOOK|B|DOC)\]\s*", re.IGNORECASE
+)
+
+
+def parse_scholar_html(html: str) -> List[ScholarPaper]:
+    """Parse a Scholar SERP HTML into a list of ScholarPaper.
+
+    Tolerates partial / malformed HTML — exceptions on individual results are
+    swallowed and the result is skipped. Returns [] on top-level parse error.
+    """
+    papers: List[ScholarPaper] = []
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception as e:
+        logger.warning(f"[SCHOLAR] parse_scholar_html top-level error: {e}")
+        return papers
+
+    # Match div.gs_r (with or without the gs_or / gs_scl secondary classes).
+    try:
+        candidates = soup.find_all("div", class_="gs_r")
+    except Exception as e:
+        logger.warning(f"[SCHOLAR] find_all gs_r failed: {e}")
+        return papers
+
+    for div in candidates:
+        try:
+            scholar_id = None
+            try:
+                scholar_id = div.get("data-cid") or None
+            except Exception:
+                scholar_id = None
+
+            h3 = div.find("h3", class_="gs_rt")
+            if h3 is None:
+                continue
+            a = h3.find("a")
+            if a is None or not a.get_text(strip=True):
+                continue
+            raw_title = h3.get_text(strip=True)
+            title = _TITLE_PREFIX_REGEX.sub("", raw_title).strip()
+            # Sometimes there is more than one prefix like [BOOK][B] — strip until stable.
+            for _ in range(3):
+                stripped = _TITLE_PREFIX_REGEX.sub("", title).strip()
+                if stripped == title:
+                    break
+                title = stripped
+            if not title:
+                continue
+
+            url = a.get("href") or None
+
+            authors: List[str] = []
+            year: Optional[int] = None
+            venue: Optional[str] = None
+            gs_a = div.find("div", class_="gs_a")
+            if gs_a is not None:
+                gs_a_text = gs_a.get_text(separator=" ", strip=True)
+                italic = gs_a.find("i")
+                if italic is not None:
+                    venue_text = italic.get_text(strip=True)
+                    venue = venue_text or None
+                # Split on " - " to isolate authors block (1st segment).
+                parts = gs_a_text.split(" - ")
+                if parts:
+                    author_str = parts[0]
+                    # Authors separated by ", " — keep raw names.
+                    candidate_authors = [a.strip() for a in author_str.split(",") if a.strip()]
+                    # Defensive: drop tokens that look like years (rare format glitches).
+                    authors = [a for a in candidate_authors if not _YEAR_REGEX.fullmatch(a)]
+                year_matches = _YEAR_REGEX.findall(gs_a_text)
+                if year_matches:
+                    try:
+                        year = int(year_matches[-1])
+                    except (ValueError, TypeError):
+                        year = None
+
+            abstract: Optional[str] = None
+            gs_rs = div.find("div", class_="gs_rs")
+            if gs_rs is not None:
+                abstract_text = gs_rs.get_text(separator=" ", strip=True)
+                abstract = abstract_text or None
+
+            citation_count = 0
+            gs_fl = div.find("div", class_="gs_fl")
+            if gs_fl is not None:
+                for link in gs_fl.find_all("a"):
+                    link_text = link.get_text(strip=True)
+                    m = _CITATION_REGEX_EN.search(link_text)
+                    if m is None:
+                        m = _CITATION_REGEX_FR.search(link_text)
+                    if m is not None:
+                        try:
+                            citation_count = int(m.group(1))
+                            break
+                        except (ValueError, TypeError):
+                            pass
+
+            pdf_url: Optional[str] = None
+            ggsm = div.find("div", class_="gs_or_ggsm")
+            if ggsm is not None:
+                pdf_a = ggsm.find("a")
+                if pdf_a is not None:
+                    pdf_text = pdf_a.get_text()
+                    if "[PDF]" in pdf_text.upper():
+                        pdf_url = pdf_a.get("href") or None
+                    else:
+                        # Some pages omit the [PDF] tag inline but the link is still a PDF.
+                        href_candidate = pdf_a.get("href") or ""
+                        if href_candidate.lower().endswith(".pdf"):
+                            pdf_url = href_candidate
+
+            papers.append(
+                ScholarPaper(
+                    scholar_id=scholar_id,
+                    title=title,
+                    authors=authors,
+                    year=year,
+                    venue=venue,
+                    abstract=abstract,
+                    url=url,
+                    pdf_url=pdf_url,
+                    citation_count=citation_count,
+                )
+            )
+        except Exception as e:
+            logger.debug(f"[SCHOLAR] skip item parse error: {e}")
+            continue
+
+    return papers
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Public API : search_scholar()
+# ───────────────────────────────────────────────────────────────────────────────
+
+
+def _build_scholar_url(query: str, limit: int) -> str:
+    """Build the Scholar SERP URL. URL-encode the query."""
+    # Encode the query value. We use httpx-friendly manual encoding to keep
+    # behaviour deterministic & avoid pulling urllib at top of module.
+    from urllib.parse import quote_plus
+
+    safe_q = quote_plus(query)
+    safe_n = max(1, min(int(limit), 20))
+    return f"{SCHOLAR_BASE_URL}?q={safe_q}&hl=fr&num={safe_n}&start=0"
+
+
+def _build_headers() -> dict:
+    """Return realistic browser headers with a randomly selected UA."""
+    return {
+        "User-Agent": random.choice(_UA_POOL),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Accept-Encoding": "gzip, deflate, br",
+        "DNT": "1",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+    }
+
+
+def _empty_batch(query: str, raw_html_size: int = 0) -> ScholarBatch:
+    """Helper for early-return empty batches (CAPTCHA, hard-stop, etc.)."""
+    return ScholarBatch(
+        query=query,
+        papers=[],
+        fetched_at=time.time(),
+        raw_html_size=raw_html_size,
+    )
+
+
+async def search_scholar(
+    query: str,
+    *,
+    limit: int = 20,
+    use_cache: bool = True,
+) -> ScholarBatch:
+    """Scrape Google Scholar SERP page 1 for the given query.
+
+    Flow:
+      1. Sanitize query, early-return empty batch if blank.
+      2. Cache HIT -> short-circuit (no rate-limit, no CB check, no proxy).
+      3. Circuit-open -> empty batch.
+      4. Decodo hard-stop (MTD > 950MB) -> empty batch.
+      5. Rate-limit (5s).
+      6. GET via get_proxied_client() (MANDATORY).
+      7. record_proxy_usage (best-effort).
+      8. Detect bad HTML (429 / 503 / CAPTCHA / too short) -> record_failure + empty.
+      9. parse_scholar_html(html) -> papers.
+      10. record_success + cache_set (skip cache if papers empty).
+
+    Never raises — all exceptions are logged as warnings and translated
+    into an empty batch. The aggregator (PR2) treats an empty batch as
+    "skip phase 4" silently.
+    """
+    query = (query or "").strip()
+    if not query:
+        return _empty_batch(query)
+
+    # 1. Cache lookup (no side effects).
+    if use_cache:
+        try:
+            cached = await _cache_get(query)
+        except Exception as e:
+            logger.debug(f"[SCHOLAR] cache_get raised: {e}")
+            cached = None
+        if cached is not None:
+            logger.info(f"[SCHOLAR] cache HIT q='{query[:60]}' ({len(cached.papers)} papers)")
+            return cached
+
+    # 2. Circuit breaker.
+    try:
+        circuit_open = await is_circuit_open()
+    except Exception as e:
+        logger.debug(f"[SCHOLAR] is_circuit_open raised: {e}")
+        circuit_open = False
+    if circuit_open:
+        logger.warning(f"[SCHOLAR] circuit OPEN — skip q='{query[:60]}'")
+        return _empty_batch(query)
+
+    # 3. Decodo proxy hard-stop.
+    try:
+        bypass = await should_bypass_proxy_async()
+    except Exception as e:
+        logger.debug(f"[SCHOLAR] should_bypass_proxy_async raised: {e}")
+        bypass = False
+    if bypass:
+        logger.warning(f"[SCHOLAR] proxy hard-stop — skip q='{query[:60]}'")
+        return _empty_batch(query)
+
+    # 4. Rate limit (5s).
+    await _rate_limit()
+
+    # 5. Build request + fire via proxy.
+    url = _build_scholar_url(query, limit)
+    headers = _build_headers()
+
+    html = ""
+    status_code: Optional[int] = None
+    try:
+        async with get_proxied_client(timeout=SCHOLAR_HTTP_TIMEOUT, headers=headers) as client:
+            resp = await client.get(url)
+            html = resp.text or ""
+            status_code = resp.status_code
+    except Exception as e:
+        logger.warning(f"[SCHOLAR] HTTP error: {e}")
+        await _record_failure("http_exception")
+        return _empty_batch(query, raw_html_size=len(html))
+
+    # 6. Telemetry (best-effort).
+    try:
+        bytes_in = len(html.encode("utf-8", errors="replace")) if html else 0
+        if bytes_in > 0:
+            await record_proxy_usage(provider="scholar_scrape", bytes_in=bytes_in)
+    except Exception as e:
+        logger.debug(f"[SCHOLAR] telemetry failed: {e}")
+
+    # 7. Bad-response detection.
+    if status_code in (429, 503):
+        await _record_failure(f"http_{status_code}")
+        return _empty_batch(query, raw_html_size=len(html))
+    bad_reason = _is_bad_html(html)
+    if bad_reason is not None:
+        await _record_failure(bad_reason)
+        return _empty_batch(query, raw_html_size=len(html))
+
+    # 8. Parse + record success + cache.
+    papers = parse_scholar_html(html)
+    await _record_success()
+
+    safe_limit = max(1, min(int(limit), 20))
+    batch = ScholarBatch(
+        query=query,
+        papers=papers[:safe_limit],
+        fetched_at=time.time(),
+        raw_html_size=len(html),
+    )
+    await _cache_set(query, batch)
+    logger.info(
+        f"[SCHOLAR] OK q='{query[:60]}' ({len(papers)} papers, html={len(html)}B)"
+    )
+    return batch
+
+
+__all__ = [
+    "SCHOLAR_BASE_URL",
+    "SCHOLAR_CACHE_KEY_PREFIX",
+    "SCHOLAR_CACHE_TTL",
+    "SCHOLAR_CB_FAIL_KEY",
+    "SCHOLAR_CB_OPEN_DURATION",
+    "SCHOLAR_CB_OPEN_KEY",
+    "SCHOLAR_CB_THRESHOLD",
+    "SCHOLAR_HTTP_TIMEOUT",
+    "SCHOLAR_MIN_HTML_BYTES",
+    "SCHOLAR_RATE_INTERVAL",
+    "SCHOLAR_RATE_LOCK_KEY",
+    "ScholarBatch",
+    "ScholarPaper",
+    "_cache_key",
+    "_is_bad_html",
+    "_record_failure",
+    "_record_success",
+    "_reset_state_for_tests",
+    "init_scholar_redis",
+    "is_circuit_open",
+    "parse_scholar_html",
+    "search_scholar",
+]

--- a/backend/tests/fixtures/scholar/serp_books.html
+++ b/backend/tests/fixtures/scholar/serp_books.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="fr"><head><meta charset="utf-8"><title>histoire de la folie - Google Scholar</title></head>
+<body>
+<div id="gs_hdr">Google Scholar - synthetic fixture pour la regression testing des prefixes [BOOK], [B], [CITATION], et des citations FR. Cette fixture contient 15 résultats représentatifs incluant livres, chapitres d'ouvrages, thèses et citations. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris. Integer in mauris eu nibh euismod gravida. Duis ac tellus et risus vulputate vehicula. Donec lobortis risus a elit. Etiam tempor. Ut ullamcorper, ligula eu tempor congue, eros est euismod turpis, id tincidunt sapien risus a quam.</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B01">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[BOOK]</span>
+      <a href="https://books.google.com/books?id=foucault1">Histoire de la folie à l'âge classique</a>
+    </h3>
+    <div class="gs_a">M Foucault - 1972 - <i>Gallimard</i></div>
+    <div class="gs_rs">Cette œuvre majeure de Michel Foucault retrace l'histoire de la conception de la folie en Occident depuis la Renaissance. L'auteur examine la transformation ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B01&hl=fr">Cité 8421 fois</a>
+      <a href="/scholar?q=related:foucault">Articles connexes</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B02">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[B]</span>
+      <a href="https://books.google.com/books?id=histoire_psy">Histoire de la psychiatrie en France</a>
+    </h3>
+    <div class="gs_a">J Postel, C Quétel - <i>Dunod</i>, 1994 - dunod.com</div>
+    <div class="gs_rs">Histoire complète de la psychiatrie française depuis le XVIIIe siècle. Couvre les figures fondatrices comme Pinel et Esquirol, les institutions et les théories ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B02&hl=fr">Cité 412 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B03">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://theses.fr/2018PA01">L'aliénation mentale dans la France révolutionnaire</a>
+    </h3>
+    <div class="gs_a">A Dubois - 2018 - theses.fr</div>
+    <div class="gs_rs">Thèse de doctorat en histoire. Cette recherche analyse les transformations de la prise en charge de l'aliénation mentale durant la période révolutionnaire ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B03&hl=fr">Cité 13 fois</a>
+    </div>
+  </div>
+  <div class="gs_or_ggsm">
+    <a href="https://theses.fr/2018PA01.pdf" class="gs_or_btn_lt">
+      <span class="gs_ctg2">[PDF]</span> theses.fr
+    </a>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B04">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[BOOK]</span>
+      <a href="https://books.google.com/books?id=naissance_clinique">Naissance de la clinique</a>
+    </h3>
+    <div class="gs_a">M Foucault - 1963 - <i>Presses Universitaires de France</i></div>
+    <div class="gs_rs">Une archéologie du regard médical. Foucault examine la transformation de la médecine clinique à la fin du XVIIIe siècle et l'émergence du regard pathologique ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B04&hl=fr">Cité 5210 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B05">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[CITATION]</span>
+      <a href="https://example.com/no-url">Réflexions sur l'hôpital général</a>
+    </h3>
+    <div class="gs_a">P Bernard - <i>Revue d'histoire moderne</i>, 1985 - persee.fr</div>
+    <div class="gs_rs">Article fondateur sur l'institution de l'hôpital général au XVIIe siècle et son rôle dans le grand renfermement des marginaux ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B05&hl=fr">Cité 67 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B06">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[BOOK]</span>
+      <a href="https://books.google.com/books?id=ricoeur_memory">La mémoire, l'histoire, l'oubli</a>
+    </h3>
+    <div class="gs_a">P Ricœur - 2000 - <i>Seuil</i></div>
+    <div class="gs_rs">Œuvre monumentale du philosophe français Paul Ricœur consacrée aux relations entre mémoire, histoire et oubli. L'auteur articule phénoménologie ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B06&hl=fr">Cité 2341 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B07">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://hal.archives-ouvertes.fr/hal-12345">Les pratiques d'enfermement avant Pinel</a>
+    </h3>
+    <div class="gs_a">L Petit, M Durand - <i>Annales HSS</i>, 2017 - cambridge.org</div>
+    <div class="gs_rs">Cette étude examine les pratiques de prise en charge des aliénés en France avant les réformes de Pinel. Nous analysons les sources institutionnelles ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B07&hl=fr">Cité 28 fois</a>
+    </div>
+  </div>
+  <div class="gs_or_ggsm">
+    <a href="https://hal.archives-ouvertes.fr/hal-12345/document" class="gs_or_btn_lt">
+      <span class="gs_ctg2">[PDF]</span> hal.archives-ouvertes.fr
+    </a>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B08">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[B]</span>
+      <a href="https://books.google.com/books?id=bachelard_rationalisme">Le rationalisme appliqué</a>
+    </h3>
+    <div class="gs_a">G Bachelard - 1949 - <i>Presses Universitaires de France</i></div>
+    <div class="gs_rs">Essai d'épistémologie consacré aux relations entre rationalisme et expérience scientifique. Bachelard développe sa notion d'obstacle épistémologique ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B08&hl=fr">Cité 1856 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B09">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/anthropologie">Anthropologie historique de la folie</a>
+    </h3>
+    <div class="gs_a">F Laplantine - <i>L'Harmattan</i>, 1992 - editions-harmattan.fr</div>
+    <div class="gs_rs">Anthropologue, l'auteur croise les approches historique et culturelle de la folie. Compare les conceptions occidentales et non-occidentales ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B09&hl=fr">Cité 145 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B10">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[BOOK]</span>
+      <a href="https://books.google.com/books?id=castel_psychanalysme">Le psychanalysme</a>
+    </h3>
+    <div class="gs_a">R Castel - 1973 - <i>Maspero</i></div>
+    <div class="gs_rs">Critique sociologique du discours psychanalytique. Castel analyse les conditions sociales de production du savoir psychanalytique en France ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B10&hl=fr">Cité 387 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B11">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/swain">Le sujet de la folie</a>
+    </h3>
+    <div class="gs_a">G Swain - <i>Privat</i>, 1977 - editions-privat.fr</div>
+    <div class="gs_rs">Ouvrage majeur sur la conception médicale et philosophique du sujet aliéné. Swain conteste certaines thèses de Foucault sur le grand renfermement ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B11&hl=fr">Cité 234 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B12">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[B]</span>
+      <a href="https://books.google.com/books?id=gauchet_revolution">La révolution psychiatrique</a>
+    </h3>
+    <div class="gs_a">M Gauchet, G Swain - 1980 - <i>Gallimard</i></div>
+    <div class="gs_rs">Étude historique sur la naissance de la psychiatrie comme discipline médicale au tournant du XIXe siècle. Examen des fondements théoriques et institutionnels ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B12&hl=fr">Cité 521 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B13">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/quetel">La folie dans les institutions</a>
+    </h3>
+    <div class="gs_a">C Quétel - <i>Tallandier</i>, 2009 - editions-tallandier.com</div>
+    <div class="gs_rs">Synthèse historique sur les institutions psychiatriques en France de l'Ancien Régime à nos jours. Couvre asiles, hôpitaux psychiatriques et CHU ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B13&hl=fr">Cité 89 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B14">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[CITATION]</span>
+      <a href="https://example.com/lacan-no-url">Écrits techniques sur la psychose</a>
+    </h3>
+    <div class="gs_a">J Lacan - 1955 - <i>Séminaire III</i></div>
+    <div class="gs_rs">Séminaire fondateur de Lacan sur la psychose, posant les bases de sa théorie de la forclusion du Nom-du-Père. Cours dispensés à Sainte-Anne ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B14&hl=fr">Cité 1287 fois</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000B15">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[BOOK]</span>
+      <a href="https://books.google.com/books?id=zemora">Récits de l'asile au XIXe siècle</a>
+    </h3>
+    <div class="gs_a">N Zemon, O Vaillant - <i>La Découverte</i>, 2005 - editionsladecouverte.fr</div>
+    <div class="gs_rs">Anthologie commentée de récits autobiographiques d'aliénés au XIXe siècle. Édition critique avec notes historiques et appareil iconographique ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000B15&hl=fr">Cité 56 fois</a>
+    </div>
+  </div>
+</div>
+
+<div id="gs_ftr">Google Scholar footer - 15 résultats - synthetic fixture testing [BOOK]/[B]/[CITATION] prefixes and FR citation format ('Cité N fois')</div>
+</body></html>

--- a/backend/tests/fixtures/scholar/serp_empty.html
+++ b/backend/tests/fixtures/scholar/serp_empty.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr"><head><meta charset="utf-8"><title>xyzzqq nonsense query - Google Scholar</title></head>
+<body>
+<div id="gs_hdr">Google Scholar - synthetic fixture pour tester le parser sur un résultat vide. Cette fixture simule une requête sans aucun résultat retourné, tout en dépassant le seuil minimum de longueur HTML utilisé par le détecteur de anti-bot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris. Integer in mauris eu nibh euismod gravida. Duis ac tellus et risus vulputate vehicula. Donec lobortis risus a elit. Etiam tempor. Ut ullamcorper, ligula eu tempor congue, eros est euismod turpis, id tincidunt sapien risus a quam. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue. Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla. Donec blandit feugiat ligula. Donec hendrerit, felis et imperdiet euismod, purus ipsum pretium metus, in lacinia nulla nisl eget sapien. Donec ut est in lectus consequat consequat. Etiam eget dui. Aliquam erat volutpat. Sed at lorem in nunc porta tristique. Proin nec augue. Quisque aliquam tempor magna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</div>
+
+<div id="gs_res_ccl_mid">
+  <div class="gs_alrt">
+    <p>Aucun résultat trouvé pour <b>xyzzqq nonsense query</b>.</p>
+    <p>Suggestions:
+      <ul>
+        <li>Assurez-vous que tous les mots sont correctement orthographiés.</li>
+        <li>Essayez des mots-clés différents.</li>
+        <li>Essayez des mots-clés plus généraux.</li>
+        <li>Essayez moins de mots-clés.</li>
+      </ul>
+    </p>
+    <p>No results found. Try a different query. Loremipsum: Suspendisse potenti. Fusce mauris vestibulum luctus, neque mauris luctus risus, in tincidunt nibh sapien et neque. Sed accumsan ligula a quam. Fusce dapibus quam id leo. Aliquam erat volutpat. Nullam mi metus, aliquet a, lacinia non, viverra nec, augue. Suspendisse potenti. Quisque facilisis odio at sapien. Aliquam vel libero. Duis sed velit. Nam ut leo eget odio dignissim cursus. Cras lacinia, ipsum at pulvinar gravida, libero magna porttitor risus, in interdum massa metus eget ipsum. Phasellus rutrum ipsum eu lectus.</p>
+    <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat.</p>
+  </div>
+</div>
+
+<div id="gs_ftr">Footer Scholar - aucun résultat correspondant - padding pour dépasser 5000 caractères de HTML afin de ne pas être confondu avec un anti-bot. Lorem ipsum: Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus. Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetur ligula vulputate sem tristique cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi. Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate, nunc. Sed adipiscing ornare risus. Morbi est est, blandit sit amet, sagittis vel, euismod vel, velit. Pellentesque egestas sem. Suspendisse commodo ullamcorper magna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante.</div>
+
+<div id="gs_padding" style="display:none">
+  Padding section to bring total HTML byte count above the 5000-byte anti-bot detection threshold without introducing parseable result divs. This section contains no `gs_r` divs and therefore will not produce any ScholarPaper entries when run through parse_scholar_html. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Curabitur pretium tincidunt lacus. Nulla gravida orci a odio.
+</div>
+</body></html>

--- a/backend/tests/fixtures/scholar/serp_normal.html
+++ b/backend/tests/fixtures/scholar/serp_normal.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html lang="fr"><head><meta charset="utf-8"><title>quantum computing - Google Scholar</title></head>
+<body>
+<div id="gs_hdr">Google Scholar Header Bar - synthetic fixture for parser regression testing - padded to provide enough bytes to bypass the minimum-length sanity check. The synthetic Scholar SERP fixture below contains 20 representative results covering peer-reviewed articles, PDFs, books and citations. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris. Integer in mauris eu nibh euismod gravida. Duis ac tellus et risus vulputate vehicula. Donec lobortis risus a elit. Etiam tempor. Ut ullamcorper, ligula eu tempor congue, eros est euismod turpis, id tincidunt sapien risus a quam.</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000001">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[PDF]</span>
+      <a href="https://example.com/quantum1.pdf">Quantum Computing: Foundations and Algorithms</a>
+    </h3>
+    <div class="gs_a">A Smith, B Johnson, C Lee - <i>Nature Physics</i>, 2023 - nature.com</div>
+    <div class="gs_rs">A comprehensive introduction to quantum computing fundamentals including superposition, entanglement, and Shor's algorithm. We cover both theoretical foundations and ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000001&hl=fr">Cited by 1247</a>
+      <a href="/scholar?q=related:abc">Related articles</a>
+    </div>
+  </div>
+  <div class="gs_or_ggsm">
+    <a href="https://example.com/quantum1.pdf" class="gs_or_btn_lt">
+      <span class="gs_ctg2">[PDF]</span> example.com
+    </a>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000002">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://arxiv.org/abs/2301.12345">A Survey of Quantum Error Correction Codes</a>
+    </h3>
+    <div class="gs_a">M Chen, K Wang - <i>arXiv preprint arXiv:2301.12345</i>, 2023 - arxiv.org</div>
+    <div class="gs_rs">We survey recent advances in quantum error correction with a focus on surface codes and color codes. The paper discusses fault-tolerant thresholds and ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000002&hl=fr">Cited by 532</a>
+      <a href="/scholar?q=related:def">Related articles</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000003">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[HTML]</span>
+      <a href="https://journals.aps.org/prx/abstract/10.1103/PhysRevX.13.011001">Variational Quantum Algorithms for Optimization Problems</a>
+    </h3>
+    <div class="gs_a">R Patel, S Gupta - <i>Physical Review X</i>, 2023 - APS</div>
+    <div class="gs_rs">Variational quantum algorithms offer a promising path to near-term quantum advantage. We analyze convergence properties for combinatorial optimization tasks ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000003&hl=fr">Cited by 421</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000004">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.org/qc-applications">Applications of Quantum Computing in Drug Discovery</a>
+    </h3>
+    <div class="gs_a">L Martin, P Nguyen, T Wong - <i>Nature Reviews Drug Discovery</i>, 2022 - nature.com</div>
+    <div class="gs_rs">Quantum computing has emerged as a transformative tool in drug discovery, enabling rapid molecular simulations. This review covers methodologies for ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000004&hl=fr">Cited by 312</a>
+    </div>
+  </div>
+  <div class="gs_or_ggsm">
+    <a href="https://example.org/qc-applications.pdf" class="gs_or_btn_lt">
+      <span class="gs_ctg2">[PDF]</span> example.org
+    </a>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000005">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://doi.org/10.1109/IEEE.2022.123">Hardware Implementations of Superconducting Qubits</a>
+    </h3>
+    <div class="gs_a">F Dubois, G Müller - <i>IEEE Transactions on Quantum Engineering</i>, 2022 - ieeexplore.ieee.org</div>
+    <div class="gs_rs">This paper presents a comparative analysis of superconducting qubit implementations from major industry players. We benchmark coherence times and gate fidelities ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000005&hl=fr">Cited by 198</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000006">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc6">Photonic Quantum Computing: Recent Advances</a>
+    </h3>
+    <div class="gs_a">H Tanaka, I Yamamoto - <i>Optics Express</i>, 2021 - osa.org</div>
+    <div class="gs_rs">Photonic quantum computing offers room-temperature operation and natural integration with telecom infrastructure. This review surveys progress over the last five years ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000006&hl=fr">Cited by 145</a>
+    </div>
+  </div>
+  <div class="gs_or_ggsm">
+    <a href="https://osa.org/photonic.pdf" class="gs_or_btn_lt">
+      <span class="gs_ctg2">[PDF]</span> osa.org
+    </a>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000007">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc7">Trapped Ion Quantum Computing at Scale</a>
+    </h3>
+    <div class="gs_a">J Schmidt, K Albrecht, L Romero - <i>Physical Review Letters</i>, 2021 - APS</div>
+    <div class="gs_rs">We demonstrate trapped ion quantum computing with 200 qubits, achieving gate fidelities exceeding 99.7%. The architecture scales linearly with ion count ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000007&hl=fr">Cited by 723</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000008">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc8">Quantum Supremacy with 53 Superconducting Qubits</a>
+    </h3>
+    <div class="gs_a">M Anderson, N Kim - <i>Nature</i>, 2019 - nature.com</div>
+    <div class="gs_rs">We demonstrate quantum supremacy on a programmable processor with 53 superconducting qubits, sampling output of a pseudo-random quantum circuit ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000008&hl=fr">Cited by 5421</a>
+    </div>
+  </div>
+  <div class="gs_or_ggsm">
+    <a href="https://example.com/qc8.pdf" class="gs_or_btn_lt">
+      <span class="gs_ctg2">[PDF]</span> example.com
+    </a>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000009">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc9">Topological Quantum Computing with Majorana Fermions</a>
+    </h3>
+    <div class="gs_a">O Lindqvist, P Romano - <i>Reviews of Modern Physics</i>, 2020 - APS</div>
+    <div class="gs_rs">Topological quantum computing using Majorana fermions promises intrinsic fault tolerance. This review covers theoretical foundations and experimental milestones ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000009&hl=fr">Cited by 891</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000010">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc10">Quantum Machine Learning: State of the Art</a>
+    </h3>
+    <div class="gs_a">Q Banerjee, R Kapoor, S Tiwari - <i>Machine Learning: Science and Technology</i>, 2022 - IOP</div>
+    <div class="gs_rs">Quantum machine learning combines quantum computing with classical machine learning techniques. We review recent developments in variational quantum circuits ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000010&hl=fr">Cited by 267</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000011">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc11">Quantum Cryptography: From Theory to Implementation</a>
+    </h3>
+    <div class="gs_a">T Fernandez, U Wallenberg - <i>Journal of Cryptology</i>, 2020 - Springer</div>
+    <div class="gs_rs">Quantum key distribution protocols enable provably secure communication. We survey BB84 and continuous-variable QKD implementations across fiber and satellite ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000011&hl=fr">Cited by 376</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000012">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc12">Noisy Intermediate-Scale Quantum (NISQ) Era</a>
+    </h3>
+    <div class="gs_a">V Preskill - <i>Quantum</i>, 2018 - quantum-journal.org</div>
+    <div class="gs_rs">The Noisy Intermediate-Scale Quantum (NISQ) era describes the current state of quantum devices, characterized by 50-100 qubits without full error correction ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000012&hl=fr">Cited by 3892</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000013">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <span class="gs_ct1">[PDF]</span>
+      <a href="https://example.com/qc13.pdf">Shor's Algorithm: Implementation and Analysis</a>
+    </h3>
+    <div class="gs_a">W Park, X Liu - <i>SIAM Journal on Computing</i>, 2019 - SIAM</div>
+    <div class="gs_rs">We present an analysis of Shor's algorithm with detailed circuit decomposition for factoring 15 and 21 on existing hardware. Resource estimates suggest ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000013&hl=fr">Cited by 234</a>
+    </div>
+  </div>
+  <div class="gs_or_ggsm">
+    <a href="https://example.com/qc13.pdf" class="gs_or_btn_lt">
+      <span class="gs_ctg2">[PDF]</span> example.com
+    </a>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000014">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc14">Grover's Search Algorithm: A Tutorial</a>
+    </h3>
+    <div class="gs_a">Y Cohen, Z Singh - <i>ACM Computing Surveys</i>, 2020 - ACM</div>
+    <div class="gs_rs">Grover's algorithm provides quadratic speedup for unstructured search. This tutorial walks through the construction of the oracle, diffusion operator and ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000014&hl=fr">Cited by 178</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000015">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc15">Quantum Networks for Distributed Computing</a>
+    </h3>
+    <div class="gs_a">A Beauchamp, B Caron - <i>Quantum Science and Technology</i>, 2022 - IOP</div>
+    <div class="gs_rs">Quantum networks enable distributed quantum computing across geographically separated nodes. We discuss entanglement distribution and quantum repeaters ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000015&hl=fr">Cited by 89</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000016">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc16">Quantum Annealing for Combinatorial Optimization</a>
+    </h3>
+    <div class="gs_a">C Dupont, D Eriksson - <i>European Physical Journal Quantum Technology</i>, 2021 - Springer</div>
+    <div class="gs_rs">Quantum annealing offers a heuristic approach to NP-hard problems. We benchmark D-Wave's quantum annealer against classical simulated annealing on ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000016&hl=fr">Cited by 156</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000017">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc17">Continuous Variable Quantum Computing</a>
+    </h3>
+    <div class="gs_a">E Fontaine, F Garcia - <i>Physical Review A</i>, 2020 - APS</div>
+    <div class="gs_rs">Continuous variable quantum computing uses infinite-dimensional Hilbert spaces of harmonic oscillators. This framework offers natural compatibility with ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000017&hl=fr">Cited by 102</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000018">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc18">Quantum Simulation of Many-Body Systems</a>
+    </h3>
+    <div class="gs_a">G Hofmann, H Inoue, I Jensen - <i>Reports on Progress in Physics</i>, 2023 - IOP</div>
+    <div class="gs_rs">Quantum simulation enables the study of strongly correlated many-body systems beyond reach of classical methods. We review analog and digital quantum simulators ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000018&hl=fr">Cited by 412</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000019">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc19">Adiabatic Quantum Computation: A Review</a>
+    </h3>
+    <div class="gs_a">J Klein, K Lambert - <i>Annual Review of Condensed Matter Physics</i>, 2018 - annualreviews.org</div>
+    <div class="gs_rs">Adiabatic quantum computation is universal and equivalent to the circuit model. This review covers the adiabatic theorem, applications to optimization ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000019&hl=fr">Cited by 743</a>
+    </div>
+  </div>
+</div>
+
+<div class="gs_r gs_or gs_scl" data-cid="0000000000000020">
+  <div class="gs_ri">
+    <h3 class="gs_rt">
+      <a href="https://example.com/qc20">Benchmarking Quantum Processors</a>
+    </h3>
+    <div class="gs_a">L Müller, M Norman - <i>npj Quantum Information</i>, 2022 - nature.com</div>
+    <div class="gs_rs">Standardized benchmarks for quantum processors include randomized benchmarking, quantum volume, and cross-entropy benchmarking. We propose new metrics ...</div>
+    <div class="gs_fl">
+      <a href="/scholar?cluster=0000000000000020&hl=fr">Cited by 567</a>
+    </div>
+  </div>
+</div>
+
+<div id="gs_ftr">Google Scholar footer - 20 results displayed - synthetic fixture for parser regression testing</div>
+</body></html>

--- a/backend/tests/test_scholar_cache.py
+++ b/backend/tests/test_scholar_cache.py
@@ -1,0 +1,133 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — Scholar cache (PR1 / spec §8)                                         ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre :                                                                          ║
+║  • Cache HIT short-circuits the HTTP fetch                                         ║
+║  • Cache MISS then HIT for the same query                                         ║
+║  • Empty batch NEVER stored (cache poisoning protection — spec §8.3)               ║
+║  • Cache key normalized on lower().strip()                                         ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from academic import scholar  # noqa: E402
+from academic.scholar import ScholarBatch, ScholarPaper  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_scholar_state():
+    scholar._reset_state_for_tests()
+    yield
+    scholar._reset_state_for_tests()
+
+
+def _sample_batch(query: str, n_papers: int = 3) -> ScholarBatch:
+    return ScholarBatch(
+        query=query,
+        papers=[
+            ScholarPaper(
+                scholar_id=f"id{i}",
+                title=f"Paper {i}",
+                authors=[f"Author {i}"],
+                year=2024,
+                citation_count=100 + i,
+            )
+            for i in range(n_papers)
+        ],
+        fetched_at=time.time(),
+        raw_html_size=10000,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_http_request(redis_client_fixture):
+    """When the cache key is populated, search_scholar must NOT issue an HTTP call."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    query = "quantum computing"
+    pre_cached = _sample_batch(query, n_papers=5)
+    await scholar._cache_set(query, pre_cached)
+
+    # Patch the proxy client factory so we can assert it's never called.
+    mock_get_client = MagicMock()
+    with patch("academic.scholar.get_proxied_client", mock_get_client):
+        result = await scholar.search_scholar(query, use_cache=True)
+
+    assert mock_get_client.call_count == 0, "HTTP client should not be invoked on cache HIT"
+    assert len(result.papers) == 5
+    assert result.papers[0].title == "Paper 0"
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_then_hit(redis_client_fixture):
+    """First call → MISS+set, second identical call → HIT, same content."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    query = "histoire de la psychiatrie"
+    batch1 = _sample_batch(query, n_papers=2)
+    await scholar._cache_set(query, batch1)
+
+    # Direct cache_get (simulates what search_scholar does on subsequent calls).
+    hit = await scholar._cache_get(query)
+    assert hit is not None
+    assert len(hit.papers) == 2
+    assert hit.query == query
+
+    # Repeated _cache_get still hits.
+    hit2 = await scholar._cache_get(query)
+    assert hit2 is not None
+    assert hit2.papers[0].title == hit.papers[0].title
+
+
+@pytest.mark.asyncio
+async def test_cache_empty_batch_not_stored(redis_client_fixture):
+    """An empty papers batch must NOT pollute the cache (spec §8.3)."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    query = "this query returned 0 papers due to captcha"
+    empty = ScholarBatch(query=query, papers=[], fetched_at=time.time(), raw_html_size=0)
+    await scholar._cache_set(query, empty)
+
+    # The key must not exist in Redis.
+    raw = await redis_client_fixture.get(scholar._cache_key(query))
+    assert raw is None, f"empty batch was wrongly cached: {raw!r}"
+
+    # And _cache_get returns None.
+    assert await scholar._cache_get(query) is None
+
+
+@pytest.mark.asyncio
+async def test_cache_key_normalized(redis_client_fixture):
+    """Cache key must be invariant under lower() and strip()."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    variants = [
+        "Quantum Computing",
+        "quantum computing",
+        "  quantum computing  ",
+        "QUANTUM COMPUTING",
+        "\tQuantum Computing\n",
+    ]
+    keys = {scholar._cache_key(v) for v in variants}
+    assert len(keys) == 1, f"variants produced different cache keys: {keys!r}"
+
+    # And different queries produce different keys.
+    other = scholar._cache_key("histoire de la folie")
+    assert other not in keys

--- a/backend/tests/test_scholar_circuit_breaker.py
+++ b/backend/tests/test_scholar_circuit_breaker.py
@@ -1,0 +1,140 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — Scholar circuit breaker (PR1 / spec §4.6)                             ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre :                                                                          ║
+║  • Open après 3 failures consécutives                                              ║
+║  • Auto-close après expiration du TTL                                              ║
+║  • Reset compteur sur success                                                      ║
+║  • Détection HTML CAPTCHA (text patterns)                                          ║
+║  • Détection HTML trop court (<5000 bytes)                                         ║
+║  • Pass-through si Redis down                                                      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from academic import scholar  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_scholar_state():
+    scholar._reset_state_for_tests()
+    yield
+    scholar._reset_state_for_tests()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cb_opens_after_3_failures(redis_client_fixture):
+    """After SCHOLAR_CB_THRESHOLD=3 consecutive failures, breaker opens."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    assert await scholar.is_circuit_open() is False
+
+    await scholar._record_failure("http_429")
+    assert await scholar.is_circuit_open() is False
+
+    await scholar._record_failure("http_429")
+    assert await scholar.is_circuit_open() is False
+
+    await scholar._record_failure("http_429")
+    assert await scholar.is_circuit_open() is True
+
+
+@pytest.mark.asyncio
+async def test_cb_closes_after_duration(redis_client_fixture, monkeypatch):
+    """When CB_OPEN key TTL expires (we emulate by deleting), CB closes."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    # Force open the breaker by direct key set in the past.
+    in_the_past = time.time() - 10  # already expired
+    await redis_client_fixture.set(scholar.SCHOLAR_CB_OPEN_KEY, str(in_the_past), ex=60)
+    assert await scholar.is_circuit_open() is False
+
+    # And confirm a fresh future open works.
+    future = time.time() + 3600
+    await redis_client_fixture.set(scholar.SCHOLAR_CB_OPEN_KEY, str(future), ex=3600)
+    assert await scholar.is_circuit_open() is True
+
+
+@pytest.mark.asyncio
+async def test_cb_resets_on_success(redis_client_fixture):
+    """Recording success after 2 failures resets the counter (no premature open)."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    await scholar._record_failure("http_429")
+    await scholar._record_failure("http_429")
+    await scholar._record_success()
+
+    # The next failure should not trigger open since counter was reset.
+    await scholar._record_failure("http_429")
+    assert await scholar.is_circuit_open() is False
+
+    await scholar._record_failure("http_429")
+    assert await scholar.is_circuit_open() is False
+
+    # Now 3rd failure since reset → open.
+    await scholar._record_failure("http_429")
+    assert await scholar.is_circuit_open() is True
+
+
+def test_cb_detects_captcha_html():
+    """HTML containing CAPTCHA markers → is_bad_html returns a reason."""
+    cases = [
+        # Each one is padded to > 5000 bytes so we test ONLY the captcha pattern.
+        ("garbage " * 1000 + "/sorry/index?continue=blah", "captcha_pattern:/sorry/index"),
+        ("garbage " * 1000 + "<title>Sorry...</title>", "captcha_pattern:<title>sorry..."),
+        ("garbage " * 1000 + "unusual traffic from your computer network detected", "captcha_pattern:unusual traffic from your computer network"),
+        ("garbage " * 1000 + "please complete this CAPTCHA to continue", "captcha_pattern:captcha"),
+    ]
+    for html, expected_substr in cases:
+        reason = scholar._is_bad_html(html)
+        assert reason is not None, f"expected bad reason for html with {expected_substr!r}"
+        assert reason == expected_substr, (
+            f"expected reason {expected_substr!r}, got {reason!r}"
+        )
+
+
+def test_cb_detects_short_html():
+    """HTML below SCHOLAR_MIN_HTML_BYTES (5000) → bad reason 'html_too_short_*'."""
+    short_html = "<html><body>tiny</body></html>"
+    assert len(short_html) < scholar.SCHOLAR_MIN_HTML_BYTES
+    reason = scholar._is_bad_html(short_html)
+    assert reason is not None
+    assert reason.startswith("html_too_short_")
+    # Long enough HTML without captcha markers → None.
+    long_html = "<html>" + ("a" * 10000) + "</html>"
+    assert scholar._is_bad_html(long_html) is None
+
+
+@pytest.mark.asyncio
+async def test_cb_passes_through_if_redis_down():
+    """No Redis client configured → CB no-ops gracefully, never raises."""
+    # We explicitly DO NOT call init_scholar_redis here (state reset by autouse fixture).
+    assert scholar._redis_client is None
+
+    # is_circuit_open returns False (fail-open).
+    assert await scholar.is_circuit_open() is False
+
+    # record_failure / record_success are silent no-ops.
+    await scholar._record_failure("http_429")
+    await scholar._record_failure("http_429")
+    await scholar._record_failure("http_429")
+    await scholar._record_failure("http_429")
+    assert await scholar.is_circuit_open() is False  # still closed (no Redis to track)
+
+    await scholar._record_success()  # no exception

--- a/backend/tests/test_scholar_parser.py
+++ b/backend/tests/test_scholar_parser.py
@@ -1,0 +1,226 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — Scholar HTML parser (PR1 / spec §11.1)                                ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre :                                                                          ║
+║  • Parsing SERP normale (20 résultats)                                            ║
+║  • Parsing SERP livres / chapitres (prefix [BOOK] / [B])                          ║
+║  • Parsing SERP vide                                                              ║
+║  • Parsing HTML malformé (résilience)                                             ║
+║  • Extraction année (regex)                                                       ║
+║  • Extraction citation count (EN "Cited by 42" + FR "Cité 13 fois")               ║
+║  • Détection pdf_url presence / absence                                           ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Add backend/src to path so we can import the package without installation.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from academic.scholar import parse_scholar_html, ScholarPaper  # noqa: E402
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "scholar")
+
+
+def _read_fixture(name: str) -> str:
+    path = os.path.join(FIXTURES_DIR, name)
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Parser tests on SERP fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_normal_serp():
+    """SERP normale → 20 résultats avec champs essentiels."""
+    html = _read_fixture("serp_normal.html")
+    papers = parse_scholar_html(html)
+
+    assert len(papers) == 20
+    assert all(isinstance(p, ScholarPaper) for p in papers)
+
+    # First paper sanity-check.
+    first = papers[0]
+    assert first.scholar_id == "0000000000000001"
+    assert first.title == "Quantum Computing: Foundations and Algorithms"
+    assert first.year == 2023
+    assert first.venue == "Nature Physics"
+    assert first.citation_count == 1247
+    assert first.url == "https://example.com/quantum1.pdf"
+    assert first.pdf_url == "https://example.com/quantum1.pdf"
+    assert first.authors and "Smith" in first.authors[0]
+
+    # Verify all 20 have a non-empty title.
+    assert all(p.title for p in papers)
+    # Verify all 20 have a scholar_id from data-cid.
+    assert all(p.scholar_id for p in papers)
+
+
+def test_parse_books_serp():
+    """SERP livres → titres correctement strippés des prefixes [BOOK] / [B] / [CITATION]."""
+    html = _read_fixture("serp_books.html")
+    papers = parse_scholar_html(html)
+
+    assert len(papers) == 15
+    titles = [p.title for p in papers]
+
+    # The [BOOK] prefix must be stripped from the title.
+    assert "Histoire de la folie à l'âge classique" in titles
+    # The [B] prefix must be stripped too.
+    assert "Histoire de la psychiatrie en France" in titles
+    # The [CITATION] prefix must be stripped.
+    assert "Réflexions sur l'hôpital général" in titles
+
+    # No remaining literal bracket prefix in any title.
+    for t in titles:
+        assert not t.startswith("[BOOK]"), f"title still has [BOOK] prefix: {t!r}"
+        assert not t.startswith("[B]"), f"title still has [B] prefix: {t!r}"
+        assert not t.startswith("[CITATION]"), f"title still has [CITATION] prefix: {t!r}"
+
+    # Specific Foucault entry: year 1972, venue Gallimard, FR citation 8421.
+    foucault = next(p for p in papers if p.title == "Histoire de la folie à l'âge classique")
+    assert foucault.year == 1972
+    assert foucault.venue == "Gallimard"
+    assert foucault.citation_count == 8421
+
+
+def test_parse_empty_serp():
+    """SERP vide → 0 résultat, pas d'exception."""
+    html = _read_fixture("serp_empty.html")
+    papers = parse_scholar_html(html)
+    assert papers == []
+
+
+def test_parse_malformed_html():
+    """HTML cassé / non-Scholar → 0 résultat, pas de crash."""
+    cases = [
+        "",
+        "not html at all",
+        "<html><body>random content</body></html>",
+        "<div class='gs_r'>incomplete div without h3",
+        "<div class='gs_r' data-cid='abc'><h3 class='gs_rt'></h3></div>",  # h3 sans <a>
+        "<div class='gs_r' data-cid='abc'><h3 class='gs_rt'><a href='#'></a></h3></div>",  # <a> vide
+    ]
+    for html in cases:
+        papers = parse_scholar_html(html)
+        assert papers == [], f"expected empty list for {html!r}, got {papers!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Year extraction (5 cas)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "gs_a_text, expected_year",
+    [
+        # Simple modern year.
+        ("AB Smith - Nature, 2023 - nature.com", 2023),
+        # Historical 1972.
+        ("M Foucault - 1972 - Gallimard", 1972),
+        # 19xx range.
+        ("J Lacan - 1955 - Séminaire III", 1955),
+        # Multiple years in text — must pick the LAST one (publication year).
+        ("Author - First paper 2010 cited heavily, republished 2020 - Journal", 2020),
+        # No year at all.
+        ("Author Name - Journal Name - publisher.com", None),
+    ],
+)
+def test_parse_year_extraction(gs_a_text: str, expected_year):
+    """Year extraction via regex \\b(19\\d{2}|20\\d{2})\\b — last match wins."""
+    html = (
+        f'<div class="gs_r" data-cid="x">'
+        f'  <h3 class="gs_rt"><a href="/x">Title</a></h3>'
+        f'  <div class="gs_a">{gs_a_text}</div>'
+        f"</div>"
+    )
+    papers = parse_scholar_html(html)
+    assert len(papers) == 1
+    assert papers[0].year == expected_year, f"text={gs_a_text!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Citation count extraction (EN + FR)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_citation_count_english():
+    """EN format: 'Cited by 42'."""
+    html = (
+        '<div class="gs_r" data-cid="x">'
+        '  <h3 class="gs_rt"><a href="/x">Title</a></h3>'
+        '  <div class="gs_fl">'
+        '    <a href="/scholar?cluster=x">Cited by 42</a>'
+        '    <a href="/related">Related articles</a>'
+        '  </div>'
+        '</div>'
+    )
+    papers = parse_scholar_html(html)
+    assert len(papers) == 1
+    assert papers[0].citation_count == 42
+
+
+def test_parse_citation_count_french():
+    """FR format: 'Cité 13 fois' (accepts e and é, with or without accent)."""
+    cases = [
+        ("Cité 13 fois", 13),
+        ("Cite 7 fois", 7),  # without accent
+        ("Cité 8421 fois", 8421),
+    ]
+    for fr_text, expected in cases:
+        html = (
+            '<div class="gs_r" data-cid="x">'
+            '  <h3 class="gs_rt"><a href="/x">Title</a></h3>'
+            '  <div class="gs_fl">'
+            f'    <a href="/scholar?cluster=x">{fr_text}</a>'
+            '  </div>'
+            '</div>'
+        )
+        papers = parse_scholar_html(html)
+        assert len(papers) == 1
+        assert papers[0].citation_count == expected, f"FR text={fr_text!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pdf_url extraction
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_pdf_url_present():
+    """PDF link via div.gs_or_ggsm > a with [PDF] tag present."""
+    html = (
+        '<div class="gs_r" data-cid="x">'
+        '  <h3 class="gs_rt"><a href="/landing">Some Paper</a></h3>'
+        '  <div class="gs_or_ggsm">'
+        '    <a href="https://example.com/paper.pdf"><span class="gs_ctg2">[PDF]</span> example.com</a>'
+        '  </div>'
+        '</div>'
+    )
+    papers = parse_scholar_html(html)
+    assert len(papers) == 1
+    assert papers[0].pdf_url == "https://example.com/paper.pdf"
+
+
+def test_parse_pdf_url_absent():
+    """No gs_or_ggsm → pdf_url None."""
+    html = (
+        '<div class="gs_r" data-cid="x">'
+        '  <h3 class="gs_rt"><a href="/landing">Paper without PDF link</a></h3>'
+        '  <div class="gs_a">Author - Journal, 2020</div>'
+        '</div>'
+    )
+    papers = parse_scholar_html(html)
+    assert len(papers) == 1
+    assert papers[0].pdf_url is None

--- a/backend/tests/test_scholar_rate_limiter.py
+++ b/backend/tests/test_scholar_rate_limiter.py
@@ -1,0 +1,151 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — Scholar rate limiter (PR1 / spec §4.5)                                ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre :                                                                          ║
+║  • Blocking under 5 s window                                                       ║
+║  • Pass-through after 5 s elapsed                                                  ║
+║  • Fallback local when Redis down (no exception)                                  ║
+║  • 4 concurrent workers serialized by the Redis lock                              ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from academic import scholar  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_scholar_state():
+    """Reset module-level state between tests (isolation)."""
+    scholar._reset_state_for_tests()
+    yield
+    scholar._reset_state_for_tests()
+
+
+@pytest.fixture
+def fast_interval(monkeypatch):
+    """Shrink the rate interval so tests don't wait 5s each.
+
+    The behaviour under test is "block until enough time elapsed" — the exact
+    interval value is incidental. We use 0.1s in tests for speed.
+    """
+    monkeypatch.setattr(scholar, "SCHOLAR_RATE_INTERVAL", 0.1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_blocks_under_5s(fast_interval, redis_client_fixture):
+    """Two back-to-back calls within the interval window must serialize."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    t0 = time.monotonic()
+    await scholar._rate_limit()
+    after_first = time.monotonic()
+    await scholar._rate_limit()
+    after_second = time.monotonic()
+
+    # First call returns immediately (< interval).
+    assert (after_first - t0) < scholar.SCHOLAR_RATE_INTERVAL, (
+        f"first call should be fast, took {after_first - t0:.3f}s"
+    )
+    # Second call must wait at least most of the interval.
+    second_call_wait = after_second - after_first
+    assert second_call_wait >= scholar.SCHOLAR_RATE_INTERVAL * 0.8, (
+        f"second call should block ~{scholar.SCHOLAR_RATE_INTERVAL}s, "
+        f"took {second_call_wait:.3f}s"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_passes_after_interval(fast_interval, redis_client_fixture):
+    """Wait > interval before the second call → no blocking."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    await scholar._rate_limit()
+    # Sleep over the interval.
+    await asyncio.sleep(scholar.SCHOLAR_RATE_INTERVAL * 1.2)
+
+    t0 = time.monotonic()
+    await scholar._rate_limit()
+    elapsed = time.monotonic() - t0
+
+    # Should be near-instant since lock TTL elapsed.
+    assert elapsed < scholar.SCHOLAR_RATE_INTERVAL * 0.5, (
+        f"call after interval should be fast, took {elapsed:.3f}s"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_fallback_local_when_redis_down(fast_interval):
+    """If Redis.get raises, we fall back to local timer (no propagated exception)."""
+    bad_redis = AsyncMock()
+    bad_redis.get = AsyncMock(side_effect=ConnectionError("redis down"))
+    bad_redis.set = AsyncMock(side_effect=ConnectionError("redis down"))
+    bad_redis.incr = AsyncMock(side_effect=ConnectionError("redis down"))
+    bad_redis.expire = AsyncMock(side_effect=ConnectionError("redis down"))
+    bad_redis.delete = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    await scholar.init_scholar_redis(bad_redis)
+
+    # First call: no exception, sets local timer.
+    t0 = time.monotonic()
+    await scholar._rate_limit()
+    first_elapsed = time.monotonic() - t0
+    assert first_elapsed < scholar.SCHOLAR_RATE_INTERVAL
+
+    # Second call: must block locally.
+    t1 = time.monotonic()
+    await scholar._rate_limit()
+    second_elapsed = time.monotonic() - t1
+    assert second_elapsed >= scholar.SCHOLAR_RATE_INTERVAL * 0.8, (
+        f"local fallback should still block, took {second_elapsed:.3f}s"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_concurrent_workers(fast_interval, redis_client_fixture):
+    """4 concurrent workers respect the Redis-shared rate window.
+
+    Spec sect. 4.5 — Redis-backed distributed delay (NOT a strict SETNX lock —
+    Scholar uses a "best-effort" timestamp marker). With fakeredis under asyncio
+    the workers serialize cooperatively : the first call goes through fast,
+    the remaining workers each see the timestamp set by an earlier sibling and
+    must wait ~interval before proceeding.
+
+    Concretely we check :
+      * At least one worker was fast (< interval / 2).
+      * All other workers had to wait >= 70% of the interval (lock honoured).
+    """
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    async def worker(idx: int) -> float:
+        t = time.monotonic()
+        await scholar._rate_limit()
+        return time.monotonic() - t
+
+    waits = await asyncio.gather(*(worker(i) for i in range(4)))
+
+    fast_calls = [w for w in waits if w < scholar.SCHOLAR_RATE_INTERVAL / 2]
+    blocked_calls = [w for w in waits if w >= scholar.SCHOLAR_RATE_INTERVAL * 0.7]
+
+    assert len(fast_calls) >= 1, f"expected >=1 fast worker, got waits={waits}"
+    assert len(blocked_calls) >= 3, (
+        f"expected >=3 workers to block >= {scholar.SCHOLAR_RATE_INTERVAL * 0.7:.3f}s, "
+        f"got waits={waits}"
+    )

--- a/backend/tests/test_scholar_search.py
+++ b/backend/tests/test_scholar_search.py
@@ -1,0 +1,210 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — Scholar end-to-end search (PR1 / spec §5.1, §4.6, §4.5, §8)            ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre :                                                                          ║
+║  • Happy path : proxy → parse → return papers, cache_set OK                       ║
+║  • Circuit ouvert → return empty batch sans hitter HTTP                            ║
+║  • Decodo hard-stop (should_bypass_proxy_async=True) → empty batch                ║
+║  • CAPTCHA HTML → record_failure incremente le compteur CB                         ║
+║  • Successful result cached for future calls                                      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from academic import scholar  # noqa: E402
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "scholar")
+
+
+def _read_fixture(name: str) -> str:
+    with open(os.path.join(FIXTURES_DIR, name), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+@pytest.fixture(autouse=True)
+def _reset_scholar_state():
+    scholar._reset_state_for_tests()
+    yield
+    scholar._reset_state_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _fast_interval(monkeypatch):
+    """Shrink rate-limit interval so end-to-end tests don't sleep 5s each."""
+    monkeypatch.setattr(scholar, "SCHOLAR_RATE_INTERVAL", 0.0)
+
+
+@pytest.fixture(autouse=True)
+def _no_proxy_telemetry(monkeypatch):
+    """Disable telemetry side-effects (avoid DB session usage in tests)."""
+    monkeypatch.setattr(
+        "academic.scholar.record_proxy_usage",
+        AsyncMock(return_value=None),
+    )
+
+
+def _make_proxied_client_cm(html: str, status_code: int = 200):
+    """Build a context-manager factory that yields a fake httpx.AsyncClient.
+
+    The returned client.get(...) yields a response object whose .text returns
+    `html` and .status_code returns `status_code`.
+    """
+    response = MagicMock()
+    response.text = html
+    response.status_code = status_code
+
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+
+    @asynccontextmanager
+    async def _factory(*args, **kwargs):
+        yield client
+
+    return _factory, client
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_happy_path(redis_client_fixture, monkeypatch):
+    """Happy path: proxied GET → 200 + valid SERP → batch with papers."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    html = _read_fixture("serp_normal.html")
+    factory, client = _make_proxied_client_cm(html, status_code=200)
+    monkeypatch.setattr("academic.scholar.get_proxied_client", factory)
+    monkeypatch.setattr(
+        "academic.scholar.should_bypass_proxy_async",
+        AsyncMock(return_value=False),
+    )
+
+    batch = await scholar.search_scholar("quantum computing", limit=20)
+
+    # Assertions on batch shape.
+    assert batch.query == "quantum computing"
+    assert batch.raw_html_size == len(html)
+    assert len(batch.papers) == 20
+    # And the proxy client was invoked once.
+    client.get.assert_called_once()
+    called_url = client.get.call_args[0][0]
+    assert called_url.startswith(scholar.SCHOLAR_BASE_URL)
+    assert "quantum" in called_url.lower()
+
+
+@pytest.mark.asyncio
+async def test_search_circuit_open_returns_empty(redis_client_fixture, monkeypatch):
+    """When the CB is open, search_scholar must return an empty batch immediately."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    # Force CB open by writing the future open_until key directly.
+    import time
+
+    future = time.time() + 3600
+    await redis_client_fixture.set(scholar.SCHOLAR_CB_OPEN_KEY, str(future), ex=3600)
+
+    factory, client = _make_proxied_client_cm("garbage")
+    monkeypatch.setattr("academic.scholar.get_proxied_client", factory)
+    monkeypatch.setattr(
+        "academic.scholar.should_bypass_proxy_async",
+        AsyncMock(return_value=False),
+    )
+
+    batch = await scholar.search_scholar("anything", limit=20)
+
+    assert batch.papers == []
+    assert batch.raw_html_size == 0
+    client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_proxy_bypass_returns_empty(redis_client_fixture, monkeypatch):
+    """When Decodo hard-stop is active, search returns empty without HTTP fetch."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    factory, client = _make_proxied_client_cm("garbage")
+    monkeypatch.setattr("academic.scholar.get_proxied_client", factory)
+    monkeypatch.setattr(
+        "academic.scholar.should_bypass_proxy_async",
+        AsyncMock(return_value=True),  # ← hard-stop triggered
+    )
+
+    batch = await scholar.search_scholar("anything", limit=20)
+
+    assert batch.papers == []
+    assert batch.raw_html_size == 0
+    client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_captcha_records_failure(redis_client_fixture, monkeypatch):
+    """CAPTCHA response → record_failure called, batch empty, CB counter incremented."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    captcha_html = "garbage " * 1500 + "<title>Sorry...</title>" + "more padding " * 200
+    assert len(captcha_html) >= scholar.SCHOLAR_MIN_HTML_BYTES
+
+    factory, client = _make_proxied_client_cm(captcha_html, status_code=200)
+    monkeypatch.setattr("academic.scholar.get_proxied_client", factory)
+    monkeypatch.setattr(
+        "academic.scholar.should_bypass_proxy_async",
+        AsyncMock(return_value=False),
+    )
+
+    batch = await scholar.search_scholar("anything", limit=20)
+    assert batch.papers == []
+    assert batch.raw_html_size == len(captcha_html)
+
+    # CB counter should be at 1.
+    raw = await redis_client_fixture.get(scholar.SCHOLAR_CB_FAIL_KEY)
+    assert raw is not None
+    assert int(raw) == 1
+
+    # Reach threshold by failing twice more → CB opens.
+    factory2, _ = _make_proxied_client_cm(captcha_html, status_code=200)
+    monkeypatch.setattr("academic.scholar.get_proxied_client", factory2)
+    await scholar.search_scholar("anything else 1", limit=20)
+    await scholar.search_scholar("anything else 2", limit=20)
+    assert await scholar.is_circuit_open() is True
+
+
+@pytest.mark.asyncio
+async def test_search_caches_successful_result(redis_client_fixture, monkeypatch):
+    """Successful search → cache_set, then second call returns from cache without HTTP."""
+    await scholar.init_scholar_redis(redis_client_fixture)
+
+    html = _read_fixture("serp_normal.html")
+    factory, client = _make_proxied_client_cm(html, status_code=200)
+    monkeypatch.setattr("academic.scholar.get_proxied_client", factory)
+    monkeypatch.setattr(
+        "academic.scholar.should_bypass_proxy_async",
+        AsyncMock(return_value=False),
+    )
+
+    # First call: HTTP hit + cache populated.
+    batch1 = await scholar.search_scholar("quantum", limit=20)
+    assert len(batch1.papers) > 0
+    assert client.get.call_count == 1
+
+    # Second call SAME query: should hit cache, no second HTTP call.
+    batch2 = await scholar.search_scholar("quantum", limit=20)
+    assert len(batch2.papers) == len(batch1.papers)
+    assert client.get.call_count == 1, (
+        f"second call should be served from cache, but HTTP was invoked again: "
+        f"{client.get.call_count}"
+    )


### PR DESCRIPTION
## Summary
- `backend/src/academic/scholar.py` (608 LOC) — service de scrape Scholar via Decodo proxy
- Rate limiter Redis 5s entre requêtes
- Circuit breaker : 3 fails / 1h pause automatique
- Cache cross-user 7 jours (key `scholar:{query_hash}`)
- 5 tests + 3 fixtures HTML → 32 tests verts

## Test plan
- [ ] Tests : `pytest backend/tests/test_scholar_*.py` → 32 passed
- [ ] PR2 ajoutera `beautifulsoup4>=4.12.0` à requirements.txt + aggregator + migration 029
- [ ] PR3 ajoutera plan gating + UI

## Notes
- Clean PR sans dépendance prod cassante (code pas appelé avant PR2)
- Spec source : `docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md`