### PR TITLE
feat(external_pages): ExternalSourcesCompact UI extension + i18n (PR 4b/4)

### DIFF
--- a/extension/__tests__/sidepanel/components/ExternalSourcesCompact.test.tsx
+++ b/extension/__tests__/sidepanel/components/ExternalSourcesCompact.test.tsx
@@ -1,0 +1,219 @@
+/** @jest-environment jsdom */
+//
+// Tests — ExternalSourcesCompact (extension/src/sidepanel/components/ExternalSourcesCompact.tsx)
+//
+// Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9.4
+//
+// Affiche les sources externes citées dans la description vidéo. Gate par plan :
+//   - free   → CTA upgrade
+//   - pro/expert → chips host + CTA web si > 3 pages
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ExternalSourcesCompact } from "../../../src/sidepanel/components/ExternalSourcesCompact";
+import Browser from "../../../src/utils/browser-polyfill";
+import type {
+  ExternalPagesData,
+  ExternalPageCitation,
+} from "../../../src/types";
+
+const tabsCreateSpy = jest.spyOn(Browser.tabs, "create");
+
+const okPage = (
+  overrides: Partial<ExternalPageCitation> = {},
+): ExternalPageCitation => ({
+  url: "https://www.example.com/article",
+  final_url: "https://www.example.com/article",
+  title: "Example article",
+  summary: "Mini-résumé Mistral de la page.",
+  key_claims: ["Claim 1"],
+  status: "ok",
+  fetched_via_proxy: false,
+  bytes_fetched: 12345,
+  ...overrides,
+});
+
+const baseStats = {
+  candidates_found: 0,
+  after_dedup: 0,
+  after_blacklist: 0,
+  after_cap: 0,
+  successful: 0,
+  paywalled: 0,
+  errored: 0,
+};
+
+const baseData = (pages: ExternalPageCitation[]): ExternalPagesData => ({
+  extracted_at: "2026-05-17T12:00:00Z",
+  schema_version: 1,
+  stats: { ...baseStats, candidates_found: pages.length, successful: pages.filter((p) => p.status === "ok").length },
+  pages,
+});
+
+describe("ExternalSourcesCompact", () => {
+  beforeEach(() => tabsCreateSpy.mockClear());
+
+  it("affiche un CTA upgrade pour les users free", () => {
+    const data = baseData([okPage()]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="free" />,
+    );
+    expect(
+      screen.getByTestId("external-sources-compact-free"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("external-sources-compact")).toBeNull();
+  });
+
+  it("CTA free → ouvre /upgrade dans un nouvel onglet", () => {
+    const data = baseData([okPage()]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="free" />,
+    );
+    fireEvent.click(screen.getByTestId("external-sources-compact-free"));
+    expect(tabsCreateSpy).toHaveBeenCalledWith({
+      url: expect.stringContaining("/upgrade"),
+    });
+  });
+
+  it("rend rien si data est null côté Pro", () => {
+    const { container } = render(
+      <ExternalSourcesCompact data={null} summaryId={42} userPlanId="pro" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("rend rien si pages est vide côté Pro", () => {
+    const { container } = render(
+      <ExternalSourcesCompact
+        data={baseData([])}
+        summaryId={42}
+        userPlanId="pro"
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("rend rien si aucune page n'a le status 'ok' côté Pro", () => {
+    const data = baseData([
+      okPage({ status: "paywall" }),
+      okPage({ status: "http_error" }),
+    ]);
+    const { container } = render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="pro" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("affiche un chip avec le host extrait (www. retiré) côté Pro", () => {
+    const data = baseData([
+      okPage({
+        final_url: "https://www.example.com/article",
+        title: "An article",
+      }),
+    ]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="pro" />,
+    );
+    expect(
+      screen.getByTestId("external-sources-compact"),
+    ).toBeInTheDocument();
+    const chip = screen.getByTestId("external-sources-compact-chip");
+    expect(chip).toHaveTextContent("example.com");
+    expect(chip).toHaveAttribute(
+      "href",
+      "https://www.example.com/article",
+    );
+    expect(chip).toHaveAttribute("target", "_blank");
+    expect(chip).toHaveAttribute("rel", "noopener noreferrer nofollow");
+  });
+
+  it("affiche max 3 chips même si plus de pages 'ok'", () => {
+    const data = baseData([
+      okPage({ final_url: "https://a.com/x" }),
+      okPage({ final_url: "https://b.com/x" }),
+      okPage({ final_url: "https://c.com/x" }),
+      okPage({ final_url: "https://d.com/x" }),
+      okPage({ final_url: "https://e.com/x" }),
+    ]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="pro" />,
+    );
+    expect(
+      screen.getAllByTestId("external-sources-compact-chip"),
+    ).toHaveLength(3);
+  });
+
+  it("affiche CTA 'view all' si data.pages.length > 3", () => {
+    const data = baseData([
+      okPage({ final_url: "https://a.com/x" }),
+      okPage({ final_url: "https://b.com/x" }),
+      okPage({ final_url: "https://c.com/x" }),
+      okPage({ final_url: "https://d.com/x" }),
+    ]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={777} userPlanId="pro" />,
+    );
+    const cta = screen.getByTestId("external-sources-compact-open-web");
+    expect(cta).toBeInTheDocument();
+    fireEvent.click(cta);
+    expect(tabsCreateSpy).toHaveBeenCalledWith({
+      url: expect.stringContaining("/hub/analysis/777"),
+    });
+  });
+
+  it("n'affiche pas le CTA web si pages.length <= 3", () => {
+    const data = baseData([
+      okPage({ final_url: "https://a.com/x" }),
+      okPage({ final_url: "https://b.com/x" }),
+    ]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="pro" />,
+    );
+    expect(
+      screen.queryByTestId("external-sources-compact-open-web"),
+    ).toBeNull();
+  });
+
+  it("expert plan affiche les chips comme pro", () => {
+    const data = baseData([okPage({ final_url: "https://expertcase.io/x" })]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="expert" />,
+    );
+    expect(
+      screen.getByTestId("external-sources-compact"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("external-sources-compact-chip"),
+    ).toHaveTextContent("expertcase.io");
+  });
+
+  it("ignore les pages avec URL invalide sans crasher", () => {
+    const data = baseData([
+      okPage({ final_url: "not-a-valid-url", url: "not-a-valid-url" }),
+      okPage({ final_url: "https://valid.com/x" }),
+    ]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="pro" />,
+    );
+    // Une chip seulement — l'URL invalide est silencieusement ignorée.
+    expect(
+      screen.getAllByTestId("external-sources-compact-chip"),
+    ).toHaveLength(1);
+  });
+
+  it("filtre uniquement les pages 'ok' (paywall/error/etc. exclues)", () => {
+    const data = baseData([
+      okPage({ final_url: "https://ok1.com/x", status: "ok" }),
+      okPage({ final_url: "https://paywall.com/x", status: "paywall" }),
+      okPage({ final_url: "https://timeout.com/x", status: "timeout" }),
+      okPage({ final_url: "https://ok2.com/x", status: "ok" }),
+    ]);
+    render(
+      <ExternalSourcesCompact data={data} summaryId={42} userPlanId="pro" />,
+    );
+    const chips = screen.getAllByTestId("external-sources-compact-chip");
+    expect(chips).toHaveLength(2);
+    expect(chips[0]).toHaveTextContent("ok1.com");
+    expect(chips[1]).toHaveTextContent("ok2.com");
+  });
+});

--- a/extension/src/i18n/en.json
+++ b/extension/src/i18n/en.json
@@ -342,5 +342,14 @@
     "disabledNotice": "Comments are disabled on this video.",
     "insufficientData": "Too few comments for a reliable verdict.",
     "openFullWeb": "Read the full analysis in the app"
+  },
+  "externalSources": {
+    "label": "sources cited",
+    "labelSingular": "source cited",
+    "viewAllOnWeb": "View details in app",
+    "upgradeRequired": "External sources with Pro",
+    "upgradeDescription": "Mini Mistral summary for each link cited in the description",
+    "upgradeCta": "Upgrade",
+    "openExternalAriaLabel": "Open {host} in a new tab"
   }
 }

--- a/extension/src/i18n/fr.json
+++ b/extension/src/i18n/fr.json
@@ -342,5 +342,14 @@
     "disabledNotice": "Commentaires désactivés sur cette vidéo.",
     "insufficientData": "Trop peu de commentaires pour un verdict fiable.",
     "openFullWeb": "Lire l'analyse complète sur l'app"
+  },
+  "externalSources": {
+    "label": "sources citées",
+    "labelSingular": "source citée",
+    "viewAllOnWeb": "Voir détails sur l'app",
+    "upgradeRequired": "Sources externes avec Pro",
+    "upgradeDescription": "Mini-résumé Mistral de chaque lien cité dans la description",
+    "upgradeCta": "Passer Pro",
+    "openExternalAriaLabel": "Ouvrir {host} dans un nouvel onglet"
   }
 }

--- a/extension/src/sidepanel/components/ExternalSourcesCompact.tsx
+++ b/extension/src/sidepanel/components/ExternalSourcesCompact.tsx
@@ -1,0 +1,216 @@
+/**
+ * DEEP SIGHT — ExternalSourcesCompact (Extension sidepanel)
+ *
+ * Affichage compact des pages externes citées dans la description de la
+ * vidéo (chips horizontales avec le host extrait, max 3 visibles, CTA web
+ * si plus de 3).
+ *
+ * Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9.4
+ *
+ * Insertion : `MainView.tsx`, dans le bloc `analysis.phase === "complete"`,
+ * APRÈS `<CommunityTakeCompact />`.
+ *
+ * Plan gating extension :
+ *  - free   → CTA discret (cohérent avec CommunityTakeCompact ; pas de spoil)
+ *  - pro    → chips + CTA web
+ *  - expert → idem pro
+ *
+ * Différence vs web/mobile : on filtre `status === "ok"` pour ne montrer
+ * que les pages effectivement résumées (pas les paywall / non_html /
+ * timeout / etc.). L'extension reste compacte — la consultation des
+ * mini-résumés se fait sur l'app web.
+ */
+
+import React from "react";
+import type {
+  ExternalPagesData,
+  ExternalPageCitation,
+} from "../../types";
+import { useTranslation } from "../../i18n/useTranslation";
+import { WEBAPP_URL } from "../../utils/config";
+import Browser from "../../utils/browser-polyfill";
+
+interface Props {
+  data: ExternalPagesData | null | undefined;
+  summaryId: number;
+  userPlanId: string;
+}
+
+/** Extrait le host d'une URL (sans `www.`). Retourne null si parsing KO. */
+function safeHost(rawUrl: string): string | null {
+  try {
+    return new URL(rawUrl).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+export const ExternalSourcesCompact: React.FC<Props> = ({
+  data,
+  summaryId,
+  userPlanId,
+}) => {
+  const { t } = useTranslation();
+
+  // Free → CTA discret (pas de spoiler des sources).
+  if (userPlanId === "free") {
+    return (
+      <button
+        type="button"
+        className="v3-card"
+        onClick={() =>
+          Browser.tabs.create({ url: `${WEBAPP_URL}/upgrade` })
+        }
+        style={{
+          width: "100%",
+          textAlign: "left",
+          cursor: "pointer",
+          background: "none",
+          border: "1px solid rgba(99, 102, 241, 0.3)",
+          padding: "10px 12px",
+        }}
+        data-testid="external-sources-compact-free"
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span aria-hidden style={{ fontSize: 14 }}>
+            🔗
+          </span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 12, fontWeight: 600, opacity: 0.95 }}>
+              {t.externalSources.upgradeRequired}{" "}
+              <span aria-hidden style={{ opacity: 0.6 }}>
+                🔒
+              </span>
+            </div>
+            <div style={{ fontSize: 11, opacity: 0.65, marginTop: 2 }}>
+              {t.externalSources.upgradeDescription}
+            </div>
+          </div>
+          <span style={{ fontSize: 11, fontWeight: 600, opacity: 0.85 }}>
+            {t.externalSources.upgradeCta} →
+          </span>
+        </div>
+      </button>
+    );
+  }
+
+  // Pas encore généré ou aucune page → silent.
+  if (!data || data.pages.length === 0) return null;
+
+  const okPages: ExternalPageCitation[] = data.pages.filter(
+    (p) => p.status === "ok",
+  );
+  // Aucune page "ok" → on n'affiche rien (les paywall/errors restent
+  // visibles en version full sur l'app web).
+  if (okPages.length === 0) return null;
+
+  const visible = okPages.slice(0, 3);
+  const hasMore = data.pages.length > 3;
+
+  // Pluriel/singulier sur la base des chips visibles.
+  const label =
+    visible.length === 1
+      ? t.externalSources.labelSingular
+      : t.externalSources.label;
+
+  return (
+    <div
+      className="v3-card"
+      data-testid="external-sources-compact"
+      style={{
+        padding: "8px 10px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 6,
+          fontSize: 12,
+        }}
+      >
+        <span aria-hidden style={{ fontSize: 13 }}>
+          🔗
+        </span>
+        <span style={{ fontWeight: 600, opacity: 0.95 }}>
+          {visible.length} {label}
+          {hasMore ? ` (+${data.pages.length - visible.length})` : ""}:
+        </span>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 4,
+            alignItems: "center",
+          }}
+        >
+          {visible.map((p) => {
+            const host = safeHost(p.final_url || p.url);
+            if (!host) return null;
+            return (
+              <a
+                key={p.final_url || p.url}
+                href={p.final_url || p.url}
+                target="_blank"
+                rel="noopener noreferrer nofollow"
+                title={p.title || host}
+                aria-label={t.externalSources.openExternalAriaLabel.replace(
+                  "{host}",
+                  host,
+                )}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  padding: "2px 8px",
+                  fontSize: 11,
+                  borderRadius: 10,
+                  border: "1px solid rgba(99, 102, 241, 0.35)",
+                  background: "rgba(99, 102, 241, 0.08)",
+                  color: "rgba(165, 180, 252, 0.95)",
+                  textDecoration: "none",
+                  maxWidth: 140,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+                data-testid="external-sources-compact-chip"
+              >
+                {host}
+              </a>
+            );
+          })}
+        </div>
+      </div>
+      {hasMore && (
+        <button
+          type="button"
+          onClick={() =>
+            Browser.tabs.create({
+              url: `${WEBAPP_URL}/hub/analysis/${summaryId}`,
+            })
+          }
+          style={{
+            alignSelf: "flex-start",
+            fontSize: 11,
+            fontWeight: 600,
+            color: "rgba(165, 180, 252, 0.95)",
+            background: "none",
+            border: "none",
+            padding: 0,
+            cursor: "pointer",
+            textDecoration: "underline",
+          }}
+          data-testid="external-sources-compact-open-web"
+        >
+          {t.externalSources.viewAllOnWeb} →
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ExternalSourcesCompact;

--- a/extension/src/sidepanel/views/MainView.tsx
+++ b/extension/src/sidepanel/views/MainView.tsx
@@ -28,6 +28,7 @@ import { PromoBanner } from "../components/PromoBanner";
 import { VoiceCallButton } from "../components/VoiceCallButton";
 import { SuggestionPills } from "../components/SuggestionPills";
 import { CommunityTakeCompact } from "../components/CommunityTakeCompact";
+import { ExternalSourcesCompact } from "../components/ExternalSourcesCompact";
 import { DeepSightSpinner } from "../shared/DeepSightSpinner";
 import { useTranslation } from "../../i18n/useTranslation";
 
@@ -793,6 +794,15 @@ export const MainView: React.FC<MainViewProps> = ({
                 Free → CTA, Pro/Expert → expandable signal + CTA web. */}
             <CommunityTakeCompact
               take={analysis.summary.community_analysis ?? null}
+              summaryId={analysis.summaryId}
+              userPlanId={userPlanId}
+            />
+
+            {/* 🔗 Sources externes citées (Sprint External Pages PR4 ext).
+                Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9.4
+                Free → CTA, Pro/Expert → chips horizontales + CTA web. */}
+            <ExternalSourcesCompact
+              data={analysis.summary.external_pages ?? null}
               summaryId={analysis.summaryId}
               userPlanId={userPlanId}
             />

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -78,6 +78,12 @@ export interface Summary {
   content_type?: "video" | "carousel" | "short" | "live";
   // 💬 Community analysis (2026-05-17 — alembic 029, sprint Comments PR4 ext).
   community_analysis?: CommunityTake | null;
+
+  // 🔗 External pages (2026-05-17 — alembic 031, sprint External Pages PR4 ext).
+  // Pages externes citées dans la description vidéo, scrapées + résumées par
+  // Mistral. NULL = pas analysé (free plan, description vide, aucune URL
+  // exploitable, toutes les pages ont échoué, etc.).
+  external_pages?: ExternalPagesData | null;
 }
 
 // ─── Community Take (verdict communauté) ──────────────────────────────────────
@@ -120,6 +126,48 @@ export interface CommunityTake {
   is_truncated?: boolean;
   disabled?: boolean;
   insufficient_data?: boolean;
+}
+
+// ─── External Pages (PR3 backend / PR4 UI extension) ──────────────────────────
+// Mirror backend `videos/external_pages/orchestrator.py` (statuts canoniques)
+// et `frontend/src/services/api.ts` (types web). Persisté JSONB dans
+// `Summary.external_pages` depuis alembic 031.
+
+export type ExternalPageStatus =
+  | "ok"
+  | "error"
+  | "paywall"
+  | "non_html"
+  | "http_error"
+  | "timeout"
+  | "empty";
+
+export interface ExternalPageCitation {
+  url: string;
+  final_url: string;
+  title: string;
+  summary: string;
+  key_claims: string[];
+  status: ExternalPageStatus;
+  fetched_via_proxy: boolean;
+  bytes_fetched: number;
+}
+
+export interface ExternalPagesStats {
+  candidates_found: number;
+  after_dedup: number;
+  after_blacklist: number;
+  after_cap: number;
+  successful: number;
+  paywalled: number;
+  errored: number;
+}
+
+export interface ExternalPagesData {
+  extracted_at: string;
+  schema_version: number;
+  stats: ExternalPagesStats;
+  pages: ExternalPageCitation[];
 }
 
 export interface Concept {


### PR DESCRIPTION
## Summary

Mirror du composant `ExternalSourcesSection` web (PR #503) en version compacte pour la sidepanel de l'extension Chrome — aligné sur le pattern `CommunityTakeCompact` (PR #502).

Spec : `docs/superpowers/specs/2026-05-17-pages-externes-citees.md` §9.4

### Ce qui est livré

- **Types** : `ExternalPageStatus` / `ExternalPageCitation` / `ExternalPagesStats` / `ExternalPagesData` + champ `external_pages?: ExternalPagesData | null` sur `Summary` (mirror backend orchestrator + frontend `api.ts`). Statuts canoniques alignés sur le backend (`ok`, `paywall`, `non_html`, `http_error`, `timeout`, `empty`, `error`).
- **Composant** `extension/src/sidepanel/components/ExternalSourcesCompact.tsx` :
  - Free → CTA upgrade discret (cohérent avec `CommunityTakeCompact` — pas de spoil des sources)
  - Pro / Expert → chips horizontales (max 3) avec host extrait via `new URL(p.final_url).hostname.replace(/^www\./, "")`, filtre `status === "ok"`, ouverture dans nouvel onglet (`target=_blank rel="noopener noreferrer nofollow"`)
  - CTA "Voir détails sur l'app" si `data.pages.length > 3` → `${WEBAPP_URL}/hub/analysis/{summaryId}`
- **i18n** FR + EN : bloc `externalSources` ajouté à `fr.json` / `en.json`
- **Wiring** dans `MainView.tsx` après `<CommunityTakeCompact />` dans `analysis.phase === "complete"`
- **12 tests Jest+jsdom** couvrant : gate plan (free CTA, pro chips), filtre `status === "ok"`, max 3 chips, CTA web conditionnel, URLs invalides ignorées, expert plan

### Fichiers (6, +511 LOC)

```
extension/__tests__/sidepanel/components/ExternalSourcesCompact.test.tsx (new)
extension/src/i18n/en.json                                                (+9)
extension/src/i18n/fr.json                                                (+9)
extension/src/sidepanel/components/ExternalSourcesCompact.tsx             (new)
extension/src/sidepanel/views/MainView.tsx                                (+10)
extension/src/types/index.ts                                              (+48)
```

### Différence vs web/mobile (assumée)

L'extension reste l'hameçon d'acquisition — UI compacte. On filtre uniquement les pages `ok` (les paywall / errors / timeouts ne sont pas affichées ; elles restent visibles sur l'app web via le CTA "Voir détails"). Pas de mini-résumé Mistral inline, pas de favicon, pas de stats successful/total — tout ça est sur l'app web.

## Test plan

- [x] `cd extension && npm run typecheck` → OK
- [x] `cd extension && npm run build` → OK (seulement warnings de taille pré-existants sur elevenlabs-sdk.js et logos)
- [x] `cd extension && npx jest sidepanel/components/ExternalSourcesCompact` → **12/12 verts**
- [x] Tests pré-existants en échec (`MainView.video-detection`, `api.test`, etc.) confirmés présents sur `origin/main` HEAD — non causés par cette PR
- [ ] Manual test : chrome://extensions → reload extension → ouvrir vidéo YouTube avec liens dans description sur compte Pro → vérifier chips visibles + CTA web si > 3
- [ ] Manual test : ouvrir même vidéo sur compte Free → vérifier CTA upgrade discret affiché à la place

## Pas de backend / frontend web / mobile

Strict extension-only — backend (PR #496/#497) et web (PR #503) déjà mergés sur main. Mobile à venir en parallèle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)