### PR TITLE
feat(auth): Sign in with Apple web frontend — bouton + SDK + i18n

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -13,6 +13,9 @@ VITE_API_URL=http://localhost:8000       # Backend URL (no trailing slash)
 # --- Google OAuth ---
 # VITE_GOOGLE_CLIENT_ID=                 # Google OAuth web client ID
 
+# --- Sign in with Apple ---
+# VITE_APPLE_CLIENT_ID=                  # Apple Service ID (ex: com.deepsightsynthesis.signin)
+
 # --- Stripe ---
 # VITE_STRIPE_PUBLIC_KEY=                # Stripe publishable key (pk_test_ or pk_live_)
 

--- a/frontend/src/components/hub/__tests__/ConversationsDrawer.test.tsx
+++ b/frontend/src/components/hub/__tests__/ConversationsDrawer.test.tsx
@@ -78,6 +78,7 @@ function renderDrawer(
     logout: vi.fn(),
     register: vi.fn(),
     loginWithGoogle: vi.fn(),
+    loginWithApple: vi.fn(),
   };
   return render(
     <MemoryRouter>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ interface AuthContextType {
     password: string,
   ) => Promise<void>;
   loginWithGoogle: () => Promise<void>;
+  loginWithApple: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -43,6 +43,7 @@ interface UseAuthReturn extends AuthState {
   // Actions
   login: (email: string, password: string) => Promise<void>;
   loginWithGoogle: () => Promise<void>;
+  loginWithApple: () => Promise<void>;
   register: (
     username: string,
     email: string,
@@ -442,6 +443,55 @@ export function useAuth(): UseAuthReturn {
   }, []);
 
   // ═══════════════════════════════════════════════════════════════════════════
+  // 🍎 LOGIN APPLE
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  const loginWithApple = useCallback(async () => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+    try {
+      // Lazy import — n'embarque le SDK Apple que si l'user clique vraiment
+      // sur le bouton. Évite de charger Apple JS sur toutes les routes.
+      const { signInWithApple } = await import("../lib/appleSignIn");
+      const appleData = await signInWithApple();
+      const response = await authApi.loginWithApple({
+        id_token: appleData.id_token,
+        email: appleData.email,
+        full_name: appleData.full_name,
+        client_platform: "web",
+      });
+      const apiUser = response.user ?? null;
+      if (mountedRef.current) {
+        setState((prev) => ({
+          ...prev,
+          user: apiUser,
+          isAuthenticated: apiUser !== null,
+          isLoading: false,
+          error: null,
+        }));
+      }
+      if (apiUser) {
+        setSentryUser(apiUser);
+      }
+    } catch (error) {
+      const message =
+        error instanceof ApiError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : "Erreur de connexion Apple";
+
+      if (mountedRef.current) {
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: message,
+        }));
+      }
+      throw error;
+    }
+  }, []);
+
+  // ═══════════════════════════════════════════════════════════════════════════
   // 📝 REGISTER
   // ═══════════════════════════════════════════════════════════════════════════
 
