### PR TITLE
feat(external_pages): pipeline v6 + v2.1 integration (PR 3 backend / 4)

### DIFF
--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -2335,23 +2335,39 @@ async def _analyze_video_background_v2_1(
                     logger.error(f"⚠️ [v2.1] Community take failed: {e}")
                     return None
 
-            # ⚡ Lancer les 5 tâches en parallèle
+            # 🔗 External pages (NEW 2026-05-17 — PR3) — 6e tâche parallèle non-bloquante.
+            async def _external_pages_v21():
+                try:
+                    from videos.external_pages.orchestrator import extract_external_pages
+
+                    return await extract_external_pages(
+                        video_info=video_info,
+                        user_plan=user_plan,
+                        lang=lang or "fr",
+                    )
+                except Exception as e:
+                    logger.warning(f"⚠️ [v2.1] External pages extraction failed: {e}")
+                    return None
+
+            # ⚡ Lancer les 6 tâches en parallèle
             (
                 (category, confidence),
                 comments_analysis_result,
                 metadata_enriched_result,
                 (_web_ctx, _enrich_src, _),
                 community_take_result,
+                external_pages_result,
             ) = await asyncio.gather(
                 _detect_cat_v21(),
                 _analyze_comments_v21(),
                 _enrich_metadata_v21(),
                 _enrich_web_v21(),
                 _community_take_v21(),
+                _external_pages_v21(),
             )
             web_context = _web_ctx
             enrichment_sources = _enrich_src
-            logger.info("⚡ [v2.1.1] Category + comments + metadata + web + community computed in PARALLEL")
+            logger.info("⚡ [v2.1.1] Category + comments + metadata + web + community + external_pages computed in PARALLEL")
 
             # ═══════════════════════════════════════════════════════════════════
             # 7. 🆕 CONSTRUIRE LE PROMPT PERSONNALISÉ
@@ -2607,6 +2623,10 @@ async def _analyze_video_background_v2_1(
                 community_take_result.model_dump(mode="json") if community_take_result is not None else None
             )
 
+            # 🔗 External pages (NEW 2026-05-17 — PR3) — déjà un dict canonique
+            # (cf orchestrator), ou None si pas généré.
+            _external_pages_dict = external_pages_result if isinstance(external_pages_result, dict) else None
+
             summary_id = await save_summary(
                 session=session,
                 user_id=user_id,
@@ -2643,6 +2663,8 @@ async def _analyze_video_background_v2_1(
                 carousel_images=video_info.get("carousel_images"),
                 # 💬 Community analysis (alembic 029)
                 community_analysis=_community_dict,
+                # 🔗 External pages (alembic 031 — PR3)
+                external_pages=_external_pages_dict,
             )
 
             # 👁️ Phase 2 plumbing V2.1 : persist visual_analysis si capturé.
@@ -3185,12 +3207,29 @@ async def _analyze_video_background_v6(
                     logger.error(f"⚠️ [v6] Community take failed: {e}")
                     return None
 
-            # ⚡ Lancer les 4 en parallèle (return_exceptions=True pour fail-safe)
+            # 🔗 External pages (NEW 2026-05-17 — PR3) — 5e tâche parallèle non-bloquante.
+            # Plan gating (free skip), description-driven, timeout interne 30s+ par page,
+            # contrat NE LÈVE JAMAIS dans l'orchestrator. Wrap supplémentaire defensive ici.
+            async def _external_pages_async():
+                try:
+                    from videos.external_pages.orchestrator import extract_external_pages
+
+                    return await extract_external_pages(
+                        video_info=video_info,
+                        user_plan=user_plan,
+                        lang=lang or "fr",
+                    )
+                except Exception as e:
+                    logger.warning(f"⚠️ [v6] External pages extraction failed: {e}")
+                    return None
+
+            # ⚡ Lancer les 5 en parallèle (return_exceptions=True pour fail-safe)
             results = await asyncio.gather(
                 _detect_category_async(),
                 _enrich_web_async(),
                 _fetch_channel_context_async(),
                 _community_take_async(),
+                _external_pages_async(),
                 return_exceptions=True,
             )
 
@@ -3229,8 +3268,17 @@ async def _analyze_video_background_v6(
                 else:
                     community_take_result = comm_result
 
+            # 🔗 Unpack external pages (avec safety) — NEW 2026-05-17 (PR3)
+            external_pages_result = None
+            if len(results) > 4:
+                ext_result = results[4]
+                if isinstance(ext_result, Exception):
+                    logger.warning(f"⚠️ [v6] External pages raised: {ext_result}")
+                else:
+                    external_pages_result = ext_result
+
             _task_store[task_id]["progress"] = 45
-            logger.info("⚡ [v6.1] Category + web + channel + community computed in PARALLEL")
+            logger.info("⚡ [v6.1] Category + web + channel + community + external_pages computed in PARALLEL")
 
             # ═══════════════════════════════════════════════════════════════════
             # 5. GÉNÉRER LE RÉSUMÉ (MISTRAL) AVEC CONTEXTE WEB
@@ -3490,6 +3538,10 @@ async def _analyze_video_background_v6(
                 community_take_result.model_dump(mode="json") if community_take_result is not None else None
             )
 
+            # 🔗 External pages (NEW 2026-05-17 — PR3) — déjà un dict canonique
+            # (cf orchestrator), ou None si pas généré.
+            _external_pages_dict_v6 = external_pages_result if isinstance(external_pages_result, dict) else None
+
             # Sauvegarder le résumé
             summary_id = await save_summary(
                 session=session,
@@ -3528,6 +3580,8 @@ async def _analyze_video_background_v6(
                 carousel_images=video_info.get("carousel_images"),
                 # 💬 Community analysis (alembic 029)
                 community_analysis=_community_dict_v6,
+                # 🔗 External pages (alembic 031 — PR3)
+                external_pages=_external_pages_dict_v6,
             )
 
             logger.info(f"💾 Summary saved: id={summary_id}")

--- a/backend/src/videos/schemas.py
+++ b/backend/src/videos/schemas.py
@@ -306,6 +306,15 @@ class SummaryResponse(BaseModel):
     # NULL = pas analysé (free plan, scrape failed, Mistral timeout, etc.).
     community_analysis: Optional[Dict[str, Any]] = None
 
+    # 🔗 External pages (NEW 2026-05-17 — alembic 031, PR3).
+    # Pages externes citées dans la description vidéo, scrapées + résumées par
+    # Mistral. Dict canonique construit par videos/external_pages/orchestrator :
+    # {extracted_at, schema_version, stats{}, pages[{url, final_url, title,
+    # summary, key_claims[], status, fetched_via_proxy, bytes_fetched}]}.
+    # NULL = pas analysé (free plan, description vide, aucune URL exploitable,
+    # toutes les pages ont échoué, etc.).
+    external_pages: Optional[Dict[str, Any]] = None
+
     is_public: bool = False
 
     class Config:

--- a/backend/src/videos/service.py
+++ b/backend/src/videos/service.py
@@ -147,6 +147,8 @@ async def save_summary(
     carousel_images: Optional[List[str]] = None,
     # 💬 Community analysis (NEW 2026-05-17 — alembic 029)
     community_analysis: Optional[Dict] = None,
+    # 🔗 External pages (NEW 2026-05-17 — alembic 031, PR3)
+    external_pages: Optional[Dict] = None,
 ) -> int:
     """Sauvegarde un nouveau résumé et retourne son ID"""
     print(f"💾 [save_summary v2] Saving video_id={video_id}, user_id={user_id}", flush=True)
@@ -318,6 +320,10 @@ async def save_summary(
     # 💬 Community analysis (alembic 029) — best-effort, ne pas bloquer si attr absent
     if community_analysis is not None and hasattr(summary, "community_analysis"):
         summary.community_analysis = community_analysis
+
+    # 🔗 External pages (alembic 031 — PR3) — best-effort, ne pas bloquer si attr absent
+    if external_pages is not None and hasattr(summary, "external_pages"):
+        summary.external_pages = external_pages
 
     # Ajouter enrichment_data si le modèle le supporte
     if enrichment_data and hasattr(summary, "enrichment_data"):

--- a/backend/tests/test_router_external_pages_integration.py
+++ b/backend/tests/test_router_external_pages_integration.py
@@ -1,0 +1,268 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — PR3 external_pages pipeline integration                                ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Couvre l'intégration de extract_external_pages dans le pipeline v6/v2.1 :         ║
+║                                                                                    ║
+║    1. save_summary persiste correctement le dict external_pages                    ║
+║    2. save_summary accepte None pour external_pages (skip persistence)             ║
+║    3. l'orchestrator est importable depuis le path qu'utilise router.py            ║
+║    4. signature compatible — extract_external_pages(video_info, user_plan, lang)   ║
+║                                                                                    ║
+║  Note : le pipeline v6 complet n'est pas testé end-to-end ici — c'est trop         ║
+║  intriqué (transcript, Mistral, save_summary etc.). On teste les blocs unitaires   ║
+║  qui forment le contrat de wire-up : import path + signature orchestrator,         ║
+║  persistence via save_summary, et le shape attendu sur le retour None.             ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+import inspect
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from videos.external_pages.orchestrator import extract_external_pages
+from videos.service import save_summary
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. Import path + signature
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_orchestrator_importable_from_router_path():
+    """router.py importe via `from videos.external_pages.orchestrator import extract_external_pages` — vérifie que ce path résout bien la coroutine."""
+    assert callable(extract_external_pages)
+    assert inspect.iscoroutinefunction(extract_external_pages)
+
+
+def test_orchestrator_signature_matches_wire_up():
+    """router.py appelle extract_external_pages(video_info=..., user_plan=..., lang=...) — vérifie que la signature accepte ces 3 kwargs."""
+    sig = inspect.signature(extract_external_pages)
+    params = sig.parameters
+    assert "video_info" in params, "router.py passe video_info=...; le param doit exister"
+    assert "user_plan" in params, "router.py passe user_plan=...; le param doit exister"
+    assert "lang" in params, "router.py passe lang=...; le param doit exister"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. save_summary persistence
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_save_summary_accepts_external_pages_kwarg():
+    """save_summary doit accepter le kwarg external_pages (PR3 wire-up)."""
+    sig = inspect.signature(save_summary)
+    assert "external_pages" in sig.parameters
+    # Default doit être None pour rester rétrocompatible
+    assert sig.parameters["external_pages"].default is None
+
+
+def test_save_summary_external_pages_default_is_none_optional_dict():
+    """external_pages: Optional[Dict] = None — vérifie annotation."""
+    sig = inspect.signature(save_summary)
+    annot = sig.parameters["external_pages"].annotation
+    # Optional[Dict] résout à Optional[Dict] / Union[Dict, None]
+    annot_str = str(annot)
+    assert "Dict" in annot_str or "dict" in annot_str.lower(), (
+        f"Expected Optional[Dict] annotation, got {annot_str}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. Orchestrator contract — NE LÈVE JAMAIS sur input dégradé
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_returns_none_on_free_plan():
+    """Free plan → skip total (cap=0). Garantit le contrat utilisé par router.py
+    qui s'appuie sur None pour skipper la persistence."""
+    video_info = {
+        "description": "Check out https://example.com/article",
+        "title": "Test",
+        "channel": "TestChan",
+    }
+    result = await extract_external_pages(video_info=video_info, user_plan="free", lang="fr")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_returns_none_on_empty_description():
+    """Description vide → None. Garantit que le wire-up ne casse pas quand
+    video_info.description est absent (typique TikTok carousel par ex)."""
+    video_info = {"description": "", "title": "Test", "channel": "TestChan"}
+    result = await extract_external_pages(video_info=video_info, user_plan="pro", lang="fr")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_returns_none_on_no_urls():
+    """Description sans URL → None."""
+    video_info = {
+        "description": "Pas d'URL ici, juste du texte sans rien d'intéressant.",
+        "title": "Test",
+        "channel": "TestChan",
+    }
+    result = await extract_external_pages(video_info=video_info, user_plan="pro", lang="fr")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_swallows_exceptions_never_raises():
+    """Le contrat strict : extract_external_pages NE LÈVE JAMAIS. Si une étape
+    interne crashe, on retourne None proprement. router.py wrap déjà en
+    try/except pour double safety, mais ce test garantit la première ligne
+    de défense au niveau de l'orchestrator."""
+    # Force resolve_urls à throw une exception arbitraire
+    with patch(
+        "videos.external_pages.orchestrator.resolve_urls",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        video_info = {
+            "description": "https://example.com/foo",
+            "title": "Test",
+            "channel": "TestChan",
+        }
+        # Doit retourner None sans propager l'exception
+        result = await extract_external_pages(
+            video_info=video_info, user_plan="pro", lang="fr"
+        )
+        assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. Shape du dict canonique (sanity — la PR2 le couvre déjà mais on
+#    documente le contrat consommé par le wire-up router/save_summary).
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_dict_shape_when_pipeline_succeeds():
+    """Quand le pipeline va jusqu'au bout, le dict retourné a la shape exacte
+    consommée par save_summary → Summary.external_pages (JSON column).
+    """
+    from videos.external_pages.scraper import ScrapedPage
+    from videos.external_pages.summarizer import PageSummary
+    from videos.external_pages.url_resolver import ResolvedURL
+
+    resolved = [
+        ResolvedURL(
+            input_url="https://example.com/a",
+            final_url="https://example.com/a",
+            status=200,
+        )
+    ]
+    scraped = ScrapedPage(
+        url="https://example.com/a",
+        final_url="https://example.com/a",
+        title="Article A",
+        text="some long text body" * 50,
+        status="ok",
+        bytes_fetched=1000,
+        fetched_via_proxy=False,
+    )
+    page_summary = PageSummary(
+        url="https://example.com/a",
+        final_url="https://example.com/a",
+        title="Article A",
+        summary="A summary",
+        key_claims=["Claim 1", "Claim 2"],
+        status="ok",
+        fetched_via_proxy=False,
+        bytes_fetched=1000,
+    )
+
+    with patch(
+        "videos.external_pages.orchestrator.resolve_urls",
+        new=AsyncMock(return_value=resolved),
+    ), patch(
+        "videos.external_pages.orchestrator.scrape_page",
+        new=AsyncMock(return_value=scraped),
+    ), patch(
+        "videos.external_pages.orchestrator.summarize_page",
+        new=AsyncMock(return_value=page_summary),
+    ):
+        video_info = {
+            "description": "Source : https://example.com/a",
+            "title": "Test",
+            "channel": "TestChan",
+        }
+        result = await extract_external_pages(
+            video_info=video_info, user_plan="pro", lang="fr"
+        )
+
+    # Shape canonique consommée par save_summary
+    assert isinstance(result, dict)
+    assert set(result.keys()) >= {"extracted_at", "schema_version", "stats", "pages"}
+    assert result["schema_version"] == 1
+    assert isinstance(result["pages"], list)
+    assert len(result["pages"]) == 1
+    page = result["pages"][0]
+    assert set(page.keys()) >= {
+        "url",
+        "final_url",
+        "title",
+        "summary",
+        "key_claims",
+        "status",
+        "fetched_via_proxy",
+        "bytes_fetched",
+    }
+    # Doit être JSON-sérialisable (column JSON)
+    import json
+
+    json.dumps(result)  # raise si non-sérialisable
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. Schemas — SummaryResponse expose external_pages
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_summary_response_exposes_external_pages_field():
+    """SummaryResponse doit exposer external_pages: Optional[Dict] pour que
+    le frontend (futur PR3.5) puisse le consommer."""
+    from videos.schemas import SummaryResponse
+
+    fields = SummaryResponse.model_fields
+    assert "external_pages" in fields, (
+        "SummaryResponse doit exposer external_pages (PR3 wire-up)"
+    )
+    # Default doit être None
+    assert fields["external_pages"].default is None
+
+
+def test_summary_response_external_pages_serializes_dict():
+    """Smoke test Pydantic v2 : SummaryResponse.external_pages accepte un dict
+    arbitraire (Dict[str, Any]) tel que le retour orchestrator."""
+    from datetime import datetime
+
+    from videos.schemas import SummaryResponse
+
+    payload = {
+        "id": 1,
+        "video_id": "abc",
+        "video_title": "T",
+        "video_channel": "C",
+        "video_duration": 60,
+        "video_url": "https://yt/abc",
+        "thumbnail_url": "",
+        "category": "tech",
+        "lang": "fr",
+        "mode": "default",
+        "model_used": "mistral-small",
+        "summary_content": "X",
+        "word_count": 1,
+        "created_at": datetime.utcnow(),
+        "external_pages": {
+            "extracted_at": "2026-05-17T00:00:00Z",
+            "schema_version": 1,
+            "stats": {"successful": 1},
+            "pages": [{"url": "https://e.com", "title": "T"}],
+        },
+    }
+    response = SummaryResponse(**payload)
+    assert response.external_pages is not None
+    assert response.external_pages["schema_version"] == 1


### PR DESCRIPTION
## Summary

PR 3/4 — wires the `extract_external_pages` orchestrator (PR 2, merged in #496) into the main DeepSight video analysis pipelines:

- **Pipeline v6** (`_analyze_video_internal`) — 5th parallel task alongside category / web enrichment / channel context / community take.
- **Pipeline v2.1** (`analyze_video_v2_1`) — 6th parallel task alongside category / comments / metadata / web / community take.

The orchestrator returns either a canonical dict `{extracted_at, schema_version, stats, pages[]}` or `None` (free plan, empty description, no URLs, all scrapes failed). The result is piped to `save_summary()` and persisted on `Summary.external_pages` (JSON column from alembic 031, already shipped with PR 2).

## Wire-up details

- Orchestrator contract: **NEVER raises** — internal try/except + last-resort safety net. Router-level wrap is defensive only.
- v6 uses `asyncio.gather(..., return_exceptions=True)` → double-safety on the unpack.
- v2.1 uses regular `asyncio.gather` because each helper catches its own exceptions and returns `None`.
- Plan gating happens **inside** the orchestrator (`PLAN_CAPS`: free=0, pro=5, expert=10) — router doesn't second-guess.
- `SummaryResponse.external_pages: Optional[Dict[str, Any]] = None` exposed for the future frontend PR (3.5).

## Files touched (~140 net LOC)

- `backend/src/videos/router.py` — 2 new helpers + gather extension + save_summary call (× 2 pipelines)
- `backend/src/videos/service.py` — `save_summary(external_pages=None)` kwarg + defensive `hasattr` persistence
- `backend/src/videos/schemas.py` — `SummaryResponse.external_pages` field
- `backend/tests/test_router_external_pages_integration.py` — **9 new unit tests** covering the wire-up contract

## Tests

9 new unit tests in `test_router_external_pages_integration.py`:

1. Orchestrator importable from the path used by `router.py`
2. Orchestrator signature accepts `video_info` / `user_plan` / `lang` kwargs
3. `save_summary` accepts `external_pages` kwarg with `None` default
4. `external_pages` annotation is `Optional[Dict]`
5. Orchestrator returns `None` on free plan
6. Orchestrator returns `None` on empty description
7. Orchestrator returns `None` on description without URLs
8. Orchestrator swallows internal exceptions (never raises) — patched `resolve_urls` to throw
9. Orchestrator dict shape matches what `save_summary` consumes (smoke test of `JSON.dumps`-ability + canonical keys)
10. `SummaryResponse` exposes `external_pages` field
11. `SummaryResponse(external_pages={...})` accepts arbitrary dict (Pydantic v2 smoke)

Approach: **direct unit tests of the helpers + orchestrator contract**, not E2E pipeline tests. The full `/api/videos/analyze` flow is too intricate to TestClient-mock cleanly (transcript extraction, Mistral, save_summary cascade, Hetzner-only deps). The unit tests pin the contract surface that the wire-up depends on — if any of these regress, the wire-up breaks deterministically.

Local note: PR 2 tests (orchestrator/scraper/summarizer) and my PR 3 tests share a pre-existing local-only circular import on Windows (`auth.service` ↔ `auth.dependencies`). **CI passes for PR 2** (#496 Backend Pytest green), and my new tests use the same import pattern + conftest plumbing, so they'll behave identically in CI.

## Scope deferred

- **PR 3.5** — Web UI (frontend `ExternalSourcesSection` + i18n + Hub integration).
- **PR 4** — Mobile + extension surfaces.

## Test plan

- [ ] CI Backend (pytest) green
- [ ] CI Frontend (vitest) green (unchanged file surface)
- [ ] Merge → Hetzner auto-deploy → smoke `/api/videos/analyze` with a Pro/Expert user on a YouTube video carrying 3-5 description URLs → `Summary.external_pages` populated
- [ ] (Manual) Free user on same video → `external_pages = NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)