### PR TITLE
feat(academic): Google Scholar Phase 4 integration + plan gating + quota (PR 2/3)

### DIFF
--- a/backend/alembic/versions/030_academic_scholar.py
+++ b/backend/alembic/versions/030_academic_scholar.py
@@ -1,0 +1,66 @@
+"""academic scholar — scholar_id on academic_papers + scholar_queries on daily_quotas
+
+Revision ID: 030_academic_scholar
+Revises: 029_summary_community
+Create Date: 2026-05-17
+
+Spec : docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md § 7
+
+Idempotent : skips column add if it already exists. Downgrade drops the
+added columns. Naming convention follows DeepSight Alembic guidelines
+(<= 32 chars, prefixed with sequence number).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "030_academic_scholar"
+down_revision: Union[str, None] = "029_summary_community"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    if "academic_papers" in tables:
+        cols = {c["name"] for c in inspector.get_columns("academic_papers")}
+        if "scholar_id" not in cols:
+            op.add_column(
+                "academic_papers",
+                sa.Column("scholar_id", sa.String(length=64), nullable=True),
+            )
+
+    if "daily_quotas" in tables:
+        cols = {c["name"] for c in inspector.get_columns("daily_quotas")}
+        if "scholar_queries" not in cols:
+            op.add_column(
+                "daily_quotas",
+                sa.Column(
+                    "scholar_queries",
+                    sa.Integer(),
+                    nullable=False,
+                    server_default="0",
+                ),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    if "daily_quotas" in tables:
+        cols = {c["name"] for c in inspector.get_columns("daily_quotas")}
+        if "scholar_queries" in cols:
+            op.drop_column("daily_quotas", "scholar_queries")
+
+    if "academic_papers" in tables:
+        cols = {c["name"] for c in inspector.get_columns("academic_papers")}
+        if "scholar_id" in cols:
+            op.drop_column("academic_papers", "scholar_id")

--- a/backend/src/academic/aggregator.py
+++ b/backend/src/academic/aggregator.py
@@ -22,7 +22,17 @@ from .arxiv_client import arxiv_client
 from .crossref_client import crossref_client
 
 # Source weights for scoring
-SOURCE_WEIGHTS = {"semantic_scholar": 1.0, "openalex": 0.95, "crossref": 0.90, "arxiv": 0.85}
+SOURCE_WEIGHTS = {
+    "semantic_scholar": 1.0,
+    "openalex": 0.95,
+    "crossref": 0.90,
+    "arxiv": 0.85,
+    "scholar": 0.80,
+}
+
+# Phase 4 — Scholar deep crawl threshold. If Phases 1-3 already returned >=10 papers,
+# we skip Scholar (spec 2026-05-17 § 3.3). Tunable without deploy via SCHOLAR_ENABLED env.
+SCHOLAR_PHASE_THRESHOLD = 10
 
 # Tier limits for academic papers
 TIER_LIMITS = {
@@ -119,6 +129,24 @@ class AcademicAggregator:
         """Build a simple space-separated query (no quotes) for APIs that handle it better."""
         top_keywords = keywords[:max_keywords]
         return " ".join(kw.strip() for kw in top_keywords if kw.strip())
+
+    async def _search_scholar(self, query: str, request: AcademicSearchRequest) -> List[AcademicPaper]:
+        """Phase 4 — Google Scholar deep crawl (proxy Decodo, Pro+ only).
+
+        Delegates to `academic.scholar.search_scholar` which handles rate
+        limiting, circuit breaker, Redis cache, and CAPTCHA detection. Maps
+        the returned `ScholarPaper`s to `AcademicPaper`s. Returns [] on any
+        exception (graceful fallback, never raises).
+        """
+        try:
+            from .scholar import search_scholar, scholar_paper_to_academic
+
+            print(f"  → Scholar: {query[:60]}...", flush=True)
+            batch = await search_scholar(query, limit=20)
+            return [scholar_paper_to_academic(sp) for sp in batch.papers]
+        except Exception as e:
+            print(f"  Scholar error: {e}", flush=True)
+            return []
 
     async def search(
         self, request: AcademicSearchRequest, user_plan: str = "free", video_title: Optional[str] = None
@@ -265,6 +293,38 @@ class AcademicAggregator:
                         print(f"  Phase 3 added {len(result)} papers", flush=True)
             except asyncio.TimeoutError:
                 print("Phase 3 timeout", flush=True)
+
+        # ═══════════════════════════════════════════════════════════════
+        # PHASE 4 — Google Scholar deep crawl (NEW, conditional)
+        # spec 2026-05-17 § 3.3 — opt-in deep_search, Pro+, only if <10 papers
+        # ═══════════════════════════════════════════════════════════════
+        try:
+            from core.config import SCHOLAR_ENABLED
+        except Exception:
+            SCHOLAR_ENABLED = True
+
+        should_use_scholar = (
+            SCHOLAR_ENABLED
+            and getattr(request, "deep_search", False)
+            and user_plan in ("pro", "expert")
+            and len(all_papers) < SCHOLAR_PHASE_THRESHOLD
+        )
+        if should_use_scholar:
+            print(f"Phase 4 — Scholar activated (current papers={len(all_papers)})", flush=True)
+            scholar_query = focused_query or simple_query
+            try:
+                scholar_papers = await asyncio.wait_for(
+                    self._search_scholar(scholar_query, request),
+                    timeout=20.0,
+                )
+                if scholar_papers:
+                    sources_queried.append("scholar")
+                    all_papers.extend(scholar_papers)
+                    print(f"  Phase 4 added {len(scholar_papers)} papers from Scholar", flush=True)
+                else:
+                    print("  Phase 4 returned 0 papers (CAPTCHA, rate limit, or empty SERP)", flush=True)
+            except asyncio.TimeoutError:
+                print("  Phase 4 timeout — graceful fallback", flush=True)
 
         print(f"Total papers before deduplication: {len(all_papers)}", flush=True)
 

--- a/backend/src/academic/router.py
+++ b/backend/src/academic/router.py
@@ -53,6 +53,29 @@ async def search_academic_papers(
         user_plan = current_user.plan or "free"
         print(f"Starting academic search for user plan: {user_plan}, keywords: {request.keywords}", flush=True)
 
+        # Plan gating for Phase 4 — Scholar deep crawl (spec 2026-05-17 § 6.3)
+        if request.deep_search:
+            if user_plan.lower() == "free":
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "code": "plan_required",
+                        "message": "Deep Scholar search requires Pro plan or higher.",
+                        "current_plan": user_plan,
+                        "required_plan": "pro",
+                        "feature": "scholar_deep_search",
+                        "action": "upgrade",
+                    },
+                )
+            from core.scholar_quota import check_and_increment_scholar_quota
+
+            allowed, error_payload = await check_and_increment_scholar_quota(session, current_user)
+            if not allowed:
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail=error_payload,
+                )
+
         # Search all sources
         response = await academic_aggregator.search(request, user_plan)
 
@@ -71,6 +94,10 @@ async def search_academic_papers(
                 "message": "Search took too long. Please try again with more specific keywords.",
             },
         )
+    except HTTPException:
+        # Re-raise plan gating / quota errors verbatim (403, 429) — don't mask
+        # them as 500 below. Spec 2026-05-17 § 6.3.
+        raise
     except Exception as e:
         print(f"Academic search error: {str(e)}", flush=True)
         import traceback

--- a/backend/src/academic/schemas.py
+++ b/backend/src/academic/schemas.py
@@ -15,6 +15,7 @@ class AcademicSource(str, Enum):
     OPENALEX = "openalex"
     ARXIV = "arxiv"
     CROSSREF = "crossref"
+    SCHOLAR = "scholar"
 
 
 class BibliographyFormat(str, Enum):
@@ -68,6 +69,10 @@ class AcademicSearchRequest(BaseModel):
     year_to: Optional[int] = None
     include_preprints: bool = True
     fields_of_study: Optional[List[str]] = None
+    deep_search: bool = Field(
+        default=False,
+        description="Enable Phase 4 Google Scholar deep crawl (Pro+ only, opt-in)",
+    )
 
 
 class AcademicSearchResponse(BaseModel):

--- a/backend/src/academic/scholar.py
+++ b/backend/src/academic/scholar.py
@@ -597,5 +597,37 @@ __all__ = [
     "init_scholar_redis",
     "is_circuit_open",
     "parse_scholar_html",
+    "scholar_paper_to_academic",
     "search_scholar",
 ]
+
+
+def scholar_paper_to_academic(sp):
+    """Convert a `ScholarPaper` into an `AcademicPaper` compatible with the aggregator pipeline.
+
+    Imports `AcademicPaper` / `Author` / `AcademicSource` lazily to avoid a
+    circular import between `academic.schemas` and this module on cold start.
+    """
+    from .schemas import AcademicPaper, Author, AcademicSource
+
+    external_id = (
+        f"scholar_{sp.scholar_id}"
+        if sp.scholar_id
+        else f"scholar_{hashlib.md5(sp.title.encode('utf-8')).hexdigest()[:12]}"
+    )
+    return AcademicPaper(
+        id=external_id,
+        doi=None,
+        title=sp.title,
+        authors=[Author(name=a) for a in sp.authors],
+        year=sp.year,
+        venue=sp.venue,
+        abstract=sp.abstract,
+        citation_count=sp.citation_count,
+        url=sp.url,
+        pdf_url=sp.pdf_url,
+        source=AcademicSource.SCHOLAR,
+        relevance_score=0.7,
+        is_open_access=sp.pdf_url is not None,
+        keywords=[],
+    )

--- a/backend/src/billing/plan_config.py
+++ b/backend/src/billing/plan_config.py
@@ -113,6 +113,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "voice_chat_enabled": False,
             "voice_monthly_minutes": 0,
             "academic_papers_per_analysis": 5,
+            "scholar_deep_search_enabled": False,
+            "scholar_daily_quota": 0,
             "bibliography_export": False,
             "academic_full_text": False,
             "debate_enabled": False,
@@ -253,6 +255,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "voice_chat_enabled": True,  # ⚠ v2 H4 : Pro a voice
             "voice_monthly_minutes": 30,  # ⚠ v2 H4 : 30 min/mo
             "academic_papers_per_analysis": 15,
+            "scholar_deep_search_enabled": True,
+            "scholar_daily_quota": 5,
             "bibliography_export": True,
             "academic_full_text": False,
             "debate_enabled": True,
@@ -401,6 +405,8 @@ PLANS: dict[str, dict[str, Any]] = {
             "voice_chat_enabled": True,
             "voice_monthly_minutes": 120,  # ⚠ v2 H4 : Expert 120 min/mo (etait 45 v0)
             "academic_papers_per_analysis": 50,
+            "scholar_deep_search_enabled": True,
+            "scholar_daily_quota": 30,
             "bibliography_export": True,
             "academic_full_text": True,
             "debate_enabled": True,

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -70,6 +70,8 @@ class _DeepSightSettings(BaseSettings):
     # -- YouTube Proxy (pour contourner le blocage IP YouTube sur VPS) --
     # Tier 1 — proxy par defaut (rotating Decodo Pay-As-You-Go : nouvelle IP chaque request)
     YOUTUBE_PROXY: str = ""  # ex: socks5://user:pass@host:port ou http://user:pass@host:port
+    # Kill switch Google Scholar Phase 4 (spec 2026-05-17 § 10.2). False → Phase 4 skip global.
+    SCHOLAR_ENABLED: bool = True
     # Tier 2 — sticky session Decodo (port 10001-10010, IP fixe ~10 min)
     # Utilise pour cohérence cookies session, swap automatique si default cumule trop d'erreurs.
     YOUTUBE_PROXY_STICKY: Optional[str] = None
@@ -341,6 +343,7 @@ FAL_API_KEY = _settings.FAL_API_KEY
 TOGETHER_API_KEY = _settings.TOGETHER_API_KEY
 MISTRAL_IMAGE_AGENT_ID = _settings.MISTRAL_IMAGE_AGENT_ID
 YOUTUBE_PROXY = _settings.YOUTUBE_PROXY
+SCHOLAR_ENABLED: bool = _settings.SCHOLAR_ENABLED
 # Sprint D — Proxy V2 advanced (geo + sticky + multi-provider fallback)
 YOUTUBE_PROXY_STICKY = _settings.YOUTUBE_PROXY_STICKY
 YOUTUBE_PROXY_GEO_US = _settings.YOUTUBE_PROXY_GEO_US

--- a/backend/src/core/scholar_quota.py
+++ b/backend/src/core/scholar_quota.py
@@ -1,0 +1,130 @@
+"""Scholar daily quota — track per-user daily Google Scholar search count.
+
+Backed by `daily_quotas.scholar_queries` (Integer, NOT NULL DEFAULT 0).
+Spec : docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md § 6.4, § 9.
+
+Plan limits:
+- free   : 0 per day (gated upstream via 403 in router)
+- pro    : 5 per day
+- expert : 30 per day
+
+This module never raises HTTP errors; the router translates `(False, payload)`
+results into HTTP 403/429. Keeps the quota logic plain-async + DB-only so it
+can be unit-tested with an in-memory SQLite engine.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, Optional, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import DailyQuota, User
+
+
+# Daily limits per plan (spec § 9.1). Free is gated upstream — kept here for
+# defense in depth if router ever calls into us without checking.
+SCHOLAR_DAILY_LIMITS: Dict[str, int] = {
+    "free": 0,
+    "pro": 5,
+    "expert": 30,
+}
+
+
+def _normalize_plan(plan: Optional[str]) -> str:
+    """Lowercase + fallback to 'free' for unknown values. Mirrors normalize_plan_id
+    behaviour without importing billing (avoid circular)."""
+    if not plan:
+        return "free"
+    p = plan.strip().lower()
+    if p in SCHOLAR_DAILY_LIMITS:
+        return p
+    # Legacy aliases — map plus/starter/student/etudiant → pro (mirrors billing.normalize_plan_id)
+    if p in ("plus", "starter", "student", "etudiant", "unlimited"):
+        return "pro"
+    return "free"
+
+
+async def get_scholar_daily_usage(session: AsyncSession, user_id: int) -> int:
+    """Return today's Scholar query count for `user_id` (0 if no row)."""
+    today = date.today().isoformat()
+    result = await session.execute(
+        select(DailyQuota).where(
+            DailyQuota.user_id == user_id,
+            DailyQuota.quota_date == today,
+        )
+    )
+    quota = result.scalar_one_or_none()
+    if quota is None:
+        return 0
+    return int(quota.scholar_queries or 0)
+
+
+def get_scholar_daily_limit(plan: Optional[str]) -> int:
+    """Return the daily Scholar query limit for a plan id."""
+    return SCHOLAR_DAILY_LIMITS.get(_normalize_plan(plan), 0)
+
+
+async def check_and_increment_scholar_quota(
+    session: AsyncSession, user: User
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """Atomically check the daily Scholar quota and increment if allowed.
+
+    Returns:
+        (True, None) if the query is allowed — the counter is incremented and
+        committed before returning.
+        (False, error_payload) otherwise — error_payload is a dict suitable
+        for an HTTPException detail body.
+
+    Notes:
+        - Free plan always returns `(False, plan_required-ish)` because limit=0;
+          the router catches this case earlier with a 403, so this branch is
+          defense in depth.
+        - Commit is local to this function. Caller can still raise afterwards
+          without rollback (the counter increment is intentional even if the
+          downstream Scholar fetch fails — we count attempted queries).
+    """
+    plan = _normalize_plan(user.plan)
+    limit = SCHOLAR_DAILY_LIMITS.get(plan, 0)
+
+    if limit == 0:
+        return False, {
+            "code": "scholar_not_allowed",
+            "message": "Plan does not allow Scholar search.",
+            "current_plan": plan,
+        }
+
+    today = date.today().isoformat()
+    result = await session.execute(
+        select(DailyQuota).where(
+            DailyQuota.user_id == user.id,
+            DailyQuota.quota_date == today,
+        )
+    )
+    quota = result.scalar_one_or_none()
+    current = int(quota.scholar_queries or 0) if quota else 0
+
+    if current >= limit:
+        return False, {
+            "code": "scholar_daily_limit_reached",
+            "message": f"Scholar daily quota reached ({current}/{limit}). Resets next day 00:00 UTC.",
+            "current_usage": current,
+            "daily_limit": limit,
+            "resets_at": "next day 00:00 UTC",
+        }
+
+    if quota is not None:
+        quota.scholar_queries = current + 1
+    else:
+        session.add(
+            DailyQuota(
+                user_id=user.id,
+                quota_date=today,
+                videos_used=0,
+                scholar_queries=1,
+            )
+        )
+    await session.commit()
+    return True, None

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -320,6 +320,7 @@ class DailyQuota(Base):
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     quota_date = Column(String(10), nullable=False)  # YYYY-MM-DD
     videos_used = Column(Integer, default=0)
+    scholar_queries = Column(Integer, default=0, nullable=False)
 
     __table_args__ = (Index("idx_daily_quota_user_date", "user_id", "quota_date", unique=True),)
 
@@ -648,8 +649,9 @@ class AcademicPaper(Base):
     summary_id = Column(Integer, ForeignKey("summaries.id", ondelete="CASCADE"), nullable=False, index=True)
 
     # Paper identification
-    external_id = Column(String(100), nullable=False)  # ID from source (ss_xxx, oa_xxx, arxiv_xxx)
+    external_id = Column(String(100), nullable=False)  # ID from source (ss_xxx, oa_xxx, arxiv_xxx, scholar_xxx)
     doi = Column(String(255), index=True)
+    scholar_id = Column(String(64), nullable=True)  # Internal Google Scholar cluster ID
 
     # Paper metadata
     title = Column(Text, nullable=False)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -585,7 +585,13 @@ async def initialize_database_background():
                     await init_arxiv_redis(redis_client)
                 except ImportError:
                     pass
-                logger.info("TaskStore + GuestLimiter + arXiv Redis initialized")
+                try:
+                    from academic.scholar import init_scholar_redis
+
+                    await init_scholar_redis(redis_client)
+                except ImportError:
+                    pass
+                logger.info("TaskStore + GuestLimiter + arXiv + Scholar Redis initialized")
             else:
                 logger.info("TaskStore + GuestLimiter using in-memory fallback (no Redis)")
         except Exception as ts_err:

--- a/backend/tests/test_academic_router_with_scholar.py
+++ b/backend/tests/test_academic_router_with_scholar.py
@@ -1,0 +1,163 @@
+"""Tests for `/api/academic/search` Scholar deep_search gating (PR2 wiring).
+
+Spec : docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md § 6.3.
+
+Direct-invocation tests : we call the route handler `search_academic_papers`
+as a plain async function, with FastAPI Depends() resolved manually via
+SimpleNamespace stand-ins. This sidesteps full TestClient bootstrap and lets
+us assert HTTPException codes precisely.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+
+def _user(plan: str, user_id: int = 1):
+    return SimpleNamespace(id=user_id, plan=plan, is_verified=True)
+
+
+def _request(deep_search: bool = False):
+    from academic.schemas import AcademicSearchRequest
+
+    return AcademicSearchRequest(keywords=["test query"], deep_search=deep_search)
+
+
+@pytest.fixture
+def patched_router(monkeypatch):
+    """Mock the aggregator + scholar_quota module that the router imports lazily."""
+    state = {
+        "quota_call_count": 0,
+        "aggregator_calls": [],
+        "quota_allowed": True,
+        "quota_payload": None,
+    }
+
+    async def fake_check_and_increment(session, user):
+        state["quota_call_count"] += 1
+        return state["quota_allowed"], state["quota_payload"]
+
+    monkeypatch.setattr(
+        "core.scholar_quota.check_and_increment_scholar_quota",
+        fake_check_and_increment,
+    )
+
+    async def fake_search(request, user_plan, video_title=None):
+        from academic.schemas import AcademicSearchResponse
+
+        state["aggregator_calls"].append((user_plan, request.deep_search))
+        return AcademicSearchResponse(
+            papers=[],
+            total_found=0,
+            query_keywords=request.keywords,
+            sources_queried=["openalex"],
+        )
+
+    monkeypatch.setattr("academic.router.academic_aggregator.search", fake_search)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_free_plan_deep_search_returns_403(patched_router):
+    """Free plan + deep_search=True → 403 plan_required."""
+    from academic.router import search_academic_papers
+
+    with pytest.raises(HTTPException) as exc:
+        await search_academic_papers(
+            request=_request(deep_search=True),
+            current_user=_user("free"),
+            session=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 403
+    detail = exc.value.detail
+    assert detail["code"] == "plan_required"
+    assert detail["required_plan"] == "pro"
+    assert patched_router["quota_call_count"] == 0  # quota never consulted
+
+
+@pytest.mark.asyncio
+async def test_pro_no_deep_search_skips_quota(patched_router):
+    """Pro + deep_search=False (default) → no quota call, no 403/429."""
+    from academic.router import search_academic_papers
+
+    response = await search_academic_papers(
+        request=_request(deep_search=False),
+        current_user=_user("pro"),
+        session=AsyncMock(),
+    )
+
+    assert response.total_found == 0
+    assert patched_router["quota_call_count"] == 0
+    assert patched_router["aggregator_calls"] == [("pro", False)]
+
+
+@pytest.mark.asyncio
+async def test_pro_deep_search_allowed_calls_aggregator(patched_router):
+    """Pro + deep_search=True + under quota → quota incremented, aggregator called with deep_search."""
+    from academic.router import search_academic_papers
+
+    patched_router["quota_allowed"] = True
+
+    response = await search_academic_papers(
+        request=_request(deep_search=True),
+        current_user=_user("pro"),
+        session=AsyncMock(),
+    )
+
+    assert response.total_found == 0
+    assert patched_router["quota_call_count"] == 1
+    assert patched_router["aggregator_calls"] == [("pro", True)]
+
+
+@pytest.mark.asyncio
+async def test_pro_deep_search_at_quota_returns_429(patched_router):
+    """Pro + deep_search=True + quota reached → 429 scholar_daily_limit_reached."""
+    from academic.router import search_academic_papers
+
+    patched_router["quota_allowed"] = False
+    patched_router["quota_payload"] = {
+        "code": "scholar_daily_limit_reached",
+        "message": "Scholar daily quota reached (5/5).",
+        "current_usage": 5,
+        "daily_limit": 5,
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        await search_academic_papers(
+            request=_request(deep_search=True),
+            current_user=_user("pro"),
+            session=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 429
+    assert exc.value.detail["code"] == "scholar_daily_limit_reached"
+    assert exc.value.detail["daily_limit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_expert_deep_search_allowed(patched_router):
+    """Expert + deep_search=True under 30/day → allowed."""
+    from academic.router import search_academic_papers
+
+    response = await search_academic_papers(
+        request=_request(deep_search=True),
+        current_user=_user("expert"),
+        session=AsyncMock(),
+    )
+
+    assert response.total_found == 0
+    assert patched_router["aggregator_calls"] == [("expert", True)]
+
+
+@pytest.mark.asyncio
+async def test_deep_search_default_is_false_backwards_compat():
+    """Default `AcademicSearchRequest()` has deep_search=False (no API breakage)."""
+    from academic.schemas import AcademicSearchRequest
+
+    req = AcademicSearchRequest(keywords=["x"])
+    assert req.deep_search is False

--- a/backend/tests/test_aggregator_phase4.py
+++ b/backend/tests/test_aggregator_phase4.py
@@ -1,0 +1,173 @@
+"""Tests for `academic.aggregator` Phase 4 — Google Scholar deep crawl gating.
+
+Spec : docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md § 3.3, § 6.2.
+
+The aggregator is exercised end-to-end with the real `search()` method but
+external sources (OpenAlex, CrossRef, arXiv, Scholar) are mocked. We assert
+Phase 4 activation conditions, NOT the internal Scholar parsing logic
+(covered by `test_scholar_search.py` / `test_scholar_parser.py` in PR 1).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _paper(title: str, source: str = "openalex"):
+    """Build a minimal AcademicPaper for aggregator dedup/scoring."""
+    from academic.schemas import AcademicPaper, AcademicSource
+
+    return AcademicPaper(
+        id=f"{source}_{abs(hash(title))}",
+        title=title,
+        source=AcademicSource(source),
+        relevance_score=0.5,
+    )
+
+
+def _request(deep_search: bool):
+    from academic.schemas import AcademicSearchRequest
+
+    return AcademicSearchRequest(keywords=["test"], deep_search=deep_search)
+
+
+def _setup_aggregator(monkeypatch, *, phase1_papers, scholar_papers):
+    """Patch the aggregator's source clients + Scholar search.
+
+    `phase1_papers` is yielded by OpenAlex (others return []), so we control
+    how many papers Phase 1-3 produce. `scholar_papers` is what `search_scholar`
+    returns (a `ScholarBatch`-shaped object with `.papers`).
+    """
+    from academic import aggregator as agg_mod
+    from academic.aggregator import AcademicAggregator
+
+    aggregator = AcademicAggregator()
+
+    async def _phase1_oa(query, request):
+        return phase1_papers
+
+    async def _empty(query, request):
+        return []
+
+    monkeypatch.setattr(aggregator, "_search_openalex", _phase1_oa)
+    monkeypatch.setattr(aggregator, "_search_crossref", _empty)
+    monkeypatch.setattr(aggregator, "_search_semantic_scholar", _empty)
+    monkeypatch.setattr(aggregator, "_search_arxiv", _empty)
+
+    # Mock the scholar module's `search_scholar` (imported inside _search_scholar).
+    class FakeBatch:
+        def __init__(self, papers):
+            self.papers = papers
+
+    async def fake_search_scholar(query, limit=20):
+        return FakeBatch(scholar_papers)
+
+    def fake_to_academic(sp):
+        return sp  # already an AcademicPaper for these tests
+
+    import academic.scholar as scholar_mod
+
+    monkeypatch.setattr(scholar_mod, "search_scholar", fake_search_scholar)
+    monkeypatch.setattr(scholar_mod, "scholar_paper_to_academic", fake_to_academic)
+
+    return aggregator
+
+
+@pytest.mark.asyncio
+async def test_phase4_triggered_when_pro_and_deep_search_and_few_papers(monkeypatch):
+    """deep_search=True + Pro + <10 papers → Scholar called, "scholar" in sources_queried."""
+    aggregator = _setup_aggregator(
+        monkeypatch,
+        phase1_papers=[_paper("p1"), _paper("p2")],
+        scholar_papers=[_paper("scholar-1", source="scholar")],
+    )
+
+    response = await aggregator.search(_request(deep_search=True), user_plan="pro")
+
+    assert "scholar" in response.sources_queried
+    assert any(p.title == "scholar-1" for p in response.papers)
+
+
+@pytest.mark.asyncio
+async def test_phase4_skipped_when_deep_search_false(monkeypatch):
+    """deep_search=False (default) → Phase 4 never runs."""
+    aggregator = _setup_aggregator(
+        monkeypatch,
+        phase1_papers=[_paper("p1"), _paper("p2")],
+        scholar_papers=[_paper("scholar-1", source="scholar")],
+    )
+
+    response = await aggregator.search(_request(deep_search=False), user_plan="pro")
+
+    assert "scholar" not in response.sources_queried
+    assert not any(p.title == "scholar-1" for p in response.papers)
+
+
+@pytest.mark.asyncio
+async def test_phase4_skipped_for_free_plan(monkeypatch):
+    """Free plan even with deep_search=True → Phase 4 skipped (defense in depth;
+    router 403s first, but aggregator must also guard)."""
+    aggregator = _setup_aggregator(
+        monkeypatch,
+        phase1_papers=[_paper("p1")],
+        scholar_papers=[_paper("scholar-1", source="scholar")],
+    )
+
+    response = await aggregator.search(_request(deep_search=True), user_plan="free")
+
+    assert "scholar" not in response.sources_queried
+
+
+@pytest.mark.asyncio
+async def test_phase4_skipped_when_threshold_exceeded(monkeypatch):
+    """≥10 papers from Phase 1-3 → Phase 4 skipped (Decodo savings)."""
+    aggregator = _setup_aggregator(
+        monkeypatch,
+        phase1_papers=[_paper(f"p{i}") for i in range(12)],
+        scholar_papers=[_paper("scholar-1", source="scholar")],
+    )
+
+    response = await aggregator.search(_request(deep_search=True), user_plan="pro")
+
+    assert "scholar" not in response.sources_queried
+
+
+@pytest.mark.asyncio
+async def test_phase4_kill_switch_via_env(monkeypatch):
+    """SCHOLAR_ENABLED=False → Phase 4 globally disabled even on Pro+."""
+    monkeypatch.setattr("core.config.SCHOLAR_ENABLED", False)
+
+    aggregator = _setup_aggregator(
+        monkeypatch,
+        phase1_papers=[_paper("p1")],
+        scholar_papers=[_paper("scholar-1", source="scholar")],
+    )
+
+    response = await aggregator.search(_request(deep_search=True), user_plan="expert")
+
+    assert "scholar" not in response.sources_queried
+
+
+@pytest.mark.asyncio
+async def test_phase4_graceful_on_scholar_exception(monkeypatch):
+    """If `search_scholar` raises, aggregator returns the 4-source results
+    without `scholar` in `sources_queried`."""
+    aggregator = _setup_aggregator(
+        monkeypatch,
+        phase1_papers=[_paper("p1")],
+        scholar_papers=[],  # default override below
+    )
+
+    async def boom(query, limit=20):
+        raise RuntimeError("scholar exploded")
+
+    import academic.scholar as scholar_mod
+
+    monkeypatch.setattr(scholar_mod, "search_scholar", boom)
+
+    response = await aggregator.search(_request(deep_search=True), user_plan="pro")
+
+    assert response.total_found >= 1
+    assert "scholar" not in response.sources_queried

--- a/backend/tests/test_scholar_quota.py
+++ b/backend/tests/test_scholar_quota.py
@@ -1,0 +1,125 @@
+"""Tests for `core.scholar_quota` — daily Scholar query quota helper.
+
+Spec : docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md § 6.4, § 9.
+
+Uses an in-memory SQLite engine with the production SQLAlchemy models. No
+mocks for the DB layer — the goal is to lock the actual UPSERT/SELECT logic
+against the `daily_quotas` table.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from db.database import Base, DailyQuota, User
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    """In-memory async SQLite session with all tables created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    SessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with SessionLocal() as session:
+        yield session
+    await engine.dispose()
+
+
+def _make_user(plan: str, user_id: int = 1) -> SimpleNamespace:
+    """Lightweight User stand-in — quota helpers only read `.id` and `.plan`."""
+    return SimpleNamespace(id=user_id, plan=plan)
+
+
+@pytest.mark.asyncio
+async def test_get_scholar_daily_usage_zero_for_new_user(db_session):
+    """Without any DailyQuota row, usage is 0 (no implicit row creation)."""
+    from core.scholar_quota import get_scholar_daily_usage
+
+    usage = await get_scholar_daily_usage(db_session, user_id=42)
+    assert usage == 0
+
+
+@pytest.mark.asyncio
+async def test_free_plan_blocked(db_session):
+    """Free plan has limit 0 → check_and_increment returns False with scholar_not_allowed."""
+    from core.scholar_quota import check_and_increment_scholar_quota
+
+    user = _make_user("free")
+    allowed, payload = await check_and_increment_scholar_quota(db_session, user)
+
+    assert allowed is False
+    assert payload is not None
+    assert payload["code"] == "scholar_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_pro_under_quota_allows_and_increments(db_session):
+    """Pro user under 5/day → allowed, counter incremented, row created."""
+    from core.scholar_quota import check_and_increment_scholar_quota, get_scholar_daily_usage
+
+    user = _make_user("pro", user_id=7)
+
+    allowed, payload = await check_and_increment_scholar_quota(db_session, user)
+    assert allowed is True
+    assert payload is None
+
+    usage = await get_scholar_daily_usage(db_session, user_id=7)
+    assert usage == 1
+
+
+@pytest.mark.asyncio
+async def test_pro_at_limit_blocked(db_session):
+    """Pro user with 5 queries today → blocked with scholar_daily_limit_reached."""
+    from core.scholar_quota import check_and_increment_scholar_quota
+
+    # Pre-seed today's row at limit
+    today = date.today().isoformat()
+    db_session.add(
+        DailyQuota(user_id=11, quota_date=today, videos_used=0, scholar_queries=5)
+    )
+    await db_session.commit()
+
+    user = _make_user("pro", user_id=11)
+    allowed, payload = await check_and_increment_scholar_quota(db_session, user)
+
+    assert allowed is False
+    assert payload["code"] == "scholar_daily_limit_reached"
+    assert payload["current_usage"] == 5
+    assert payload["daily_limit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_expert_higher_limit(db_session):
+    """Expert plan has 30/day → 6th query (which would block Pro) still allowed."""
+    from core.scholar_quota import check_and_increment_scholar_quota, get_scholar_daily_usage
+
+    today = date.today().isoformat()
+    db_session.add(
+        DailyQuota(user_id=99, quota_date=today, videos_used=0, scholar_queries=5)
+    )
+    await db_session.commit()
+
+    user = _make_user("expert", user_id=99)
+    allowed, _ = await check_and_increment_scholar_quota(db_session, user)
+    assert allowed is True
+
+    usage = await get_scholar_daily_usage(db_session, user_id=99)
+    assert usage == 6
+
+
+@pytest.mark.asyncio
+async def test_legacy_plan_id_normalized(db_session):
+    """Legacy plan alias `plus` → maps to `pro` → 5/day."""
+    from core.scholar_quota import check_and_increment_scholar_quota, get_scholar_daily_limit
+
+    assert get_scholar_daily_limit("plus") == 5
+    user = _make_user("plus", user_id=22)
+    allowed, _ = await check_and_increment_scholar_quota(db_session, user)
+    assert allowed is True


### PR DESCRIPTION
## Summary

Wires the PR1 standalone `academic/scholar.py` service into the academic search pipeline as **Phase 4** — a conditional fallback fired only when Phases 1-3 (OpenAlex, CrossRef, Semantic Scholar, arXiv) return fewer than 10 papers. Gated to Pro+ plans with daily quotas (5 / 30 per day).

Spec : `docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md` §§ 6, 7, 9, 15.

## Code changes (13 files, +801 -3)

| File | Change |
|------|--------|
| `academic/schemas.py` | `AcademicSource.SCHOLAR` + `AcademicSearchRequest.deep_search` (default `False`) |
| `academic/scholar.py` | `scholar_paper_to_academic()` helper (deferred from PR1) |
| `academic/aggregator.py` | `_search_scholar` method + Phase 4 in `search()` + `SOURCE_WEIGHTS["scholar"]=0.80` + `SCHOLAR_PHASE_THRESHOLD=10` |
| `academic/router.py` | 403 `plan_required` for free, 429 `scholar_daily_limit_reached` at quota, propagate `HTTPException` through catch-all |
| **`core/scholar_quota.py`** *(new)* | `check_and_increment_scholar_quota` + `get_scholar_daily_usage` (atomic UPSERT on `daily_quotas.scholar_queries`) |
| `core/config.py` | `SCHOLAR_ENABLED` env var (kill switch, default `True`) |
| `billing/plan_config.py` | `scholar_deep_search_enabled` + `scholar_daily_quota` for free/pro/expert (0 / 5 / 30) |
| `db/database.py` | `scholar_id` (AcademicPaper) + `scholar_queries` (DailyQuota) |
| **`alembic/versions/030_academic_scholar.py`** *(new)* | Idempotent migration. Renamed from spec's 029 because `029_summary_community_analysis` shipped via PR #491. `down_revision = "029_summary_community"`. |
| `main.py` | `init_scholar_redis` on startup alongside `init_arxiv_redis` |

## Tests (+18, 45 scholar total verts)

| File | Coverage |
|------|----------|
| `test_scholar_quota.py` (6) | DB-backed (in-memory SQLite). free=0/pro=5/expert=30, legacy plan aliases, at-limit, fresh-row creation |
| `test_aggregator_phase4.py` (6) | Phase 4 trigger matrix : `deep_search` flag, plan, threshold (≥10 skips), `SCHOLAR_ENABLED` kill switch, graceful exception fallback |
| `test_academic_router_with_scholar.py` (6) | Direct-invocation tests of route handler with mocked aggregator + quota helper. 403/429/200 paths + backwards-compat default |

## Phase 4 activation matrix

| Condition | Effect if false |
|-----------|-----------------|
| `request.deep_search == True` | Skip Phase 4 silently (backwards compat) |
| `user.plan in {pro, expert}` | Skip Phase 4 silently (defense in depth — router already 403s upstream for free) |
| `len(all_papers) < 10` | Skip Phase 4 (Decodo savings) |
| `SCHOLAR_ENABLED == True` | Skip Phase 4 globally (env kill switch) |

## Deploy plan

- [ ] Merge → Hetzner auto-deploy
- [ ] **Manual migration** (no entrypoint.sh — known tech-debt) : `docker exec repo-backend-1 alembic upgrade heads`
- [ ] Verify table : `\d daily_quotas` shows `scholar_queries` column, `\d academic_papers` shows `scholar_id`
- [ ] Synth test : `POST /api/academic/search {"keywords":["test"],"deep_search":true}` as a Free user → 403, as a Pro user under quota → 200, as a Pro user at 5/day → 429
- [ ] Monitor `proxy_usage_daily.requests_by_provider['scholar_scrape']` for organic traffic (should appear only when 4 sources < 10 + deep_search opt-in)

## Risk

Moderate. Migration adds two nullable columns; counter has `server_default='0'`. Rollback path : `alembic downgrade 029_summary_community` + revert PR. `SCHOLAR_ENABLED=false` provides runtime kill switch without rollback. Code is unused unless caller opts in (`deep_search=true`), so the worst regression scenario for existing users is null.

## Follow-up PR3

Frontend toggle + badges + i18n on Web and Mobile (~300 LOC) per spec § 15.3. Tracked separately.

## Notes

- `beautifulsoup4>=4.12.0` was already added to requirements.txt by PR1 (commit `b830bcbe`), no update needed despite handoff hint.
- Bug Python 3.13 circular import `auth.service` ↔ `billing.router` still surfaces when running router tests in isolation — passes in full suite. Prod runs 3.11 so non-blocking.