### PR TITLE
fix(discover): rebalance Tournesol weight + responsive mobile web

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -61,7 +61,9 @@ class _DeepSightSettings(BaseSettings):
     TOGETHER_API_KEY: str = ""
     MISTRAL_IMAGE_AGENT_ID: str = ""  # Mistral Agents API — DeepSight Art Director
     GEMINI_API_KEY: str = ""  # Google AI Studio — Gemini 3 Pro Image (Nano Banana Pro) pour doodles Tuteur
-    TUTOR_DOODLE_DAILY_CAP: int = 300  # Cap global quotidien images doodle Tuteur (Redis counter, anti-abuse + plafond coût)
+    TUTOR_DOODLE_DAILY_CAP: int = (
+        300  # Cap global quotidien images doodle Tuteur (Redis counter, anti-abuse + plafond coût)
+    )
 
     # -- Miro (Débat IA v2 — boards générés sur compte org DeepSight) --
     # Cf. docs/superpowers/specs/2026-05-04-debate-ia-v2.md §7.4.

--- a/backend/src/core/scholar_quota.py
+++ b/backend/src/core/scholar_quota.py
@@ -67,9 +67,7 @@ def get_scholar_daily_limit(plan: Optional[str]) -> int:
     return SCHOLAR_DAILY_LIMITS.get(_normalize_plan(plan), 0)
 
 
-async def check_and_increment_scholar_quota(
-    session: AsyncSession, user: User
-) -> Tuple[bool, Optional[Dict[str, Any]]]:
+async def check_and_increment_scholar_quota(session: AsyncSession, user: User) -> Tuple[bool, Optional[Dict[str, Any]]]:
     """Atomically check the daily Scholar quota and increment if allowed.
 
     Returns:

--- a/backend/src/images/keyword_images.py
+++ b/backend/src/images/keyword_images.py
@@ -634,9 +634,7 @@ async def _stage2_gemini_doodle(visual_prompt: str) -> tuple[bytes, str]:
             import base64
 
             image_bytes = base64.b64decode(inline["data"])
-            logger.info(
-                f"🖼️ Doodle generated (Gemini 3 Pro Image): {len(image_bytes)} bytes"
-            )
+            logger.info(f"🖼️ Doodle generated (Gemini 3 Pro Image): {len(image_bytes)} bytes")
             return image_bytes, IMAGE_MODEL_GEMINI_DOODLE
     raise RuntimeError(f"Gemini response missing inlineData: {result}")
 
@@ -652,18 +650,12 @@ async def _stage2_generate_doodle(visual_prompt: str) -> tuple[bytes, str]:
         try:
             return await _stage2_gemini_doodle(visual_prompt)
         except Exception as e:
-            logger.warning(
-                f"⚠️ Gemini doodle failed, trying DALL-E 3 fallback: {e}"
-            )
+            logger.warning(f"⚠️ Gemini doodle failed, trying DALL-E 3 fallback: {e}")
 
     if get_openai_key():
-        return await _stage2_dalle3(
-            f"{visual_prompt}. {TUTOR_DOODLE_STYLE_SUFFIX}"
-        )
+        return await _stage2_dalle3(f"{visual_prompt}. {TUTOR_DOODLE_STYLE_SUFFIX}")
 
-    raise RuntimeError(
-        "No doodle backend available (need GEMINI_API_KEY or OPENAI_API_KEY)"
-    )
+    raise RuntimeError("No doodle backend available (need GEMINI_API_KEY or OPENAI_API_KEY)")
 
 
 def _post_process_doodle(image_bytes: bytes) -> bytes:
@@ -829,16 +821,13 @@ async def get_doodle_url(term: str, pool=None) -> Optional[str]:
     thash = _term_hash(term, style="tutor_doodle")
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT image_url FROM keyword_images "
-            "WHERE term_hash = $1 AND style = 'tutor_doodle' AND status = 'ready'",
+            "SELECT image_url FROM keyword_images WHERE term_hash = $1 AND style = 'tutor_doodle' AND status = 'ready'",
             thash,
         )
     return row["image_url"] if row else None
 
 
-async def batch_get_doodle_urls(
-    terms: list[str], pool=None
-) -> dict[str, str]:
+async def batch_get_doodle_urls(terms: list[str], pool=None) -> dict[str, str]:
     """Batch lookup doodle URLs for multiple terms. Returns {term_hash: image_url}.
 
     Hashes are computed with `style='tutor_doodle'`, so they discriminate from

