### PR TITLE
feat(tutor): frontend store + carrousel + polling (PR #3/4 — Carrousel Tuteur)

### DIFF
--- a/frontend/src/components/Tutor/ConceptCard.tsx
+++ b/frontend/src/components/Tutor/ConceptCard.tsx
@@ -1,0 +1,98 @@
+// frontend/src/components/Tutor/ConceptCard.tsx
+//
+// Carte individuelle pour le carrousel "Concepts illustrés du Tuteur"
+// (sprint 2026-05-18 — Expert only). Sous-composant feuille de
+// `TutorConceptsCarousel` — minimaliste, dimensions compactes pour ~6-8
+// visibles côte à côte sur une largeur Hub typique.
+//
+// Comportement par status :
+//   - "ready"   + image_url truthy → <img> carrée lazy, alt=term.
+//                                    Si onError → composant retourne null
+//                                    (spec Maxime : pas de fallback texte).
+//   - "pending"                    → DoodleIcon "sparkles" pulse 32px
+//                                    centré dans la même boîte (placeholder
+//                                    discret pendant la génération Gemini).
+//   - "failed" / "throttled" /     → null (carte invisible — la spec demande
+//     "missing"                      « ne rien afficher si pas généré »).
+
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+import DoodleIcon from "../doodles/DoodleIcon";
+import type { TutorConceptItem } from "../../types/conceptImage";
+
+export interface ConceptCardProps {
+  concept: TutorConceptItem;
+  onClick?: (concept: TutorConceptItem) => void;
+}
+
+const ConceptCard: React.FC<ConceptCardProps> = ({ concept, onClick }) => {
+  const [hasError, setHasError] = useState(false);
+
+  // Filtres durs : statuts non rendus retournent null (carte invisible).
+  if (
+    concept.status === "failed" ||
+    concept.status === "throttled" ||
+    concept.status === "missing"
+  ) {
+    return null;
+  }
+
+  // Image failed à charger côté <img> → null (pas de fallback texte demandé).
+  if (concept.status === "ready" && (!concept.image_url || hasError)) {
+    return null;
+  }
+
+  const handleActivate = () => {
+    onClick?.(concept);
+  };
+
+  const displayLabel =
+    concept.term.length > 20
+      ? `${concept.term.slice(0, 18)}…`
+      : concept.term;
+
+  return (
+    <motion.li
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="snap-start shrink-0 w-24 flex flex-col items-center cursor-pointer group"
+      onClick={handleActivate}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleActivate();
+        }
+      }}
+      aria-label={concept.term}
+      data-testid={`concept-card-${concept.term_hash}`}
+      data-status={concept.status}
+    >
+      <div className="w-24 h-24 rounded-xl bg-white/[0.03] border border-white/[0.06] flex items-center justify-center overflow-hidden group-hover:bg-white/[0.06] group-hover:border-white/10 transition-all">
+        {concept.status === "ready" && concept.image_url ? (
+          <img
+            src={concept.image_url}
+            alt={concept.term}
+            loading="lazy"
+            onError={() => setHasError(true)}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          // status === "pending" → placeholder doodle discret animé.
+          <DoodleIcon
+            name="sparkles"
+            size={32}
+            className="opacity-40 animate-pulse"
+          />
+        )}
+      </div>
+      <span className="mt-1.5 text-[11px] text-text-secondary text-center truncate max-w-full px-1">
+        {displayLabel}
+      </span>
+    </motion.li>
+  );
+};
+
+export default ConceptCard;

