### PR TITLE
feat(external_pages): ExternalSourcesSection UI web + i18n + plan gating (PR 3.5/4)

### DIFF
--- a/frontend/src/components/AnalysisHub/SynthesisTab.tsx
+++ b/frontend/src/components/AnalysisHub/SynthesisTab.tsx
@@ -34,6 +34,7 @@ import { KeywordsModal } from "../KeywordsModal";
 import { AnalysisActionBar } from "../analysis/AnalysisActionBar";
 import { DebateContextualCTA } from "../debate";
 import { CommunityTakeSection } from "../CommunityTakeSection";
+import { ExternalSourcesSection } from "../ExternalSourcesSection";
 import { videoApi, shareApi } from "../../services/api";
 import { sanitizeTitle } from "../../utils/sanitize";
 import type { Summary, EnrichedConcept } from "../../services/api";
@@ -265,6 +266,18 @@ export const SynthesisTab: React.FC<SynthesisTabProps> = ({
         <div className="mt-6 not-prose">
           <CommunityTakeSection
             take={selectedSummary.community_analysis}
+            userPlan={user?.plan}
+            language={language}
+            onUpgradeClick={() => onNavigate("/pricing")}
+          />
+        </div>
+
+        {/* 🔗 Sources externes citées — scrape + Mistral mini-summary (PR3.5 web).
+            Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9
+            Plan gating : free → CTA upgrade, pro/expert → cards horizontales. */}
+        <div className="mt-6 not-prose">
+          <ExternalSourcesSection
+            data={selectedSummary.external_pages}
             userPlan={user?.plan}
             language={language}
             onUpgradeClick={() => onNavigate("/pricing")}

--- a/frontend/src/components/ExternalSourceCard.tsx
+++ b/frontend/src/components/ExternalSourceCard.tsx
@@ -1,0 +1,147 @@
+/**
+ * DEEP SIGHT — ExternalSourceCard
+ *
+ * Card individuelle dans <ExternalSourcesSection>. Affiche favicon + host +
+ * titre + résumé Mistral + 2 key_claims max + lien "Ouvrir".
+ *
+ * Status gating :
+ *  - ok                                    → résumé + claims complet
+ *  - paywall                               → notice "Article payant"
+ *  - http_error / non_html                 → notice "Page introuvable"
+ *  - error / timeout / empty               → notice "Contenu non extractible"
+ */
+
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+import { ExternalLink, AlertCircle, Lock, FileX } from "lucide-react";
+import type { ExternalPageCitation } from "../services/api";
+
+interface Props {
+  page: ExternalPageCitation;
+  index: number;
+  language: "fr" | "en";
+}
+
+const SAFE_HOST = (rawUrl: string): string => {
+  try {
+    return new URL(rawUrl).hostname.replace(/^www\./, "");
+  } catch {
+    return rawUrl.slice(0, 60);
+  }
+};
+
+export const ExternalSourceCard: React.FC<Props> = ({
+  page,
+  index,
+  language,
+}) => {
+  const host = SAFE_HOST(page.final_url);
+  const [faviconError, setFaviconError] = useState(false);
+  const faviconUrl = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=32`;
+
+  const renderBody = () => {
+    if (page.status === "paywall") {
+      return (
+        <div className="flex items-center gap-2 text-amber-400 text-xs">
+          <Lock className="w-3.5 h-3.5 shrink-0" />
+          <span>
+            {language === "fr"
+              ? "Article payant non accessible"
+              : "Paywalled article"}
+          </span>
+        </div>
+      );
+    }
+    if (page.status === "http_error" || page.status === "non_html") {
+      return (
+        <div className="flex items-center gap-2 text-rose-400 text-xs">
+          <FileX className="w-3.5 h-3.5 shrink-0" />
+          <span>
+            {language === "fr" ? "Page introuvable" : "Page not found"}
+          </span>
+        </div>
+      );
+    }
+    if (
+      page.status === "error" ||
+      page.status === "timeout" ||
+      page.status === "empty"
+    ) {
+      return (
+        <div className="flex items-center gap-2 text-text-muted text-xs">
+          <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+          <span>
+            {language === "fr"
+              ? "Contenu non extractible"
+              : "Content unavailable"}
+          </span>
+        </div>
+      );
+    }
+    return (
+      <>
+        <p className="text-sm text-text-secondary line-clamp-3 leading-relaxed">
+          {page.summary}
+        </p>
+        {page.key_claims.length > 0 && (
+          <ul className="mt-2 text-xs text-text-muted list-disc list-inside space-y-1">
+            {page.key_claims.slice(0, 2).map((claim, i) => (
+              <li key={i} className="line-clamp-1">
+                {claim}
+              </li>
+            ))}
+          </ul>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, delay: index * 0.04 }}
+      className="snap-start flex-shrink-0 w-72 bg-white/5 border border-white/10 rounded-xl p-4 hover:border-indigo-400/30 transition-colors backdrop-blur-xl flex flex-col"
+      data-testid="external-source-card"
+      data-index={index}
+    >
+      <header className="flex items-center gap-2 mb-2 min-w-0">
+        {!faviconError ? (
+          <img
+            src={faviconUrl}
+            width={16}
+            height={16}
+            alt=""
+            className="rounded-sm shrink-0"
+            onError={() => setFaviconError(true)}
+          />
+        ) : (
+          <div className="w-4 h-4 rounded-sm bg-indigo-500/20 shrink-0" />
+        )}
+        <span className="text-xs text-text-muted truncate">{host}</span>
+      </header>
+
+      <h4
+        className="text-sm font-semibold text-text-primary line-clamp-2 mb-2"
+        title={page.title || page.final_url}
+      >
+        {page.title || page.final_url}
+      </h4>
+
+      <div className="flex-1">{renderBody()}</div>
+
+      <a
+        href={page.final_url}
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        className="mt-3 inline-flex items-center gap-1 text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+        aria-label={`${language === "fr" ? "Ouvrir" : "Open"} ${page.title || host}`}
+      >
+        {language === "fr" ? "Ouvrir" : "Open"}
+        <ExternalLink className="w-3 h-3" />
+      </a>
+    </motion.article>
+  );
+};
+
+export default ExternalSourceCard;

--- a/frontend/src/components/ExternalSourcesSection.tsx
+++ b/frontend/src/components/ExternalSourcesSection.tsx
@@ -1,0 +1,96 @@
+/**
+ * DEEP SIGHT — ExternalSourcesSection
+ *
+ * Pages externes citées dans la description vidéo (URLs scrapées + résumées
+ * par Mistral). Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9.
+ *
+ * Gating :
+ *  - free  → <ExternalSourcesUpgradeCTA />
+ *  - pro   → vue complète (cap 5 pages)
+ *  - expert → vue complète (cap 10 pages)
+ *
+ * Empty states : `data=null` (rien à afficher, silent), `data.pages.length===0`
+ * (idem, silent — pipeline backend retourne null dans ce cas mais on défend).
+ */
+
+import React from "react";
+import { motion } from "framer-motion";
+import { Link2 } from "lucide-react";
+import type { ExternalPagesData } from "../services/api";
+import { canAccess } from "../config/planPrivileges";
+import { ExternalSourcesUpgradeCTA } from "./ExternalSourcesUpgradeCTA";
+import { ExternalSourceCard } from "./ExternalSourceCard";
+
+interface Props {
+  data: ExternalPagesData | null | undefined;
+  userPlan: string | undefined | null;
+  language: "fr" | "en";
+  onUpgradeClick?: () => void;
+}
+
+export const ExternalSourcesSection: React.FC<Props> = ({
+  data,
+  userPlan,
+  language,
+  onUpgradeClick,
+}) => {
+  const plan = (userPlan || "free").toLowerCase();
+  const isAllowed = canAccess(plan, "external_sources", "web");
+
+  // Free plan → CTA upgrade (afficher même si pas de data, pour discoverability).
+  if (!isAllowed) {
+    return (
+      <ExternalSourcesUpgradeCTA
+        language={language}
+        onUpgradeClick={onUpgradeClick}
+      />
+    );
+  }
+
+  // Pas encore généré ou aucune page exploitable → silent (pipeline asynchrone,
+  // peut être null si description vide / aucune URL / toutes les pages ont échoué).
+  if (!data || !data.pages || data.pages.length === 0) {
+    return null;
+  }
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="rounded-xl bg-white/5 border border-indigo-500/20 backdrop-blur-xl p-5"
+      data-testid="external-sources-section"
+    >
+      <header className="flex items-start gap-3 mb-4">
+        <div className="w-10 h-10 rounded-lg bg-indigo-500/15 flex items-center justify-center shrink-0">
+          <Link2 className="w-5 h-5 text-indigo-400" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-semibold text-text-primary">
+            {language === "fr"
+              ? "Sources externes citées"
+              : "External sources cited"}
+          </h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            {language === "fr"
+              ? `${data.stats.successful}/${data.pages.length} pages traitées`
+              : `${data.stats.successful}/${data.pages.length} pages processed`}
+          </p>
+        </div>
+      </header>
+
+      <div className="flex overflow-x-auto gap-3 pb-2 snap-x snap-mandatory -mx-1 px-1">
+        {data.pages.map((page, i) => (
+          <ExternalSourceCard
+            key={`${page.final_url}-${i}`}
+            page={page}
+            index={i}
+            language={language}
+          />
+        ))}
+      </div>
+    </motion.section>
+  );
+};
+
+export default ExternalSourcesSection;

--- a/frontend/src/components/ExternalSourcesUpgradeCTA.tsx
+++ b/frontend/src/components/ExternalSourcesUpgradeCTA.tsx
@@ -1,0 +1,64 @@
+/**
+ * DEEP SIGHT — ExternalSourcesUpgradeCTA
+ *
+ * CTA discret pour les users free : "Sources externes citées — disponible avec Pro".
+ * Click → navigate vers /pricing (ou handler custom).
+ */
+
+import React from "react";
+import { Link2, ArrowRight, Lock } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+interface Props {
+  language: "fr" | "en";
+  onUpgradeClick?: () => void;
+}
+
+export const ExternalSourcesUpgradeCTA: React.FC<Props> = ({
+  language,
+  onUpgradeClick,
+}) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    if (onUpgradeClick) {
+      onUpgradeClick();
+    } else {
+      navigate("/pricing");
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="w-full text-left rounded-xl bg-gradient-to-br from-indigo-500/8 to-cyan-500/8 border border-indigo-500/20 hover:border-indigo-400/40 backdrop-blur-xl p-4 transition-colors group"
+      data-testid="external-sources-upgrade-cta"
+    >
+      <div className="flex items-center gap-3">
+        <div className="w-9 h-9 rounded-lg bg-indigo-500/15 flex items-center justify-center shrink-0">
+          <Link2 className="w-4 h-4 text-indigo-400" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-text-primary flex items-center gap-1.5">
+            {language === "fr"
+              ? "Sources externes citées"
+              : "External sources cited"}
+            <Lock className="w-3 h-3 text-text-muted" />
+          </h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            {language === "fr"
+              ? "Mini-résumé de chaque lien cité dans la description — disponible avec Pro"
+              : "Mini-summary of each link cited in the description — available with Pro"}
+          </p>
+        </div>
+        <span className="text-xs font-medium text-indigo-400 flex items-center gap-1 shrink-0 group-hover:text-indigo-300">
+          {language === "fr" ? "Passer Pro" : "Upgrade"}
+          <ArrowRight className="w-3.5 h-3.5" />
+        </span>
+      </div>
+    </button>
+  );
+};
+
+export default ExternalSourcesUpgradeCTA;

--- a/frontend/src/components/__tests__/ExternalSourcesSection.test.tsx
+++ b/frontend/src/components/__tests__/ExternalSourcesSection.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Tests ExternalSourcesSection — pages externes citées (spec PR3.5 web)
+ * Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "../../__tests__/test-utils";
+import { ExternalSourcesSection } from "../ExternalSourcesSection";
+import type {
+  ExternalPagesData,
+  ExternalPageCitation,
+} from "../../services/api";
+
+const okPage = (over: Partial<ExternalPageCitation> = {}): ExternalPageCitation => ({
+  url: "https://example.com/article",
+  final_url: "https://example.com/article",
+  title: "Un article exemple",
+  summary:
+    "Résumé Mistral de la page externe en 2-3 phrases pertinentes pour le viewer.",
+  key_claims: ["Claim 1", "Claim 2"],
+  status: "ok",
+  fetched_via_proxy: false,
+  bytes_fetched: 12_345,
+  ...over,
+});
+
+const baseData: ExternalPagesData = {
+  extracted_at: "2026-05-17T20:00:00Z",
+  schema_version: 1,
+  stats: {
+    candidates_found: 3,
+    after_dedup: 3,
+    after_blacklist: 3,
+    after_cap: 3,
+    successful: 2,
+    paywalled: 1,
+    errored: 0,
+  },
+  pages: [
+    okPage(),
+    okPage({
+      url: "https://example.org/paper",
+      final_url: "https://example.org/paper",
+      title: "Paper référencé",
+    }),
+    okPage({
+      url: "https://nytimes.com/locked",
+      final_url: "https://nytimes.com/locked",
+      title: "Article payant",
+      status: "paywall",
+      summary: "",
+      key_claims: [],
+    }),
+  ],
+};
+
+describe("ExternalSourcesSection", () => {
+  it("affiche un CTA upgrade pour les users free", () => {
+    renderWithProviders(
+      <ExternalSourcesSection
+        data={baseData}
+        userPlan="free"
+        language="fr"
+      />,
+    );
+    expect(
+      screen.getByTestId("external-sources-upgrade-cta"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("external-sources-section")).toBeNull();
+  });
+
+  it("ne rend rien si data est null côté Pro", () => {
+    const { container } = renderWithProviders(
+      <ExternalSourcesSection data={null} userPlan="pro" language="fr" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("ne rend rien si data.pages est vide côté Pro", () => {
+    const empty: ExternalPagesData = { ...baseData, pages: [] };
+    const { container } = renderWithProviders(
+      <ExternalSourcesSection data={empty} userPlan="pro" language="fr" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("affiche la section complète pour un user Pro avec des pages valides", () => {
+    renderWithProviders(
+      <ExternalSourcesSection
+        data={baseData}
+        userPlan="pro"
+        language="fr"
+      />,
+    );
+    expect(
+      screen.getByTestId("external-sources-section"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Sources externes citées")).toBeInTheDocument();
+    expect(screen.getByText("2/3 pages traitées")).toBeInTheDocument();
+    expect(screen.getAllByTestId("external-source-card")).toHaveLength(3);
+  });
+
+  it("rend la même chose pour Expert (cap géré côté backend, le payload arrive déjà capé)", () => {
+    renderWithProviders(
+      <ExternalSourcesSection
+        data={baseData}
+        userPlan="expert"
+        language="fr"
+      />,
+    );
+    expect(
+      screen.getByTestId("external-sources-section"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId("external-source-card")).toHaveLength(3);
+  });
+
+  it("affiche le notice 'Article payant' pour status=paywall", () => {
+    renderWithProviders(
+      <ExternalSourcesSection
+        data={baseData}
+        userPlan="pro"
+        language="fr"
+      />,
+    );
+    expect(
+      screen.getByText(/Article payant non accessible/i),
+    ).toBeInTheDocument();
+  });
+
+  it("affiche le notice 'Page introuvable' pour status=http_error", () => {
+    const data: ExternalPagesData = {
+      ...baseData,
+      pages: [okPage({ status: "http_error", summary: "", key_claims: [] })],
+    };
+    renderWithProviders(
+      <ExternalSourcesSection data={data} userPlan="pro" language="fr" />,
+    );
+    expect(screen.getByText("Page introuvable")).toBeInTheDocument();
+  });
+
+  it("affiche le notice 'Contenu non extractible' pour status=timeout", () => {
+    const data: ExternalPagesData = {
+      ...baseData,
+      pages: [okPage({ status: "timeout", summary: "", key_claims: [] })],
+    };
+    renderWithProviders(
+      <ExternalSourcesSection data={data} userPlan="pro" language="fr" />,
+    );
+    expect(screen.getByText("Contenu non extractible")).toBeInTheDocument();
+  });
+
+  it("rend les labels anglais quand language=en", () => {
+    renderWithProviders(
+      <ExternalSourcesSection
+        data={baseData}
+        userPlan="pro"
+        language="en"
+      />,
+    );
+    expect(screen.getByText("External sources cited")).toBeInTheDocument();
+    expect(screen.getByText("2/3 pages processed")).toBeInTheDocument();
+    expect(screen.getAllByText("Open")).toHaveLength(3);
+  });
+
+  it("limite key_claims à 2 par card même si plus dans le payload", () => {
+    const data: ExternalPagesData = {
+      ...baseData,
+      pages: [
+        okPage({
+          key_claims: ["A", "B", "C", "D", "E"],
+        }),
+      ],
+    };
+    renderWithProviders(
+      <ExternalSourcesSection data={data} userPlan="pro" language="fr" />,
+    );
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.queryByText("C")).toBeNull();
+  });
+
+  it("appelle onUpgradeClick quand le user free clique sur la CTA", async () => {
+    const onUpgradeClick = vi.fn();
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ExternalSourcesSection
+        data={baseData}
+        userPlan="free"
+        language="fr"
+        onUpgradeClick={onUpgradeClick}
+      />,
+    );
+    await user.click(screen.getByTestId("external-sources-upgrade-cta"));
+    expect(onUpgradeClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("liens 'Ouvrir' ont target=_blank et rel=noopener noreferrer nofollow", () => {
+    renderWithProviders(
+      <ExternalSourcesSection
+        data={baseData}
+        userPlan="pro"
+        language="fr"
+      />,
+    );
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBeGreaterThan(0);
+    links.forEach((link) => {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link.getAttribute("rel")).toContain("noopener");
+      expect(link.getAttribute("rel")).toContain("noreferrer");
+      expect(link.getAttribute("rel")).toContain("nofollow");
+    });
+  });
+});

--- a/frontend/src/config/planPrivileges.ts
+++ b/frontend/src/config/planPrivileges.ts
@@ -277,11 +277,16 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
 // ACCÈS PAR FEATURE × PLATEFORME (mirror backend `is_feature_available`)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-export type CanAccessFeature = "community_take";
+export type CanAccessFeature = "community_take" | "external_sources";
 export type Platform = "web" | "mobile" | "extension";
 
 const FEATURE_ACCESS: Record<CanAccessFeature, Record<Platform, PlanId[]>> = {
   community_take: {
+    web: ["pro", "expert"],
+    mobile: ["pro", "expert"],
+    extension: ["pro", "expert"],
+  },
+  external_sources: {
     web: ["pro", "expert"],
     mobile: ["pro", "expert"],
     extension: ["pro", "expert"],

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1018,5 +1018,18 @@
       "neutral": "Neutral",
       "question": "Question"
     }
+  },
+  "externalSources": {
+    "title": "External sources cited",
+    "processed": "pages processed",
+    "open": "Open",
+    "paywalled": "Paywalled article",
+    "notFound": "Page not found",
+    "unavailable": "Content unavailable",
+    "cited": "sources cited",
+    "viewAllOnWeb": "View details on web app",
+    "upgradeRequired": "External sources cited",
+    "upgradeDescription": "Mini-summary of each link cited in the description — available with Pro",
+    "upgradeCta": "Upgrade"
   }
 }

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1018,5 +1018,18 @@
       "neutral": "Neutre",
       "question": "Question"
     }
+  },
+  "externalSources": {
+    "title": "Sources externes citées",
+    "processed": "pages traitées",
+    "open": "Ouvrir",
+    "paywalled": "Article payant non accessible",
+    "notFound": "Page introuvable",
+    "unavailable": "Contenu non extractible",
+    "cited": "sources citées",
+    "viewAllOnWeb": "Voir détails sur l'app web",
+    "upgradeRequired": "Sources externes citées",
+    "upgradeDescription": "Mini-résumé de chaque lien cité dans la description — disponible avec Pro",
+    "upgradeCta": "Passer Pro"
   }
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -172,6 +172,12 @@ export interface Summary {
   // Verdict communauté issu du scrape + Mistral. NULL = pas analysé (free,
   // scrape failed, timeout, vidéo sans commentaires significatifs).
   community_analysis?: CommunityTake | null;
+
+  // 🔗 External pages (2026-05-17 — alembic 031, PR3 backend / PR3.5 UI web).
+  // Pages externes citées dans la description vidéo, scrapées + résumées par
+  // Mistral. NULL = pas analysé (free plan, description vide, aucune URL
+  // exploitable, toutes les pages ont échoué, etc.).
+  external_pages?: ExternalPagesData | null;
 }
 
 // ─── Community Take (verdict communauté) ──────────────────────────────────────
@@ -215,6 +221,47 @@ export interface CommunityTake {
   is_truncated?: boolean;
   disabled?: boolean;
   insufficient_data?: boolean;
+}
+
+// ─── External Pages (PR3 backend / PR3.5 UI web) ──────────────────────────────
+// Mirror backend `videos/external_pages/orchestrator.py`. Persisté JSONB dans
+// `Summary.external_pages` depuis alembic 031.
+
+export type ExternalPageStatus =
+  | "ok"
+  | "error"
+  | "paywall"
+  | "non_html"
+  | "http_error"
+  | "timeout"
+  | "empty";
+
+export interface ExternalPageCitation {
+  url: string;
+  final_url: string;
+  title: string;
+  summary: string;
+  key_claims: string[];
+  status: ExternalPageStatus;
+  fetched_via_proxy: boolean;
+  bytes_fetched: number;
+}
+
+export interface ExternalPagesStats {
+  candidates_found: number;
+  after_dedup: number;
+  after_blacklist: number;
+  after_cap: number;
+  successful: number;
+  paywalled: number;
+  errored: number;
+}
+
+export interface ExternalPagesData {
+  extracted_at: string;
+  schema_version: number;
+  stats: ExternalPagesStats;
+  pages: ExternalPageCitation[];
 }
 
 // ─── Summary extras (refonte Option A 2026-05-06) ─────────────────────────────


### PR DESCRIPTION
## Summary

Spec : `docs/superpowers/specs/2026-05-17-pages-externes-citees.md` §9

Backend PR2+PR3 (#496+#497) wirent déjà `extract_external_pages` dans la pipeline v6 et v2.1, et persistent le dict canonique sur `Summary.external_pages` (alembic 031). Cette PR expose ce payload côté **Web** uniquement.

- Types TS `ExternalPagesData` / `ExternalPageCitation` / `ExternalPageStatus` mirror du backend `videos/external_pages/orchestrator.py`
- Section principale `<ExternalSourcesSection>` : horizontal scroll snap-x, gating free → CTA, render silent si pas de pages
- Card individuelle `<ExternalSourceCard>` : favicon Google s2 + fallback, line-clamp summary, max 2 key_claims, notices statut `paywall` / `http_error` / `non_html` / `timeout` / `empty`
- CTA discret `<ExternalSourcesUpgradeCTA>` pour les users free
- Monté dans `SynthesisTab` entre `<CommunityTakeSection>` et `<ConceptsGlossary>`
- i18n FR + EN ajoutées (utilisées par mobile/extension PR4)
- Plan gating SSOT via `canAccess(plan, "external_sources", "web")` : pro/expert sur web/mobile/extension

## Test plan

- [x] 12 tests unit verts (gating free/pro/expert + null/empty + statuses + i18n + a11y `rel="noopener noreferrer nofollow"` sur tous les liens)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean sur fichiers touchés (warnings préexistants sur SynthesisTab.tsx / api.ts hors scope)
- [x] CommunityTakeSection.test.tsx + planPrivileges.test.ts toujours verts (41+11 tests, aucun régression)

## Reste à faire (hors scope cette PR)

- Mobile PR4 : `<ExternalSourcesSection>` RN avec le même payload (`mobile/src/components/analysis/`)
- Extension PR4 : `<ExternalSourcesCompact>` chips compactes

🤖 Generated with [Claude Code](https://claude.com/claude-code)