### PR TITLE
feat(tutor): mount TutorConceptsCarousel (re-open après merge PR #509)

### DIFF
--- a/frontend/src/components/Tutor/TutorFullscreen.tsx
+++ b/frontend/src/components/Tutor/TutorFullscreen.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from "react-router-dom";
 import { ChevronLeft, Send, X } from "lucide-react";
 import { useTutorStore } from "../../store/tutorStore";
 import { useLanguage } from "../../contexts/LanguageContext";
+import TutorConceptsCarousel from "./TutorConceptsCarousel";
 
 const stopPropagation = (e: React.PointerEvent | React.MouseEvent) => {
   e.stopPropagation();
@@ -111,6 +112,18 @@ export const TutorFullscreen: React.FC = () => {
           <X className="w-5 h-5" />
         </button>
       </header>
+
+      {/* Concepts illustrés (carrousel horizontal — sprint 2026-05-18).
+          Bord-à-bord sous le header. Visible Expert-only ; self-gated via
+          PLAN_FEATURES[plan].tutorConceptsCarousel. Click → injecte le
+          concept dans la conv active (no-op si pas de session ouverte). */}
+      <TutorConceptsCarousel
+        onConceptClick={(c) => {
+          if (phase === "mini-chat") {
+            void submitTextTurn(c.term);
+          }
+        }}
+      />
 
       {/* Body */}
       <div

--- a/frontend/src/components/Tutor/__tests__/TutorFullscreen.test.tsx
+++ b/frontend/src/components/Tutor/__tests__/TutorFullscreen.test.tsx
@@ -15,6 +15,13 @@ vi.mock("../../../contexts/LanguageContext", () => ({
   useLanguage: () => ({ language: "fr" }),
 }));
 
+// Mock TutorConceptsCarousel : ses dépendances (AuthContext, planPrivileges,
+// store actions concepts) ne sont pas pertinentes pour tester TutorFullscreen.
+// Le mount du carrousel est testé séparément dans TutorConceptsCarousel.test.tsx.
+vi.mock("../TutorConceptsCarousel", () => ({
+  default: () => null,
+}));
+
 vi.mock("../../../services/api", () => ({
   tutorApi: {
     sessionStart: vi.fn().mockResolvedValue({


### PR DESCRIPTION
Re-open de [PR #510](https://github.com/Fonira/DeepSight-Main/pull/510) (fermée auto après suppression de sa base `feat/tutor-concept-frontend` par le merge de [PR #509](https://github.com/Fonira/DeepSight-Main/pull/509)).

Rebase clean sur main. Contenu identique : mount `<TutorConceptsCarousel />` dans TutorFullscreen.tsx + mock vi pour le test existant. 21/21 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)