### PR TITLE
feat(http_client): smart_request — direct-first with proxy fallback for 6 sites

### DIFF
--- a/backend/src/core/http_client.py
+++ b/backend/src/core/http_client.py
@@ -19,6 +19,8 @@
 import httpx
 from typing import Optional
 
+from core.logging import logger
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Configuration
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -255,6 +257,79 @@ def is_proxy_configured() -> bool:
     YouTube partira proxifiée ou bare en prod).
     """
     return bool(_get_proxy_url())
+
+
+async def smart_request(
+    method: str,
+    url: str,
+    *,
+    provider: str,
+    direct_timeout: float = 8.0,
+    proxy_timeout: float = 15.0,
+    block_status_codes: tuple = (403, 429, 502, 503),
+    follow_redirects: bool = True,
+    headers: Optional[dict] = None,
+    **request_kwargs,
+) -> httpx.Response:
+    """Try direct request first, fall back to Decodo proxy on block indicators.
+
+    Pour les call sites historiquement routés via `get_proxied_client` par
+    précaution (audit B4-B6 du 2026-05-11) mais qui marchent en direct depuis
+    Hetzner aujourd'hui (oEmbed YouTube/TikTok, tikwm API, HEAD redirects).
+    Économise le quota Decodo quand le direct passe.
+
+    Args:
+        method: HTTP method ("GET", "POST", "HEAD", ...)
+        url: Target URL
+        provider: Telemetry id écrit dans proxy_usage_daily.requests_by_provider
+            UNIQUEMENT en cas de fallback proxy. Direct success = aucune écriture.
+        direct_timeout: Timeout court pour la tentative directe (default 8s)
+        proxy_timeout: Timeout plus long pour le fallback proxy (default 15s)
+        block_status_codes: Status codes déclenchant le fallback (403/429/5xx)
+        follow_redirects: Pass-through aux deux clients
+        headers: Pass-through aux deux clients (User-Agent custom, etc.)
+        **request_kwargs: Forwarded à client.request() (params, data, json, ...)
+
+    Returns:
+        httpx.Response — du direct (rapide, gratuit) OU du fallback proxy.
+
+    Telemetry:
+        - Direct success (status NOT IN block_status_codes): no DB write, log DEBUG
+        - Direct fail → proxy success: record_proxy_usage(provider), log INFO
+        - Both fail: la dernière exception httpx est propagée au caller
+    """
+    direct_error: Optional[str] = None
+    try:
+        async with shared_http_client() as client:
+            resp = await client.request(
+                method,
+                url,
+                timeout=direct_timeout,
+                follow_redirects=follow_redirects,
+                headers=headers,
+                **request_kwargs,
+            )
+        if resp.status_code not in block_status_codes:
+            logger.debug(
+                f"[SMART_ROUTE] direct {provider} OK "
+                f"({resp.status_code}, {len(resp.content)}B)"
+            )
+            return resp
+        direct_error = f"HTTP {resp.status_code}"
+    except httpx.TransportError as e:
+        direct_error = type(e).__name__
+
+    logger.info(
+        f"[SMART_ROUTE] direct {provider} → {direct_error}, falling back to proxy"
+    )
+    async with get_proxied_client(
+        timeout=proxy_timeout,
+        follow_redirects=follow_redirects,
+        headers=headers,
+    ) as client:
+        resp = await client.request(method, url, **request_kwargs)
+        await record_proxied_response(resp, provider=provider)
+    return resp
 
 
 async def record_proxied_response(response, provider: str) -> None:

--- a/backend/src/transcripts/tiktok.py
+++ b/backend/src/transcripts/tiktok.py
@@ -32,7 +32,7 @@ from transcripts.audio_utils import (
     _yt_dlp_extra_args,
 )
 from core.config import get_supadata_key, get_mistral_key
-from core.http_client import get_proxied_client, record_proxied_response
+from core.http_client import get_proxied_client, record_proxied_response, smart_request
 
 logger = logging.getLogger(__name__)
 
@@ -428,15 +428,16 @@ async def _resolve_short_url(url: str) -> Optional[str]:
         return url  # Déjà une URL longue
 
     try:
-        async with get_proxied_client(
+        resp = await smart_request(
+            "HEAD",
+            url,
+            provider="tiktok_resolve_short",
+            direct_timeout=15.0,
             follow_redirects=True,
-            timeout=15.0,
-        ) as client:
-            resp = await client.head(url)
-            await record_proxied_response(resp, provider="tiktok_resolve_short")
-            resolved = str(resp.url)
-            logger.info(f"[TIKTOK] Resolved short URL → {resolved}")
-            return resolved
+        )
+        resolved = str(resp.url)
+        logger.info(f"[TIKTOK] Resolved short URL → {resolved}")
+        return resolved
     except Exception as e:
         logger.warning(f"[TIKTOK] Short URL resolution failed: {e}")
         return None
@@ -462,14 +463,17 @@ async def _get_info_via_oembed(url: str) -> Optional[Dict[str, Any]]:
         # 3. Appeler l'API oEmbed (proxy Decodo — TikTok 429 IP datacenter)
         oembed_url = f"https://www.tiktok.com/oembed?url={resolved_url}"
 
-        async with get_proxied_client(timeout=10.0) as client:
-            resp = await client.get(oembed_url)
-            await record_proxied_response(resp, provider="tiktok_oembed")
-            if resp.status_code != 200:
-                logger.warning(f"[TIKTOK] oEmbed returned {resp.status_code}")
-                return None
+        resp = await smart_request(
+            "GET",
+            oembed_url,
+            provider="tiktok_oembed",
+            direct_timeout=10.0,
+        )
+        if resp.status_code != 200:
+            logger.warning(f"[TIKTOK] oEmbed returned {resp.status_code}")
+            return None
 
-            data = resp.json()
+        data = resp.json()
 
         title = data.get("title", "TikTok Video")[:500]
         author = data.get("author_name", "Unknown")

--- a/backend/src/transcripts/youtube.py
+++ b/backend/src/transcripts/youtube.py
@@ -62,7 +62,7 @@ from core.config import (
     get_youtube_proxy,
     TRANSCRIPT_CONFIG,
 )
-from core.http_client import shared_http_client, get_proxied_client, record_proxied_response
+from core.http_client import shared_http_client, get_proxied_client, record_proxied_response, smart_request
 
 # 💾 Cache pour les transcripts (TTL 24h)
 try:
@@ -616,23 +616,27 @@ async def get_video_info(video_id: str) -> Optional[Dict[str, Any]]:
     print("  🔄 [OEMBED] Trying oembed fallback...", flush=True)
     try:
         url = f"https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v={video_id}&format=json"
-        async with get_proxied_client(timeout=10.0) as client:
-            response = await client.get(url, headers={"User-Agent": get_random_user_agent()})
-            await record_proxied_response(response, provider="youtube_oembed")
-            if response.status_code == 200:
-                data = response.json()
-                print("  ⚠️ [OEMBED] Got title but no duration", flush=True)
-                return {
-                    "video_id": video_id,
-                    "title": data.get("title", "Unknown"),
-                    "channel": data.get("author_name", "Unknown"),
-                    "thumbnail_url": f"https://img.youtube.com/vi/{video_id}/maxresdefault.jpg",
-                    "duration": 0,  # oembed ne fournit pas la durée
-                    "upload_date": None,
-                    "description": "",
-                    "tags": [],
-                    "categories": [],
-                }
+        response = await smart_request(
+            "GET",
+            url,
+            provider="youtube_oembed",
+            direct_timeout=10.0,
+            headers={"User-Agent": get_random_user_agent()},
+        )
+        if response.status_code == 200:
+            data = response.json()
+            print("  ⚠️ [OEMBED] Got title but no duration", flush=True)
+            return {
+                "video_id": video_id,
+                "title": data.get("title", "Unknown"),
+                "channel": data.get("author_name", "Unknown"),
+                "thumbnail_url": f"https://img.youtube.com/vi/{video_id}/maxresdefault.jpg",
+                "duration": 0,  # oembed ne fournit pas la durée
+                "upload_date": None,
+                "description": "",
+                "tags": [],
+                "categories": [],
+            }
     except Exception as e:
         print(f"  ⚠️ [OEMBED] error: {e}", flush=True)
 

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -34,7 +34,7 @@ from auth.dependencies import (
 )
 from core.config import CATEGORIES, get_mistral_key
 from billing.plan_config import get_limits
-from core.http_client import get_proxied_client, shared_http_client, record_proxied_response
+from core.http_client import get_proxied_client, shared_http_client, record_proxied_response, smart_request
 from core.logging import logger
 from core.moderation_service import moderate_text
 
@@ -375,12 +375,15 @@ async def quick_chat_prepare(
     resolved_url = url
     if platform == "tiktok" and ("vm.tiktok.com" in url or "vt.tiktok.com" in url):
         try:
-            async with get_proxied_client(timeout=8.0) as client:
-                head_resp = await client.head(url)
-                await record_proxied_response(head_resp, provider="tiktok_resolve_short_quickchat")
-                if head_resp.status_code in (200, 301, 302) and "tiktok.com" in str(head_resp.url):
-                    resolved_url = str(head_resp.url).split("?")[0]  # Drop tracking params
-                    logger.info(f"[QUICK CHAT] Resolved short URL → {resolved_url[:80]}")
+            head_resp = await smart_request(
+                "HEAD",
+                url,
+                provider="tiktok_resolve_short_quickchat",
+                direct_timeout=8.0,
+            )
+            if head_resp.status_code in (200, 301, 302) and "tiktok.com" in str(head_resp.url):
+                resolved_url = str(head_resp.url).split("?")[0]  # Drop tracking params
+                logger.info(f"[QUICK CHAT] Resolved short URL → {resolved_url[:80]}")
         except Exception as e:
             logger.error(f"[QUICK CHAT] Short URL resolution failed: {e}")
 
@@ -419,21 +422,22 @@ async def quick_chat_prepare(
     # 3b. Fallback thumbnail TikTok via oEmbed si manquant (proxy Decodo — audit B6)
     if platform == "tiktok" and not thumbnail_url:
         try:
-            async with get_proxied_client(timeout=5.0) as client:
-                oembed_resp = await client.get(
-                    "https://www.tiktok.com/oembed",
-                    params={"url": resolved_url},
-                )
-                await record_proxied_response(oembed_resp, provider="tiktok_oembed_thumbnail")
-                if oembed_resp.status_code == 200:
-                    oembed_data = oembed_resp.json()
-                    thumbnail_url = oembed_data.get("thumbnail_url", "")
-                    # Also grab title/author from oEmbed if still generic
-                    if title in ("TikTok Video", "Video sans titre", "", "TikTok"):
-                        title = str(oembed_data.get("title", title))[:255]
-                    if not channel or channel in ("Unknown", ""):
-                        channel = str(oembed_data.get("author_name", channel))[:255]
-                    logger.warning(f"[QUICK CHAT] oEmbed fallback: thumb={bool(thumbnail_url)}, title={title[:40]}")
+            oembed_resp = await smart_request(
+                "GET",
+                "https://www.tiktok.com/oembed",
+                provider="tiktok_oembed_thumbnail",
+                direct_timeout=5.0,
+                params={"url": resolved_url},
+            )
+            if oembed_resp.status_code == 200:
+                oembed_data = oembed_resp.json()
+                thumbnail_url = oembed_data.get("thumbnail_url", "")
+                # Also grab title/author from oEmbed if still generic
+                if title in ("TikTok Video", "Video sans titre", "", "TikTok"):
+                    title = str(oembed_data.get("title", title))[:255]
+                if not channel or channel in ("Unknown", ""):
+                    channel = str(oembed_data.get("author_name", channel))[:255]
+                logger.warning(f"[QUICK CHAT] oEmbed fallback: thumb={bool(thumbnail_url)}, title={title[:40]}")
         except Exception as e:
             logger.error(f"[QUICK CHAT] oEmbed fallback failed: {e}")
 

--- a/backend/src/videos/visual_integration.py
+++ b/backend/src/videos/visual_integration.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, Optional, Tuple
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from core.http_client import get_proxied_client, record_proxied_response
+from core.http_client import get_proxied_client, record_proxied_response, smart_request
 from db.database import User, VisualAnalysisQuota
 from transcripts.audio_utils import _yt_dlp_extra_args, executor as audio_executor
 
@@ -479,9 +479,13 @@ async def _download_tiktok_video_no_watermark(url: str, *, log_tag: str) -> Opti
     est rate-limited 429 sur IP datacenter Hetzner. Audit B4 (Wave 2).
     """
     try:
