### PR TITLE
feat(external_pages): URL extractor + filter + resolver (PR 1/3)

### DIFF
--- a/backend/src/videos/external_pages/__init__.py
+++ b/backend/src/videos/external_pages/__init__.py
@@ -1,0 +1,53 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  📚 external_pages — Extraction des pages externes citées dans une vidéo          ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Pipeline 3 étapes :                                                               ║
+║    1. extraction d'URLs (regex sur description / transcript)                       ║
+║    2. nettoyage & filtrage (strip utm_*, blacklist youtube/tiktok, self-channel)   ║
+║    3. résolution HEAD (follow_redirects, drop sur timeout / >5 hops, dedup)        ║
+║                                                                                    ║
+║  PR 1 (cette PR) : pas de scraping, pas de Mistral, pas de DB.                     ║
+║  PR 2 (à venir)  : scraper + summarizer + storage colonne summaries.ext_pages.     ║
+║  PR 3 (à venir)  : intégration dans videos/router.py.                              ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from .constants import (
+    BLACKLIST_HOSTS,
+    SHORTENER_HOSTS,
+    TRACKING_PARAMS,
+    MAX_HOPS,
+    TIMEOUTS,
+    PLAN_CAPS,
+)
+from .url_extractor import (
+    extract_urls_from_text,
+    clean_url,
+    is_blacklisted,
+    clean_and_filter_urls,
+)
+from .url_resolver import (
+    ResolvedURL,
+    resolve_url,
+    resolve_urls,
+)
+
+__all__ = [
+    # constants
+    "BLACKLIST_HOSTS",
+    "SHORTENER_HOSTS",
+    "TRACKING_PARAMS",
+    "MAX_HOPS",
+    "TIMEOUTS",
+    "PLAN_CAPS",
+    # extractor
+    "extract_urls_from_text",
+    "clean_url",
+    "is_blacklisted",
+    "clean_and_filter_urls",
+    # resolver
+    "ResolvedURL",
+    "resolve_url",
+    "resolve_urls",
+]

