### PR TITLE
feat(workspaces): bouton Créer un workspace sur /hub/workspaces

### DIFF
--- a/frontend/src/components/hub/ConversationsDrawer.tsx
+++ b/frontend/src/components/hub/ConversationsDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect } from "react";
+import React, { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   X,
@@ -27,6 +27,12 @@ interface Props {
    * fourni, la barre input n'est pas rendue.
    */
   onAnalyze?: (url: string) => void | Promise<void>;
+  /**
+   * Quand `true`, active automatiquement le mode multi-select à l'ouverture
+   * du drawer (one-shot par cycle open/close). Utilisé par le bouton "Créer
+   * un workspace" sur `/hub/workspaces` qui navigue vers `/hub?newWorkspace=1`.
+   */
+  autoSelectMode?: boolean;
 }
 
 const PLATFORM_ICON: Record<
@@ -82,6 +88,7 @@ export const ConversationsDrawer: React.FC<Props> = ({
   activeConvId,
   onSelect,
   onAnalyze,
+  autoSelectMode = false,
 }) => {
   const navigate = useNavigate();
   const { user } = useAuthContext();
@@ -107,6 +114,21 @@ export const ConversationsDrawer: React.FC<Props> = ({
       setSelectedSummaryIds(new Set());
     }
   }, [open]);
+
+  // Auto-activation du mode select à l'ouverture quand demandé par le parent
+  // (ex. bouton "Créer un workspace" depuis /hub/workspaces). One-shot par
+  // cycle open/close — le ref est reset quand le drawer se referme.
+  const autoActivatedRef = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      autoActivatedRef.current = false;
+      return;
+    }
+    if (autoSelectMode && canUseHubWorkspace && !autoActivatedRef.current) {
+      setIsSelectMode(true);
+      autoActivatedRef.current = true;
+    }
+  }, [open, autoSelectMode, canUseHubWorkspace]);
 
   const exitSelectMode = useCallback(() => {
     setIsSelectMode(false);

--- a/frontend/src/pages/HubPage.tsx
+++ b/frontend/src/pages/HubPage.tsx
@@ -275,6 +275,28 @@ const HubPageInner: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [voiceAutoOpen]);
 
+  // ── Workspace creation auto-open — `/hub?newWorkspace=1` ──
+  // Bouton "Créer un workspace" sur /hub/workspaces navigue ici avec ce flag,
+  // ce qui ouvre le ConversationsDrawer en mode multi-select prêt à cocher
+  // les analyses qui composeront le nouveau workspace. Le flag est stripé
+  // immédiatement pour que back-nav / reload n'inflige pas le mode select.
+  const newWorkspaceAutoOpen = searchParams.get("newWorkspace") === "1";
+  const [autoSelectModeNext, setAutoSelectModeNext] = React.useState(false);
+  useEffect(() => {
+    if (!newWorkspaceAutoOpen) return;
+    setAutoSelectModeNext(true);
+    if (!drawerOpen) toggleDrawer();
+    const next = new URLSearchParams(searchParams);
+    next.delete("newWorkspace");
+    setSearchParams(next, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [newWorkspaceAutoOpen]);
+  // Reset l'auto-select quand le drawer se referme — sinon la prochaine
+  // ouverture manuelle hériterait du flag.
+  useEffect(() => {
+    if (!drawerOpen) setAutoSelectModeNext(false);
+  }, [drawerOpen]);
+
   const { analyze: triggerAnalyze, error: hookError } = useAnalyzeAndOpenHub();
   // Affiche les erreurs du hook (URL invalide, fetch failed) dans le placeholder.
   useEffect(() => {
@@ -886,6 +908,7 @@ const HubPageInner: React.FC = () => {
               setSearchParams({ conv: String(id) });
             }}
             onAnalyze={triggerAnalyze}
+            autoSelectMode={autoSelectModeNext}
           />
 
           <NewConversationModal

--- a/frontend/src/pages/HubWorkspacesPage.tsx
+++ b/frontend/src/pages/HubWorkspacesPage.tsx
@@ -30,6 +30,7 @@ import {
   Calendar,
   Crown,
   Layers,
+  Plus,
   RefreshCw,
   Sparkles,
   Trash2,
@@ -875,13 +876,26 @@ const HubWorkspacesPage: React.FC = () => {
         <div className="min-h-screen p-4 sm:p-6 lg:p-8 pb-8 pt-14 lg:pt-8">
           <div className="max-w-5xl mx-auto">
             {!isDetailMode && (
-              <header className="mb-8">
-                <h1 className="text-2xl sm:text-3xl font-semibold text-white mb-2">
-                  Mes Workspaces
-                </h1>
-                <p className="text-sm text-text-secondary">
-                  Tableaux Miro pour explorer plusieurs analyses ensemble.
-                </p>
+              <header className="mb-8 flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h1 className="text-2xl sm:text-3xl font-semibold text-white mb-2">
+                    Mes Workspaces
+                  </h1>
+                  <p className="text-sm text-text-secondary">
+                    Tableaux Miro pour explorer plusieurs analyses ensemble.
+                  </p>
+                </div>
+                {isExpert && (
+                  <button
+                    type="button"
+                    onClick={() => navigate("/hub?newWorkspace=1")}
+                    data-testid="hub-workspaces-create-cta"
+                    className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-indigo-500/15 hover:bg-indigo-500/25 border border-indigo-400/30 text-sm font-medium text-indigo-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60"
+                  >
+                    <Plus className="w-4 h-4" />
+                    Créer un workspace
+                  </button>
+                )}
               </header>
             )}
             {renderInner()}


### PR DESCRIPTION
## Summary

Expose la création de workspace directement depuis `/hub/workspaces` (page Mes Workspaces). Aujourd'hui la création nécessite de passer par Hub > ConversationsDrawer > select mode — non-discoverable depuis la page workspaces elle-même.

Le bouton "Créer un workspace" navigue vers `/hub?newWorkspace=1`, qui ouvre le `ConversationsDrawer` en mode multi-select prêt à cocher 2-20 analyses, réutilisant **tout** le flow de création existant (modal, validation backend, store Zustand). Pattern URL-flag copié de `?voice=1`.

## Files changed

- **`ConversationsDrawer.tsx`** : nouvelle prop `autoSelectMode?: boolean`. Activation one-shot via `useRef` à chaque cycle open→close pour éviter une re-activation involontaire lors d'une ouverture manuelle ultérieure.
- **`HubPage.tsx`** : détection `?newWorkspace=1` → ouvre le drawer + propage `autoSelectMode={true}`, puis strip le param (sinon back-nav ou reload re-déclencherait le select mode).
- **`HubWorkspacesPage.tsx`** : bouton header (icône Plus + label) à droite du titre. Gating Expert cohérent avec le reste de la feature (`isExpert` déjà calculé ligne 710).

## Test plan

- [ ] **Preview Vercel** : ouvrir `/hub/workspaces` → bouton "Créer un workspace" visible à droite du titre
- [ ] Clic → navigation vers `/hub` + ConversationsDrawer auto-ouvert + select mode actif
- [ ] URL après ouverture = `/hub` (sans param `?newWorkspace=1`)
- [ ] Cocher 2-20 analyses + "Créer workspace" → modal s'ouvre, nom requis, workspace créé
- [ ] Fermer le drawer puis le rouvrir manuellement → PAS en select mode (one-shot validé)
- [ ] Plan Free/Pro → bouton invisible (gating Expert)

## Tests automatisés

- Typecheck ✓ (0 erreur)
- Vitest ciblé : 24/24 passés (ConversationsDrawer 10, CreateWorkspaceModal 7, HubWorkspacesPage 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)