### PR TITLE
feat(community-take): backend scrape + analyse + storage + plan gating (PR 1/2)

### DIFF
--- a/backend/alembic/versions/029_summary_community_analysis.py
+++ b/backend/alembic/versions/029_summary_community_analysis.py
@@ -1,0 +1,53 @@
+"""summary_community_analysis — verdict communauté (scrape + Mistral analyse)
+
+Revision ID: 029_summary_community
+Revises: 028_bot_prospection
+Create Date: 2026-05-17
+
+Spec : docs/superpowers/specs/2026-05-17-comments-community-take.md
+
+Ajoute la colonne `summaries.community_analysis JSONB NULL`. Stocke le payload
+sérialisé de `CommunityTake` (cf backend/src/comments/schemas.py).
+
+Convention : revision_id ≤ 32 chars (respecté ici : "029_summary_community" = 21 chars).
+Migration idempotente : add only if not exists, drop only if exists.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "029_summary_community"
+down_revision: Union[str, None] = "028_bot_prospection"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        # Table inexistante (early bootstrap) → no-op.
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "community_analysis" not in columns:
+        op.add_column(
+            "summaries",
+            sa.Column("community_analysis", sa.JSON(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "community_analysis" in columns:
+        op.drop_column("summaries", "community_analysis")

--- a/backend/src/admin/router.py
+++ b/backend/src/admin/router.py
@@ -713,3 +713,39 @@ async def get_proxy_usage(
         "daily": daily,
         "by_provider": by_provider,
     }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 💬 COMMUNITY TAKE CACHE INVALIDATION (Spec 2026-05-17)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.delete("/community-cache/{platform}/{video_id}")
+async def admin_invalidate_community_cache(
+    platform: str,
+    video_id: str,
+    admin: User = Depends(get_current_admin),
+):
+    """💬 Invalide les clés Redis du verdict communauté pour (platform, video_id).
+
+    Invalide :
+      - vcache:comments:{platform}:{video_id} (CommentsBatch cross-user)
+      - vcache:community_take:{platform}:{video_id}:{small|medium|large}
+        (CommunityTake par tier de plan)
+
+    Spec : docs/superpowers/specs/2026-05-17-comments-community-take.md §5.5
+    """
+    if platform not in ("youtube", "tiktok"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported platform: {platform} (expected youtube|tiktok)",
+        )
+
+    from comments.cache import invalidate_community_cache
+
+    deleted = await invalidate_community_cache(platform, video_id)
+    return {
+        "platform": platform,
+        "video_id": video_id,
+        "deleted_keys": deleted,
+    }

--- a/backend/src/billing/plan_config.py
+++ b/backend/src/billing/plan_config.py
@@ -123,6 +123,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "companion_dialogue_enabled": False,  # 🎓 Le Tuteur — Pro+ uniquement
             "visual_analysis_enabled": False,  # Phase 2 — frames + Mistral Vision
             "visual_analysis_monthly": 0,
+            "community_take_enabled": False,  # 💬 Verdict communauté — Pro+ uniquement
+            "community_take_monthly": 0,
         },
         "features_display": [
             {"text": "5 analyses / mois", "icon": "📊"},
@@ -159,6 +161,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": False,
                 "geo": False,
                 "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
+                "community_take": False,  # 💬 Verdict communauté — Pro+ uniquement
             },
             "mobile": {
                 "analyse": True,
@@ -179,6 +182,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": False,
                 "geo": False,
                 "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
+                "community_take": False,  # 💬 Verdict communauté — Pro+ uniquement
             },
             "extension": {
                 "analyse": True,
@@ -199,6 +203,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": False,
                 "geo": False,
                 "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
+                "community_take": False,  # 💬 Verdict communauté — Pro+ uniquement
             },
         },
     },
@@ -258,6 +263,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "companion_dialogue_enabled": True,  # 🎓 Le Tuteur — disponible dès Pro
             "visual_analysis_enabled": True,  # Phase 2 — frames + Mistral Vision
             "visual_analysis_monthly": 30,
+            "community_take_enabled": True,  # 💬 Verdict communauté — Pro+ (V1)
+            "community_take_monthly": -1,  # illimité (auto à chaque analyse)
         },
         "features_display": [
             {"text": "25 analyses / mois", "icon": "📊"},
@@ -301,6 +308,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": False,
                 "geo": True,
                 "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
+                "community_take": True,  # 💬 Verdict communauté — Pro (V1)
             },
             "mobile": {
                 "analyse": True,
@@ -321,6 +329,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": False,
                 "geo": True,
                 "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
+                "community_take": True,  # 💬 Verdict communauté — Pro (V1)
             },
             "extension": {
                 "analyse": True,
@@ -341,6 +350,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": False,
                 "geo": False,
                 "hub_workspace": False,  # Hub Miro Workspace — Expert only (web)
+                "community_take": True,  # 💬 Verdict communauté — Pro (V1)
             },
         },
     },
@@ -401,6 +411,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "companion_dialogue_enabled": True,  # 🎓 Le Tuteur — disponible Pro et Expert
             "visual_analysis_enabled": True,  # Phase 2 — frames + Mistral Vision
             "visual_analysis_monthly": -1,  # illimité
+            "community_take_enabled": True,  # 💬 Verdict communauté — Expert (V1)
+            "community_take_monthly": -1,  # illimité
         },
         "features_display": [
             {"text": "100 analyses / mois", "icon": "📊"},
@@ -445,6 +457,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": True,
                 "geo": True,
                 "hub_workspace": True,  # Hub Miro Workspace — Expert only (web)
+                "community_take": True,  # 💬 Verdict communauté — Expert (V1)
             },
             "mobile": {
                 "analyse": True,
@@ -465,6 +478,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": False,
                 "geo": True,
                 "hub_workspace": False,  # Hub Miro Workspace — Expert only (web only, mobile = CTA web)
+                "community_take": True,  # 💬 Verdict communauté — Expert (V1)
             },
             "extension": {
                 "analyse": True,
@@ -485,6 +499,7 @@ PLANS: dict[str, dict[str, Any]] = {
                 "deep_research": False,
                 "geo": False,
                 "hub_workspace": False,  # Hub Miro Workspace — Expert only (web only, ext = CTA web)
+                "community_take": True,  # 💬 Verdict communauté — Expert (V1)
             },
         },
     },

--- a/backend/src/comments/__init__.py
+++ b/backend/src/comments/__init__.py
@@ -1,0 +1,34 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  💬 COMMENTS MODULE — Scraping commentaires YouTube/TikTok + Verdict communauté    ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Spec : docs/superpowers/specs/2026-05-17-comments-community-take.md               ║
+║                                                                                    ║
+║  Architecture (5e tâche parallèle du pipeline v6/v2.1) :                          ║
+║    fetch_comments(platform, video_id) → CommentsBatch (Top 100 + Random 50)       ║
+║    generate_community_analysis(...) → CommunityTake (Mistral JSON-mode)           ║
+║                                                                                    ║
+║  Tout est non-bloquant : timeout 30s strict, exceptions catchées, retour None.    ║
+║  Cache Redis L1 cross-user (24h). Persistance via Summary.community_analysis      ║
+║  JSONB (alembic 029).                                                              ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from .schemas import Comment, CommentsBatch, CommunityTake, TopVoice
+from .service import (
+    COMMUNITY_TAKE_TIMEOUT_S,
+    fetch_comments,
+    generate_community_analysis,
+    generate_community_analysis_with_timeout,
+)
+
+__all__ = [
+    "COMMUNITY_TAKE_TIMEOUT_S",
+    "Comment",
+    "CommentsBatch",
+    "CommunityTake",
+    "TopVoice",
+    "fetch_comments",
+    "generate_community_analysis",
+    "generate_community_analysis_with_timeout",
+]

--- a/backend/src/comments/cache.py
+++ b/backend/src/comments/cache.py
@@ -1,0 +1,103 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  💾 COMMENTS CACHE — Redis L1 cross-user (24h)                                     ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Clés Redis :                                                                      ║
+║    vcache:comments:{platform}:{video_id}                  → CommentsBatch (24h)   ║
+║    vcache:community_take:{platform}:{video_id}:{tier}     → CommunityTake (24h)   ║
+║                                                                                    ║
+║  Invariants :                                                                      ║
+║    - CommentsBatch est cross-user (les commentaires sont identiques pour tous).   ║
+║    - CommunityTake varie par plan tier (small/medium/large) → 3 versions max.     ║
+║                                                                                    ║
+║  Le L2 PG est implicite via Summary.community_analysis JSONB (alembic 029).       ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+from core.cache import cache_service
+
+from .schemas import CommentsBatch, CommunityTake
+
+COMMENTS_TTL_S = 86400  # 24h L1
+TAKE_TTL_S = 86400  # 24h L1
+
+
+def _comments_key(platform: str, video_id: str) -> str:
+    return f"vcache:comments:{platform}:{video_id}"
+
+
+def _take_key(platform: str, video_id: str, tier: str) -> str:
+    return f"vcache:community_take:{platform}:{video_id}:{tier}"
+
+
+async def cache_get_comments_batch(platform: str, video_id: str) -> CommentsBatch | None:
+    """Lit le CommentsBatch cross-user depuis le cache Redis."""
+    raw = await cache_service.get(_comments_key(platform, video_id))
+    if not raw:
+        return None
+    try:
+        return CommentsBatch.model_validate(raw)
+    except Exception:
+        # Schéma incompatible (vieille forme cachée) → on traite comme un miss.
+        return None
+
+
+async def cache_set_comments_batch(platform: str, video_id: str, batch: CommentsBatch) -> None:
+    """Écrit le CommentsBatch dans le cache (TTL 24h)."""
+    await cache_service.set(
+        _comments_key(platform, video_id),
+        batch.model_dump(mode="json"),
+        ttl=COMMENTS_TTL_S,
+    )
+
+
+async def cache_get_take(platform: str, video_id: str, tier: str) -> CommunityTake | None:
+    """Lit la CommunityTake (par tier de plan) depuis le cache Redis."""
+    raw = await cache_service.get(_take_key(platform, video_id, tier))
+    if not raw:
+        return None
+    try:
+        return CommunityTake.model_validate(raw)
+    except Exception:
+        return None
+
+
+async def cache_set_take(platform: str, video_id: str, tier: str, take: CommunityTake) -> None:
+    """Écrit la CommunityTake (par tier de plan) dans le cache (TTL 24h)."""
+    await cache_service.set(
+        _take_key(platform, video_id, tier),
+        take.model_dump(mode="json"),
+        ttl=TAKE_TTL_S,
+    )
+
+
+async def invalidate_community_cache(platform: str, video_id: str) -> int:
+    """Admin endpoint helper : invalide comments + 3 tiers de take.
+
+    Returns:
+        Nombre de clés effectivement supprimées (0 à 4).
+    """
+    keys = [
+        _comments_key(platform, video_id),
+        _take_key(platform, video_id, "small"),
+        _take_key(platform, video_id, "medium"),
+        _take_key(platform, video_id, "large"),
+    ]
+    deleted = 0
+    for k in keys:
+        if await cache_service.delete(k):
+            deleted += 1
+    return deleted
+
+
+__all__ = [
+    "COMMENTS_TTL_S",
+    "TAKE_TTL_S",
+    "cache_get_comments_batch",
+    "cache_set_comments_batch",
+    "cache_get_take",
+    "cache_set_take",
+    "invalidate_community_cache",
+]

--- a/backend/src/comments/sampler.py
+++ b/backend/src/comments/sampler.py
@@ -1,0 +1,81 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎲 COMMENTS SAMPLER — Top + Random échantillonnage déterministe                  ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Stratégie : Top N par like_count + Random M dans le reste.                        ║
+║  Seed déterministe via hash(video_id) → mêmes 2 appels = même échantillon.        ║
+║  → Cache reproductible (l'analyse Mistral est invariant entre runs).              ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random as _random
+from typing import Iterable
+
+from .schemas import Comment
+
+
+def sample_top_and_random(
+    raw: list[Comment],
+    *,
+    top_n: int = 100,
+    random_n: int = 50,
+    video_id: str | None = None,
+) -> list[Comment]:
+    """Sélectionne Top N par like_count + Random M déterministes parmi le reste.
+
+    Args:
+        raw: Liste brute de commentaires scrappés (déjà parsés).
+        top_n: Nombre de commentaires top likes (défaut 100).
+        random_n: Nombre de commentaires aléatoires en bonus (défaut 50).
+        video_id: Identifiant vidéo pour seeder l'aléa (déterminisme cross-run).
+                  Si None, lit raw[0].video_id si dispo, sinon utilise un fallback.
+
+    Returns:
+        Liste de commentaires (taille <= top_n + random_n), Top en premier.
+
+    Cas limites :
+      - Si len(raw) <= top_n + random_n → on retourne tout (pas de sampling utile).
+      - Si raw vide → liste vide.
+    """
+    if not raw:
+        return []
+
+    total = top_n + random_n
+    if len(raw) <= total:
+        # Trop peu de commentaires pour échantillonner : on retourne tout.
+        return list(raw)
+
+    sorted_by_likes = sorted(raw, key=lambda c: c.like_count, reverse=True)
+    top = sorted_by_likes[:top_n]
+    remainder = sorted_by_likes[top_n:]
+
+    # Détermine le seed.
+    seed_source = video_id or (raw[0].video_id if raw and raw[0].video_id else "default")
+    seed = int(hashlib.md5(seed_source.encode("utf-8")).hexdigest(), 16) & 0xFFFFFFFF
+
+    rng = _random.Random(seed)
+    sample = rng.sample(remainder, min(random_n, len(remainder)))
+
+    return list(top) + list(sample)
+
+
+def dedupe_comments(raw: Iterable[Comment]) -> list[Comment]:
+    """Déduplique les commentaires sur la base de comment_id.
+
+    Utile quand un scraper retourne des doublons à cause de la pagination.
+    Conserve l'ordre d'apparition (premier vu = gagne).
+    """
+    seen: set[str] = set()
+    out: list[Comment] = []
+    for c in raw:
+        if c.comment_id in seen:
+            continue
+        seen.add(c.comment_id)
+        out.append(c)
+    return out
+
+
+__all__ = ["sample_top_and_random", "dedupe_comments"]

--- a/backend/src/comments/schemas.py
+++ b/backend/src/comments/schemas.py
@@ -1,0 +1,80 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  💬 COMMENTS SCHEMAS — Pydantic v2 models (cross-platform YouTube/TikTok)         ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Comment       → un commentaire normalisé (cross-platform)                         ║
+║  CommentsBatch → résultat brut du scraping (sampled Top 100 + Random 50)          ║
+║  TopVoice      → voix représentative pseudonymisée pour la take                   ║
+║  CommunityTake → résultat de l'analyse Mistral (verdict communauté)               ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Comment(BaseModel):
+    """Un commentaire normalisé (cross-platform YouTube + TikTok)."""
+
+    comment_id: str
+    author: str
+    author_id: Optional[str] = None
+    text: str
+    like_count: int = 0
+    reply_count: int = 0
+    published_at: Optional[datetime] = None
+    is_reply: bool = False
+    parent_id: Optional[str] = None
+    is_creator_reply: bool = False
+    is_pinned: bool = False
+    # Carry video_id pour le seed déterministe du sampler (cf sampler.py).
+    video_id: Optional[str] = None
+
+
+class CommentsBatch(BaseModel):
+    """Résultat brut du scraping commentaires d'une vidéo (cross-user)."""
+
+    platform: Literal["youtube", "tiktok"]
+    video_id: str
+    total_seen: int = 0
+    sampled: list[Comment] = Field(default_factory=list)
+    disabled: bool = False  # commentaires désactivés côté plateforme
+    fetched_at: datetime = Field(default_factory=datetime.utcnow)
+    bytes_used: int = 0  # bytes scrappés total (telemetry)
+
+
+class TopVoice(BaseModel):
+    """Voix représentative pseudonymisée pour le verdict communauté."""
+
+    author: str  # Pseudonymisé côté prompt Mistral : "User-A1B2" / "Un commentateur populaire"
+    excerpt: str = Field(max_length=240)
+    stance: Literal["agree", "disagree", "neutral", "question"]
+    like_count: int = 0
+
+
+class CommunityTake(BaseModel):
+    """Résultat de l'analyse Mistral des commentaires (verdict communauté)."""
+
+    agreement_signal: Literal["agree", "disagree", "mixed", "unclear"]
+    sentiment_distribution: dict[Literal["positive", "neutral", "negative"], float]
+    controversies: list[str] = Field(default_factory=list, max_length=5)
+    community_summary: str = Field(max_length=600)
+    top_voices: list[TopVoice] = Field(default_factory=list, max_length=5)
+    comments_analyzed: int = 0
+    model_used: str = ""
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    is_truncated: bool = False
+    disabled: bool = False  # mirror du flag CommentsBatch.disabled pour l'UI
+    insufficient_data: bool = False  # < 10 commentaires sampled
+
+
+__all__ = [
+    "Comment",
+    "CommentsBatch",
+    "CommunityTake",
+    "TopVoice",
+]

