### PR TITLE
fix(tutor): auto-restart session on 404 (Redis TTL expired after idle > 1h)

### DIFF
--- a/frontend/src/store/__tests__/tutorStore.test.ts
+++ b/frontend/src/store/__tests__/tutorStore.test.ts
@@ -1,26 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useTutorStore } from "../tutorStore";
 
-vi.mock("../../services/api", () => ({
-  tutorApi: {
-    sessionStart: vi.fn().mockResolvedValue({
-      session_id: "tutor-test123",
-      first_prompt: "Comment expliqueriez-vous ce concept ?",
-      audio_url: null,
-    }),
-    sessionTurn: vi.fn().mockResolvedValue({
-      ai_response: "Très bien.",
-      audio_url: null,
-      turn_count: 3,
-    }),
-    sessionEnd: vi.fn().mockResolvedValue({
-      duration_sec: 45,
-      turns_count: 3,
-      source_summary_url: null,
-      source_video_title: null,
-    }),
-  },
-}));
+vi.mock("../../services/api", () => {
+  class ApiError extends Error {
+    status: number;
+    data?: Record<string, unknown>;
+    constructor(message: string, status: number, data?: Record<string, unknown>) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+      this.data = data;
+    }
+    get isNotFound() {
+      return this.status === 404;
+    }
+  }
+  return {
+    ApiError,
+    tutorApi: {
+      sessionStart: vi.fn().mockResolvedValue({
+        session_id: "tutor-test123",
+        first_prompt: "Comment expliqueriez-vous ce concept ?",
+        audio_url: null,
+      }),
+      sessionTurn: vi.fn().mockResolvedValue({
+        ai_response: "Très bien.",
+        audio_url: null,
+        turn_count: 3,
+      }),
+      sessionEnd: vi.fn().mockResolvedValue({
+        duration_sec: 45,
+        turns_count: 3,
+        source_summary_url: null,
+        source_video_title: null,
+      }),
+    },
+  };
+});
 
 describe("tutorStore", () => {
   beforeEach(() => {
@@ -167,5 +183,106 @@ describe("tutorStore", () => {
     expect(s.phase).toBe("idle");
     expect(s.sessionId).toBeNull();
     expect(s.messages).toEqual([]);
+  });
+
+  // Regression : Redis TTL=1h, après idle > 1h le backend répond 404 sur /turn.
+  // submitTextTurn doit relancer une session avec le même concept et rejouer
+  // le turn sans propager l'erreur ni dupliquer le user turn déjà affiché.
+  it("submitTextTurn auto-restarts the session on 404 (expired Redis) and replays the turn", async () => {
+    const api = (await import("../../services/api")) as unknown as {
+      ApiError: new (
+        message: string,
+        status: number,
+        data?: Record<string, unknown>,
+      ) => Error & { status: number };
+      tutorApi: {
+        sessionStart: ReturnType<typeof vi.fn>;
+        sessionTurn: ReturnType<typeof vi.fn>;
+        sessionEnd: ReturnType<typeof vi.fn>;
+      };
+    };
+
+    // Ouvre la conv : 1er sessionStart succeeds, on enchaîne sur un /turn OK.
+    await useTutorStore.getState().startSession({
+      concept_term: "Shannon, 1948",
+      concept_def: "Théorie de l'information",
+      mode: "text",
+    });
+    expect(useTutorStore.getState().sessionId).toBe("tutor-test123");
+
+    // Idle > 1h : prochain /turn renvoie 404, puis le store doit relancer une
+    // session (nouvel id) et retry le /turn avec la nouvelle session.
+    api.tutorApi.sessionTurn
+      .mockRejectedValueOnce(new api.ApiError("Session non trouvée", 404))
+      .mockResolvedValueOnce({
+        ai_response: "Reprenons. Que pensez-vous de la théorie ?",
+        audio_url: null,
+        turn_count: 1,
+      });
+    api.tutorApi.sessionStart.mockResolvedValueOnce({
+      session_id: "tutor-refresh999",
+      first_prompt: "Nouvel opener (discarded)",
+      audio_url: null,
+    });
+
+    await useTutorStore.getState().submitTextTurn("g");
+
+    const s = useTutorStore.getState();
+    expect(s.sessionId).toBe("tutor-refresh999");
+    expect(s.error).toBeNull();
+    expect(s.loading).toBe(false);
+    // L'historique : opener user "Shannon, 1948" + opener assistant + user "g"
+    // + nouvel assistant reply. Le first_prompt du restart n'est PAS injecté
+    // (il est silencieusement discarded — Magistral repart de zéro côté backend).
+    expect(s.messages).toHaveLength(4);
+    expect(s.messages[2]).toMatchObject({ role: "user", content: "g" });
+    expect(s.messages[3].role).toBe("assistant");
+    expect(s.messages[3].content).toBe(
+      "Reprenons. Que pensez-vous de la théorie ?",
+    );
+    // Une seule occurrence de "g" : pas de double-push optimiste.
+    expect(s.messages.filter((m) => m.content === "g")).toHaveLength(1);
+    // sessionStart a bien été appelée avec le concept préservé dans le store.
+    expect(api.tutorApi.sessionStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        concept_term: "Shannon, 1948",
+        concept_def: "Théorie de l'information",
+        mode: "text",
+      }),
+    );
+  });
+
+  it("submitTextTurn surfaces non-404 errors without restarting", async () => {
+    const api = (await import("../../services/api")) as unknown as {
+      ApiError: new (
+        message: string,
+        status: number,
+        data?: Record<string, unknown>,
+      ) => Error & { status: number };
+      tutorApi: {
+        sessionStart: ReturnType<typeof vi.fn>;
+        sessionTurn: ReturnType<typeof vi.fn>;
+        sessionEnd: ReturnType<typeof vi.fn>;
+      };
+    };
+
+    await useTutorStore.getState().startSession({
+      concept_term: "X",
+      concept_def: "Y",
+      mode: "text",
+    });
+    const startCallsBefore = api.tutorApi.sessionStart.mock.calls.length;
+
+    api.tutorApi.sessionTurn.mockRejectedValueOnce(
+      new api.ApiError("Service indisponible", 502),
+    );
+
+    await useTutorStore.getState().submitTextTurn("Mon message");
+
+    const s = useTutorStore.getState();
+    expect(s.error).toBe("Service indisponible");
+    expect(s.loading).toBe(false);
+    // Pas de restart : sessionStart n'a pas été rappelée.
+    expect(api.tutorApi.sessionStart.mock.calls.length).toBe(startCallsBefore);
   });
 });

