### PR TITLE
fix(cors): autoriser les chrome-extension origins (appel rapide voice)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1061,9 +1061,15 @@ async def health_ready():
 
 
 # Configuration CORS - CRITIQUE pour éviter les erreurs 502
+# allow_origin_regex : autorise les chrome-extension://<id> (SW de l'extension
+# DeepSight) qui ne peuvent pas être listées en dur (l'ID change selon le mode
+# d'installation : Web Store, unpacked dev, packed). Sans ça, Starlette
+# CORSMiddleware rejette le préflight avec 400 "Disallowed CORS origin" sur
+# /api/voice/catalog et /api/voice/preferences (cassait l'appel rapide voice).
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
+    allow_origin_regex=r"chrome-extension://[a-z0-9]+",
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
     allow_headers=["Authorization", "Content-Type", "X-Platform", "X-Requested-With"],


### PR DESCRIPTION
## Bug

**Symptôme** : Toast "Connexion impossible / Erreur agent" lors du clic sur "Appel rapide" dans l'extension DeepSight (sidepanel).

**Root cause** : `Starlette CORSMiddleware` rejette les origines `chrome-extension://<id>` avec **400 "Disallowed CORS origin"** sur le préflight OPTIONS `/api/voice/catalog` et `/api/voice/preferences`.

Reproduit avec :
\`\`\`bash
curl -i -X OPTIONS https://api.deepsightsynthesis.com/api/voice/catalog \
  -H "Origin: chrome-extension://abcd1234" \
  -H "Access-Control-Request-Method: GET" \
  -H "Access-Control-Request-Headers: authorization,content-type"
# Avant ce fix : 400 Bad Request, body "Disallowed CORS origin"
\`\`\`

## Fix

Ajout de \`allow_origin_regex=r"chrome-extension://[a-z0-9]+"\` au CORSMiddleware. Les chrome-extension origins (ID alphanum 32 chars) sont désormais acceptés en plus de la liste blanche `ALLOWED_ORIGINS` existante. Le regex étant nominatif (pas wildcard `*`), `allow_credentials=True` reste valide.

## Pourquoi c'est nécessaire

- Les IDs chrome-extension changent selon le mode d'installation (Web Store, unpacked dev, packed). Impossible à hardcoder.
- Avant Chrome ~145, le SW MV3 bypassait le préflight CORS via `host_permissions` du manifest. Le comportement a changé récemment → préflight maintenant déclenché → le fix devient nécessaire.

## Test plan

- [x] Reproduction du 400 confirmée en prod (logs Hetzner + curl direct)
- [ ] Après auto-deploy : `curl -i -X OPTIONS https://api.deepsightsynthesis.com/api/voice/catalog -H "Origin: chrome-extension://abcd1234" ...` retourne **200 OK** (au lieu de 400)
- [ ] Appel rapide dans l'extension DeepSight chargée localement → la session voice s'établit, l'agent répond

## Scope

1 fichier, +6 lignes (5 commentaires + 1 ligne de code). Aucun risque pour le frontend web / mobile (les origines listées explicitement sont toujours acceptées en priorité).

🤖 Generated with [Claude Code](https://claude.com/claude-code)