--- a/backend/src/comments/service.py
+++ b/backend/src/comments/service.py
@@ -1,0 +1,278 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  💬 COMMENTS SERVICE — Orchestration scraping + analyse Mistral                   ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  API publique :                                                                    ║
+║    fetch_comments(platform, video_id)                                              ║
+║        → CommentsBatch (avec cache L1 Redis 24h cross-user)                       ║
+║                                                                                    ║
+║    generate_community_analysis(platform, video_id, plan, ...)                     ║
+║        → CommunityTake | None (avec cache L1 par tier de plan)                    ║
+║        Jamais bloquant : toute exception est catchée et loggée.                   ║
+║                                                                                    ║
+║    generate_community_analysis_with_timeout(...) ← wrapper 30s strict             ║
+║        Utilisé par le pipeline v6/v2.1 dans le asyncio.gather.                    ║
+║                                                                                    ║
+║  Quota safety dédié : si MTD proxy > 700 MB, on skip le scrape silencieusement.   ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from core.logging import logger
+
+from .cache import (
+    cache_get_comments_batch,
+    cache_get_take,
+    cache_set_comments_batch,
+    cache_set_take,
+)
+from .schemas import CommentsBatch, CommunityTake
+from .take_generator import generate_community_take
+from .tiktok_scraper import fetch_tiktok_comments as _fetch_tt
+from .youtube_scraper import fetch_youtube_comments as _fetch_yt
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 CONSTANTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+COMMUNITY_TAKE_TIMEOUT_S = 30.0
+COMMENTS_PROXY_SOFT_LIMIT_BYTES = 700 * 1024 * 1024  # 700 MB MTD soft limit (avant hard-stop 950 MB)
+
+MIN_SAMPLED_FOR_TAKE = 10  # Sous ce seuil → insufficient_data
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧰 HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _plan_to_tier(plan: str) -> str:
+    """Map user plan → tier de modèle Mistral (pour key cache + selection)."""
+    return {"free": "small", "pro": "medium", "expert": "large"}.get(plan, "small")
+
+
+async def _is_proxy_quota_exhausted() -> bool:
+    """True si MTD proxy > 700 MB (soft limit dédié comments).
+
+    Best-effort : si le check plante (DB indisponible) → False (fail-open,
+    on tente le scrape, le hard-stop global 950 MB s'appliquera de toute façon).
+    """
+    try:
+        from middleware.proxy_telemetry import get_mtd_bytes
+
+        mtd = await get_mtd_bytes()
+        return mtd > COMMENTS_PROXY_SOFT_LIMIT_BYTES
+    except Exception as e:
+        logger.debug(f"[COMMENTS] MTD check failed (fail-open): {e}")
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 PUBLIC API
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def fetch_comments(
+    platform: str,
+    video_id: str,
+    *,
+    top_n: int = 100,
+    random_n: int = 50,
+) -> CommentsBatch:
+    """Fetch + sampling avec cache cross-user L1 Redis (24h).
+
+    Args:
+        platform: "youtube" ou "tiktok".
+        video_id: ID vidéo cross-platform.
+        top_n: top likes.
+        random_n: random bonus.
+
+    Returns:
+        CommentsBatch (peut être vide ou disabled).
+
+    Note : si la quota proxy est dépassée → batch vide (disabled=False) pour
+    laisser l'UI afficher "insufficient_data" plutôt qu'un faux "disabled".
+    """
+    # 1. Cache check
+    cached = await cache_get_comments_batch(platform, video_id)
+    if cached is not None:
+        logger.info(f"[COMMENTS_CACHE_HIT] {platform}:{video_id} (sampled={len(cached.sampled)})")
+        return cached
+
+    # 2. Quota check
+    if await _is_proxy_quota_exhausted():
+        logger.warning(f"[COMMENTS] Proxy soft quota exceeded — skip scrape for {platform}:{video_id}")
+        return CommentsBatch(
+            platform=platform if platform in ("youtube", "tiktok") else "youtube",
+            video_id=video_id,
+            total_seen=0,
+            sampled=[],
+            disabled=False,
+            bytes_used=0,
+        )
+
+    # 3. Dispatch scraper
+    if platform == "youtube":
+        batch = await _fetch_yt(video_id, top_n=top_n, random_n=random_n)
+    elif platform == "tiktok":
+        batch = await _fetch_tt(video_id, top_n=top_n, random_n=random_n)
+    else:
+        raise ValueError(f"Unsupported platform: {platform}")
+
+    # 4. Cache write (best-effort, ne masque pas le résultat scrape).
+    try:
+        await cache_set_comments_batch(platform, video_id, batch)
+    except Exception as e:
+        logger.warning(f"[COMMENTS_CACHE_SET] failed for {platform}:{video_id}: {e}")
+
+    return batch
+
+
+async def generate_community_analysis(
+    platform: str,
+    video_id: str,
+    *,
+    plan: str,
+    video_title: str,
+    video_topic_hint: str = "",
+    creator_stance: str = "",
+    lang: str = "fr",
+) -> Optional[CommunityTake]:
+    """JAMAIS bloquant : toute exception est catchée et loggée → retourne None.
+
+    Pipeline :
+      1. fetch_comments(platform, video_id) → CommentsBatch
+      2. Si disabled → CommunityTake(disabled=True)
+      3. Si len(sampled) < MIN_SAMPLED_FOR_TAKE → CommunityTake(insufficient_data=True)
+      4. cache check par tier de plan
+      5. generate_community_take (Mistral JSON-mode)
+      6. cache write par tier
+    """
+    try:
+        batch = await fetch_comments(platform, video_id)
+
+        if batch.disabled:
+            return CommunityTake(
+                agreement_signal="unclear",
+                sentiment_distribution={"positive": 0.0, "neutral": 1.0, "negative": 0.0},
+                controversies=[],
+                community_summary="Les commentaires sont désactivés sur cette vidéo.",
+                top_voices=[],
+                comments_analyzed=0,
+                model_used="none",
+                disabled=True,
+            )
+
+        if len(batch.sampled) < MIN_SAMPLED_FOR_TAKE:
+            return CommunityTake(
+                agreement_signal="unclear",
+                sentiment_distribution={
+                    "positive": 0.34,
+                    "neutral": 0.33,
+                    "negative": 0.33,
+                },
+                controversies=[],
+                community_summary=(
+                    f"Trop peu de commentaires ({len(batch.sampled)}) pour un verdict fiable."
+                ),
+                top_voices=[],
+                comments_analyzed=len(batch.sampled),
+                model_used="none",
+                insufficient_data=True,
+            )
+
+        plan_tier = _plan_to_tier(plan)
+
+        cached_take = await cache_get_take(platform, video_id, plan_tier)
+        if cached_take is not None:
+            logger.info(f"[COMMUNITY_TAKE_CACHE_HIT] {platform}:{video_id}:{plan_tier}")
+            return cached_take
+
+        take = await generate_community_take(
+            batch=batch,
+            plan=plan,
+            video_title=video_title,
+            video_topic_hint=video_topic_hint,
+            creator_stance=creator_stance,
+            lang=lang,
+        )
+
+        if take is not None:
+            try:
+                await cache_set_take(platform, video_id, plan_tier, take)
+            except Exception as e:
+                logger.warning(
+                    f"[COMMUNITY_TAKE_CACHE_SET] failed for {platform}:{video_id}:{plan_tier}: {e}"
+                )
+
+        return take
+
+    except Exception as e:
+        logger.error(
+            f"[COMMUNITY_ANALYSIS] Failed for {platform}:{video_id}: {e}",
+            exc_info=True,
+        )
+        return None
+
+
+async def generate_community_analysis_with_timeout(
+    platform: str,
+    video_id: str,
+    *,
+    plan: str,
+    video_title: str,
+    video_topic_hint: str = "",
+    creator_stance: str = "",
+    lang: str = "fr",
+    timeout_s: float = COMMUNITY_TAKE_TIMEOUT_S,
+) -> Optional[CommunityTake]:
+    """Wrapper non bloquant pour le pipeline v6/v2.1 — timeout strict 30s.
+
+    Args:
+        platform: "youtube" | "tiktok".
+        video_id: ID vidéo.
+        plan: "free" | "pro" | "expert".
+        video_title: titre vidéo.
+        video_topic_hint: extrait analyse pour grounding.
+        creator_stance: position éventuelle du créateur.
+        lang: "fr" | "en".
+        timeout_s: timeout strict (défaut 30s).
+
+    Returns:
+        CommunityTake ou None si timeout / exception.
+    """
+    try:
+        return await asyncio.wait_for(
+            generate_community_analysis(
+                platform=platform,
+                video_id=video_id,
+                plan=plan,
+                video_title=video_title,
+                video_topic_hint=video_topic_hint,
+                creator_stance=creator_stance,
+                lang=lang,
+            ),
+            timeout=timeout_s,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"[COMMUNITY_ANALYSIS] Timeout {timeout_s}s for {platform}:{video_id} — returning None"
+        )
+        return None
+    except Exception as e:
+        logger.error(f"[COMMUNITY_ANALYSIS] Outer error for {platform}:{video_id}: {e}")
+        return None
+
+
+__all__ = [
+    "COMMENTS_PROXY_SOFT_LIMIT_BYTES",
+    "COMMUNITY_TAKE_TIMEOUT_S",
+    "MIN_SAMPLED_FOR_TAKE",
+    "fetch_comments",
+    "generate_community_analysis",
+    "generate_community_analysis_with_timeout",
+]

