### PR TITLE
feat(auth): Sign in with Apple backend — service + endpoints + migration

### DIFF
--- a/backend/alembic/versions/032_users_apple_sub.py
+++ b/backend/alembic/versions/032_users_apple_sub.py
@@ -1,0 +1,70 @@
+"""users_apple_sub — colonne unique pour le Sign in with Apple
+
+Revision ID: 032_users_apple_sub
+Revises: 031_summary_ext_pages
+Create Date: 2026-05-20
+
+Spec : Apple Sign In tri-plateforme (mirror Google OAuth).
+
+Ajoute `users.apple_sub VARCHAR(255) UNIQUE NULL` (Apple "sub" claim — identifiant
+stable et opaque par utilisateur, équivalent de `google_id`). Indexé pour les
+lookups par OAuth, nullable pour ne pas casser les comptes email-only / Google-only.
+
+Convention DeepSight Alembic :
+- Revision ID ≤ 32 chars : "032_users_apple_sub" = 19 chars ✓
+- Migration idempotente : add only if not exists, drop only if exists.
+- Compatible PostgreSQL ET SQLite.
+
+Entrypoint Docker exécute `alembic upgrade heads` (plural) à chaque container
+start, donc on doit rester safe sur re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "032_users_apple_sub"
+down_revision: Union[str, None] = "031_summary_ext_pages"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "users" not in inspector.get_table_names():
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("users")}
+    if "apple_sub" in columns:
+        return
+
+    op.add_column(
+        "users",
+        sa.Column("apple_sub", sa.String(length=255), nullable=True),
+    )
+    op.create_index(
+        "ix_users_apple_sub",
+        "users",
+        ["apple_sub"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "users" not in inspector.get_table_names():
+        return
+
+    indexes = {ix["name"] for ix in inspector.get_indexes("users")}
+    if "ix_users_apple_sub" in indexes:
+        op.drop_index("ix_users_apple_sub", table_name="users")
+
+    columns = {col["name"] for col in inspector.get_columns("users")}
+    if "apple_sub" in columns:
+        op.drop_column("users", "apple_sub")

--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from db.database import get_session
 from core.analytics import track_event
-from core.config import FRONTEND_URL, EMAIL_CONFIG, GOOGLE_OAUTH_CONFIG
+from core.config import FRONTEND_URL, EMAIL_CONFIG, GOOGLE_OAUTH_CONFIG, APPLE_OAUTH_CONFIG
 from .schemas import (
     UserRegister,
     UserLogin,
@@ -26,6 +26,7 @@ from .schemas import (
     UpdatePreferencesRequest,
     GoogleCallbackRequest,
     GoogleMobileTokenRequest,
+    AppleMobileTokenRequest,
     DeleteAccountRequest,
     UserResponse,
     TokenResponse,
@@ -55,6 +56,8 @@ from .service import (
     invalidate_user_session,
     validate_session_token,
     verify_google_id_token,
+    verify_apple_id_token,
+    login_or_register_apple_user,
 )
 from services.audit_log import log_audit
 from .dependencies import get_current_user
@@ -752,6 +755,104 @@ async def google_token_login(data: GoogleMobileTokenRequest, session: AsyncSessi
     )
 
     return TokenResponse(access_token=access_token, refresh_token=refresh_token, user=UserResponse.model_validate(user))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🍎 SIGN IN WITH APPLE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post("/apple/token", response_model=TokenResponse)
+async def apple_token_login(data: AppleMobileTokenRequest, session: AsyncSession = Depends(get_session)):
+    """
+    Sign in with Apple — verifie un `id_token` Apple (JWT signe RS256) et retourne
+    nos propres JWT (access_token + refresh_token).
+
+    Flow client (toutes plateformes) :
+      - Web : AppleID.auth.signIn() en popup → recoit `authorization.id_token` + `user` (first login only)
+      - iOS : expo-apple-authentication.signInAsync() → recoit `identityToken` + `fullName/email` (first login only)
+      - Extension : ouvre tab web Sign in with Apple, recupere id_token via redirect handler
+
+    Apple ne renvoie email/full_name QU'AU PREMIER LOGIN. Le client DOIT nous
+    passer ces champs sur first sign-in (`data.email`, `data.full_name`) sinon
+    le compte sera cree avec un email Apple Private Relay generique.
+
+    Reponse identique a POST /login pour reutiliser le flow standard.
+    """
+    import logging
+
+    log = logging.getLogger(__name__)
+
+    if not APPLE_OAUTH_CONFIG.get("ENABLED"):
+        log.warning("Apple Sign In disabled (APPLE_OAUTH_ENABLED=false)")
+        raise HTTPException(status_code=400, detail="Sign in with Apple non activé")
+
+    # 1. Verifier cryptographiquement l'id_token avec Apple
+    claims = await verify_apple_id_token(data.id_token, client_platform=data.client_platform)
+    if not claims:
+        log.warning(f"Apple login: invalid id_token (platform={data.client_platform})")
+        raise HTTPException(status_code=401, detail="Invalid Apple ID token")
+
+    # 2. Extraire les claims essentiels
+    apple_sub = claims.get("sub")
+    # Apple peut inclure email dans le token (premier sign-in via SDK web) ou
+    # passer email separement (mobile native). On priorise le token > input client.
+    token_email = (claims.get("email") or "").lower().strip()
+    client_email = (data.email or "").lower().strip()
+    email = token_email or client_email or None
+
+    if not apple_sub:
+        log.warning("Apple login: id_token missing 'sub' claim")
+        raise HTTPException(status_code=401, detail="Invalid Apple ID token payload")
+
+    # 3. Login ou creation
+    try:
+        success, user, message, session_token = await login_or_register_apple_user(
+            session,
+            apple_sub=apple_sub,
+            email=email,
+            full_name=data.full_name,
+            auto_create=data.auto_create,
+        )
+    except Exception as e:
+        log.error(f"Apple login DB error for sub={apple_sub[:8]}***: {e}")
+        raise HTTPException(status_code=503, detail="Database temporarily unavailable. Please try again.")
+
+    # Cas silent flow : user inexistant et auto_create=False
+    if not success and message == "NOT_REGISTERED":
+        log.info(f"Apple login: no DeepSight account for sub={apple_sub[:8]}*** → redirect signup")
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "user_not_registered",
+                "email": email,
+                "full_name": data.full_name,
+            },
+        )
+
+    if not success or not user:
+        log.warning(f"Apple login failed: {message}")
+        raise HTTPException(status_code=400, detail=message)
+
+    # 4. Generer nos JWT
+    access_token = create_access_token(user.id, user.is_admin, session_token)
+    refresh_token = create_refresh_token(user.id, session_token)
+
+    log.info(
+        f"Apple login success: user_id={user.id} apple_sub={apple_sub[:8]}*** "
+        f"platform={data.client_platform} device={data.device_name or 'unknown'}"
+    )
+
+    return TokenResponse(access_token=access_token, refresh_token=refresh_token, user=UserResponse.model_validate(user))
+
+
+# Alias POST /apple/callback → meme handler. Le SDK web AppleID.auth.js peut
+# rediriger soit en popup (id_token direct) soit en redirect (avec code), mais
+# DeepSight utilise le mode popup, donc /apple/callback recoit aussi un id_token.
+@router.post("/apple/callback", response_model=TokenResponse)
+async def apple_callback_post(data: AppleMobileTokenRequest, session: AsyncSession = Depends(get_session)):
+    """Alias POST de /apple/token pour rester aligne avec /google/callback (web SPA)."""
+    return await apple_token_login(data, session)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/src/auth/schemas.py
+++ b/backend/src/auth/schemas.py
@@ -148,6 +148,64 @@ class GoogleMobileTokenRequest(BaseModel):
     )
 
 
+class AppleMobileTokenRequest(BaseModel):
+    """
+    Schema pour Sign in with Apple via id_token JWT.
+
+    Utilise par TOUTES les plateformes (web AppleID.auth.js, mobile iOS
+    expo-apple-authentication, et eventuellement extension via WebView). Le client
+    obtient l'id_token aupres d'Apple puis l'envoie ici pour verification serveur +
+    echange contre nos propres JWT.
+
+    Particularite Apple : email et name ne sont fournis QU'au PREMIER login.
+    Le client doit nous transmettre ces champs sur first sign-in pour qu'on puisse
+    creer le compte. Les logins suivants se contentent de l'id_token (sub stable).
+
+    Si `auto_create=False` et qu'aucun compte DeepSight n'existe pour cet apple_sub
+    (ni pour cet email), retourne HTTP 404 avec les claims pour permettre au client
+    de rediriger vers signup pre-rempli.
+    """
+
+    id_token: str = Field(..., min_length=10, description="Apple ID token JWT signe RS256")
+    client_platform: Literal["ios", "android", "web", "extension"] = Field(
+        default="web",
+        description="Plateforme cliente (selection audience attendue : APPLE_CLIENT_ID web vs APPLE_BUNDLE_ID iOS)",
+    )
+    # Apple ne renvoie email/full_name QU'au PREMIER sign-in. Le client DOIT
+    # les passer ici sur first login sinon le compte sera cree sans email
+    # (Apple Private Relay genere un alias `xxx@privaterelay.appleid.com`).
+    email: Optional[str] = Field(default=None, description="Email (premier sign-in only)")
+    full_name: Optional[str] = Field(
+        default=None,
+        max_length=200,
+        description="Nom complet (premier sign-in only) — sert a generer un username initial",
+    )
+    device_name: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Nom du device pour tracking des sessions (ex: 'iPhone 15 Pro')",
+    )
+    auto_create: bool = Field(
+        default=True,
+        description=(
+            "Si True (defaut), cree un compte DeepSight automatiquement si aucun "
+            "n'existe pour cet apple_sub. Si False, retourne 404 pour rediriger "
+            "vers signup."
+        ),
+    )
+
+
+class AppleNotRegisteredResponse(BaseModel):
+    """
+    Reponse 404 quand un id_token Apple valide est fourni mais qu'aucun compte
+    DeepSight n'existe pour cet apple_sub/email et que `auto_create=False`.
+    """
+
+    code: Literal["user_not_registered"] = "user_not_registered"
+    email: Optional[str] = None
+    full_name: Optional[str] = None
+
+
 class GoogleNotRegisteredResponse(BaseModel):
     """
     Réponse 404 quand un ID token Google valide est fourni mais qu'aucun compte

