### PR TITLE
fix(ci): relax Deploy Backend smoke test timeout — accommodate cold start

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -146,11 +146,19 @@ jobs:
       - name: Smoke test /health
         id: healthcheck
         run: |
+          # Cold start on Hetzner takes ~30-40s (alembic upgrade + 4 uvicorn
+          # workers loading the full module tree). The previous `--retry 5
+          # --retry-delay 3` (max ~16s) was too tight and caused false rollbacks
+          # on Scholar PR2 deploy (2026-05-17) even though the container was
+          # healthy a few seconds later. 15s warmup + 12 × 5s retries gives
+          # ~75s budget — comfortable margin without making failed deploys slow.
+          echo "Waiting 15s for container cold start..."
+          sleep 15
           echo "Probing ${HEALTH_URL}"
           curl -fsS \
             --max-time 30 \
-            --retry 5 \
-            --retry-delay 3 \
+            --retry 12 \
+            --retry-delay 5 \
             --retry-all-errors \
             "${HEALTH_URL}"
           echo ""


### PR DESCRIPTION
## Summary

The Deploy Backend workflow's smoke test gave the container a max of ~16s to be ready (`--retry 5 --retry-delay 3`). On a fresh container the cold start is closer to 30-40s — `alembic upgrade head` in entrypoint + 4 uvicorn workers importing the full module tree (Mistral, Stripe, Redis, Sentry, …).

That caused **false rollbacks** on Scholar PR2 deploy (commit `c59655b7`, 2026-05-17). The container was healthy each time but the smoke test gave up too early.

| Attempt | Trigger | Outcome |
|---|---|---|
| 15:16:34 | `push` after #494 merge | 502/502/502/502/502/503 → auto rollback |
| 15:22:40 | `workflow_dispatch` retry | Same pattern → auto rollback |
| 15:24 | Manual SSH `docker build` + recreate | ✓ Container healthy 30s later, new code running |

## Fix

- 15s `sleep` before the first probe (warmup)
- `--retry 12 --retry-delay 5` → up to 12 retries × 5s = ~60s budget after warmup
- Total ~75s budget per deploy. Comfortable margin without making genuine breakage slow to surface (a crashloop still reports within ~80s instead of `--max-time 30 × 5 retries` infinity).

## Test plan

- [x] Container currently running new Scholar PR2 image (id `cea9042b1e52`) via manual recreate
- [ ] Merge → next Deploy Backend run uses the new smoke test → should land cleanly
- [ ] Watch for the "Waiting 15s for container cold start..." line in the workflow log

## Notes

Pre-existing rollback path is unchanged — if the smoke test STILL fails after 75s, the workflow rolls back as before. So we don't lose the safety net, just stop tripping it on healthy deploys.