### PR TITLE
feat(tutor): endpoints + service + pregen concepts (re-open après merge PR #507)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1259,6 +1259,19 @@ if TUTOR_ROUTER_AVAILABLE:
     app.include_router(tutor_router, prefix="/api/tutor", tags=["Tutor"])
     logger.info("🎓 Tutor router loaded (POST /api/tutor/session/start)")
 
+# 🎨 Tutor concepts router (carrousel doodles — sprint 2026-05-18)
+try:
+    from tutor.concepts_router import router as tutor_concepts_router
+
+    app.include_router(
+        tutor_concepts_router,
+        prefix="/api/tutor/concepts",
+        tags=["Tutor Concepts"],
+    )
+    logger.info("🎨 Tutor concepts router loaded (GET/POST /api/tutor/concepts)")
+except Exception as e:
+    logger.warning(f"⚠️ tutor_concepts_router not loaded: {e}")
+
 # 🎮 Gamification router (XP, badges, streaks)
 if GAMIFICATION_ROUTER_AVAILABLE:
     app.include_router(gamification_router, prefix="/api/gamification", tags=["Gamification"])

--- a/backend/src/tutor/concepts_router.py
+++ b/backend/src/tutor/concepts_router.py
@@ -1,0 +1,181 @@
+"""Endpoints REST pour le carrousel concepts illustrés Tuteur.
+
+Routes:
+- GET  /api/tutor/concepts           — liste concepts du user + images si ready
+- POST /api/tutor/concepts/generate  — déclenche la gen d'un concept précis
+- POST /api/tutor/concepts/refresh   — force re-fetch (stub V1)
+
+Gating: réservé au plan Expert (admin bypass). Cap quotidien Redis 300/jour
+global (cf core.config.TUTOR_DOODLE_DAILY_CAP).
+"""
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import get_current_user
+from core.config import TUTOR_DOODLE_DAILY_CAP
+from db.database import User, get_session
+from images.keyword_images import _term_hash, generate_doodle_image, get_doodle_url
+
+from .concepts_schemas import (
+    GenerateConceptRequest,
+    GenerateConceptResponse,
+    TutorConceptItem,
+    TutorConceptsResponse,
+)
+from .concepts_service import (
+    attach_image_urls,
+    check_lookup_pending,
+    collect_user_concepts,
+    consume_daily_cap,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+def _check_expert_gating(user: User) -> None:
+    """Gate Expert-only (admin bypass).
+
+    Le carrousel est une feature premium (consomme cap quotidien global +
+    crédits IA pour Gemini). On le réserve à Expert pour la V1, en cohérence
+    avec le positionnement "outils d'étude avancés".
+    """
+    if getattr(user, "is_admin", False):
+        return
+    plan = (user.plan or "").lower()
+    if plan != "expert":
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "feature_blocked",
+                "message": "Carrousel de concepts illustrés réservé au plan Expert",
+                "required_plan": "expert",
+            },
+        )
+
+
+@router.get("", response_model=TutorConceptsResponse)
+async def list_concepts(
+    limit: int = 20,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    """Retourne les concepts du user illustrés ou en cours de génération.
+
+    Concepts merged depuis:
+      (a) les `## ` headings du `summary_content` des analyses récentes
+      (b) `entities_extracted.concepts` (et fallback "keywords"/"entities")
+    Dédup par SHA256(normalized term). Images résolues via lookup
+    `keyword_images` style='tutor_doodle'.
+
+    Query params:
+      limit : int dans [1, 50], défaut 20.
+    """
+    _check_expert_gating(user)
+    limit = max(1, min(50, limit))
+
+    concepts = await collect_user_concepts(user.id, db, limit=limit)
+    if not concepts:
+        return TutorConceptsResponse(
+            concepts=[], total=0, ready_count=0, pending_count=0
+        )
+
+    concepts = await attach_image_urls(concepts)
+    concepts = await check_lookup_pending(concepts)
+
+    items = [
+        TutorConceptItem(
+            term=c["term"],
+            term_hash=c["term_hash"],
+            category=c.get("category"),
+            image_url=c.get("image_url"),
+            status=c.get("status", "missing"),
+        )
+        for c in concepts
+    ]
+    ready = sum(1 for i in items if i.status == "ready")
+    pending = sum(1 for i in items if i.status in ("pending", "missing"))
+    return TutorConceptsResponse(
+        concepts=items,
+        total=len(items),
+        ready_count=ready,
+        pending_count=pending,
+    )
+
+
+@router.post("/generate", response_model=GenerateConceptResponse)
+async def generate_concept(
+    body: GenerateConceptRequest,
+    user: User = Depends(get_current_user),
+):
+    """Déclenche la génération asynchrone d'un doodle pour un concept précis.
+
+    Idempotent: si le doodle existe déjà (status='ready'), retourne l'URL
+    directement sans consommer le cap. Sinon enqueue fire-and-forget et
+    retourne status='pending' — le frontend poll `GET /api/tutor/concepts`
+    pour récupérer l'URL quand prête.
+
+    Si le cap quotidien est atteint, retourne status='throttled', cap_remaining=0.
+    """
+    _check_expert_gating(user)
+    term = body.term.strip()
+    if not term:
+        raise HTTPException(400, "term is required")
+
+    # Idempotency: doodle déjà ready ?
+    existing_url = await get_doodle_url(term)
+    if existing_url:
+        return GenerateConceptResponse(
+            term=term,
+            term_hash=_term_hash(term, style="tutor_doodle"),
+            status="ready",
+            image_url=existing_url,
+            cap_remaining=TUTOR_DOODLE_DAILY_CAP,
+        )
+
+    # Check cap before enqueueing (atomic INCRBY)
+    allowed, remaining = await consume_daily_cap(n=1)
+    if not allowed:
+        return GenerateConceptResponse(
+            term=term,
+            term_hash=_term_hash(term, style="tutor_doodle"),
+            status="throttled",
+            image_url=None,
+            cap_remaining=0,
+        )
+
+    # Enqueue background gen. consume_daily_cap a déjà incrémenté, donc on
+    # appelle directement generate_doodle_image (pas enqueue_doodle_generation
+    # qui re-incrémenterait le cap).
+    async def _bg():
+        try:
+            await generate_doodle_image(term, body.definition, body.category)
+        except Exception as e:
+            logger.error(f"Manual doodle gen failed '{term}': {e}")
+
+    asyncio.create_task(_bg())
+
+    return GenerateConceptResponse(
+        term=term,
+        term_hash=_term_hash(term, style="tutor_doodle"),
+        status="pending",
+        image_url=None,
+        cap_remaining=remaining,
+    )
+
+
+@router.post("/refresh")
+async def refresh_concepts(user: User = Depends(get_current_user)):
+    """Force-refresh: invalide tout cache Redis applicatif pour ce user.
+
+    Note V1: la liste est recalculée à chaque GET /concepts (pas de cache
+    user-level), donc cet endpoint est un no-op fonctionnel. Stub volontaire
+    pour V2 si on ajoute un cache 30min user-level — le frontend peut déjà
+    s'y reposer pour le bouton "Refresh".
+    """
+    _check_expert_gating(user)
+    return {"refreshed": True}

--- a/backend/src/tutor/concepts_schemas.py
+++ b/backend/src/tutor/concepts_schemas.py
@@ -1,0 +1,69 @@
+"""Pydantic v2 schemas for the Tutor concepts carrousel API (sprint 2026-05-18).
+
+Endpoints exposes:
+- GET  /api/tutor/concepts           → TutorConceptsResponse
+- POST /api/tutor/concepts/generate  → GenerateConceptResponse
+- POST /api/tutor/concepts/refresh   → {refreshed: true}
+
+Reserved to Expert plan (admin bypass) via `_check_expert_gating` in the router.
+"""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+# Status d'un concept dans le carrousel:
+# - "ready"     : image_url disponible (doodle généré + uploadé R2)
+# - "pending"   : row keyword_images en cours de génération
+# - "failed"    : la génération précédente a échoué (rétry possible)
+# - "throttled" : cap quotidien atteint (300/jour global), à retenter demain
+# - "missing"   : aucune row keyword_images, génération pas encore lancée
+ConceptStatus = Literal["ready", "pending", "failed", "throttled", "missing"]
+
+
+class TutorConceptItem(BaseModel):
+    """Un concept du carrousel Tuteur."""
+
+    term: str
+    # SHA256(payload) avec style="tutor_doodle" — cf images.keyword_images._term_hash
+    term_hash: str
+    category: Optional[str] = None
+    # None tant que le doodle n'est pas généré (status != "ready")
+    image_url: Optional[str] = None
+    status: ConceptStatus
+
+
+class TutorConceptsResponse(BaseModel):
+    """Réponse de GET /api/tutor/concepts."""
+
+    concepts: list[TutorConceptItem]
+    total: int
+    ready_count: int
+    pending_count: int
+
+
+class GenerateConceptRequest(BaseModel):
+    """Body de POST /api/tutor/concepts/generate."""
+
+    term: str = Field(min_length=1, max_length=200)
+    # Définition courte (optionnelle) injectée dans le prompt de génération.
+    definition: str = Field(default="", max_length=600)
+    category: Optional[str] = Field(default=None, max_length=50)
+
+
+class GenerateConceptResponse(BaseModel):
+    """Réponse de POST /api/tutor/concepts/generate.
+
+    Cas:
+    - status="ready"     : doodle existait déjà, image_url retournée (idempotent)
+    - status="pending"   : génération asynchrone enqueue, frontend doit poll GET /concepts
+    - status="throttled" : cap quotidien atteint, image_url=None, cap_remaining=0
+    """
+
+    term: str
+    term_hash: str
+    status: ConceptStatus
+    image_url: Optional[str] = None
+    # Cap quotidien Tutor doodle restant (sur 300/jour global).
+    cap_remaining: int

--- a/backend/src/tutor/concepts_service.py
+++ b/backend/src/tutor/concepts_service.py
@@ -1,0 +1,354 @@
+"""Service layer pour le carrousel concepts Tuteur (sprint 2026-05-18).
+
+Orchestrateur entre l'historique user (`## ` headings + entities.concepts), le
+cache de doodles (table keyword_images style='tutor_doodle'), et le cap Redis
+quotidien global 300/jour.
+
+Pas de dépendance Celery (confirmed prod: aucun worker Celery). Génération
+asynchrone via `asyncio.create_task` fire-and-forget — la task ouvre sa propre
+session DB (`async_session_maker()`) car la session de requête HTTP est fermée
+avant que la task ne s'exécute.
+"""
+
+import asyncio
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+from core.config import TUTOR_DOODLE_DAILY_CAP, is_gemini_available
+from images.keyword_images import (
+    _term_hash,
+    batch_get_doodle_urls,
+    generate_doodle_image,
+    _get_pool as _get_image_pool,
+)
+
+logger = logging.getLogger(__name__)
+
+# Regex pour extraire les "## " headings du summary_content (mirror voice/tutor_memory).
+# Note: on utilise [ \t] et non \s pour ne pas faire matcher \n et confondre 2 lignes.
+_HEADING_PATTERN = re.compile(r"^##[ \t]+([^\n]+?)[ \t]*$", re.MULTILINE)
+
+
+def _daily_cap_key() -> str:
+    """Redis key pour le compteur quotidien global de doodles Tutor."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return f"tutor_doodle:quota:{today}"
+
+
+def _get_redis():
+    """Retourne le client Redis partagé via cache_service, ou None si indisponible.
+
+    Pattern identique à `tutor.router._get_redis` mais ne lève pas d'HTTPException
+    — on retourne None et l'appelant décide (best-effort sur le cap quotidien).
+    """
+    try:
+        from core.cache import cache_service
+    except Exception:
+        return None
+    if cache_service is None or cache_service.backend is None:
+        return None
+    return getattr(cache_service.backend, "redis", None)
+
+
+def _extract_key_topics(summary_content: str) -> list[str]:
+    """Extrait les `## ` headings d'un markdown summary.
+
+    Même logique que `voice/tutor_memory._extract_key_topics` (duplicat délibéré
+    pour éviter un couplage cross-module qui n'apporte rien). Filtre les
+    headings vides ou trop courts (<2 chars).
+    """
+    if not summary_content:
+        return []
+    matches = _HEADING_PATTERN.findall(summary_content)
+    return [m.strip() for m in matches if m.strip() and len(m.strip()) >= 2]
+
+
+def _extract_entities_concepts(entities_extracted) -> list[str]:
+    """Extrait les concepts depuis Summary.entities_extracted (JSON ou dict).
+
+    Formats supportés:
+      - dict {"concepts": ["str1", "str2"]}
+      - dict {"concepts": [{"term": "x", ...}]}
+      - dict {"keywords": [...]} ou {"entities": [...]} (fallback)
+      - string JSON (sérialisé en DB côté SQLite)
+      - None ou liste vide → []
+    """
+    if not entities_extracted:
+        return []
+    if isinstance(entities_extracted, str):
+        try:
+            entities_extracted = json.loads(entities_extracted)
+        except (json.JSONDecodeError, TypeError):
+            return []
+    out: list[str] = []
+    if isinstance(entities_extracted, dict):
+        for key in ("concepts", "keywords", "entities"):
+            vals = entities_extracted.get(key)
+            if isinstance(vals, list):
+                for v in vals:
+                    if isinstance(v, str) and len(v.strip()) >= 2:
+                        out.append(v.strip())
+                    elif isinstance(v, dict) and "term" in v and isinstance(v["term"], str):
+                        if len(v["term"].strip()) >= 2:
+                            out.append(v["term"].strip())
+                break  # première clé non-vide gagne
+    return out
+
+
+def _normalize_concept(term: str) -> str:
+    """Normalize a concept term for dedup (lowercase, trim, collapse whitespace)."""
+    return " ".join(term.lower().strip().split())
+
+
+async def collect_user_concepts(
+    user_id: int,
+    db,  # AsyncSession SQLAlchemy
+    limit: int = 30,
+) -> list[dict]:
+    """Merge key_topics ∪ entities.concepts depuis les analyses récentes du user.
+
+    Stratégie:
+      - Lookup au plus 100 derniers summaries (cap pour borner la requête)
+      - Pour chaque summary, extract:
+          1. `## ` headings via `_extract_key_topics`
+          2. concepts via `_extract_entities_concepts`
+      - Dédup par SHA256(normalized term)
+      - Retourne max `limit` concepts (premiers vus = plus récents)
+
+    Returns:
+      list[dict] : [{"term": str, "term_hash": str (style='tutor_doodle'),
+                     "category": "concept", "source_summary_id": int}]
+    """
+    from sqlalchemy import select, desc
+    from db.database import Summary
+
+    stmt = (
+        select(Summary.id, Summary.summary_content, Summary.entities_extracted)
+        .where(Summary.user_id == user_id)
+        .order_by(desc(Summary.id))
+        .limit(100)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    seen_norms: set[str] = set()
+    out: list[dict] = []
+    for row in rows:
+        sid = row[0]
+        content = row[1] or ""
+        entities = row[2]
+        # 1. key_topics from "## " headings
+        for term in _extract_key_topics(content):
+            norm = _normalize_concept(term)
+            if not norm or norm in seen_norms:
+                continue
+            seen_norms.add(norm)
+            out.append({
+                "term": term[:200],
+                "term_hash": _term_hash(term, style="tutor_doodle"),
+                "category": "concept",
+                "source_summary_id": sid,
+            })
+            if len(out) >= limit:
+                return out
+        # 2. entities.concepts
+        for term in _extract_entities_concepts(entities):
+            norm = _normalize_concept(term)
+            if not norm or norm in seen_norms:
+                continue
+            seen_norms.add(norm)
+            out.append({
+                "term": term[:200],
+                "term_hash": _term_hash(term, style="tutor_doodle"),
+                "category": "concept",
+                "source_summary_id": sid,
+            })
+            if len(out) >= limit:
+                return out
+    return out
+
+
+async def attach_image_urls(concepts: list[dict]) -> list[dict]:
+    """Pour chaque concept, lookup `image_url` dans keyword_images (style='tutor_doodle').
+
+    Mutate-and-return : ajoute `image_url` et `status` ("ready" si trouvé,
+    "missing" sinon). `check_lookup_pending` raffinera ensuite "missing" en
+    "pending"/"failed" si une row est déjà en cours.
+    """
+    if not concepts:
+        return concepts
+    terms = [c["term"] for c in concepts]
+    pool = await _get_image_pool()
+    url_map = await batch_get_doodle_urls(terms, pool=pool)
+    # `batch_get_doodle_urls` retourne {term_hash: url} ; nos concepts ont déjà term_hash.
+    for c in concepts:
+        url = url_map.get(c["term_hash"])
+        c["image_url"] = url
+        c["status"] = "ready" if url else "missing"
+    return concepts
+
+
+async def check_lookup_pending(concepts: list[dict]) -> list[dict]:
+    """Raffine le status des concepts "missing" en regardant la DB.
+
+    Pour les concepts dont aucun image_url n'a été trouvé (status="missing"),
+    regarde si une row keyword_images existe déjà avec status='pending' ou
+    'failed' (style='tutor_doodle'). Si oui, met à jour le status.
+    """
+    missing_hashes = [c["term_hash"] for c in concepts if c.get("status") == "missing"]
+    if not missing_hashes:
+        return concepts
+    pool = await _get_image_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT term_hash, status FROM keyword_images "
+            "WHERE term_hash = ANY($1) AND style = 'tutor_doodle'",
+            missing_hashes,
+        )
+    status_map = {r["term_hash"]: r["status"] for r in rows}
+    for c in concepts:
+        if c.get("status") == "missing":
+            db_status = status_map.get(c["term_hash"])
+            if db_status in ("pending", "failed"):
+                c["status"] = db_status
+    return concepts
+
+
+async def consume_daily_cap(n: int = 1) -> tuple[bool, int]:
+    """Consume atomique du cap Redis global.
+
+    Returns:
+      (allowed, remaining_after) — `allowed` False si le cap serait dépassé.
+      Si dépassé, rollback du counter (DECRBY) pour ne pas pénaliser les
+      tentatives suivantes.
+
+    Comportement Redis indisponible : on autorise (best-effort, ne bloque pas
+    le user). C'est volontaire — le cap est anti-abuse, pas un hard-quota
+    business. Si Redis tombe, on accepte de dépasser temporairement.
+    """
+    redis = _get_redis()
+    if redis is None:
+        logger.warning("Redis indisponible pour daily cap, autorise par défaut")
+        return True, TUTOR_DOODLE_DAILY_CAP
+
+    key = _daily_cap_key()
+    try:
+        new_count = await redis.incrby(key, n)
+        if new_count == n:
+            # Première hit du jour : set TTL 25h pour résister à un skew d'horloge / DST.
+            await redis.expire(key, 86400 + 3600)
+        if new_count > TUTOR_DOODLE_DAILY_CAP:
+            await redis.decrby(key, n)  # rollback
+            return False, max(0, TUTOR_DOODLE_DAILY_CAP - (new_count - n))
+        return True, max(0, TUTOR_DOODLE_DAILY_CAP - new_count)
+    except Exception as e:
+        logger.warning(f"Redis daily cap error: {e} — autorise par défaut")
+        return True, TUTOR_DOODLE_DAILY_CAP
+
+
+async def enqueue_doodle_generation(
+    term: str,
+    definition: str = "",
+    category: Optional[str] = None,
+) -> None:
+    """Fire-and-forget de la génération d'un doodle via `asyncio.create_task`.
+
+    Consomme 1 unité du cap Redis ; no-op si dépassé. La task background
+    appelle `generate_doodle_image` qui handle Gemini → DALL-E fallback,
+    post-process, R2 upload et DB UPSERT.
+    """
+    allowed, _ = await consume_daily_cap(n=1)
+    if not allowed:
+        logger.warning(f"Daily doodle cap reached, skipping '{term}'")
+        return
+
+    async def _bg():
+        try:
+            url = await generate_doodle_image(term, definition, category)
+            if url:
+                logger.info(f"Doodle ready: '{term}' -> {url}")
+        except Exception as e:
+            logger.error(f"Doodle gen failed for '{term}': {e}")
+
+    asyncio.create_task(_bg())
+
+
+async def enqueue_top_concepts_doodles(
+    summary_id: int,
+    user_id: int,
+    top_n: int = 3,
+) -> int:
+    """Post-analyse hook: pré-génère les top N concepts d'un summary en doodle.
+
+    Appelé depuis videos/router.py après une analyse réussie. Ouvre sa propre
+    session DB (`async_session_maker()`) car la session HTTP est fermée avant
+    que cette task ne s'exécute (cf. asyncio.create_task fire-and-forget).
+
+    Filtre les concepts déjà présents dans keyword_images (évite re-gen).
+
+    Returns:
+      Nombre de doodles enqueue (cap quotidien peut réduire ce nombre dans
+      les tasks background, mais ce return reflète seulement les concepts
+      sélectionnés pour génération).
+    """
+    if not is_gemini_available():
+        return 0
+    from sqlalchemy import select
+    from db.database import async_session_maker, Summary
+
+    async with async_session_maker() as db:
+        stmt = select(Summary.summary_content, Summary.entities_extracted).where(
+            Summary.id == summary_id
+        )
+        result = await db.execute(stmt)
+        row = result.first()
+        if not row:
+            return 0
+        content = row[0] or ""
+        entities = row[1]
+
+    # Merge concepts depuis ce seul summary
+    seen: set[str] = set()
+    picks: list[str] = []
+    for term in _extract_key_topics(content):
+        norm = _normalize_concept(term)
+        if norm and norm not in seen:
+            seen.add(norm)
+            picks.append(term[:200])
+        if len(picks) >= top_n:
+            break
+    if len(picks) < top_n:
+        for term in _extract_entities_concepts(entities):
+            norm = _normalize_concept(term)
+            if norm and norm not in seen:
+                seen.add(norm)
+                picks.append(term[:200])
+            if len(picks) >= top_n:
+                break
+
+    if not picks:
+        return 0
+
+    # Filtre les concepts déjà cached ou pending dans keyword_images
+    pool = await _get_image_pool()
+    hashes = [_term_hash(t, style="tutor_doodle") for t in picks]
+    async with pool.acquire() as conn:
+        existing = await conn.fetch(
+            "SELECT term_hash FROM keyword_images "
+            "WHERE term_hash = ANY($1) AND style = 'tutor_doodle'",
+            hashes,
+        )
+    existing_set = {r["term_hash"] for r in existing}
+
+    enqueued = 0
+    for term in picks:
+        thash = _term_hash(term, style="tutor_doodle")
+        if thash in existing_set:
+            continue
+        await enqueue_doodle_generation(term, definition="", category="concept")
+        enqueued += 1
+    logger.info(f"Pre-gen {enqueued} tutor doodles for summary {summary_id} (user={user_id})")
+    return enqueued

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -3629,6 +3629,18 @@ async def _analyze_video_background_v6(
             except Exception as img_err:
                 logger.error(f"⚠️ [IMAGES] Keyword image enqueue failed (non-blocking): {img_err}")
 
+            # 🎨 Tutor concepts: pré-gen top 3 doodles pour le carrousel (non-blocking).
+            # Sprint 2026-05-18 — Phase 5.3. La task ouvre sa propre session DB
+            # (la session HTTP `session` ici sera fermée avant l'exécution).
+            try:
+                from tutor.concepts_service import enqueue_top_concepts_doodles
+
+                asyncio.create_task(
+                    enqueue_top_concepts_doodles(summary_id, user_id, top_n=3)
+                )
+            except Exception as td_err:
+                logger.warning(f"⚠️ enqueue_top_concepts_doodles failed: {td_err}")
+
             # 🖼️ Persist thumbnail to R2 (non-blocking)
             try:
                 from storage.thumbnail_generator import ensure_thumbnail

--- a/backend/tests/test_tutor_concepts.py
+++ b/backend/tests/test_tutor_concepts.py
@@ -1,0 +1,851 @@
+"""Tests pour le carrousel concepts Tuteur (sprint 2026-05-18).
+
+Couvre:
+- tutor.concepts_schemas (DTOs Pydantic)
+- tutor.concepts_service (extraction, dédup, cap Redis)
+- tutor.concepts_router (endpoints REST + plan gating Expert)
+
+Pattern conftest:
+- DATABASE_URL = sqlite (jamais touché en pratique, dependencies overridées)
+- get_session override -> AsyncMock
+- get_current_user override -> mock User
+- cache_service.backend.redis = fakeredis pour le cap quotidien
+- _get_image_pool / DB lookup mockés via monkeypatch / AsyncMock
+"""
+
+import os
+import sys
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Setup env avant tout import
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from httpx import AsyncClient, ASGITransport
+import fakeredis.aioredis
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Module-level imports (after path setup) — tests unitaires purs
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_module_imports_ok():
+    """Smoke test: les modules s'importent sans crash."""
+    from tutor import concepts_schemas, concepts_service, concepts_router  # noqa: F401
+
+    assert hasattr(concepts_service, "collect_user_concepts")
+    assert hasattr(concepts_service, "consume_daily_cap")
+    assert hasattr(concepts_router, "router")
+
+
+def test_schemas_status_literal_values():
+    """ConceptStatus accepte les 5 valeurs attendues."""
+    from tutor.concepts_schemas import TutorConceptItem
+
+    for status in ("ready", "pending", "failed", "throttled", "missing"):
+        item = TutorConceptItem(term="x", term_hash="abc", status=status)
+        assert item.status == status
+
+    # Status invalide -> ValidationError
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        TutorConceptItem(term="x", term_hash="abc", status="bogus")
+
+
+def test_schemas_generate_request_validates_lengths():
+    """term min=1 max=200, definition max=600, category max=50."""
+    from pydantic import ValidationError
+
+    from tutor.concepts_schemas import GenerateConceptRequest
+
+    # OK
+    req = GenerateConceptRequest(term="ok")
+    assert req.definition == ""
+    assert req.category is None
+
+    # term vide -> erreur
+    with pytest.raises(ValidationError):
+        GenerateConceptRequest(term="")
+
+    # term trop long
+    with pytest.raises(ValidationError):
+        GenerateConceptRequest(term="x" * 201)
+
+    # definition trop longue
+    with pytest.raises(ValidationError):
+        GenerateConceptRequest(term="x", definition="d" * 601)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers d'extraction (purs, pas d'I/O)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_extract_key_topics_simple():
+    from tutor.concepts_service import _extract_key_topics
+
+    md = """# Title
+
+## Premier concept
+some content
+
+## Deuxième concept
+more
+
+### Sub heading (ignored, 3 hashes)
+
+## Third-One"""
+    out = _extract_key_topics(md)
+    assert out == ["Premier concept", "Deuxième concept", "Third-One"]
+
+
+def test_extract_key_topics_ignores_empty_and_short():
+    from tutor.concepts_service import _extract_key_topics
+
+    md = """##
+## a
+## ok"""
+    # "" filtré, "a" filtré (len<2 après strip), "ok" garde
+    assert _extract_key_topics(md) == ["ok"]
+
+
+def test_extract_key_topics_handles_none_and_empty():
+    from tutor.concepts_service import _extract_key_topics
+
+    assert _extract_key_topics("") == []
+    assert _extract_key_topics(None) == []
+
+
+def test_extract_key_topics_accents():
+    from tutor.concepts_service import _extract_key_topics
+
+    md = "## Phénoménologie\n## Hégémonie culturelle"
+    assert _extract_key_topics(md) == ["Phénoménologie", "Hégémonie culturelle"]
+
+
+def test_extract_entities_concepts_dict_strings():
+    from tutor.concepts_service import _extract_entities_concepts
+
+    entities = {"concepts": ["IA", "Algorithme", "x"]}  # "x" filtré (len<2 ok mais len("x")==1 filtré)
+    out = _extract_entities_concepts(entities)
+    assert out == ["IA", "Algorithme"]
+
+
+def test_extract_entities_concepts_dict_objects():
+    from tutor.concepts_service import _extract_entities_concepts
+
+    entities = {
+        "concepts": [
+            {"term": "Biais cognitif", "definition": "..."},
+            {"term": "  Heuristique  "},  # trimmé
+            {"no_term_field": "x"},  # ignoré
+        ]
+    }
+    out = _extract_entities_concepts(entities)
+    assert out == ["Biais cognitif", "Heuristique"]
+
+
+def test_extract_entities_concepts_fallback_keys():
+    from tutor.concepts_service import _extract_entities_concepts
+
+    # "concepts" absent → fallback "keywords"
+    entities = {"keywords": ["KW1", "KW2"]}
+    assert _extract_entities_concepts(entities) == ["KW1", "KW2"]
+    # "keywords" absent → fallback "entities"
+    entities = {"entities": ["E1"]}
+    assert _extract_entities_concepts(entities) == ["E1"]
+
+
+def test_extract_entities_concepts_string_json():
+    from tutor.concepts_service import _extract_entities_concepts
+
+    s = json.dumps({"concepts": ["Alpha", "Beta"]})
+    assert _extract_entities_concepts(s) == ["Alpha", "Beta"]
+
+
+def test_extract_entities_concepts_invalid_json():
+    from tutor.concepts_service import _extract_entities_concepts
+
+    assert _extract_entities_concepts("not json") == []
+    assert _extract_entities_concepts(None) == []
+    assert _extract_entities_concepts("") == []
+    assert _extract_entities_concepts([]) == []
+
+
+def test_normalize_concept():
+    from tutor.concepts_service import _normalize_concept
+
+    assert _normalize_concept("Foo Bar") == "foo bar"
+    assert _normalize_concept("  foo   bar  ") == "foo bar"
+    assert _normalize_concept("FOO\tBAR") == "foo bar"
+    assert _normalize_concept("Phénoménologie") == "phénoménologie"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Plan gating
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_mock_user(plan: str = "expert", uid: int = 1, is_admin: bool = False):
+    u = MagicMock()
+    u.id = uid
+    u.email = f"{plan}@test.fr"
+    u.plan = plan
+    u.is_admin = is_admin
+    return u
+
+
+def test_check_expert_gating_free_raises_403():
+    from fastapi import HTTPException
+
+    from tutor.concepts_router import _check_expert_gating
+
+    with pytest.raises(HTTPException) as exc:
+        _check_expert_gating(_make_mock_user(plan="free"))
+    assert exc.value.status_code == 403
+    assert exc.value.detail.get("required_plan") == "expert"
+
+
+def test_check_expert_gating_pro_raises_403():
+    from fastapi import HTTPException
+
+    from tutor.concepts_router import _check_expert_gating
+
+    with pytest.raises(HTTPException):
+        _check_expert_gating(_make_mock_user(plan="pro"))
+
+
+def test_check_expert_gating_expert_passes():
+    from tutor.concepts_router import _check_expert_gating
+
+    # Pas d'exception = succès
+    _check_expert_gating(_make_mock_user(plan="expert"))
+
+
+def test_check_expert_gating_admin_bypass():
+    from tutor.concepts_router import _check_expert_gating
+
+    _check_expert_gating(_make_mock_user(plan="free", is_admin=True))
+
+
+def test_check_expert_gating_none_plan():
+    """plan=None → 403 (traité comme free)."""
+    from fastapi import HTTPException
+
+    from tutor.concepts_router import _check_expert_gating
+
+    user = _make_mock_user(plan="expert")
+    user.plan = None
+    with pytest.raises(HTTPException):
+        _check_expert_gating(user)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Service: collect_user_concepts (dédup, limit)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_db_with_rows(rows: list[tuple]):
+    """Construit un AsyncMock de db.execute().all() retournant les rows fournies."""
+    db = AsyncMock()
+    exec_result = MagicMock()
+    exec_result.all.return_value = rows
+    db.execute.return_value = exec_result
+    return db
+
+
+@pytest.mark.asyncio
+async def test_collect_user_concepts_dedup_across_summaries():
+    from tutor.concepts_service import collect_user_concepts
+
+    rows = [
+        (101, "## Concept A\n## Concept B\n", None),
+        (102, "## concept a\n## Concept C\n", None),  # "concept a" dup
+    ]
+    db = _make_db_with_rows(rows)
+    out = await collect_user_concepts(user_id=1, db=db, limit=10)
+    terms = [c["term"] for c in out]
+    assert "Concept A" in terms
+    assert "Concept B" in terms
+    assert "Concept C" in terms
+    # Dédup → la 2nde occurrence "concept a" (lowercase) doit être skipped
+    assert sum(1 for t in terms if t.lower() == "concept a") == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_user_concepts_respects_limit():
+    from tutor.concepts_service import collect_user_concepts
+
+    rows = [
+        (101, "## Alpha\n## Beta\n## Gamma\n## Delta\n## Epsilon\n", None),
+    ]
+    db = _make_db_with_rows(rows)
+    out = await collect_user_concepts(user_id=1, db=db, limit=3)
+    assert len(out) == 3
+    assert [c["term"] for c in out] == ["Alpha", "Beta", "Gamma"]
+
+
+@pytest.mark.asyncio
+async def test_collect_user_concepts_merges_headings_and_entities():
+    from tutor.concepts_service import collect_user_concepts
+
+    rows = [
+        (101, "## H1\n", {"concepts": ["E1", "E2"]}),
+    ]
+    db = _make_db_with_rows(rows)
+    out = await collect_user_concepts(user_id=1, db=db, limit=10)
+    terms = [c["term"] for c in out]
+    assert terms == ["H1", "E1", "E2"]
+
+
+@pytest.mark.asyncio
+async def test_collect_user_concepts_empty_rows():
+    from tutor.concepts_service import collect_user_concepts
+
+    db = _make_db_with_rows([])
+    out = await collect_user_concepts(user_id=1, db=db, limit=10)
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_collect_user_concepts_term_hash_uses_tutor_style():
+    """Le term_hash retourné doit utiliser style='tutor_doodle' (pas le legacy 'photo')."""
+    import hashlib
+
+    from tutor.concepts_service import collect_user_concepts
+
+    rows = [(101, "## Test\n", None)]
+    db = _make_db_with_rows(rows)
+    out = await collect_user_concepts(user_id=1, db=db, limit=10)
+    expected = hashlib.sha256("tutor_doodle:test".encode("utf-8")).hexdigest()
+    assert out[0]["term_hash"] == expected
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Service: consume_daily_cap (Redis)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+async def fake_redis_in_cache():
+    """Injecte fakeredis dans cache_service.backend.redis (cleanup automatique)."""
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    from core.cache import cache_service
+
+    saved = cache_service.backend
+    fake_backend = MagicMock()
+    fake_backend.redis = client
+    cache_service.backend = fake_backend
+    try:
+        yield client
+    finally:
+        cache_service.backend = saved
+        await client.flushall()
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_cap_first_call_succeeds(fake_redis_in_cache):
+    from core.config import TUTOR_DOODLE_DAILY_CAP
+    from tutor.concepts_service import consume_daily_cap
+
+    allowed, remaining = await consume_daily_cap(n=1)
+    assert allowed is True
+    assert remaining == TUTOR_DOODLE_DAILY_CAP - 1
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_cap_blocks_when_exceeded(fake_redis_in_cache, monkeypatch):
+    """Mock un cap très bas et vérifie le rollback quand dépassé."""
+    monkeypatch.setattr("tutor.concepts_service.TUTOR_DOODLE_DAILY_CAP", 3)
+    from tutor.concepts_service import consume_daily_cap
+
+    # 3 consommations OK
+    for i in range(3):
+        allowed, _ = await consume_daily_cap(n=1)
+        assert allowed is True
+    # 4ème → bloqué
+    allowed, remaining = await consume_daily_cap(n=1)
+    assert allowed is False
+    assert remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_cap_redis_unavailable_allows():
+    """Si Redis est down (cache_service.backend = None), on autorise."""
+    from core.cache import cache_service
+    from core.config import TUTOR_DOODLE_DAILY_CAP
+    from tutor.concepts_service import consume_daily_cap
+
+    saved = cache_service.backend
+    cache_service.backend = None
+    try:
+        allowed, remaining = await consume_daily_cap(n=1)
+        assert allowed is True
+        assert remaining == TUTOR_DOODLE_DAILY_CAP
+    finally:
+        cache_service.backend = saved
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Endpoints (FastAPI TestClient)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def mock_session():
+    s = AsyncMock()
+    s.execute = AsyncMock()
+    s.commit = AsyncMock()
+    s.rollback = AsyncMock()
+    s.close = AsyncMock()
+    return s
+
+
+@pytest.fixture
+def app(mock_session):
+    """FastAPI app avec override get_session."""
+    from main import app
+    from db.database import get_session
+
+    async def override_session():
+        return mock_session
+
+    app.dependency_overrides[get_session] = override_session
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def authenticated_expert_client(app, fake_redis_in_cache):
+    from auth.dependencies import get_current_user
+
+    async def override_user():
+        return _make_mock_user(plan="expert", uid=1)
+
+    app.dependency_overrides[get_current_user] = override_user
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+async def authenticated_pro_client(app, fake_redis_in_cache):
+    """Pro user — devrait être bloqué (403)."""
+    from auth.dependencies import get_current_user
+
+    async def override_user():
+        return _make_mock_user(plan="pro", uid=2)
+
+    app.dependency_overrides[get_current_user] = override_user
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+async def authenticated_free_client(app, fake_redis_in_cache):
+    from auth.dependencies import get_current_user
+
+    async def override_user():
+        return _make_mock_user(plan="free", uid=3)
+
+    app.dependency_overrides[get_current_user] = override_user
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+async def unauthenticated_client(app, fake_redis_in_cache):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+# --- GET /api/tutor/concepts ---
+
+
+@pytest.mark.asyncio
+async def test_list_concepts_free_user_403(authenticated_free_client):
+    resp = await authenticated_free_client.get("/api/tutor/concepts")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_concepts_pro_user_403(authenticated_pro_client):
+    resp = await authenticated_pro_client.get("/api/tutor/concepts")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_concepts_unauthenticated_401(unauthenticated_client):
+    resp = await unauthenticated_client.get("/api/tutor/concepts")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_concepts_expert_empty(authenticated_expert_client, monkeypatch):
+    """Expert user, 0 concepts → response avec listes vides."""
+
+    async def fake_collect(user_id, db, limit=20):
+        return []
+
+    monkeypatch.setattr("tutor.concepts_router.collect_user_concepts", fake_collect)
+    resp = await authenticated_expert_client.get("/api/tutor/concepts")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["concepts"] == []
+    assert data["total"] == 0
+    assert data["ready_count"] == 0
+    assert data["pending_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_concepts_expert_with_mocked_concepts(
+    authenticated_expert_client, monkeypatch
+):
+    """Expert user, 3 concepts (1 ready, 1 pending, 1 missing) → response cohérente."""
+    from images.keyword_images import _term_hash
+
+    fake_concepts = [
+        {"term": "Alpha", "term_hash": _term_hash("Alpha", style="tutor_doodle"), "category": "concept"},
+        {"term": "Beta", "term_hash": _term_hash("Beta", style="tutor_doodle"), "category": "concept"},
+        {"term": "Gamma", "term_hash": _term_hash("Gamma", style="tutor_doodle"), "category": "concept"},
+    ]
+
+    async def fake_collect(user_id, db, limit=20):
+        # Copie défensive
+        return [dict(c) for c in fake_concepts]
+
+    async def fake_attach(concepts):
+        # Alpha ready, Beta+Gamma missing
+        for c in concepts:
+            if c["term"] == "Alpha":
+                c["image_url"] = "https://r2.example/alpha.webp"
+                c["status"] = "ready"
+            else:
+                c["image_url"] = None
+                c["status"] = "missing"
+        return concepts
+
+    async def fake_pending(concepts):
+        # Beta becomes pending, Gamma stays missing
+        for c in concepts:
+            if c["term"] == "Beta":
+                c["status"] = "pending"
+        return concepts
+
+    monkeypatch.setattr("tutor.concepts_router.collect_user_concepts", fake_collect)
+    monkeypatch.setattr("tutor.concepts_router.attach_image_urls", fake_attach)
+    monkeypatch.setattr("tutor.concepts_router.check_lookup_pending", fake_pending)
+
+    resp = await authenticated_expert_client.get("/api/tutor/concepts")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total"] == 3
+    assert data["ready_count"] == 1
+    assert data["pending_count"] == 2  # Beta(pending) + Gamma(missing)
+    statuses = {c["term"]: c["status"] for c in data["concepts"]}
+    assert statuses == {"Alpha": "ready", "Beta": "pending", "Gamma": "missing"}
+
+
+@pytest.mark.asyncio
+async def test_list_concepts_admin_bypass(app, fake_redis_in_cache, monkeypatch):
+    """Admin avec plan=free passe le gating."""
+    from auth.dependencies import get_current_user
+
+    async def override_user():
+        return _make_mock_user(plan="free", uid=99, is_admin=True)
+
+    app.dependency_overrides[get_current_user] = override_user
+
+    async def fake_collect(user_id, db, limit=20):
+        return []
+
+    monkeypatch.setattr("tutor.concepts_router.collect_user_concepts", fake_collect)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/tutor/concepts")
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_list_concepts_limit_clamped(authenticated_expert_client, monkeypatch):
+    """limit=1000 doit être clampé à 50 max."""
+    captured = {}
+
+    async def fake_collect(user_id, db, limit=20):
+        captured["limit"] = limit
+        return []
+
+    monkeypatch.setattr("tutor.concepts_router.collect_user_concepts", fake_collect)
+    resp = await authenticated_expert_client.get("/api/tutor/concepts?limit=1000")
+    assert resp.status_code == 200
+    assert captured["limit"] == 50
+
+    # limit=0 → clamp à 1
+    resp = await authenticated_expert_client.get("/api/tutor/concepts?limit=0")
+    assert resp.status_code == 200
+    assert captured["limit"] == 1
+
+
+# --- POST /api/tutor/concepts/generate ---
+
+
+@pytest.mark.asyncio
+async def test_generate_concept_idempotent_when_ready(
+    authenticated_expert_client, monkeypatch
+):
+    """Si get_doodle_url retourne déjà une URL → status='ready' sans consommer cap."""
+
+    async def fake_get_url(term, pool=None):
+        return "https://r2.example/term.webp"
+
+    monkeypatch.setattr("tutor.concepts_router.get_doodle_url", fake_get_url)
+
+    resp = await authenticated_expert_client.post(
+        "/api/tutor/concepts/generate",
+        json={"term": "MyTerm", "definition": "", "category": None},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "ready"
+    assert data["image_url"] == "https://r2.example/term.webp"
+
+
+@pytest.mark.asyncio
+async def test_generate_concept_pending_path(authenticated_expert_client, monkeypatch):
+    """Doodle pas en cache → status='pending' + cap décrémenté."""
+
+    async def fake_get_url(term, pool=None):
+        return None
+
+    monkeypatch.setattr("tutor.concepts_router.get_doodle_url", fake_get_url)
+
+    # Évite l'appel réel à generate_doodle_image dans la task
+    async def fake_gen(term, definition, category=None, pool=None):
+        return None
+
+    monkeypatch.setattr("tutor.concepts_router.generate_doodle_image", fake_gen)
+
+    resp = await authenticated_expert_client.post(
+        "/api/tutor/concepts/generate",
+        json={"term": "NewTerm"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "pending"
+    assert data["image_url"] is None
+    assert data["cap_remaining"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_generate_concept_throttled(authenticated_expert_client, monkeypatch):
+    """Si cap atteint → status='throttled', cap_remaining=0."""
+
+    async def fake_get_url(term, pool=None):
+        return None
+
+    monkeypatch.setattr("tutor.concepts_router.get_doodle_url", fake_get_url)
+
+    async def fake_consume(n=1):
+        return False, 0
+
+    monkeypatch.setattr("tutor.concepts_router.consume_daily_cap", fake_consume)
+
+    resp = await authenticated_expert_client.post(
+        "/api/tutor/concepts/generate",
+        json={"term": "X"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "throttled"
+    assert data["image_url"] is None
+    assert data["cap_remaining"] == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_concept_free_user_403(authenticated_free_client):
+    resp = await authenticated_free_client.post(
+        "/api/tutor/concepts/generate", json={"term": "X"}
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_generate_concept_validation_empty_term(authenticated_expert_client):
+    """term="" → 422 (Pydantic validation)."""
+    resp = await authenticated_expert_client.post(
+        "/api/tutor/concepts/generate", json={"term": ""}
+    )
+    assert resp.status_code == 422
+
+
+# --- POST /api/tutor/concepts/refresh ---
+
+
+@pytest.mark.asyncio
+async def test_refresh_concepts_expert(authenticated_expert_client):
+    resp = await authenticated_expert_client.post("/api/tutor/concepts/refresh")
+    assert resp.status_code == 200
+    assert resp.json() == {"refreshed": True}
+
+
+@pytest.mark.asyncio
+async def test_refresh_concepts_free_403(authenticated_free_client):
+    resp = await authenticated_free_client.post("/api/tutor/concepts/refresh")
+    assert resp.status_code == 403
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# enqueue_top_concepts_doodles (post-analyse hook)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_enqueue_top_concepts_no_gemini_returns_zero(monkeypatch):
+    """is_gemini_available()=False → 0 doodles enqueue."""
+    monkeypatch.setattr("tutor.concepts_service.is_gemini_available", lambda: False)
+    from tutor.concepts_service import enqueue_top_concepts_doodles
+
+    n = await enqueue_top_concepts_doodles(summary_id=1, user_id=1, top_n=3)
+    assert n == 0
+
+
+@pytest.mark.asyncio
+async def test_enqueue_top_concepts_picks_top_n(monkeypatch, fake_redis_in_cache):
+    """Avec 5 concepts disponibles, top_n=2 → 2 doodles enqueue."""
+    monkeypatch.setattr("tutor.concepts_service.is_gemini_available", lambda: True)
+
+    # Mock async_session_maker -> retourne un fake context manager
+    class FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def execute(self, stmt):
+            exec_result = MagicMock()
+            exec_result.first.return_value = (
+                "## C1\n## C2\n## C3\n## C4\n## C5\n",
+                None,
+            )
+            return exec_result
+
+    monkeypatch.setattr("db.database.async_session_maker", lambda: FakeDB())
+
+    # Mock le pool DB (recherche existence) → aucun concept déjà existant
+    class FakePool:
+        async def acquire(self):
+            return FakeConn()
+
+    class FakeConn:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def fetch(self, query, *args):
+            return []
+
+    pool = MagicMock()
+
+    async def fake_acquire():
+        return FakeConn()
+
+    pool.acquire = lambda: _AsyncContextManager(FakeConn())
+
+    class _AsyncContextManager:
+        def __init__(self, inner):
+            self.inner = inner
+
+        async def __aenter__(self):
+            return self.inner
+
+        async def __aexit__(self, *args):
+            return None
+
+    async def fake_get_pool():
+        return pool
+
+    monkeypatch.setattr("tutor.concepts_service._get_image_pool", fake_get_pool)
+
+    # Mock generate_doodle_image pour ne pas réellement appeler Gemini
+    async def fake_gen(term, definition, category=None, pool=None):
+        return None
+
+    monkeypatch.setattr("tutor.concepts_service.generate_doodle_image", fake_gen)
+
+    from tutor.concepts_service import enqueue_top_concepts_doodles
+
+    n = await enqueue_top_concepts_doodles(summary_id=42, user_id=1, top_n=2)
+    assert n == 2
+
+
+@pytest.mark.asyncio
+async def test_enqueue_top_concepts_skips_existing(monkeypatch, fake_redis_in_cache):
+    """Si tous les hashes sont déjà existants → 0 enqueue."""
+    import hashlib
+
+    monkeypatch.setattr("tutor.concepts_service.is_gemini_available", lambda: True)
+
+    class FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def execute(self, stmt):
+            r = MagicMock()
+            r.first.return_value = ("## OnlyConcept\n", None)
+            return r
+
+    monkeypatch.setattr("db.database.async_session_maker", lambda: FakeDB())
+
+    # Hash existant simulé
+    existing_hash = hashlib.sha256("tutor_doodle:onlyconcept".encode()).hexdigest()
+
+    class FakeConn:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def fetch(self, query, *args):
+            return [{"term_hash": existing_hash}]
+
+    class _Cm:
+        def __init__(self, inner):
+            self.inner = inner
+
+        async def __aenter__(self):
+            return self.inner
+
+        async def __aexit__(self, *args):
+            return None
+
+    pool = MagicMock()
+    pool.acquire = lambda: _Cm(FakeConn())
+
+    async def fake_get_pool():
+        return pool
+
+    monkeypatch.setattr("tutor.concepts_service._get_image_pool", fake_get_pool)
+
+    async def fake_gen(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("tutor.concepts_service.generate_doodle_image", fake_gen)
+
+    from tutor.concepts_service import enqueue_top_concepts_doodles
+
+    n = await enqueue_top_concepts_doodles(summary_id=42, user_id=1, top_n=3)
+    assert n == 0


### PR DESCRIPTION
Re-open de [PR #508](https://github.com/Fonira/DeepSight-Main/pull/508) (fermée auto après suppression de sa base `feat/tutor-concept-pipeline` par le merge de [PR #507](https://github.com/Fonira/DeepSight-Main/pull/507)).

Rebase clean sur main (1 commit skipped car déjà applied via squash de #507).

Contenu identique : endpoints `/api/tutor/concepts/*` + service + pregen hook + 43/43 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)