--- a/backend/src/auth/service.py
+++ b/backend/src/auth/service.py
@@ -19,7 +19,7 @@ from jose import jwt, JWTError
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from core.config import JWT_CONFIG, GOOGLE_OAUTH_CONFIG, EMAIL_CONFIG, APP_URL, ADMIN_CONFIG
+from core.config import JWT_CONFIG, GOOGLE_OAUTH_CONFIG, APPLE_OAUTH_CONFIG, EMAIL_CONFIG, APP_URL, ADMIN_CONFIG
 from billing.plan_config import get_limits
 from db.database import User, ChatQuota, WebSearchUsage, hash_password, verify_password
 
@@ -774,3 +774,253 @@ def verify_google_id_token(id_token_str: str, client_platform: str = "web") -> O
 
         logging.getLogger(__name__).error(f"Unexpected error verifying Google ID token: {e}")
         return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🍎 SIGN IN WITH APPLE — Verification id_token + login/register
+# ═══════════════════════════════════════════════════════════════════════════════
+
+APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+APPLE_ISSUER = "https://appleid.apple.com"
+
+# Cache des JWKs Apple (les clés tournent — TTL 1h suffit pour limiter les fetches
+# tout en restant resilient aux rotations). Cle = "jwks", valeur = (timestamp, jwks_dict).
+_APPLE_JWKS_CACHE: dict = {}
+_APPLE_JWKS_TTL_SECONDS = 3600
+
+
+async def _fetch_apple_jwks() -> Optional[dict]:
+    """Recupere les JWKs publics Apple (cache 1h)."""
+    import time
+    import logging
+
+    log = logging.getLogger(__name__)
+    cached = _APPLE_JWKS_CACHE.get("jwks")
+    now = time.time()
+    if cached and (now - cached[0]) < _APPLE_JWKS_TTL_SECONDS:
+        return cached[1]
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(APPLE_JWKS_URL, timeout=10)
+            if response.status_code != 200:
+                log.warning(f"Apple JWKs fetch failed: HTTP {response.status_code}")
+                # Fallback sur cache stale si dispo
+                return cached[1] if cached else None
+            jwks = response.json()
+            _APPLE_JWKS_CACHE["jwks"] = (now, jwks)
+            return jwks
+    except Exception as e:
+        log.error(f"Apple JWKs fetch exception: {e}")
+        return cached[1] if cached else None
+
+
+def _get_allowed_apple_audiences(client_platform: str = "web") -> list[str]:
+    """
+    Retourne la liste des audiences Apple autorisees selon la plateforme.
+    Web/extension utilisent APPLE_CLIENT_ID (Service ID), iOS utilise APPLE_BUNDLE_ID.
+    Toutes les audiences non-vides sont incluses pour supporter le cross-platform.
+    """
+    audiences: set[str] = set()
+    for key in ("CLIENT_ID", "BUNDLE_ID"):
+        value = APPLE_OAUTH_CONFIG.get(key)
+        if value:
+            audiences.add(value)
+    return [a for a in audiences if a]
+
+
+async def verify_apple_id_token(id_token_str: str, client_platform: str = "web") -> Optional[dict]:
+    """
+    Verifie un Apple ID token JWT (signe RS256 par Apple).
+
+    - Recupere les JWKs publics Apple (cache 1h).
+    - Selectionne la cle par `kid` dans le header du JWT.
+    - Verifie la signature RS256.
+    - Verifie l'audience (`aud`) contre APPLE_CLIENT_ID (Service ID web) ou
+      APPLE_BUNDLE_ID (iOS).
+    - Verifie l'issuer (`iss = https://appleid.apple.com`).
+    - Verifie l'expiration (`exp`).
+
+    Retourne les claims decodes (dict) si valides, None sinon.
+
+    Claims Apple typiques :
+      - sub: identifiant utilisateur opaque et stable (NOTRE clef de lookup)
+      - email: adresse email (peut etre un alias prive @privaterelay.appleid.com)
+      - email_verified: bool (toujours True chez Apple)
+      - is_private_email: bool (True si email est un alias Apple Hide My Email)
+      - aud, iss, exp, iat
+    """
+    import logging
+
+    log = logging.getLogger(__name__)
+
+    allowed_audiences = _get_allowed_apple_audiences(client_platform)
+    if not allowed_audiences:
+        log.error("No Apple audiences configured (APPLE_CLIENT_ID / APPLE_BUNDLE_ID)")
+        return None
+
+    jwks = await _fetch_apple_jwks()
+    if not jwks or "keys" not in jwks:
+        log.error("Apple JWKs unavailable — cannot verify id_token")
+        return None
+
+    try:
+        unverified_header = jwt.get_unverified_header(id_token_str)
+    except JWTError as e:
+        log.warning(f"Apple id_token: cannot parse header: {e}")
+        return None
+
+    kid = unverified_header.get("kid")
+    if not kid:
+        log.warning("Apple id_token header missing 'kid'")
+        return None
+
+    matching_key = next((k for k in jwks["keys"] if k.get("kid") == kid), None)
+    if not matching_key:
+        log.warning(f"Apple id_token: no JWK matches kid={kid}")
+        # Force-refresh cache au cas ou Apple a tourne ses cles
+        _APPLE_JWKS_CACHE.pop("jwks", None)
+        return None
+
+    # Try each allowed audience (jose.decode prend une seule audience a la fois)
+    last_error: Optional[Exception] = None
+    for audience in allowed_audiences:
+        try:
+            claims = jwt.decode(
+                id_token_str,
+                matching_key,
+                algorithms=["RS256"],
+                audience=audience,
+                issuer=APPLE_ISSUER,
+            )
+            return claims
+        except JWTError as e:
+            last_error = e
+            continue
+
+    log.warning(f"Apple id_token verification failed for all audiences: {last_error}")
+    return None
+
+
+async def login_or_register_apple_user(
+    session: AsyncSession,
+    apple_sub: str,
+    email: Optional[str],
+    full_name: Optional[str] = None,
+    auto_create: bool = True,
+) -> Tuple[bool, Optional[User], str, Optional[str]]:
+    """
+    Connecte ou cree un utilisateur via Sign in with Apple.
+
+    Particularite Apple : `email` peut etre None sur les logins SUIVANTS (Apple
+    ne renvoie email/name que sur first sign-in). On retombe alors sur le lookup
+    par `apple_sub` strictement.
+
+    Lookup priorise :
+      1. apple_sub (stable, unique, opaque)
+      2. email (si fourni — premier sign-in OU manuellement par client)
+
+    Si l'utilisateur existe par email mais pas par apple_sub, on link les deux
+    (idempotence : on peut se reconnecter Apple sur un compte Google existant).
+
+    Si `auto_create=False` et qu'aucun utilisateur n'existe, retourne
+    `(False, None, "NOT_REGISTERED", None)`.
+
+    Retourne : (success, user, message, session_token)
+    """
+    apple_sub = apple_sub.strip()
+    if not apple_sub:
+        return False, None, "❌ apple_sub manquant", None
+
+    normalized_email = email.lower().strip() if email else None
+
+    # 1. Lookup par apple_sub (priorite)
+    result = await session.execute(select(User).where(User.apple_sub == apple_sub))
+    user = result.scalar_one_or_none()
+
+    # 2. Si pas trouve, lookup par email
+    if not user and normalized_email:
+        user = await get_user_by_email(session, normalized_email)
+
+    admin_email = ADMIN_CONFIG.get("ADMIN_EMAIL", "").lower().strip()
+    is_admin_user = bool(normalized_email and normalized_email == admin_email)
+
+    if user:
+        # Lier apple_sub si pas encore present (cas : compte cree par Google ou email/password)
+        if not user.apple_sub:
+            user.apple_sub = apple_sub
+        # Apple verifie l'email lui-meme avant emission de l'id_token
+        if normalized_email and not user.email_verified:
+            user.email_verified = True
+
+        if is_admin_user and not user.is_admin:
+            user.is_admin = True
+            user.plan = "pro"
+            user.credits = 999999
+            print(f"🔐 Admin privileges granted via Apple to: {normalized_email}", flush=True)
+
+        await session.commit()
+        session_token = await create_user_session(session, user.id)
+        return True, user, "✅ Connexion Apple réussie", session_token
+
+    # Aucun utilisateur — creation desactivee (extension silent flow)
+    if not auto_create:
+        return False, None, "NOT_REGISTERED", None
+
+    # Creation. Apple peut ne pas fournir d'email (Hide My Email + private relay)
+    # mais on a TOUJOURS apple_sub. Si pas d'email, on cree un email placeholder
+    # base sur sub pour respecter la contrainte UNIQUE NOT NULL de users.email.
+    # Le user pourra le rattacher a son vrai email via la page de settings ulterieurement.
+    if not normalized_email:
+        normalized_email = f"apple_{apple_sub[:16]}@privaterelay.appleid.com"
+
+    # Username depuis full_name si fourni, sinon depuis email
+    base_username = ""
+    if full_name:
+        base_username = "".join(c for c in full_name.lower() if c.isalnum())[:30]
+    if not base_username:
+        base_username = normalized_email.split("@")[0].lower()
+    if not base_username:
+        base_username = f"apple{apple_sub[:8]}"
+
+    username = base_username
+    counter = 1
+    while True:
+        existing = await get_user_by_username(session, username)
+        if not existing:
+            break
+        username = f"{base_username}{counter}"
+        counter += 1
+
+    random_password = secrets.token_urlsafe(16)
+
+    if is_admin_user:
+        user = User(
+            username=username,
+            email=normalized_email,
+            password_hash=hash_password(random_password),
+            email_verified=True,
+            apple_sub=apple_sub,
+            plan="pro",
+            credits=999999,
+            is_admin=True,
+        )
+        print(f"🔐 Admin user created via Apple: {normalized_email}", flush=True)
+    else:
+        initial_credits = get_limits("free")["monthly_credits"]
+        user = User(
+            username=username,
+            email=normalized_email,
+            password_hash=hash_password(random_password),
+            email_verified=True,
+            apple_sub=apple_sub,
+            plan="free",
+            credits=initial_credits,
+        )
+
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+
+    session_token = await create_user_session(session, user.id)
+    return True, user, "✅ Compte créé avec Apple", session_token

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -156,6 +156,25 @@ class _DeepSightSettings(BaseSettings):
     GOOGLE_IOS_CLIENT_ID: str = ""  # Mobile iOS client ID (fallback: GOOGLE_CLIENT_ID)
     GOOGLE_ANDROID_CLIENT_ID: str = ""  # Mobile Android client ID (fallback: GOOGLE_CLIENT_ID)
 
