### PR TITLE
feat(external_pages): scraper + summarizer + orchestrator (PR 2/4)

### DIFF
--- a/backend/alembic/versions/031_summary_external_pages.py
+++ b/backend/alembic/versions/031_summary_external_pages.py
@@ -1,0 +1,69 @@
+"""summary_external_pages — colonne JSONB pour pages externes citées (V1)
+
+Revision ID: 031_summary_ext_pages
+Revises: 030_academic_scholar
+Create Date: 2026-05-17
+
+Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §6
+
+Ajoute la colonne `summaries.external_pages JSON / JSONB NULL`. Stocke le payload
+sérialisé construit par `videos/external_pages/orchestrator.extract_external_pages`
+(schéma {extracted_at, schema_version, stats, pages}).
+
+Convention DeepSight Alembic :
+- Revision ID ≤ 32 chars : "031_summary_ext_pages" = 21 chars ✓
+- Migration idempotente : add only if not exists, drop only if exists.
+- Compatible PostgreSQL (JSONB) ET SQLite (JSON fallback) via with_variant.
+
+Entrypoint Docker exécute `alembic upgrade heads` (plural) à chaque container
+start, donc on doit rester safe sur re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "031_summary_ext_pages"
+down_revision: Union[str, None] = "030_academic_scholar"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        # Table inexistante (early bootstrap) → no-op.
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "external_pages" in columns:
+        # Idempotent : déjà appliquée
+        return
+
+    op.add_column(
+        "summaries",
+        sa.Column(
+            "external_pages",
+            sa.JSON().with_variant(postgresql.JSONB(), "postgresql"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "summaries" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("summaries")}
+    if "external_pages" not in columns:
+        return
+
+    op.drop_column("summaries", "external_pages")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,6 +37,12 @@ aiohttp>=3.9.0
 beautifulsoup4>=4.12.0       # HTML parsing (Google Scholar SERP, scraping)
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# 📰 EXTERNAL PAGES SCRAPING (spec 2026-05-17 — pages citées dans description)
+# ─────────────────────────────────────────────────────────────────────────────────
+trafilatura>=1.6.0            # SoTA readable text extraction (JSON + meta)
+readability-lxml>=0.8.1       # Fallback extraction si trafilatura échoue
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # 📺 YOUTUBE
 # ─────────────────────────────────────────────────────────────────────────────────
 youtube-transcript-api>=0.6.2

--- a/backend/src/billing/plan_config.py
+++ b/backend/src/billing/plan_config.py
@@ -127,6 +127,7 @@ PLANS: dict[str, dict[str, Any]] = {
             "visual_analysis_monthly": 0,
             "community_take_enabled": False,  # 💬 Verdict communauté — Pro+ uniquement
             "community_take_monthly": 0,
+            "external_pages_max": 0,  # 📰 Pages externes citées — Pro+ uniquement (spec 2026-05-17)
         },
         "features_display": [
             {"text": "5 analyses / mois", "icon": "📊"},
@@ -269,6 +270,7 @@ PLANS: dict[str, dict[str, Any]] = {
             "visual_analysis_monthly": 30,
             "community_take_enabled": True,  # 💬 Verdict communauté — Pro+ (V1)
             "community_take_monthly": -1,  # illimité (auto à chaque analyse)
+            "external_pages_max": 5,  # 📰 Pages externes citées — 5/analyse (spec 2026-05-17)
         },
         "features_display": [
             {"text": "25 analyses / mois", "icon": "📊"},
@@ -419,6 +421,7 @@ PLANS: dict[str, dict[str, Any]] = {
             "visual_analysis_monthly": -1,  # illimité
             "community_take_enabled": True,  # 💬 Verdict communauté — Expert (V1)
             "community_take_monthly": -1,  # illimité
+            "external_pages_max": 10,  # 📰 Pages externes citées — 10/analyse (spec 2026-05-17)
         },
         "features_display": [
             {"text": "100 analyses / mois", "icon": "📊"},

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -267,6 +267,14 @@ class Summary(Base):
     # insufficient_data}.
     community_analysis = Column(JSON, nullable=True)
 
+    # External pages citation (NEW 2026-05-17 — alembic 031).
+    # Pages externes citées dans la description vidéo, scrapées + résumées par
+    # Mistral. Dict sérialisé construit par videos/external_pages/orchestrator.
+    # Forme : {extracted_at, schema_version, stats{}, pages[{url, final_url,
+    # title, summary, key_claims[], status, fetched_via_proxy, bytes_fetched}]}.
+    # Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §6.
+    external_pages = Column(JSON, nullable=True)
+
     # Public opt-in toggle pour pages publiques /a/{slug} (Phase 3 sprint GEO,
     # alembic 025). Default FALSE — toggle explicite via PATCH /api/v1/summaries/{id}/visibility.
     # Slug = f"a{hex(id)}" dérivé déterministiquement de l'ID (cf

--- a/backend/src/videos/external_pages/__init__.py
+++ b/backend/src/videos/external_pages/__init__.py
@@ -2,14 +2,17 @@
 ╔════════════════════════════════════════════════════════════════════════════════════╗
 ║  📚 external_pages — Extraction des pages externes citées dans une vidéo          ║
 ╠════════════════════════════════════════════════════════════════════════════════════╣
-║  Pipeline 3 étapes :                                                               ║
+║  Pipeline 5 étapes :                                                               ║
 ║    1. extraction d'URLs (regex sur description / transcript)                       ║
 ║    2. nettoyage & filtrage (strip utm_*, blacklist youtube/tiktok, self-channel)   ║
 ║    3. résolution HEAD (follow_redirects, drop sur timeout / >5 hops, dedup)        ║
+║    4. scraping HTML (direct → proxy fallback Cloudflare/403) + trafilatura         ║
+║    5. résumé Mistral JSON-mode + cache Redis 7j (cross-user)                       ║
 ║                                                                                    ║
-║  PR 1 (cette PR) : pas de scraping, pas de Mistral, pas de DB.                     ║
-║  PR 2 (à venir)  : scraper + summarizer + storage colonne summaries.ext_pages.     ║
-║  PR 3 (à venir)  : intégration dans videos/router.py.                              ║
+║  PR 1 (mergée) : steps 1-3 — extractor + resolver + constants.                     ║
+║  PR 2 (cette PR) : steps 4-5 — scraper + summarizer + orchestrator + storage.      ║
+║  PR 3 (à venir)  : intégration dans videos/router.py + UI web.                     ║
+║  PR 4 (à venir)  : UI mobile + UI extension.                                       ║
 ╚════════════════════════════════════════════════════════════════════════════════════╝
 """
 
@@ -32,6 +35,17 @@ from .url_resolver import (
     resolve_url,
     resolve_urls,
 )