--- a/frontend/src/store/tutorStore.ts
+++ b/frontend/src/store/tutorStore.ts
@@ -12,7 +12,7 @@
 
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
-import { tutorApi } from "../services/api";
+import { tutorApi, ApiError } from "../services/api";
 import type { TutorLang, TutorPhase, TutorTurn } from "../types/tutor";
 import type { TutorConceptItem } from "../types/conceptImage";
 
@@ -203,7 +203,14 @@ export const useTutorStore = create<TutorState>()(
     },
 
     submitTextTurn: async (input) => {
-      const sessionId = get().sessionId;
+      const {
+        sessionId,
+        conceptTerm,
+        conceptDef,
+        summaryId,
+        sourceVideoTitle,
+        lang,
+      } = get();
       if (!sessionId) return;
       set((s) => {
         s.messages.push({
@@ -226,6 +233,44 @@ export const useTutorStore = create<TutorState>()(
           s.loading = false;
         });
       } catch (err) {
+        // Redis TTL=1h ; après idle > 1h le backend renvoie 404 « Session non
+        // trouvée ou expirée ». Plutôt qu'afficher une erreur, on relance une
+        // session avec le même concept (préservé dans le store) et on rejoue
+        // le turn de l'utilisateur. L'historique Magistral est perdu mais le
+        // concept reste, donc le Tuteur continue la même piste.
+        const isExpired =
+          err instanceof ApiError && err.status === 404 && Boolean(conceptTerm);
+        if (isExpired && conceptTerm) {
+          try {
+            const fresh = await tutorApi.sessionStart({
+              concept_term: conceptTerm,
+              concept_def: conceptDef ?? "",
+              summary_id: summaryId ?? undefined,
+              source_video_title: sourceVideoTitle ?? undefined,
+              mode: "text",
+              lang,
+            });
+            const turnResp = await tutorApi.sessionTurn(fresh.session_id, {
+              user_input: input,
+            });
+            set((s) => {
+              s.sessionId = fresh.session_id;
+              s.messages.push({
+                role: "assistant",
+                content: turnResp.ai_response,
+                timestamp_ms: Date.now(),
+              });
+              s.loading = false;
+            });
+            return;
+          } catch (restartErr) {
+            set((s) => {
+              s.error = (restartErr as Error).message;
+              s.loading = false;
+            });
+            return;
+          }
+        }
         set((s) => {
           s.error = (err as Error).message;
           s.loading = false;


### PR DESCRIPTION
## Symptôme

Maxime ouvre le Tuteur, reçoit la 1ère réponse Magistral, puis revient ~2h plus tard et tape une réponse → le Tuteur ne répond plus. Les requêtes `POST /api/tutor/session/{id}/turn` répondent `404 Not Found`.

## Root cause

Le backend stocke les sessions Tuteur en Redis avec `SESSION_TTL_SECONDS = 60 * 60` (`backend/src/tutor/service.py:21`). Après > 1h d'inactivité, Redis évince la clé et `load_session()` retourne `None` → 404.

**Reproduction observée en prod** (Caddy `/data/logs/access.log`) :

| UTC | Endpoint | Status |
|-----|----------|--------|
| `14:47:21` | `POST /api/tutor/session/start` | 200 |
| `15:47:21` | (Redis TTL expire) | — |
| `17:05:56` | `POST /api/tutor/session/tutor-edb525f1196f/turn` ("g") | 404 |
| `17:06:15` | `POST /api/tutor/session/tutor-edb525f1196f/turn` ("alo ?") | 404 |

Gap = 2h 18min → ~78 min au-delà du TTL. Aucun autre `/session/start` dans l'intervalle. Pas de bug backend ; trou UX pré-existant depuis le launch du Tuteur (2026-05-11), pas une régression du sprint Carrousel.

## Fix

`tutorStore.submitTextTurn` :
1. Intercepte `ApiError.status === 404`
2. Relance `sessionStart` avec le `conceptTerm`/`conceptDef`/`summaryId`/`sourceVideoTitle`/`lang` toujours présents dans le store
3. Rejoue le turn de l'utilisateur sur la nouvelle session
4. Push uniquement le nouvel assistant reply — pas de duplication du user turn déjà optimiste-pushed

**Tradeoff assumé** : Magistral perd l'historique de la conversation pré-expiration (le contexte > 1h est de toute façon stale), mais le concept reste donc le Tuteur reprend la même piste. Le `first_prompt` généré par le restart est discarded silencieusement.

**Pourquoi pas backend** :
- Bump TTL = band-aid qui n'élimine pas le problème
- Persist Postgres = refactor lourd, hors scope rapide (V2)
- L'auto-restart est invisible pour l'utilisateur et préserve l'UX immédiatement

## Tests

- **Nouveau** : `submitTextTurn auto-restarts the session on 404 (expired Redis) and replays the turn` — vérifie `sessionId` remplacé, pas de duplication du user turn, pas d'erreur exposée, `sessionStart` rappelée avec le concept préservé
- **Nouveau** : `submitTextTurn surfaces non-404 errors without restarting` — vérifie qu'on n'auto-restart QUE sur 404 (502 par ex remonte normalement)
- `13/13` `tutorStore.test.ts` (11 existants + 2 nouveaux)
- `116/116` `src/store/__tests__/` (non-régression)
- `tsc --noEmit` clean

## Test plan (post-merge)

- [ ] Vercel preview deploy ready
- [ ] Maxime ouvre le Tuteur, ferme l'onglet, attend > 1h, tape un message → réponse normale du Tuteur (pas d'erreur visible)
- [ ] Vérifier en DevTools Network : on voit la séquence `/turn → 404` puis `/session/start → 200` puis `/turn → 200` (~10s total avec génération Magistral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)