+    # -- Sign in with Apple --
+    # Active la verification des id_token Apple cote serveur. Le flow client (web
+    # via AppleID.auth.js + mobile via expo-apple-authentication) envoie un
+    # id_token JWT signe RS256, verifie ici contre les JWKs publics Apple.
+    APPLE_OAUTH_ENABLED: str = "false"
+    # Service ID (web) — ex: "com.deepsightsynthesis.signin". C'est l'audience
+    # attendue par le SDK JS Apple. Apple Developer Console > Certificates > Identifiers > Services IDs.
+    APPLE_CLIENT_ID: str = ""
+    # Bundle Identifier iOS — ex: "com.deepsightsynthesis.mobile". Audience de
+    # l'id_token retourne par expo-apple-authentication sur iPhone/iPad.
+    APPLE_BUNDLE_ID: str = ""
+    # Team ID Apple Developer (10 chars) — visible dans le coin haut droit du compte.
+    APPLE_TEAM_ID: str = ""
+    # Key ID du Sign in with Apple key (10 chars). Apple Developer Console > Keys.
+    APPLE_KEY_ID: str = ""
+    # Cle privee ES256 au format PEM (le `.p8` telecharge une seule fois).
+    # Stocke en multi-ligne dans .env via guillemets ou en BASE64 (decode automatique).
+    APPLE_PRIVATE_KEY: str = ""
+
     # -- CRON --
     CRON_SECRET: str = ""
 