--- a/backend/src/tutor/concepts_router.py
+++ b/backend/src/tutor/concepts_router.py
@@ -80,9 +80,7 @@ async def list_concepts(
 
     concepts = await collect_user_concepts(user.id, db, limit=limit)
     if not concepts:
-        return TutorConceptsResponse(
-            concepts=[], total=0, ready_count=0, pending_count=0
-        )
+        return TutorConceptsResponse(concepts=[], total=0, ready_count=0, pending_count=0)
 
     concepts = await attach_image_urls(concepts)
     concepts = await check_lookup_pending(concepts)

--- a/backend/src/tutor/concepts_service.py
+++ b/backend/src/tutor/concepts_service.py
@@ -146,12 +146,14 @@ async def collect_user_concepts(
             if not norm or norm in seen_norms:
                 continue
             seen_norms.add(norm)
-            out.append({
-                "term": term[:200],
-                "term_hash": _term_hash(term, style="tutor_doodle"),
-                "category": "concept",
-                "source_summary_id": sid,
-            })
+            out.append(
+                {
+                    "term": term[:200],
+                    "term_hash": _term_hash(term, style="tutor_doodle"),
+                    "category": "concept",
+                    "source_summary_id": sid,
+                }
+            )
             if len(out) >= limit:
                 return out
         # 2. entities.concepts
@@ -160,12 +162,14 @@ async def collect_user_concepts(
             if not norm or norm in seen_norms:
                 continue
             seen_norms.add(norm)
-            out.append({
-                "term": term[:200],
-                "term_hash": _term_hash(term, style="tutor_doodle"),
-                "category": "concept",
-                "source_summary_id": sid,
-            })
+            out.append(
+                {
+                    "term": term[:200],
+                    "term_hash": _term_hash(term, style="tutor_doodle"),
+                    "category": "concept",
+                    "source_summary_id": sid,
+                }
+            )
             if len(out) >= limit:
                 return out
     return out
@@ -204,8 +208,7 @@ async def check_lookup_pending(concepts: list[dict]) -> list[dict]:
     pool = await _get_image_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            "SELECT term_hash, status FROM keyword_images "
-            "WHERE term_hash = ANY($1) AND style = 'tutor_doodle'",
+            "SELECT term_hash, status FROM keyword_images WHERE term_hash = ANY($1) AND style = 'tutor_doodle'",
             missing_hashes,
         )
     status_map = {r["term_hash"]: r["status"] for r in rows}
@@ -300,9 +303,7 @@ async def enqueue_top_concepts_doodles(
     from db.database import async_session_maker, Summary
 
     async with async_session_maker() as db:
-        stmt = select(Summary.summary_content, Summary.entities_extracted).where(
-            Summary.id == summary_id
-        )
+        stmt = select(Summary.summary_content, Summary.entities_extracted).where(Summary.id == summary_id)
         result = await db.execute(stmt)
         row = result.first()
         if not row:
@@ -337,8 +338,7 @@ async def enqueue_top_concepts_doodles(
     hashes = [_term_hash(t, style="tutor_doodle") for t in picks]
     async with pool.acquire() as conn:
         existing = await conn.fetch(
-            "SELECT term_hash FROM keyword_images "
-            "WHERE term_hash = ANY($1) AND style = 'tutor_doodle'",
+            "SELECT term_hash FROM keyword_images WHERE term_hash = ANY($1) AND style = 'tutor_doodle'",
             hashes,
         )
     existing_set = {r["term_hash"] for r in existing}

--- a/backend/src/videos/external_pages/orchestrator.py
+++ b/backend/src/videos/external_pages/orchestrator.py
@@ -150,11 +150,7 @@ def _compute_stats(
     """Calcule les stats du pipeline (spec §6)."""
     successful = sum(1 for p in summaries if p.status == "ok")
     paywalled = sum(1 for p in summaries if p.status == "paywall")
-    errored = sum(
-        1
-        for p in summaries
-        if p.status in ("error", "non_html", "http_error", "timeout", "empty")
-    )
+    errored = sum(1 for p in summaries if p.status in ("error", "non_html", "http_error", "timeout", "empty"))
     return {
         "candidates_found": candidates_found,
         "after_dedup": after_cleanup,
@@ -205,9 +201,7 @@ async def extract_external_pages(
         # ── Inputs
         description = _extract_video_field(video_info, "description", "video_description")
         video_title = _extract_video_field(video_info, "title", "video_title")
-        creator_channel = _extract_video_field(
-            video_info, "channel", "channel_name", "video_channel"
-        )
+        creator_channel = _extract_video_field(video_info, "channel", "channel_name", "video_channel")
         channel_url = _extract_video_field(video_info, "channel_url")
 
         if not description:

--- a/backend/src/videos/external_pages/scraper.py
+++ b/backend/src/videos/external_pages/scraper.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 

--- a/backend/src/videos/external_pages/scraper.py
+++ b/backend/src/videos/external_pages/scraper.py
@@ -50,6 +50,7 @@ from core.http_client import get_proxied_client, shared_http_client
 try:
     from middleware.proxy_telemetry import record_proxy_usage
 except Exception:  # pragma: no cover — defensive import (tests / minimal env)
+
     async def record_proxy_usage(**_kwargs):  # type: ignore
         return None
 
@@ -62,8 +63,8 @@ logger = logging.getLogger("deepsight.external_pages.scraper")
 # ═══════════════════════════════════════════════════════════════════════════════
 
 MAX_HTML_BYTES: int = 500 * 1024  # 500 KB — au-delà on truncate
-SCRAPE_TIMEOUT: float = 12.0      # spec §4 — par URL
-MIN_TEXT_LEN: int = 200           # spec §4 edge cases — < 200 chars → status="empty"
+SCRAPE_TIMEOUT: float = 12.0  # spec §4 — par URL
+MIN_TEXT_LEN: int = 200  # spec §4 edge cases — < 200 chars → status="empty"
 
 # Patterns détection paywall (case-insensitive sur HTML lowered)
 # Spec §4 — couvre Substack premium, Medium, Bloomberg/WSJ/NYT, Le Monde, etc.
@@ -185,10 +186,7 @@ async def _fetch_html(
                 status = int(resp.status_code)
 
                 # Skip non-HTML content-types tôt — pas la peine de stream
-                if content_type and any(
-                    content_type.startswith(prefix)
-                    for prefix in SKIP_CONTENT_TYPE_PREFIXES
-                ):
+                if content_type and any(content_type.startswith(prefix) for prefix in SKIP_CONTENT_TYPE_PREFIXES):
                     return None, 0, content_type, status
 
                 buf = bytearray()
@@ -206,16 +204,13 @@ async def _fetch_html(
                     html = buf.decode("latin-1", errors="replace")
                 return html, len(buf), content_type, status
     except httpx.TimeoutException as exc:
-        logger.debug("[EXTERNAL_PAGES] timeout fetching %s (proxy=%s): %s",
-                     url, use_proxy, exc)
+        logger.debug("[EXTERNAL_PAGES] timeout fetching %s (proxy=%s): %s", url, use_proxy, exc)
         return None, 0, "", 0
     except httpx.HTTPError as exc:
-        logger.debug("[EXTERNAL_PAGES] http error fetching %s (proxy=%s): %s",
-                     url, use_proxy, exc)
+        logger.debug("[EXTERNAL_PAGES] http error fetching %s (proxy=%s): %s", url, use_proxy, exc)
         return None, 0, "", 0
     except Exception as exc:  # noqa: BLE001 — best-effort
-        logger.debug("[EXTERNAL_PAGES] unexpected error fetching %s (proxy=%s): %s",
-                     url, use_proxy, exc)
+        logger.debug("[EXTERNAL_PAGES] unexpected error fetching %s (proxy=%s): %s", url, use_proxy, exc)
         return None, 0, "", 0
 
 
@@ -333,9 +328,7 @@ async def scrape_page(
     fetched_via_proxy = False
 
     # — Tentative 1 : direct (IP Hetzner)
-    html, bytes_fetched, content_type, status = await _fetch_html(
-        target, use_proxy=False, timeout=timeout
-    )
+    html, bytes_fetched, content_type, status = await _fetch_html(target, use_proxy=False, timeout=timeout)
 
     # — Détection d'un block : 403/429 OU signal Cloudflare dans le HTML
     cf_in_html = bool(html) and _detect_cloudflare(html)
@@ -344,11 +337,11 @@ async def scrape_page(
     if block_signal:
         logger.info(
             "[EXTERNAL_PAGES] %s → block signal (status=%s, cf=%s), retry via proxy",
-            target, status, cf_in_html,
+            target,
+            status,
+            cf_in_html,
         )
-        html_p, bytes_p, ct_p, status_p = await _fetch_html(
-            target, use_proxy=True, timeout=timeout
-        )
+        html_p, bytes_p, ct_p, status_p = await _fetch_html(target, use_proxy=True, timeout=timeout)
         # Si le retry a réussi à tirer quelque chose, on remplace l'état
         if status_p != 0:
             html = html_p
@@ -384,12 +377,7 @@ async def scrape_page(
         )
 
     # 2) Content-type non-HTML rejeté tôt
-    if (
-        content_type
-        and any(
-            content_type.startswith(prefix) for prefix in SKIP_CONTENT_TYPE_PREFIXES
-        )
-    ):
+    if content_type and any(content_type.startswith(prefix) for prefix in SKIP_CONTENT_TYPE_PREFIXES):
         return ScrapedPage(
             url=url,
             final_url=target,

--- a/backend/src/videos/external_pages/summarizer.py
+++ b/backend/src/videos/external_pages/summarizer.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional
 
 from core.cache import cache_service

--- a/backend/src/videos/external_pages/summarizer.py
+++ b/backend/src/videos/external_pages/summarizer.py
@@ -162,7 +162,7 @@ def _build_prompt(
         f"{context_line}"
         f"Titre de la page : {page_title or 'inconnu'}\n\n"
         f"Contenu de la page (extrait) :\n{page_text[:MAX_TEXT_FOR_PROMPT]}\n\n"
-        f'Résume cette page en 2-3 phrases claires en {target_lang}. '
+        f"Résume cette page en 2-3 phrases claires en {target_lang}. "
         f"Liste 1-3 affirmations clés. Réponds en JSON "
         f'{{"summary": "...", "key_claims": ["...", "..."]}}'
     )
@@ -254,11 +254,7 @@ async def summarize_page(
 
     if cached_raw is not None:
         try:
-            cached_data = (
-                json.loads(cached_raw)
-                if isinstance(cached_raw, (str, bytes, bytearray))
-                else cached_raw
-            )
+            cached_data = json.loads(cached_raw) if isinstance(cached_raw, (str, bytes, bytearray)) else cached_raw
             if isinstance(cached_data, dict):
                 summary = cached_data.get("summary")
                 key_claims = cached_data.get("key_claims") or []

--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -71,11 +71,13 @@ OPTIMAL_DURATIONS = {
 }
 
 # Poids du scoring - RELEVANCE est le plus important !
+# 2026-05-20 : rebalance pour rapprocher des résultats YouTube standards.
+# Tournesol passe de 0.20 → 0.05 (bonus discret), engagement bumpé.
 SCORING_WEIGHTS = {
-    "relevance": 0.40,  # ⭐ Priorité aux termes de recherche exacts
-    "tournesol": 0.20,
-    "academic": 0.15,
-    "engagement": 0.10,
+    "relevance": 0.45,  # ⭐ Priorité aux termes de recherche exacts
+    "tournesol": 0.05,  # Bonus discret pour vidéos Tournesol-scorées
+    "academic": 0.10,
+    "engagement": 0.20,  # YouTube-like : vues/likes pèsent davantage
     "freshness": 0.08,
     "duration": 0.07,
     "clickbait_penalty": 0.10,
@@ -1330,94 +1332,25 @@ class IntelligentDiscovery:
                 if len(final_candidates) >= max_results:
                     break
 
-        # 5. 🌻 PROMOTION TOURNESOL - Garantir au moins 1 vidéo Tournesol visible en haut
-        #    Stratégie: Chercher la meilleure vidéo avec score Tournesol et la promouvoir
+        # 5. 🌻 Promotion Tournesol discrète : 1 seule vidéo, uniquement si aucune
+        # Tournesol n'est déjà présente naturellement. Pas de fallback hardcodé.
+        # Le ranking YouTube domine ; Tournesol reste un bonus.
+        has_tournesol_naturally = any(
+            c.is_tournesol_pick or c.tournesol_score > 0.55 for c in final_candidates[:10]
+        )
 
-        # 5a. Compter les vidéos Tournesol et leurs positions
-        tournesol_videos = [
-            (i, c) for i, c in enumerate(final_candidates) if c.is_tournesol_pick or c.tournesol_score > 0.55
-        ]
-        print(f"🌻 [PROMO] Found {len(tournesol_videos)} Tournesol videos in results", flush=True)
-
-        for idx, vid in tournesol_videos:
-            print(
-                f"   Position {idx + 1}: {vid.title[:50]} (score={vid.tournesol_score:.2f}, pick={vid.is_tournesol_pick})",
-                flush=True,
-            )
-
-        # 5b. Trouver la meilleure vidéo Tournesol (la plus pertinente)
-        best_tournesol_in_results = None
-        best_tournesol_index = -1
-        best_tournesol_relevance = -1.0
-
-        for i, candidate in enumerate(final_candidates):
-            # Marquer comme pick si score Tournesol positif (au cas où ça n'a pas été fait)
-            if candidate.tournesol_score > 0.55 and not candidate.is_tournesol_pick:
-                candidate.is_tournesol_pick = True
-                print(f"🌻 [FIX] Marked {candidate.video_id} as Tournesol pick", flush=True)
-
-            if candidate.is_tournesol_pick:
-                if candidate.relevance_score > best_tournesol_relevance:
-                    best_tournesol_in_results = candidate
-                    best_tournesol_index = i
-                    best_tournesol_relevance = candidate.relevance_score
-
-        # 5c. Promouvoir la vidéo Tournesol en position 3 si elle est plus bas
-        if best_tournesol_in_results and best_tournesol_index > 2:
-            # Retirer de sa position actuelle
-            final_candidates.pop(best_tournesol_index)
-            # Insérer en position 3 (index 2)
-            insert_pos = min(2, len(final_candidates))
-            final_candidates.insert(insert_pos, best_tournesol_in_results)
-            print(
-                f"🌻 [PROMO] Promoted '{best_tournesol_in_results.title[:40]}' from #{best_tournesol_index + 1} to #{insert_pos + 1}",
-                flush=True,
-            )
-        elif best_tournesol_in_results:
-            print(f"🌻 [PROMO] Tournesol video already in top 3 at position #{best_tournesol_index + 1}", flush=True)
-
-        # 5d. Si AUCUNE vidéo Tournesol dans les résultats, essayer l'API Tournesol
-        has_tournesol_in_top5 = any(c.is_tournesol_pick for c in final_candidates[:5])
-
-        if not has_tournesol_in_top5:
-            print("🌻 [PROMO] No Tournesol in top 5, calling Tournesol API...", flush=True)
+        if not has_tournesol_naturally and len(final_candidates) >= 3:
             existing_ids = [c.video_id for c in final_candidates]
             tournesol_pick = await TournesolPromotion.get_tournesol_pick(query, existing_ids)
-
             if tournesol_pick:
                 tournesol_pick.relevance_score = QualityScorer._calculate_relevance_score(tournesol_pick, query)
-                tournesol_pick.final_score = 100.0
+                tournesol_pick.final_score = 50.0  # Score modeste, pas de promotion artificielle
                 tournesol_pick.is_tournesol_pick = True
-
-                insert_position = min(2, len(final_candidates))
+                insert_position = min(4, len(final_candidates))
                 final_candidates.insert(insert_position, tournesol_pick)
-
                 if len(final_candidates) > max_results:
                     final_candidates.pop()
-
-                print(
-                    f"🌻 [PROMO] API pick added at position {insert_position + 1}: {tournesol_pick.title[:40]}",
-                    flush=True,
-                )
-            else:
-                # 🌻 FALLBACK HARDCODÉ - Toujours avoir une vidéo Tournesol
-                print("🌻 [PROMO] Using hardcoded Tournesol fallback", flush=True)
-                fallback_pick = TournesolPromotion.get_hardcoded_fallback(existing_ids)
-                if fallback_pick:
-                    fallback_pick.is_tournesol_pick = True
-                    fallback_pick.tournesol_score = 1.0
-                    fallback_pick.final_score = 90.0
-
-                    insert_position = min(2, len(final_candidates))
-                    final_candidates.insert(insert_position, fallback_pick)
-
-                    if len(final_candidates) > max_results:
-                        final_candidates.pop()
-
-                    print(
-                        f"🌻 [PROMO] Hardcoded fallback added at position {insert_position + 1}: {fallback_pick.title[:40]}",
-                        flush=True,
-                    )
+                logger.info(f"🌻 Discreet Tournesol pick added at position {insert_position + 1}")
 
         elapsed_ms = int((time.time() - start_time) * 1000)
 
@@ -1588,24 +1521,34 @@ class IntelligentDiscoveryService:
                 final_candidates.append(candidate)
                 channel_counts[candidate.channel_id] += 1
 
-                if len(final_candidates) >= max_results - 1:  # -1 pour Tournesol
+                if len(final_candidates) >= max_results:
                     break
 
-        # 5. 🌻 Ajouter la vidéo Tournesol sponsorisée
-        existing_ids = [c.video_id for c in final_candidates]
-        logger.info(f"🌻 Searching Tournesol pick for query: '{query}'")
-        tournesol_pick = await TournesolPromotion.get_tournesol_pick(query, existing_ids)
+        # 5. 🌻 Promotion Tournesol discrète : 1 seule vidéo ajoutée UNIQUEMENT si
+        # aucune vidéo Tournesol n'est déjà présente naturellement dans les résultats
+        # YouTube. Pas de fallback hardcodé — on respecte le ranking YouTube.
+        has_tournesol_naturally = any(
+            c.is_tournesol_pick or c.tournesol_score > 0.55 for c in final_candidates[:10]
+        )
 
-        if tournesol_pick:
-            tournesol_pick.relevance_score = QualityScorer._calculate_relevance_score(tournesol_pick, query)
-            tournesol_pick.final_score = 100.0
+        if not has_tournesol_naturally and len(final_candidates) >= 3:
+            existing_ids = [c.video_id for c in final_candidates]
+            logger.info(f"🌻 No Tournesol naturally — fetching 1 discreet pick for: '{query}'")
+            tournesol_pick = await TournesolPromotion.get_tournesol_pick(query, existing_ids)
 
-            # Insérer en position 3 (après les 2 meilleures)
-            insert_position = min(2, len(final_candidates))
-            final_candidates.insert(insert_position, tournesol_pick)
-            logger.info(f"🌻 Tournesol pick added at position {insert_position + 1}: {tournesol_pick.title[:50]}")
-        else:
-            logger.warning(f"⚠️ No Tournesol pick found for query: '{query}'")
+            if tournesol_pick:
+                tournesol_pick.relevance_score = QualityScorer._calculate_relevance_score(tournesol_pick, query)
+                # Score modeste : pas de 100.0 artificiel, juste mid-pack pour ne pas
+                # truster le sommet de la liste
+                tournesol_pick.final_score = 50.0
+
+                # Insérer en position 5 (plus discret qu'avant), seulement si on a la place
+                insert_position = min(4, len(final_candidates))
+                final_candidates.insert(insert_position, tournesol_pick)
+                # Cap à max_results : retirer le dernier si on dépasse
+                if len(final_candidates) > max_results:
+                    final_candidates.pop()
+                logger.info(f"🌻 Tournesol pick added at position {insert_position + 1}: {tournesol_pick.title[:50]}")
 
         duration_ms = int((time.time() - start_time) * 1000)
 

--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -1335,9 +1335,7 @@ class IntelligentDiscovery:
         # 5. 🌻 Promotion Tournesol discrète : 1 seule vidéo, uniquement si aucune
         # Tournesol n'est déjà présente naturellement. Pas de fallback hardcodé.
         # Le ranking YouTube domine ; Tournesol reste un bonus.
-        has_tournesol_naturally = any(
-            c.is_tournesol_pick or c.tournesol_score > 0.55 for c in final_candidates[:10]
-        )
+        has_tournesol_naturally = any(c.is_tournesol_pick or c.tournesol_score > 0.55 for c in final_candidates[:10])
 
         if not has_tournesol_naturally and len(final_candidates) >= 3:
             existing_ids = [c.video_id for c in final_candidates]
@@ -1527,9 +1525,7 @@ class IntelligentDiscoveryService:
         # 5. 🌻 Promotion Tournesol discrète : 1 seule vidéo ajoutée UNIQUEMENT si
         # aucune vidéo Tournesol n'est déjà présente naturellement dans les résultats
         # YouTube. Pas de fallback hardcodé — on respecte le ranking YouTube.
-        has_tournesol_naturally = any(
-            c.is_tournesol_pick or c.tournesol_score > 0.55 for c in final_candidates[:10]
-        )
+        has_tournesol_naturally = any(c.is_tournesol_pick or c.tournesol_score > 0.55 for c in final_candidates[:10])
 
         if not has_tournesol_naturally and len(final_candidates) >= 3:
             existing_ids = [c.video_id for c in final_candidates]

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -2367,7 +2367,9 @@ async def _analyze_video_background_v2_1(
             )
             web_context = _web_ctx
             enrichment_sources = _enrich_src
-            logger.info("⚡ [v2.1.1] Category + comments + metadata + web + community + external_pages computed in PARALLEL")
+            logger.info(
+                "⚡ [v2.1.1] Category + comments + metadata + web + community + external_pages computed in PARALLEL"
+            )
 
             # ═══════════════════════════════════════════════════════════════════
             # 7. 🆕 CONSTRUIRE LE PROMPT PERSONNALISÉ
@@ -3635,9 +3637,7 @@ async def _analyze_video_background_v6(
             try:
                 from tutor.concepts_service import enqueue_top_concepts_doodles
 
-                asyncio.create_task(
-                    enqueue_top_concepts_doodles(summary_id, user_id, top_n=3)
-                )
+                asyncio.create_task(enqueue_top_concepts_doodles(summary_id, user_id, top_n=3))
             except Exception as td_err:
                 logger.warning(f"⚠️ enqueue_top_concepts_doodles failed: {td_err}")
 

--- a/frontend/src/components/VideoDiscoveryModal.tsx
+++ b/frontend/src/components/VideoDiscoveryModal.tsx
@@ -536,7 +536,7 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-stretch sm:items-center justify-center p-0 sm:p-4">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -544,15 +544,15 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
       />
 
       {/* Modal */}
-      <div className="relative w-full max-w-5xl max-h-[90vh] bg-bg-primary rounded-2xl shadow-2xl overflow-hidden flex flex-col animate-scaleIn">
+      <div className="relative w-full max-w-5xl h-full sm:h-auto max-h-[100dvh] sm:max-h-[90vh] bg-bg-primary rounded-none sm:rounded-2xl shadow-2xl overflow-hidden flex flex-col animate-scaleIn">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border-default">
-          <div>
-            <h2 className="text-lg font-semibold text-text-primary flex items-center gap-2">
-              <Search className="w-5 h-5 text-purple-500" />
-              {t.title}
+        <div className="flex items-center justify-between gap-3 px-4 py-3 sm:px-6 sm:py-4 border-b border-border-default">
+          <div className="min-w-0">
+            <h2 className="text-base sm:text-lg font-semibold text-text-primary flex items-center gap-2">
+              <Search className="w-5 h-5 text-purple-500 shrink-0" />
+              <span className="truncate">{t.title}</span>
             </h2>
-            <p className="text-sm text-text-secondary mt-0.5">
+            <p className="text-xs sm:text-sm text-text-secondary mt-0.5 truncate">
               {allowMultiple
                 ? t.subtitleMultiple.replace("{max}", maxSelection.toString())
                 : t.subtitle}
@@ -561,7 +561,7 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
 
           <button
             onClick={onClose}
-            className="p-2 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-bg-hover transition-colors"
+            className="p-2 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-bg-hover transition-colors shrink-0"
           >
             <X className="w-5 h-5" />
           </button>
@@ -569,8 +569,8 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
 
         {/* Stats bar */}
         {discovery && (
-          <div className="flex items-center justify-between px-6 py-3 bg-bg-tertiary/50 border-b border-border-subtle">
-            <div className="flex items-center gap-4 text-sm text-text-secondary">
+          <div className="flex items-start sm:items-center justify-between flex-col sm:flex-row gap-3 px-4 sm:px-6 py-3 bg-bg-tertiary/50 border-b border-border-subtle">
+            <div className="flex flex-wrap items-center gap-x-2 sm:gap-x-3 gap-y-1 text-xs sm:text-sm text-text-secondary">
               <span>
                 <strong className="text-text-primary">
                   {discovery.candidates.length}
@@ -578,26 +578,20 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
                 {t.found.replace("{count}", "")}
               </span>
               <span className="text-text-tertiary">•</span>
-              <span>
+              <span className="truncate max-w-[50vw] sm:max-w-none">
                 {t.searchedIn}: {discovery.languages_searched.join(", ")}
               </span>
-              <span className="text-text-tertiary">•</span>
-              <span>
+              <span className="text-text-tertiary hidden sm:inline">•</span>
+              <span className="hidden sm:inline">
                 {t.duration.replace(
                   "{ms}",
                   discovery.search_duration_ms.toString(),
                 )}
               </span>
-              {discovery.tournesol_available && (
-                <>
-                  <span className="text-text-tertiary">•</span>
-                  <span className="flex items-center gap-1">🌻 Tournesol</span>
-                </>
-              )}
             </div>
 
             {/* Filters */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
               {/* Sort */}
               <div className="flex items-center gap-2">
                 <span className="text-xs text-text-tertiary">{t.sortBy}</span>
@@ -637,7 +631,7 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
         )}
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="flex-1 overflow-y-auto p-3 sm:p-6">
           {loading ? (
             <div className="flex flex-col items-center justify-center py-12">
               <DeepSightSpinner size="lg" />
@@ -668,8 +662,8 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between px-6 py-4 border-t border-border-default bg-bg-tertiary/50">
-          <div className="flex items-center gap-4 text-sm">
+        <div className="flex items-center justify-between gap-2 flex-wrap px-4 py-3 sm:px-6 sm:py-4 border-t border-border-default bg-bg-tertiary/50">
+          <div className="flex items-center gap-2 sm:gap-4 text-xs sm:text-sm">
             {selectedIds.size > 0 && (
               <span className="text-text-primary font-medium">
                 {t.selected.replace("{count}", selectedIds.size.toString())}
@@ -682,19 +676,21 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
             </span>
           </div>
 
-          <div className="flex items-center gap-3">
-            <button onClick={onClose} className="btn btn-ghost">
-              Annuler
+          <div className="flex items-center gap-2 sm:gap-3">
+            <button onClick={onClose} className="btn btn-ghost text-sm">
+              {language === "fr" ? "Annuler" : "Cancel"}
             </button>
             <button
               onClick={handleConfirm}
               disabled={selectedIds.size === 0 || !hasEnoughCredits}
-              className="btn btn-primary"
+              className="btn btn-primary text-sm"
             >
               {!hasEnoughCredits ? (
                 <>
                   <AlertTriangle className="w-4 h-4" />
-                  {t.insufficientCredits}
+                  <span className="hidden sm:inline">
+                    {t.insufficientCredits}
+                  </span>
                 </>
               ) : (
                 <>

--- a/frontend/src/components/VideoDiscoveryModal_v3.tsx
+++ b/frontend/src/components/VideoDiscoveryModal_v3.tsx
@@ -730,7 +730,7 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-stretch sm:items-center justify-center p-0 sm:p-4">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -738,15 +738,15 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
       />
 
       {/* Modal */}
-      <div className="relative w-full max-w-6xl max-h-[92vh] bg-bg-primary rounded-2xl shadow-2xl overflow-hidden flex flex-col animate-scaleIn">
+      <div className="relative w-full max-w-6xl h-full sm:h-auto max-h-[100dvh] sm:max-h-[92vh] bg-bg-primary rounded-none sm:rounded-2xl shadow-2xl overflow-hidden flex flex-col animate-scaleIn">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border-default">
-          <div>
-            <h2 className="text-lg font-semibold text-text-primary flex items-center gap-2">
-              <Search className="w-5 h-5 text-purple-500" />
-              {t.title}
+        <div className="flex items-center justify-between gap-3 px-4 py-3 sm:px-6 sm:py-4 border-b border-border-default">
+          <div className="min-w-0">
+            <h2 className="text-base sm:text-lg font-semibold text-text-primary flex items-center gap-2">
+              <Search className="w-5 h-5 text-purple-500 shrink-0" />
+              <span className="truncate">{t.title}</span>
             </h2>
-            <p className="text-sm text-text-secondary mt-0.5">
+            <p className="text-xs sm:text-sm text-text-secondary mt-0.5 truncate">
               {allowMultiple
                 ? t.subtitleMultiple.replace("{max}", maxSelection.toString())
                 : t.subtitle}
@@ -755,7 +755,7 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
 
           <button
             onClick={onClose}
-            className="p-2 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-bg-hover transition-colors"
+            className="p-2 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-bg-hover transition-colors shrink-0"
           >
             <X className="w-5 h-5" />
           </button>
@@ -763,10 +763,10 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
 
         {/* Stats bar */}
         {discovery && (
-          <div className="px-6 py-3 bg-bg-tertiary/50 border-b border-border-subtle space-y-3">
+          <div className="px-4 sm:px-6 py-3 bg-bg-tertiary/50 border-b border-border-subtle space-y-3">
             {/* First row: Stats and filters */}
-            <div className="flex items-center justify-between flex-wrap gap-3">
-              <div className="flex items-center gap-4 text-sm text-text-secondary">
+            <div className="flex items-start sm:items-center justify-between flex-col sm:flex-row gap-3">
+              <div className="flex flex-wrap items-center gap-x-2 sm:gap-x-3 gap-y-1 text-xs sm:text-sm text-text-secondary">
                 <span>
                   <strong className="text-text-primary">
                     {discovery.candidates.length}
@@ -774,28 +774,20 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
                   {t.found.replace("{count}", "")}
                 </span>
                 <span className="text-text-tertiary">•</span>
-                <span>
+                <span className="truncate max-w-[50vw] sm:max-w-none">
                   {t.searchedIn}: {discovery.languages_searched.join(", ")}
                 </span>
-                <span className="text-text-tertiary">•</span>
-                <span>
+                <span className="text-text-tertiary hidden sm:inline">•</span>
+                <span className="hidden sm:inline">
                   {t.duration.replace(
                     "{ms}",
                     discovery.search_duration_ms.toString(),
                   )}
                 </span>
-                {discovery.tournesol_available && (
-                  <>
-                    <span className="text-text-tertiary">•</span>
-                    <span className="flex items-center gap-1">
-                      🌻 Tournesol
-                    </span>
-                  </>
-                )}
               </div>
 
               {/* Filters */}
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
                 {/* Sort */}
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-text-tertiary">{t.sortBy}</span>
@@ -849,7 +841,7 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
         )}
 
         {/* Content */}
-        <div ref={scrollContainerRef} className="flex-1 overflow-y-auto p-6">
+        <div ref={scrollContainerRef} className="flex-1 overflow-y-auto p-3 sm:p-6">
           {loading ? (
             <div className="flex flex-col items-center justify-center py-12">
               <DeepSightSpinner
@@ -910,8 +902,8 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between px-6 py-4 border-t border-border-default bg-bg-tertiary/50">
-          <div className="flex items-center gap-4 text-sm">
+        <div className="flex items-center justify-between gap-2 flex-wrap px-4 py-3 sm:px-6 sm:py-4 border-t border-border-default bg-bg-tertiary/50">
+          <div className="flex items-center gap-2 sm:gap-4 text-xs sm:text-sm">
             {selectedIds.size > 0 && (
               <span className="text-text-primary font-medium">
                 {t.selected.replace("{count}", selectedIds.size.toString())}
@@ -924,19 +916,21 @@ export const VideoDiscoveryModal: React.FC<VideoDiscoveryModalProps> = ({
             </span>
           </div>
 
-          <div className="flex items-center gap-3">
-            <button onClick={onClose} className="btn btn-ghost">
+          <div className="flex items-center gap-2 sm:gap-3">
+            <button onClick={onClose} className="btn btn-ghost text-sm">
               {language === "fr" ? "Annuler" : "Cancel"}
             </button>
             <button
               onClick={handleConfirm}
               disabled={selectedIds.size === 0 || !hasEnoughCredits}
-              className="btn btn-primary"
+              className="btn btn-primary text-sm"
             >
               {!hasEnoughCredits ? (
                 <>
                   <AlertTriangle className="w-4 h-4" />
-                  {t.insufficientCredits}
+                  <span className="hidden sm:inline">
+                    {t.insufficientCredits}
+                  </span>
                 </>
               ) : (
                 <>

--- a/frontend/src/components/academic/__tests__/PaperCard.test.tsx
+++ b/frontend/src/components/academic/__tests__/PaperCard.test.tsx
@@ -19,7 +19,7 @@ const basePaper: AcademicPaper = {
   abstract: "An abstract of the test paper.",
   citation_count: 42,
   url: "https://example.com/p-1",
-  pdf_url: null,
+  pdf_url: undefined,
   source: "semantic_scholar",
   relevance_score: 0.95,
   is_open_access: false,

--- a/frontend/src/components/hub/__tests__/FullscreenChatView.test.tsx
+++ b/frontend/src/components/hub/__tests__/FullscreenChatView.test.tsx
@@ -12,8 +12,20 @@ beforeAll(() => {
     vi.fn() as unknown as typeof Element.prototype.scrollTo;
 });
 
-vi.mock("../../../contexts/LanguageContext", () => ({
-  useLanguage: () => ({ language: "fr" }),
+vi.mock("../../../contexts/LanguageContext", async () => {
+  const React = await import("react");
+  return {
+    useLanguage: () => ({ language: "fr" }),
+    LanguageContext: React.createContext({ language: "fr" }),
+  };
+});
+
+vi.mock("../../../contexts/AuthContext", () => ({
+  useAuthContext: () => ({
+    user: { id: 1, plan: "expert", is_admin: false },
+    isAuthenticated: true,
+    loading: false,
+  }),
 }));
 
 vi.mock("../../../services/api", () => ({

--- a/frontend/src/pages/DashboardPageLegacy.tsx
+++ b/frontend/src/pages/DashboardPageLegacy.tsx
@@ -278,6 +278,34 @@ export const DashboardPage: React.FC = () => {
   // L'onglet Analyse est TOUJOURS vide quand on y arrive depuis un autre onglet.
   // Les synthèses de l'historique s'affichent désormais inline dans l'onglet Historique.
 
+  // === 🔍 Pre-fill + auto-search depuis query string (?q=...) ===
+  // Arrive ici quand l'utilisateur lance une recherche depuis DashboardPageMinimal,
+  // qui redirige vers /?legacy=1&q=<query>. On pré-remplit le SmartInputBar et
+  // déclenche immédiatement la découverte pour éviter à l'utilisateur de retaper.
+  const [pendingAutoSearch, setPendingAutoSearch] = useState<string | null>(
+    null,
+  );
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get("q");
+    if (q && q.trim().length > 0) {
+      setSmartInput((prev) => ({
+        ...prev,
+        mode: "search",
+        searchQuery: q,
+        searchLanguages: prev.searchLanguages || ["fr", "en"],
+      }));
+      setPendingAutoSearch(q);
+      // Nettoyer le query param sans recharger pour éviter de re-trigger
+      params.delete("q");
+      const newSearch = params.toString();
+      const newUrl =
+        window.location.pathname + (newSearch ? `?${newSearch}` : "");
+      window.history.replaceState({}, "", newUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // === 🕐 Charger les données de fiabilité quand un résumé est sélectionné ===
 
   useEffect(() => {
@@ -485,6 +513,54 @@ export const DashboardPage: React.FC = () => {
       pollingRef.current = false;
     }
   };
+
+  // === 🔍 Auto-trigger discover dès que smartInput est aligné avec pendingAutoSearch ===
+  useEffect(() => {
+    if (!pendingAutoSearch) return;
+    if (
+      smartInput.mode !== "search" ||
+      smartInput.searchQuery !== pendingAutoSearch
+    )
+      return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        setLoadingMessage(
+          language === "fr" ? "Recherche intelligente..." : "Smart search...",
+        );
+        const discovery = await videoApi.discover(pendingAutoSearch, {
+          languages: smartInput.searchLanguages || ["fr", "en"],
+          limit: 20,
+          minQuality: 30,
+          targetDuration: "default",
+        });
+        if (cancelled) return;
+        setDiscoveryResult(discovery);
+        setShowDiscoveryModal(true);
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : language === "fr"
+                ? "Erreur de recherche"
+                : "Search error",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+          setPendingAutoSearch(null);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingAutoSearch, smartInput.mode, smartInput.searchQuery]);
 
   const handleAnalyze = async () => {
     // Validation selon le mode


### PR DESCRIPTION
## Summary
- Backend `intelligent_discovery.py` : poids Tournesol dans le scoring 0.20 → 0.05, engagement 0.10 → 0.20. Plus de promotion forcée à position 3, plus de fallback hardcodé 6 vidéos. Au max 1 vidéo Tournesol ajoutée discrètement à pos 5 si aucune n'apparaît naturellement.
- VideoDiscoveryModal V2 + V3 : full-screen mobile (`max-h-[100dvh] sm:max-h-[92vh]`, `rounded-none sm:rounded-2xl`), padding et gap adaptatifs, footer wrap correct.
- DashboardPageLegacy : lecture du `?q=` envoyé par DashboardPageMinimal → pre-fill SmartInputBar + auto-trigger discover (évite à l'utilisateur de retaper sa recherche).

## Why
La recherche YouTube intégrée affichait surtout des vidéos Tournesol (insertion forcée + scoring favorable + fallback hardcodé) au lieu de la sélection YouTube standard attendue. Bonus : la version mobile navigateur cassait sur petits écrans.

## Test plan
- [ ] /?legacy=1 → SmartInputBar mode search → "intelligence artificielle" → modal s'ouvre avec ~20 vidéos YouTube, max 1 Tournesol visible (badge 🌻)
- [ ] Test mobile web (DevTools 375px) : modal full-screen, header/stats/footer wrap proprement, grid 1 colonne
- [ ] /?legacy=1&q=climat → SmartInputBar pré-rempli, modal s'ouvre automatiquement sans re-clic
- [ ] PlaylistPage discovery flow : modal V2 toujours fonctionnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)