@@ -690,6 +740,7 @@ export function useAuth(): UseAuthReturn {
     loading: state.isLoading,
     login,
     loginWithGoogle,
+    loginWithApple,
     register,
     verifyEmail,
     logout,

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -68,6 +68,7 @@
     "login": "Sign in",
     "register": "Sign up",
     "loginWithGoogle": "Continue with Google",
+    "loginWithApple": "Continue with Apple",
     "loginWithEmail": "Sign in with email",
     "email": "Email address",
     "password": "Password",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -68,6 +68,7 @@
     "login": "Connexion",
     "register": "Inscription",
     "loginWithGoogle": "Continuer avec Google",
+    "loginWithApple": "Continuer avec Apple",
     "loginWithEmail": "Se connecter par email",
     "email": "Adresse email",
     "password": "Mot de passe",

--- a/frontend/src/lib/appleSignIn.ts
+++ b/frontend/src/lib/appleSignIn.ts
@@ -1,0 +1,175 @@
+/**
+ * Sign in with Apple — wrapper TypeScript autour du SDK web AppleID.auth.js.
+ *
+ * Charge le script Apple à la demande, initialise le client, retourne une
+ * promesse résolue avec `{ id_token, email?, full_name? }` après que l'user
+ * autorise dans le popup.
+ *
+ * Note : Apple ne renvoie `user.email` / `user.name` QU'AU PREMIER sign-in
+ * (ou aprés révocation depuis Settings > Apple ID > Password & Security >
+ * Apps Using Apple ID). Les logins suivants ne contiennent que l'id_token.
+ */
+
+const APPLE_SDK_URL =
+  "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";
+
+interface AppleAuthInitOptions {
+  clientId: string;
+  scope: string;
+  redirectURI: string;
+  state?: string;
+  usePopup: boolean;
+}
+
+interface AppleAuthResponse {
+  authorization: {
+    id_token: string;
+    code: string;
+    state: string;
+  };
+  user?: {
+    email?: string;
+    name?: {
+      firstName?: string;
+      lastName?: string;
+    };
+  };
+}
+
+interface AppleAuthError {
+  error: string;
+}
+
+interface AppleIDAuth {
+  init: (options: AppleAuthInitOptions) => void;
+  signIn: () => Promise<AppleAuthResponse>;
+}
+
+interface AppleIDGlobal {
+  auth: AppleIDAuth;
+}
+
+declare global {
+  interface Window {
+    AppleID?: AppleIDGlobal;
+  }
+}
+
+export interface AppleSignInResult {
+  id_token: string;
+  email: string | null;
+  full_name: string | null;
+}
+
+let sdkPromise: Promise<void> | null = null;
+
+function loadAppleSDK(): Promise<void> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("Apple Sign In requires a browser"));
+  }
+  if (window.AppleID) {
+    return Promise.resolve();
+  }
+  if (sdkPromise) {
+    return sdkPromise;
+  }
+  sdkPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${APPLE_SDK_URL}"]`,
+    );
+    if (existing) {
+      existing.addEventListener("load", () => resolve());
+      existing.addEventListener("error", () =>
+        reject(new Error("Failed to load Apple Sign In SDK")),
+      );
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = APPLE_SDK_URL;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    script.onerror = () =>
+      reject(new Error("Failed to load Apple Sign In SDK"));
+    document.head.appendChild(script);
+  });
+  return sdkPromise;
+}
+
+function generateState(): string {
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function isAppleAuthError(value: unknown): value is AppleAuthError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "error" in value &&
+    typeof (value as { error: unknown }).error === "string"
+  );
+}
+
+/**
+ * Déclenche le flow Sign in with Apple en popup web.
+ *
+ * @throws {Error} Si le SDK ne charge pas, si la config est invalide, ou si
+ *   l'user annule (l'erreur "popup_closed_by_user" / "user_cancelled_authorize"
+ *   est propagée comme une `Error` standard).
+ */
+export async function signInWithApple(): Promise<AppleSignInResult> {
+  const clientId = import.meta.env.VITE_APPLE_CLIENT_ID as string | undefined;
+  if (!clientId) {
+    throw new Error(
+      "VITE_APPLE_CLIENT_ID non configuré — Sign in with Apple indisponible.",
+    );
+  }
+  // Apple SDK exige un redirectURI même en mode popup (validation, pas redirect réel).
+  // On utilise window.location.origin pour pointer toujours sur le domaine courant.
+  const redirectURI = window.location.origin;
+
+  await loadAppleSDK();
+  if (!window.AppleID) {
+    throw new Error("Apple Sign In SDK indisponible après chargement.");
+  }
+
+  const state = generateState();
+  window.AppleID.auth.init({
+    clientId,
+    scope: "name email",
+    redirectURI,
+    state,
+    usePopup: true,
+  });
+
+  let response: AppleAuthResponse;
+  try {
+    response = await window.AppleID.auth.signIn();
+  } catch (err: unknown) {
+    if (isAppleAuthError(err)) {
+      // Erreurs SDK Apple : popup_closed_by_user, user_cancelled_authorize, etc.
+      throw new Error(`Apple Sign In annulé : ${err.error}`);
+    }
+    throw err instanceof Error ? err : new Error("Apple Sign In a échoué");
+  }
+
+  if (!response.authorization?.id_token) {
+    throw new Error("Apple n'a pas retourné d'id_token.");
+  }
+  if (response.authorization.state !== state) {
+    throw new Error("State CSRF mismatch — abandon Apple Sign In.");
+  }
+
+  const name = response.user?.name;
+  const fullName =
+    name && (name.firstName || name.lastName)
+      ? `${name.firstName ?? ""} ${name.lastName ?? ""}`.trim() || null
+      : null;
+
+  return {
+    id_token: response.authorization.id_token,
+    email: response.user?.email ?? null,
+    full_name: fullName,
+  };
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -477,16 +477,21 @@ export const Login: React.FC = () => {
                 {t.auth.loginWithGoogle}
               </motion.button>
 
-              <motion.button
-                onClick={handleAppleLogin}
-                disabled={loading}
-                className="mt-2.5 w-full flex items-center justify-center gap-2.5 py-2.5 px-4 rounded-md border border-border-default bg-bg-secondary text-text-primary text-sm font-medium hover:bg-bg-hover hover:border-border-strong transition-all disabled:opacity-40"
-                whileTap={{ scale: 0.98 }}
-                aria-label={t.auth.loginWithApple}
-              >
-                <AppleIcon className="w-4.5 h-4.5" />
-                {t.auth.loginWithApple}
-              </motion.button>
+              {/* Bouton Apple masque tant que VITE_APPLE_CLIENT_ID n'est pas
+                  configure cote Vercel — evite d'afficher un bouton casse en
+                  prod le temps que la config Apple Developer Console soit faite. */}
+              {import.meta.env.VITE_APPLE_CLIENT_ID && (
+                <motion.button
+                  onClick={handleAppleLogin}
+                  disabled={loading}
+                  className="mt-2.5 w-full flex items-center justify-center gap-2.5 py-2.5 px-4 rounded-md border border-border-default bg-bg-secondary text-text-primary text-sm font-medium hover:bg-bg-hover hover:border-border-strong transition-all disabled:opacity-40"
+                  whileTap={{ scale: 0.98 }}
+                  aria-label={t.auth.loginWithApple}
+                >
+                  <AppleIcon className="w-4.5 h-4.5" />
+                  {t.auth.loginWithApple}
+                </motion.button>
+              )}
 
               <div className="relative my-6">
                 <div className="absolute inset-0 flex items-center">

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -42,6 +42,13 @@ const GoogleIcon: React.FC<{ className?: string }> = ({ className }) => (
   </svg>
 );
 
+// === Apple Icon (logo officiel monochrome) ===
+const AppleIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M17.05 12.04c-.03-2.93 2.4-4.34 2.51-4.4-1.37-2-3.5-2.28-4.25-2.31-1.81-.18-3.53 1.06-4.45 1.06-.92 0-2.34-1.04-3.85-1.01-1.98.03-3.81 1.15-4.83 2.91-2.06 3.58-.53 8.87 1.48 11.78.98 1.43 2.15 3.02 3.68 2.96 1.48-.06 2.04-.96 3.83-.96 1.79 0 2.29.96 3.86.93 1.59-.03 2.6-1.45 3.57-2.88 1.13-1.66 1.59-3.27 1.62-3.35-.04-.02-3.11-1.19-3.17-4.73zM14.13 3.6c.82-.99 1.36-2.37 1.21-3.74-1.17.05-2.59.78-3.43 1.77-.75.87-1.41 2.27-1.23 3.62 1.31.1 2.63-.66 3.45-1.65z" />
+  </svg>
+);
+
 // === Logo ===
 const Logo: React.FC = () => {
   return (
@@ -67,6 +74,7 @@ export const Login: React.FC = () => {
   const {
     login,
     loginWithGoogle,
+    loginWithApple,
     register,
     verifyEmail,
     isAuthenticated,
@@ -238,6 +246,19 @@ export const Login: React.FC = () => {
     } catch (err: unknown) {
       const msg = (err as { message?: string } | null)?.message;
       setError(msg || t.errors.generic);
+      setLoading(false);
+    }
+  };
+
+  const handleAppleLogin = async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      await loginWithApple();
+    } catch (err: unknown) {
+      const msg = (err as { message?: string } | null)?.message;
+      setError(msg || t.errors.generic);
+    } finally {
       setLoading(false);
     }
   };
@@ -443,7 +464,7 @@ export const Login: React.FC = () => {
             </p>
           </div>
 
-          {/* Google OAuth */}
+          {/* Google + Apple OAuth */}
           {!showVerification && (
             <>
               <motion.button
@@ -454,6 +475,17 @@ export const Login: React.FC = () => {
               >
                 <GoogleIcon className="w-4.5 h-4.5" />
                 {t.auth.loginWithGoogle}
+              </motion.button>
+
+              <motion.button
+                onClick={handleAppleLogin}
+                disabled={loading}
+                className="mt-2.5 w-full flex items-center justify-center gap-2.5 py-2.5 px-4 rounded-md border border-border-default bg-bg-secondary text-text-primary text-sm font-medium hover:bg-bg-hover hover:border-border-strong transition-all disabled:opacity-40"
+                whileTap={{ scale: 0.98 }}
+                aria-label={t.auth.loginWithApple}
+              >
+                <AppleIcon className="w-4.5 h-4.5" />
+                {t.auth.loginWithApple}
               </motion.button>
 
               <div className="relative my-6">

--- a/frontend/src/pages/__tests__/Login.test.tsx
+++ b/frontend/src/pages/__tests__/Login.test.tsx
@@ -39,6 +39,7 @@ const defaultAuthState = {
   loading: false,
   login: vi.fn(),
   loginWithGoogle: vi.fn(),
+  loginWithApple: vi.fn(),
   register: vi.fn(),
   verifyEmail: vi.fn(),
   logout: vi.fn(),
@@ -345,6 +346,24 @@ describe("Login Page - Google OAuth", () => {
     await user.click(googleButton);
 
     expect(mockLoginWithGoogle).toHaveBeenCalled();
+  });
+
+  it("should call loginWithApple when Apple button clicked", async () => {
+    const user = userEvent.setup();
+    const mockLoginWithApple = vi.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthState,
+      loginWithApple: mockLoginWithApple,
+    });
+
+    renderWithProviders(<Login />);
+
+    const appleButton = screen.getByRole("button", {
+      name: /Continuer avec Apple/i,
+    });
+    await user.click(appleButton);
+
+    expect(mockLoginWithApple).toHaveBeenCalled();
   });
 
   it("should show loading state spinner when authLoading", () => {

--- a/frontend/src/pages/__tests__/Login.test.tsx
+++ b/frontend/src/pages/__tests__/Login.test.tsx
@@ -349,6 +349,9 @@ describe("Login Page - Google OAuth", () => {
   });
 
   it("should call loginWithApple when Apple button clicked", async () => {
+    // Le bouton Apple n'est rendu que si VITE_APPLE_CLIENT_ID est defini —
+    // sinon il reste masque pour eviter d'afficher un bouton casse en prod.
+    vi.stubEnv("VITE_APPLE_CLIENT_ID", "com.deepsightsynthesis.signin");
     const user = userEvent.setup();
     const mockLoginWithApple = vi.fn().mockResolvedValue(undefined);
     mockUseAuth.mockReturnValue({
@@ -364,6 +367,16 @@ describe("Login Page - Google OAuth", () => {
     await user.click(appleButton);
 
     expect(mockLoginWithApple).toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it("should hide Apple button when VITE_APPLE_CLIENT_ID is undefined", () => {
+    vi.unstubAllEnvs();
+    mockUseAuth.mockReturnValue(defaultAuthState);
+    renderWithProviders(<Login />);
+    expect(
+      screen.queryByRole("button", { name: /Continuer avec Apple/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("should show loading state spinner when authLoading", () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1001,6 +1001,33 @@ export const authApi = {
     return response;
   },
 
+  /**
+   * Sign in with Apple — envoie l'id_token Apple au backend qui le vérifie
+   * (JWKs Apple) puis retourne nos JWT. Le client_platform est "web" depuis
+   * le frontend, "ios"/"android" depuis mobile, "extension" depuis Chrome.
+   */
+  async loginWithApple(payload: {
+    id_token: string;
+    email?: string | null;
+    full_name?: string | null;
+    client_platform?: "web" | "ios" | "android" | "extension";
+    device_name?: string;
+  }): Promise<TokenResponse> {
+    const response = await request<TokenResponse>("/api/auth/apple/token", {
+      method: "POST",
+      body: {
+        id_token: payload.id_token,
+        email: payload.email ?? undefined,
+        full_name: payload.full_name ?? undefined,
+        client_platform: payload.client_platform ?? "web",
+        device_name: payload.device_name,
+      },
+      skipAuth: true,
+    });
+    setTokens(response.access_token, response.refresh_token);
+    return response;
+  },
+
   async me(_options?: { skipCache?: boolean }): Promise<User> {
     // Note: skipCache non implémenté côté client, géré côté serveur
     return request("/api/auth/me");


### PR DESCRIPTION
## Summary

Frontend web pour Sign in with Apple — PR 2/3 du sprint tri-plateforme (backend #518 mergé en premier).

### Changements
- **`lib/appleSignIn.ts`** : wrapper TypeScript propre autour du SDK web `AppleID.auth.js` (lazy load + popup + state CSRF + types stricts, zéro `any`)
- **`services/api.ts`** : `authApi.loginWithApple({ id_token, email, full_name, ... })` qui POST `/api/auth/apple/token`
- **`hooks/useAuth.ts`** : `loginWithApple()` dynamic-import du SDK, ouvre popup, envoie au backend, met à jour state + Sentry
- **`contexts/AuthContext.tsx`** : ajout `loginWithApple` à `AuthContextType`
- **`pages/Login.tsx`** : bouton "Continuer avec Apple" sous Google, `AppleIcon` SVG monochrome inline, `handleAppleLogin`
- **`i18n` FR + EN** : "Continuer avec Apple" / "Continue with Apple"
- **`.env.example`** : `VITE_APPLE_CLIENT_ID`
- **`Login.test.tsx`** : test "Apple button clicked → loginWithApple appelé" (27/27 verts)
- **`ConversationsDrawer.test.tsx`** : fix mock interface

## ENV var Vercel à configurer

```env
VITE_APPLE_CLIENT_ID=com.deepsightsynthesis.signin
```

## Apple Developer Console (rappel cross-PR)

Déjà documenté dans #518 ; côté web on a besoin du **Service ID** créé dans Apple Developer Console > Identifiers > Services IDs, avec :
- Domains : `www.deepsightsynthesis.com`
- Return URLs : `https://api.deepsightsynthesis.com/api/auth/apple/callback`

Pour validation du domaine, Apple va demander de servir un fichier `apple-developer-domain-association.txt` à `https://www.deepsightsynthesis.com/.well-known/apple-developer-domain-association.txt` (à hosting côté Vercel/frontend `public/`).

## Test plan

- [x] `npm run typecheck` propre
- [x] `npm test src/pages/__tests__/Login.test.tsx` → 27/27 verts (dont nouveau test Apple)
- [ ] (post-deploy + ENV var configurée) ouvrir page `/login` → bouton "Continuer avec Apple" visible sous Google
- [ ] (post-deploy) click bouton → popup Apple s'ouvre → autoriser → redirect dashboard
- [ ] (post-deploy) click + annuler popup → message d'erreur "Apple Sign In annulé" propre

## Dépendances
- **Dépend de #518** (backend endpoint `/api/auth/apple/token`)
- Si déployé avant le merge backend, le bouton renvoie 404 (acceptable car ENV `VITE_APPLE_CLIENT_ID` non set par défaut → indisponible)

## Décisions
- Un seul fichier helper `appleSignIn.ts` plutôt qu'un context séparé : Apple n'a pas besoin de state global, juste un trigger one-shot
- SDK chargé en lazy import (dans `useAuth.loginWithApple`) plutôt qu'en top-level — évite ~30 KB JS sur toutes les autres routes
- AppleIcon inline plutôt que `lucide-react` (n'a pas Apple logo) ou import package — 1 SVG ne mérite pas une dépendance

🤖 Generated with [Claude Code](https://claude.com/claude-code)