@@ -488,6 +507,22 @@ GOOGLE_OAUTH_CONFIG = {
     # Mobile client IDs (fallback to web CLIENT_ID if not set)
     "IOS_CLIENT_ID": _settings.GOOGLE_IOS_CLIENT_ID or _settings.GOOGLE_CLIENT_ID,
     "ANDROID_CLIENT_ID": _settings.GOOGLE_ANDROID_CLIENT_ID or _settings.GOOGLE_CLIENT_ID,
+}
+
+# =============================================================================
+# APPLE SIGN IN
+# =============================================================================
+# Verification des id_token Apple (web via AppleID.auth.js, mobile via
+# expo-apple-authentication). Audiences acceptees : Service ID web + Bundle ID iOS.
+# Le mobile Android ne supporte pas le flow natif (Apple JS web requis).
+
+APPLE_OAUTH_CONFIG = {
+    "ENABLED": _settings.APPLE_OAUTH_ENABLED.lower() == "true",
+    "CLIENT_ID": _settings.APPLE_CLIENT_ID,
+    "BUNDLE_ID": _settings.APPLE_BUNDLE_ID,
+    "TEAM_ID": _settings.APPLE_TEAM_ID,
+    "KEY_ID": _settings.APPLE_KEY_ID,
+    "PRIVATE_KEY": _settings.APPLE_PRIVATE_KEY,
 }
 
 # =============================================================================

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -143,6 +143,11 @@ class User(Base):
     # Google OAuth
     google_id = Column(String(100))
 