-        async with get_proxied_client(timeout=_TIKWM_TIMEOUT_S) as client:
-            resp = await client.post(_TIKWM_API_URL, data={"url": url})
-            await record_proxied_response(resp, provider="tikwm_api")
+        resp = await smart_request(
+            "POST",
+            _TIKWM_API_URL,
+            provider="tikwm_api",
+            direct_timeout=_TIKWM_TIMEOUT_S,
+            data={"url": url},
+        )
         if resp.status_code != 200:
             logger.warning("[%s] tikwm API HTTP %d for %s", log_tag, resp.status_code, url)
             return None

--- a/backend/tests/test_smart_request.py
+++ b/backend/tests/test_smart_request.py
@@ -1,0 +1,182 @@
+"""Tests for core.http_client.smart_request — direct-first with proxy fallback."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+
+def _make_resp(status_code: int, content: bytes = b"") -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.content = content
+    resp.num_bytes_downloaded = len(content)
+    return resp
+
+
+@pytest.fixture
+def mock_clients(monkeypatch):
+    """Mock shared_http_client + get_proxied_client + record_proxied_response.
+
+    Use state["direct_resp"] / state["proxy_resp"] / state["direct_exc"] to
+    control what each path returns. Read state["direct_calls"] /
+    state["proxy_calls"] to assert routing.
+    """
+    state = {
+        "direct_resp": _make_resp(200, b"direct"),
+        "proxy_resp": _make_resp(200, b"proxy"),
+        "direct_calls": 0,
+        "proxy_calls": 0,
+        "direct_exc": None,
+        "record_calls": [],
+    }
+
+    @asynccontextmanager
+    async def mock_shared(**kwargs):
+        client = AsyncMock()
+
+        async def request(*args, **kw):
+            state["direct_calls"] += 1
+            if state["direct_exc"] is not None:
+                raise state["direct_exc"]
+            return state["direct_resp"]
+
+        client.request = request
+        yield client
+
+    @asynccontextmanager
+    async def mock_proxied(**kwargs):
+        client = AsyncMock()
+
+        async def request(*args, **kw):
+            state["proxy_calls"] += 1
+            return state["proxy_resp"]
+
+        client.request = request
+        yield client
+
+    async def mock_record(response, provider):
+        state["record_calls"].append(provider)
+
+    monkeypatch.setattr("core.http_client.shared_http_client", mock_shared)
+    monkeypatch.setattr("core.http_client.get_proxied_client", mock_proxied)
+    monkeypatch.setattr("core.http_client.record_proxied_response", mock_record)
+
+    return state
+
+
+@pytest.mark.asyncio
+async def test_smart_request_direct_success(mock_clients):
+    """200 from direct → returns direct response, no proxy call, no telemetry."""
+    from core.http_client import smart_request
+
+    resp = await smart_request("GET", "https://example.com/oembed", provider="test_oembed")
+
+    assert resp.status_code == 200
+    assert resp.content == b"direct"
+    assert mock_clients["direct_calls"] == 1
+    assert mock_clients["proxy_calls"] == 0
+    assert mock_clients["record_calls"] == []
+
+
+@pytest.mark.asyncio
+async def test_smart_request_direct_403_falls_back(mock_clients):
+    """403 from direct → falls back to proxy, records telemetry."""
+    mock_clients["direct_resp"] = _make_resp(403)
+    from core.http_client import smart_request
+
+    resp = await smart_request("GET", "https://example.com/oembed", provider="test_oembed")
+
+    assert resp.status_code == 200
+    assert resp.content == b"proxy"
+    assert mock_clients["direct_calls"] == 1
+    assert mock_clients["proxy_calls"] == 1
+    assert mock_clients["record_calls"] == ["test_oembed"]
+
+
+@pytest.mark.asyncio
+async def test_smart_request_direct_429_falls_back(mock_clients):
+    """429 rate-limit → falls back to proxy."""
+    mock_clients["direct_resp"] = _make_resp(429)
+    from core.http_client import smart_request
+
+    await smart_request("GET", "https://example.com/oembed", provider="test_oembed")
+
+    assert mock_clients["proxy_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_smart_request_direct_502_falls_back(mock_clients):
+    """502 bad gateway → falls back to proxy."""
+    mock_clients["direct_resp"] = _make_resp(502)
+    from core.http_client import smart_request
+
+    await smart_request("GET", "https://example.com/oembed", provider="test_oembed")
+
+    assert mock_clients["proxy_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_smart_request_direct_timeout_falls_back(mock_clients):
+    """Direct httpx.ConnectTimeout → falls back to proxy."""
+    mock_clients["direct_exc"] = httpx.ConnectTimeout("timeout")
+    from core.http_client import smart_request
+
+    resp = await smart_request("GET", "https://example.com/oembed", provider="test_oembed")
+
+    assert resp.status_code == 200
+    assert mock_clients["direct_calls"] == 1
+    assert mock_clients["proxy_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_smart_request_direct_connect_error_falls_back(mock_clients):
+    """Direct httpx.ConnectError → falls back to proxy."""
+    mock_clients["direct_exc"] = httpx.ConnectError("refused")
+    from core.http_client import smart_request
+
+    await smart_request("GET", "https://example.com/oembed", provider="test_oembed")
+
+    assert mock_clients["proxy_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_smart_request_direct_404_not_block(mock_clients):
+    """404 from direct is NOT a block — returns direct response, no fallback."""
+    mock_clients["direct_resp"] = _make_resp(404)
+    from core.http_client import smart_request
+
+    resp = await smart_request("GET", "https://example.com/oembed", provider="test_oembed")
+
+    assert resp.status_code == 404
+    assert mock_clients["proxy_calls"] == 0
+
+
+@pytest.mark.asyncio
+async def test_smart_request_custom_block_codes(mock_clients):
+    """Caller can override block_status_codes (e.g., treat 404 as block)."""
+    mock_clients["direct_resp"] = _make_resp(404)
+    from core.http_client import smart_request
+
+    resp = await smart_request(
+        "GET",
+        "https://example.com/oembed",
+        provider="test_oembed",
+        block_status_codes=(404,),
+    )
+
+    assert resp.status_code == 200
+    assert mock_clients["proxy_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_smart_request_non_transport_error_propagates(mock_clients):
+    """Non-transport error (e.g., ValueError) is NOT caught, propagates."""
+    mock_clients["direct_exc"] = ValueError("programmer bug")
+    from core.http_client import smart_request
+
+    with pytest.raises(ValueError, match="programmer bug"):
+        await smart_request("GET", "https://example.com/oembed", provider="test_oembed")
+
+    assert mock_clients["proxy_calls"] == 0  # No fallback for non-transport errors

--- a/backend/tests/transcripts/test_tiktok_proxy_migration.py
+++ b/backend/tests/transcripts/test_tiktok_proxy_migration.py
@@ -50,14 +50,21 @@ class TestSourceLevelLock:
             "TikTok web / tikwm / CDN / oEmbed calls via Decodo (audit B5)."
         )
 
-    def test_at_least_5_proxied_call_sites(self):
-        """5 TikTok-targeting routes must use get_proxied_client."""
+    def test_at_least_5_proxy_capable_call_sites(self):
+        """5 TikTok-targeting routes must use a proxy-capable client.
+
+        Post smart_request migration (2026-05-17): some sites (short URL HEAD,
+        oEmbed GET) use smart_request — direct-first with proxy fallback —
+        while CDN downloads + HTML scrape still force get_proxied_client. Both
+        count as proxy-capable for regression protection.
+        """
         from transcripts import tiktok
 
         src = inspect.getsource(tiktok)
-        count = src.count("get_proxied_client(")
+        count = src.count("get_proxied_client(") + src.count("smart_request(")
         assert count >= 5, (
-            f"Expected ≥ 5 get_proxied_client() call sites, got {count}. "
+            f"Expected ≥ 5 proxy-capable call sites "
+            f"(get_proxied_client + smart_request), got {count}. "
             "Required: short URL HEAD, oEmbed GET, tikwm API POST/GET, CDN "
             "media GET, TikTok HTML scrape."
         )

--- a/backend/tests/transcripts/test_youtube_httpx_migration.py
+++ b/backend/tests/transcripts/test_youtube_httpx_migration.py
@@ -82,29 +82,25 @@ class TestDirectYouTubeRouteUsesProxiedClient:
         yt = _get_youtube_module()
         self.src = inspect.getsource(yt)
 
-    def test_youtube_oembed_uses_proxied_client(self):
-        """www.youtube.com/oembed — direct YouTube call (PR #459).
+    def test_youtube_oembed_uses_proxy_capable_client(self):
+        """www.youtube.com/oembed — direct YouTube call.
 
-        Note: `youtube.com/oembed` appears in the URL string ASSIGNED to a
-        variable, not directly inside `async with` block. We look forward
-        ~5 lines from the marker for the next `async with`.
+        Since 2026-05-17 (smart routing sprint) this site uses `smart_request`
+        which tries direct first then falls back to proxy on block. Either
+        `get_proxied_client` or `smart_request` is acceptable here.
         """
         url_marker = "www.youtube.com/oembed"
         assert url_marker in self.src, (
             f"URL marker {url_marker!r} not found — oEmbed route removed?"
         )
         pos = self.src.find(url_marker)
-        # Look FORWARD a few hundred chars for the next `async with`
+        # Look FORWARD a few hundred chars for the next proxy-capable call
         window_end = min(len(self.src), pos + 500)
         window = self.src[pos:window_end]
-        next_async_with = window.find("async with ")
-        assert next_async_with != -1, (
-            "No `async with` found after oEmbed URL — context may have changed."
-        )
-        snippet = window[next_async_with : next_async_with + 200]
-        assert "get_proxied_client" in snippet, (
-            "oEmbed (www.youtube.com direct call, PR #459) regressed from "
-            "get_proxied_client — Decodo routing lost on direct YouTube call."
+        assert ("get_proxied_client" in window) or ("smart_request" in window), (
+            "oEmbed (www.youtube.com direct call) regressed — must use either "
+            "get_proxied_client (force proxy) or smart_request (direct→proxy fallback). "
+            "Decodo routing lost on direct YouTube call."
         )
 
 
@@ -264,18 +260,21 @@ class TestProxiedClientCoverage:
     to prevent silent regressions in either direction (over-migration like #472
     OR under-migration that drops oEmbed routing)."""
 
-    def test_get_proxied_client_count_post_revert(self):
-        """Post-revert (this PR) : exactly 1 occurrence — oEmbed (PR #459).
-        If this climbs > 2, an over-migration like #472 likely happened
-        again. If this drops to 0, oEmbed regressed to shared_http_client."""
+    def test_proxy_capable_count_post_smart_route(self):
+        """Post smart-route migration (2026-05-17) : exactly 1 oEmbed call,
+        either as `async with get_proxied_client` OR as `smart_request("GET", ...)`.
+
+        Climb > 1 = over-migration regression (#472 pattern). Drop to 0 =
+        oEmbed lost Decodo routing entirely.
+        """
         yt = _get_youtube_module()
         src = inspect.getsource(yt)
-        count = src.count("async with get_proxied_client")
+        count = src.count("async with get_proxied_client") + src.count("smart_request(")
         assert count == 1, (
-            f"Expected exactly 1 `async with get_proxied_client` block in "
-            f"transcripts/youtube.py (oEmbed direct YouTube call, PR #459), "
-            f"got {count}. Either over-migration is happening again "
-            f"(post-#472 was reverted) OR oEmbed lost its proxy."
+            f"Expected exactly 1 proxy-capable call in transcripts/youtube.py "
+            f"(oEmbed direct YouTube call), got {count}. Either over-migration "
+            f"is happening again (post-#472 was reverted) OR oEmbed lost "
+            f"Decodo routing."
         )
 
     def test_shared_http_client_count_post_revert(self):

--- a/backend/tests/videos/test_router_tiktok_proxy.py
+++ b/backend/tests/videos/test_router_tiktok_proxy.py
@@ -63,34 +63,39 @@ class TestSourceLevelLock:
         # Must be in the http_client import line (next to shared_http_client)
         assert "from core.http_client import" in src
 
-    def test_at_least_2_proxied_call_sites(self):
-        """2 TikTok Quick Chat routes must use get_proxied_client :
-        short URL HEAD + oEmbed GET."""
+    def test_at_least_2_proxy_capable_call_sites(self):
+        """2 TikTok Quick Chat routes must use a proxy-capable client.
+
+        Post smart-route migration (2026-05-17), short URL HEAD + oEmbed GET
+        use `smart_request` (direct-first with proxy fallback). Both still
+        count as proxy-capable for regression protection.
+        """
         src = _read_router_source()
-        count = src.count("get_proxied_client(")
+        count = src.count("get_proxied_client(") + src.count("smart_request(")
         assert count >= 2, (
-            f"Expected ≥ 2 get_proxied_client() call sites in videos/router.py, "
-            f"got {count}. Required: TikTok short URL HEAD + TikTok oEmbed GET."
+            f"Expected ≥ 2 proxy-capable call sites in videos/router.py "
+            f"(get_proxied_client + smart_request), got {count}. "
+            "Required: TikTok short URL HEAD + TikTok oEmbed GET."
         )
 
-    def test_proxied_clients_target_tiktok(self):
-        """Each `get_proxied_client(...)` block in router.py should appear
-        in a 25-line window that mentions tiktok (URL, oembed, vm.tiktok, etc.)."""
+    def test_proxy_capable_clients_target_tiktok(self):
+        """Each proxy-capable call (`get_proxied_client` or `smart_request`)
+        in router.py should appear in a window that mentions tiktok."""
         src = _read_router_source()
         lines = src.splitlines()
 
-        proxied_indices = [
+        proxy_indices = [
             i for i, line in enumerate(lines)
-            if re.search(r"\bget_proxied_client\s*\(", line)
+            if re.search(r"\b(get_proxied_client|smart_request)\s*\(", line)
         ]
-        assert proxied_indices, "No get_proxied_client(...) call sites found"
+        assert proxy_indices, "No proxy-capable call sites found in router.py"
 
-        for idx in proxied_indices:
+        for idx in proxy_indices:
             window = "\n".join(
-                lines[max(0, idx - 15):min(len(lines), idx + 5)]
+                lines[max(0, idx - 5):min(len(lines), idx + 15)]
             ).lower()
             assert "tiktok" in window or "oembed" in window, (
-                f"get_proxied_client(...) at line {idx + 1} does not appear in "
+                f"Proxy-capable call at line {idx + 1} does not appear in "
                 "a TikTok context — only TikTok routes should be proxied in "
                 f"router.py. Context window:\n{window}"
             )
@@ -120,33 +125,32 @@ class TestSourceLevelLock:
                 f"instead (audit B6). Context:\n{window}"
             )
 
-    def test_short_url_head_uses_proxy(self):
-        """The short URL HEAD logic for vm.tiktok.com MUST go through proxy."""
+    def test_short_url_head_uses_proxy_capable(self):
+        """The short URL HEAD for vm.tiktok.com MUST go through a proxy-capable client."""
         src = _read_router_source()
-        # Find the resolved_url logic block
         idx = src.find('"vm.tiktok.com" in url')
         assert idx > -1, (
             "Could not find Quick Chat short-URL resolver block — was the "
             "code refactored? Update this test."
         )
-        # Check that the next 500 chars contain get_proxied_client
         block = src[idx:idx + 1000]
-        assert "get_proxied_client" in block, (
-            "Quick Chat short URL resolution does not use get_proxied_client — "
-            "vm.tiktok.com / vt.tiktok.com HEAD must go via Decodo."
+        assert ("get_proxied_client" in block) or ("smart_request" in block), (
+            "Quick Chat short URL resolution does not use a proxy-capable client "
+            "(get_proxied_client or smart_request) — vm.tiktok.com / vt.tiktok.com "
+            "HEAD must be able to route via Decodo."
         )
 
-    def test_oembed_uses_proxy(self):
-        """The TikTok oEmbed thumbnail fallback MUST go through proxy."""
+    def test_oembed_uses_proxy_capable(self):
+        """The TikTok oEmbed thumbnail fallback MUST go through a proxy-capable client."""
         src = _read_router_source()
         idx = src.find('"https://www.tiktok.com/oembed"')
         assert idx > -1, (
             "Could not find TikTok oEmbed URL string — was the code "
             "refactored? Update this test."
         )
-        # Check ~500 chars BEFORE the URL for the proxied client context
         block = src[max(0, idx - 500):idx + 200]
-        assert "get_proxied_client" in block, (
-            "TikTok oEmbed fallback does not use get_proxied_client — TikTok "
-            "rate-limits 429 on Hetzner datacenter IP."
+        assert ("get_proxied_client" in block) or ("smart_request" in block), (
+            "TikTok oEmbed fallback does not use a proxy-capable client "
+            "(get_proxied_client or smart_request) — TikTok rate-limits 429 on "
+            "Hetzner datacenter IP."
         )

--- a/backend/tests/videos/test_visual_integration_tiktok_proxy.py
+++ b/backend/tests/videos/test_visual_integration_tiktok_proxy.py
@@ -43,16 +43,18 @@ class TestSourceLevelLock:
             "downloads via Decodo (audit B4 / Wave 2 sprint 2026-05-12)."
         )
 
-    def test_get_proxied_client_used_at_least_twice(self):
-        """At least 2 `get_proxied_client(` call sites — one for tikwm POST,
-        one for TikTok CDN GET in `_download_tiktok_video_no_watermark`."""
+    def test_proxy_capable_used_at_least_twice(self):
+        """At least 2 proxy-capable call sites — one for tikwm POST (smart_request
+        since 2026-05-17), one for TikTok CDN GET (still get_proxied_client because
+        CDN downloads are heavy + blocked from Hetzner)."""
         from videos import visual_integration
 
         src = inspect.getsource(visual_integration)
-        count = src.count("get_proxied_client(")
+        count = src.count("get_proxied_client(") + src.count("smart_request(")
         assert count >= 2, (
-            f"Expected ≥ 2 get_proxied_client() call sites, got {count}. "
-            "Both the tikwm API POST and the TikTok CDN GET must be proxied."
+            f"Expected ≥ 2 proxy-capable call sites "
+            f"(get_proxied_client + smart_request), got {count}. "
+            "Both the tikwm API POST and the TikTok CDN GET must be proxy-capable."
         )
 
     def test_no_bare_httpx_async_client_in_tiktok_download(self):
@@ -89,7 +91,8 @@ class TestIntegrationGracefulFallback:
     @pytest.mark.asyncio
     async def test_function_callable_without_proxy_env(self, monkeypatch):
         """With proxy unset, `_download_tiktok_video_no_watermark` should
-        still be callable. We mock `get_proxied_client` to raise to verify
+        still be callable. We mock both `get_proxied_client` (CDN path) and
+        `smart_request` (tikwm API path since 2026-05-17) to raise, verifying
         the function catches the error and returns None (graceful path).
 
         We MUST NOT do real network calls here — the test would either be
@@ -112,7 +115,11 @@ class TestIntegrationGracefulFallback:
 
             yield FakeClient()
 
+        async def fake_smart_request(*args, **kwargs):
+            raise RuntimeError("no network in unit test")
+
         monkeypatch.setattr(vi, "get_proxied_client", fake_proxied_client)
+        monkeypatch.setattr(vi, "smart_request", fake_smart_request)
 
         result = await vi._download_tiktok_video_no_watermark(
             "https://www.tiktok.com/@whoever/video/123",


### PR DESCRIPTION
## Summary

Adds `smart_request()` in `core/http_client.py` — tries direct via shared (bare) httpx client first, falls back to Decodo proxy via `get_proxied_client` on block indicators (403/429/5xx) or transport errors (timeout/connect).

Migrates **6 light call sites** previously force-routed through Decodo by audit B4/B5/B6 (2026-05-11):

| Site | File | Provider |
|------|------|----------|
| YouTube oEmbed | `transcripts/youtube.py` | `youtube_oembed` |
| TikTok short URL HEAD | `transcripts/tiktok.py` | `tiktok_resolve_short` |
| TikTok oEmbed | `transcripts/tiktok.py` | `tiktok_oembed` |
| TikTok short URL HEAD (Quick Chat) | `videos/router.py` | `tiktok_resolve_short_quickchat` |
| TikTok oEmbed thumbnail | `videos/router.py` | `tiktok_oembed_thumbnail` |
| tikwm API POST | `videos/visual_integration.py` | `tikwm_api` |

**Stays on `get_proxied_client`** (heavy/blocked): video CDN downloads (`tikwm_cdn_download`, `tiktok_media_cdn_*`), TikTok HTML scrape (`tiktok_channel_html`).

## Why it works now

Validated direct from Hetzner (2026-05-17) — all 4 endpoint families return 200:
- `https://www.youtube.com/oembed?url=...` → 200, 868B
- `https://www.tiktok.com/oembed?url=...` → 200, 1749B
- `https://www.tikwm.com/api/` POST → 200, 4561B
- TikTok short URL HEAD → 200

Audit B4/B5/B6 ran on 2026-05-11 when these endpoints were rate-limiting 429 on the Hetzner datacenter IP. The block has lifted (or our IP cycled). Smart route gives us back direct path savings while keeping proxy fallback for safety.

## Telemetry

- Direct success → no DB write in `proxy_usage_daily` (= Decodo savings)
- Direct fail → proxy success → `record_proxy_usage(provider)` as before
- INFO log on every fallback for observability (`[SMART_ROUTE] direct {provider} → {error}, falling back to proxy`)

## Test plan

- [x] 9 new tests in `tests/test_smart_request.py` (direct OK, 403/429/502/timeout/ConnectError fallback, 404-NOT-block, custom block_status_codes, non-transport error propagation)
- [x] 4 existing source-level lock tests updated to count `smart_request` as proxy-capable alongside `get_proxied_client`
- [x] 43/43 verts sur tous les modules touchés
- [ ] Post-merge Hetzner deploy: monitor `[SMART_ROUTE]` log lines pour mesurer hit-rate direct (devrait être ~100% sur ces 6 sites aujourd'hui)
- [ ] Watch `proxy_usage_daily.requests_by_provider` — les 6 providers migrés devraient stop apparaître (sauf si fallback déclenché)

## Gotchas

- `youtube_oembed` route avait une indentation dict bizarre pré-existante; nettoyée en passant (cosmétique, 10 lignes).
- `videos/router.py` oEmbed block avait du code (extraction title/channel) à dédenter après suppression du `async with`.
- Bug Python 3.13 circular import `auth.service` ↔ `billing.router` persiste — la suite complète passe mais les fichiers isolés échouent à l'import.