### PR TITLE
feat(external_pages): ExternalSourcesSection UI mobile + i18n + plan gating (PR 4a/4)

### DIFF
--- a/mobile/app/(tabs)/analysis/[id].tsx
+++ b/mobile/app/(tabs)/analysis/[id].tsx
@@ -38,10 +38,11 @@ import { AcademicSourcesSection } from "@/components/academic";
 import { FactCheckButton } from "@/components/factcheck";
 import { WebEnrichment } from "@/components/enrichment";
 import { VisualTab } from "@/components/analysis/VisualTab";
-import type { VisualAnalysis, CommunityTake } from "@/types";
+import type { VisualAnalysis, CommunityTake, ExternalPagesData } from "@/types";
 import { usePlan } from "@/contexts/PlanContext";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { CommunityTakeSection } from "@/components/CommunityTakeSection";
+import { ExternalSourcesSection } from "@/components/ExternalSourcesSection";
 import {
   SemanticHighlighterProvider,
   HighlightNavigationBar,
@@ -449,18 +450,30 @@ function AnalysisDetailScreenInner() {
           // Le container parent réserve déjà la footprint TabBar — le scroll
           // du content peut donc se contenter d'une marge respiration.
           bottomPadding={isFullscreen ? insets.bottom + sp.lg : sp["2xl"]}
-          // 💬 Verdict communauté (Sprint Comments PR3 mobile)
+          // 💬 Verdict communauté (Sprint Comments PR3 mobile) +
+          // 🔗 Sources externes citées (PR4 mobile).
           // Spec : docs/superpowers/specs/2026-05-17-comments-community-take.md §7.2
+          //        docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9
           // Rendu dans le scrollable du résumé pour bénéficier du même scroll.
           footer={
-            <CommunityTakeSection
-              take={
-                (summary as { community_analysis?: CommunityTake | null } | undefined)
-                  ?.community_analysis ?? null
-              }
-              language={(language as "fr" | "en") || "fr"}
-              onUpgradeClick={() => router.push("/(tabs)/subscription")}
-            />
+            <>
+              <CommunityTakeSection
+                take={
+                  (summary as { community_analysis?: CommunityTake | null } | undefined)
+                    ?.community_analysis ?? null
+                }
+                language={(language as "fr" | "en") || "fr"}
+                onUpgradeClick={() => router.push("/(tabs)/subscription")}
+              />
+              <ExternalSourcesSection
+                data={
+                  (summary as { external_pages?: ExternalPagesData | null } | undefined)
+                    ?.external_pages ?? null
+                }
+                language={(language as "fr" | "en") || "fr"}
+                onUpgradeClick={() => router.push("/(tabs)/subscription")}
+              />
+            </>
           }
         />
       </View>

--- a/mobile/src/components/ExternalSourceCard.tsx
+++ b/mobile/src/components/ExternalSourceCard.tsx
@@ -1,0 +1,276 @@
+/**
+ * DEEP SIGHT — ExternalSourceCard (Mobile)
+ *
+ * Card individuelle dans <ExternalSourcesSection>. Affiche favicon + host +
+ * titre + résumé Mistral + 2 key_claims max + lien "Ouvrir".
+ *
+ * Status gating (valeurs backend canoniques, voir
+ * `videos/external_pages/orchestrator.py` + `summarizer.py` + `scraper.py`) :
+ *  - ok                                    → résumé + claims complet
+ *  - paywall                               → notice "Article payant"
+ *  - http_error / non_html                 → notice "Page introuvable"
+ *  - error / timeout / empty               → notice "Contenu non extractible"
+ *
+ * Mirror du frontend `ExternalSourceCard.tsx` (PR #503).
+ */
+
+import React, { useState } from "react";
+import { View, Text, Image, Pressable, Linking, StyleSheet } from "react-native";
+import Animated, { FadeIn } from "react-native-reanimated";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../contexts/ThemeContext";
+import { sp, borderRadius } from "../theme/spacing";
+import { fontFamily, fontSize } from "../theme/typography";
+import type { ExternalPageCitation } from "../types";
+
+interface Props {
+  page: ExternalPageCitation;
+  index: number;
+  language: "fr" | "en";
+}
+
+const SAFE_HOST = (rawUrl: string): string => {
+  try {
+    return new URL(rawUrl).hostname.replace(/^www\./, "");
+  } catch {
+    return rawUrl.slice(0, 60);
+  }
+};
+
+export const ExternalSourceCard: React.FC<Props> = ({
+  page,
+  index,
+  language,
+}) => {
+  const { colors } = useTheme();
+  const host = SAFE_HOST(page.final_url);
+  const [faviconError, setFaviconError] = useState(false);
+  const faviconUrl = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=32`;
+
+  const handleOpen = () => {
+    Linking.openURL(page.final_url).catch(() => {
+      // Silently fail — best-effort link open.
+    });
+  };
+
+  const renderBody = () => {
+    if (page.status === "paywall") {
+      return (
+        <View style={styles.noticeRow}>
+          <Ionicons name="lock-closed-outline" size={14} color="#fbbf24" />
+          <Text style={[styles.noticeText, { color: "#fbbf24" }]}>
+            {language === "fr"
+              ? "Article payant non accessible"
+              : "Paywalled article"}
+          </Text>
+        </View>
+      );
+    }
+    if (page.status === "http_error" || page.status === "non_html") {
+      return (
+        <View style={styles.noticeRow}>
+          <Ionicons name="document-outline" size={14} color="#fb7185" />
+          <Text style={[styles.noticeText, { color: "#fb7185" }]}>
+            {language === "fr" ? "Page introuvable" : "Page not found"}
+          </Text>
+        </View>
+      );
+    }
+    if (
+      page.status === "error" ||
+      page.status === "timeout" ||
+      page.status === "empty"
+    ) {
+      return (
+        <View style={styles.noticeRow}>
+          <Ionicons name="alert-circle-outline" size={14} color={colors.textMuted} />
+          <Text style={[styles.noticeText, { color: colors.textMuted }]}>
+            {language === "fr"
+              ? "Contenu non extractible"
+              : "Content unavailable"}
+          </Text>
+        </View>
+      );
+    }
+    return (
+      <>
+        <Text
+          style={[styles.summary, { color: colors.textSecondary }]}
+          numberOfLines={3}
+        >
+          {page.summary}
+        </Text>
+        {page.key_claims.length > 0 && (
+          <View style={styles.claimsList}>
+            {page.key_claims.slice(0, 2).map((claim, i) => (
+              <View key={i} style={styles.claimRow}>
+                <Text style={[styles.claimBullet, { color: colors.textMuted }]}>
+                  •
+                </Text>
+                <Text
+                  style={[styles.claimText, { color: colors.textMuted }]}
+                  numberOfLines={1}
+                >
+                  {claim}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(250).delay(index * 40)}
+      style={[
+        styles.card,
+        {
+          backgroundColor: colors.surfaceSecondary,
+          borderColor: colors.border,
+        },
+      ]}
+      testID="external-source-card-mobile"
+    >
+      {/* Header : favicon + host */}
+      <View style={styles.header}>
+        {!faviconError ? (
+          <Image
+            source={{ uri: faviconUrl }}
+            style={styles.favicon}
+            onError={() => setFaviconError(true)}
+          />
+        ) : (
+          <View
+            style={[
+              styles.faviconFallback,
+              { backgroundColor: colors.accentSecondary + "33" },
+            ]}
+          />
+        )}
+        <Text
+          style={[styles.host, { color: colors.textMuted }]}
+          numberOfLines={1}
+        >
+          {host}
+        </Text>
+      </View>
+
+      {/* Title */}
+      <Text
+        style={[styles.title, { color: colors.textPrimary }]}
+        numberOfLines={2}
+      >
+        {page.title || page.final_url}
+      </Text>
+
+      {/* Body */}
+      <View style={styles.body}>{renderBody()}</View>
+
+      {/* Footer link */}
+      <Pressable
+        onPress={handleOpen}
+        style={({ pressed }) => [
+          styles.openLink,
+          { opacity: pressed ? 0.6 : 1 },
+        ]}
+        accessibilityLabel={`${language === "fr" ? "Ouvrir" : "Open"} ${page.title || host}`}
+        accessibilityRole="link"
+      >
+        <Text style={[styles.openLinkText, { color: colors.accentSecondary }]}>
+          {language === "fr" ? "Ouvrir" : "Open"}
+        </Text>
+        <Ionicons
+          name="open-outline"
+          size={12}
+          color={colors.accentSecondary}
+        />
+      </Pressable>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    width: 280,
+    padding: sp.md,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    marginRight: sp.sm,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.xs,
+    marginBottom: sp.xs,
+  },
+  favicon: {
+    width: 16,
+    height: 16,
+    borderRadius: 2,
+  },
+  faviconFallback: {
+    width: 16,
+    height: 16,
+    borderRadius: 2,
+  },
+  host: {
+    flex: 1,
+    fontFamily: fontFamily.body,
+    fontSize: 11,
+  },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
+    marginBottom: sp.xs,
+  },
+  body: {
+    flex: 1,
+    minHeight: 60,
+  },
+  summary: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  claimsList: {
+    marginTop: sp.xs,
+    gap: 2,
+  },
+  claimRow: {
+    flexDirection: "row",
+    gap: 4,
+  },
+  claimBullet: {
+    fontFamily: fontFamily.body,
+    fontSize: 11,
+  },
+  claimText: {
+    flex: 1,
+    fontFamily: fontFamily.body,
+    fontSize: 11,
+  },
+  noticeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  noticeText: {
+    fontFamily: fontFamily.body,
+    fontSize: 12,
+  },
+  openLink: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginTop: sp.sm,
+    alignSelf: "flex-start",
+  },
+  openLinkText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: 12,
+  },
+});
+
+export default ExternalSourceCard;

--- a/mobile/src/components/ExternalSourcesSection.tsx
+++ b/mobile/src/components/ExternalSourcesSection.tsx
@@ -1,0 +1,160 @@
+/**
+ * DEEP SIGHT — ExternalSourcesSection (Mobile)
+ *
+ * Pages externes citées dans la description vidéo (URLs scrapées + résumées
+ * par Mistral). Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9.
+ *
+ * Insertion : tab Résumé du PagerView dans `app/(tabs)/analysis/[id].tsx`,
+ * rendu juste après `<CommunityTakeSection>` dans le `footer` passé à
+ * `<AnalysisContentDisplay />`.
+ *
+ * Gating mobile :
+ *  - free   → <ExternalSourcesUpgradeCTA />
+ *  - pro    → cards horizontales scrollables (cap 5 pages backend)
+ *  - expert → cards horizontales scrollables (cap 10 pages backend)
+ *
+ * Empty states : `data=null` (rien à afficher, silent), `data.pages.length===0`
+ * (idem, silent — pipeline backend retourne null dans ce cas mais on défend).
+ *
+ * Mirror du frontend `ExternalSourcesSection.tsx` (PR #503).
+ */
+
+import React from "react";
+import { View, Text, ScrollView, StyleSheet } from "react-native";
+import Animated, { FadeIn } from "react-native-reanimated";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../contexts/ThemeContext";
+import { usePlan } from "../hooks/usePlan";
+import { sp, borderRadius } from "../theme/spacing";
+import { fontFamily, fontSize } from "../theme/typography";
+import { canAccess } from "../config/planPrivileges";
+import type { ExternalPagesData } from "../types";
+import { ExternalSourcesUpgradeCTA } from "./ExternalSourcesUpgradeCTA";
+import { ExternalSourceCard } from "./ExternalSourceCard";
+
+interface Props {
+  data: ExternalPagesData | null | undefined;
+  language: "fr" | "en";
+  onUpgradeClick?: () => void;
+}
+
+export const ExternalSourcesSection: React.FC<Props> = ({
+  data,
+  language,
+  onUpgradeClick,
+}) => {
+  const { colors } = useTheme();
+  const { plan } = usePlan();
+  const isAllowed = canAccess(plan, "external_sources", "mobile");
+
+  // Free plan → CTA upgrade (discoverability).
+  if (!isAllowed) {
+    return (
+      <ExternalSourcesUpgradeCTA
+        language={language}
+        onUpgradeClick={onUpgradeClick}
+      />
+    );
+  }
+
+  // Pas encore généré ou aucune page exploitable → silent (pipeline asynchrone,
+  // peut être null si description vide / aucune URL / toutes les pages ont échoué).
+  if (!data || !data.pages || data.pages.length === 0) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(300)}
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.surface,
+          borderColor: colors.accentSecondary + "33",
+        },
+      ]}
+      testID="external-sources-section-mobile"
+    >
+      {/* Header */}
+      <View style={styles.header}>
+        <View
+          style={[
+            styles.iconBubble,
+            { backgroundColor: colors.accentSecondary + "22" },
+          ]}
+        >
+          <Ionicons name="link-outline" size={20} color={colors.accentSecondary} />
+        </View>
+        <View style={styles.headerText}>
+          <Text style={[styles.title, { color: colors.textPrimary }]}>
+            {language === "fr"
+              ? "Sources externes citées"
+              : "External sources cited"}
+          </Text>
+          <Text style={[styles.subtitle, { color: colors.textMuted }]}>
+            {language === "fr"
+              ? `${data.stats.successful}/${data.pages.length} pages traitées`
+              : `${data.stats.successful}/${data.pages.length} pages processed`}
+          </Text>
+        </View>
+      </View>
+
+      {/* Cards horizontales scrollables */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+        testID="external-sources-scroll-mobile"
+      >
+        {data.pages.map((page, i) => (
+          <ExternalSourceCard
+            key={`${page.final_url}-${i}`}
+            page={page}
+            index={i}
+            language={language}
+          />
+        ))}
+      </ScrollView>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: sp.lg,
+    marginVertical: sp.md,
+    padding: sp.lg,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: sp.md,
+    marginBottom: sp.md,
+  },
+  iconBubble: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerText: {
+    flex: 1,
+  },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+  },
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+    marginTop: 2,
+  },
+  scrollContent: {
+    paddingRight: sp.lg,
+  },
+});
+
+export default ExternalSourcesSection;

--- a/mobile/src/components/ExternalSourcesUpgradeCTA.tsx
+++ b/mobile/src/components/ExternalSourcesUpgradeCTA.tsx
@@ -1,0 +1,134 @@
+/**
+ * DEEP SIGHT — ExternalSourcesUpgradeCTA (Mobile)
+ *
+ * CTA discret pour les users free : "Sources externes citées — disponible avec Pro".
+ * Tap → navigue vers /(tabs)/subscription (ou handler custom).
+ *
+ * Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9 (Mobile)
+ * Mirror du frontend `ExternalSourcesUpgradeCTA.tsx` (PR #503).
+ */
+
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import { useTheme } from "../contexts/ThemeContext";
+import { sp, borderRadius } from "../theme/spacing";
+import { fontFamily, fontSize } from "../theme/typography";
+
+interface Props {
+  language: "fr" | "en";
+  onUpgradeClick?: () => void;
+}
+
+export const ExternalSourcesUpgradeCTA: React.FC<Props> = ({
+  language,
+  onUpgradeClick,
+}) => {
+  const { colors } = useTheme();
+
+  const handlePress = () => {
+    if (onUpgradeClick) {
+      onUpgradeClick();
+    } else {
+      router.push("/(tabs)/subscription");
+    }
+  };
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={({ pressed }) => [
+        styles.container,
+        {
+          backgroundColor: colors.surface,
+          borderColor: colors.accentSecondary + "33",
+          opacity: pressed ? 0.8 : 1,
+        },
+      ]}
+      testID="external-sources-upgrade-cta-mobile"
+    >
+      <View
+        style={[
+          styles.iconBubble,
+          { backgroundColor: colors.accentSecondary + "22" },
+        ]}
+      >
+        <Ionicons name="link-outline" size={18} color={colors.accentSecondary} />
+      </View>
+      <View style={styles.text}>
+        <View style={styles.titleRow}>
+          <Text style={[styles.title, { color: colors.textPrimary }]}>
+            {language === "fr"
+              ? "Sources externes citées"
+              : "External sources cited"}
+          </Text>
+          <Ionicons
+            name="lock-closed-outline"
+            size={12}
+            color={colors.textMuted}
+          />
+        </View>
+        <Text style={[styles.subtitle, { color: colors.textMuted }]}>
+          {language === "fr"
+            ? "Mini-résumé de chaque lien cité dans la description — disponible avec Pro"
+            : "Mini-summary of each link cited in the description — available with Pro"}
+        </Text>
+      </View>
+      <View style={styles.cta}>
+        <Text style={[styles.ctaText, { color: colors.accentSecondary }]}>
+          {language === "fr" ? "Passer Pro" : "Upgrade"}
+        </Text>
+        <Ionicons name="arrow-forward" size={14} color={colors.accentSecondary} />
+      </View>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.md,
+    marginHorizontal: sp.lg,
+    marginVertical: sp.md,
+    padding: sp.md,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+  },
+  iconBubble: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  text: {
+    flex: 1,
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.xs,
+  },
+  title: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
+  },
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: 11,
+    marginTop: 2,
+  },
+  cta: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  ctaText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: 12,
+  },
+});
+
+export default ExternalSourcesUpgradeCTA;

--- a/mobile/src/components/__tests__/ExternalSourcesSection.test.tsx
+++ b/mobile/src/components/__tests__/ExternalSourcesSection.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Tests ExternalSourcesSection mobile — pages externes citées (spec PR4 mobile)
+ * Spec : docs/superpowers/specs/2026-05-17-pages-externes-citees.md §9 (Mobile)
+ */
+
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+jest.mock("../../contexts/ThemeContext", () => ({
+  useTheme: () => ({
+    colors: {
+      background: "#0a0a0f",
+      surface: "#15151f",
+      surfaceSecondary: "#12121a",
+      border: "rgba(255,255,255,0.06)",
+      borderLight: "rgba(255,255,255,0.12)",
+      textPrimary: "#ffffff",
+      textSecondary: "#f1f5f9",
+      textTertiary: "#cbd5e1",
+      textMuted: "#94a3b8",
+      accentSecondary: "#9B6B4A",
+      amber: "#f59e0b",
+    },
+    isDark: true,
+  }),
+}));
+
+const mockPlan = { value: "pro" as "free" | "pro" | "expert" };
+jest.mock("../../hooks/usePlan", () => ({
+  usePlan: () => ({ plan: mockPlan.value }),
+}));
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  router: { push: (...args: unknown[]) => mockPush(...args) },
+}));
+
+const mockOpenURL = jest.fn((_url: string) => Promise.resolve());
+jest.mock("react-native/Libraries/Linking/Linking", () => ({
+  openURL: (url: string) => mockOpenURL(url),
+}));
+
+jest.mock("react-native-reanimated", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const View = require("react-native").View;
+  return {
+    __esModule: true,
+    default: { View },
+    FadeIn: {
+      duration: () => ({ delay: () => ({}) }),
+      delay: () => ({}),
+    },
+    useAnimatedStyle: () => ({}),
+    useSharedValue: () => ({ value: 0 }),
+    withRepeat: () => 0,
+    withTiming: () => 0,
+  };
+});
+
+import { ExternalSourcesSection } from "../ExternalSourcesSection";
+import type {
+  ExternalPagesData,
+  ExternalPageCitation,
+  ExternalPageStatus,
+} from "../../types";
+
+const okPage = (
+  url: string,
+  title: string,
+  summary: string,
+): ExternalPageCitation => ({
+  url,
+  final_url: url,
+  title,
+  summary,
+  key_claims: ["Claim 1", "Claim 2", "Claim 3"],
+  status: "ok",
+  fetched_via_proxy: false,
+  bytes_fetched: 12345,
+});
+
+const statusPage = (
+  status: ExternalPageStatus,
+  url = "https://example.com/x",
+): ExternalPageCitation => ({
+  url,
+  final_url: url,
+  title: "Example",
+  summary: "",
+  key_claims: [],
+  status,
+  fetched_via_proxy: false,
+  bytes_fetched: 0,
+});
+
+const baseData: ExternalPagesData = {
+  extracted_at: "2026-05-17T12:00:00Z",
+  schema_version: 1,
+  stats: {
+    candidates_found: 3,
+    after_dedup: 3,
+    after_blacklist: 3,
+    after_cap: 3,
+    successful: 2,
+    paywalled: 1,
+    errored: 0,
+  },
+  pages: [
+    okPage(
+      "https://nature.com/article",
+      "Article scientifique",
+      "Étude récente sur le sujet X qui démontre Y.",
+    ),
+    okPage(
+      "https://www.lemonde.fr/article",
+      "Analyse économique",
+      "Décryptage des marchés et de leur évolution.",
+    ),
+    statusPage("paywall", "https://nytimes.com/article"),
+  ],
+};
+
+describe("ExternalSourcesSection (mobile)", () => {
+  beforeEach(() => {
+    mockPlan.value = "pro";
+    mockPush.mockClear();
+    mockOpenURL.mockClear();
+  });
+
+  it("affiche une CTA upgrade pour les users free", () => {
+    mockPlan.value = "free";
+    const { getByTestId, queryByTestId } = render(
+      <ExternalSourcesSection data={baseData} language="fr" />,
+    );
+    expect(getByTestId("external-sources-upgrade-cta-mobile")).toBeTruthy();
+    expect(queryByTestId("external-sources-section-mobile")).toBeNull();
+  });
+
+  it("ne rend rien quand data est null côté Pro", () => {
+    const { toJSON } = render(
+      <ExternalSourcesSection data={null} language="fr" />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("ne rend rien quand pages est vide côté Pro", () => {
+    const emptyData: ExternalPagesData = { ...baseData, pages: [] };
+    const { toJSON } = render(
+      <ExternalSourcesSection data={emptyData} language="fr" />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("affiche la section pour Pro avec data valide", () => {
+    const { getByTestId, getByText } = render(
+      <ExternalSourcesSection data={baseData} language="fr" />,
+    );
+    expect(getByTestId("external-sources-section-mobile")).toBeTruthy();
+    expect(getByText("Sources externes citées")).toBeTruthy();
+    expect(getByText("2/3 pages traitées")).toBeTruthy();
+  });
+
+  it("rend une card par page", () => {
+    const { queryAllByTestId } = render(
+      <ExternalSourcesSection data={baseData} language="fr" />,
+    );
+    expect(queryAllByTestId("external-source-card-mobile")).toHaveLength(3);
+  });
+
+  it("affiche la notice paywall pour une page status=paywall", () => {
+    const data: ExternalPagesData = {
+      ...baseData,
+      pages: [statusPage("paywall")],
+    };
+    const { getByText } = render(
+      <ExternalSourcesSection data={data} language="fr" />,
+    );
+    expect(getByText("Article payant non accessible")).toBeTruthy();
+  });
+
+  it("affiche la notice page introuvable pour http_error et non_html", () => {
+    const data1: ExternalPagesData = {
+      ...baseData,
+      pages: [statusPage("http_error")],
+    };
+    const { getByText, rerender } = render(
+      <ExternalSourcesSection data={data1} language="fr" />,
+    );
+    expect(getByText("Page introuvable")).toBeTruthy();
+
+    const data2: ExternalPagesData = {
+      ...baseData,
+      pages: [statusPage("non_html")],
+    };
+    rerender(<ExternalSourcesSection data={data2} language="fr" />);
+    expect(getByText("Page introuvable")).toBeTruthy();
+  });
+
+  it("affiche la notice contenu non extractible pour timeout/error/empty", () => {
+    const data: ExternalPagesData = {
+      ...baseData,
+      pages: [statusPage("timeout"), statusPage("error"), statusPage("empty")],
+    };
+    const { getAllByText } = render(
+      <ExternalSourcesSection data={data} language="fr" />,
+    );
+    expect(getAllByText("Contenu non extractible")).toHaveLength(3);
+  });
+
+  it("affiche les labels EN quand language=en", () => {
+    const { getByText } = render(
+      <ExternalSourcesSection data={baseData} language="en" />,
+    );
+    expect(getByText("External sources cited")).toBeTruthy();
+    expect(getByText("2/3 pages processed")).toBeTruthy();
+  });
+
+  it("appelle onUpgradeClick quand free user tap la CTA", () => {
+    mockPlan.value = "free";
+    const onUpgradeClick = jest.fn();
+    const { getByTestId } = render(
+      <ExternalSourcesSection
+        data={baseData}
+        language="fr"
+        onUpgradeClick={onUpgradeClick}
+      />,
+    );
+    fireEvent.press(getByTestId("external-sources-upgrade-cta-mobile"));
+    expect(onUpgradeClick).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("navigue vers /(tabs)/subscription par défaut quand free user tap la CTA", () => {
+    mockPlan.value = "free";
+    const { getByTestId } = render(
+      <ExternalSourcesSection data={baseData} language="fr" />,
+    );
+    fireEvent.press(getByTestId("external-sources-upgrade-cta-mobile"));
+    expect(mockPush).toHaveBeenCalledWith("/(tabs)/subscription");
+  });
+});

--- a/mobile/src/config/planPrivileges.ts
+++ b/mobile/src/config/planPrivileges.ts
@@ -298,11 +298,16 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
 // ACCЁS PAR FEATURE × PLATEFORME (mirror backend `is_feature_available`)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-export type CanAccessFeature = "community_take";
+export type CanAccessFeature = "community_take" | "external_sources";
 export type Platform = "web" | "mobile" | "extension";
 
 const FEATURE_ACCESS: Record<CanAccessFeature, Record<Platform, PlanId[]>> = {
   community_take: {
+    web: ["pro", "expert"],
+    mobile: ["pro", "expert"],
+    extension: ["pro", "expert"],
+  },
+  external_sources: {
     web: ["pro", "expert"],
     mobile: ["pro", "expert"],
     extension: ["pro", "expert"],

--- a/mobile/src/i18n/en.json
+++ b/mobile/src/i18n/en.json
@@ -1009,5 +1009,18 @@
       "neutral": "Neutral",
       "question": "Question"
     }
+  },
+  "externalSources": {
+    "title": "External sources cited",
+    "processed": "pages processed",
+    "open": "Open",
+    "paywalled": "Paywalled article",
+    "notFound": "Page not found",
+    "unavailable": "Content unavailable",
+    "cited": "sources cited",
+    "viewAllOnWeb": "View details on web app",
+    "upgradeRequired": "External sources cited",
+    "upgradeDescription": "Mini-summary of each link cited in the description — available with Pro",
+    "upgradeCta": "Upgrade"
   }
 }

--- a/mobile/src/i18n/fr.json
+++ b/mobile/src/i18n/fr.json
@@ -1009,5 +1009,18 @@
       "neutral": "Neutre",
       "question": "Question"
     }
+  },
+  "externalSources": {
+    "title": "Sources externes citées",
+    "processed": "pages traitées",
+    "open": "Ouvrir",
+    "paywalled": "Article payant non accessible",
+    "notFound": "Page introuvable",
+    "unavailable": "Contenu non extractible",
+    "cited": "sources citées",
+    "viewAllOnWeb": "Voir détails sur l'app web",
+    "upgradeRequired": "Sources externes citées",
+    "upgradeDescription": "Mini-résumé de chaque lien cité dans la description — disponible avec Pro",
+    "upgradeCta": "Passer Pro"
   }
 }

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -678,6 +678,8 @@ export const videoApi = {
       visual_analysis?: import("../types").VisualAnalysis | null;
       // 💬 Sprint Comments — verdict communauté (alembic 029)
       community_analysis?: import("../types").CommunityTake | null;
+      // 🔗 PR3 External pages (alembic 031)
+      external_pages?: import("../types").ExternalPagesData | null;
     }>(`/api/videos/summary/${summaryId}`);
 
     // Transform backend response to mobile format
@@ -725,6 +727,8 @@ export const videoApi = {
       visual_analysis: response.visual_analysis ?? null,
       // 💬 Sprint Comments PR3 mobile — verdict communauté (peut être null si free, scrape failed, timeout)
       community_analysis: response.community_analysis ?? null,
+      // 🔗 PR4 External pages — sources externes citées (peut être null si free, description vide, toutes les URL ont échoué)
+      external_pages: response.external_pages ?? null,
     } as AnalysisSummary & {
       notes?: string;
       tags?: string;

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -142,6 +142,12 @@ export interface AnalysisSummary {
   // Verdict communauté issu du scrape commentaires + Mistral. NULL = pas
   // analysé (free plan, scrape failed, timeout, vidéo sans commentaires).
   community_analysis?: CommunityTake | null;
+
+  // 🔗 External pages (2026-05-17 — alembic 031, PR3 backend / PR4 UI mobile).
+  // Pages externes citées dans la description vidéo, scrapées + résumées par
+  // Mistral. NULL = pas analysé (free plan, description vide, aucune URL
+  // exploitable, toutes les pages ont échoué, etc.).
+  external_pages?: ExternalPagesData | null;
 }
 
 // ─── Community Take (verdict communauté) ──────────────────────────────────────
@@ -186,6 +192,48 @@ export interface CommunityTake {
   is_truncated?: boolean;
   disabled?: boolean;
   insufficient_data?: boolean;
+}
+
+// ─── External Pages (PR3 backend / PR4 UI mobile) ─────────────────────────────
+// Mirror frontend `services/api.ts::ExternalPagesData` et backend
+// `videos/external_pages/orchestrator.py`. Persisté JSONB dans
+// `Summary.external_pages` depuis alembic 031.
+
+export type ExternalPageStatus =
+  | "ok"
+  | "error"
+  | "paywall"
+  | "non_html"
+  | "http_error"
+  | "timeout"
+  | "empty";
+
+export interface ExternalPageCitation {
+  url: string;
+  final_url: string;
+  title: string;
+  summary: string;
+  key_claims: string[];
+  status: ExternalPageStatus;
+  fetched_via_proxy: boolean;
+  bytes_fetched: number;
+}
+
+export interface ExternalPagesStats {
+  candidates_found: number;
+  after_dedup: number;
+  after_blacklist: number;
+  after_cap: number;
+  successful: number;
+  paywalled: number;
+  errored: number;
+}
+
+export interface ExternalPagesData {
+  extracted_at: string;
+  schema_version: number;
+  stats: ExternalPagesStats;
+  pages: ExternalPageCitation[];
 }
 
 export interface AnalysisRequest {


### PR DESCRIPTION
## Summary

Mirror exact de la PR #503 web (commit `4453d28`) côté mobile React Native — feature "Pages externes citées" pour DeepSight.

- Sprint Pages externes citées : chaque analyse vidéo enrichit les Summary avec un mini-résumé Mistral de chaque URL externe trouvée dans la description du créateur. Backend (PRs #496+#497, alembic 031) + Web UI (PR #503) déjà mergées. Ce PR complète l'UI mobile.
- Composants RN : `ExternalSourcesSection` (ScrollView horizontal de cards), `ExternalSourceCard` (favicon + host + titre + résumé + 2 key_claims + lien `Linking.openURL`), `ExternalSourcesUpgradeCTA` (Pressable free → /(tabs)/subscription).
- Plan gating via `canAccess(plan, "external_sources", "mobile")` : free → CTA, pro/expert → render. Mirror exact du frontend (`external_sources` ajouté dans `FEATURE_ACCESS` côté mobile).
- Types `ExternalPagesData` / `ExternalPageCitation` / `ExternalPageStatus` / `ExternalPagesStats` ajoutés à `mobile/src/types/index.ts`. Champ `external_pages?` ajouté sur `AnalysisSummary` + propagation dans `videoApi.getSummary` (`mobile/src/services/api.ts`).
- i18n FR + EN bloc `externalSources` ajouté (mêmes keys que le frontend).
- Wiring : `<ExternalSourcesSection>` rendu juste après `<CommunityTakeSection>` dans le `footer` de `<AnalysisContentDisplay>` (tab Résumé du PagerView dans `app/(tabs)/analysis/[id].tsx`), wrappées en Fragment.

## Spec

`docs/superpowers/specs/2026-05-17-pages-externes-citees.md` §9 (sous-section Mobile, lignes ~1319-1354).

⚠️ Note : la spec écrit `paywalled` / `not_found` / `skipped_content_type` pour l'UI, mais le backend orchestrator émet `paywall` / `http_error` / `non_html` / `timeout` / `empty` / `error` / `ok`. La source de vérité = backend, donc on mirror les vraies valeurs status (avec les libellés UI correspondants).

## Référence

PR #503 (frontend web) — squash commit `4453d28` :
- `frontend/src/services/api.ts` — types ExternalPagesData etc.
- `frontend/src/config/planPrivileges.ts` — entry `external_sources`
- `frontend/src/components/ExternalSourcesSection.tsx` — section principale
- `frontend/src/components/ExternalSourceCard.tsx` — card individuelle
- `frontend/src/components/ExternalSourcesUpgradeCTA.tsx` — CTA free
- `frontend/src/components/AnalysisHub/SynthesisTab.tsx` — wiring entre CommunityTakeSection et ConceptsGlossary
- `frontend/src/i18n/{fr,en}.json` — bloc externalSources

## Test plan

- [x] `npm run typecheck` clean sur les fichiers touchés (un seul échec pré-existant dans `hub/HubAnalysisSheet.tsx`, déjà présent sur main — non lié)
- [x] `npm run test -- --testPathPattern=ExternalSources` — 11/11 verts (gating free / null / empty / pro render / status paywall / http_error / non_html / timeout / error / empty / i18n EN / onUpgradeClick / router fallback)
- [x] `npm run test -- --testPathPattern=CommunityTake` — 9/9 verts (régression zéro sur la sister section)
- [ ] **À valider visuellement** : ouvrir une analyse YouTube pro/expert avec URL dans la description sur un dev build mobile → vérifier que la section s'affiche horizontalement scrollable, favicons chargent, tap sur "Ouvrir" lance le navigateur. Sur free → CTA visible.
- [ ] **À valider** : EAS OTA après merge → group runtime 1.2.0.

## Fichiers

10 fichiers, +920 / -11.

**Modifiés** :
- `mobile/app/(tabs)/analysis/[id].tsx` (+22 / -10)
- `mobile/src/config/planPrivileges.ts` (+6 / -1)
- `mobile/src/i18n/{fr,en}.json` (+13 / -0 chacun)
- `mobile/src/services/api.ts` (+4 / -0)
- `mobile/src/types/index.ts` (+48 / -0)

**Nouveaux** :
- `mobile/src/components/ExternalSourcesSection.tsx` (160 LOC)
- `mobile/src/components/ExternalSourceCard.tsx` (276 LOC)
- `mobile/src/components/ExternalSourcesUpgradeCTA.tsx` (134 LOC)
- `mobile/src/components/__tests__/ExternalSourcesSection.test.tsx` (243 LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)