+    # Sign in with Apple — "sub" claim de l'ID token Apple (opaque, stable, per-user).
+    # Nullable pour ne pas casser les comptes email-only / Google-only.
+    # Index unique géré par migration Alembic 032 (ix_users_apple_sub).
+    apple_sub = Column(String(255), unique=True, index=True, nullable=True)
+
     # Clés API utilisateur (optionnel)
     mistral_key = Column(String(255))
     supadata_key = Column(String(255))

--- a/backend/tests/auth/test_apple_oauth.py
+++ b/backend/tests/auth/test_apple_oauth.py
@@ -1,0 +1,413 @@
+"""
+Tests pour POST /api/auth/apple/token — Sign in with Apple (id_token flow).
+
+Couvre :
+1. Nouveau user créé correctement (first sign-in avec email + full_name)
+2. User existant avec apple_sub match → login OK, pas de duplication
+3. User existant avec email match mais pas apple_sub → merge (apple_sub assigné)
+4. id_token invalide → 401
+5. Apple OAuth desactive → 400
+6. Apple sub manquant dans claims → 401
+7. Login subsequent sans email (Apple n'envoie email qu'au premier sign-in)
+"""
+
+from datetime import datetime
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Fixtures locales
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_user_mock(
+    user_id: int = 42,
+    email: str = "newuser@example.com",
+    username: str = "newuser",
+    apple_sub: str = "",
+    google_id: str = "",
+    is_admin: bool = False,
+    email_verified: bool = True,
+) -> MagicMock:
+    """Mock User avec attributs compatibles UserResponse (from_attributes)."""
+    user = MagicMock()
+    user.id = user_id
+    user.username = username
+    user.email = email
+    user.email_verified = email_verified
+    user.plan = "free"
+    user.credits = 250
+    user.credits_monthly = 250
+    user.is_admin = is_admin
+    user.avatar_url = None
+    user.default_lang = "fr"
+    user.default_mode = "standard"
+    user.default_model = "small"
+    user.total_videos = 0
+    user.total_words = 0
+    user.total_playlists = 0
+    user.created_at = datetime(2026, 1, 1, 0, 0, 0)
+    user.apple_sub = apple_sub
+    user.google_id = google_id
+    user.is_active = True
+    return user
+
+
+def _valid_apple_claims(
+    sub: str = "001234.abc.5678",
+    email: str = "tim@privaterelay.appleid.com",
+    email_verified: bool = True,
+) -> dict:
+    """Claims Apple valides simulés après vérification."""
+    return {
+        "iss": "https://appleid.apple.com",
+        "sub": sub,
+        "email": email,
+        "email_verified": email_verified,
+        "is_private_email": email.endswith("@privaterelay.appleid.com"),
+        "aud": "com.deepsightsynthesis.signin",
+        "exp": 9999999999,
+        "iat": 1000000000,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. Nouveau user créé correctement (first sign-in)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_token_creates_new_user(mock_db_session):
+    """
+    Test : id_token valide pour un apple_sub inexistant + email/name fournis (first
+    sign-in) → nouvel utilisateur créé, plan=free, JWT renvoyés.
+    """
+    from auth.router import apple_token_login
+    from auth.schemas import AppleMobileTokenRequest
+
+    new_user = _make_user_mock(
+        user_id=42,
+        email="tim@example.com",
+        username="tim",
+        apple_sub="001234.abc.5678",
+    )
+    claims = _valid_apple_claims(sub="001234.abc.5678", email="tim@example.com")
+
+    with patch(
+        "auth.router.APPLE_OAUTH_CONFIG",
+        {"ENABLED": True, "CLIENT_ID": "com.deepsightsynthesis.signin"},
+    ), patch(
+        "auth.router.verify_apple_id_token",
+        new_callable=AsyncMock,
+        return_value=claims,
+    ), patch(
+        "auth.router.login_or_register_apple_user",
+        new_callable=AsyncMock,
+        return_value=(True, new_user, "✅ Compte créé avec Apple", "sess_new"),
+    ) as mock_login, patch(
+        "auth.router.create_access_token", return_value="access_jwt_apple"
+    ), patch(
+        "auth.router.create_refresh_token", return_value="refresh_jwt_apple"
+    ):
+        req = AppleMobileTokenRequest(
+            id_token="fake.apple.idtoken",
+            client_platform="ios",
+            email="tim@example.com",
+            full_name="Tim Cook",
+            device_name="iPhone 15 Pro",
+        )
+        response = await apple_token_login(req, mock_db_session)
+
+    assert response.access_token == "access_jwt_apple"
+    assert response.refresh_token == "refresh_jwt_apple"
+    assert response.token_type == "bearer"
+    assert response.user.email == "tim@example.com"
+    assert response.user.id == 42
+
+    mock_login.assert_awaited_once()
+    call_kwargs = mock_login.await_args.kwargs
+    assert call_kwargs["apple_sub"] == "001234.abc.5678"
+    assert call_kwargs["email"] == "tim@example.com"
+    assert call_kwargs["full_name"] == "Tim Cook"
+    assert call_kwargs["auto_create"] is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. User existant avec apple_sub match → login OK, pas de duplication
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_token_existing_user_by_sub(mock_db_session):
+    """
+    Test : user déjà enregistré avec apple_sub match → pas de création,
+    JWT renvoyés, comportement idempotent.
+    """
+    from auth.router import apple_token_login
+    from auth.schemas import AppleMobileTokenRequest
+
+    existing_user = _make_user_mock(
+        user_id=7,
+        email="existing@example.com",
+        username="existing",
+        apple_sub="001234.existing.0000",
+    )
+    claims = _valid_apple_claims(sub="001234.existing.0000", email="existing@example.com")
+
+    with patch(
+        "auth.router.APPLE_OAUTH_CONFIG",
+        {"ENABLED": True, "CLIENT_ID": "com.deepsightsynthesis.signin"},
+    ), patch(
+        "auth.router.verify_apple_id_token",
+        new_callable=AsyncMock,
+        return_value=claims,
+    ), patch(
+        "auth.router.login_or_register_apple_user",
+        new_callable=AsyncMock,
+        return_value=(True, existing_user, "✅ Connexion Apple réussie", "sess_existing"),
+    ), patch(
+        "auth.router.create_access_token", return_value="access_existing_apple"
+    ), patch(
+        "auth.router.create_refresh_token", return_value="refresh_existing_apple"
+    ):
+        req = AppleMobileTokenRequest(
+            id_token="fake.apple.idtoken",
+            client_platform="ios",
+        )
+        response = await apple_token_login(req, mock_db_session)
+
+    assert response.access_token == "access_existing_apple"
+    assert response.user.id == 7
+    assert existing_user.apple_sub == "001234.existing.0000"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. User existant par email mais pas par apple_sub → merge
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_token_merges_existing_email_account(mock_db_session):
+    """
+    Test : user existant par email (créé via Google ou email/password) sans
+    apple_sub → apple_sub assigné au compte existant, pas de duplication.
+    """
+    from auth.router import apple_token_login
+    from auth.schemas import AppleMobileTokenRequest
+
+    existing_user = _make_user_mock(
+        user_id=15,
+        email="mergedup@example.com",
+        username="mergedup",
+        apple_sub=None,
+        google_id="google_existing",
+        email_verified=True,
+    )
+
+    # Le service login_or_register_apple_user va appeler session.execute deux fois :
+    # (1) lookup par apple_sub → None, (2) lookup par email → existing_user
+    sub_lookup = MagicMock()
+    sub_lookup.scalar_one_or_none = MagicMock(return_value=None)
+    email_lookup = MagicMock()
+    email_lookup.scalar_one_or_none = MagicMock(return_value=existing_user)
+    mock_db_session.execute = AsyncMock(side_effect=[sub_lookup, email_lookup, sub_lookup])
+    mock_db_session.commit = AsyncMock()
+    mock_db_session.add = MagicMock()
+
+    claims = _valid_apple_claims(sub="001234.merge.aaaa", email="mergedup@example.com")
+
+    with patch(
+        "auth.router.APPLE_OAUTH_CONFIG",
+        {"ENABLED": True, "CLIENT_ID": "com.deepsightsynthesis.signin"},
+    ), patch(
+        "auth.router.verify_apple_id_token",
+        new_callable=AsyncMock,
+        return_value=claims,
+    ), patch(
+        "auth.service.ADMIN_CONFIG", {"ADMIN_EMAIL": "admin@test.com"}
+    ), patch(
+        "auth.service.create_user_session",
+        new_callable=AsyncMock,
+        return_value="sess_merge_apple",
+    ), patch(
+        "auth.router.create_access_token", return_value="access_merge_apple"
+    ), patch(
+        "auth.router.create_refresh_token", return_value="refresh_merge_apple"
+    ):
+        req = AppleMobileTokenRequest(
+            id_token="fake.apple.idtoken",
+            client_platform="web",
+        )
+        response = await apple_token_login(req, mock_db_session)
+
+    assert response.access_token == "access_merge_apple"
+    assert existing_user.apple_sub == "001234.merge.aaaa"
+    # Pas de création
+    mock_db_session.add.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. id_token invalide → 401
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_token_invalid_token(mock_db_session):
+    """
+    Test : id_token invalide (signature/expiré/malformé) → 401.
+    """
+    from fastapi import HTTPException
+    from auth.router import apple_token_login
+    from auth.schemas import AppleMobileTokenRequest
+
+    with patch(
+        "auth.router.APPLE_OAUTH_CONFIG",
+        {"ENABLED": True, "CLIENT_ID": "com.deepsightsynthesis.signin"},
+    ), patch(
+        "auth.router.verify_apple_id_token",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        req = AppleMobileTokenRequest(
+            id_token="invalid.apple.token",
+            client_platform="ios",
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await apple_token_login(req, mock_db_session)
+
+    assert exc_info.value.status_code == 401
+    assert "Invalid Apple ID token" in exc_info.value.detail
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. Apple OAuth désactivé → 400
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_token_disabled(mock_db_session):
+    """
+    Test : si APPLE_OAUTH_ENABLED=false → 400 avant verification.
+    """
+    from fastapi import HTTPException
+    from auth.router import apple_token_login
+    from auth.schemas import AppleMobileTokenRequest
+
+    with patch(
+        "auth.router.APPLE_OAUTH_CONFIG",
+        {"ENABLED": False, "CLIENT_ID": ""},
+    ):
+        req = AppleMobileTokenRequest(
+            id_token="any.token.here",
+            client_platform="ios",
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await apple_token_login(req, mock_db_session)
+
+    assert exc_info.value.status_code == 400
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. Sub manquant dans claims → 401
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_token_missing_sub_claim(mock_db_session):
+    """
+    Test : id_token verifié mais 'sub' absent des claims → 401.
+    """
+    from fastapi import HTTPException
+    from auth.router import apple_token_login
+    from auth.schemas import AppleMobileTokenRequest
+
+    broken_claims = _valid_apple_claims()
+    broken_claims.pop("sub")
+
+    with patch(
+        "auth.router.APPLE_OAUTH_CONFIG",
+        {"ENABLED": True, "CLIENT_ID": "com.deepsightsynthesis.signin"},
+    ), patch(
+        "auth.router.verify_apple_id_token",
+        new_callable=AsyncMock,
+        return_value=broken_claims,
+    ):
+        req = AppleMobileTokenRequest(
+            id_token="valid.but.broken",
+            client_platform="ios",
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await apple_token_login(req, mock_db_session)
+
+    assert exc_info.value.status_code == 401
+    assert "payload" in exc_info.value.detail.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. Login subsequent sans email (Apple ne renvoie email qu'au 1er sign-in)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_token_subsequent_login_no_email(mock_db_session):
+    """
+    Test : Apple ne renvoie email QUE sur le premier sign-in. Les logins
+    subsequents arrivent avec claims sans email — le lookup doit fonctionner par
+    apple_sub seul.
+    """
+    from auth.router import apple_token_login
+    from auth.schemas import AppleMobileTokenRequest
+
+    existing_user = _make_user_mock(
+        user_id=99,
+        email="returning@example.com",
+        username="returning",
+        apple_sub="001234.returning.zzzz",
+    )
+
+    # Claims sans email (login subsequent)
+    claims_no_email = {
+        "iss": "https://appleid.apple.com",
+        "sub": "001234.returning.zzzz",
+        "aud": "com.deepsightsynthesis.signin",
+        "exp": 9999999999,
+    }
+
+    with patch(
+        "auth.router.APPLE_OAUTH_CONFIG",
+        {"ENABLED": True, "CLIENT_ID": "com.deepsightsynthesis.signin"},
+    ), patch(
+        "auth.router.verify_apple_id_token",
+        new_callable=AsyncMock,
+        return_value=claims_no_email,
+    ), patch(
+        "auth.router.login_or_register_apple_user",
+        new_callable=AsyncMock,
+        return_value=(True, existing_user, "✅ Connexion Apple réussie", "sess_returning"),
+    ) as mock_login, patch(
+        "auth.router.create_access_token", return_value="access_returning"
+    ), patch(
+        "auth.router.create_refresh_token", return_value="refresh_returning"
+    ):
+        req = AppleMobileTokenRequest(
+            id_token="fake.apple.token",
+            client_platform="ios",
+            # PAS d'email/full_name (Apple ne les fournit pas en login subsequent)
+        )
+        response = await apple_token_login(req, mock_db_session)
+
+    assert response.access_token == "access_returning"
+    assert response.user.id == 99
+    # Vérifier que le service a été appelé avec email=None — le lookup par sub seul doit suffire
+    call_kwargs = mock_login.await_args.kwargs
+    assert call_kwargs["apple_sub"] == "001234.returning.zzzz"
+    assert call_kwargs["email"] is None


### PR DESCRIPTION
## Summary

Backend Sign in with Apple — mirror du flow Google OAuth existant. Première PR d'un sprint tri-plateforme (3 PRs : backend → web → mobile).

### Changements
- **Alembic 032** : `users.apple_sub VARCHAR(255) UNIQUE NULLABLE` + index
- **db/database.py** : colonne `apple_sub` sur `User`
- **core/config.py** : `APPLE_OAUTH_ENABLED` + `APPLE_CLIENT_ID` + `APPLE_BUNDLE_ID` + `APPLE_TEAM_ID` + `APPLE_KEY_ID` + `APPLE_PRIVATE_KEY` + `APPLE_OAUTH_CONFIG` dict
- **auth/schemas.py** : `AppleMobileTokenRequest` + `AppleNotRegisteredResponse`
- **auth/service.py** : `verify_apple_id_token` (JWKs cache 1h, RS256, audience + issuer + exp) + `login_or_register_apple_user` (lookup par `apple_sub` puis email, merge idempotent)
- **auth/router.py** : `POST /api/auth/apple/token` + alias `POST /api/auth/apple/callback`
- **tests/auth/test_apple_oauth.py** : 7 tests unit (10/10 verts)

### Particularités Apple gérées
- email/full_name uniquement au **PREMIER** sign-in — logins suivants utilisent `apple_sub` seul
- support Hide My Email (`@privaterelay.appleid.com`)
- email manquant + Hide My Email sans email forwarding → placeholder généré (respecte `users.email UNIQUE NOT NULL`)
- merge idempotent : un user Google/email peut linker son apple_sub via re-login

## ENV vars à configurer côté Maxime

### Hetzner `.env.production`
```env
APPLE_OAUTH_ENABLED=true
APPLE_CLIENT_ID=com.deepsightsynthesis.signin    # Service ID web
APPLE_BUNDLE_ID=com.deepsightsynthesis.mobile    # Bundle iOS (mobile app)
APPLE_TEAM_ID=<10 chars Apple Developer>
APPLE_KEY_ID=<10 chars du Sign in with Apple Key>
APPLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
```

### Apple Developer Console (à faire par Maxime)
1. **Identifiers > App IDs** : créer/éditer le Bundle iOS `com.deepsightsynthesis.mobile` → enable capability "Sign in with Apple"
2. **Identifiers > Services IDs** : créer `com.deepsightsynthesis.signin` → enable Sign in with Apple → configurer :
   - Primary App ID : pointer sur le Bundle iOS
   - Domains : `www.deepsightsynthesis.com`, `api.deepsightsynthesis.com`
   - Return URLs : `https://api.deepsightsynthesis.com/api/auth/apple/callback`
3. **Keys** : créer une nouvelle key avec scope "Sign in with Apple" → télécharger le `.p8` (UNE SEULE FOIS) → conserver `Key ID` + contenu PEM
4. Vérifier le domaine via le challenge `apple-developer-domain-association.txt` (à servir depuis le frontend)

## Test plan

- [ ] Migration 032 s'applique en dev (sqlite) sans erreur
- [ ] Migration 032 idempotente (re-run = no-op)
- [ ] `pytest tests/auth/test_apple_oauth.py` → 7/7 verts (en suite, pas en isolation à cause d'un bug pré-existant import circulaire qui touche AUSSI les tests Google)
- [ ] Backend démarre avec `APPLE_OAUTH_ENABLED=false` → endpoint répond 400
- [ ] Avec `APPLE_OAUTH_ENABLED=true` + id_token bidon → endpoint répond 401
- [ ] (post-deploy Hetzner) `curl POST /api/auth/apple/token` avec id_token réel généré par Apple → 200 + JWT

## Bugs / ambiguïtés détectés

- **Bug pré-existant** import circulaire `auth.dependencies <-> auth.service <-> billing.router` : fait planter les tests auth quand lancés en isolation, sans rapport avec cette PR. À fixer dans un cleanup séparé.
- **Décision prise** : un seul endpoint canonique `/apple/token` avec alias `/apple/callback` plutôt que 2 endpoints distincts (le flow Apple SDK Web et expo-apple-authentication retournent tous les deux un `id_token`, contrairement à Google qui distingue `code` pour le web et `id_token` pour le mobile).
- **À valider Maxime** : nommage Bundle ID iOS — je suppose `com.deepsightsynthesis.mobile` mais Maxime peut avoir une autre convention dans Apple Developer Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)