--- a/backend/src/videos/external_pages/constants.py
+++ b/backend/src/videos/external_pages/constants.py
@@ -1,0 +1,150 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  ⚙️  Constantes pour le pipeline external_pages                                    ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  - TRACKING_PARAMS  : query params à supprimer (utm_*, fbclid, gclid, …)           ║
+║  - BLACKLIST_HOSTS  : hôtes à exclure systématiquement (YouTube, TikTok, etc.)     ║
+║  - SHORTENER_HOSTS  : raccourcisseurs URL (informationnel — utilisé par PR 2 pour  ║
+║                      forcer le HEAD avant scrape)                                  ║
+║  - MAX_HOPS         : nombre maximum de redirects HTTP à suivre                    ║
+║  - TIMEOUTS         : timeouts http pour HEAD / GET                                ║
+║  - PLAN_CAPS        : nombre max d'URLs résolues / page-cards par plan             ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from typing import Dict, Set
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧹 Tracking parameters — à strip de toutes les URLs
+# ═══════════════════════════════════════════════════════════════════════════════
+# Couvre les standards les plus répandus :
+# - utm_* : Google Analytics / campagnes
+# - fbclid : Facebook click ID
+# - gclid : Google click ID
+# - mc_cid / mc_eid : MailChimp
+# - igshid : Instagram
+# - ref : referrer générique très souvent tracking
+# - _ga, _gl : Google Analytics linker
+TRACKING_PARAMS: Set[str] = {
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "utm_id",
+    "utm_name",
+    "utm_brand",
+    "utm_social",
+    "utm_social-type",
+    "fbclid",
+    "gclid",
+    "gclsrc",
+    "dclid",
+    "msclkid",
+    "mc_cid",
+    "mc_eid",
+    "igshid",
+    "_ga",
+    "_gl",
+    "yclid",
+    "twclid",
+    "ttclid",  # TikTok
+    "spm",  # Aliexpress / Lazada
+    "ref",
+    "ref_src",
+    "ref_url",
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚫 Blacklist hosts — exclure ces hôtes du pipeline external_pages
+# ═══════════════════════════════════════════════════════════════════════════════
+# Rationale :
+# - YouTube / TikTok : on analyse déjà la vidéo elle-même, pas pertinent.
+# - facebook.com / instagram.com / twitter.com / x.com : pages de login souvent,
+#   contenu privé, pas adapté au scraping HEAD/GET.
+# - réseaux sociaux navigation pure : on ne tire rien d'utile via HEAD.
+BLACKLIST_HOSTS: Set[str] = {
+    # YouTube
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+    "youtube-nocookie.com",
+    # TikTok
+    "tiktok.com",
+    "www.tiktok.com",
+    "m.tiktok.com",
+    "vm.tiktok.com",
+    "vt.tiktok.com",
+    # Sociaux navigation (login wall, contenu privé)
+    "facebook.com",
+    "www.facebook.com",
+    "m.facebook.com",
+    "instagram.com",
+    "www.instagram.com",
+    "twitter.com",
+    "www.twitter.com",
+    "x.com",
+    "www.x.com",
+    "linkedin.com",
+    "www.linkedin.com",
+    # Plateformes vidéo concurrentes (on n'analyse pas la vidéo, juste la page)
+    "twitch.tv",
+    "www.twitch.tv",
+    "vimeo.com",
+    "www.vimeo.com",
+    "dailymotion.com",
+    "www.dailymotion.com",
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔗 URL shorteners — utilisé par PR 2 pour expansion préalable
+# ═══════════════════════════════════════════════════════════════════════════════
+SHORTENER_HOSTS: Set[str] = {
+    "bit.ly",
+    "tinyurl.com",
+    "t.co",
+    "goo.gl",
+    "ow.ly",
+    "is.gd",
+    "buff.ly",
+    "lnkd.in",
+    "shor.tn",
+    "rebrand.ly",
+    "cutt.ly",
+    "tiny.cc",
+    "rb.gy",
+    "shorturl.at",
+    "trib.al",
+    "amzn.to",
+    "fb.me",
+    "youtu.be",  # YouTube short — mais déjà blacklisté
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚦 Limites de résolution
+# ═══════════════════════════════════════════════════════════════════════════════
+# Au-delà de MAX_HOPS redirects, on considère que l'URL est suspecte ou pirate.
+MAX_HOPS: int = 5
+
+# Timeouts (secondes) — courts car on parse beaucoup d'URLs en parallèle.
+TIMEOUTS: Dict[str, float] = {
+    "head": 5.0,  # HEAD request pour résolution
+    "get": 8.0,  # GET request (PR 2 — scraping)
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📊 Plan caps — nombre max d'URLs externes traitées par plan
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cap *post*-filtrage (après blacklist / dedup). PR 2/3 utiliseront ces caps
+# pour limiter le scraping (économise du quota proxy et latence Mistral).
+PLAN_CAPS: Dict[str, int] = {
+    "free": 3,
+    "pro": 8,
+    "expert": 15,
+    # legacy / fallback
+    "plus": 5,
+    "starter": 3,
+}

--- a/backend/src/videos/external_pages/constants.py
+++ b/backend/src/videos/external_pages/constants.py
@@ -140,11 +140,15 @@ TIMEOUTS: Dict[str, float] = {
 # ═══════════════════════════════════════════════════════════════════════════════
 # Cap *post*-filtrage (après blacklist / dedup). PR 2/3 utiliseront ces caps
 # pour limiter le scraping (économise du quota proxy et latence Mistral).
+#
+# Free=0 : feature gatée Pro+ → l'UI affiche un CTA upgrade côté frontend.
+# Les plans legacy ("plus", "starter") sont normalisés vers "pro"/"free"
+# via core/plan_limits.normalize_plan_id, donc pas d'entries dédiées ici.
+# Tout plan inconnu fallback à 0 via .get(plan, 0) côté orchestrator.
+#
+# Source de vérité : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §8
 PLAN_CAPS: Dict[str, int] = {
-    "free": 3,
-    "pro": 8,
-    "expert": 15,
-    # legacy / fallback
-    "plus": 5,
-    "starter": 3,
+    "free": 0,
+    "pro": 5,
+    "expert": 10,
 }

--- a/backend/src/videos/external_pages/url_extractor.py
+++ b/backend/src/videos/external_pages/url_extractor.py
@@ -1,0 +1,277 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🔎 url_extractor — Extraction, nettoyage et filtrage d'URLs                       ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Pipeline d'extraction d'URLs depuis le texte (description vidéo, transcript) :    ║
+║                                                                                    ║
+║    extract_urls_from_text(text) ──┐                                                ║
+║                                   ├─► clean_and_filter_urls(urls, self_channel) ─► ║
+║    [URLs candidates]              │   [URLs propres, dédup, plafonnées]            ║
+║                                   │                                                ║
+║    clean_url(url)  ───────────────┘                                                ║
+║    is_blacklisted(url)                                                             ║
+║                                                                                    ║
+║  Pas d'I/O réseau dans ce module — pure manipulation de strings.                   ║
+║  La résolution HEAD (network) est dans url_resolver.py.                            ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional
+from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
+
+from .constants import BLACKLIST_HOSTS, TRACKING_PARAMS
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔎 Regex d'extraction
+# ═══════════════════════════════════════════════════════════════════════════════
+# Capture les URLs avec scheme http(s) explicite OU www.* (sans scheme).
+# - groupe 1 : URL complète (scheme inclus)
+# - groupe 2 : URL www. (sans scheme)
+#
+# La regex évite d'être trop gourmande sur les caractères de fin (`.,;:!?)]}>"\``)
+# qui sont systématiquement strip post-match par _strip_trailing_punct.
+_URL_REGEX = re.compile(
+    r"""(?:
+        (?P<full>https?://[^\s<>"'`)]+)
+      |
+        (?:^|[\s(<\[])(?P<www>www\.[^\s<>"'`)]+)
+    )""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Punctuation finale à strip post-match (très commun en fin de phrase)
+_TRAILING_PUNCT = ".,;:!?)”’\"'>}]"
+
+
+def _strip_trailing_punct(url: str) -> str:
+    """Retire les caractères de ponctuation traînant en fin d'URL.
+
+    Cas typique : "Visit https://example.com." → "https://example.com"
+    On strip en boucle pour gérer "https://x.com),." par exemple.
+    """
+    while url and url[-1] in _TRAILING_PUNCT:
+        url = url[:-1]
+    return url
+
+
+def extract_urls_from_text(text: Optional[str]) -> List[str]:
+    """Extrait toutes les URLs candidates depuis un texte libre.
+
+    Caractéristiques :
+    - Capture http://, https://, et www.* (auquel on ajoute le scheme https://).
+    - Strip la ponctuation traînante (.,;:!? etc.).
+    - Préserve l'ordre d'apparition.
+    - Pas de dédup ici (clean_and_filter_urls s'en occupe après nettoyage).
+
+    Args:
+        text: Texte source (description, transcript, etc.). None et "" → [].
+
+    Returns:
+        Liste des URLs trouvées, dans l'ordre. Vide si rien à extraire.
+    """
+    if not text:
+        return []
+
+    urls: List[str] = []
+    for match in _URL_REGEX.finditer(text):
+        raw = match.group("full") or match.group("www")
+        if not raw:
+            continue
+        cleaned_raw = _strip_trailing_punct(raw)
+        if not cleaned_raw:
+            continue
+        # Si on a matché un "www.X" sans scheme, ajouter https://
+        if cleaned_raw.lower().startswith("www."):
+            cleaned_raw = "https://" + cleaned_raw
+        urls.append(cleaned_raw)
+    return urls
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧹 clean_url — Strip tracking params + normalise host
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def clean_url(url: str) -> Optional[str]:
+    """Nettoie une URL : strip tracking params, lowercase host, valide structure.
+
+    - Retire tous les query params listés dans TRACKING_PARAMS (utm_*, fbclid, …)
+    - Lowercase le host (netloc), préserve path/query/fragment intacts
+    - Retire le fragment ?  → non, on garde (anchors utiles pour reading)
+    - Retourne None si URL invalide (pas de scheme http(s), pas de netloc, etc.)
+
+    Args:
+        url: URL à nettoyer.
+
+    Returns:
+        URL nettoyée (str) ou None si invalide.
+    """
+    if not url or not isinstance(url, str):
+        return None
+
+    try:
+        parsed = urlparse(url.strip())
+    except (ValueError, TypeError):
+        return None
+
+    # Scheme obligatoire (http ou https)
+    if parsed.scheme.lower() not in ("http", "https"):
+        return None
+    # Host obligatoire
+    if not parsed.netloc:
+        return None
+
+    # Lowercase le host (netloc peut contenir user:pass@host:port → on lowercase tout)
+    netloc_lower = parsed.netloc.lower()
+
+    # Strip tracking params dans la query
+    if parsed.query:
+        # parse_qsl conserve l'ordre des params
+        kept = [
+            (k, v)
+            for k, v in parse_qsl(parsed.query, keep_blank_values=True)
+            if k.lower() not in TRACKING_PARAMS
+        ]
+        new_query = urlencode(kept)
+    else:
+        new_query = ""
+
+    cleaned = urlunparse(
+        (
+            parsed.scheme.lower(),
+            netloc_lower,
+            parsed.path,
+            parsed.params,
+            new_query,
+            parsed.fragment,
+        )
+    )
+    return cleaned
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚫 is_blacklisted — Filtres hosts (YouTube/TikTok/self-channel)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _normalize_host(host: str) -> str:
+    """Strip 'www.' et lowercase pour comparaison cohérente."""
+    host = (host or "").lower().strip()
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def is_blacklisted(
+    url: str, self_channel_host: Optional[str] = None
+) -> bool:
+    """Détermine si une URL doit être exclue du pipeline.
+
+    Critères :
+    - URL invalide (pas de scheme/host) → blacklisted (rien à faire avec).
+    - Host dans BLACKLIST_HOSTS (YouTube, TikTok, sociaux, etc.).
+    - Host == self_channel_host (le créateur référence sa propre boutique
+      ou son propre site — non pertinent comme "page externe citée").
+
+    Args:
+        url: URL à vérifier (typiquement déjà passée par clean_url).
+        self_channel_host: Optionnel — host du créateur de la vidéo.
+                           Ex : si la vidéo vient de la chaîne "TomScott", on peut
+                           passer "tomscott.com" pour filtrer ses propres liens.
+
+    Returns:
+        True si l'URL doit être exclue, False sinon.
+    """
+    if not url or not isinstance(url, str):
+        return True
+
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return True
+
+    if parsed.scheme.lower() not in ("http", "https"):
+        return True
+    if not parsed.netloc:
+        return True
+
+    host_norm = _normalize_host(parsed.netloc)
+    host_with_www = "www." + host_norm
+
+    # Blacklist directe (gère "www.X" et "X" car la liste contient les deux variantes)
+    if (
+        parsed.netloc.lower() in BLACKLIST_HOSTS
+        or host_norm in BLACKLIST_HOSTS
+        or host_with_www in BLACKLIST_HOSTS
+    ):
+        return True
+
+    # Subdomain match — ex : music.youtube.com est blacklisté car suffix == youtube.com
+    for blocked in BLACKLIST_HOSTS:
+        blocked_norm = _normalize_host(blocked)
+        if host_norm == blocked_norm or host_norm.endswith("." + blocked_norm):
+            return True
+
+    # Self-channel
+    if self_channel_host:
+        self_norm = _normalize_host(self_channel_host)
+        if self_norm and (
+            host_norm == self_norm or host_norm.endswith("." + self_norm)
+        ):
+            return True
+
+    return False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎯 clean_and_filter_urls — Pipeline complet
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def clean_and_filter_urls(
+    urls: List[str],
+    self_channel_host: Optional[str] = None,
+    max_count: int = 50,
+) -> List[str]:
+    """Pipeline complet : clean → filter → dedup → cap.
+
+    Étapes (ordre fixe) :
+      1. clean_url(u)         → strip tracking, lowercase host
+      2. is_blacklisted(u)    → exclure YouTube/TikTok/self-channel
+      3. dédup                → garder première occurrence, ordre préservé
+      4. cap                  → tronquer à max_count
+
+    Args:
+        urls: Liste d'URLs candidates (typiquement la sortie de
+              extract_urls_from_text).
+        self_channel_host: Host à exclure (le créateur de la vidéo).
+        max_count: Plafond sur la sortie (défaut 50, à plafonner avec
+                   PLAN_CAPS en amont selon plan).
+
+    Returns:
+        Liste finale d'URLs propres, dans l'ordre d'apparition.
+    """
+    if not urls:
+        return []
+
+    seen: set = set()
+    result: List[str] = []
+
+    for raw in urls:
+        cleaned = clean_url(raw)
+        if cleaned is None:
+            continue
+        if is_blacklisted(cleaned, self_channel_host=self_channel_host):
+            continue
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        result.append(cleaned)
+        if len(result) >= max_count:
+            break
+
+    return result

--- a/backend/src/videos/external_pages/url_resolver.py
+++ b/backend/src/videos/external_pages/url_resolver.py
@@ -1,0 +1,187 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🔗 url_resolver — Résolution HEAD (follow_redirects + dedup par final_url)        ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Étape 3 du pipeline external_pages :                                              ║
+║                                                                                    ║
+║    [URLs cleanées]                                                                 ║
+║         │                                                                          ║
+║         ▼                                                                          ║
+║    resolve_urls(urls)  →  [ResolvedURL(input_url, final_url, status), ...]         ║
+║                                                                                    ║
+║  Pour chaque URL :                                                                 ║
+║    - HEAD request via httpx, follow_redirects=True                                 ║
+║    - Drop si timeout / dns error / > MAX_HOPS redirects                            ║
+║    - Drop si HTTP 5xx (erreur serveur — pas utile à scraper en PR 2)               ║
+║    - Garde l'URL finale (après redirects) comme clé de dédup                       ║
+║                                                                                    ║
+║  Note : PR 1 utilise le shared http client bare. Le proxy Decodo                   ║
+║  (get_proxied_client) sera enroulé dans une factory utilisée par PR 2 pour les     ║
+║  GETs qui peuvent toucher des sites bloquant les IPs datacenter.                   ║
+║  Ici, on l'utilise déjà comme fallback safe pour HEAD (court, faible volume).      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List, Optional
+
+import httpx
+
+from core.http_client import get_proxied_client
+
+from .constants import MAX_HOPS, TIMEOUTS
+
+logger = logging.getLogger("deepsight.external_pages.resolver")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 Dataclass — URL résolue
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass(frozen=True)
+class ResolvedURL:
+    """URL résolue après suivi des redirects HTTP.
+
+    Attributs :
+        input_url : URL d'entrée (avant follow_redirects)
+        final_url : URL finale (après tous les hops)
+        status    : Code HTTP final (200, 404, etc.)
+    """
+
+    input_url: str
+    final_url: str
+    status: int
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 resolve_url — Résolution unitaire
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def resolve_url(
+    client: httpx.AsyncClient, url: str
+) -> Optional[ResolvedURL]:
+    """Résout une URL via HEAD + follow_redirects.
+
+    Args:
+        client: httpx.AsyncClient déjà configuré (timeouts, follow_redirects).
+                On peut passer le shared client OU un client proxy.
+        url:    URL à résoudre (typiquement déjà nettoyée via clean_url).
+
+    Returns:
+        ResolvedURL si succès (HTTP 2xx/3xx/4xx hors 5xx).
+        None si :
+          - timeout
+          - erreur DNS / connexion
+          - > MAX_HOPS redirects (suspicion redirect chain)
+          - HTTP 5xx
+          - exception inattendue
+
+    Note : on accepte HTTP 4xx (le client/utilisateur peut juger pertinent).
+    On drop seulement 5xx (serveur down — pas de contenu à scraper en PR 2).
+    """
+    if not url:
+        return None
+
+    try:
+        response = await client.head(
+            url,
+            follow_redirects=True,
+            timeout=TIMEOUTS["head"],
+        )
+    except httpx.TimeoutException:
+        logger.debug("HEAD timeout for %s", url)
+        return None
+    except httpx.ConnectError:
+        logger.debug("HEAD connect error for %s", url)
+        return None
+    except httpx.HTTPError as exc:
+        # Couvre RequestError, RemoteProtocolError, etc.
+        logger.debug("HEAD http error for %s: %s", url, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — best-effort, swallow tout
+        # Toute exception inattendue : on drop sans crasher le pipeline
+        logger.debug("HEAD unexpected error for %s: %s", url, exc)
+        return None
+
+    # Vérifie le nombre de hops (history contient les responses intermédiaires)
+    history_count = len(response.history or [])
+    if history_count > MAX_HOPS:
+        logger.debug(
+            "HEAD %s exceeded MAX_HOPS (%d > %d), dropping",
+            url,
+            history_count,
+            MAX_HOPS,
+        )
+        return None
+
+    status = int(response.status_code)
+    # Drop 5xx (serveur down)
+    if status >= 500:
+        logger.debug("HEAD %s returned 5xx (%d), dropping", url, status)
+        return None
+
+    final_url = str(response.url)
+    return ResolvedURL(input_url=url, final_url=final_url, status=status)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔁 resolve_urls — Batch (dedup par final_url)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def resolve_urls(
+    urls: List[str],
+    *,
+    use_proxy: bool = True,
+) -> List[ResolvedURL]:
+    """Résout un batch d'URLs en parallèle, déduplique par final_url.
+
+    Garde l'ordre d'apparition (première occurrence de chaque final_url).
+
+    Args:
+        urls:      Liste d'URLs (typiquement la sortie de clean_and_filter_urls).
+        use_proxy: Si True, route via get_proxied_client (Decodo). Si False,
+                   utilise un client httpx bare (utile pour les tests / dev).
+
+    Returns:
+        Liste de ResolvedURL, dédup par final_url, ordre préservé.
+    """
+    if not urls:
+        return []
+
+    seen_final: set = set()
+    results: List[ResolvedURL] = []
+
+    if use_proxy:
+        # get_proxied_client est un asynccontextmanager — pour les tests il est
+        # patché via unittest.mock.
+        async with get_proxied_client(
+            timeout=TIMEOUTS["head"], follow_redirects=True
+        ) as client:
+            for url in urls:
+                resolved = await resolve_url(client, url)
+                if resolved is None:
+                    continue
+                if resolved.final_url in seen_final:
+                    continue
+                seen_final.add(resolved.final_url)
+                results.append(resolved)
+    else:
+        async with httpx.AsyncClient(
+            timeout=TIMEOUTS["head"], follow_redirects=True
+        ) as client:
+            for url in urls:
+                resolved = await resolve_url(client, url)
+                if resolved is None:
+                    continue
+                if resolved.final_url in seen_final:
+                    continue
+                seen_final.add(resolved.final_url)
+                results.append(resolved)
+
+    return results

--- a/backend/tests/test_url_extractor.py
+++ b/backend/tests/test_url_extractor.py
@@ -1,0 +1,318 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — url_extractor (extraction / nettoyage / filtrage URLs externes)        ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Module : videos.external_pages.url_extractor                                      ║
+║  Couvre :                                                                          ║
+║    - extract_urls_from_text() : extraction regex robuste                           ║
+║    - clean_url() : strip tracking params + normalisation host                      ║
+║    - is_blacklisted() : filtres youtube/tiktok/self-channel                        ║
+║    - clean_and_filter_urls() : pipeline complet (dedup + cap)                      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import pytest
+
+from videos.external_pages.url_extractor import (
+    extract_urls_from_text,
+    clean_url,
+    is_blacklisted,
+    clean_and_filter_urls,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — extract_urls_from_text
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestExtractUrlsFromText:
+    """Extraction d'URLs depuis du texte libre (description, transcript, etc.)."""
+
+    def test_extracts_https_url(self):
+        text = "Visit https://example.com for more info."
+        urls = extract_urls_from_text(text)
+        assert "https://example.com" in urls
+
+    def test_extracts_http_url(self):
+        text = "Old http://example.com link here."
+        urls = extract_urls_from_text(text)
+        assert "http://example.com" in urls
+
+    def test_extracts_www_url_adds_scheme(self):
+        """www.X. sans scheme → https://www.X."""
+        text = "Check www.example.com for details."
+        urls = extract_urls_from_text(text)
+        assert any(u.startswith("https://www.example.com") for u in urls)
+
+    def test_strips_trailing_period(self):
+        text = "Visit https://example.com."
+        urls = extract_urls_from_text(text)
+        assert "https://example.com" in urls
+
+    def test_strips_trailing_comma(self):
+        text = "Visit https://example.com, then example2."
+        urls = extract_urls_from_text(text)
+        assert "https://example.com" in urls
+
+    def test_strips_trailing_semicolon(self):
+        text = "Visit https://example.com; later."
+        urls = extract_urls_from_text(text)
+        assert "https://example.com" in urls
+
+    def test_strips_trailing_colon(self):
+        text = "Link: https://example.com:"
+        urls = extract_urls_from_text(text)
+        # Strip le ":" final, mais pas si c'est un port (ici on n'a pas de port)
+        assert "https://example.com" in urls
+
+    def test_strips_trailing_question_mark(self):
+        text = "Have you seen https://example.com?"
+        urls = extract_urls_from_text(text)
+        assert "https://example.com" in urls
+
+    def test_strips_trailing_exclamation(self):
+        text = "Look at https://example.com!"
+        urls = extract_urls_from_text(text)
+        assert "https://example.com" in urls
+
+    def test_strips_closing_parenthesis(self):
+        text = "(see https://example.com)"
+        urls = extract_urls_from_text(text)
+        assert "https://example.com" in urls
+
+    def test_extracts_multiple_urls(self):
+        text = "Two links: https://a.com and https://b.com here."
+        urls = extract_urls_from_text(text)
+        assert "https://a.com" in urls
+        assert "https://b.com" in urls
+
+    def test_empty_text_returns_empty_list(self):
+        assert extract_urls_from_text("") == []
+
+    def test_none_safe_returns_empty_list(self):
+        # Doit pas crasher si None
+        assert extract_urls_from_text(None) == []  # type: ignore[arg-type]
+
+    def test_no_url_returns_empty_list(self):
+        text = "Just plain text without any link."
+        assert extract_urls_from_text(text) == []
+
+    def test_preserves_url_path_and_query(self):
+        text = "API doc: https://example.com/api/v1/foo?bar=baz"
+        urls = extract_urls_from_text(text)
+        assert "https://example.com/api/v1/foo?bar=baz" in urls
+
+    def test_extracts_url_with_fragment(self):
+        text = "Anchor https://example.com/page#section."
+        urls = extract_urls_from_text(text)
+        # On accepte que le fragment soit présent (sans le point final)
+        assert any(u.startswith("https://example.com/page#section") for u in urls)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — clean_url
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestCleanUrl:
+    """Nettoyage : strip tracking params, lowercase host."""
+
+    def test_strips_utm_source(self):
+        cleaned = clean_url("https://example.com/page?utm_source=newsletter")
+        assert "utm_source" not in cleaned
+        assert cleaned.startswith("https://example.com/page")
+
+    def test_strips_utm_medium(self):
+        cleaned = clean_url("https://example.com/page?utm_medium=email")
+        assert "utm_medium" not in cleaned
+
+    def test_strips_utm_campaign(self):
+        cleaned = clean_url("https://example.com/page?utm_campaign=spring")
+        assert "utm_campaign" not in cleaned
+
+    def test_strips_fbclid(self):
+        cleaned = clean_url("https://example.com/page?fbclid=abc123")
+        assert "fbclid" not in cleaned
+
+    def test_strips_gclid(self):
+        cleaned = clean_url("https://example.com/page?gclid=xyz789")
+        assert "gclid" not in cleaned
+
+    def test_strips_multiple_tracking_params(self):
+        cleaned = clean_url(
+            "https://example.com/page?utm_source=a&utm_medium=b&fbclid=c"
+        )
+        assert "utm_source" not in cleaned
+        assert "utm_medium" not in cleaned
+        assert "fbclid" not in cleaned
+
+    def test_preserves_business_query_params(self):
+        cleaned = clean_url("https://example.com/page?id=123&page=2")
+        assert "id=123" in cleaned
+        assert "page=2" in cleaned
+
+    def test_lowercases_host(self):
+        cleaned = clean_url("https://EXAMPLE.com/MyPage")
+        assert "example.com" in cleaned
+
+    def test_preserves_path_case(self):
+        """Le host est lowercased, le path/query restent intacts."""
+        cleaned = clean_url("https://EXAMPLE.com/MyPage")
+        assert "/MyPage" in cleaned
+
+    def test_invalid_url_returns_none(self):
+        assert clean_url("not a url") is None
+
+    def test_empty_string_returns_none(self):
+        assert clean_url("") is None
+
+    def test_no_scheme_returns_none(self):
+        """Sans scheme : c'est `extract_urls_from_text` qui doit ajouter https://."""
+        assert clean_url("example.com") is None
+
+    def test_strips_default_port_80_http(self):
+        # Pas obligatoire mais cohérent : netloc lowercased
+        cleaned = clean_url("https://EXAMPLE.com:443/")
+        assert cleaned is not None
+
+    def test_mixed_tracking_and_business_params(self):
+        cleaned = clean_url(
+            "https://example.com/page?id=42&utm_source=foo&gclid=bar&page=2"
+        )
+        assert "id=42" in cleaned
+        assert "page=2" in cleaned
+        assert "utm_source" not in cleaned
+        assert "gclid" not in cleaned
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — is_blacklisted
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestIsBlacklisted:
+    """Filtrage : exclure YouTube/TikTok + self-channel + sociaux navigation."""
+
+    def test_youtube_com_is_blacklisted(self):
+        assert is_blacklisted("https://www.youtube.com/watch?v=abc") is True
+
+    def test_youtube_short_url_is_blacklisted(self):
+        assert is_blacklisted("https://youtu.be/abc123") is True
+
+    def test_tiktok_com_is_blacklisted(self):
+        assert is_blacklisted("https://www.tiktok.com/@user/video/123") is True
+
+    def test_legit_blog_not_blacklisted(self):
+        assert is_blacklisted("https://medium.com/some-article") is False
+
+    def test_news_site_not_blacklisted(self):
+        assert is_blacklisted("https://www.lemonde.fr/article-xyz") is False
+
+    def test_personal_blog_not_blacklisted(self):
+        assert is_blacklisted("https://example.com/blog/post-1") is False
+
+    def test_youtube_subdomain_blacklisted(self):
+        assert is_blacklisted("https://music.youtube.com/playlist") is True
+
+    def test_self_channel_url_blacklisted_when_passed(self):
+        """Quand on passe le channel URL du créateur, on l'exclut."""
+        result = is_blacklisted(
+            "https://www.somecreator.com/about",
+            self_channel_host="somecreator.com",
+        )
+        assert result is True
+
+    def test_other_host_not_blacklisted_with_self_channel(self):
+        result = is_blacklisted(
+            "https://medium.com/article",
+            self_channel_host="somecreator.com",
+        )
+        assert result is False
+
+    def test_invalid_url_treated_as_blacklisted(self):
+        """Une URL invalide / unparseable doit être considérée non-passable."""
+        assert is_blacklisted("not-a-url") is True
+
+    def test_empty_url_treated_as_blacklisted(self):
+        assert is_blacklisted("") is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — clean_and_filter_urls
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestCleanAndFilterUrls:
+    """Pipeline complet : clean + filter + dedup + cap."""
+
+    def test_dedup_after_cleaning(self):
+        """Deux URLs distinctes avec mêmes utm devraient devenir identiques après clean."""
+        urls = [
+            "https://example.com/page?utm_source=a",
+            "https://example.com/page?utm_source=b",
+        ]
+        result = clean_and_filter_urls(urls)
+        assert len(result) == 1
+
+    def test_respects_max_count(self):
+        urls = [f"https://example{i}.com" for i in range(20)]
+        result = clean_and_filter_urls(urls, max_count=5)
+        assert len(result) == 5
+
+    def test_preserves_order(self):
+        urls = ["https://c.com", "https://a.com", "https://b.com"]
+        result = clean_and_filter_urls(urls)
+        # Pas de sort alpha — on garde l'ordre d'arrivée
+        assert result == ["https://c.com", "https://a.com", "https://b.com"]
+
+    def test_excludes_blacklisted_urls(self):
+        urls = [
+            "https://www.youtube.com/watch?v=abc",
+            "https://medium.com/article",
+        ]
+        result = clean_and_filter_urls(urls)
+        assert any("youtube.com" in u for u in result) is False
+        assert any("medium.com" in u for u in result) is True
+
+    def test_excludes_self_channel(self):
+        urls = [
+            "https://someblog.com/post-1",
+            "https://medium.com/article",
+        ]
+        result = clean_and_filter_urls(
+            urls, self_channel_host="someblog.com"
+        )
+        assert any("someblog.com" in u for u in result) is False
+        assert any("medium.com" in u for u in result) is True
+
+    def test_empty_input_returns_empty(self):
+        assert clean_and_filter_urls([]) == []
+
+    def test_all_blacklisted_returns_empty(self):
+        urls = [
+            "https://www.youtube.com/watch?v=a",
+            "https://www.tiktok.com/@u/video/1",
+            "https://youtu.be/x",
+        ]
+        assert clean_and_filter_urls(urls) == []
+
+    def test_invalid_urls_filtered_out(self):
+        urls = [
+            "not a url",
+            "https://medium.com/article",
+            "",
+        ]
+        result = clean_and_filter_urls(urls)
+        assert len(result) == 1
+        assert "medium.com" in result[0]
+
+    def test_default_max_count_is_reasonable(self):
+        """clean_and_filter_urls sans max_count laisse passer plusieurs URLs."""
+        urls = [f"https://example{i}.com" for i in range(3)]
+        result = clean_and_filter_urls(urls)
+        assert len(result) == 3

--- a/backend/tests/test_url_resolver.py
+++ b/backend/tests/test_url_resolver.py
@@ -1,0 +1,271 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — url_resolver (HEAD requests, redirect following, dedup)                ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Module : videos.external_pages.url_resolver                                       ║
+║  Couvre :                                                                          ║
+║    - resolve_url() : HEAD avec follow_redirects, gestion timeout/erreurs           ║
+║    - resolve_urls() : batch + dedup par final_url                                  ║
+║    - ResolvedURL dataclass : status + final_url                                    ║
+║                                                                                    ║
+║  Stratégie de mock : monkey-patch httpx.AsyncClient.head pour ne pas faire de       ║
+║  vrai I/O. Une fixture `make_head_response(status, final_url)` simule la réponse.  ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from videos.external_pages.url_resolver import (
+    ResolvedURL,
+    resolve_url,
+    resolve_urls,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ HELPERS — fake httpx response
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_response(
+    status: int = 200,
+    final_url: str = "https://example.com",
+    history: Optional[list] = None,
+) -> MagicMock:
+    """Crée une fausse httpx.Response avec status_code et URL finale."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.url = httpx.URL(final_url)
+    resp.history = history or []
+    resp.headers = {"content-type": "text/html"}
+    return resp
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — ResolvedURL dataclass
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestResolvedURLDataclass:
+    def test_create_minimal(self):
+        r = ResolvedURL(
+            input_url="https://a.com",
+            final_url="https://a.com",
+            status=200,
+        )
+        assert r.input_url == "https://a.com"
+        assert r.final_url == "https://a.com"
+        assert r.status == 200
+
+    def test_create_with_redirect(self):
+        r = ResolvedURL(
+            input_url="https://bit.ly/abc",
+            final_url="https://final-destination.com/page",
+            status=200,
+        )
+        assert r.input_url != r.final_url
+
+    def test_dataclass_equality(self):
+        a = ResolvedURL(input_url="x", final_url="y", status=200)
+        b = ResolvedURL(input_url="x", final_url="y", status=200)
+        assert a == b
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — resolve_url
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestResolveUrl:
+    """Résolution unitaire d'une URL : HEAD, follow redirects, error handling."""
+
+    async def test_resolves_200_direct(self):
+        fake_client = AsyncMock()
+        fake_client.head.return_value = _make_response(
+            status=200, final_url="https://example.com"
+        )
+        result = await resolve_url(fake_client, "https://example.com")
+        assert result is not None
+        assert result.status == 200
+        assert result.final_url == "https://example.com"
+        assert result.input_url == "https://example.com"
+
+    async def test_follows_redirect(self):
+        """HEAD avec follow_redirects=True → final_url différente de input_url."""
+        fake_client = AsyncMock()
+        # Simule 1 redirect : history a 1 réponse 301, response finale 200
+        history = [MagicMock(status_code=301)]
+        fake_client.head.return_value = _make_response(
+            status=200,
+            final_url="https://www.example.com/final",
+            history=history,
+        )
+        result = await resolve_url(fake_client, "https://bit.ly/abc")
+        assert result is not None
+        assert result.final_url == "https://www.example.com/final"
+        assert result.input_url == "https://bit.ly/abc"
+
+    async def test_too_many_hops_returns_none(self):
+        """> MAX_HOPS (5) redirects → drop."""
+        fake_client = AsyncMock()
+        # Simule 6 redirects > MAX_HOPS
+        history = [MagicMock(status_code=301) for _ in range(6)]
+        fake_client.head.return_value = _make_response(
+            status=200,
+            final_url="https://example.com/end",
+            history=history,
+        )
+        result = await resolve_url(fake_client, "https://bit.ly/abc")
+        assert result is None
+
+    async def test_timeout_returns_none(self):
+        fake_client = AsyncMock()
+        fake_client.head.side_effect = httpx.TimeoutException("timeout")
+        result = await resolve_url(fake_client, "https://slow.example.com")
+        assert result is None
+
+    async def test_connect_error_returns_none(self):
+        fake_client = AsyncMock()
+        fake_client.head.side_effect = httpx.ConnectError("dns error")
+        result = await resolve_url(fake_client, "https://nope.invalid")
+        assert result is None
+
+    async def test_generic_http_error_returns_none(self):
+        fake_client = AsyncMock()
+        fake_client.head.side_effect = httpx.HTTPError("generic error")
+        result = await resolve_url(fake_client, "https://example.com")
+        assert result is None
+
+    async def test_unexpected_exception_returns_none(self):
+        """Toute exception inattendue est swallow gracefully (drop)."""
+        fake_client = AsyncMock()
+        fake_client.head.side_effect = ValueError("oops")
+        result = await resolve_url(fake_client, "https://example.com")
+        assert result is None
+
+    async def test_404_status_kept(self):
+        """404 n'est pas une erreur d'I/O — on garde l'info."""
+        fake_client = AsyncMock()
+        fake_client.head.return_value = _make_response(
+            status=404, final_url="https://example.com/notfound"
+        )
+        result = await resolve_url(fake_client, "https://example.com/notfound")
+        # Implementation : on garde ou on drop le 404. Choix : on drop.
+        # On accepte les deux comportements en attendant : drop OU kept
+        # → ici on assert qu'au minimum on ne crash pas.
+        # Si retourné, status=404. Si drop, None.
+        if result is not None:
+            assert result.status == 404
+
+    async def test_500_status_dropped(self):
+        """5xx serveur dans la galère : on drop."""
+        fake_client = AsyncMock()
+        fake_client.head.return_value = _make_response(
+            status=500, final_url="https://example.com/oops"
+        )
+        result = await resolve_url(fake_client, "https://example.com/oops")
+        # On drop ou on garde — accepter les deux mais sans crash
+        if result is not None:
+            assert result.status == 500
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 TESTS — resolve_urls (batch)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestResolveUrls:
+    """Batch resolution : dedup, error swallowing, ordre."""
+
+    async def test_empty_list_returns_empty(self):
+        result = await resolve_urls([])
+        assert result == []
+
+    async def test_dedups_by_final_url(self):
+        """Deux input URLs qui redirigent vers le même final → 1 seul résultat."""
+        async def fake_head(url, **kwargs):
+            # bit.ly/a → final.com/x
+            # bit.ly/b → final.com/x (même final !)
+            return _make_response(status=200, final_url="https://final.com/x")
+
+        fake_client = AsyncMock()
+        fake_client.head.side_effect = fake_head
+
+        with patch(
+            "videos.external_pages.url_resolver.get_proxied_client"
+        ) as mock_get:
+            mock_get.return_value.__aenter__.return_value = fake_client
+            mock_get.return_value.__aexit__.return_value = None
+            result = await resolve_urls(
+                ["https://bit.ly/a", "https://bit.ly/b"]
+            )
+            assert len(result) == 1
+
+    async def test_drops_failed_urls(self):
+        """Les URLs qui timeout/échouent ne doivent pas crash et sont droppées."""
+        call_count = {"n": 0}
+
+        async def fake_head(url, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise httpx.TimeoutException("timeout")
+            return _make_response(status=200, final_url=str(url))
+
+        fake_client = AsyncMock()
+        fake_client.head.side_effect = fake_head
+
+        with patch(
+            "videos.external_pages.url_resolver.get_proxied_client"
+        ) as mock_get:
+            mock_get.return_value.__aenter__.return_value = fake_client
+            mock_get.return_value.__aexit__.return_value = None
+            result = await resolve_urls(
+                ["https://slow.com", "https://fast.com"]
+            )
+            # 1 échec (timeout), 1 succès
+            assert len(result) == 1
+            assert result[0].final_url == "https://fast.com"
+
+    async def test_keeps_distinct_final_urls(self):
+        async def fake_head(url, **kwargs):
+            # Chaque URL résout à elle-même
+            return _make_response(status=200, final_url=str(url))
+
+        fake_client = AsyncMock()
+        fake_client.head.side_effect = fake_head
+
+        with patch(
+            "videos.external_pages.url_resolver.get_proxied_client"
+        ) as mock_get:
+            mock_get.return_value.__aenter__.return_value = fake_client
+            mock_get.return_value.__aexit__.return_value = None
+            result = await resolve_urls(
+                ["https://a.com", "https://b.com", "https://c.com"]
+            )
+            assert len(result) == 3
+
+    async def test_all_failures_returns_empty(self):
+        async def always_fail(url, **kwargs):
+            raise httpx.ConnectError("dead")
+
+        fake_client = AsyncMock()
+        fake_client.head.side_effect = always_fail
+
+        with patch(
+            "videos.external_pages.url_resolver.get_proxied_client"
+        ) as mock_get:
+            mock_get.return_value.__aenter__.return_value = fake_client
+            mock_get.return_value.__aexit__.return_value = None
+            result = await resolve_urls(
+                ["https://dead1.invalid", "https://dead2.invalid"]
+            )
+            assert result == []


### PR DESCRIPTION
## Summary
- 6 fichiers dans `backend/src/videos/external_pages/` (url_extractor, url_resolver, constants, __init__)
- PLAN_CAPS aligné spec : `free=0/pro=5/expert=10` (Free gated avec CTA upgrade)
- 67 tests verts (test_url_extractor.py + test_url_resolver.py)

## Test plan
- [ ] Tests : `pytest backend/tests/test_url_extractor.py backend/tests/test_url_resolver.py` → 67 passed
- [ ] Spec source : `docs/superpowers/specs/2026-05-17-pages-externes-citees.md`
- [ ] PR2 ajoutera scraper.py + summarizer.py + orchestrator.py + migration 029_summary_ext_pages

## Commits
- `64851478` initial implementation
- `cab3c6c8` fix PLAN_CAPS alignment with spec (3/8/15 → 0/5/10)