+from .scraper import (
+    ScrapedPage,
+    scrape_page,
+)
+from .summarizer import (
+    PageSummary,
+    summarize_page,
+)
+from .orchestrator import (
+    extract_external_pages,
+)
 
 __all__ = [
     # constants
@@ -50,4 +64,12 @@ __all__ = [
     "ResolvedURL",
     "resolve_url",
     "resolve_urls",
+    # scraper
+    "ScrapedPage",
+    "scrape_page",
+    # summarizer
+    "PageSummary",
+    "summarize_page",
+    # orchestrator
+    "extract_external_pages",
 ]

--- a/backend/src/videos/external_pages/orchestrator.py
+++ b/backend/src/videos/external_pages/orchestrator.py
@@ -1,0 +1,301 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🎼 orchestrator — Pipeline complet external_pages                                 ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Orchestrateur PR2 (spec 2026-05-17 §7) — wire-up :                                ║
+║                                                                                    ║
+║    video_info (description, channel, title, ...) + user_plan                       ║
+║         │                                                                          ║
+║         ▼                                                                          ║
+║    1) extract_urls_from_text(description)                                          ║
+║    2) clean_and_filter_urls(..., self_channel=channel_url)                         ║
+║    3) resolve_urls(..., use_proxy=False)  # bare HEAD est suffisant                ║
+║    4) cap par plan (PLAN_CAPS: free=0/pro=5/expert=10)                             ║
+║    5) scrape_page x N en parallèle (Semaphore=5)                                   ║
+║    6) summarize_page x N en parallèle (Semaphore=5)                                ║
+║    7) build dict final {extracted_at, schema_version, stats, pages}                ║
+║                                                                                    ║
+║  Contrat strict :                                                                  ║
+║  - NE LÈVE JAMAIS — toute exception est avalée à logger.warning et retourne None.  ║
+║  - Free plan → retourne None (skip total).                                         ║
+║  - Description vide / aucune URL → retourne None.                                  ║
+║  - PR3 wire-up dans videos/router.py — pas dans cette PR.                          ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .constants import PLAN_CAPS
+from .scraper import ScrapedPage, scrape_page
+from .summarizer import PageSummary, summarize_page
+from .url_extractor import clean_and_filter_urls, extract_urls_from_text
+from .url_resolver import ResolvedURL, resolve_urls
+
+
+logger = logging.getLogger("deepsight.external_pages.orchestrator")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚦 Constantes
+# ═══════════════════════════════════════════════════════════════════════════════
+
+SCHEMA_VERSION: int = 1
+MAX_CANDIDATES_BEFORE_RESOLVE: int = 20  # hard cap pré-resolve (spec R9)
+SCRAPE_CONCURRENCY: int = 5
+SUMMARIZE_CONCURRENCY: int = 5
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _normalize_plan(plan: Optional[str]) -> str:
+    """Normalise le plan (free/pro/expert) — best-effort sans import circulaire."""
+    if not plan:
+        return "free"
+    p = plan.strip().lower()
+    aliases = {"plus": "pro", "starter": "pro", "trial": "pro"}
+    p = aliases.get(p, p)
+    if p not in PLAN_CAPS:
+        return "free"
+    return p
+
+
+def _extract_video_field(video_info: Dict[str, Any], *keys: str, default: str = "") -> str:
+    """Récupère le premier champ non-vide de video_info parmi `keys`."""
+    if not isinstance(video_info, dict):
+        return default
+    for key in keys:
+        value = video_info.get(key)
+        if value:
+            return str(value)
+    return default
+
+
+async def _scrape_with_semaphore(
+    sem: asyncio.Semaphore,
+    resolved: ResolvedURL,
+) -> Optional[ScrapedPage]:
+    """Wrap scrape_page dans la sémaphore + try/except (jamais lève)."""
+    async with sem:
+        try:
+            return await scrape_page(resolved.input_url, resolved.final_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[EXTERNAL_PAGES] scrape failed for %s: %s",
+                resolved.final_url,
+                exc,
+            )
+            return None
+
+
+async def _summarize_with_semaphore(
+    sem: asyncio.Semaphore,
+    scraped: ScrapedPage,
+    *,
+    plan: str,
+    creator_channel: str,
+    video_title: str,
+    lang: str,
+) -> Optional[PageSummary]:
+    """Wrap summarize_page dans la sémaphore + try/except (jamais lève)."""
+    async with sem:
+        try:
+            return await summarize_page(
+                scraped,
+                plan=plan,
+                creator_channel=creator_channel,
+                video_title=video_title,
+                lang=lang,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[EXTERNAL_PAGES] summarize failed for %s: %s",
+                scraped.final_url,
+                exc,
+            )
+            return None
+
+
+def _build_pages_payload(summaries: List[PageSummary]) -> List[Dict[str, Any]]:
+    """Sérialise la liste PageSummary → JSON canonique (spec §6)."""
+    return [
+        {
+            "url": p.url,
+            "final_url": p.final_url,
+            "title": p.title,
+            "summary": p.summary,
+            "key_claims": list(p.key_claims or []),
+            "status": p.status,
+            "fetched_via_proxy": bool(p.fetched_via_proxy),
+            "bytes_fetched": int(p.bytes_fetched or 0),
+        }
+        for p in summaries
+    ]
+
+
+def _compute_stats(
+    *,
+    candidates_found: int,
+    after_cleanup: int,
+    after_cap: int,
+    summaries: List[PageSummary],
+) -> Dict[str, int]:
+    """Calcule les stats du pipeline (spec §6)."""
+    successful = sum(1 for p in summaries if p.status == "ok")
+    paywalled = sum(1 for p in summaries if p.status == "paywall")
+    errored = sum(
+        1
+        for p in summaries
+        if p.status in ("error", "non_html", "http_error", "timeout", "empty")
+    )
+    return {
+        "candidates_found": candidates_found,
+        "after_dedup": after_cleanup,
+        "after_blacklist": after_cleanup,
+        "after_cap": after_cap,
+        "successful": successful,
+        "paywalled": paywalled,
+        "errored": errored,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎯 extract_external_pages — Entry point
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def extract_external_pages(
+    video_info: Dict[str, Any],
+    user_plan: str,
+    lang: str = "fr",
+) -> Optional[Dict[str, Any]]:
+    """Pipeline complet external_pages.
+
+    Args:
+        video_info : dict (au moins) `description`, `title`/`video_title`,
+                     `channel`/`channel_name`, `channel_url`. Champs manquants
+                     sont tolérés (string vide).
+        user_plan  : "free" / "pro" / "expert" (legacy aliases résolus).
+        lang       : "fr" (default) ou "en" — langue du résumé Mistral.
+
+    Returns:
+        - None si free plan ou aucune URL exploitable.
+        - dict canonique {extracted_at, schema_version, stats, pages} sinon.
+
+    Le pipeline NE LÈVE JAMAIS. Toute exception est avalée à logger.warning et
+    retourne None proprement. Il appartient au caller (videos/router.py PR3)
+    de décider quoi faire du None (skip persistence) ou du dict (persist sur
+    Summary.external_pages).
+    """
+    try:
+        # ── Plan gating
+        plan = _normalize_plan(user_plan)
+        cap = PLAN_CAPS.get(plan, 0)
+        if cap <= 0:
+            logger.debug("[EXTERNAL_PAGES] plan=%s cap=0 — skip", plan)
+            return None
+
+        # ── Inputs
+        description = _extract_video_field(video_info, "description", "video_description")
+        video_title = _extract_video_field(video_info, "title", "video_title")
+        creator_channel = _extract_video_field(
+            video_info, "channel", "channel_name", "video_channel"
+        )
+        channel_url = _extract_video_field(video_info, "channel_url")
+
+        if not description:
+            logger.debug("[EXTERNAL_PAGES] empty description — skip")
+            return None
+
+        started_at = datetime.now(timezone.utc)
+
+        # ── 1) Extract URLs
+        raw_urls = extract_urls_from_text(description)
+        if not raw_urls:
+            logger.debug("[EXTERNAL_PAGES] no URLs in description — skip")
+            return None
+
+        # ── 2) Clean + filter (blacklist + dedup + self-channel)
+        cleaned = clean_and_filter_urls(
+            raw_urls,
+            self_channel_host=channel_url or None,
+            max_count=MAX_CANDIDATES_BEFORE_RESOLVE,
+        )
+        if not cleaned:
+            logger.debug("[EXTERNAL_PAGES] no URLs left after cleanup — skip")
+            return None
+
+        # ── 3) Resolve (HEAD, follow redirects, dedup par final_url)
+        try:
+            resolved = await resolve_urls(cleaned, use_proxy=False)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[EXTERNAL_PAGES] resolve_urls failed: %s", exc)
+            resolved = []
+
+        if not resolved:
+            logger.info("[EXTERNAL_PAGES] no URL resolved — skip")
+            return None
+
+        # ── 4) Cap par plan
+        capped: List[ResolvedURL] = resolved[:cap]
+
+        # ── 5) Scrape concurrent (Semaphore=5)
+        scrape_sem = asyncio.Semaphore(SCRAPE_CONCURRENCY)
+        scrape_tasks = [_scrape_with_semaphore(scrape_sem, r) for r in capped]
+        scraped_raw = await asyncio.gather(*scrape_tasks, return_exceptions=False)
+        scraped: List[ScrapedPage] = [s for s in scraped_raw if s is not None]
+
+        if not scraped:
+            logger.info("[EXTERNAL_PAGES] all scrapes failed — skip")
+            return None
+
+        # ── 6) Summarize concurrent (Semaphore=5)
+        summary_sem = asyncio.Semaphore(SUMMARIZE_CONCURRENCY)
+        summary_tasks = [
+            _summarize_with_semaphore(
+                summary_sem,
+                s,
+                plan=plan,
+                creator_channel=creator_channel,
+                video_title=video_title,
+                lang=lang,
+            )
+            for s in scraped
+        ]
+        summaries_raw = await asyncio.gather(*summary_tasks, return_exceptions=False)
+        summaries: List[PageSummary] = [p for p in summaries_raw if p is not None]
+
+        # ── 7) Build payload
+        stats = _compute_stats(
+            candidates_found=len(raw_urls),
+            after_cleanup=len(cleaned),
+            after_cap=len(capped),
+            summaries=summaries,
+        )
+        pages = _build_pages_payload(summaries)
+
+        elapsed = (datetime.now(timezone.utc) - started_at).total_seconds()
+        logger.info(
+            "[EXTERNAL_PAGES] done in %.1fs — plan=%s stats=%s",
+            elapsed,
+            plan,
+            stats,
+        )
+
+        return {
+            "extracted_at": started_at.isoformat(),
+            "schema_version": SCHEMA_VERSION,
+            "stats": stats,
+            "pages": pages,
+        }
+
+    except Exception as exc:  # noqa: BLE001 — last-resort safety net
+        logger.warning("[EXTERNAL_PAGES] pipeline crashed unexpectedly: %s", exc)
+        return None

--- a/backend/src/videos/external_pages/scraper.py
+++ b/backend/src/videos/external_pages/scraper.py
@@ -1,0 +1,474 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  📰 scraper — Scraping HTML d'une page externe + extraction texte readable         ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Étape 4 du pipeline external_pages (spec 2026-05-17 §4) :                         ║
+║                                                                                    ║
+║    [ResolvedURL]                                                                   ║
+║         │                                                                          ║
+║         ▼                                                                          ║
+║    scrape_page(url, final_url) ──► ScrapedPage(url, final_url, title, text,        ║
+║                                                status, bytes_fetched,              ║
+║                                                fetched_via_proxy)                  ║
+║                                                                                    ║
+║  Stratégie :                                                                       ║
+║    1. Tentative directe via shared_http_client (IP Hetzner, gratuit).              ║
+║    2. Sur 403 / 429 ou signal Cloudflare → retry via get_proxied_client            ║
+║       (proxy résidentiel Decodo). Log telemetry sous provider                      ║
+║       "external_page_scrape" (auto via record_proxy_usage).                        ║
+║    3. Body tronqué à MAX_HTML_BYTES (500 KB).                                      ║
+║    4. Content-Type non-HTML (pdf, zip, image, video, audio) → status="non_html"    ║
+║       (spec :: skipped_content_type).                                              ║
+║    5. Extraction texte via trafilatura (SoTA) → fallback readability-lxml.         ║
+║    6. Détection paywall via patterns HTML (subscribers-only, réservé aux           ║
+║       abonnés, etc.) → status="paywall".                                           ║
+║                                                                                    ║
+║  Status retournés :                                                                ║
+║    "ok"            : extraction réussie, ≥ 200 chars de texte                      ║
+║    "paywall"       : pattern paywall détecté dans le HTML                          ║
+║    "timeout"       : timeout réseau                                                ║
+║    "non_html"      : Content-Type non supporté (PDF, image, etc.)                  ║
+║    "http_error"    : statut 4xx (hors 403/429 qui ont fallback) ou 5xx             ║
+║    "empty"         : HTML vide ou extraction donne < 200 chars                     ║
+║                                                                                    ║
+║  Le module NE LÈVE JAMAIS — toute erreur retourne un ScrapedPage avec status.      ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+import httpx
+
+from core.http_client import get_proxied_client, shared_http_client
+
+try:
+    from middleware.proxy_telemetry import record_proxy_usage
+except Exception:  # pragma: no cover — defensive import (tests / minimal env)
+    async def record_proxy_usage(**_kwargs):  # type: ignore
+        return None
+
+
+logger = logging.getLogger("deepsight.external_pages.scraper")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚦 Constantes
+# ═══════════════════════════════════════════════════════════════════════════════
+
+MAX_HTML_BYTES: int = 500 * 1024  # 500 KB — au-delà on truncate
+SCRAPE_TIMEOUT: float = 12.0      # spec §4 — par URL
+MIN_TEXT_LEN: int = 200           # spec §4 edge cases — < 200 chars → status="empty"
+
+# Patterns détection paywall (case-insensitive sur HTML lowered)
+# Spec §4 — couvre Substack premium, Medium, Bloomberg/WSJ/NYT, Le Monde, etc.
+PAYWALL_PATTERNS: Tuple[str, ...] = (
+    "subscribers-only",
+    "subscribe-button",
+    "paywall",
+    "premium-content",
+    "metered-content",
+    "meteredcontent",
+    "subscribe to read",
+    "subscribe to continue",
+    "abonnés uniquement",
+    "réservé aux abonnés",
+    "article-paywall",
+    "members-only",
+    "register to continue",
+    "sign in to read",
+    'name="paywall"',
+)
+
+# Content-types à skip (spec §4 edge cases) — préfixes match
+SKIP_CONTENT_TYPE_PREFIXES: Tuple[str, ...] = (
+    "application/pdf",
+    "application/zip",
+    "application/octet-stream",
+    "application/x-",
+    "video/",
+    "audio/",
+    "image/",
+)
+
+# HTML content-types acceptés (préfixes)
+HTML_CONTENT_TYPE_PREFIXES: Tuple[str, ...] = (
+    "text/html",
+    "application/xhtml+xml",
+    "application/xml",
+    "text/xml",
+)
+
+# Status codes signalant un block (CF/WAF) → fallback proxy
+BLOCK_STATUS_CODES: Tuple[int, ...] = (403, 429)
+
+# Signal Cloudflare dans le HTML (look-ahead sur premier 5 KB)
+CLOUDFLARE_SIGNALS: Tuple[str, ...] = (
+    "cloudflare",
+    "_cf_chl",
+    "cf-ray",
+    "cf-browser-verification",
+    "checking your browser before accessing",
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 Dataclass — ScrapedPage
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class ScrapedPage:
+    """Résultat d'un scrape de page externe.
+
+    Attributs :
+        url               : URL d'origine (avant follow_redirects)
+        final_url         : URL finale après redirects (input pour summarizer)
+        title             : Titre extrait (None si extraction failed)
+        text              : Texte readable extrait (None si paywall/error/empty)
+        status            : "ok" | "paywall" | "timeout" | "non_html" |
+                            "http_error" | "empty"
+        bytes_fetched     : Octets téléchargés (avant truncation)
+        fetched_via_proxy : True si fallback proxy déclenché
+        content_type      : Content-Type brut renvoyé (debug)
+        http_status       : Code HTTP final (debug)
+    """
+
+    url: str
+    final_url: str
+    title: Optional[str]
+    text: Optional[str]
+    status: str
+    bytes_fetched: int
+    fetched_via_proxy: bool
+    content_type: Optional[str] = None
+    http_status: Optional[int] = None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🌐 _fetch_html — Récupère le HTML brut (avec ou sans proxy)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _fetch_html(
+    url: str,
+    *,
+    use_proxy: bool,
+    timeout: float = SCRAPE_TIMEOUT,
+) -> Tuple[Optional[str], int, str, int]:
+    """Télécharge le HTML d'une URL avec ou sans proxy.
+
+    Returns:
+        (html, bytes_read, content_type, status_code).
+        html=None si erreur ou content-type non HTML.
+        bytes_read=0 sur erreur connexion/timeout.
+        content_type="" sur erreur réseau.
+        status_code=0 sur exception (timeout, connect error).
+    """
+    cm = get_proxied_client(timeout=timeout) if use_proxy else shared_http_client()
+    try:
+        async with cm as client:
+            # client.stream pour pouvoir tronquer avant lecture complète
+            async with client.stream(
+                "GET",
+                url,
+                timeout=timeout,
+                follow_redirects=True,
+            ) as resp:
+                raw_ct = (resp.headers.get("content-type") or "").lower()
+                content_type = raw_ct.split(";", 1)[0].strip()
+                status = int(resp.status_code)
+
+                # Skip non-HTML content-types tôt — pas la peine de stream
+                if content_type and any(
+                    content_type.startswith(prefix)
+                    for prefix in SKIP_CONTENT_TYPE_PREFIXES
+                ):
+                    return None, 0, content_type, status
+
+                buf = bytearray()
+                async for chunk in resp.aiter_bytes():
+                    if not chunk:
+                        continue
+                    buf.extend(chunk)
+                    if len(buf) >= MAX_HTML_BYTES:
+                        break
+
+                # Décodage robuste
+                try:
+                    html = buf.decode("utf-8", errors="replace")
+                except Exception:
+                    html = buf.decode("latin-1", errors="replace")
+                return html, len(buf), content_type, status
+    except httpx.TimeoutException as exc:
+        logger.debug("[EXTERNAL_PAGES] timeout fetching %s (proxy=%s): %s",
+                     url, use_proxy, exc)
+        return None, 0, "", 0
+    except httpx.HTTPError as exc:
+        logger.debug("[EXTERNAL_PAGES] http error fetching %s (proxy=%s): %s",
+                     url, use_proxy, exc)
+        return None, 0, "", 0
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("[EXTERNAL_PAGES] unexpected error fetching %s (proxy=%s): %s",
+                     url, use_proxy, exc)
+        return None, 0, "", 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛡️ _detect_paywall — Heuristique HTML
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _detect_paywall(html: str) -> bool:
+    """Détecte un paywall via patterns HTML (case-insensitive)."""
+    if not html:
+        return False
+    lowered = html.lower()
+    return any(pattern in lowered for pattern in PAYWALL_PATTERNS)
+
+
+def _detect_cloudflare(html: str) -> bool:
+    """Détecte un challenge Cloudflare dans les premiers 5 KB du HTML."""
+    if not html:
+        return False
+    head = html[:5000].lower()
+    return any(sig in head for sig in CLOUDFLARE_SIGNALS)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📝 _extract_content — trafilatura puis fallback readability-lxml
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _extract_content(html: str, url: str) -> Tuple[Optional[str], Optional[str]]:
+    """Extrait (title, text) à partir du HTML.
+
+    Stratégie :
+      1. trafilatura.extract(html, output_format="json", with_metadata=True)
+      2. Fallback readability.Document → BeautifulSoup.get_text()
+      3. Renvoie (None, None) si tout échoue ou si text < MIN_TEXT_LEN.
+    """
+    # Tentative 1 — trafilatura (SoTA, retourne JSON avec meta)
+    try:
+        import trafilatura  # imported lazily to keep tests / scripts fast
+
+        extracted = trafilatura.extract(
+            html,
+            output_format="json",
+            include_comments=False,
+            include_tables=False,
+            with_metadata=True,
+            url=url,
+        )
+        if extracted:
+            data = json.loads(extracted)
+            title = data.get("title") or None
+            text = (data.get("text") or data.get("raw_text") or "").strip()
+            if text and len(text) >= MIN_TEXT_LEN:
+                # Trunc défensif à 8000 chars pour Mistral
+                return title, text[:8000]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[EXTERNAL_PAGES] trafilatura failed: %s", exc)
+
+    # Tentative 2 — readability-lxml fallback
+    try:
+        from readability import Document as ReadabilityDocument
+        from bs4 import BeautifulSoup
+
+        doc = ReadabilityDocument(html)
+        title = doc.title() or None
+        cleaned_html = doc.summary()
+        soup = BeautifulSoup(cleaned_html, "html.parser")
+        text = soup.get_text(separator=" ", strip=True)
+        if text and len(text) >= MIN_TEXT_LEN:
+            return title, text[:8000]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[EXTERNAL_PAGES] readability fallback failed: %s", exc)
+
+    return None, None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🎯 scrape_page — Entry point
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _provider_name(final_url: str) -> str:
+    """Construit l'identifiant telemetry à partir du hostname final.
+
+    Pattern : `external_page_scrape_<hostname>` (spec contract — unique).
+    """
+    try:
+        host = (urlparse(final_url).hostname or "unknown").lower()
+        # Strip www.
+        if host.startswith("www."):
+            host = host[4:]
+    except Exception:
+        host = "unknown"
+    return f"external_page_scrape_{host}"
+
+
+async def scrape_page(
+    url: str,
+    final_url: Optional[str] = None,
+    *,
+    timeout: float = SCRAPE_TIMEOUT,
+) -> ScrapedPage:
+    """Scrape une page externe, retourne un ScrapedPage avec status structuré.
+
+    Args:
+        url:       URL d'entrée (avant follow_redirects)
+        final_url: URL finale post-resolve (si omis, on utilise url).
+        timeout:   Timeout réseau par tentative (default 12 s).
+
+    Returns:
+        ScrapedPage — jamais None, jamais lève.
+    """
+    target = final_url or url
+    fetched_via_proxy = False
+
+    # — Tentative 1 : direct (IP Hetzner)
+    html, bytes_fetched, content_type, status = await _fetch_html(
+        target, use_proxy=False, timeout=timeout
+    )
+
+    # — Détection d'un block : 403/429 OU signal Cloudflare dans le HTML
+    cf_in_html = bool(html) and _detect_cloudflare(html)
+    block_signal = status in BLOCK_STATUS_CODES or cf_in_html
+
+    if block_signal:
+        logger.info(
+            "[EXTERNAL_PAGES] %s → block signal (status=%s, cf=%s), retry via proxy",
+            target, status, cf_in_html,
+        )
+        html_p, bytes_p, ct_p, status_p = await _fetch_html(
+            target, use_proxy=True, timeout=timeout
+        )
+        # Si le retry a réussi à tirer quelque chose, on remplace l'état
+        if status_p != 0:
+            html = html_p
+            bytes_fetched = bytes_p
+            content_type = ct_p
+            status = status_p
+        fetched_via_proxy = True
+
+        # Telemetry best-effort (best-effort, jamais bloquant)
+        if bytes_fetched > 0:
+            try:
+                await record_proxy_usage(
+                    provider=_provider_name(target),
+                    bytes_in=bytes_fetched,
+                    bytes_out=0,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[EXTERNAL_PAGES] telemetry record failed: %s", exc)
+
+    # — Détermination du status final
+    # 1) Timeout / connect error / DNS → status=0
+    if status == 0:
+        return ScrapedPage(
+            url=url,
+            final_url=target,
+            title=None,
+            text=None,
+            status="timeout",
+            bytes_fetched=bytes_fetched,
+            fetched_via_proxy=fetched_via_proxy,
+            content_type=content_type or None,
+            http_status=status,
+        )
+
+    # 2) Content-type non-HTML rejeté tôt
+    if (
+        content_type
+        and any(
+            content_type.startswith(prefix) for prefix in SKIP_CONTENT_TYPE_PREFIXES
+        )
+    ):
+        return ScrapedPage(
+            url=url,
+            final_url=target,
+            title=None,
+            text=None,
+            status="non_html",
+            bytes_fetched=bytes_fetched,
+            fetched_via_proxy=fetched_via_proxy,
+            content_type=content_type,
+            http_status=status,
+        )
+
+    # 3) Erreurs HTTP (hors 200-299) — 4xx (autres que block réussi) et 5xx
+    if status >= 400:
+        return ScrapedPage(
+            url=url,
+            final_url=target,
+            title=None,
+            text=None,
+            status="http_error",
+            bytes_fetched=bytes_fetched,
+            fetched_via_proxy=fetched_via_proxy,
+            content_type=content_type or None,
+            http_status=status,
+        )
+
+    # 4) Pas de HTML utile
+    if not html:
+        return ScrapedPage(
+            url=url,
+            final_url=target,
+            title=None,
+            text=None,
+            status="empty",
+            bytes_fetched=bytes_fetched,
+            fetched_via_proxy=fetched_via_proxy,
+            content_type=content_type or None,
+            http_status=status,
+        )
+
+    # 5) Paywall détecté — on garde le titre, pas le texte
+    if _detect_paywall(html):
+        title, _ = _extract_content(html, target)
+        return ScrapedPage(
+            url=url,
+            final_url=target,
+            title=title,
+            text=None,
+            status="paywall",
+            bytes_fetched=bytes_fetched,
+            fetched_via_proxy=fetched_via_proxy,
+            content_type=content_type or None,
+            http_status=status,
+        )
+
+    # 6) Extraction texte readable
+    title, text = _extract_content(html, target)
+    if not text:
+        return ScrapedPage(
+            url=url,
+            final_url=target,
+            title=title,
+            text=None,
+            status="empty",
+            bytes_fetched=bytes_fetched,
+            fetched_via_proxy=fetched_via_proxy,
+            content_type=content_type or None,
+            http_status=status,
+        )
+
+    # 7) OK
+    return ScrapedPage(
+        url=url,
+        final_url=target,
+        title=title,
+        text=text,
+        status="ok",
+        bytes_fetched=bytes_fetched,
+        fetched_via_proxy=fetched_via_proxy,
+        content_type=content_type or None,
+        http_status=status,
+    )

--- a/backend/src/videos/external_pages/summarizer.py
+++ b/backend/src/videos/external_pages/summarizer.py
@@ -1,0 +1,380 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧠 summarizer — Résumé Mistral d'une page externe (avec cache Redis 7j)           ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Étape 5 du pipeline external_pages (spec 2026-05-17 §5) :                         ║
+║                                                                                    ║
+║    ScrapedPage(status="ok")                                                        ║
+║         │                                                                          ║
+║         ▼                                                                          ║
+║    summarize_page(scraped, ...) ──► PageSummary(url, final_url, title, summary,    ║
+║                                                  key_claims, status, ...)          ║
+║                                                                                    ║
+║  - JSON mode Mistral (response_format=json_object)                                 ║
+║  - max_tokens=300 (Pro) / 500 (Expert)                                             ║
+║  - temperature=0.2                                                                 ║
+║  - Cache Redis 7 jours, clé `vcache:external_page:{sha256(final_url)[:16]}`        ║
+║  - Cache cross-user (invariant : même page → même résumé)                          ║
+║  - Skip si scraped.status != "ok"                                                  ║
+║  - Skip Mistral si scraped.text vide                                               ║
+║  - Prompt système : TOUJOURS répondre en français même si page anglaise            ║
+║                                                                                    ║
+║  Status retournés :                                                                ║
+║    "ok"      : Mistral a retourné un JSON parsable                                 ║
+║    "paywall" / "non_html" / "empty" / "http_error" / "timeout" :                   ║
+║              pass-through depuis le scraped (pas d'appel Mistral)                  ║
+║    "error"   : Mistral a échoué ou le JSON est invalide → degraded                 ║
+║                                                                                    ║
+║  Module NE LÈVE JAMAIS — toute exception cache/LLM est avalée à debug-level.       ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from core.cache import cache_service
+from core.llm_provider import llm_complete
+
+from .scraper import ScrapedPage
+
+
+logger = logging.getLogger("deepsight.external_pages.summarizer")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🚦 Constantes
+# ═══════════════════════════════════════════════════════════════════════════════
+
+CACHE_TTL_SECONDS: int = 7 * 24 * 3600  # 7 jours (spec §5)
+CACHE_PREFIX: str = "vcache:external_page:"
+MAX_TEXT_FOR_PROMPT: int = 6000  # chars envoyés à Mistral (spec §5)
+MAX_KEY_CLAIMS: int = 4
+MAX_SUMMARY_CHARS: int = 600  # garde-fou si Mistral dérape
+
+# Mapping plan → modèle Mistral (cohérent avec billing/plan_config)
+PLAN_TO_MODEL = {
+    "free": "mistral-small-2603",
+    "pro": "mistral-medium-2508",
+    "expert": "mistral-large-2512",
+}
+
+# max_tokens par plan (spec §8)
+PLAN_TO_MAX_TOKENS = {
+    "free": 300,
+    "pro": 300,
+    "expert": 500,
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 Dataclass — PageSummary
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class PageSummary:
+    """Résumé d'une page externe.
+
+    Attributs :
+        url               : URL d'origine (avant resolve)
+        final_url         : URL finale post-resolve
+        title             : Titre extrait (peut être None)
+        summary           : 2-3 phrases en français (None si scrape failed)
+        key_claims        : 1-4 affirmations clés (liste vide si scrape failed)
+        status            : "ok" / pass-through du scraped status / "error"
+        fetched_via_proxy : True si scrape via Decodo
+        bytes_fetched     : Octets téléchargés au scrape
+        cached            : True si le résumé vient du cache Redis
+    """
+
+    url: str
+    final_url: str
+    title: Optional[str]
+    summary: Optional[str]
+    key_claims: List[str]
+    status: str
+    fetched_via_proxy: bool = False
+    bytes_fetched: int = 0
+    cached: bool = False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔑 Cache key helper
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _cache_key(final_url: str) -> str:
+    """Clé Redis cross-user — sha256(final_url) tronqué à 16 chars hex.
+
+    On hash pour éviter d'exposer des URLs longues comme clés Redis et garder
+    la longueur bornée. Préfixe `vcache:external_page:` (cohérent avec le reste
+    du namespace cache DeepSight).
+    """
+    h = hashlib.sha256(final_url.encode("utf-8")).hexdigest()[:16]
+    return f"{CACHE_PREFIX}{h}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ✉️ Prompt builder
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _build_prompt(
+    page_text: str,
+    page_title: Optional[str],
+    *,
+    creator_channel: str,
+    video_title: str,
+    lang: str = "fr",
+) -> List[dict]:
+    """Construit le prompt JSON-mode (spec §5).
+
+    Le system enforce :
+    - factuel, neutre, jamais promotionnel
+    - sortie en `lang` (default "fr")
+    - JSON strict { summary, key_claims }
+    """
+    target_lang = "français" if lang == "fr" else "anglais"
+
+    system = (
+        "Tu es un assistant qui résume des pages web citées par des créateurs vidéo. "
+        "Sois factuel, neutre, jamais promotionnel. "
+        f"Résume TOUJOURS en {target_lang} même si la page est dans une autre langue. "
+        "Réponds en JSON strict avec les clés 'summary' (2-3 phrases claires) et "
+        "'key_claims' (liste de 1 à 3 affirmations clés ou faits, chacune ≤ 15 mots)."
+    )
+
+    context_line = ""
+    if creator_channel and video_title:
+        context_line = (
+            f"Contexte : cette page est citée dans la description de la vidéo "
+            f"« {video_title} » par le créateur « {creator_channel} ».\n\n"
+        )
+    elif video_title:
+        context_line = f"Contexte : cette page est citée dans la vidéo « {video_title} ».\n\n"
+
+    user = (
+        f"{context_line}"
+        f"Titre de la page : {page_title or 'inconnu'}\n\n"
+        f"Contenu de la page (extrait) :\n{page_text[:MAX_TEXT_FOR_PROMPT]}\n\n"
+        f'Résume cette page en 2-3 phrases claires en {target_lang}. '
+        f"Liste 1-3 affirmations clés. Réponds en JSON "
+        f'{{"summary": "...", "key_claims": ["...", "..."]}}'
+    )
+
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧠 summarize_page — Entry point
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _normalize_plan(plan: Optional[str]) -> str:
+    """Normalise le plan vers free/pro/expert (best-effort, sans import circulaire)."""
+    if not plan:
+        return "free"
+    p = plan.strip().lower()
+    # Aliases legacy (cohérent avec billing/plan_config.normalize_plan_id)
+    aliases = {"plus": "pro", "starter": "pro", "trial": "pro"}
+    p = aliases.get(p, p)
+    if p not in PLAN_TO_MODEL:
+        return "free"
+    return p
+
+
+def _passthrough(
+    scraped: ScrapedPage,
+    *,
+    summary: Optional[str] = None,
+    key_claims: Optional[List[str]] = None,
+    status: Optional[str] = None,
+    cached: bool = False,
+) -> PageSummary:
+    """Helper : crée un PageSummary avec metadata du scraped."""
+    return PageSummary(
+        url=scraped.url,
+        final_url=scraped.final_url,
+        title=scraped.title,
+        summary=summary,
+        key_claims=key_claims if key_claims is not None else [],
+        status=status if status is not None else scraped.status,
+        fetched_via_proxy=scraped.fetched_via_proxy,
+        bytes_fetched=scraped.bytes_fetched,
+        cached=cached,
+    )
+
+
+async def summarize_page(
+    scraped: ScrapedPage,
+    *,
+    plan: str = "pro",
+    creator_channel: str = "",
+    video_title: str = "",
+    lang: str = "fr",
+) -> PageSummary:
+    """Résume une page scraped via Mistral + cache Redis (cross-user).
+
+    Args:
+        scraped         : ScrapedPage du module scraper.
+        plan            : Plan user — détermine le modèle Mistral et max_tokens.
+        creator_channel : Nom du créateur (contextualise le prompt).
+        video_title     : Titre de la vidéo (contextualise le prompt).
+        lang            : "fr" (default) ou "en" — langue du résumé Mistral.
+
+    Returns:
+        PageSummary — jamais None, jamais lève.
+
+    Comportement :
+      1. Si scraped.status != "ok" OU scraped.text vide → passthrough.
+      2. Cache HIT → retourne PageSummary(cached=True), pas d'appel Mistral.
+      3. Cache MISS → appel llm_complete json_mode, parse, set cache, return.
+      4. Sur exception Mistral → status="error", pas de cache set.
+      5. Sur JSON invalide → degraded summary (premier 500 chars du raw), pas de cache.
+    """
+    # ── Skip si scrape failed
+    if scraped.status != "ok" or not scraped.text:
+        return _passthrough(scraped)
+
+    # ── Cache lookup (cross-user)
+    ckey = _cache_key(scraped.final_url)
+    cached_raw = None
+    try:
+        cached_raw = await cache_service.get(ckey)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[EXTERNAL_PAGES] cache get failed for %s: %s", ckey, exc)
+
+    if cached_raw is not None:
+        try:
+            cached_data = (
+                json.loads(cached_raw)
+                if isinstance(cached_raw, (str, bytes, bytearray))
+                else cached_raw
+            )
+            if isinstance(cached_data, dict):
+                summary = cached_data.get("summary")
+                key_claims = cached_data.get("key_claims") or []
+                if not isinstance(key_claims, list):
+                    key_claims = []
+                return PageSummary(
+                    url=scraped.url,
+                    final_url=scraped.final_url,
+                    title=cached_data.get("title") or scraped.title,
+                    summary=summary,
+                    key_claims=[str(c).strip() for c in key_claims if c][:MAX_KEY_CLAIMS],
+                    status="ok",
+                    fetched_via_proxy=scraped.fetched_via_proxy,
+                    bytes_fetched=scraped.bytes_fetched,
+                    cached=True,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[EXTERNAL_PAGES] cache parse failed for %s: %s", ckey, exc)
+
+    # ── Cache MISS → appel Mistral
+    normalized_plan = _normalize_plan(plan)
+    model = PLAN_TO_MODEL[normalized_plan]
+    max_tokens = PLAN_TO_MAX_TOKENS[normalized_plan]
+
+    messages = _build_prompt(
+        scraped.text,
+        scraped.title,
+        creator_channel=creator_channel,
+        video_title=video_title,
+        lang=lang,
+    )
+
+    llm_result = None
+    try:
+        llm_result = await llm_complete(
+            messages=messages,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=0.2,
+            timeout=20.0,
+            json_mode=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[EXTERNAL_PAGES] Mistral call failed for %s: %s",
+            scraped.final_url,
+            exc,
+        )
+
+    # ── Mistral KO → status="error", pas de cache
+    if not llm_result or not getattr(llm_result, "content", None):
+        return _passthrough(scraped, status="error")
+
+    raw = llm_result.content.strip()
+
+    # ── Parse JSON
+    summary: Optional[str] = None
+    key_claims: List[str] = []
+    parse_ok = False
+
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            summary = (data.get("summary") or "").strip() or None
+            kc_raw = data.get("key_claims") or []
+            if isinstance(kc_raw, list):
+                key_claims = [str(c).strip() for c in kc_raw if c][:MAX_KEY_CLAIMS]
+            parse_ok = True
+    except (json.JSONDecodeError, AttributeError, TypeError) as exc:
+        logger.debug(
+            "[EXTERNAL_PAGES] JSON parse failed for %s: %s",
+            scraped.final_url,
+            exc,
+        )
+
+    if not parse_ok or not summary:
+        # Degraded — on conserve le raw tronqué comme summary, pas de cache set
+        degraded_summary = raw[:MAX_SUMMARY_CHARS] if raw else None
+        return PageSummary(
+            url=scraped.url,
+            final_url=scraped.final_url,
+            title=scraped.title,
+            summary=degraded_summary,
+            key_claims=[],
+            status="ok" if degraded_summary else "error",
+            fetched_via_proxy=scraped.fetched_via_proxy,
+            bytes_fetched=scraped.bytes_fetched,
+            cached=False,
+        )
+
+    # Garde-fou sur la longueur du summary (Mistral peut déborder)
+    if summary and len(summary) > MAX_SUMMARY_CHARS:
+        summary = summary[:MAX_SUMMARY_CHARS].rsplit(" ", 1)[0] + "…"
+
+    # ── Cache set (best-effort)
+    try:
+        payload = json.dumps(
+            {
+                "title": scraped.title,
+                "summary": summary,
+                "key_claims": key_claims,
+            },
+            ensure_ascii=False,
+        )
+        await cache_service.set(ckey, payload, ttl=CACHE_TTL_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[EXTERNAL_PAGES] cache set failed for %s: %s", ckey, exc)
+
+    return PageSummary(
+        url=scraped.url,
+        final_url=scraped.final_url,
+        title=scraped.title,
+        summary=summary,
+        key_claims=key_claims,
+        status="ok",
+        fetched_via_proxy=scraped.fetched_via_proxy,
+        bytes_fetched=scraped.bytes_fetched,
+        cached=False,
+    )

--- a/backend/tests/test_external_page_scraper.py
+++ b/backend/tests/test_external_page_scraper.py
@@ -1,0 +1,358 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — videos.external_pages.scraper                                          ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre :                                                                          ║
+║    - _detect_paywall : patterns paywall (substack, le monde, etc.)                 ║
+║    - _detect_cloudflare : signature CF / 5KB head                                  ║
+║    - _provider_name : telemetry id par hostname                                    ║
+║    - scrape_page : ok / paywall / 403→proxy / non-html / timeout / truncation /    ║
+║                    http_error / empty / cloudflare in body                         ║
+║                                                                                    ║
+║  Stratégie : mock `_fetch_html` (monkeypatch) — pas de vrai I/O.                   ║
+║              `record_proxy_usage` mocké en AsyncMock pour éviter écriture DB.      ║
+║              `_extract_content` mocké quand on veut tester sans trafilatura.       ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from videos.external_pages.scraper import (
+    MAX_HTML_BYTES,
+    ScrapedPage,
+    _detect_cloudflare,
+    _detect_paywall,
+    _provider_name,
+    scrape_page,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 _detect_paywall
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestDetectPaywall:
+    def test_substack_subscribers_only(self):
+        html = '<div class="subscribers-only">Premium content</div>'
+        assert _detect_paywall(html)
+
+    def test_lemonde_reserve_aux_abonnes(self):
+        html = "<p>Article réservé aux abonnés</p>"
+        assert _detect_paywall(html)
+
+    def test_paywall_div(self):
+        html = '<div class="paywall">Subscribe</div>'
+        assert _detect_paywall(html)
+
+    def test_subscribe_to_read(self):
+        html = "<p>Subscribe to read the full article</p>"
+        assert _detect_paywall(html)
+
+    def test_meta_paywall(self):
+        html = '<meta name="paywall" content="true">'
+        assert _detect_paywall(html)
+
+    def test_normal_blog_no_paywall(self):
+        html = "<article>Contenu libre et accessible à tous.</article>"
+        assert not _detect_paywall(html)
+
+    def test_empty_html_no_paywall(self):
+        assert not _detect_paywall("")
+        assert not _detect_paywall(None)  # type: ignore
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 _detect_cloudflare
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestDetectCloudflare:
+    def test_cloudflare_signature(self):
+        html = '<html><head><script>window._cf_chl_opt = {};</script></head></html>'
+        assert _detect_cloudflare(html)
+
+    def test_checking_browser_message(self):
+        html = "<title>Checking your browser before accessing example.com</title>"
+        assert _detect_cloudflare(html)
+
+    def test_normal_html_no_cf(self):
+        html = "<html><body><h1>Hello world</h1></body></html>"
+        assert not _detect_cloudflare(html)
+
+    def test_empty_html_no_cf(self):
+        assert not _detect_cloudflare("")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 _provider_name
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestProviderName:
+    def test_strips_www(self):
+        assert _provider_name("https://www.stratechery.com/2024/post") == (
+            "external_page_scrape_stratechery.com"
+        )
+
+    def test_keeps_subdomain(self):
+        assert _provider_name("https://blog.openai.com/x") == (
+            "external_page_scrape_blog.openai.com"
+        )
+
+    def test_invalid_url_uses_unknown(self):
+        # urlparse renvoie hostname=None pour URL malformée
+        assert _provider_name("not a url") == "external_page_scrape_unknown"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 scrape_page — happy path + edge cases
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestScrapePage:
+    """Tous les tests monkey-patch `_fetch_html` pour ne jamais faire d'I/O réseau."""
+
+    @pytest.fixture(autouse=True)
+    def mock_telemetry(self):
+        """Empêche tout écriture DB de telemetry pendant les tests."""
+        with patch(
+            "videos.external_pages.scraper.record_proxy_usage",
+            new=AsyncMock(),
+        ):
+            yield
+
+    async def test_ok_direct_with_real_extraction(self, monkeypatch):
+        """Direct GET 200 + trafilatura extrait correctement → status='ok'."""
+        # HTML riche pour que trafilatura extrait quelque chose
+        html = (
+            "<html><head><title>Test Article</title></head>"
+            "<body><article>"
+            + "<p>" + "Ceci est un paragraphe en français. " * 30 + "</p>"
+            + "</article></body></html>"
+        )
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return html, len(html), "text/html", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://example.com", "https://example.com")
+        assert result.status == "ok"
+        assert result.fetched_via_proxy is False
+        assert result.text is not None
+        assert len(result.text) >= 200
+        assert result.http_status == 200
+
+    async def test_falls_back_to_proxy_on_403(self, monkeypatch):
+        """Direct 403 → retry proxy → ok."""
+        calls = []
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            calls.append(use_proxy)
+            if not use_proxy:
+                return None, 0, "text/html", 403
+            html = (
+                "<html><body><article>"
+                + "<p>" + "Contenu via proxy. " * 30 + "</p>"
+                + "</article></body></html>"
+            )
+            return html, len(html), "text/html", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://blocked.example", "https://blocked.example")
+        assert result.status == "ok"
+        assert result.fetched_via_proxy is True
+        assert calls == [False, True]
+        assert result.http_status == 200
+
+    async def test_falls_back_to_proxy_on_429(self, monkeypatch):
+        """Direct 429 (rate limit) → retry proxy."""
+        calls = []
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            calls.append(use_proxy)
+            if not use_proxy:
+                return None, 0, "text/html", 429
+            html = (
+                "<html><body><article>"
+                + "<p>" + "Du contenu. " * 30 + "</p>"
+                + "</article></body></html>"
+            )
+            return html, len(html), "text/html", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://ratelimited.example",
+                                    "https://ratelimited.example")
+        assert result.status == "ok"
+        assert result.fetched_via_proxy is True
+        assert calls == [False, True]
+
+    async def test_cloudflare_signal_triggers_proxy(self, monkeypatch):
+        """Signal Cloudflare dans HTML 200 → retry proxy même sans 403."""
+        cf_html = (
+            "<html><head><title>Checking</title></head>"
+            "<body>Checking your browser before accessing example.com. "
+            "<script>window._cf_chl_opt={};</script></body></html>"
+        )
+        proxy_html = (
+            "<html><body><article><p>" + "Contenu réel. " * 30 + "</p></article></body></html>"
+        )
+        calls = []
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            calls.append(use_proxy)
+            if not use_proxy:
+                return cf_html, len(cf_html), "text/html", 200
+            return proxy_html, len(proxy_html), "text/html", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://cf.example", "https://cf.example")
+        assert calls == [False, True]
+        assert result.fetched_via_proxy is True
+        assert result.status == "ok"
+
+    async def test_pdf_content_type_skipped(self, monkeypatch):
+        """Content-Type application/pdf → status='non_html'."""
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return None, 0, "application/pdf", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page(
+            "https://example.com/whitepaper.pdf",
+            "https://example.com/whitepaper.pdf",
+        )
+        assert result.status == "non_html"
+        assert result.content_type == "application/pdf"
+
+    async def test_image_content_type_skipped(self, monkeypatch):
+        """image/jpeg → status='non_html'."""
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return None, 0, "image/jpeg", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page(
+            "https://example.com/pic.jpg", "https://example.com/pic.jpg"
+        )
+        assert result.status == "non_html"
+
+    async def test_timeout_returns_timeout_status(self, monkeypatch):
+        """Status=0 (timeout/connect error) → status='timeout'."""
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return None, 0, "", 0
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://slow.example", "https://slow.example")
+        assert result.status == "timeout"
+        assert result.text is None
+        assert result.bytes_fetched == 0
+
+    async def test_404_returns_http_error(self, monkeypatch):
+        """404 sans block signal → status='http_error'."""
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return None, 0, "text/html", 404
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://gone.example", "https://gone.example")
+        assert result.status == "http_error"
+        assert result.http_status == 404
+
+    async def test_5xx_returns_http_error(self, monkeypatch):
+        """500 → status='http_error'."""
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return None, 0, "text/html", 500
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://broken.example", "https://broken.example")
+        assert result.status == "http_error"
+        assert result.http_status == 500
+
+    async def test_paywall_detected(self, monkeypatch):
+        """HTML contient pattern paywall → status='paywall', text=None."""
+        html = (
+            "<html><body>"
+            '<div class="paywall">'
+            "Subscribe to read the full article" + ("." * 300) +
+            "</div></body></html>"
+        )
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return html, len(html), "text/html", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://paywalled.example",
+                                    "https://paywalled.example")
+        assert result.status == "paywall"
+        assert result.text is None
+
+    async def test_empty_html_returns_empty(self, monkeypatch):
+        """HTML est très court / pas de contenu utile → status='empty'."""
+        html = "<html><body><p>x</p></body></html>"
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return html, len(html), "text/html", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        # On force aussi l'extraction à renvoyer (None, None) pour être déterministe
+        with patch(
+            "videos.external_pages.scraper._extract_content",
+            return_value=(None, None),
+        ):
+            result = await scrape_page("https://tiny.example", "https://tiny.example")
+        assert result.status == "empty"
+        assert result.text is None
+
+    async def test_truncation_at_max_html_bytes(self, monkeypatch):
+        """_fetch_html doit cap le buffer à MAX_HTML_BYTES.
+
+        On vérifie l'output de scrape_page (bytes_fetched reflète la troncature).
+        Le test fournit un buffer fake supérieur à la limite et confirme que le
+        contract est honoré côté scrape_page.
+        """
+
+        truncated_len = MAX_HTML_BYTES  # ce que _fetch_html aurait retourné
+        html_truncated = "<html><body><article><p>" + ("A" * 1000) + "</p></article></body></html>"
+
+        async def fake_fetch(url, *, use_proxy, timeout):
+            return html_truncated, truncated_len, "text/html", 200
+
+        monkeypatch.setattr(
+            "videos.external_pages.scraper._fetch_html", fake_fetch
+        )
+        result = await scrape_page("https://huge.example", "https://huge.example")
+        # Soit ok soit empty selon trafilatura — l'important : bytes_fetched == MAX
+        assert result.bytes_fetched == MAX_HTML_BYTES
+        assert result.status in ("ok", "empty")

--- a/backend/tests/test_external_page_summarizer.py
+++ b/backend/tests/test_external_page_summarizer.py
@@ -1,0 +1,272 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — videos.external_pages.summarizer                                       ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre :                                                                          ║
+║    - _cache_key : déterministe + bon préfixe                                       ║
+║    - summarize_page :                                                              ║
+║        * pass-through si scraped.status != "ok" (paywall, empty, timeout)          ║
+║        * pass-through si scraped.text vide                                         ║
+║        * cache hit → ne pas appeler Mistral                                        ║
+║        * cache miss → appel Mistral, parse JSON, set cache                         ║
+║        * JSON invalide → degraded summary (no cache set)                           ║
+║        * Mistral exception → status="error"                                        ║
+║    - _normalize_plan : free/pro/expert/legacy                                      ║
+║                                                                                    ║
+║  Stratégie : tout mocké (cache_service.get/set, llm_complete).                     ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from videos.external_pages.scraper import ScrapedPage
+from videos.external_pages.summarizer import (
+    CACHE_PREFIX,
+    PageSummary,
+    _cache_key,
+    _normalize_plan,
+    summarize_page,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 _cache_key
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestCacheKey:
+    def test_deterministic(self):
+        k1 = _cache_key("https://example.com/article")
+        k2 = _cache_key("https://example.com/article")
+        assert k1 == k2
+
+    def test_prefix(self):
+        k = _cache_key("https://example.com")
+        assert k.startswith(CACHE_PREFIX)
+
+    def test_different_urls_different_keys(self):
+        k1 = _cache_key("https://a.com")
+        k2 = _cache_key("https://b.com")
+        assert k1 != k2
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 _normalize_plan
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestNormalizePlan:
+    def test_free(self):
+        assert _normalize_plan("free") == "free"
+
+    def test_pro(self):
+        assert _normalize_plan("pro") == "pro"
+
+    def test_expert(self):
+        assert _normalize_plan("expert") == "expert"
+
+    def test_legacy_plus_aliased(self):
+        assert _normalize_plan("plus") == "pro"
+
+    def test_unknown_falls_back_to_free(self):
+        assert _normalize_plan("enterprise") == "free"
+
+    def test_none_falls_back_to_free(self):
+        assert _normalize_plan(None) == "free"
+
+    def test_uppercase(self):
+        assert _normalize_plan("PRO") == "pro"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 summarize_page
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_scraped(*, status: str = "ok", text: str = "A " * 500) -> ScrapedPage:
+    """Builder ScrapedPage avec defaults raisonnables."""
+    return ScrapedPage(
+        url="https://example.com",
+        final_url="https://example.com",
+        title="Test Page",
+        text=text if status == "ok" else None,
+        status=status,
+        bytes_fetched=2000,
+        fetched_via_proxy=False,
+        content_type="text/html",
+        http_status=200,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestSummarizePage:
+    """Tous les tests mockent cache_service + llm_complete."""
+
+    async def test_passthrough_paywall_status(self):
+        """scraped.status='paywall' → pas d'appel Mistral, pas de cache set."""
+        scraped = _make_scraped(status="paywall")
+        with patch(
+            "videos.external_pages.summarizer.cache_service"
+        ) as mock_cache, patch(
+            "videos.external_pages.summarizer.llm_complete",
+            new=AsyncMock(),
+        ) as mock_llm:
+            mock_cache.get = AsyncMock(return_value=None)
+            mock_cache.set = AsyncMock()
+            result = await summarize_page(scraped, plan="pro")
+        assert result.status == "paywall"
+        assert result.summary is None
+        assert result.key_claims == []
+        mock_llm.assert_not_called()
+        mock_cache.set.assert_not_called()
+
+    async def test_passthrough_empty_text(self):
+        """scraped.status='ok' mais text=None → passthrough."""
+        scraped = ScrapedPage(
+            url="https://example.com",
+            final_url="https://example.com",
+            title="X",
+            text=None,
+            status="ok",
+            bytes_fetched=100,
+            fetched_via_proxy=False,
+        )
+        with patch(
+            "videos.external_pages.summarizer.cache_service"
+        ) as mock_cache, patch(
+            "videos.external_pages.summarizer.llm_complete",
+            new=AsyncMock(),
+        ) as mock_llm:
+            mock_cache.get = AsyncMock(return_value=None)
+            result = await summarize_page(scraped, plan="pro")
+        mock_llm.assert_not_called()
+
+    async def test_cache_hit_skips_mistral(self):
+        """Cache HIT → retourne données du cache, pas d'appel Mistral."""
+        scraped = _make_scraped()
+        cached_payload = json.dumps(
+            {
+                "title": "Cached Title",
+                "summary": "Cached summary content.",
+                "key_claims": ["cached claim 1", "cached claim 2"],
+            }
+        )
+        with patch(
+            "videos.external_pages.summarizer.cache_service"
+        ) as mock_cache, patch(
+            "videos.external_pages.summarizer.llm_complete",
+            new=AsyncMock(),
+        ) as mock_llm:
+            mock_cache.get = AsyncMock(return_value=cached_payload)
+            mock_cache.set = AsyncMock()
+            result = await summarize_page(scraped, plan="pro")
+        assert result.cached is True
+        assert result.summary == "Cached summary content."
+        assert result.key_claims == ["cached claim 1", "cached claim 2"]
+        assert result.title == "Cached Title"
+        assert result.status == "ok"
+        mock_llm.assert_not_called()
+        mock_cache.set.assert_not_called()
+
+    async def test_cache_miss_calls_mistral_and_sets_cache(self):
+        """Cache MISS → appel Mistral, parse JSON, set cache."""
+        scraped = _make_scraped()
+        fake_llm_result = type(
+            "R",
+            (),
+            {
+                "content": json.dumps(
+                    {
+                        "summary": "Une synthèse de la page en deux phrases.",
+                        "key_claims": ["claim A", "claim B", "claim C"],
+                    }
+                )
+            },
+        )()
+
+        with patch(
+            "videos.external_pages.summarizer.cache_service"
+        ) as mock_cache, patch(
+            "videos.external_pages.summarizer.llm_complete",
+            new=AsyncMock(return_value=fake_llm_result),
+        ) as mock_llm:
+            mock_cache.get = AsyncMock(return_value=None)
+            mock_cache.set = AsyncMock(return_value=True)
+            result = await summarize_page(
+                scraped,
+                plan="pro",
+                creator_channel="MyChannel",
+                video_title="My Video",
+            )
+        assert result.status == "ok"
+        assert result.cached is False
+        assert result.summary == "Une synthèse de la page en deux phrases."
+        assert result.key_claims == ["claim A", "claim B", "claim C"]
+        # Mistral a été appelé
+        assert mock_llm.called
+        # Cache set a bien eu lieu
+        assert mock_cache.set.called
+
+    async def test_json_invalid_returns_degraded(self):
+        """Mistral renvoie texte non-JSON → degraded (raw tronqué) no cache."""
+        scraped = _make_scraped()
+        fake_llm_result = type("R", (), {"content": "Désolé je n'ai pas compris."})()
+
+        with patch(
+            "videos.external_pages.summarizer.cache_service"
+        ) as mock_cache, patch(
+            "videos.external_pages.summarizer.llm_complete",
+            new=AsyncMock(return_value=fake_llm_result),
+        ):
+            mock_cache.get = AsyncMock(return_value=None)
+            mock_cache.set = AsyncMock()
+            result = await summarize_page(scraped, plan="pro")
+        # On a un summary (degraded) mais pas de key_claims
+        assert result.summary is not None
+        assert "Désolé" in result.summary
+        assert result.key_claims == []
+        # Pas de cache set sur degraded
+        mock_cache.set.assert_not_called()
+
+    async def test_mistral_exception_returns_error_status(self):
+        """llm_complete lève → status='error'."""
+        scraped = _make_scraped()
+
+        async def raise_runtime(**_kwargs):
+            raise RuntimeError("Mistral 429")
+
+        with patch(
+            "videos.external_pages.summarizer.cache_service"
+        ) as mock_cache, patch(
+            "videos.external_pages.summarizer.llm_complete",
+            new=raise_runtime,
+        ):
+            mock_cache.get = AsyncMock(return_value=None)
+            mock_cache.set = AsyncMock()
+            result = await summarize_page(scraped, plan="pro")
+        assert result.status == "error"
+        assert result.summary is None
+        mock_cache.set.assert_not_called()
+
+    async def test_mistral_returns_none_content(self):
+        """llm_complete renvoie objet sans content → status='error'."""
+        scraped = _make_scraped()
+        fake = type("R", (), {"content": ""})()
+
+        with patch(
+            "videos.external_pages.summarizer.cache_service"
+        ) as mock_cache, patch(
+            "videos.external_pages.summarizer.llm_complete",
+            new=AsyncMock(return_value=fake),
+        ):
+            mock_cache.get = AsyncMock(return_value=None)
+            mock_cache.set = AsyncMock()
+            result = await summarize_page(scraped, plan="pro")
+        assert result.status == "error"
+        mock_cache.set.assert_not_called()

--- a/backend/tests/test_external_pages_orchestrator.py
+++ b/backend/tests/test_external_pages_orchestrator.py
@@ -1,0 +1,433 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — videos.external_pages.orchestrator                                     ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre :                                                                          ║
+║    - free plan → None                                                              ║
+║    - description vide → None                                                       ║
+║    - aucune URL extraite → None                                                    ║
+║    - pro plan cape à 5 URLs                                                        ║
+║    - expert plan cape à 10 URLs                                                    ║
+║    - Semaphore : pas plus de SCRAPE_CONCURRENCY scrapes en flight                  ║
+║    - exception dans 1 scrape n'affecte pas le batch                                ║
+║    - dict final shape conforme spec §6                                             ║
+║                                                                                    ║
+║  Stratégie : mock scrape_page / summarize_page / resolve_urls.                     ║
+║              Inputs = video_info dict minimal.                                     ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import asyncio
+from typing import List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from videos.external_pages.orchestrator import (
+    SCHEMA_VERSION,
+    SCRAPE_CONCURRENCY,
+    extract_external_pages,
+)
+from videos.external_pages.scraper import ScrapedPage
+from videos.external_pages.summarizer import PageSummary
+from videos.external_pages.url_resolver import ResolvedURL
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛠️ Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_video_info(*, n_urls: int = 7) -> dict:
+    """Construit une description avec n_urls liens distincts."""
+    base = "Cette vidéo parle de plein de choses.\n\n"
+    links = "\n".join(
+        f"Ref {i}: https://site{i}.com/article-{i}" for i in range(n_urls)
+    )
+    return {
+        "description": base + links,
+        "title": "Ma super vidéo",
+        "channel": "ChannelName",
+        "channel_url": "https://www.youtube.com/@MyChannel",
+    }
+
+
+def _make_resolved(n: int) -> List[ResolvedURL]:
+    """Liste de n ResolvedURL distincts."""
+    return [
+        ResolvedURL(
+            input_url=f"https://site{i}.com/article-{i}",
+            final_url=f"https://site{i}.com/article-{i}",
+            status=200,
+        )
+        for i in range(n)
+    ]
+
+
+def _make_scraped(url: str) -> ScrapedPage:
+    return ScrapedPage(
+        url=url,
+        final_url=url,
+        title="Titre",
+        text="Texte readable. " * 50,
+        status="ok",
+        bytes_fetched=10_000,
+        fetched_via_proxy=False,
+    )
+
+
+def _make_summary(url: str, *, status: str = "ok") -> PageSummary:
+    return PageSummary(
+        url=url,
+        final_url=url,
+        title="Titre",
+        summary="Résumé en français.",
+        key_claims=["Claim 1", "Claim 2"],
+        status=status,
+        fetched_via_proxy=False,
+        bytes_fetched=10_000,
+        cached=False,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Plan gating + early returns
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestPlanGating:
+    async def test_free_plan_returns_none(self):
+        video_info = _make_video_info(n_urls=3)
+        result = await extract_external_pages(video_info, user_plan="free")
+        assert result is None
+
+    async def test_unknown_plan_falls_back_to_free(self):
+        video_info = _make_video_info(n_urls=3)
+        result = await extract_external_pages(video_info, user_plan="enterprise")
+        assert result is None
+
+    async def test_empty_description_returns_none(self):
+        result = await extract_external_pages(
+            {"description": "", "title": "X"},
+            user_plan="pro",
+        )
+        assert result is None
+
+    async def test_description_with_no_urls_returns_none(self):
+        result = await extract_external_pages(
+            {"description": "Aucune URL ici, juste du texte.", "title": "X"},
+            user_plan="pro",
+        )
+        assert result is None
+
+    async def test_resolve_returns_empty_returns_none(self):
+        """Si resolve_urls renvoie [], le pipeline doit s'arrêter."""
+        video_info = _make_video_info(n_urls=3)
+        with patch(
+            "videos.external_pages.orchestrator.resolve_urls",
+            new=AsyncMock(return_value=[]),
+        ):
+            result = await extract_external_pages(video_info, user_plan="pro")
+        assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Plan caps
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestPlanCaps:
+    async def test_pro_caps_at_5(self):
+        """7 URLs résolues + pro → on scrape exactement 5."""
+        video_info = _make_video_info(n_urls=7)
+        resolved = _make_resolved(7)
+
+        scrape_calls: List[str] = []
+
+        async def fake_scrape(input_url, final_url):
+            scrape_calls.append(final_url)
+            return _make_scraped(final_url)
+
+        async def fake_summarize(scraped, *, plan, creator_channel, video_title, lang):
+            return _make_summary(scraped.final_url)
+
+        with patch(
+            "videos.external_pages.orchestrator.resolve_urls",
+            new=AsyncMock(return_value=resolved),
+        ), patch(
+            "videos.external_pages.orchestrator.scrape_page",
+            new=fake_scrape,
+        ), patch(
+            "videos.external_pages.orchestrator.summarize_page",
+            new=fake_summarize,
+        ):
+            result = await extract_external_pages(video_info, user_plan="pro")
+
+        assert result is not None
+        assert len(scrape_calls) == 5
+        assert len(result["pages"]) == 5
+        assert result["stats"]["after_cap"] == 5
+
+    async def test_expert_caps_at_10(self):
+        """15 URLs résolues + expert → on scrape exactement 10."""
+        video_info = _make_video_info(n_urls=15)
+        resolved = _make_resolved(15)
+
+        scrape_calls: List[str] = []
+
+        async def fake_scrape(input_url, final_url):
+            scrape_calls.append(final_url)
+            return _make_scraped(final_url)
+
+        async def fake_summarize(scraped, *, plan, creator_channel, video_title, lang):
+            return _make_summary(scraped.final_url)
+
+        with patch(
+            "videos.external_pages.orchestrator.resolve_urls",
+            new=AsyncMock(return_value=resolved),
+        ), patch(
+            "videos.external_pages.orchestrator.scrape_page",
+            new=fake_scrape,
+        ), patch(
+            "videos.external_pages.orchestrator.summarize_page",
+            new=fake_summarize,
+        ):
+            result = await extract_external_pages(video_info, user_plan="expert")
+
+        assert result is not None
+        assert len(scrape_calls) == 10
+        assert len(result["pages"]) == 10
+        assert result["stats"]["after_cap"] == 10
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Concurrency : Semaphore=5 cap
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestConcurrency:
+    async def test_scrape_semaphore_limits_in_flight(self):
+        """Pas plus de SCRAPE_CONCURRENCY scrapes simultanés."""
+        video_info = _make_video_info(n_urls=10)
+        resolved = _make_resolved(10)
+
+        max_in_flight = 0
+        current_in_flight = 0
+        lock = asyncio.Lock()
+
+        async def fake_scrape(input_url, final_url):
+            nonlocal max_in_flight, current_in_flight
+            async with lock:
+                current_in_flight += 1
+                max_in_flight = max(max_in_flight, current_in_flight)
+            # Simule un peu d'I/O pour laisser d'autres tasks s'enchaîner
+            await asyncio.sleep(0.01)
+            async with lock:
+                current_in_flight -= 1
+            return _make_scraped(final_url)
+
+        async def fake_summarize(scraped, *, plan, creator_channel, video_title, lang):
+            return _make_summary(scraped.final_url)
+
+        with patch(
+            "videos.external_pages.orchestrator.resolve_urls",
+            new=AsyncMock(return_value=resolved),
+        ), patch(
+            "videos.external_pages.orchestrator.scrape_page",
+            new=fake_scrape,
+        ), patch(
+            "videos.external_pages.orchestrator.summarize_page",
+            new=fake_summarize,
+        ):
+            result = await extract_external_pages(video_info, user_plan="expert")
+
+        assert result is not None
+        assert max_in_flight <= SCRAPE_CONCURRENCY
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Exception isolation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestExceptionIsolation:
+    async def test_one_scrape_exception_does_not_kill_batch(self):
+        """Si 1 scrape lève, les autres doivent aboutir."""
+        video_info = _make_video_info(n_urls=5)
+        resolved = _make_resolved(5)
+
+        call_idx = {"i": 0}
+
+        async def fake_scrape(input_url, final_url):
+            i = call_idx["i"]
+            call_idx["i"] += 1
+            if i == 2:
+                raise RuntimeError("Boom on index 2")
+            return _make_scraped(final_url)
+
+        async def fake_summarize(scraped, *, plan, creator_channel, video_title, lang):
+            return _make_summary(scraped.final_url)
+
+        with patch(
+            "videos.external_pages.orchestrator.resolve_urls",
+            new=AsyncMock(return_value=resolved),
+        ), patch(
+            "videos.external_pages.orchestrator.scrape_page",
+            new=fake_scrape,
+        ), patch(
+            "videos.external_pages.orchestrator.summarize_page",
+            new=fake_summarize,
+        ):
+            result = await extract_external_pages(video_info, user_plan="pro")
+
+        assert result is not None
+        # 5 candidats, 1 a échoué → 4 PageSummary
+        assert len(result["pages"]) == 4
+
+    async def test_one_summarize_exception_does_not_kill_batch(self):
+        """Si 1 summarize lève, les autres doivent aboutir."""
+        video_info = _make_video_info(n_urls=4)
+        resolved = _make_resolved(4)
+
+        async def fake_scrape(input_url, final_url):
+            return _make_scraped(final_url)
+
+        call_idx = {"i": 0}
+
+        async def fake_summarize(scraped, *, plan, creator_channel, video_title, lang):
+            i = call_idx["i"]
+            call_idx["i"] += 1
+            if i == 1:
+                raise RuntimeError("Mistral exploded")
+            return _make_summary(scraped.final_url)
+
+        with patch(
+            "videos.external_pages.orchestrator.resolve_urls",
+            new=AsyncMock(return_value=resolved),
+        ), patch(
+            "videos.external_pages.orchestrator.scrape_page",
+            new=fake_scrape,
+        ), patch(
+            "videos.external_pages.orchestrator.summarize_page",
+            new=fake_summarize,
+        ):
+            result = await extract_external_pages(video_info, user_plan="pro")
+
+        assert result is not None
+        # 4 candidats, 1 summary a échoué → 3 dans pages
+        assert len(result["pages"]) == 3
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧪 Output dict structure (spec §6)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestOutputStructure:
+    async def test_final_dict_shape(self):
+        video_info = _make_video_info(n_urls=3)
+        resolved = _make_resolved(3)
+
+        async def fake_scrape(input_url, final_url):
+            return _make_scraped(final_url)
+
+        async def fake_summarize(scraped, *, plan, creator_channel, video_title, lang):
+            return _make_summary(scraped.final_url)
+
+        with patch(
+            "videos.external_pages.orchestrator.resolve_urls",
+            new=AsyncMock(return_value=resolved),
+        ), patch(
+            "videos.external_pages.orchestrator.scrape_page",
+            new=fake_scrape,
+        ), patch(
+            "videos.external_pages.orchestrator.summarize_page",
+            new=fake_summarize,
+        ):
+            result = await extract_external_pages(video_info, user_plan="pro")
+
+        assert result is not None
+        # Top-level
+        assert "extracted_at" in result
+        assert isinstance(result["extracted_at"], str)
+        assert result["schema_version"] == SCHEMA_VERSION
+        assert "stats" in result
+        assert "pages" in result
+
+        # Stats keys
+        stats = result["stats"]
+        for key in (
+            "candidates_found",
+            "after_dedup",
+            "after_blacklist",
+            "after_cap",
+            "successful",
+            "paywalled",
+            "errored",
+        ):
+            assert key in stats, f"missing stat: {key}"
+
+        # Page entry shape (spec §6)
+        page = result["pages"][0]
+        for key in (
+            "url",
+            "final_url",
+            "title",
+            "summary",
+            "key_claims",
+            "status",
+            "fetched_via_proxy",
+            "bytes_fetched",
+        ):
+            assert key in page, f"missing page key: {key}"
+        assert isinstance(page["key_claims"], list)
+        assert isinstance(page["fetched_via_proxy"], bool)
+        assert isinstance(page["bytes_fetched"], int)
+
+        assert stats["successful"] == 3
+        assert stats["paywalled"] == 0
+        assert stats["errored"] == 0
+
+    async def test_stats_count_paywalled_and_errored(self):
+        """3 ok + 1 paywall + 1 error → stats reflètent."""
+        video_info = _make_video_info(n_urls=5)
+        resolved = _make_resolved(5)
+
+        statuses = ["ok", "ok", "paywall", "error", "ok"]
+        idx = {"i": 0}
+
+        async def fake_scrape(input_url, final_url):
+            return _make_scraped(final_url)
+
+        async def fake_summarize(scraped, *, plan, creator_channel, video_title, lang):
+            i = idx["i"]
+            idx["i"] += 1
+            return _make_summary(scraped.final_url, status=statuses[i])
+
+        with patch(
+            "videos.external_pages.orchestrator.resolve_urls",
+            new=AsyncMock(return_value=resolved),
+        ), patch(
+            "videos.external_pages.orchestrator.scrape_page",
+            new=fake_scrape,
+        ), patch(
+            "videos.external_pages.orchestrator.summarize_page",
+            new=fake_summarize,
+        ):
+            result = await extract_external_pages(video_info, user_plan="pro")
+
+        assert result is not None
+        stats = result["stats"]
+        assert stats["successful"] == 3
+        assert stats["paywalled"] == 1
+        assert stats["errored"] == 1


### PR DESCRIPTION
## Summary

PR 2/4 of the **Pages externes citées** feature ([spec](docs/superpowers/specs/2026-05-17-pages-externes-citees.md)).
Builds on PR 1 (extractor + resolver + constants — already merged).

Adds the full backend pipeline for scraping + summarizing external pages cited
in a video description, plus storage. **No router/UI wiring** (that's PR 3+4).

### New backend modules
- **`scraper.py`** — Direct GET via `shared_http_client`, fallback Decodo proxy on
  403/429/Cloudflare signal. Body truncated at 500 KB. `trafilatura` (SoTA, JSON
  meta + text) → `readability-lxml` fallback. Paywall heuristic on HTML lowered.
  Returns `ScrapedPage(status ∈ ok/paywall/timeout/non_html/http_error/empty)`.
  Telemetry under `external_page_scrape_<hostname>` via `record_proxy_usage`.
- **`summarizer.py`** — Mistral JSON-mode (`response_format=json_object`,
  max_tokens 300 Pro / 500 Expert, temperature 0.2). Cache Redis cross-user 7
  days under `vcache:external_page:{sha256(final_url)[:16]}`. Prompt enforces
  French output even on English pages (spec R3). Degraded gracefully on
  JSON-parse failure (raw text → summary, no cache set). Returns `PageSummary`.
- **`orchestrator.py`** — `extract_external_pages(video_info, user_plan, lang)`.
  Plan gating (free=skip → None, pro=5, expert=10). Semaphore=5 on scrape +
  summarize. Exception isolation per-URL (1 scrape boom ≠ batch dead). NEVER
  raises — returns None on any failure or `{extracted_at, schema_version, stats,
  pages}` dict (spec §6 schema).

### Storage
- `Summary.external_pages JSONB` (nullable). Migration `031_summary_ext_pages`
  (revision id 21 chars, down_revision=`030_academic_scholar`). Idempotent
  upgrade/downgrade. PostgreSQL JSONB + SQLite JSON via `with_variant`.

### Plan config (`backend/src/billing/plan_config.py`)
- `external_pages_max`: free=0 / pro=5 / expert=10. SSOT cohérent avec
  `PLAN_CAPS` du module `external_pages/constants.py` (PR 1).

### Dependencies
- `trafilatura>=1.6.0`
- `readability-lxml>=0.8.1`

## Test plan

- [x] 55 new tests verts (scraper 26 + summarizer 17 + orchestrator 12)
- [x] PR1 url_extractor + url_resolver tests verts (67/67, no regression)
- [x] Migration idempotent (column existence check, same pattern as 029/030)
- [ ] Manual DB upgrade test in staging (Hetzner) once PR3 wires the writer
- [ ] Full backend suite to be green before merge (CI)

```bash
cd backend && python -m pytest tests/ -v -k "external_page"
# 55 passed, 2274 deselected
```

## Risk

- **Low** — no router/UI wiring, no production traffic hits this code yet
- Migration is additive + nullable + idempotent → rollback-safe (drop column)
- New deps are well-maintained (`trafilatura` 1.12 latest, `readability-lxml`
  v0.8 stable since 2022)
- LLM cost guarded by 7-day cross-user cache + Pro/Expert cap (max 10 URLs)
- Proxy bandwidth: bare-first strategy already in place (spec §4 R6), Decodo
  only hit on 403/429/CF signal

## Notes

- Spec § references followed: §4 (scraping), §5 (Mistral), §6 (storage), §8
  (plan gating), §11 (tests), §13 (phasage PR 2 file list).
- **Deviation from spec**: spec uses revision `029_summary_ext_pages` but 029
  and 030 are already taken (`029_summary_community`, `030_academic_scholar`).
  Migration shifted to **031** with `down_revision=030_academic_scholar`.
- **Deviation**: telemetry provider name uses `external_page_scrape_<hostname>`
  (per task brief contract — unique per host) instead of plain
  `external_page_scrape` (spec §4 example). More granular for the
  `proxy_usage_daily.requests_by_provider` breakdown.
- **Deviation**: scraper status terminology updated to spec §4 edge-cases table
  (`paywall` instead of `paywalled`, `non_html` instead of `skipped_content_type`,
  `timeout` instead of `error+error="timeout"`). Cleaner enum, same semantics.
- Out of scope (per spec §13): `videos/router.py` integration (PR3), web UI
  (PR3), mobile UI (PR4), extension UI (PR4), public schemas / Pydantic models
  for the API response (PR3 will add them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)