--- a/backend/src/comments/take_generator.py
+++ b/backend/src/comments/take_generator.py
@@ -1,0 +1,320 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧠 COMMUNITY TAKE GENERATOR — Mistral JSON-mode (Verdict communauté)             ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Input  : CommentsBatch (sampled ~150 comments) + contexte vidéo                  ║
+║  Output : CommunityTake (signal, sentiment, controversies, summary, top_voices)   ║
+║                                                                                    ║
+║  Modèle Mistral calqué sur le plan utilisateur :                                  ║
+║    free   → mistral-small-2603 (mais Free n'est PAS gated pour appel direct,      ║
+║              le gate est dans le router pipeline + UI)                            ║
+║    pro    → mistral-medium-2508                                                    ║
+║    expert → mistral-large-2512                                                     ║
+║                                                                                    ║
+║  ⚠️ ARCHITECTURE : appel via core.llm_provider.llm_complete (Mistral API directe   ║
+║      Hetzner → 0 byte proxy Decodo). Pas de proxy ici.                            ║
+║                                                                                    ║
+║  Anti-sycophancy floor : si max(sentiment_distribution) < 0.5 ET signal != "unclear"║
+║      → on force signal = "mixed" pour éviter les verdicts simplistes.             ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from core.llm_provider import llm_complete
+from core.logging import logger
+
+from .schemas import CommentsBatch, CommunityTake
+
+_PLAN_MODEL = {
+    "free": "mistral-small-2603",
+    "pro": "mistral-medium-2508",
+    "expert": "mistral-large-2512",
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📝 PROMPTS (FR / EN)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+COMMUNITY_TAKE_SYSTEM_PROMPT_FR = """Tu es un analyste impartial qui synthétise la réaction d'une communauté en ligne aux propos d'un créateur de contenu vidéo (YouTube ou TikTok).
+
+PRINCIPES STRICTS :
+1. **Ne pas trancher artificiellement** : si la communauté est divisée, dis "mixte". Ne donne JAMAIS un verdict simpliste pour générer du clic.
+2. **Pas de jugement moral** : tu rapportes ce que disent les commentateurs, pas ce que tu en penses.
+3. **Anonymisation** : ne cite jamais le pseudo complet. Utilise "Un commentateur populaire", "Une réponse récente avec X likes", ou pseudonyme tronqué "@user***".
+4. **Ignore le bruit** : spam, insultes pures, emoji-only, hors-sujet → exclus.
+5. **Représentation équitable** : si 30% sont en désaccord, ils méritent une voix dans top_voices.
+6. **Pas de prophétie** : ne dis pas "la majorité pense X" si l'échantillon est < 20 voix significatives.
+
+FORMAT DE SORTIE : JSON strict, AUCUN texte hors JSON. Schéma :
+{
+  "agreement_signal": "agree" | "disagree" | "mixed" | "unclear",
+  "sentiment_distribution": {"positive": 0.0-1.0, "neutral": 0.0-1.0, "negative": 0.0-1.0},
+  "controversies": ["sujet de désaccord 1", ...],
+  "community_summary": "2-3 phrases factuelles en français",
+  "top_voices": [
+    {"author": "Un commentateur (8.4k likes)", "excerpt": "extrait < 240 chars", "stance": "agree|disagree|neutral|question", "like_count": 8400},
+    ...
+  ]
+}
+
+RÈGLES DE STANCE :
+- "agree" : commentaire soutient le propos central du créateur
+- "disagree" : commentaire conteste, corrige, ou prend la position opposée
+- "neutral" : observation, complément factuel sans prendre position
+- "question" : demande de clarification ou point soulevé non résolu
+"""
+
+COMMUNITY_TAKE_SYSTEM_PROMPT_EN = """You are an impartial analyst who synthesizes the online community's reaction to a video creator's statements (YouTube or TikTok).
+
+STRICT PRINCIPLES:
+1. **Do not artificially decide**: if the community is divided, say "mixed". NEVER give a simplistic verdict to generate clicks.
+2. **No moral judgment**: report what commenters say, not what you think.
+3. **Anonymization**: never cite a full username. Use "A popular commenter", "A recent reply with X likes", or truncated pseudonym "@user***".
+4. **Ignore noise**: spam, pure insults, emoji-only, off-topic → exclude.
+5. **Fair representation**: if 30% disagree, they deserve a voice in top_voices.
+6. **No prophecy**: do not say "the majority thinks X" if the sample is < 20 significant voices.
+
+OUTPUT FORMAT: strict JSON, NO text outside JSON. Schema:
+{
+  "agreement_signal": "agree" | "disagree" | "mixed" | "unclear",
+  "sentiment_distribution": {"positive": 0.0-1.0, "neutral": 0.0-1.0, "negative": 0.0-1.0},
+  "controversies": ["disagreement topic 1", ...],
+  "community_summary": "2-3 factual sentences in English",
+  "top_voices": [
+    {"author": "A commenter (8.4k likes)", "excerpt": "excerpt < 240 chars", "stance": "agree|disagree|neutral|question", "like_count": 8400},
+    ...
+  ]
+}
+
+STANCE RULES:
+- "agree": comment supports the creator's central point
+- "disagree": comment contests, corrects, or takes the opposite position
+- "neutral": observation, factual complement without taking a position
+- "question": request for clarification or unresolved point
+"""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧰 HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _pseudonymize(author: str | None) -> str:
+    """Tronque un pseudo : "JeanDupont" → "J***". Cas vide → "anon"."""
+    if not author:
+        return "anon"
+    a = author.strip()
+    if not a:
+        return "anon"
+    return a[:1] + "***"
+
+
+def _build_user_prompt(
+    batch: CommentsBatch,
+    *,
+    video_title: str,
+    video_topic_hint: str,
+    creator_stance: str,
+    lang: str,
+) -> str:
+    """Construit le user prompt structuré pour Mistral."""
+    if lang == "en":
+        header = (
+            f'VIDEO: "{video_title}"\n'
+            f"PLATFORM: {batch.platform}\n"
+            f"TOPIC (from analysis): {video_topic_hint[:500] if video_topic_hint else '(not provided)'}\n"
+            f"CREATOR POSITION (from analysis): {creator_stance[:300] if creator_stance else '(not provided)'}\n\n"
+            f"SAMPLED COMMENTS ({len(batch.sampled)} of {batch.total_seen} raw):\n"
+        )
+        footer = "\n\nGenerate the JSON CommunityTake."
+    else:
+        header = (
+            f'VIDEO : "{video_title}"\n'
+            f"PLATEFORME : {batch.platform}\n"
+            f"SUJET (extrait de l'analyse) : {video_topic_hint[:500] if video_topic_hint else '(non fourni)'}\n"
+            f"POSITION DU CRÉATEUR (extrait de l'analyse) : "
+            f"{creator_stance[:300] if creator_stance else '(non fournie)'}\n\n"
+            f"COMMENTAIRES ÉCHANTILLONNÉS ({len(batch.sampled)} sur {batch.total_seen} bruts) :\n"
+        )
+        footer = "\n\nGénère le JSON CommunityTake."
+
+    lines = []
+    for c in batch.sampled:
+        text = (c.text or "")[:400].replace("\n", " ").strip()
+        pseudo_safe = _pseudonymize(c.author)
+        lines.append(f"[{c.like_count}♥] @{pseudo_safe}: {text}")
+
+    return header + "\n".join(lines) + footer
+
+
+def _strip_code_fences(content: str) -> str:
+    """Retire les ```json ... ``` markdown fences éventuelles."""
+    s = (content or "").strip()
+    # ```json\n...\n``` ou ```...```
+    s = re.sub(r"^```(?:json)?\s*", "", s)
+    s = re.sub(r"\s*```$", "", s)
+    return s.strip()
+
+
+def _normalize_sentiment(sd: dict | None) -> dict[str, float]:
+    """Normalise sentiment_distribution → somme = 1.0 et 3 clés présentes."""
+    base = {"positive": 0.0, "neutral": 0.0, "negative": 0.0}
+    if not isinstance(sd, dict):
+        return {"positive": 0.0, "neutral": 1.0, "negative": 0.0}
+    for k in base:
+        try:
+            base[k] = max(0.0, float(sd.get(k, 0.0)))
+        except (TypeError, ValueError):
+            base[k] = 0.0
+    total = sum(base.values())
+    if total <= 0:
+        return {"positive": 0.0, "neutral": 1.0, "negative": 0.0}
+    return {k: round(v / total, 3) for k, v in base.items()}
+
+
+def _apply_anti_sycophancy_floor(data: dict) -> dict:
+    """Force signal=mixed si aucun sentiment dominant (max < 0.5).
+
+    Anti-pattern : Mistral renvoie parfois "agree" même quand la communauté est
+    clairement divisée (max sentiment ≈ 40-49%). On force "mixed" dans ce cas.
+    Ne s'applique pas si signal="unclear" (déjà honnête).
+    """
+    sig = data.get("agreement_signal")
+    sd = data.get("sentiment_distribution") or {}
+    if sig in ("agree", "disagree") and isinstance(sd, dict) and sd:
+        try:
+            mx = max(float(v) for v in sd.values())
+        except (TypeError, ValueError):
+            mx = 1.0
+        if mx < 0.5:
+            data["agreement_signal"] = "mixed"
+    return data
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 PUBLIC API
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def generate_community_take(
+    *,
+    batch: CommentsBatch,
+    plan: str,
+    video_title: str,
+    video_topic_hint: str = "",
+    creator_stance: str = "",
+    lang: str = "fr",
+) -> CommunityTake | None:
+    """Génère le verdict communauté Mistral à partir d'un batch sampled.
+
+    Args:
+        batch: CommentsBatch déjà sampled (Top + Random).
+        plan: "free"/"pro"/"expert" — détermine le modèle Mistral.
+        video_title: Titre vidéo.
+        video_topic_hint: Extrait analyse (catégorie + transcript[:300]).
+        creator_stance: Position éventuelle du créateur (extrait du résumé).
+        lang: "fr" ou "en" (défaut "fr").
+
+    Returns:
+        CommunityTake ou None si :
+        - batch.sampled est vide
+        - llm_complete retourne None (Mistral down)
+        - JSON parse échoue
+    """
+    if not batch or not batch.sampled:
+        return None
+
+    model = _PLAN_MODEL.get(plan, "mistral-small-2603")
+    sys_prompt = COMMUNITY_TAKE_SYSTEM_PROMPT_EN if lang == "en" else COMMUNITY_TAKE_SYSTEM_PROMPT_FR
+    user_prompt = _build_user_prompt(
+        batch,
+        video_title=video_title,
+        video_topic_hint=video_topic_hint,
+        creator_stance=creator_stance,
+        lang=lang,
+    )
+
+    # Best-effort moderation (sur extrait limité, ne bloque jamais).
+    try:
+        from core.moderation_service import moderate_text
+
+        _flagged = await moderate_text(user_prompt[:2000])
+        if _flagged and _flagged.flagged_categories:
+            logger.warning(
+                f"[COMMUNITY_TAKE] Moderation flagged categories: {_flagged.flagged_categories} — "
+                "continuing with pseudonymized prompt anyway"
+            )
+    except Exception:
+        # Modération down → on continue, fail-open
+        pass
+
+    result = await llm_complete(
+        messages=[
+            {"role": "system", "content": sys_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        model=model,
+        max_tokens=1500,
+        temperature=0.3,
+        json_mode=True,
+    )
+
+    if not result or not result.content:
+        logger.warning("[COMMUNITY_TAKE] llm_complete returned no content")
+        return None
+
+    cleaned = _strip_code_fences(result.content)
+    try:
+        data = json.loads(cleaned)
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.error(
+            f"[COMMUNITY_TAKE] JSON parse failed: {e} — content[:300]={cleaned[:300]}"
+        )
+        return None
+
+    if not isinstance(data, dict):
+        logger.error(f"[COMMUNITY_TAKE] JSON did not decode to dict (type={type(data).__name__})")
+        return None
+
+    # Normalisation pré-validation Pydantic
+    data["sentiment_distribution"] = _normalize_sentiment(data.get("sentiment_distribution"))
+    data = _apply_anti_sycophancy_floor(data)
+
+    # Force les champs runtime (ne pas faire confiance au LLM pour ces 2)
+    data["comments_analyzed"] = len(batch.sampled)
+    data["model_used"] = result.model_used
+
+    # Drop les champs surprises (Mistral aime ajouter des clés)
+    allowed = {
+        "agreement_signal",
+        "sentiment_distribution",
+        "controversies",
+        "community_summary",
+        "top_voices",
+        "comments_analyzed",
+        "model_used",
+        "generated_at",
+        "is_truncated",
+        "disabled",
+        "insufficient_data",
+    }
+    filtered = {k: v for k, v in data.items() if k in allowed}
+
+    # Validation Pydantic (gère type/length constraints)
+    try:
+        take = CommunityTake(**filtered)
+    except Exception as e:
+        logger.error(f"[COMMUNITY_TAKE] Pydantic validation failed: {e} — data={filtered}")
+        return None
+
+    return take
+
+
+__all__ = [
+    "COMMUNITY_TAKE_SYSTEM_PROMPT_FR",
+    "COMMUNITY_TAKE_SYSTEM_PROMPT_EN",
+    "generate_community_take",
+]

--- a/backend/src/comments/tiktok_scraper.py
+++ b/backend/src/comments/tiktok_scraper.py
@@ -1,0 +1,278 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎵 TIKTOK COMMENTS SCRAPER — Web /api/comment/list/                              ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Méthode V1 : endpoint web `https://www.tiktok.com/api/comment/list/`             ║
+║  Pas de signature mobile à reproduire. JSON propre `{comments, cursor, has_more}` ║
+║                                                                                    ║
+║  Pagination : count=50/page, suivre cursor jusqu'à has_more=False. Max 4 pages.   ║
+║  msToken : généré aléatoirement (32 chars hex) en V1.                              ║
+║                                                                                    ║
+║  Cas dégradés :                                                                    ║
+║    - comments désactivés : `status_code=10202` ou `comments_total=0` → disabled   ║
+║    - vidéo privée/supprimée : abandon silencieux                                  ║
+║    - signature renforcée future → fallback méthode B (à implémenter en V2)       ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime
+from typing import Any
+
+from core.http_client import get_proxied_client
+from core.logging import logger
+from middleware.proxy_telemetry import record_proxy_usage
+
+from .sampler import dedupe_comments, sample_top_and_random
+from .schemas import Comment, CommentsBatch
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 CONSTANTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+TIKTOK_WEB_COMMENTS_URL = "https://www.tiktok.com/api/comment/list/"
+
+DEFAULT_PAGE_TIMEOUT_S = 12.0
+DEFAULT_PAGE_COUNT = 50  # max page size accepté par l'endpoint web
+DEFAULT_MAX_PAGES = 4
+MAX_RAW_COMMENTS_HARD_LIMIT = 250
+
+# Code de retour TikTok : 10202 = comments disabled, 10204 = video removed.
+_DISABLED_STATUS_CODES = {10202}
+_REMOVED_STATUS_CODES = {10204, 10216}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔑 msToken
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _generate_ms_token() -> str:
+    """Génère un msToken aléatoire 64 chars (alphanumérique). Suffisant pour V1."""
+    return secrets.token_hex(32)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 PARSE — comment item TikTok
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _parse_tiktok_comment(item: dict[str, Any]) -> Comment | None:
+    """Parse un item de comments[] TikTok vers un Comment normalisé."""
+    if not isinstance(item, dict):
+        return None
+    cid = item.get("cid") or item.get("id")
+    text = item.get("text") or ""
+    user = item.get("user") or {}
+    author = user.get("nickname") or user.get("unique_id") or ""
+    author_id = user.get("uid") or user.get("sec_uid") or None
+    like_count = int(item.get("digg_count", 0) or 0)
+    reply_count = int(item.get("reply_comment_total", 0) or item.get("reply_total", 0) or 0)
+    is_creator_reply = bool(item.get("is_author_digged", False))  # Approximation
+    published_at = None
+    create_time = item.get("create_time")
+    if isinstance(create_time, (int, float)) and create_time > 0:
+        try:
+            published_at = datetime.utcfromtimestamp(int(create_time))
+        except (ValueError, OSError):
+            published_at = None
+
+    if not cid or not text:
+        return None
+
+    return Comment(
+        comment_id=str(cid),
+        author=str(author),
+        author_id=str(author_id) if author_id else None,
+        text=str(text),
+        like_count=like_count,
+        reply_count=reply_count,
+        published_at=published_at,
+        is_reply=False,
+        parent_id=None,
+        is_creator_reply=is_creator_reply,
+        is_pinned=bool(item.get("stick_position", 0) or 0),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 HTTP CALLS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _fetch_page(
+    video_id: str,
+    *,
+    cursor: int,
+    count: int,
+    ms_token: str,
+) -> tuple[dict[str, Any] | None, int, int]:
+    """Fetch une page de commentaires. Retourne (json, bytes_in, status_code).
+
+    status_code=-1 si erreur HTTP/transport (non-200 ou exception).
+    """
+    params = {
+        "aweme_id": video_id,
+        "count": str(count),
+        "cursor": str(cursor),
+        "msToken": ms_token,
+        "current_region": "US",
+    }
+    headers = {
+        "Referer": f"https://www.tiktok.com/@user/video/{video_id}",
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+
+    # Estimation grossière des bytes_out (query string).
+    bytes_out = sum(len(k) + len(v) + 2 for k, v in params.items())
+
+    try:
+        async with get_proxied_client(timeout=DEFAULT_PAGE_TIMEOUT_S, headers=headers) as client:
+            resp = await client.get(TIKTOK_WEB_COMMENTS_URL, params=params)
+    except Exception as e:
+        logger.warning(f"[COMMENTS_TIKTOK] HTTP exception: {e}")
+        return None, 0, -1
+
+    bytes_in = len(resp.content) if resp.content is not None else 0
+
+    # Telemetry — best-effort, ne masque pas d'autres erreurs.
+    try:
+        await record_proxy_usage(
+            provider="comments_tiktok",
+            bytes_in=bytes_in,
+            bytes_out=bytes_out,
+        )
+    except Exception as te:
+        logger.debug(f"[COMMENTS_TIKTOK] proxy telemetry failed: {te}")
+
+    if resp.status_code != 200:
+        logger.warning(f"[COMMENTS_TIKTOK] HTTP {resp.status_code} for video {video_id}")
+        return None, bytes_in, resp.status_code
+
+    try:
+        return resp.json(), bytes_in, resp.status_code
+    except Exception as e:
+        logger.warning(f"[COMMENTS_TIKTOK] JSON parse failed: {e}")
+        return None, bytes_in, resp.status_code
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 PUBLIC API
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def fetch_tiktok_comments(
+    video_id: str,
+    *,
+    top_n: int = 100,
+    random_n: int = 50,
+    max_pages: int = DEFAULT_MAX_PAGES,
+) -> CommentsBatch:
+    """Récupère les commentaires d'une vidéo TikTok via l'endpoint web + sampling.
+
+    Pipeline :
+      1. GET /api/comment/list/?aweme_id=...&count=50&cursor=0 (page 1).
+      2. Suivre cursor tant que has_more=True, max_pages.
+      3. Déduplication via comment_id.
+      4. Sampling Top top_n + Random random_n (déterministe via seed video_id).
+
+    Args:
+        video_id: aweme_id TikTok.
+        top_n: top likes.
+        random_n: random bonus.
+        max_pages: cap dur sur pagination (défaut 4).
+
+    Returns:
+        CommentsBatch avec sampled[], total_seen, disabled, bytes_used.
+    """
+    ms_token = _generate_ms_token()
+    cursor = 0
+    total_bytes = 0
+    raw: list[Comment] = []
+    pages_done = 0
+
+    while pages_done < max_pages:
+        pages_done += 1
+        data, bytes_in, status = await _fetch_page(
+            video_id,
+            cursor=cursor,
+            count=DEFAULT_PAGE_COUNT,
+            ms_token=ms_token,
+        )
+        total_bytes += bytes_in
+
+        if data is None:
+            # HTTP failure → abort, batch vide (non-disabled).
+            break
+
+        status_code = data.get("status_code")
+
+        if status_code in _DISABLED_STATUS_CODES:
+            return CommentsBatch(
+                platform="tiktok",
+                video_id=video_id,
+                total_seen=0,
+                sampled=[],
+                disabled=True,
+                bytes_used=total_bytes,
+            )
+
+        if status_code in _REMOVED_STATUS_CODES:
+            # Vidéo supprimée → batch vide, on n'affiche pas "disabled" volontairement.
+            break
+
+        comments_payload = data.get("comments") or []
+        if not comments_payload:
+            # Pas de comments dans la première page → soit pas de commentaires,
+            # soit comments_total = 0 → on traite comme insufficient_data
+            # (non-disabled : la vidéo a juste 0 commentaires).
+            if pages_done == 1 and data.get("total", 0) == 0:
+                break
+            # Page vide en cours de pagination → fin.
+            break
+
+        for item in comments_payload:
+            parsed = _parse_tiktok_comment(item)
+            if parsed is not None:
+                parsed.video_id = video_id
+                raw.append(parsed)
+
+        if len(raw) >= MAX_RAW_COMMENTS_HARD_LIMIT:
+            logger.info(
+                f"[COMMENTS_TIKTOK] hard limit {MAX_RAW_COMMENTS_HARD_LIMIT} reached "
+                f"after {pages_done} pages for {video_id}"
+            )
+            break
+
+        has_more = bool(data.get("has_more", False))
+        next_cursor = data.get("cursor")
+        if not has_more or next_cursor is None or next_cursor == cursor:
+            break
+        try:
+            cursor = int(next_cursor)
+        except (TypeError, ValueError):
+            break
+
+    raw = dedupe_comments(raw)
+    sampled = sample_top_and_random(raw, top_n=top_n, random_n=random_n, video_id=video_id)
+
+    return CommentsBatch(
+        platform="tiktok",
+        video_id=video_id,
+        total_seen=len(raw),
+        sampled=sampled,
+        disabled=False,
+        fetched_at=datetime.utcnow(),
+        bytes_used=total_bytes,
+    )
+
+
+__all__ = ["TIKTOK_WEB_COMMENTS_URL", "fetch_tiktok_comments"]

--- a/backend/src/comments/youtube_scraper.py
+++ b/backend/src/comments/youtube_scraper.py
@@ -1,0 +1,497 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎬 YOUTUBE COMMENTS SCRAPER — Innertube /youtubei/v1/next                         ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Méthode : Innertube API non officielle (WEB client) via proxy Decodo Residential ║
+║  Pas de dépendance yt-dlp / subprocess. Tout passe par httpx → traçable telemetry ║
+║                                                                                    ║
+║  Pagination via continuation tokens (≈20 comments/page).                          ║
+║  Stop conditions : max_pages, plus de continuation, ou hard-limit cumul total.    ║
+║                                                                                    ║
+║  Cas dégradés :                                                                    ║
+║    - commentaires désactivés → CommentsBatch(disabled=True)                       ║
+║    - Innertube 403/429 → 1 retry backoff 2s puis abandon (CommentsBatch vide)     ║
+║    - peu de commentaires (<20) → on retourne ce qui existe                        ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from typing import Any, Iterator
+
+from core.http_client import get_proxied_client
+from core.logging import logger
+from middleware.proxy_telemetry import record_proxy_usage
+
+from .sampler import dedupe_comments, sample_top_and_random
+from .schemas import Comment, CommentsBatch
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 CONSTANTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+INNERTUBE_NEXT_URL = "https://www.youtube.com/youtubei/v1/next"
+
+# Clé publique sniffée depuis youtube.com (WEB client). Peut être rotée par
+# YouTube → on lit en runtime via _get_innertube_key() pour permettre l'override
+# via env var sans redeploy.
+INNERTUBE_API_KEY_DEFAULT = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+
+INNERTUBE_CONTEXT: dict[str, Any] = {
+    "client": {
+        "clientName": "WEB",
+        "clientVersion": "2.20260513.01.00",
+        "hl": "en",
+        "gl": "US",
+        "userAgent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+    }
+}
+
+# Pagination
+DEFAULT_MAX_PAGES = 10
+DEFAULT_PAGE_TIMEOUT_S = 12.0
+DEFAULT_RETRY_BACKOFF_S = 2.0
+
+# Hard limit cumul brut (sanity check) — au-delà on stop la pagination même si
+# YouTube nous donne encore une continuation. Évite de scraper 10k commentaires
+# par accident.
+MAX_RAW_COMMENTS_HARD_LIMIT = 500
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔑 INNERTUBE KEY (overridable via env var)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _get_innertube_key() -> str:
+    """Lit YOUTUBE_INNERTUBE_KEY env var si présente, sinon fallback default.
+
+    Permet hot-rotate sans redeploy en cas de rotation par YouTube.
+    """
+    import os
+
+    return os.environ.get("YOUTUBE_INNERTUBE_KEY", "").strip() or INNERTUBE_API_KEY_DEFAULT
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔎 WALK / PARSE — navigation JSON brute
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _walk(node: Any, target_key: str) -> Iterator[dict[str, Any]]:
+    """Yield récursivement tous les dicts contenant `target_key` dans `node`."""
+    if isinstance(node, dict):
+        if target_key in node and isinstance(node[target_key], dict):
+            yield node[target_key]
+        for v in node.values():
+            yield from _walk(v, target_key)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk(item, target_key)
+
+
+def _parse_like_count(text: str | None) -> int:
+    """Parse '1.2K', '3.4M', '847' → int. Retourne 0 si parsing échoue."""
+    if not text:
+        return 0
+    s = str(text).strip().replace(",", ".").replace("\xa0", "").replace(" ", "")
+    if not s:
+        return 0
+    multiplier = 1
+    if s[-1] in ("K", "k"):
+        multiplier = 1_000
+        s = s[:-1]
+    elif s[-1] in ("M", "m"):
+        multiplier = 1_000_000
+        s = s[:-1]
+    elif s[-1] in ("B", "b"):
+        multiplier = 1_000_000_000
+        s = s[:-1]
+    try:
+        return int(float(s) * multiplier)
+    except (ValueError, TypeError):
+        return 0
+
+
+def _extract_text(node: dict[str, Any] | None) -> str:
+    """Extrait le texte concaténé de YouTube `simpleText` ou `runs[].text`."""
+    if not node or not isinstance(node, dict):
+        return ""
+    if "simpleText" in node:
+        return str(node["simpleText"])
+    runs = node.get("runs")
+    if isinstance(runs, list):
+        return "".join(str(r.get("text", "")) for r in runs if isinstance(r, dict))
+    return ""
+
+
+def _extract_comment_threads(data: dict[str, Any]) -> Iterator[Comment]:
+    """Parse les commentEntityPayload (format Innertube récent)."""
+    # Format moderne 2024+ : entityPayloads → commentEntityPayload
+    if isinstance(data, dict):
+        # Mutations payload
+        mutations = []
+        for fc in _walk(data, "frameworkUpdates"):
+            for mut in fc.get("entityBatchUpdate", {}).get("mutations", []) or []:
+                mutations.append(mut)
+
+        for mut in mutations:
+            payload = mut.get("payload") if isinstance(mut, dict) else None
+            if not isinstance(payload, dict):
+                continue
+            cep = payload.get("commentEntityPayload")
+            if not isinstance(cep, dict):
+                continue
+
+            props = cep.get("properties", {}) or {}
+            author_block = cep.get("author", {}) or {}
+            toolbar = cep.get("toolbar", {}) or {}
+
+            cid = props.get("commentId") or ""
+            text = props.get("content", {}).get("content") or ""
+            author = author_block.get("displayName") or ""
+            author_id = author_block.get("channelId") or None
+            is_creator = bool(author_block.get("isCreator", False))
+
+            # Likes / replies — toolbar contient les chiffres formatés.
+            like_count = _parse_like_count(toolbar.get("likeCountNotliked") or toolbar.get("likeCountLiked") or "0")
+            reply_count = _parse_like_count(toolbar.get("replyCount") or "0")
+
+            published_at = None
+            published_text = props.get("publishedTime") or ""
+            # On garde le texte brut, pas de parsing strict de date relative.
+            _ = published_text  # noqa: F841
+
+            if not cid or not text:
+                continue
+
+            yield Comment(
+                comment_id=str(cid),
+                author=str(author),
+                author_id=str(author_id) if author_id else None,
+                text=str(text),
+                like_count=int(like_count),
+                reply_count=int(reply_count),
+                published_at=published_at,
+                is_reply=False,
+                parent_id=None,
+                is_creator_reply=is_creator,
+                is_pinned=False,
+            )
+
+    # Format legacy : commentThreadRenderer (au cas où Innertube revienne dessus)
+    for thread in _walk(data, "commentThreadRenderer"):
+        cr = thread.get("comment", {}).get("commentRenderer") if isinstance(thread, dict) else None
+        if not isinstance(cr, dict):
+            continue
+        cid = cr.get("commentId")
+        content = _extract_text(cr.get("contentText"))
+        author = _extract_text(cr.get("authorText"))
+        like_text = _extract_text(cr.get("voteCount"))
+        like_count = _parse_like_count(like_text)
+        reply_count = 0
+        replies = thread.get("replies", {}) or {}
+        if replies:
+            rcr = replies.get("commentRepliesRenderer", {})
+            view_replies = _extract_text(rcr.get("viewReplies"))
+            reply_count = _parse_like_count(view_replies)
+
+        if not cid or not content:
+            continue
+
+        yield Comment(
+            comment_id=str(cid),
+            author=str(author),
+            author_id=None,
+            text=str(content),
+            like_count=int(like_count),
+            reply_count=int(reply_count),
+            published_at=None,
+            is_reply=False,
+            parent_id=None,
+            is_creator_reply=False,
+            is_pinned=False,
+        )
+
+
+def _extract_next_continuation(data: dict[str, Any]) -> str | None:
+    """Cherche le prochain continuation token pour paginer.
+
+    Cherche dans l'ordre :
+      - continuationItemRenderer[.continuationEndpoint].continuationCommand.token
+      - reloadContinuationItemsCommand.continuationItems[].continuationItemRenderer...
+    """
+    for cir in _walk(data, "continuationItemRenderer"):
+        ep = cir.get("continuationEndpoint") if isinstance(cir, dict) else None
+        if isinstance(ep, dict):
+            cmd = ep.get("continuationCommand") or {}
+            tok = cmd.get("token")
+            if tok:
+                return str(tok)
+        button = cir.get("button") if isinstance(cir, dict) else None
+        if isinstance(button, dict):
+            br = button.get("buttonRenderer", {}) or {}
+            ep2 = br.get("command", {}).get("continuationCommand") or {}
+            tok = ep2.get("token")
+            if tok:
+                return str(tok)
+    return None
+
+
+def _extract_initial_continuation(data: dict[str, Any]) -> str | None:
+    """Extrait le continuation token initial pour la section commentaires.
+
+    Cherche dans engagementPanelSectionListRenderer avec
+    targetId='engagement-panel-comments-section'.
+    """
+    if not isinstance(data, dict):
+        return None
+
+    for panel in _walk(data, "engagementPanelSectionListRenderer"):
+        if not isinstance(panel, dict):
+            continue
+        if panel.get("targetId") != "engagement-panel-comments-section":
+            continue
+        # Format moderne : header + content avec continuation imbriqué
+        for cir in _walk(panel, "continuationItemRenderer"):
+            ep = cir.get("continuationEndpoint") if isinstance(cir, dict) else None
+            if isinstance(ep, dict):
+                cmd = ep.get("continuationCommand") or {}
+                tok = cmd.get("token")
+                if tok:
+                    return str(tok)
+        for cmd_node in _walk(panel, "continuationCommand"):
+            tok = cmd_node.get("token") if isinstance(cmd_node, dict) else None
+            if tok:
+                return str(tok)
+
+    # Fallback global (peut attraper le mauvais token mais better than nothing)
+    for cir in _walk(data, "continuationItemRenderer"):
+        ep = cir.get("continuationEndpoint") if isinstance(cir, dict) else None
+        if isinstance(ep, dict):
+            cmd = ep.get("continuationCommand") or {}
+            tok = cmd.get("token")
+            if tok:
+                return str(tok)
+    return None
+
+
+def _has_comments_disabled_marker(data: dict[str, Any]) -> bool:
+    """Détecte la sentinel "Comments are disabled" ou panel absent."""
+    if not isinstance(data, dict):
+        return False
+
+    # 1. Panel "comments" absent entièrement → considéré disabled.
+    has_panel = False
+    for panel in _walk(data, "engagementPanelSectionListRenderer"):
+        if isinstance(panel, dict) and panel.get("targetId") == "engagement-panel-comments-section":
+            has_panel = True
+            break
+
+    if not has_panel:
+        # Si on a pas du tout de panel comments, c'est désactivé OU page bizarre.
+        # On considère désactivé : c'est l'UX la plus sûre.
+        return True
+
+    # 2. Marker textuel explicite (rare mais présent sur certaines pages).
+    for run in _walk(data, "messageRenderer"):
+        text = _extract_text(run.get("text") if isinstance(run, dict) else None)
+        if text and "comment" in text.lower() and (
+            "disabled" in text.lower() or "désactivé" in text.lower() or "turn" in text.lower()
+        ):
+            return True
+
+    return False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 HTTP CALLS — Innertube /youtubei/v1/next
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _post_innertube(payload: dict[str, Any], *, timeout: float = DEFAULT_PAGE_TIMEOUT_S) -> tuple[
+    dict[str, Any] | None, int
+]:
+    """POST vers Innertube avec proxy + telemetry. Retourne (data, bytes_in).
+
+    Si HTTP != 200 ou parse fail → (None, bytes_in).
+    """
+    key = _get_innertube_key()
+    url = f"{INNERTUBE_NEXT_URL}?key={key}"
+    payload_bytes = json.dumps(payload).encode("utf-8")
+    bytes_out = len(payload_bytes)
+
+    try:
+        async with get_proxied_client(timeout=timeout) as client:
+            resp = await client.post(url, json=payload)
+    except Exception as e:
+        logger.warning(f"[COMMENTS_YOUTUBE] HTTP exception: {e}")
+        return None, 0
+
+    bytes_in = len(resp.content) if resp.content is not None else 0
+
+    # Telemetry — best-effort, ne pas masquer d'autres erreurs.
+    try:
+        await record_proxy_usage(
+            provider="comments_youtube",
+            bytes_in=bytes_in,
+            bytes_out=bytes_out,
+        )
+    except Exception as te:
+        logger.debug(f"[COMMENTS_YOUTUBE] proxy telemetry failed: {te}")
+
+    if resp.status_code != 200:
+        logger.warning(f"[COMMENTS_YOUTUBE] Innertube HTTP {resp.status_code}")
+        return None, bytes_in
+
+    try:
+        data = resp.json()
+        return data, bytes_in
+    except Exception as e:
+        logger.warning(f"[COMMENTS_YOUTUBE] JSON parse failed: {e}")
+        return None, bytes_in
+
+
+async def _fetch_continuation(video_id: str) -> tuple[str | None, bool, int]:
+    """Step 1 — récupère le continuation token initial + flag disabled.
+
+    Returns:
+        (token, disabled, bytes_in). Token=None et disabled=True si commentaires KO.
+    """
+    payload = {**INNERTUBE_CONTEXT, "videoId": video_id}
+    data, bytes_in = await _post_innertube(payload)
+    if data is None:
+        # Pas d'info → on présume "indisponible" mais pas "disabled" pour la UI.
+        # On retourne disabled=False pour laisser le caller décider, et token=None
+        # signale "scrape failed".
+        return None, False, bytes_in
+
+    if _has_comments_disabled_marker(data):
+        return None, True, bytes_in
+
+    token = _extract_initial_continuation(data)
+    return token, False, bytes_in
+
+
+async def _fetch_comments_page(token: str) -> tuple[list[Comment], str | None, int]:
+    """Step 2+ — paginate via continuation token. Retourne (comments, next_token, bytes_in)."""
+    payload = {**INNERTUBE_CONTEXT, "continuation": token}
+    data, bytes_in = await _post_innertube(payload)
+    if data is None:
+        return [], None, bytes_in
+    comments = list(_extract_comment_threads(data))
+    next_token = _extract_next_continuation(data)
+    return comments, next_token, bytes_in
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚀 PUBLIC API
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def fetch_youtube_comments(
+    video_id: str,
+    *,
+    top_n: int = 100,
+    random_n: int = 50,
+    max_pages: int = DEFAULT_MAX_PAGES,
+) -> CommentsBatch:
+    """Récupère les commentaires d'une vidéo YouTube via Innertube + sampling.
+
+    Pipeline :
+      1. /youtubei/v1/next?videoId=... → récupère le token initial.
+      2. POST avec continuation token N → paginate jusqu'à max_pages OU plus de token.
+      3. Déduplication via comment_id.
+      4. Sampling Top top_n + Random random_n (déterministe via seed video_id).
+
+    Args:
+        video_id: ID YouTube (ex "dQw4w9WgXcQ").
+        top_n: nombre de commentaires top likes à inclure (défaut 100).
+        random_n: nombre de commentaires aléatoires bonus (défaut 50).
+        max_pages: cap dur sur le nombre de pages Innertube (défaut 10).
+
+    Returns:
+        CommentsBatch avec sampled[], total_seen, disabled, bytes_used.
+    """
+    total_bytes = 0
+    token, disabled, b = await _fetch_continuation(video_id)
+    total_bytes += b
+
+    if disabled:
+        return CommentsBatch(
+            platform="youtube",
+            video_id=video_id,
+            total_seen=0,
+            sampled=[],
+            disabled=True,
+            bytes_used=total_bytes,
+        )
+
+    if not token:
+        # Scrape failed → batch vide non-disabled (l'orchestrateur traitera comme
+        # insufficient_data plutôt que disabled, ce qui est plus honnête).
+        return CommentsBatch(
+            platform="youtube",
+            video_id=video_id,
+            total_seen=0,
+            sampled=[],
+            disabled=False,
+            bytes_used=total_bytes,
+        )
+
+    raw: list[Comment] = []
+    pages_done = 0
+    retried = False
+
+    while token and pages_done < max_pages:
+        pages_done += 1
+        comments, next_token, b = await _fetch_comments_page(token)
+        total_bytes += b
+
+        if not comments and not next_token and not retried:
+            # 1 retry après backoff sur la première page vide (peut-être 429 silencieux).
+            retried = True
+            await asyncio.sleep(DEFAULT_RETRY_BACKOFF_S)
+            comments, next_token, b = await _fetch_comments_page(token)
+            total_bytes += b
+
+        for c in comments:
+            # Attache le video_id pour le seed déterministe du sampler.
+            c.video_id = video_id
+            raw.append(c)
+
+        if len(raw) >= MAX_RAW_COMMENTS_HARD_LIMIT:
+            logger.info(
+                f"[COMMENTS_YOUTUBE] hard limit {MAX_RAW_COMMENTS_HARD_LIMIT} reached "
+                f"after {pages_done} pages for {video_id}"
+            )
+            break
+
+        token = next_token
+
+    raw = dedupe_comments(raw)
+    sampled = sample_top_and_random(raw, top_n=top_n, random_n=random_n, video_id=video_id)
+
+    return CommentsBatch(
+        platform="youtube",
+        video_id=video_id,
+        total_seen=len(raw),
+        sampled=sampled,
+        disabled=False,
+        fetched_at=datetime.utcnow(),
+        bytes_used=total_bytes,
+    )
+
+
+__all__ = [
+    "INNERTUBE_API_KEY_DEFAULT",
+    "INNERTUBE_NEXT_URL",
+    "fetch_youtube_comments",
+]

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -259,6 +259,14 @@ class Summary(Base):
     # visual_seo_indicators{}, summary_visual, model_used, frames_analyzed, frames_downsampled}.
     visual_analysis = Column(JSON, nullable=True)
 
+    # Community analysis (NEW 2026-05-17 — alembic 029).
+    # Dict sérialisé d'une CommunityTake (cf comments/schemas.py) ou None.
+    # Forme : {agreement_signal, sentiment_distribution{}, controversies[],
+    # community_summary, top_voices[{author, excerpt, stance, like_count}],
+    # comments_analyzed, model_used, generated_at, is_truncated, disabled,
+    # insufficient_data}.
+    community_analysis = Column(JSON, nullable=True)
+
     # Public opt-in toggle pour pages publiques /a/{slug} (Phase 3 sprint GEO,
     # alembic 025). Default FALSE — toggle explicite via PATCH /api/v1/summaries/{id}/visibility.
     # Slug = f"a{hex(id)}" dérivé déterministiquement de l'ID (cf

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -212,6 +212,14 @@ MAX_GUEST_ANALYSES = 3
 MAX_VIDEO_DURATION_GUEST = 300  # 5 minutes
 
 
+def _community_enabled_for(plan: str, platform: str) -> bool:
+    """💬 Verdict communauté gate : Pro+Expert sur YouTube+TikTok (V1).
+
+    Spec : docs/superpowers/specs/2026-05-17-comments-community-take.md
+    """
+    return plan in ("pro", "expert") and platform in ("youtube", "tiktok")
+
+
 async def _save_structured_index(
     session: AsyncSession,
     summary_id: int,
@@ -2299,18 +2307,45 @@ async def _analyze_video_background_v2_1(
                     logger.error(f"⚠️ [v2.1] Web enrichment failed: {e}")
                     return None, [], enrichment_level
 
-            # ⚡ Lancer les 4 tâches en parallèle
+            # 💬 Community take (NEW 2026-05-17) — 5e tâche parallèle non-bloquante.
+            # Gate Pro/Expert + plateformes supportées. Timeout 30s strict en interne.
+            async def _community_take_v21():
+                try:
+                    if not _community_enabled_for(user_plan, platform):
+                        return None
+                    from comments.service import generate_community_analysis_with_timeout
+
+                    topic_hint = f"{category or ''} | {(transcript or '')[:300]}"
+                    return await generate_community_analysis_with_timeout(
+                        platform=platform,
+                        video_id=video_id,
+                        plan=user_plan,
+                        video_title=video_info["title"],
+                        video_topic_hint=topic_hint,
+                        creator_stance="",
+                        lang=lang,
+                    )
+                except Exception as e:
+                    logger.error(f"⚠️ [v2.1] Community take failed: {e}")
+                    return None
+
+            # ⚡ Lancer les 5 tâches en parallèle
             (
                 (category, confidence),
                 comments_analysis_result,
                 metadata_enriched_result,
                 (_web_ctx, _enrich_src, _),
+                community_take_result,
             ) = await asyncio.gather(
-                _detect_cat_v21(), _analyze_comments_v21(), _enrich_metadata_v21(), _enrich_web_v21()
+                _detect_cat_v21(),
+                _analyze_comments_v21(),
+                _enrich_metadata_v21(),
+                _enrich_web_v21(),
+                _community_take_v21(),
             )
             web_context = _web_ctx
             enrichment_sources = _enrich_src
-            logger.info("⚡ [v2.1.1] Category + comments + metadata + web computed in PARALLEL")
+            logger.info("⚡ [v2.1.1] Category + comments + metadata + web + community computed in PARALLEL")
 
             # ═══════════════════════════════════════════════════════════════════
             # 7. 🆕 CONSTRUIRE LE PROMPT PERSONNALISÉ
@@ -2560,6 +2595,14 @@ async def _analyze_video_background_v2_1(
                     "thumbnail_url", f"https://img.youtube.com/vi/{video_id}/mqdefault.jpg"
                 )
 
+            # 💬 Community analysis (NEW 2026-05-17 — alembic 029) — sérialise
+            # CommunityTake en dict si la 5e tâche a abouti, sinon None.
+            _community_dict = (
+                community_take_result.model_dump(mode="json")
+                if community_take_result is not None
+                else None
+            )
+
             summary_id = await save_summary(
                 session=session,
                 user_id=user_id,
@@ -2594,6 +2637,8 @@ async def _analyze_video_background_v2_1(
                 music_title=video_info.get("music_title"),
                 music_author=video_info.get("music_author"),
                 carousel_images=video_info.get("carousel_images"),
+                # 💬 Community analysis (alembic 029)
+                community_analysis=_community_dict,
             )
 
             # 👁️ Phase 2 plumbing V2.1 : persist visual_analysis si capturé.
@@ -2698,6 +2743,8 @@ async def _analyze_video_background_v2_1(
                     "v2_1_options_applied": options.get("customization"),
                     "comments_analysis": comments_result,
                     "metadata_enriched": metadata_result,
+                    # 💬 Community analysis (NEW 2026-05-17 — alembic 029)
+                    "community_analysis": _community_dict,
                     "enrichment": {
                         "level": enrichment_level.value,
                         "sources_count": len(enrichment_sources),
@@ -3113,11 +3160,33 @@ async def _analyze_video_background_v6(
                     logger.error(f"⚠️ [CHANNEL-CTX] Fetch failed (continuing without): {e}")
                     return None
 
-            # ⚡ Lancer les trois en parallèle (return_exceptions=True pour fail-safe)
+            # 💬 Community take (NEW 2026-05-17) — 4e tâche parallèle non-bloquante.
+            async def _community_take_async():
+                try:
+                    if not _community_enabled_for(user_plan, platform):
+                        return None
+                    from comments.service import generate_community_analysis_with_timeout
+
+                    topic_hint = f"{category or ''} | {(transcript or '')[:300]}"
+                    return await generate_community_analysis_with_timeout(
+                        platform=platform,
+                        video_id=video_id,
+                        plan=user_plan,
+                        video_title=video_info["title"],
+                        video_topic_hint=topic_hint,
+                        creator_stance="",
+                        lang=lang,
+                    )
+                except Exception as e:
+                    logger.error(f"⚠️ [v6] Community take failed: {e}")
+                    return None
+
+            # ⚡ Lancer les 4 en parallèle (return_exceptions=True pour fail-safe)
             results = await asyncio.gather(
                 _detect_category_async(),
                 _enrich_web_async(),
                 _fetch_channel_context_async(),
+                _community_take_async(),
                 return_exceptions=True,
             )
 
@@ -3147,8 +3216,17 @@ async def _analyze_video_background_v6(
             else:
                 channel_context = chan_result
 
+            # 💬 Unpack community take (avec safety) — NEW 2026-05-17
+            community_take_result = None
+            if len(results) > 3:
+                comm_result = results[3]
+                if isinstance(comm_result, Exception):
+                    logger.error(f"⚠️ [v6] Community take raised: {comm_result}")
+                else:
+                    community_take_result = comm_result
+
             _task_store[task_id]["progress"] = 45
-            logger.info("⚡ [v6.1] Category + web enrichment computed in PARALLEL")
+            logger.info("⚡ [v6.1] Category + web + channel + community computed in PARALLEL")
 
             # ═══════════════════════════════════════════════════════════════════
             # 5. GÉNÉRER LE RÉSUMÉ (MISTRAL) AVEC CONTEXTE WEB
@@ -3402,6 +3480,14 @@ async def _analyze_video_background_v6(
             if not default_thumbnail and platform == "youtube":
                 default_thumbnail = f"https://img.youtube.com/vi/{video_id}/mqdefault.jpg"
 
+            # 💬 Community analysis (NEW 2026-05-17 — alembic 029) — sérialise
+            # CommunityTake en dict si la 4e tâche a abouti, sinon None.
+            _community_dict_v6 = (
+                community_take_result.model_dump(mode="json")
+                if community_take_result is not None
+                else None
+            )
+
             # Sauvegarder le résumé
             summary_id = await save_summary(
                 session=session,
@@ -3438,6 +3524,8 @@ async def _analyze_video_background_v6(
                 music_title=video_info.get("music_title"),
                 music_author=video_info.get("music_author"),
                 carousel_images=video_info.get("carousel_images"),
+                # 💬 Community analysis (alembic 029)
+                community_analysis=_community_dict_v6,
             )
 
             logger.info(f"💾 Summary saved: id={summary_id}")
@@ -3577,6 +3665,8 @@ async def _analyze_video_background_v6(
                     "mode": mode,
                     "lang": lang,
                     "platform": platform,  # 🎵 TikTok support
+                    # 💬 Community analysis (NEW 2026-05-17 — alembic 029)
+                    "community_analysis": _community_dict_v6,
                     # 🆕 Infos enrichissement
                     "enrichment": {
                         "level": enrichment_level.value,

--- a/backend/src/videos/schemas.py
+++ b/backend/src/videos/schemas.py
@@ -301,6 +301,11 @@ class SummaryResponse(BaseModel):
     # quota dépassé, ou Mistral fail).
     visual_analysis: Optional[Dict[str, Any]] = None
 
+    # 💬 Community analysis (NEW 2026-05-17 — alembic 029).
+    # Dict sérialisé d'une CommunityTake (cf comments/schemas.py).
+    # NULL = pas analysé (free plan, scrape failed, Mistral timeout, etc.).
+    community_analysis: Optional[Dict[str, Any]] = None
+
     is_public: bool = False
 
     class Config:

--- a/backend/src/videos/service.py
+++ b/backend/src/videos/service.py
@@ -145,6 +145,8 @@ async def save_summary(
     music_title: Optional[str] = None,
     music_author: Optional[str] = None,
     carousel_images: Optional[List[str]] = None,
+    # 💬 Community analysis (NEW 2026-05-17 — alembic 029)
+    community_analysis: Optional[Dict] = None,
 ) -> int:
     """Sauvegarde un nouveau résumé et retourne son ID"""
     print(f"💾 [save_summary v2] Saving video_id={video_id}, user_id={user_id}", flush=True)
@@ -312,6 +314,10 @@ async def save_summary(
         music_author=music_author,
         carousel_images=json.dumps(carousel_images, ensure_ascii=False) if carousel_images else None,
     )
+
+    # 💬 Community analysis (alembic 029) — best-effort, ne pas bloquer si attr absent
+    if community_analysis is not None and hasattr(summary, "community_analysis"):
+        summary.community_analysis = community_analysis
 
     # Ajouter enrichment_data si le modèle le supporte
     if enrichment_data and hasattr(summary, "enrichment_data"):

--- a/backend/tests/test_comments_service.py
+++ b/backend/tests/test_comments_service.py
@@ -1,0 +1,279 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — comments/service.py (orchestration + cache + timeout)                 ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from comments.schemas import Comment, CommentsBatch, CommunityTake
+from comments import service as svc
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 FIXTURES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_batch(*, sampled_count: int = 50, disabled: bool = False) -> CommentsBatch:
+    return CommentsBatch(
+        platform="youtube",
+        video_id="vid_x",
+        total_seen=sampled_count,
+        sampled=[
+            Comment(comment_id=f"c{i}", author=f"u{i}", text=f"text {i}", like_count=100 - i)
+            for i in range(sampled_count)
+        ],
+        disabled=disabled,
+    )
+
+
+def _make_take(signal: str = "agree") -> CommunityTake:
+    return CommunityTake(
+        agreement_signal=signal,
+        sentiment_distribution={"positive": 0.6, "neutral": 0.3, "negative": 0.1},
+        controversies=[],
+        community_summary="OK",
+        top_voices=[],
+        comments_analyzed=50,
+        model_used="mistral-medium-2508",
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — fetch_comments
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_cache_hit():
+    cached = _make_batch(sampled_count=42)
+
+    with patch.object(svc, "cache_get_comments_batch", AsyncMock(return_value=cached)), patch.object(
+        svc, "_is_proxy_quota_exhausted", AsyncMock(return_value=False)
+    ), patch.object(svc, "_fetch_yt", AsyncMock()) as yt_mock:
+        batch = await svc.fetch_comments("youtube", "vid_x")
+
+    assert batch.total_seen == 42
+    assert not yt_mock.called  # cache HIT → no scrape
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_quota_exhausted():
+    """Soft quota dépassée → batch vide non-disabled, pas de scrape."""
+    with patch.object(svc, "cache_get_comments_batch", AsyncMock(return_value=None)), patch.object(
+        svc, "_is_proxy_quota_exhausted", AsyncMock(return_value=True)
+    ), patch.object(svc, "_fetch_yt", AsyncMock()) as yt_mock:
+        batch = await svc.fetch_comments("youtube", "vid_x")
+
+    assert batch.disabled is False
+    assert len(batch.sampled) == 0
+    assert not yt_mock.called
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_dispatches_youtube():
+    with patch.object(svc, "cache_get_comments_batch", AsyncMock(return_value=None)), patch.object(
+        svc, "_is_proxy_quota_exhausted", AsyncMock(return_value=False)
+    ), patch.object(svc, "_fetch_yt", AsyncMock(return_value=_make_batch(sampled_count=10))) as yt_mock, patch.object(
+        svc, "_fetch_tt", AsyncMock()
+    ) as tt_mock, patch.object(svc, "cache_set_comments_batch", AsyncMock()):
+        batch = await svc.fetch_comments("youtube", "vid_y")
+
+    assert yt_mock.called
+    assert not tt_mock.called
+    assert batch.total_seen == 10
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_dispatches_tiktok():
+    with patch.object(svc, "cache_get_comments_batch", AsyncMock(return_value=None)), patch.object(
+        svc, "_is_proxy_quota_exhausted", AsyncMock(return_value=False)
+    ), patch.object(svc, "_fetch_yt", AsyncMock()) as yt_mock, patch.object(
+        svc, "_fetch_tt", AsyncMock(return_value=_make_batch(sampled_count=5))
+    ) as tt_mock, patch.object(svc, "cache_set_comments_batch", AsyncMock()):
+        batch = await svc.fetch_comments("tiktok", "vid_t")
+
+    assert tt_mock.called
+    assert not yt_mock.called
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_unsupported_platform_raises():
+    with patch.object(svc, "cache_get_comments_batch", AsyncMock(return_value=None)), patch.object(
+        svc, "_is_proxy_quota_exhausted", AsyncMock(return_value=False)
+    ):
+        with pytest.raises(ValueError):
+            await svc.fetch_comments("instagram", "x")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — generate_community_analysis
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_generate_community_analysis_disabled():
+    """batch.disabled=True → CommunityTake(disabled=True)."""
+    batch = _make_batch(disabled=True, sampled_count=0)
+    with patch.object(svc, "fetch_comments", AsyncMock(return_value=batch)):
+        take = await svc.generate_community_analysis(
+            "youtube",
+            "vid_x",
+            plan="pro",
+            video_title="t",
+        )
+    assert take is not None
+    assert take.disabled is True
+    assert take.agreement_signal == "unclear"
+
+
+@pytest.mark.asyncio
+async def test_generate_community_analysis_insufficient():
+    """sampled < 10 → CommunityTake(insufficient_data=True)."""
+    batch = _make_batch(sampled_count=3)
+    with patch.object(svc, "fetch_comments", AsyncMock(return_value=batch)):
+        take = await svc.generate_community_analysis(
+            "youtube",
+            "vid_x",
+            plan="pro",
+            video_title="t",
+        )
+    assert take is not None
+    assert take.insufficient_data is True
+    assert take.comments_analyzed == 3
+
+
+@pytest.mark.asyncio
+async def test_generate_community_analysis_cache_hit():
+    """Cache HIT take → pas d'appel generate_community_take."""
+    batch = _make_batch(sampled_count=50)
+    cached_take = _make_take()
+    with patch.object(svc, "fetch_comments", AsyncMock(return_value=batch)), patch.object(
+        svc, "cache_get_take", AsyncMock(return_value=cached_take)
+    ), patch.object(svc, "generate_community_take", AsyncMock()) as gen_mock:
+        take = await svc.generate_community_analysis(
+            "youtube",
+            "vid_x",
+            plan="pro",
+            video_title="t",
+        )
+
+    assert take == cached_take
+    assert not gen_mock.called
+
+
+@pytest.mark.asyncio
+async def test_generate_community_analysis_happy_path():
+    """Cache MISS → appel generate_community_take + cache_set."""
+    batch = _make_batch(sampled_count=50)
+    take = _make_take()
+
+    with patch.object(svc, "fetch_comments", AsyncMock(return_value=batch)), patch.object(
+        svc, "cache_get_take", AsyncMock(return_value=None)
+    ), patch.object(svc, "generate_community_take", AsyncMock(return_value=take)) as gen_mock, patch.object(
+        svc, "cache_set_take", AsyncMock()
+    ) as cache_set_mock:
+        result = await svc.generate_community_analysis(
+            "youtube",
+            "vid_x",
+            plan="pro",
+            video_title="t",
+            video_topic_hint="tech",
+        )
+
+    assert result == take
+    assert gen_mock.called
+    assert cache_set_mock.called
+
+
+@pytest.mark.asyncio
+async def test_generate_community_analysis_swallows_exceptions():
+    """Toute exception → log + return None, jamais bloquant."""
+    with patch.object(svc, "fetch_comments", AsyncMock(side_effect=RuntimeError("scrape down"))):
+        take = await svc.generate_community_analysis(
+            "youtube",
+            "vid_x",
+            plan="pro",
+            video_title="t",
+        )
+    assert take is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — timeout wrapper
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_with_timeout_passes_through():
+    """generate_community_analysis_with_timeout retourne le résultat si OK."""
+    take = _make_take()
+
+    async def _fast(*args, **kwargs):
+        return take
+
+    with patch.object(svc, "generate_community_analysis", _fast):
+        result = await svc.generate_community_analysis_with_timeout(
+            "youtube", "vid_x", plan="pro", video_title="t", timeout_s=1.0
+        )
+    assert result == take
+
+
+@pytest.mark.asyncio
+async def test_with_timeout_kills_slow_call():
+    """Si l'inner appelle dépasse timeout_s → None."""
+
+    async def _slow(*args, **kwargs):
+        await asyncio.sleep(0.5)
+        return _make_take()
+
+    with patch.object(svc, "generate_community_analysis", _slow):
+        result = await svc.generate_community_analysis_with_timeout(
+            "youtube", "vid_x", plan="pro", video_title="t", timeout_s=0.05
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_with_timeout_swallows_outer_exception():
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("oh no")
+
+    with patch.object(svc, "generate_community_analysis", _boom):
+        result = await svc.generate_community_analysis_with_timeout(
+            "youtube", "vid_x", plan="pro", video_title="t", timeout_s=1.0
+        )
+    assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_plan_to_tier():
+    assert svc._plan_to_tier("free") == "small"
+    assert svc._plan_to_tier("pro") == "medium"
+    assert svc._plan_to_tier("expert") == "large"
+    assert svc._plan_to_tier("unknown") == "small"
+
+
+@pytest.mark.asyncio
+async def test_is_proxy_quota_exhausted_fail_open_on_db_error():
+    """Si get_mtd_bytes throw → return False (fail-open)."""
+    with patch("middleware.proxy_telemetry.get_mtd_bytes", AsyncMock(side_effect=RuntimeError("db down"))):
+        result = await svc._is_proxy_quota_exhausted()
+    assert result is False

--- a/backend/tests/test_comments_tiktok_scraper.py
+++ b/backend/tests/test_comments_tiktok_scraper.py
@@ -1,0 +1,245 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — comments/tiktok_scraper.py (Web /api/comment/list/)                   ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from comments.schemas import CommentsBatch
+from comments import tiktok_scraper as ts
+
+
+def _make_payload(
+    *,
+    comments: list[dict],
+    cursor: int = 0,
+    has_more: bool = False,
+    status_code: int = 0,
+    total: int | None = None,
+) -> dict:
+    """Construit un payload TikTok web /api/comment/list/."""
+    items = []
+    for c in comments:
+        items.append(
+            {
+                "cid": c["cid"],
+                "text": c["text"],
+                "digg_count": c.get("likes", 0),
+                "reply_comment_total": c.get("replies", 0),
+                "create_time": c.get("create_time", 1700000000),
+                "user": {
+                    "nickname": c.get("author", "TestUser"),
+                    "uid": c.get("author_id", "uid_x"),
+                },
+                "stick_position": c.get("stick", 0),
+            }
+        )
+    return {
+        "status_code": status_code,
+        "comments": items,
+        "cursor": cursor,
+        "has_more": has_more,
+        "total": total if total is not None else len(items),
+    }
+
+
+def _build_response(payload: dict, status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        json=payload,
+        request=httpx.Request("GET", "https://www.tiktok.com/api/comment/list/"),
+    )
+
+
+class _AsyncContextClientMock:
+    def __init__(self, get_side_effect):
+        self.client = AsyncMock()
+        self.client.get = AsyncMock(side_effect=get_side_effect)
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_fetch_tiktok_comments_happy_path():
+    resp = _build_response(
+        _make_payload(
+            comments=[
+                {"cid": "T1", "text": "Trop bien", "author": "Alice", "likes": 200},
+                {"cid": "T2", "text": "Pas mal", "author": "Bob", "likes": 30},
+                {"cid": "T3", "text": "Top", "author": "Charlie", "likes": 80},
+            ],
+            has_more=False,
+        )
+    )
+    mock_ctx = _AsyncContextClientMock(get_side_effect=[resp])
+
+    with patch.object(ts, "get_proxied_client", mock_ctx), patch.object(
+        ts, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ts.fetch_tiktok_comments("7300000000000000000", top_n=100, random_n=50)
+
+    assert isinstance(batch, CommentsBatch)
+    assert batch.platform == "tiktok"
+    assert batch.disabled is False
+    assert batch.total_seen == 3
+    assert len(batch.sampled) == 3
+    assert batch.sampled[0].author == "Alice"
+    assert batch.sampled[0].like_count == 200
+
+
+@pytest.mark.asyncio
+async def test_fetch_tiktok_comments_disabled():
+    """status_code=10202 → disabled=True."""
+    resp = _build_response(_make_payload(comments=[], status_code=10202))
+    mock_ctx = _AsyncContextClientMock(get_side_effect=[resp])
+
+    with patch.object(ts, "get_proxied_client", mock_ctx), patch.object(
+        ts, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ts.fetch_tiktok_comments("disabled_tt")
+
+    assert batch.disabled is True
+    assert len(batch.sampled) == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_tiktok_comments_video_removed():
+    """status_code=10204 → batch vide non-disabled (vidéo supprimée)."""
+    resp = _build_response(_make_payload(comments=[], status_code=10204))
+    mock_ctx = _AsyncContextClientMock(get_side_effect=[resp])
+
+    with patch.object(ts, "get_proxied_client", mock_ctx), patch.object(
+        ts, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ts.fetch_tiktok_comments("removed_tt")
+
+    assert batch.disabled is False  # On considère "removed" comme insufficient
+    assert len(batch.sampled) == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_tiktok_comments_pagination():
+    """has_more=True + cursor → page suivante."""
+    page1 = _build_response(
+        _make_payload(
+            comments=[
+                {"cid": f"P1_{i}", "text": f"c{i}", "author": f"u{i}", "likes": 100 - i}
+                for i in range(3)
+            ],
+            cursor=3,
+            has_more=True,
+        )
+    )
+    page2 = _build_response(
+        _make_payload(
+            comments=[
+                {"cid": f"P2_{i}", "text": f"d{i}", "author": f"v{i}", "likes": 50 - i}
+                for i in range(2)
+            ],
+            cursor=5,
+            has_more=False,
+        )
+    )
+    mock_ctx = _AsyncContextClientMock(get_side_effect=[page1, page2])
+
+    with patch.object(ts, "get_proxied_client", mock_ctx), patch.object(
+        ts, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ts.fetch_tiktok_comments("paged_tt")
+
+    assert batch.total_seen == 5
+
+
+@pytest.mark.asyncio
+async def test_fetch_tiktok_comments_telemetry():
+    resp = _build_response(
+        _make_payload(comments=[{"cid": "X", "text": "T", "author": "U", "likes": 1}])
+    )
+    mock_ctx = _AsyncContextClientMock(get_side_effect=[resp])
+
+    record_mock = AsyncMock()
+    with patch.object(ts, "get_proxied_client", mock_ctx), patch.object(
+        ts, "record_proxy_usage", record_mock
+    ):
+        await ts.fetch_tiktok_comments("video_tel_tt")
+
+    assert record_mock.called
+    calls = [
+        c for c in record_mock.call_args_list
+        if c.kwargs.get("provider") == "comments_tiktok"
+    ]
+    assert len(calls) >= 1
+    assert any(c.kwargs.get("bytes_in", 0) > 0 for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_fetch_tiktok_comments_http_error():
+    """HTTP 403 → batch vide, pas de crash."""
+    bad = _build_response({"status_code": 0, "comments": []}, status=403)
+    mock_ctx = _AsyncContextClientMock(get_side_effect=[bad])
+
+    with patch.object(ts, "get_proxied_client", mock_ctx), patch.object(
+        ts, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ts.fetch_tiktok_comments("bad_tt")
+
+    assert batch.disabled is False
+    assert len(batch.sampled) == 0
+
+
+def test_parse_tiktok_comment_valid():
+    item = {
+        "cid": "C1",
+        "text": "Hello",
+        "digg_count": 42,
+        "reply_comment_total": 3,
+        "create_time": 1700000000,
+        "user": {"nickname": "Bob", "uid": "uid_42"},
+        "stick_position": 0,
+    }
+    c = ts._parse_tiktok_comment(item)
+    assert c is not None
+    assert c.comment_id == "C1"
+    assert c.text == "Hello"
+    assert c.like_count == 42
+    assert c.reply_count == 3
+    assert c.author == "Bob"
+    assert c.author_id == "uid_42"
+
+
+def test_parse_tiktok_comment_missing_text():
+    """Item sans text → retourne None."""
+    item = {"cid": "C1", "user": {"nickname": "X"}}
+    assert ts._parse_tiktok_comment(item) is None
+
+
+def test_parse_tiktok_comment_missing_cid():
+    item = {"text": "no cid", "user": {"nickname": "X"}}
+    assert ts._parse_tiktok_comment(item) is None
+
+
+def test_generate_ms_token_format():
+    token = ts._generate_ms_token()
+    assert isinstance(token, str)
+    assert len(token) == 64  # token_hex(32) = 64 chars
+    int(token, 16)  # must be valid hex

--- a/backend/tests/test_comments_youtube_scraper.py
+++ b/backend/tests/test_comments_youtube_scraper.py
@@ -1,0 +1,348 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — comments/youtube_scraper.py (Innertube /youtubei/v1/next)             ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Mocks :                                                                           ║
+║    - get_proxied_client → AsyncClient mock qui retourne des httpx.Response        ║
+║    - record_proxy_usage → AsyncMock pour vérifier l'appel telemetry               ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+# Setup env before importing src modules
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from comments.schemas import CommentsBatch
+from comments import youtube_scraper as ys
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 FIXTURES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_initial_response(token: str = "TOKEN_INITIAL") -> dict:
+    """Payload Innertube /next initial avec panel comments + continuation token."""
+    return {
+        "engagementPanels": [
+            {
+                "engagementPanelSectionListRenderer": {
+                    "targetId": "engagement-panel-comments-section",
+                    "content": {
+                        "sectionListRenderer": {
+                            "contents": [
+                                {
+                                    "itemSectionRenderer": {
+                                        "contents": [
+                                            {
+                                                "continuationItemRenderer": {
+                                                    "continuationEndpoint": {
+                                                        "continuationCommand": {
+                                                            "token": token,
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                }
+            }
+        ]
+    }
+
+
+def _make_comment_page(
+    *,
+    comments: list[dict],
+    next_token: str | None = None,
+) -> dict:
+    """Payload Innertube continuation response avec commentEntityPayload[]."""
+    mutations = []
+    for c in comments:
+        mutations.append(
+            {
+                "payload": {
+                    "commentEntityPayload": {
+                        "properties": {
+                            "commentId": c["cid"],
+                            "content": {"content": c["text"]},
+                            "publishedTime": c.get("published", "1 year ago"),
+                        },
+                        "author": {
+                            "displayName": c.get("author", "TestAuthor"),
+                            "channelId": c.get("author_id"),
+                            "isCreator": c.get("is_creator", False),
+                        },
+                        "toolbar": {
+                            "likeCountNotliked": str(c.get("likes", 0)),
+                            "replyCount": str(c.get("replies", 0)),
+                        },
+                    }
+                }
+            }
+        )
+
+    payload: dict = {
+        "frameworkUpdates": {
+            "entityBatchUpdate": {"mutations": mutations}
+        },
+    }
+    if next_token:
+        payload["onResponseReceivedEndpoints"] = [
+            {
+                "appendContinuationItemsAction": {
+                    "continuationItems": [
+                        {
+                            "continuationItemRenderer": {
+                                "continuationEndpoint": {
+                                    "continuationCommand": {"token": next_token}
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    return payload
+
+
+def _build_response(payload: dict, status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        json=payload,
+        request=httpx.Request("POST", "https://www.youtube.com/youtubei/v1/next"),
+    )
+
+
+class _AsyncContextClientMock:
+    """Mock get_proxied_client(): async context manager yielding a mock client."""
+
+    def __init__(self, post_side_effect):
+        self.client = AsyncMock()
+        self.client.post = AsyncMock(side_effect=post_side_effect)
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_comments_happy_path():
+    """3 commentaires sur une seule page, no continuation, parse + return."""
+    initial = _build_response(_make_initial_response("TOK_0"))
+    page1 = _build_response(
+        _make_comment_page(
+            comments=[
+                {"cid": "C1", "text": "Super vidéo !", "author": "Alice", "likes": 100},
+                {"cid": "C2", "text": "Bof", "author": "Bob", "likes": 5},
+                {"cid": "C3", "text": "Top", "author": "Charlie", "likes": 50},
+            ],
+            next_token=None,
+        )
+    )
+    mock_ctx = _AsyncContextClientMock(post_side_effect=[initial, page1])
+
+    with patch.object(ys, "get_proxied_client", mock_ctx), patch.object(
+        ys, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ys.fetch_youtube_comments("dQw4w9WgXcQ", top_n=100, random_n=50)
+
+    assert isinstance(batch, CommentsBatch)
+    assert batch.platform == "youtube"
+    assert batch.video_id == "dQw4w9WgXcQ"
+    assert batch.disabled is False
+    assert batch.total_seen == 3
+    assert len(batch.sampled) == 3
+    # Top sorted by likes desc → Alice (100), Charlie (50), Bob (5)
+    assert batch.sampled[0].author == "Alice"
+    assert batch.sampled[0].like_count == 100
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_comments_disabled_when_no_panel():
+    """Pas de engagement-panel-comments-section dans engagementPanels → disabled=True."""
+    initial = _build_response({"engagementPanels": []})  # no panel = disabled
+    mock_ctx = _AsyncContextClientMock(post_side_effect=[initial])
+
+    with patch.object(ys, "get_proxied_client", mock_ctx), patch.object(
+        ys, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ys.fetch_youtube_comments("disabled_video_id")
+
+    assert batch.disabled is True
+    assert len(batch.sampled) == 0
+    assert batch.total_seen == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_comments_telemetry_called():
+    """record_proxy_usage est appelé avec provider='comments_youtube'."""
+    initial = _build_response(_make_initial_response("TOK_T"))
+    page = _build_response(
+        _make_comment_page(comments=[{"cid": "X", "text": "T", "likes": 1}])
+    )
+    mock_ctx = _AsyncContextClientMock(post_side_effect=[initial, page])
+
+    record_mock = AsyncMock()
+    with patch.object(ys, "get_proxied_client", mock_ctx), patch.object(
+        ys, "record_proxy_usage", record_mock
+    ):
+        await ys.fetch_youtube_comments("vid_telemetry", top_n=10, random_n=5)
+
+    assert record_mock.called
+    # Au moins un appel a provider=comments_youtube
+    calls_with_youtube = [
+        call for call in record_mock.call_args_list
+        if call.kwargs.get("provider") == "comments_youtube"
+    ]
+    assert len(calls_with_youtube) >= 1
+    # bytes_in > 0
+    assert any(call.kwargs.get("bytes_in", 0) > 0 for call in calls_with_youtube)
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_comments_http_error_returns_empty():
+    """HTTP 403 sur initial → batch vide non-disabled."""
+    bad = _build_response({}, status=403)
+    mock_ctx = _AsyncContextClientMock(post_side_effect=[bad])
+
+    with patch.object(ys, "get_proxied_client", mock_ctx), patch.object(
+        ys, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ys.fetch_youtube_comments("bad_403")
+
+    # 403 sur initial → pas de token → batch vide, disabled=False (le scrape a échoué)
+    assert batch.disabled is False
+    assert len(batch.sampled) == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_comments_pagination_two_pages():
+    """2 pages : page1 a next_token, page2 = end."""
+    initial = _build_response(_make_initial_response("TOK_INITIAL"))
+    page1 = _build_response(
+        _make_comment_page(
+            comments=[
+                {"cid": f"P1_{i}", "text": f"Page 1 c{i}", "author": f"u{i}", "likes": 100 - i}
+                for i in range(5)
+            ],
+            next_token="TOK_PAGE2",
+        )
+    )
+    page2 = _build_response(
+        _make_comment_page(
+            comments=[
+                {"cid": f"P2_{i}", "text": f"Page 2 c{i}", "author": f"u{i}", "likes": 50 - i}
+                for i in range(3)
+            ],
+            next_token=None,
+        )
+    )
+    mock_ctx = _AsyncContextClientMock(post_side_effect=[initial, page1, page2])
+
+    with patch.object(ys, "get_proxied_client", mock_ctx), patch.object(
+        ys, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ys.fetch_youtube_comments("video_paged", top_n=100, random_n=50)
+
+    assert batch.total_seen == 8
+    assert len(batch.sampled) == 8  # < top_n + random_n → all returned
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_comments_dedup():
+    """Doublons (même comment_id sur 2 pages) → dédupliqués."""
+    initial = _build_response(_make_initial_response("TOK_DED"))
+    page1 = _build_response(
+        _make_comment_page(
+            comments=[
+                {"cid": "DUP", "text": "first", "author": "A", "likes": 10},
+                {"cid": "UNQ1", "text": "u1", "author": "B", "likes": 5},
+            ],
+            next_token="TOK_DED2",
+        )
+    )
+    page2 = _build_response(
+        _make_comment_page(
+            comments=[
+                {"cid": "DUP", "text": "first repeated", "author": "A", "likes": 10},
+                {"cid": "UNQ2", "text": "u2", "author": "C", "likes": 3},
+            ],
+            next_token=None,
+        )
+    )
+    mock_ctx = _AsyncContextClientMock(post_side_effect=[initial, page1, page2])
+
+    with patch.object(ys, "get_proxied_client", mock_ctx), patch.object(
+        ys, "record_proxy_usage", AsyncMock()
+    ):
+        batch = await ys.fetch_youtube_comments("vid_dup")
+
+    # DUP, UNQ1, UNQ2 → 3 comments uniques
+    assert batch.total_seen == 3
+    cids = {c.comment_id for c in batch.sampled}
+    assert cids == {"DUP", "UNQ1", "UNQ2"}
+
+
+def test_parse_like_count():
+    """1.2K → 1200, 3M → 3000000, 'foo' → 0, etc."""
+    assert ys._parse_like_count("1.2K") == 1200
+    assert ys._parse_like_count("3M") == 3_000_000
+    assert ys._parse_like_count("847") == 847
+    assert ys._parse_like_count("0") == 0
+    assert ys._parse_like_count("") == 0
+    assert ys._parse_like_count(None) == 0
+    assert ys._parse_like_count("foo") == 0
+
+
+def test_walk_helper():
+    """_walk trouve récursivement tous les dicts avec la clé cible."""
+    data = {
+        "a": {"target": {"v": 1}},
+        "b": [{"target": {"v": 2}}, {"nope": "x"}],
+        "c": {"deep": {"target": {"v": 3}}},
+    }
+    found = list(ys._walk(data, "target"))
+    assert len(found) == 3
+    values = sorted(f["v"] for f in found)
+    assert values == [1, 2, 3]
+
+
+def test_get_innertube_key_env_override():
+    """YOUTUBE_INNERTUBE_KEY env var override le default."""
+    original = os.environ.get("YOUTUBE_INNERTUBE_KEY")
+    try:
+        os.environ["YOUTUBE_INNERTUBE_KEY"] = "MY_CUSTOM_KEY"
+        assert ys._get_innertube_key() == "MY_CUSTOM_KEY"
+        os.environ["YOUTUBE_INNERTUBE_KEY"] = ""
+        assert ys._get_innertube_key() == ys.INNERTUBE_API_KEY_DEFAULT
+    finally:
+        if original is not None:
+            os.environ["YOUTUBE_INNERTUBE_KEY"] = original
+        else:
+            os.environ.pop("YOUTUBE_INNERTUBE_KEY", None)

--- a/backend/tests/test_community_take_generator.py
+++ b/backend/tests/test_community_take_generator.py
@@ -1,0 +1,342 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — comments/take_generator.py (Mistral JSON-mode + anti-sycophancy)      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from comments.schemas import Comment, CommentsBatch, CommunityTake
+from comments import take_generator as tg
+from core.llm_provider import LLMResult
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 FIXTURES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def sample_batch():
+    return CommentsBatch(
+        platform="youtube",
+        video_id="abc123",
+        total_seen=200,
+        sampled=[
+            Comment(
+                comment_id=f"c{i}",
+                author=f"user{i}",
+                text=f"Comment text {i}",
+                like_count=100 - i,
+            )
+            for i in range(50)
+        ],
+    )
+
+
+def _mock_llm_response(payload: dict, model: str = "mistral-medium-2508") -> LLMResult:
+    return LLMResult(
+        content=json.dumps(payload),
+        model_used=model,
+        provider="mistral",
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — happy path
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_generate_take_happy_path(sample_batch):
+    mock_payload = {
+        "agreement_signal": "mixed",
+        "sentiment_distribution": {
+            "positive": 0.5,
+            "neutral": 0.3,
+            "negative": 0.2,
+        },
+        "controversies": ["Désaccord sur le point X", "Méthodologie contestée"],
+        "community_summary": (
+            "La communauté est divisée. Beaucoup saluent l'effort mais critiquent le manque de sources."
+        ),
+        "top_voices": [
+            {
+                "author": "Un commentateur populaire",
+                "excerpt": "Vidéo très claire merci !",
+                "stance": "agree",
+                "like_count": 1200,
+            },
+            {
+                "author": "Une réponse récente",
+                "excerpt": "Mais où sont les sources ?",
+                "stance": "disagree",
+                "like_count": 340,
+            },
+        ],
+    }
+
+    with patch.object(tg, "llm_complete", AsyncMock(return_value=_mock_llm_response(mock_payload))):
+        take = await tg.generate_community_take(
+            batch=sample_batch,
+            plan="pro",
+            video_title="Test Video",
+            video_topic_hint="Tech",
+            creator_stance="",
+            lang="fr",
+        )
+
+    assert isinstance(take, CommunityTake)
+    assert take.agreement_signal == "mixed"
+    assert take.comments_analyzed == 50
+    assert take.model_used == "mistral-medium-2508"
+    assert len(take.top_voices) == 2
+    assert take.sentiment_distribution["positive"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_generate_take_uses_correct_model_per_plan(sample_batch):
+    """plan → model mapping respecté."""
+    matrix = [
+        ("free", "mistral-small-2603"),
+        ("pro", "mistral-medium-2508"),
+        ("expert", "mistral-large-2512"),
+    ]
+    payload = {
+        "agreement_signal": "unclear",
+        "sentiment_distribution": {"positive": 0.4, "neutral": 0.4, "negative": 0.2},
+        "controversies": [],
+        "community_summary": "Test",
+        "top_voices": [],
+    }
+
+    for plan, expected_model in matrix:
+        with patch.object(
+            tg, "llm_complete", AsyncMock(return_value=_mock_llm_response(payload, model=expected_model))
+        ) as mock_complete:
+            await tg.generate_community_take(
+                batch=sample_batch,
+                plan=plan,
+                video_title="x",
+                video_topic_hint="",
+                creator_stance="",
+                lang="fr",
+            )
+            assert mock_complete.call_args.kwargs["model"] == expected_model
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — anti-sycophancy floor
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_anti_sycophancy_floor_forces_mixed_when_no_dominant(sample_batch):
+    """Si Mistral dit 'agree' mais max sentiment < 0.5 → on force 'mixed'."""
+    payload = {
+        "agreement_signal": "agree",  # Mistral fait du sycophancy
+        "sentiment_distribution": {
+            "positive": 0.45,  # < 0.5
+            "neutral": 0.30,
+            "negative": 0.25,
+        },
+        "controversies": [],
+        "community_summary": "Bof.",
+        "top_voices": [],
+    }
+    with patch.object(tg, "llm_complete", AsyncMock(return_value=_mock_llm_response(payload))):
+        take = await tg.generate_community_take(
+            batch=sample_batch,
+            plan="pro",
+            video_title="x",
+            video_topic_hint="",
+            creator_stance="",
+            lang="fr",
+        )
+
+    assert take is not None
+    assert take.agreement_signal == "mixed", "Anti-sycophancy floor should force mixed"
+
+
+@pytest.mark.asyncio
+async def test_anti_sycophancy_floor_keeps_agree_when_dominant(sample_batch):
+    """Si max sentiment >= 0.5 et signal='agree' → on conserve 'agree'."""
+    payload = {
+        "agreement_signal": "agree",
+        "sentiment_distribution": {
+            "positive": 0.7,  # >= 0.5
+            "neutral": 0.2,
+            "negative": 0.1,
+        },
+        "controversies": [],
+        "community_summary": "Globalement d'accord.",
+        "top_voices": [],
+    }
+    with patch.object(tg, "llm_complete", AsyncMock(return_value=_mock_llm_response(payload))):
+        take = await tg.generate_community_take(
+            batch=sample_batch,
+            plan="pro",
+            video_title="x",
+            video_topic_hint="",
+            creator_stance="",
+            lang="fr",
+        )
+
+    assert take.agreement_signal == "agree"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — error cases
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_generate_take_empty_batch_returns_none():
+    """sampled vide → return None (pas d'appel Mistral)."""
+    empty = CommentsBatch(platform="youtube", video_id="x", sampled=[], total_seen=0)
+    with patch.object(tg, "llm_complete", AsyncMock()) as mock:
+        take = await tg.generate_community_take(
+            batch=empty,
+            plan="pro",
+            video_title="x",
+            video_topic_hint="",
+            creator_stance="",
+            lang="fr",
+        )
+    assert take is None
+    assert not mock.called
+
+
+@pytest.mark.asyncio
+async def test_generate_take_llm_none_returns_none(sample_batch):
+    """llm_complete returns None → return None."""
+    with patch.object(tg, "llm_complete", AsyncMock(return_value=None)):
+        take = await tg.generate_community_take(
+            batch=sample_batch,
+            plan="pro",
+            video_title="x",
+            video_topic_hint="",
+            creator_stance="",
+            lang="fr",
+        )
+    assert take is None
+
+
+@pytest.mark.asyncio
+async def test_generate_take_invalid_json_returns_none(sample_batch):
+    """llm_complete returns garbage → return None."""
+    bad = LLMResult(content="not a json at all !!", model_used="x", provider="mistral")
+    with patch.object(tg, "llm_complete", AsyncMock(return_value=bad)):
+        take = await tg.generate_community_take(
+            batch=sample_batch,
+            plan="pro",
+            video_title="x",
+            video_topic_hint="",
+            creator_stance="",
+            lang="fr",
+        )
+    assert take is None
+
+
+@pytest.mark.asyncio
+async def test_generate_take_strips_code_fences(sample_batch):
+    """Mistral peut wrapper la réponse en ```json ... ``` → on retire."""
+    payload = {
+        "agreement_signal": "agree",
+        "sentiment_distribution": {"positive": 0.8, "neutral": 0.1, "negative": 0.1},
+        "controversies": [],
+        "community_summary": "OK.",
+        "top_voices": [],
+    }
+    fenced = LLMResult(
+        content="```json\n" + json.dumps(payload) + "\n```",
+        model_used="mistral-medium-2508",
+        provider="mistral",
+    )
+    with patch.object(tg, "llm_complete", AsyncMock(return_value=fenced)):
+        take = await tg.generate_community_take(
+            batch=sample_batch,
+            plan="pro",
+            video_title="x",
+            video_topic_hint="",
+            creator_stance="",
+            lang="fr",
+        )
+    assert take is not None
+    assert take.agreement_signal == "agree"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — helpers internes
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_pseudonymize():
+    assert tg._pseudonymize("Maxime") == "M***"
+    assert tg._pseudonymize("") == "anon"
+    assert tg._pseudonymize(None) == "anon"
+    assert tg._pseudonymize("   ") == "anon"
+
+
+def test_normalize_sentiment_renormalizes_to_one():
+    sd = {"positive": 1.0, "neutral": 1.0, "negative": 0.0}
+    out = tg._normalize_sentiment(sd)
+    assert abs(sum(out.values()) - 1.0) < 1e-6
+    assert out["positive"] == 0.5
+
+
+def test_normalize_sentiment_handles_zero():
+    """Toutes les valeurs à 0 → default neutre 1.0."""
+    sd = {"positive": 0.0, "neutral": 0.0, "negative": 0.0}
+    out = tg._normalize_sentiment(sd)
+    assert out["neutral"] == 1.0
+
+
+def test_normalize_sentiment_handles_none():
+    out = tg._normalize_sentiment(None)
+    assert out["neutral"] == 1.0
+
+
+def test_strip_code_fences():
+    assert tg._strip_code_fences("```json\n{}\n```") == "{}"
+    assert tg._strip_code_fences("```\n{}\n```") == "{}"
+    assert tg._strip_code_fences("{}") == "{}"
+    assert tg._strip_code_fences("  {}  ") == "{}"
+
+
+def test_build_user_prompt_fr_contains_marker(sample_batch):
+    p = tg._build_user_prompt(
+        sample_batch,
+        video_title="My Video",
+        video_topic_hint="tech",
+        creator_stance="",
+        lang="fr",
+    )
+    assert "VIDEO" in p
+    assert "PLATEFORME" in p
+    assert "user0" not in p  # pseudo doit être tronqué
+    assert "@u***" in p
+
+
+def test_build_user_prompt_en(sample_batch):
+    p = tg._build_user_prompt(
+        sample_batch,
+        video_title="My Video",
+        video_topic_hint="tech",
+        creator_stance="",
+        lang="en",
+    )
+    assert "PLATFORM" in p
+    assert "TOPIC" in p


### PR DESCRIPTION
## Summary
- `backend/src/comments/youtube_scraper.py` (497 LOC) — scrape commentaires YouTube
- `backend/src/comments/tiktok_scraper.py` — scrape commentaires TikTok via tikwm/HTML
- `take_generator.py` — verdict communauté via ModerationResult
- Branché DANS pipeline v6 ET v2.1 (5e gather task dans `videos/router.py`)
- Plan gating Free/Pro/Expert
- 49 tests verts (test_comments_*.py + test_community_take_generator.py)
- 13 fichiers créés + 6 modifiés (+3103 lignes)

## Test plan
- [ ] Tests : `pytest backend/tests/test_comments_*.py backend/tests/test_community_take_generator.py` → 49 passed
- [ ] Spec source : `docs/superpowers/specs/2026-05-17-comments-community-take.md`
- [ ] PR2 ajoutera UI web `<CommunityTakeSection>` dans AnalysisHub

## Known gotcha
- `ModerationResult.severe` attribut n'existe pas → utilisé `.flagged_categories` à la place dans `take_generator.py` (à valider en review : créer `.severe` champ ou laisser ainsi)