--- a/frontend/src/components/Tutor/TutorConceptsCarousel.tsx
+++ b/frontend/src/components/Tutor/TutorConceptsCarousel.tsx
@@ -1,0 +1,183 @@
+// frontend/src/components/Tutor/TutorConceptsCarousel.tsx
+//
+// Bandeau horizontal "Concepts illustrés" du Tuteur (sprint 2026-05-18).
+// Gating Expert (plan ou is_admin). Scroll horizontal manuel snap-x avec
+// gradient masks gauche/droite pour signaler le débordement.
+//
+// Lifecycle :
+//   - Mount   → `startConceptsPolling()` (back-off 5s/10s/30s, auto-stop
+//                 après 60s sans pending — géré dans le store).
+//   - Unmount → `stopConceptsPolling()`.
+//
+// Source de vérité : `useTutorStore` (Agent B). Lecture en sélecteurs leaf
+// (`s => s.x`) — JAMAIS destructure un objet entier sous peine de re-render
+// storm React #300/#310 (cf. TutorHub.tsx l.203-213).
+//
+// i18n inline (pattern identique à TutorHub.tsx). Pas d'ajout de lib.
+
+import React, { useContext, useEffect } from "react";
+import { motion } from "framer-motion";
+import { useTutorStore } from "../../store/tutorStore";
+import { useAuthContext } from "../../contexts/AuthContext";
+import { PLAN_FEATURES, type PlanId } from "../../config/planPrivileges";
+import { LanguageContext } from "../../contexts/LanguageContext";
+import ConceptCard from "./ConceptCard";
+import type { TutorConceptItem } from "../../types/conceptImage";
+
+export interface TutorConceptsCarouselProps {
+  onConceptClick?: (concept: TutorConceptItem) => void;
+}
+
+const I18N = {
+  fr: {
+    title: "Concepts",
+    empty: "Aucun concept illustré pour le moment.",
+    loading: "Chargement…",
+    throttledHint:
+      "Quota d'illustrations atteint — réessayez demain.",
+    regionLabel: "Concepts illustrés du Tuteur",
+  },
+  en: {
+    title: "Concepts",
+    empty: "No illustrated concepts yet.",
+    loading: "Loading…",
+    throttledHint: "Illustration quota reached — try again tomorrow.",
+    regionLabel: "Tutor illustrated concepts",
+  },
+} as const;
+
+/**
+ * Gating helper : Expert plan OR is_admin → composant rendu.
+ * Mirror de la matrice `PLAN_FEATURES[plan].tutorConceptsCarousel`.
+ */
+function userCanSeeCarousel(
+  plan: string | undefined,
+  isAdmin: boolean | undefined,
+): boolean {
+  if (isAdmin === true) return true;
+  const normalized = (plan ?? "free") as PlanId;
+  return Boolean(PLAN_FEATURES[normalized]?.tutorConceptsCarousel);
+}
+
+const TutorConceptsCarousel: React.FC<TutorConceptsCarouselProps> = ({
+  onConceptClick,
+}) => {
+  // ── Auth gating ────────────────────────────────────────────────────────
+  const { user } = useAuthContext();
+  const allowed = userCanSeeCarousel(user?.plan, user?.is_admin);
+
+  // ── Language (safe fallback if no provider — same pattern as TutorHub) ─
+  const languageCtx = useContext(LanguageContext);
+  const language: "fr" | "en" =
+    languageCtx?.language === "en" ? "en" : "fr";
+  const t = I18N[language];
+
+  // ── Zustand selectors (leaf-by-leaf, stable refs) ──────────────────────
+  const concepts = useTutorStore((s) => s.concepts);
+  const conceptsLoading = useTutorStore((s) => s.conceptsLoading);
+  const conceptsLastFetch = useTutorStore((s) => s.conceptsLastFetch);
+  const startConceptsPolling = useTutorStore((s) => s.startConceptsPolling);
+  const stopConceptsPolling = useTutorStore((s) => s.stopConceptsPolling);
+
+  // ── Lifecycle : mount → polling, unmount → stop ────────────────────────
+  useEffect(() => {
+    if (!allowed) return undefined;
+    startConceptsPolling();
+    return () => {
+      stopConceptsPolling();
+    };
+    // Sélecteurs Zustand pour actions = refs stables : safe à omettre.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allowed]);
+
+  if (!allowed) {
+    return null;
+  }
+
+  // Filtre : on n'affiche que ready + pending. Failed/throttled/missing
+  // sont retirés du carrousel (la carte serait null de toute façon —
+  // évite des trous visuels dans le snap).
+  const visibleConcepts = concepts.filter(
+    (c) => c.status === "ready" || c.status === "pending",
+  );
+
+  const handleClick = (concept: TutorConceptItem) => {
+    if (concept.status !== "ready") {
+      // Pending → no-op (laisser le polling finir le job).
+      return;
+    }
+    onConceptClick?.(concept);
+  };
+
+  // Empty state :
+  //   - loading + premier fetch (lastFetch null) → render rien (silent).
+  //   - !loading + lastFetch ≠ null + 0 visible → empty message centré.
+  const hasFetchedAtLeastOnce = conceptsLastFetch !== null;
+  const showEmptyState =
+    visibleConcepts.length === 0 && !conceptsLoading && hasFetchedAtLeastOnce;
+  const showSilentLoading =
+    visibleConcepts.length === 0 && conceptsLoading && !hasFetchedAtLeastOnce;
+
+  return (
+    <motion.section
+      role="region"
+      aria-label={t.regionLabel}
+      aria-busy={conceptsLoading}
+      className="relative w-full border-b border-white/[0.04] bg-bg-primary/30 backdrop-blur-sm"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+      data-testid="tutor-concepts-carousel"
+    >
+      {/* Title row */}
+      <div className="flex items-center justify-between px-4 pt-3 pb-1">
+        <h3 className="text-xs font-medium text-text-tertiary uppercase tracking-wider">
+          {t.title}
+        </h3>
+        {conceptsLoading && (
+          <span className="text-[10px] text-text-tertiary">{t.loading}</span>
+        )}
+      </div>
+
+      {/* Body */}
+      {showSilentLoading ? (
+        // Premier fetch en cours → rien (le badge "loading" suffit).
+        <div className="px-4 pb-3" data-testid="tutor-concepts-silent" />
+      ) : showEmptyState ? (
+        <p
+          className="px-4 pb-3 text-xs text-text-tertiary text-center"
+          data-testid="tutor-concepts-empty"
+        >
+          {t.empty}
+        </p>
+      ) : (
+        <div className="relative">
+          <ul
+            className="flex gap-3 overflow-x-auto scroll-smooth snap-x snap-mandatory px-4 pb-3 pt-1 scrollbar-thin"
+            style={{ scrollbarColor: "rgba(255,255,255,0.05) transparent" }}
+            data-testid="tutor-concepts-list"
+          >
+            {visibleConcepts.map((c) => (
+              <ConceptCard
+                key={c.term_hash}
+                concept={c}
+                onClick={handleClick}
+              />
+            ))}
+          </ul>
+          {/* Gradient masks pour signaler scrollable */}
+          <div
+            className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-bg-primary to-transparent"
+            aria-hidden="true"
+          />
+          <div
+            className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-bg-primary to-transparent"
+            aria-hidden="true"
+          />
+        </div>
+      )}
+    </motion.section>
+  );
+};
+
+export default TutorConceptsCarousel;

--- a/frontend/src/components/Tutor/__tests__/TutorConceptsCarousel.test.tsx
+++ b/frontend/src/components/Tutor/__tests__/TutorConceptsCarousel.test.tsx
@@ -1,0 +1,260 @@
+// frontend/src/components/Tutor/__tests__/TutorConceptsCarousel.test.tsx
+//
+// Tests Vitest + Testing Library pour le carrousel "Concepts illustrés"
+// (sprint 2026-05-18). Mocke useTutorStore + useAuthContext pour isoler
+// le composant des dépendances réseau et store réel.
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import TutorConceptsCarousel from "../TutorConceptsCarousel";
+import type {
+  TutorConceptItem,
+  TutorConceptStatus,
+} from "../../../types/conceptImage";
+
+// ── Mock the Zustand store (leaf-selector aware) ────────────────────────
+vi.mock("../../../store/tutorStore", () => ({
+  useTutorStore: vi.fn(),
+}));
+
+// ── Mock AuthContext (default: Expert non-admin user) ───────────────────
+const authMock: {
+  user:
+    | { plan: string | undefined; is_admin: boolean; email?: string }
+    | null;
+} = {
+  user: { plan: "expert", is_admin: false, email: "test@example.com" },
+};
+
+vi.mock("../../../contexts/AuthContext", () => ({
+  useAuthContext: () => authMock,
+}));
+
+// Imports happen AFTER vi.mock — typed access requires re-import.
+import { useTutorStore } from "../../../store/tutorStore";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+interface StoreState {
+  concepts: TutorConceptItem[];
+  conceptsLoading: boolean;
+  conceptsLastFetch: number | null;
+  fetchConcepts: ReturnType<typeof vi.fn>;
+  generateConcept: ReturnType<typeof vi.fn>;
+  startConceptsPolling: ReturnType<typeof vi.fn>;
+  stopConceptsPolling: ReturnType<typeof vi.fn>;
+}
+
+let mockState: StoreState;
+
+function mockStore(state: Partial<StoreState> = {}) {
+  mockState = {
+    concepts: [],
+    conceptsLoading: false,
+    conceptsLastFetch: null,
+    fetchConcepts: vi.fn(),
+    generateConcept: vi.fn(),
+    startConceptsPolling: vi.fn(),
+    stopConceptsPolling: vi.fn(),
+    ...state,
+  };
+  (useTutorStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (selector: (s: StoreState) => unknown) => selector(mockState),
+  );
+}
+
+function makeConcept(
+  term: string,
+  status: TutorConceptStatus,
+  imageUrl?: string,
+): TutorConceptItem {
+  return {
+    term,
+    term_hash: `hash_${term.replace(/\s+/g, "_")}_${status}`,
+    category: null,
+    image_url: imageUrl ?? null,
+    status,
+  };
+}
+
+beforeEach(() => {
+  authMock.user = { plan: "expert", is_admin: false, email: "test@example.com" };
+  mockStore();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TutorConceptsCarousel", () => {
+  // ── Gating tests ──────────────────────────────────────────────────────
+  it("returns null for a free user (no region rendered)", () => {
+    authMock.user = { plan: "free", is_admin: false };
+    mockStore();
+    const { container } = render(<TutorConceptsCarousel />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole("region")).toBeNull();
+  });
+
+  it("returns null for a pro user", () => {
+    authMock.user = { plan: "pro", is_admin: false };
+    mockStore();
+    const { container } = render(<TutorConceptsCarousel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders for an admin user even with plan=free (admin bypass)", () => {
+    authMock.user = { plan: "free", is_admin: true };
+    mockStore({ conceptsLastFetch: Date.now() });
+    render(<TutorConceptsCarousel />);
+    expect(
+      screen.getByRole("region", { name: /concepts/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders for an Expert plan user", () => {
+    mockStore({ conceptsLastFetch: Date.now() });
+    render(<TutorConceptsCarousel />);
+    expect(
+      screen.getByRole("region", { name: /concepts/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── Empty / loading states ─────────────────────────────────────────────
+  it("renders silently (no empty message) on first fetch in flight", () => {
+    mockStore({
+      concepts: [],
+      conceptsLoading: true,
+      conceptsLastFetch: null,
+    });
+    render(<TutorConceptsCarousel />);
+    // Region exists but no empty message — silent state has the dedicated marker.
+    expect(screen.queryByTestId("tutor-concepts-empty")).toBeNull();
+    expect(screen.getByTestId("tutor-concepts-silent")).toBeInTheDocument();
+  });
+
+  it("renders empty state message once a fetch returned 0 concepts", () => {
+    mockStore({
+      concepts: [],
+      conceptsLoading: false,
+      conceptsLastFetch: Date.now(),
+    });
+    render(<TutorConceptsCarousel />);
+    expect(screen.getByTestId("tutor-concepts-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("tutor-concepts-list")).toBeNull();
+  });
+
+  // ── Rendering & filtering ──────────────────────────────────────────────
+  it("renders 3 cards for 2 ready + 1 pending concepts", () => {
+    const concepts: TutorConceptItem[] = [
+      makeConcept("Rasoir d'Occam", "ready", "https://r2.example.com/a.png"),
+      makeConcept("Effet Dunning-Kruger", "ready", "https://r2.example.com/b.png"),
+      makeConcept("Biais de confirmation", "pending"),
+    ];
+    mockStore({ concepts, conceptsLastFetch: Date.now() });
+    render(<TutorConceptsCarousel />);
+
+    const list = screen.getByTestId("tutor-concepts-list");
+    // 3 li children (cards).
+    expect(list.querySelectorAll("li")).toHaveLength(3);
+    // 2 <img> for ready concepts.
+    expect(list.querySelectorAll("img")).toHaveLength(2);
+  });
+
+  it("filters out failed/throttled/missing concepts (only ready+pending visible)", () => {
+    const concepts: TutorConceptItem[] = [
+      makeConcept("Concept-ready", "ready", "https://r2.example.com/x.png"),
+      makeConcept("Concept-failed", "failed"),
+      makeConcept("Concept-throttled", "throttled"),
+      makeConcept("Concept-missing", "missing"),
+    ];
+    mockStore({ concepts, conceptsLastFetch: Date.now() });
+    render(<TutorConceptsCarousel />);
+
+    const list = screen.getByTestId("tutor-concepts-list");
+    expect(list.querySelectorAll("li")).toHaveLength(1);
+    expect(screen.getByAltText("Concept-ready")).toBeInTheDocument();
+  });
+
+  // ── Click handling ─────────────────────────────────────────────────────
+  it("calls onConceptClick with the concept when clicking a ready card", () => {
+    const ready = makeConcept(
+      "Rasoir d'Occam",
+      "ready",
+      "https://r2.example.com/a.png",
+    );
+    mockStore({ concepts: [ready], conceptsLastFetch: Date.now() });
+    const onConceptClick = vi.fn();
+    render(<TutorConceptsCarousel onConceptClick={onConceptClick} />);
+
+    const card = screen.getByTestId(`concept-card-${ready.term_hash}`);
+    fireEvent.click(card);
+
+    expect(onConceptClick).toHaveBeenCalledTimes(1);
+    expect(onConceptClick).toHaveBeenCalledWith(ready);
+  });
+
+  it("does NOT call onConceptClick when clicking a pending card (no-op)", () => {
+    const pending = makeConcept("Concept-en-cours", "pending");
+    mockStore({ concepts: [pending], conceptsLastFetch: Date.now() });
+    const onConceptClick = vi.fn();
+    render(<TutorConceptsCarousel onConceptClick={onConceptClick} />);
+
+    const card = screen.getByTestId(`concept-card-${pending.term_hash}`);
+    fireEvent.click(card);
+
+    expect(onConceptClick).not.toHaveBeenCalled();
+  });
+
+  // ── Accessibility ──────────────────────────────────────────────────────
+  it("exposes a region role with descriptive aria-label", () => {
+    mockStore({ conceptsLastFetch: Date.now() });
+    render(<TutorConceptsCarousel />);
+    const region = screen.getByRole("region");
+    expect(region).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/concepts/i),
+    );
+  });
+
+  it("sets aria-busy=true while conceptsLoading is true", () => {
+    mockStore({
+      concepts: [makeConcept("X", "ready", "https://r2.example.com/x.png")],
+      conceptsLoading: true,
+      conceptsLastFetch: Date.now(),
+    });
+    render(<TutorConceptsCarousel />);
+    const region = screen.getByRole("region");
+    expect(region).toHaveAttribute("aria-busy", "true");
+  });
+
+  // ── Lifecycle (polling start/stop) ─────────────────────────────────────
+  it("calls startConceptsPolling on mount", () => {
+    mockStore();
+    render(<TutorConceptsCarousel />);
+    expect(mockState.startConceptsPolling).toHaveBeenCalledTimes(1);
+    expect(mockState.stopConceptsPolling).not.toHaveBeenCalled();
+  });
+
+  it("calls stopConceptsPolling on unmount", () => {
+    mockStore();
+    const { unmount } = render(<TutorConceptsCarousel />);
+    expect(mockState.stopConceptsPolling).not.toHaveBeenCalled();
+    unmount();
+    expect(mockState.stopConceptsPolling).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT start polling when user is not allowed (free plan)", () => {
+    authMock.user = { plan: "free", is_admin: false };
+    mockStore();
+    render(<TutorConceptsCarousel />);
+    expect(mockState.startConceptsPolling).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/config/planPrivileges.ts
+++ b/frontend/src/config/planPrivileges.ts
@@ -208,6 +208,10 @@ export interface PlanFeatures {
   semanticSearchTooltip: boolean;
   visualAnalysis: boolean;
   communityTake: boolean;
+  // Sprint 2026-05-18 — Carrousel concepts illustrés Tuteur, Expert-only
+  // (cf. backend tutor/concepts_router._check_expert_gating + spec
+  //  docs/superpowers/specs/2026-05-18-tutor-concept-carousel).
+  tutorConceptsCarousel: boolean;
 }
 
 export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
@@ -230,6 +234,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     semanticSearchTooltip: false,
     visualAnalysis: false,
     communityTake: false,
+    tutorConceptsCarousel: false,
   },
   pro: {
     flashcards: true,
@@ -250,6 +255,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     semanticSearchTooltip: true,
     visualAnalysis: true,
     communityTake: true,
+    tutorConceptsCarousel: false,
   },
   expert: {
     flashcards: true,
@@ -270,6 +276,7 @@ export const PLAN_FEATURES: Record<PlanId, PlanFeatures> = {
     semanticSearchTooltip: true,
     visualAnalysis: true,
     communityTake: true,
+    tutorConceptsCarousel: true,
   },
 };
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -187,6 +187,13 @@
     "errors": {
       "session_failed": "Session failed — please retry",
       "plan_required": "Available with Pro or Expert"
+    },
+    "concepts": {
+      "title": "Key concepts",
+      "empty": "No concepts yet — analyze a video to generate some.",
+      "loading": "Loading…",
+      "throttledHint": "Daily quota reached — try again tomorrow.",
+      "regionLabel": "Illustrated concepts"
     }
   },
   "onboarding": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -187,6 +187,13 @@
     "errors": {
       "session_failed": "Session impossible — réessayez",
       "plan_required": "Disponible avec Pro ou Expert"
+    },
+    "concepts": {
+      "title": "Concepts clés",
+      "empty": "Aucun concept disponible — analyse une vidéo pour en générer.",
+      "loading": "Chargement…",
+      "throttledHint": "Quota quotidien atteint — réessaie demain.",
+      "regionLabel": "Concepts illustrés"
     }
   },
   "onboarding": {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -25,6 +25,11 @@ import type {
   SessionTurnResponse,
   SessionEndResponse,
 } from "../types/tutor";
+import type {
+  TutorConceptsResponse,
+  GenerateConceptRequest,
+  GenerateConceptResponse,
+} from "../types/conceptImage";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // ⚙️ CONFIGURATION
@@ -1740,6 +1745,48 @@ export const tutorApi = {
    */
   async sessionEnd(sessionId: string): Promise<SessionEndResponse> {
     return request<SessionEndResponse>(`/api/tutor/session/${sessionId}/end`, {
+      method: "POST",
+      body: {},
+    });
+  },
+
+  // ── Concept illustrations (sprint 2026-05-18 — Expert only) ──────────────
+  // Endpoints livrés par backend/src/tutor/concepts_router.py.
+  // Le polling côté store applique un back-off 5s → 10s → 30s avec arrêt
+  // automatique après 60s sans `pending`.
+
+  /**
+   * 📜 Liste des concepts illustrés du user (cache R2 + statuses).
+   * Endpoint: GET /api/tutor/concepts?limit={limit}
+   */
+  async listConcepts(limit = 20): Promise<TutorConceptsResponse> {
+    return request<TutorConceptsResponse>(
+      `/api/tutor/concepts?limit=${limit}`,
+    );
+  },
+
+  /**
+   * ✨ Génère (ou récupère depuis cache) une illustration pour un concept.
+   * Endpoint: POST /api/tutor/concepts/generate
+   *
+   * Idempotent : si déjà ready en cache, retourne l'URL sans consommer
+   * le cap quotidien (300/jour global).
+   */
+  async generateConcept(
+    payload: GenerateConceptRequest,
+  ): Promise<GenerateConceptResponse> {
+    return request<GenerateConceptResponse>("/api/tutor/concepts/generate", {
+      method: "POST",
+      body: payload as unknown as Record<string, unknown>,
+    });
+  },
+
+  /**
+   * 🔄 Hook UX V1 : noop fonctionnel pour bouton « Rafraîchir » du carrousel.
+   * Endpoint: POST /api/tutor/concepts/refresh
+   */
+  async refreshConcepts(): Promise<{ refreshed: boolean }> {
+    return request<{ refreshed: boolean }>("/api/tutor/concepts/refresh", {
       method: "POST",
       body: {},
     });

--- a/frontend/src/store/__tests__/tutorStore.concepts.test.ts
+++ b/frontend/src/store/__tests__/tutorStore.concepts.test.ts
@@ -1,0 +1,306 @@
+// frontend/src/store/__tests__/tutorStore.concepts.test.ts
+//
+// Tests pour les actions concepts du store Tuteur (sprint 2026-05-18,
+// PR #3 — carrousel concepts illustrés Expert only).
+//
+// Couvre :
+// - fetchConcepts (succès + erreur préserve la liste)
+// - generateConcept (upsert idempotent + erreur silencieuse)
+// - startConceptsPolling (back-off 5s → 10s → 30s + idempotence)
+// - stopConceptsPolling (clear timer + flag down)
+// - clearConcepts (reset complet)
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useTutorStore } from "../tutorStore";
+import { tutorApi } from "../../services/api";
+import type {
+  TutorConceptItem,
+  TutorConceptsResponse,
+  GenerateConceptResponse,
+} from "../../types/conceptImage";
+
+vi.mock("../../services/api", () => ({
+  tutorApi: {
+    listConcepts: vi.fn(),
+    generateConcept: vi.fn(),
+    refreshConcepts: vi.fn(),
+    // Inclure les autres méthodes utilisées par les actions existantes du
+    // store, sinon `reset()` / autres tests indirects pourraient casser
+    // lors d'un appel transitif.
+    sessionStart: vi.fn(),
+    sessionTurn: vi.fn(),
+    sessionEnd: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(tutorApi);
+
+const conceptReady = (overrides?: Partial<TutorConceptItem>): TutorConceptItem => ({
+  term: "Rasoir d'Occam",
+  term_hash: "hash-occam",
+  category: "philosophy",
+  image_url: "https://r2.example.com/occam.webp",
+  status: "ready",
+  ...overrides,
+});
+
+const conceptPending = (overrides?: Partial<TutorConceptItem>): TutorConceptItem => ({
+  term: "Téléologie",
+  term_hash: "hash-teleo",
+  category: "philosophy",
+  image_url: null,
+  status: "pending",
+  ...overrides,
+});
+
+const responseFromConcepts = (
+  items: TutorConceptItem[],
+): TutorConceptsResponse => ({
+  concepts: items,
+  total: items.length,
+  ready_count: items.filter((c) => c.status === "ready").length,
+  pending_count: items.filter((c) => c.status === "pending").length,
+});
+
+describe("tutorStore — concepts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    useTutorStore.getState().stopConceptsPolling();
+    useTutorStore.getState().reset();
+  });
+
+  afterEach(() => {
+    useTutorStore.getState().stopConceptsPolling();
+    vi.useRealTimers();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // fetchConcepts
+  // ──────────────────────────────────────────────────────────────────────
+
+  it("fetchConcepts populates the store with the API response", async () => {
+    const items = [conceptReady(), conceptPending()];
+    mockedApi.listConcepts.mockResolvedValueOnce(responseFromConcepts(items));
+
+    await useTutorStore.getState().fetchConcepts();
+
+    const s = useTutorStore.getState();
+    expect(s.concepts).toHaveLength(2);
+    expect(s.concepts[0].term_hash).toBe("hash-occam");
+    expect(s.conceptsLoading).toBe(false);
+    expect(s.conceptsError).toBeNull();
+    expect(s.conceptsLastFetch).not.toBeNull();
+    expect(typeof s.conceptsLastFetch).toBe("number");
+  });
+
+  it("fetchConcepts on failure sets error and preserves the existing list", async () => {
+    // Premier fetch OK pour pré-populer.
+    mockedApi.listConcepts.mockResolvedValueOnce(
+      responseFromConcepts([conceptReady()]),
+    );
+    await useTutorStore.getState().fetchConcepts();
+    expect(useTutorStore.getState().concepts).toHaveLength(1);
+
+    // Second fetch rejette → la liste doit être préservée.
+    mockedApi.listConcepts.mockRejectedValueOnce(new Error("network down"));
+    await useTutorStore.getState().fetchConcepts();
+
+    const s = useTutorStore.getState();
+    expect(s.conceptsError).toBe("network down");
+    expect(s.conceptsLoading).toBe(false);
+    expect(s.concepts).toHaveLength(1); // Pas wipé.
+    expect(s.concepts[0].term_hash).toBe("hash-occam");
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // generateConcept
+  // ──────────────────────────────────────────────────────────────────────
+
+  it("generateConcept adds a new concept when the term_hash is unknown", async () => {
+    const resp: GenerateConceptResponse = {
+      term: "Stoïcisme",
+      term_hash: "hash-stoic",
+      status: "pending",
+      image_url: null,
+      cap_remaining: 299,
+    };
+    mockedApi.generateConcept.mockResolvedValueOnce(resp);
+
+    await useTutorStore
+      .getState()
+      .generateConcept("Stoïcisme", "Philosophie pratique", "philosophy");
+
+    const s = useTutorStore.getState();
+    expect(s.concepts).toHaveLength(1);
+    expect(s.concepts[0].term_hash).toBe("hash-stoic");
+    expect(s.concepts[0].status).toBe("pending");
+  });
+
+  it("generateConcept updates the existing item in place (no duplicate)", async () => {
+    // Pré-popule avec un concept pending.
+    mockedApi.listConcepts.mockResolvedValueOnce(
+      responseFromConcepts([conceptPending({ term_hash: "hash-x" })]),
+    );
+    await useTutorStore.getState().fetchConcepts();
+    expect(useTutorStore.getState().concepts).toHaveLength(1);
+
+    // generateConcept retourne le même term_hash mais status=ready.
+    const resp: GenerateConceptResponse = {
+      term: "Téléologie",
+      term_hash: "hash-x",
+      status: "ready",
+      image_url: "https://r2.example.com/x.webp",
+      cap_remaining: 295,
+    };
+    mockedApi.generateConcept.mockResolvedValueOnce(resp);
+
+    await useTutorStore
+      .getState()
+      .generateConcept("Téléologie", "Finalité", "philosophy");
+
+    const s = useTutorStore.getState();
+    expect(s.concepts).toHaveLength(1); // Pas de doublon.
+    expect(s.concepts[0].status).toBe("ready");
+    expect(s.concepts[0].image_url).toBe("https://r2.example.com/x.webp");
+  });
+
+  it("generateConcept on failure is silent (no error in store, no throw)", async () => {
+    mockedApi.generateConcept.mockRejectedValueOnce(new Error("rate-limited"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(
+      useTutorStore.getState().generateConcept("X", "", null),
+    ).resolves.toBeUndefined();
+
+    const s = useTutorStore.getState();
+    expect(s.conceptsError).toBeNull(); // Silencieux.
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // startConceptsPolling — back-off + arrêts auto
+  // ──────────────────────────────────────────────────────────────────────
+
+  it("startConceptsPolling triggers an immediate fetch then schedules a 5s back-off", async () => {
+    // Réponse pending → polling continue.
+    mockedApi.listConcepts.mockResolvedValue(
+      responseFromConcepts([conceptPending()]),
+    );
+
+    useTutorStore.getState().startConceptsPolling();
+    expect(useTutorStore.getState().conceptsPollingActive).toBe(true);
+
+    // Premier fetch déclenché immédiatement (microtask).
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockedApi.listConcepts).toHaveBeenCalledTimes(1);
+
+    // Avancer 5s pour déclencher le second tick.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockedApi.listConcepts).toHaveBeenCalledTimes(2);
+
+    // Avancer 10s pour le 3e tick.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockedApi.listConcepts).toHaveBeenCalledTimes(3);
+
+    // Avancer 30s pour le 4e tick (et tous suivants).
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(mockedApi.listConcepts).toHaveBeenCalledTimes(4);
+  });
+
+  it("polling stops after ~60s without any pending concept (after some pending was seen)", async () => {
+    // Premier fetch : pending présent.
+    // Tous les suivants : aucun pending.
+    mockedApi.listConcepts
+      .mockResolvedValueOnce(responseFromConcepts([conceptPending()]))
+      .mockResolvedValue(responseFromConcepts([conceptReady()]));
+
+    useTutorStore.getState().startConceptsPolling();
+    await vi.advanceTimersByTimeAsync(0); // tick 1 (pending → set _lastPendingSeenAt)
+
+    // Boucle jusqu'à 90s écoulés depuis le dernier pending vu — devrait stop.
+    // 5s + 10s + 30s = 45s ; 5+10+30+30 = 75s ; suffisant pour dépasser 60s.
+    await vi.advanceTimersByTimeAsync(5_000); // tick 2 (no pending)
+    await vi.advanceTimersByTimeAsync(10_000); // tick 3 (no pending)
+    await vi.advanceTimersByTimeAsync(30_000); // tick 4 (no pending, >60s écoulés)
+    await vi.advanceTimersByTimeAsync(30_000); // safety
+
+    expect(useTutorStore.getState().conceptsPollingActive).toBe(false);
+  });
+
+  it("polling stops after 3 attempts when no pending is ever seen", async () => {
+    // Aucun pending jamais retourné.
+    mockedApi.listConcepts.mockResolvedValue(
+      responseFromConcepts([conceptReady()]),
+    );
+
+    useTutorStore.getState().startConceptsPolling();
+    await vi.advanceTimersByTimeAsync(0); // tick 1, attempt 0 → no pending, attempt<3 → continue
+    await vi.advanceTimersByTimeAsync(5_000); // tick 2, attempt 1
+    await vi.advanceTimersByTimeAsync(10_000); // tick 3, attempt 2
+    await vi.advanceTimersByTimeAsync(30_000); // tick 4, attempt 3 → stop
+
+    expect(useTutorStore.getState().conceptsPollingActive).toBe(false);
+    // Pas plus de 4 fetches (le 4e tick déclenche le stop avant scheduling).
+    expect(mockedApi.listConcepts.mock.calls.length).toBeLessThanOrEqual(5);
+  });
+
+  it("startConceptsPolling is idempotent (calling it twice does not double-fetch)", async () => {
+    mockedApi.listConcepts.mockResolvedValue(
+      responseFromConcepts([conceptPending()]),
+    );
+
+    useTutorStore.getState().startConceptsPolling();
+    useTutorStore.getState().startConceptsPolling(); // no-op
+
+    await vi.advanceTimersByTimeAsync(0);
+    // Un seul fetch initial malgré 2 appels.
+    expect(mockedApi.listConcepts).toHaveBeenCalledTimes(1);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // stopConceptsPolling + clearConcepts
+  // ──────────────────────────────────────────────────────────────────────
+
+  it("stopConceptsPolling clears the timer and prevents further fetches", async () => {
+    mockedApi.listConcepts.mockResolvedValue(
+      responseFromConcepts([conceptPending()]),
+    );
+
+    useTutorStore.getState().startConceptsPolling();
+    await vi.advanceTimersByTimeAsync(0); // tick 1
+    expect(mockedApi.listConcepts).toHaveBeenCalledTimes(1);
+
+    useTutorStore.getState().stopConceptsPolling();
+    expect(useTutorStore.getState().conceptsPollingActive).toBe(false);
+
+    // Avancer beaucoup de temps : aucun fetch supplémentaire.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockedApi.listConcepts).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearConcepts resets list, stops polling, and clears error", async () => {
+    mockedApi.listConcepts.mockResolvedValueOnce(
+      responseFromConcepts([conceptReady(), conceptPending()]),
+    );
+    await useTutorStore.getState().fetchConcepts();
+    expect(useTutorStore.getState().concepts).toHaveLength(2);
+
+    // Mock pending pour que le polling reste actif si on ne l'arrête pas.
+    mockedApi.listConcepts.mockResolvedValue(
+      responseFromConcepts([conceptPending()]),
+    );
+    useTutorStore.getState().startConceptsPolling();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(useTutorStore.getState().conceptsPollingActive).toBe(true);
+
+    useTutorStore.getState().clearConcepts();
+
+    const s = useTutorStore.getState();
+    expect(s.concepts).toEqual([]);
+    expect(s.conceptsError).toBeNull();
+    expect(s.conceptsLastFetch).toBeNull();
+    expect(s.conceptsPollingActive).toBe(false);
+  });
+});

--- a/frontend/src/store/tutorStore.ts
+++ b/frontend/src/store/tutorStore.ts
@@ -14,6 +14,7 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { tutorApi } from "../services/api";
 import type { TutorLang, TutorPhase, TutorTurn } from "../types/tutor";
+import type { TutorConceptItem } from "../types/conceptImage";
 
 export interface StartSessionOpts {
   concept_term: string;
@@ -38,6 +39,13 @@ export interface TutorState {
   /** True quand la conv est rendue en vue Hub fullscreen (/hub?fsChat=tutor). */
   fullscreen: boolean;
 
+  // ── Concept illustrations (sprint 2026-05-18 — Expert only) ────────────
+  concepts: TutorConceptItem[];
+  conceptsLoading: boolean;
+  conceptsError: string | null;
+  conceptsLastFetch: number | null;
+  conceptsPollingActive: boolean;
+
   openPrompting: () => void;
   cancelPrompting: () => void;
   startSession: (opts: StartSessionOpts) => Promise<void>;
@@ -54,6 +62,16 @@ export interface TutorState {
   endSession: (opts?: { keepMessages?: boolean }) => Promise<void>;
   setFullscreen: (v: boolean) => void;
   reset: () => void;
+
+  fetchConcepts: (limit?: number) => Promise<void>;
+  generateConcept: (
+    term: string,
+    definition?: string,
+    category?: string | null,
+  ) => Promise<void>;
+  startConceptsPolling: () => void;
+  stopConceptsPolling: () => void;
+  clearConcepts: () => void;
 }
 
 const INITIAL: Pick<
@@ -69,6 +87,11 @@ const INITIAL: Pick<
   | "loading"
   | "error"
   | "fullscreen"
+  | "concepts"
+  | "conceptsLoading"
+  | "conceptsError"
+  | "conceptsLastFetch"
+  | "conceptsPollingActive"
 > = {
   phase: "idle",
   sessionId: null,
@@ -81,7 +104,37 @@ const INITIAL: Pick<
   loading: false,
   error: null,
   fullscreen: false,
+  concepts: [],
+  conceptsLoading: false,
+  conceptsError: null,
+  conceptsLastFetch: null,
+  conceptsPollingActive: false,
 };
+
+// ── Polling concepts illustrés (back-off 5s → 10s → 30s) ──────────────────
+// Module-level guard pour éviter les doubles timers : `startConceptsPolling`
+// est idempotent. Quand plus aucun concept n'est `pending` pendant 60s, on
+// stoppe automatiquement le polling (le composant peut le relancer au mount
+// suivant si nécessaire).
+let _pollTimerId: ReturnType<typeof setTimeout> | null = null;
+let _pollAttempt = 0;
+let _lastPendingSeenAt: number | null = null;
+const POLL_INTERVALS_MS = [5_000, 10_000, 30_000];
+const POLL_NO_PENDING_TIMEOUT_MS = 60_000;
+
+function _computeNextDelay(): number {
+  const idx = Math.min(_pollAttempt, POLL_INTERVALS_MS.length - 1);
+  return POLL_INTERVALS_MS[idx];
+}
+
+function _resetPollGuards(): void {
+  if (_pollTimerId !== null) {
+    clearTimeout(_pollTimerId);
+    _pollTimerId = null;
+  }
+  _pollAttempt = 0;
+  _lastPendingSeenAt = null;
+}
 
 export const useTutorStore = create<TutorState>()(
   immer((set, get) => ({
@@ -210,5 +263,134 @@ export const useTutorStore = create<TutorState>()(
       set((s) => {
         Object.assign(s, INITIAL);
       }),
+
+    // ── Concept illustrations actions ──────────────────────────────────────
+    // NOTE : mutations en place via immer pour préserver les selectors leaf
+    // (cf. TutorHub.tsx l.203-213 — éviter React #300/#310 re-render storm).
+
+    fetchConcepts: async (limit = 20) => {
+      set((s) => {
+        s.conceptsLoading = true;
+        s.conceptsError = null;
+      });
+      try {
+        const resp = await tutorApi.listConcepts(limit);
+        set((s) => {
+          s.concepts = resp.concepts;
+          s.conceptsLoading = false;
+          s.conceptsLastFetch = Date.now();
+        });
+      } catch (err) {
+        set((s) => {
+          s.conceptsError = (err as Error).message;
+          s.conceptsLoading = false;
+        });
+      }
+    },
+
+    generateConcept: async (term, definition, category) => {
+      try {
+        const resp = await tutorApi.generateConcept({
+          term,
+          definition,
+          category,
+        });
+        set((s) => {
+          // Upsert le concept retourné dans la liste (par term_hash).
+          const idx = s.concepts.findIndex(
+            (c) => c.term_hash === resp.term_hash,
+          );
+          const next: TutorConceptItem = {
+            term: resp.term,
+            term_hash: resp.term_hash,
+            category: category ?? null,
+            image_url: resp.image_url ?? null,
+            status: resp.status,
+          };
+          if (idx >= 0) {
+            s.concepts[idx] = next;
+          } else {
+            s.concepts.push(next);
+          }
+        });
+      } catch (err) {
+        // Silent log — pas de UX bloquant côté carrousel (le statut "failed"
+        // est déjà géré par la liste retournée par fetchConcepts).
+        console.warn("[tutorStore] generateConcept failed", err);
+      }
+    },
+
+    startConceptsPolling: () => {
+      // Idempotent : si polling déjà actif, no-op (évite doubles timers).
+      if (get().conceptsPollingActive) return;
+
+      set((s) => {
+        s.conceptsPollingActive = true;
+      });
+      _pollAttempt = 0;
+      _lastPendingSeenAt = null;
+
+      const tick = async () => {
+        // Si le polling a été stoppé entre deux ticks, sortir proprement.
+        if (!get().conceptsPollingActive) return;
+
+        await get().fetchConcepts();
+
+        if (!get().conceptsPollingActive) return;
+
+        const concepts = get().concepts;
+        const pendingCount = concepts.filter(
+          (c) => c.status === "pending",
+        ).length;
+        const now = Date.now();
+
+        if (pendingCount > 0) {
+          // Pending détecté → on continue à poller, on enregistre l'horodatage.
+          _lastPendingSeenAt = now;
+        } else if (_lastPendingSeenAt !== null) {
+          // Pending vu auparavant, plus rien maintenant → stop si >60s écoulé.
+          if (now - _lastPendingSeenAt >= POLL_NO_PENDING_TIMEOUT_MS) {
+            get().stopConceptsPolling();
+            return;
+          }
+        } else {
+          // Aucun pending depuis le début. On donne 3 attempts pour laisser
+          // une chance au backend de pre-gen, puis on coupe.
+          if (_pollAttempt >= 3) {
+            get().stopConceptsPolling();
+            return;
+          }
+        }
+
+        // Calcule le delay AVANT incrément pour respecter le back-off
+        // documenté : 1er reschedule à 5s, 2e à 10s, 3e+ à 30s.
+        const delay = _computeNextDelay();
+        _pollAttempt += 1;
+        _pollTimerId = setTimeout(() => {
+          void tick();
+        }, delay);
+      };
+
+      // Premier fetch immédiat puis enchaînement back-off.
+      void tick();
+    },
+
+    stopConceptsPolling: () => {
+      _resetPollGuards();
+      set((s) => {
+        s.conceptsPollingActive = false;
+      });
+    },
+
+    clearConcepts: () => {
+      _resetPollGuards();
+      set((s) => {
+        s.concepts = [];
+        s.conceptsLoading = false;
+        s.conceptsError = null;
+        s.conceptsLastFetch = null;
+        s.conceptsPollingActive = false;
+      });
+    },
   })),
 );

--- a/frontend/src/types/conceptImage.ts
+++ b/frontend/src/types/conceptImage.ts
@@ -1,0 +1,48 @@
+// frontend/src/types/conceptImage.ts
+//
+// Types frontend miroir des schémas Pydantic backend
+// (`backend/src/tutor/concepts_router.py` — PR #1 + #2 du sprint 2026-05-18
+// « Carrousel concepts illustrés Tuteur »).
+//
+// API REST :
+// - GET  /api/tutor/concepts?limit=20            → TutorConceptsResponse
+// - POST /api/tutor/concepts/generate            → GenerateConceptResponse
+// - POST /api/tutor/concepts/refresh             → { refreshed: boolean }
+//
+// Plan requis : Expert (gating backend `_check_expert_gating`).
+
+export type TutorConceptStatus =
+  | "ready"
+  | "pending"
+  | "failed"
+  | "throttled"
+  | "missing";
+
+export interface TutorConceptItem {
+  term: string;
+  term_hash: string;
+  category?: string | null;
+  image_url?: string | null;
+  status: TutorConceptStatus;
+}
+
+export interface TutorConceptsResponse {
+  concepts: TutorConceptItem[];
+  total: number;
+  ready_count: number;
+  pending_count: number;
+}
+
+export interface GenerateConceptRequest {
+  term: string;
+  definition?: string;
+  category?: string | null;
+}
+
+export interface GenerateConceptResponse {
+  term: string;
+  term_hash: string;
+  status: TutorConceptStatus;
+  image_url?: string | null;
+  cap_remaining: number;
+}


### PR DESCRIPTION
## Summary

PR #3 sur 4 du sprint **Carrousel concepts illustrés Tuteur**. Frontend complet (types + API client + store Zustand + polling auto + composants UI + i18n + plan flag). **Base = main** (indépendant du backend pour les tests — utilise des mocks).

Implémenté via **3 sub-agents Opus 4.7 en parallèle** (skill `superpowers:dispatching-parallel-agents`) :
- **Agent A** : types + API client + i18n + plan flag (5 fichiers)
- **Agent B** : store extension + polling + tests (2 fichiers)
- **Agent C** : composants UI + tests (3 fichiers)

⏱️ **Wall-clock 3 agents //** : ~25 min vs ~75 min séquentiel.

## Composants frontend

### `<TutorConceptsCarousel />`
Bandeau horizontal sous header de `TutorFullscreen` (mount = PR #4). Scroll manuel + `scroll-snap-x` + masques gradient gauche/droit. Gating Expert-only via `PLAN_FEATURES[plan].tutorConceptsCarousel` + admin bypass. Polling auto au mount, stop au unmount.

### `<ConceptCard />`
Carte individuelle 96x96px. Affichage conditionnel par status :
- `ready` + image_url → `<img loading="lazy">` (avec onError → `null`)
- `pending` → spinner `<DoodleIcon name="sparkles" />` animate-pulse
- `failed` / `throttled` / `missing` → **return null** (carte invisible, spec Maxime "ne rien afficher si pas généré")

### Store `tutorStore.ts` extension
State : `concepts`, `conceptsLoading`, `conceptsError`, `conceptsLastFetch`, `conceptsPollingActive`.
Actions : `fetchConcepts`, `generateConcept`, `startConceptsPolling`, `stopConceptsPolling`, `clearConcepts`.

**Polling logic** (timers module-level, idempotent) :
- Back-off **5s → 10s → 30s → 30s** (clamped au dernier index)
- **Auto-stop après 60s sans pending** (suite à un pending vu)
- **Auto-stop après 3 attempts sans pending jamais vu** (no-pending-from-start)
- Sélecteurs leaf Zustand respectés (cf. `TutorHub.tsx:203-213` doc crash React #300/#310)

## Files

| Type | Fichier | LoC |
|---|---|---|
| 🆕 | `types/conceptImage.ts` | 48 |
| 🆕 | `components/Tutor/ConceptCard.tsx` | 98 |
| 🆕 | `components/Tutor/TutorConceptsCarousel.tsx` | 183 |
| 🆕 | `components/Tutor/__tests__/TutorConceptsCarousel.test.tsx` | 260 |
| 🆕 | `store/__tests__/tutorStore.concepts.test.ts` | 259 |
| ✏️ | `services/api.ts` | +47 |
| ✏️ | `store/tutorStore.ts` | +220 |
| ✏️ | `config/planPrivileges.ts` | +5 |
| ✏️ | `i18n/fr.json` | +7 |
| ✏️ | `i18n/en.json` | +7 |
| **Total** | | **+1145** |

## Tests

**26/26 verts** ✅ (sur les nouveaux fichiers).
**Régression check** : `tutorStore.test.ts` 11/11 + `planPrivileges.test.ts` 41/41 OK.
**Typecheck** : 0 errors (`tsc --noEmit -p tsconfig.app.json`).

Couverture tests composant (15) :
- Gating Free/Pro/Expert/admin
- Empty state silent (loading initial) vs fetched (no concepts)
- Filtrage statuses (failed/throttled/missing → masqués)
- Click callbacks (ready vs pending)
- a11y (region role + aria-busy)
- Lifecycle mount/unmount polling
- Polling disabled si pas Expert

Couverture tests store (11) :
- fetchConcepts succès + erreur (préserve liste)
- generateConcept add new + update existing + silent error
- Polling back-off 5s/10s/30s vérifié
- Auto-stop 60s sans pending
- Auto-stop 3 attempts no-pending-from-start
- Idempotence startConceptsPolling
- stopConceptsPolling clear timer
- clearConcepts reset complet

## Test plan reviewer

- [ ] Preview Vercel : le carrousel n'apparait pas encore visuellement (mount = PR #4) — vérifier que le bundle inclut bien les nouveaux fichiers sans erreur
- [ ] Console F12 sur n'importe quelle page : pas d'erreur d'import / type
- [ ] Vérifier que `tutorApi.listConcepts(20)` est appelable depuis la console DevTools (`window.tutorApi` si exposé)

## Suite

**PR #4** : mount du composant — 3 lignes dans `TutorFullscreen.tsx` :
```tsx
import TutorConceptsCarousel from "../../components/Tutor/TutorConceptsCarousel";
// ... sous le header ...
<TutorConceptsCarousel onConceptClick={(c) => submitTextTurn(c.term)} />
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)