### PR TITLE
feat(scholar): UI mobile — Switch deep_search + badge via Scholar (PR 3b/3)

### DIFF
--- a/mobile/src/components/academic/AcademicSourcesSection.tsx
+++ b/mobile/src/components/academic/AcademicSourcesSection.tsx
@@ -7,6 +7,8 @@ import {
   ActivityIndicator,
   ScrollView,
   Alert,
+  Switch,
+  Pressable,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
@@ -49,6 +51,7 @@ export const AcademicSourcesSection: React.FC<AcademicSourcesSectionProps> = ({
   const [tierLimitReached, setTierLimitReached] = useState(false);
   const [tierLimit, setTierLimit] = useState<number | null>(null);
   const [totalFound, setTotalFound] = useState(0);
+  const [deepSearch, setDeepSearch] = useState(false);
 
   const [selectedPapers, setSelectedPapers] = useState<Set<string>>(new Set());
   const [showExportModal, setShowExportModal] = useState(false);
@@ -56,7 +59,19 @@ export const AcademicSourcesSection: React.FC<AcademicSourcesSectionProps> = ({
   const plan = normalizePlanId(userPlan);
   const canSearch = hasFeature(plan, "academicSearch");
   const canExport = hasFeature(plan, "bibliographyExport");
+  const canDeepSearch = plan === "pro" || plan === "expert";
   const paperLimit = getLimit(plan, "academicPapersPerAnalysis");
+
+  const showScholarTooltip = useCallback(() => {
+    Alert.alert(
+      tr("Recherche approfondie (Scholar)", "Deep search (Scholar)"),
+      tr(
+        "Inclut Google Scholar pour plus de profondeur. Limite 5/jour (Pro) ou 30/jour (Expert).",
+        "Includes Google Scholar for deeper coverage. Limit 5/day (Pro) or 30/day (Expert).",
+      ),
+      [{ text: "OK" }],
+    );
+  }, [tr]);
 
   const handleSearch = useCallback(async () => {
     if (!canSearch) {
@@ -69,7 +84,9 @@ export const AcademicSourcesSection: React.FC<AcademicSourcesSectionProps> = ({
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
     try {
-      const response = await academicApi.enrich(summaryId);
+      const response = await academicApi.enrich(summaryId, {
+        deep_search: canDeepSearch && deepSearch,
+      });
       setPapers(response.papers);
       setTotalFound(response.total_found);
       setTierLimitReached(response.tier_limit_reached);
@@ -85,7 +102,7 @@ export const AcademicSourcesSection: React.FC<AcademicSourcesSectionProps> = ({
     } finally {
       setLoading(false);
     }
-  }, [summaryId, canSearch, onUpgrade, tr]);
+  }, [summaryId, canSearch, canDeepSearch, deepSearch, onUpgrade, tr]);
 
   const handleSelectPaper = (paper: AcademicPaper) => {
     setSelectedPapers((prev) => {
@@ -165,6 +182,49 @@ export const AcademicSourcesSection: React.FC<AcademicSourcesSectionProps> = ({
               "Find scientific papers related to this analysis from Semantic Scholar, OpenAlex, and arXiv.",
             )}
           </Text>
+
+          {/* Deep search toggle (Pro+) / CTA (Free) — spec §13.2 */}
+          {canDeepSearch ? (
+            <View style={styles.deepSearchRow} testID="deep-search-row">
+              <Switch
+                value={deepSearch}
+                onValueChange={setDeepSearch}
+                trackColor={{ false: colors.border, true: "#7C3AED" }}
+                thumbColor="#FFFFFF"
+                testID="deep-search-switch"
+              />
+              <Text
+                style={[styles.deepSearchLabel, { color: colors.textSecondary }]}
+              >
+                {tr("Recherche approfondie (Scholar)", "Deep search (Scholar)")}
+              </Text>
+              <TouchableOpacity
+                onPress={showScholarTooltip}
+                accessibilityLabel={tr(
+                  "Plus d'informations sur Deep search",
+                  "More info about Deep search",
+                )}
+                hitSlop={8}
+                testID="deep-search-tooltip"
+              >
+                <Ionicons
+                  name="information-circle-outline"
+                  size={16}
+                  color={colors.textTertiary}
+                />
+              </TouchableOpacity>
+            </View>
+          ) : plan === "free" ? (
+            <Pressable
+              onPress={() => onUpgrade?.()}
+              style={styles.deepSearchCta}
+              testID="deep-search-upgrade-cta"
+            >
+              <Text style={[styles.deepSearchCtaText, { color: "#A78BFA" }]}>
+                {tr("Deep search Pro+ →", "Deep search Pro+ →")}
+              </Text>
+            </Pressable>
+          ) : null}
 
           <Button
             title={tr("Rechercher des sources", "Find Sources")}
@@ -378,6 +438,25 @@ const styles = StyleSheet.create({
   },
   searchButton: {
     minWidth: 200,
+  },
+  deepSearchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.xs,
+    marginBottom: Spacing.md,
+  },
+  deepSearchLabel: {
+    fontSize: Typography.fontSize.xs,
+    fontFamily: Typography.fontFamily.body,
+  },
+  deepSearchCta: {
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.sm,
+    marginBottom: Spacing.md,
+  },
+  deepSearchCtaText: {
+    fontSize: Typography.fontSize.xs,
+    fontFamily: Typography.fontFamily.bodyMedium,
   },
   upgradeHint: {
     fontSize: Typography.fontSize.xs,

--- a/mobile/src/components/academic/PaperCard.tsx
+++ b/mobile/src/components/academic/PaperCard.tsx
@@ -28,12 +28,16 @@ const SOURCE_COLORS: Record<string, string> = {
   semantic_scholar: "#1857B6",
   openalex: "#C93C20",
   arxiv: "#B31B1B",
+  crossref: "#047857",
+  scholar: "#7C3AED",
 };
 
 const SOURCE_NAMES: Record<string, string> = {
   semantic_scholar: "Semantic Scholar",
   openalex: "OpenAlex",
   arxiv: "arXiv",
+  crossref: "Crossref",
+  scholar: "via Scholar",
 };
 
 const PaperCardComponent: React.FC<PaperCardProps> = ({

--- a/mobile/src/components/academic/__tests__/AcademicSourcesSection.test.tsx
+++ b/mobile/src/components/academic/__tests__/AcademicSourcesSection.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests AcademicSourcesSection mobile — toggle Scholar deep_search (spec PR3b)
+ * Spec : docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md §13.2
+ */
+
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+jest.mock("../../../contexts/ThemeContext", () => ({
+  useTheme: () => ({
+    colors: {
+      background: "#0a0a0f",
+      surface: "#15151f",
+      borderDefault: "rgba(255,255,255,0.06)",
+      textPrimary: "#ffffff",
+      textSecondary: "#f1f5f9",
+      textTertiary: "#cbd5e1",
+      accentPrimary: "#6366f1",
+      warning: "#f59e0b",
+      error: "#ef4444",
+    },
+    isDark: true,
+  }),
+}));
+
+jest.mock("../../../contexts/LanguageContext", () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+    tr: (fr: string, _en: string) => fr,
+  }),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(() => Promise.resolve()),
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium" },
+}));
+
+const mockEnrich = jest.fn();
+jest.mock("../../../services/api", () => ({
+  academicApi: {
+    enrich: (...args: unknown[]) => mockEnrich(...args),
+    search: jest.fn(),
+    getPapers: jest.fn(),
+    exportBibliography: jest.fn(),
+  },
+}));
+
+jest.mock("../../ui", () => {
+  const RN = require("react-native");
+  const Card = ({ children, style }: { children: React.ReactNode; style?: unknown }) => (
+    <RN.View style={style}>{children}</RN.View>
+  );
+  const Button = ({
+    title,
+    onPress,
+    testID,
+  }: {
+    title: string;
+    onPress?: () => void;
+    testID?: string;
+  }) => (
+    <RN.TouchableOpacity onPress={onPress} testID={testID ?? `btn-${title}`}>
+      <RN.Text>{title}</RN.Text>
+    </RN.TouchableOpacity>
+  );
+  const Badge = ({ children }: { children: React.ReactNode }) => (
+    <RN.View>
+      <RN.Text>{children}</RN.Text>
+    </RN.View>
+  );
+  return { Card, Button, Badge };
+});
+
+jest.mock("../BibliographyExport", () => ({
+  BibliographyExportModal: () => null,
+}));
+
+jest.mock("../PaperCard", () => ({
+  PaperCard: () => null,
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: ({ name }: { name: string }) => {
+    const RN = require("react-native");
+    return <RN.Text>{`[icon:${name}]`}</RN.Text>;
+  },
+}));
+
+import { AcademicSourcesSection } from "../AcademicSourcesSection";
+
+const baseResponse = {
+  papers: [],
+  total_found: 0,
+  query_keywords: ["test"],
+  sources_queried: ["openalex"],
+  cached: false,
+  tier_limit_reached: false,
+  tier_limit: undefined,
+};
+
+describe("AcademicSourcesSection — Scholar deep_search toggle (mobile)", () => {
+  beforeEach(() => {
+    mockEnrich.mockReset();
+    mockEnrich.mockResolvedValue(baseResponse);
+  });
+
+  it("affiche le Switch deep_search pour un user Pro", () => {
+    const { getByTestId, queryByTestId } = render(
+      <AcademicSourcesSection summaryId="42" userPlan="pro" />,
+    );
+    expect(getByTestId("deep-search-switch")).toBeTruthy();
+    expect(getByTestId("deep-search-row")).toBeTruthy();
+    expect(queryByTestId("deep-search-upgrade-cta")).toBeNull();
+  });
+
+  it("affiche le Switch pour un user Expert", () => {
+    const { getByTestId } = render(
+      <AcademicSourcesSection summaryId="42" userPlan="expert" />,
+    );
+    expect(getByTestId("deep-search-switch")).toBeTruthy();
+  });
+
+  it("affiche la CTA upgrade pour un user Free (pas de Switch)", () => {
+    const onUpgrade = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <AcademicSourcesSection
+        summaryId="42"
+        userPlan="free"
+        onUpgrade={onUpgrade}
+      />,
+    );
+    expect(queryByTestId("deep-search-switch")).toBeNull();
+    expect(getByTestId("deep-search-upgrade-cta")).toBeTruthy();
+  });
+
+  it("appelle onUpgrade quand le user free clique sur la CTA", () => {
+    const onUpgrade = jest.fn();
+    const { getByTestId } = render(
+      <AcademicSourcesSection
+        summaryId="42"
+        userPlan="free"
+        onUpgrade={onUpgrade}
+      />,
+    );
+    fireEvent.press(getByTestId("deep-search-upgrade-cta"));
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("passe deep_search=false par défaut au call enrich (Pro)", async () => {
+    const { getByTestId } = render(
+      <AcademicSourcesSection summaryId="42" userPlan="pro" />,
+    );
+    fireEvent.press(getByTestId("btn-Rechercher des sources"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockEnrich).toHaveBeenCalledTimes(1);
+    expect(mockEnrich).toHaveBeenCalledWith("42", { deep_search: false });
+  });
+
+  it("passe deep_search=true au call enrich quand le Switch est activé", async () => {
+    const { getByTestId } = render(
+      <AcademicSourcesSection summaryId="42" userPlan="pro" />,
+    );
+    fireEvent(getByTestId("deep-search-switch"), "valueChange", true);
+    fireEvent.press(getByTestId("btn-Rechercher des sources"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockEnrich).toHaveBeenCalledWith("42", { deep_search: true });
+  });
+});

--- a/mobile/src/components/academic/__tests__/PaperCard.test.tsx
+++ b/mobile/src/components/academic/__tests__/PaperCard.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests PaperCard mobile — badges sources (Scholar + Crossref ajoutés PR3b)
+ * Spec : docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md §13.2
+ */
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+jest.mock("../../../contexts/ThemeContext", () => ({
+  useTheme: () => ({
+    colors: {
+      background: "#0a0a0f",
+      surface: "#15151f",
+      borderDefault: "rgba(255,255,255,0.06)",
+      textPrimary: "#ffffff",
+      textSecondary: "#f1f5f9",
+      textTertiary: "#cbd5e1",
+      accentPrimary: "#6366f1",
+      success: "#22c55e",
+    },
+    isDark: true,
+  }),
+}));
+
+jest.mock("../../../contexts/LanguageContext", () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+    tr: (fr: string, _en: string) => fr,
+  }),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(() => Promise.resolve()),
+  notificationAsync: jest.fn(() => Promise.resolve()),
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium", Heavy: "heavy" },
+  NotificationFeedbackType: { Success: "success", Warning: "warning", Error: "error" },
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: ({ name }: { name: string }) => {
+    const RN = require("react-native");
+    return <RN.Text>{`[icon:${name}]`}</RN.Text>;
+  },
+}));
+
+import { PaperCard } from "../PaperCard";
+import type { AcademicPaper } from "../../../services/api";
+
+const basePaper: AcademicPaper = {
+  id: "p-1",
+  doi: "10.1000/test",
+  title: "A test paper about epistemology",
+  authors: [{ name: "Doe, J." }],
+  year: 2024,
+  venue: "Journal of Tests",
+  abstract: "An abstract of the test paper.",
+  citation_count: 42,
+  url: "https://example.com/p-1",
+  pdf_url: undefined,
+  source: "semantic_scholar",
+  relevance_score: 0.95,
+  is_open_access: false,
+  keywords: ["test"],
+};
+
+describe("PaperCard — source badges (mobile)", () => {
+  it("affiche le badge 'Semantic Scholar' pour source=semantic_scholar", () => {
+    const { getByText } = render(<PaperCard paper={basePaper} />);
+    expect(getByText("Semantic Scholar")).toBeTruthy();
+  });
+
+  it("affiche le badge 'OpenAlex' pour source=openalex", () => {
+    const { getByText } = render(
+      <PaperCard paper={{ ...basePaper, source: "openalex" }} />,
+    );
+    expect(getByText("OpenAlex")).toBeTruthy();
+  });
+
+  it("affiche le badge 'arXiv' pour source=arxiv", () => {
+    const { getByText } = render(
+      <PaperCard paper={{ ...basePaper, source: "arxiv" }} />,
+    );
+    expect(getByText("arXiv")).toBeTruthy();
+  });
+
+  it("affiche le badge 'Crossref' pour source=crossref", () => {
+    const { getByText } = render(
+      <PaperCard paper={{ ...basePaper, source: "crossref" }} />,
+    );
+    expect(getByText("Crossref")).toBeTruthy();
+  });
+
+  it("affiche le badge 'via Scholar' pour source=scholar", () => {
+    const { getByText } = render(
+      <PaperCard paper={{ ...basePaper, source: "scholar" }} />,
+    );
+    expect(getByText("via Scholar")).toBeTruthy();
+  });
+});

--- a/mobile/src/i18n/en.json
+++ b/mobile/src/i18n/en.json
@@ -958,8 +958,17 @@
     "sources": {
       "semanticScholar": "Semantic Scholar",
       "openAlex": "OpenAlex",
-      "arxiv": "arXiv"
+      "arxiv": "arXiv",
+      "crossref": "Crossref",
+      "scholar": "via Scholar"
     },
+    "deepSearchToggle": "Deep search (Scholar)",
+    "deepSearchTooltip": "Includes Google Scholar for deeper coverage. Limit 5/day (Pro) or 30/day (Expert).",
+    "deepSearchUpgradeFree": "Deep search Pro+ →",
+    "scholarBadge": "via Scholar",
+    "scholarDisclaimer": "Data provided by Google Scholar for informational use. Verify the original sources.",
+    "scholarQuotaReached": "Scholar limit reached ({{current}}/{{limit}}). Resets at midnight UTC.",
+    "scholarRequiresPro": "Scholar search requires a Pro or Expert plan.",
     "exportModal": {
       "title": "Export Bibliography",
       "chooseFormat": "Choose format",

--- a/mobile/src/i18n/fr.json
+++ b/mobile/src/i18n/fr.json
@@ -958,8 +958,17 @@
     "sources": {
       "semanticScholar": "Semantic Scholar",
       "openAlex": "OpenAlex",
-      "arxiv": "arXiv"
+      "arxiv": "arXiv",
+      "crossref": "Crossref",
+      "scholar": "via Scholar"
     },
+    "deepSearchToggle": "Recherche approfondie (Scholar)",
+    "deepSearchTooltip": "Inclut Google Scholar pour plus de profondeur. Limite 5/jour (Pro) ou 30/jour (Expert).",
+    "deepSearchUpgradeFree": "Deep search Pro+ →",
+    "scholarBadge": "via Scholar",
+    "scholarDisclaimer": "Données fournies par Google Scholar à titre informatif. Vérifier les sources originales.",
+    "scholarQuotaReached": "Limite Scholar atteinte ({{current}}/{{limit}}). Reset à minuit UTC.",
+    "scholarRequiresPro": "La recherche Scholar nécessite un plan Pro ou Expert.",
     "exportModal": {
       "title": "Exporter la bibliographie",
       "chooseFormat": "Choisir le format",

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -958,7 +958,7 @@ export interface AcademicPaper {
   citation_count: number;
   url?: string;
   pdf_url?: string;
-  source: "semantic_scholar" | "openalex" | "arxiv";
+  source: "semantic_scholar" | "openalex" | "arxiv" | "crossref" | "scholar";
   relevance_score: number;
   is_open_access: boolean;
   keywords: string[];
@@ -999,14 +999,19 @@ export const academicApi = {
     });
   },
 
-  // Enrich a summary with academic sources
+  // Enrich a summary with academic sources.
+  // When deep_search=true (Pro+ only), also queries Google Scholar via Phase 4.
   async enrich(
     summaryId: string,
-    maxPapers?: number,
+    options?: { maxPapers?: number; deep_search?: boolean },
   ): Promise<AcademicSearchResponse> {
+    const { maxPapers, deep_search } = options ?? {};
+    const body: Record<string, unknown> = {};
+    if (maxPapers !== undefined) body.max_papers = maxPapers;
+    if (deep_search) body.deep_search = true;
     return request(`/api/academic/enrich/${summaryId}`, {
       method: "POST",
-      body: maxPapers ? { max_papers: maxPapers } : undefined,
+      body: Object.keys(body).length > 0 ? body : undefined,
       timeout: TIMEOUTS.FACT_CHECK,
     });
   },


### PR DESCRIPTION
## Summary

Spec : `docs/superpowers/specs/2026-05-17-google-scholar-deep-crawl.md` §13.2

Mirror de PR3a web (#513, déjà sur main `e5a2c0e0`). Backend `/enrich/{id}` accepte déjà `deep_search` depuis PR3a — cette PR expose le toggle côté **Mobile** uniquement.

- `mobile/src/services/api.ts` : signature `academicApi.enrich(id, { maxPapers?, deep_search? })` + type `source` étendu avec `"crossref" | "scholar"`
- `mobile/src/components/academic/AcademicSourcesSection.tsx` :
  - Switch RN visible pro/expert avec tooltip Ionicons → Alert FR/EN
  - Free → `<Pressable>` discret "Deep search Pro+ →" qui appelle `onUpgrade`
  - `deep_search` pass-through au call `enrich`
- `mobile/src/components/academic/PaperCard.tsx` : SOURCE_COLORS + SOURCE_NAMES étendus (crossref emerald, scholar violet "via Scholar")
- `mobile/src/i18n/{fr,en}.json` : keys `academic.deepSearch*` + sources étendues

## Test plan

- [x] 11/11 tests Jest verts (6 AcademicSourcesSection + 5 PaperCard)
- [x] `tsc --noEmit` clean sur fichiers touchés (HubAnalysisSheet error pré-existant hors scope)
- [x] backward compat : default `deep_search=undefined` ne change rien aux callers existants

## Deploy

Mobile = code sur main → OTA push via `eas update --branch production` (à lancer manuellement par Maxime ou approuver permission classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)