### PR TITLE
feat(auth): Sign in with Apple mobile — expo-apple-authentication iOS only

### DIFF
--- a/mobile/__tests__/contexts/AuthContext.test.tsx
+++ b/mobile/__tests__/contexts/AuthContext.test.tsx
@@ -15,11 +15,14 @@ const mockRegister = jest.fn();
 const mockVerifyEmail = jest.fn();
 const mockResendVerification = jest.fn();
 
+const mockAppleTokenLogin = jest.fn();
+
 jest.mock("../../src/services/api", () => ({
   authApi: {
     login: (...args: any[]) => mockLogin(...args),
     getMe: (...args: any[]) => mockGetMe(...args),
     googleTokenLogin: (...args: any[]) => mockGoogleTokenLogin(...args),
+    appleTokenLogin: (...args: any[]) => mockAppleTokenLogin(...args),
     logout: (...args: any[]) => mockLogout(...args),
     forgotPassword: (...args: any[]) => mockForgotPassword(...args),
     register: (...args: any[]) => mockRegister(...args),
@@ -420,6 +423,61 @@ describe("AuthContext", () => {
 
       expect(result.current.user).toBeNull();
       expect(mockClearTokens).toHaveBeenCalled();
+    });
+  });
+
+  describe("loginWithApple", () => {
+    it("exchanges identityToken for session and sets user", async () => {
+      mockHasTokens.mockResolvedValue(false);
+      mockAppleTokenLogin.mockResolvedValue({
+        access_token: "apple-access",
+        refresh_token: "apple-refresh",
+        user: mockUser,
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.loginWithApple({
+          identityToken: "fake.apple.idtoken",
+          email: "test@privaterelay.appleid.com",
+          fullName: "Test User",
+        });
+      });
+
+      expect(mockAppleTokenLogin).toHaveBeenCalledWith({
+        identityToken: "fake.apple.idtoken",
+        email: "test@privaterelay.appleid.com",
+        fullName: "Test User",
+      });
+      expect(result.current.user).toEqual(mockUser);
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    it("surfaces error on backend failure", async () => {
+      const { ApiError } = require("../../src/services/api");
+      mockHasTokens.mockResolvedValue(false);
+      mockAppleTokenLogin.mockRejectedValue(
+        new ApiError("Invalid Apple ID token", 401),
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await expect(
+        act(async () => {
+          await result.current.loginWithApple({
+            identityToken: "bad.token",
+          });
+        }),
+      ).rejects.toBeInstanceOf(ApiError);
+
+      // User reste null (pas de session creee), backend a bien ete appele
+      expect(result.current.user).toBeNull();
+      expect(mockAppleTokenLogin).toHaveBeenCalledWith({
+        identityToken: "bad.token",
+      });
     });
   });
 });

--- a/mobile/__tests__/utils/test-utils.tsx
+++ b/mobile/__tests__/utils/test-utils.tsx
@@ -29,6 +29,8 @@ const mockAuthContext = {
   pendingVerificationEmail: null,
   login: jest.fn(),
   loginWithGoogle: jest.fn(),
+  loginWithGoogleToken: jest.fn(),
+  loginWithApple: jest.fn(),
   register: jest.fn(),
   verifyEmail: jest.fn(),
   logout: jest.fn(),

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -15,6 +15,7 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
+      "usesAppleSignIn": true,
       "bundleIdentifier": "com.deepsight.app",
       "buildNumber": "6",
       "appleTeamId": "XGPXQ9KQ2G",
@@ -132,6 +133,7 @@
       "expo-font",
       "expo-secure-store",
       "expo-audio",
+      "expo-apple-authentication",
       [
         "expo-notifications",
         {

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -17,6 +17,7 @@ import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import * as Google from "expo-auth-session/providers/google";
 import * as WebBrowser from "expo-web-browser";
+import * as AppleAuthentication from "expo-apple-authentication";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { useTheme } from "@/contexts/ThemeContext";
@@ -37,12 +38,15 @@ WebBrowser.maybeCompleteAuthSession();
 export default function LoginScreen() {
   const router = useRouter();
   const { colors, isDark } = useTheme();
-  const { login: contextLogin, loginWithGoogleToken } = useAuth();
+  const { login: contextLogin, loginWithGoogleToken, loginWithApple } =
+    useAuth();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [appleLoading, setAppleLoading] = useState(false);
+  const [appleAvailable, setAppleAvailable] = useState(false);
   const [errors, setErrors] = useState<{ email?: string; password?: string }>(
     {},
   );
@@ -139,6 +143,61 @@ export default function LoginScreen() {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     promptAsync();
   }, [promptAsync]);
+
+  // Sign in with Apple — iOS only. Indispo sur Android & Expo Go web,
+  // donc on check `isAvailableAsync` au mount + on cache le bouton sinon.
+  React.useEffect(() => {
+    if (Platform.OS !== "ios") return;
+    AppleAuthentication.isAvailableAsync()
+      .then((available) => setAppleAvailable(available))
+      .catch(() => setAppleAvailable(false));
+  }, []);
+
+  const handleApplePress = useCallback(async () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setAppleLoading(true);
+    try {
+      const credential = await AppleAuthentication.signInAsync({
+        requestedScopes: [
+          AppleAuthentication.AppleAuthenticationScope.EMAIL,
+          AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+        ],
+      });
+      if (!credential.identityToken) {
+        Alert.alert(
+          "Erreur Apple",
+          "Apple n'a pas retourné de jeton d'identité.",
+        );
+        return;
+      }
+      const fullName = credential.fullName
+        ? `${credential.fullName.givenName ?? ""} ${
+            credential.fullName.familyName ?? ""
+          }`.trim() || null
+        : null;
+      await loginWithApple({
+        identityToken: credential.identityToken,
+        email: credential.email ?? null,
+        fullName,
+      });
+    } catch (error) {
+      // Apple lance `ERR_REQUEST_CANCELED` quand l'user annule la sheet — pas une erreur réelle
+      const code = (error as { code?: string } | null)?.code;
+      if (code === "ERR_REQUEST_CANCELED") {
+        return;
+      }
+      if (error instanceof ApiError) {
+        Alert.alert(
+          "Erreur Apple",
+          error.message || "Échec de la connexion Apple",
+        );
+      } else {
+        Alert.alert("Erreur", "Impossible de se connecter avec Apple.");
+      }
+    } finally {
+      setAppleLoading(false);
+    }
+  }, [loginWithApple]);
 
   return (
     <SafeAreaView
@@ -308,7 +367,7 @@ export default function LoginScreen() {
               size="lg"
               fullWidth
               loading={googleLoading}
-              disabled={loading || googleLoading}
+              disabled={loading || googleLoading || appleLoading}
               onPress={handleGooglePress}
               icon={
                 <Ionicons
@@ -318,6 +377,34 @@ export default function LoginScreen() {
                 />
               }
             />
+
+            {/* Apple button — iOS only (Apple Authentication SDK indispo Android) */}
+            {Platform.OS === "ios" && appleAvailable && (
+              <View style={styles.appleButtonWrap} pointerEvents="box-none">
+                <AppleAuthentication.AppleAuthenticationButton
+                  buttonType={
+                    AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN
+                  }
+                  buttonStyle={
+                    isDark
+                      ? AppleAuthentication.AppleAuthenticationButtonStyle.WHITE
+                      : AppleAuthentication.AppleAuthenticationButtonStyle.BLACK
+                  }
+                  cornerRadius={borderRadius.md}
+                  style={styles.appleButton}
+                  onPress={handleApplePress}
+                />
+                {appleLoading && (
+                  <View
+                    style={[
+                      styles.appleButtonOverlay,
+                      { backgroundColor: colors.bgPrimary + "AA" },
+                    ]}
+                    pointerEvents="auto"
+                  />
+                )}
+              </View>
+            )}
           </View>
 
           {/* Register link */}
@@ -462,5 +549,21 @@ const styles = StyleSheet.create({
   footerLink: {
     fontFamily: fontFamily.bodySemiBold,
     fontSize: fontSize.sm,
+  },
+  appleButtonWrap: {
+    marginTop: sp.md,
+    position: "relative",
+  },
+  appleButton: {
+    width: "100%",
+    height: 48,
+  },
+  appleButtonOverlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderRadius: borderRadius.md,
   },
 });

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -53,6 +53,24 @@ jest.mock("expo-linear-gradient", () => ({
   LinearGradient: "LinearGradient",
 }));
 
+// expo-apple-authentication — natif iOS only, mock complet pour Jest
+jest.mock("expo-apple-authentication", () => ({
+  isAvailableAsync: jest.fn().mockResolvedValue(true),
+  signInAsync: jest.fn().mockResolvedValue({
+    identityToken: "fake.apple.identitytoken",
+    authorizationCode: "fake_code",
+    email: "test@privaterelay.appleid.com",
+    fullName: { givenName: "Test", familyName: "User" },
+    user: "001234.testuser.5678",
+    realUserStatus: 1,
+    state: null,
+  }),
+  AppleAuthenticationScope: { EMAIL: 0, FULL_NAME: 1 },
+  AppleAuthenticationButton: "AppleAuthenticationButton",
+  AppleAuthenticationButtonStyle: { WHITE: 0, BLACK: 1, WHITE_OUTLINE: 2 },
+  AppleAuthenticationButtonType: { SIGN_IN: 0, CONTINUE: 1, SIGN_UP: 2 },
+}));
+
 jest.mock("@react-native-google-signin/google-signin", () => ({
   GoogleSignin: {
     configure: jest.fn(),

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -7,9 +7,7 @@
     "": {
       "name": "deepsight-mobile",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "dependencies": {
-        "@deepsight/lighting-engine": "file:../packages/lighting-engine",
         "@elevenlabs/client": "^0.15.2",
         "@elevenlabs/react-native": "^0.5.12",
         "@expo/vector-icons": "^15.0.3",
@@ -25,6 +23,7 @@
         "@shopify/flash-list": "^2.2.2",
         "@tanstack/react-query": "^5.17.0",
         "expo": "^54.0.32",
+        "expo-apple-authentication": "~8.0.8",
         "expo-audio": "^1.1.1",
         "expo-auth-session": "~7.0.10",
         "expo-av": "~16.0.8",
@@ -78,7 +77,6 @@
         "@testing-library/react-native": "^12.9.0",
         "@types/jest": "^29.5.12",
         "@types/react": "~19.1.10",
-        "@types/react-native": "~0.73.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "babel-plugin-module-resolver": "^5.0.0",
@@ -96,6 +94,7 @@
     "../packages/lighting-engine": {
       "name": "@deepsight/lighting-engine",
       "version": "3.0.0",
+      "extraneous": true,
       "license": "UNLICENSED",
       "devDependencies": {
         "typescript": "^5.4.0",
@@ -1613,10 +1612,6 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
       "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
-    },
-    "node_modules/@deepsight/lighting-engine": {
-      "resolved": "../packages/lighting-engine",
-      "link": true
     },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
@@ -5063,17 +5058,6 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-native": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.73.0.tgz",
-      "integrity": "sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==",
-      "deprecated": "This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-native": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -9313,6 +9297,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-8.0.8.tgz",
+      "integrity": "sha512-TwCHWXYR1kS0zaeV7QZKLWYluxsvqL31LFJubzK30njZqeWoWO89HZ8nZVaeXbFV1LrArKsze4BmMb+94wS0AQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-application": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -41,6 +41,7 @@
     "@shopify/flash-list": "^2.2.2",
     "@tanstack/react-query": "^5.17.0",
     "expo": "^54.0.32",
+    "expo-apple-authentication": "~8.0.8",
     "expo-audio": "^1.1.1",
     "expo-auth-session": "~7.0.10",
     "expo-av": "~16.0.8",

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -59,6 +59,11 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<void>;
   loginWithGoogle: () => Promise<void>;
   loginWithGoogleToken: (accessToken: string) => Promise<void>;
+  loginWithApple: (payload: {
+    identityToken: string;
+    email?: string | null;
+    fullName?: string | null;
+  }) => Promise<void>;
   register: (
     username: string,
     email: string,
@@ -141,6 +146,42 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
               : "Échec de la connexion Google",
           );
         }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [registerPushToken],
+  );
+
+  // Sign in with Apple (iOS only — appele depuis (auth)/login.tsx avec les
+  // claims retournes par expo-apple-authentication). Le caller doit passer
+  // email + fullName sur le PREMIER sign-in (Apple ne les renvoie pas apres).
+  const loginWithApple = useCallback(
+    async (payload: {
+      identityToken: string;
+      email?: string | null;
+      fullName?: string | null;
+    }) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await authApi.appleTokenLogin(payload);
+        setUser(response.user);
+        await userStorage.setUser(response.user);
+        analytics.identify(String(response.user.id), response.user.plan);
+        analytics.track("login", { method: "apple" });
+        registerPushToken();
+      } catch (err) {
+        if (__DEV__) {
+          console.error("Apple token exchange failed:", err);
+        }
+        setError(
+          err instanceof ApiError
+            ? err.message
+            : "Échec de la connexion Apple",
+        );
+        throw err;
       } finally {
         setIsLoading(false);
       }
@@ -481,6 +522,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         login,
         loginWithGoogle,
         loginWithGoogleToken,
+        loginWithApple,
         register,
         verifyEmail,
         logout,

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -344,6 +344,32 @@ export const authApi = {
     return response;
   },
 
+  // Sign in with Apple (iOS only via expo-apple-authentication).
+  // Apple ne renvoie email/fullName QU'AU PREMIER sign-in — le caller doit
+  // nous les passer sur first login, sinon le backend genere un placeholder.
+  async appleTokenLogin(payload: {
+    identityToken: string;
+    email?: string | null;
+    fullName?: string | null;
+  }): Promise<{ access_token: string; refresh_token: string; user: User }> {
+    const response = await request<{
+      access_token: string;
+      refresh_token: string;
+      user: User;
+    }>("/api/auth/apple/token", {
+      method: "POST",
+      body: {
+        id_token: payload.identityToken,
+        email: payload.email ?? undefined,
+        full_name: payload.fullName ?? undefined,
+        client_platform: Platform.OS === "ios" ? "ios" : "android",
+      },
+      requiresAuth: false,
+    });
+    await tokenStorage.setTokens(response.access_token, response.refresh_token);
+    return response;
+  },
+
   async getMe(): Promise<User> {
     return request("/api/auth/me");
   },


### PR DESCRIPTION
## Summary

Mobile Expo pour Sign in with Apple — PR 3/3 du sprint tri-plateforme. iOS only (Android sans SDK natif).

### Changements
- **`package.json`** : `expo-apple-authentication ~8.0.8` (compat SDK 54)
- **`app.json`** :
  - `ios.usesAppleSignIn: true` (génère l'entitlement Apple)
  - plugin `expo-apple-authentication` (config plugin Expo)
- **`src/services/api.ts`** : `authApi.appleTokenLogin({ identityToken, email, fullName })` qui POST `/api/auth/apple/token`
- **`src/contexts/AuthContext.tsx`** : `loginWithApple` exposé, gère `setUser` + analytics + push token
- **`app/(auth)/login.tsx`** :
  - import `expo-apple-authentication`
  - `useEffect` check `isAvailableAsync` au mount (iOS only)
  - `handleApplePress` avec `signInAsync({ requestedScopes: [EMAIL, FULL_NAME] })`
  - `<AppleAuthenticationButton>` natif sous le bouton Google (style auto dark/light)
  - silencieusement ignore `ERR_REQUEST_CANCELED` (user dismiss sheet)
- **`jest.setup.js`** : mock `expo-apple-authentication`
- **`__tests__/contexts/AuthContext.test.tsx`** : 2 tests Apple (happy + erreur)
- **`__tests__/utils/test-utils.tsx`** : ajout `loginWithApple` au mock

## Tests
- ✅ `npm test` → **439/439 verts** (suite mobile complète)
- ⚠️ `npm run typecheck` → 1 erreur pré-existante `HubAnalysisSheet.tsx` (hors scope cette PR)

## ENV vars
Aucune côté client (le `Bundle ID` est dans `app.json` : `com.deepsight.app`). Côté backend (PR #518) :
```env
APPLE_OAUTH_ENABLED=true
APPLE_BUNDLE_ID=com.deepsight.app    # = bundleIdentifier de app.json
```

## Apple Developer Console (rappel cross-PR)
Documenté dans #518 ; côté mobile, vérifier dans **Apple Developer Console > Identifiers > App IDs** que le App ID `com.deepsight.app` a la capability **"Sign in with Apple"** activée. Sinon : éditer l'App ID, cocher la capability, sauvegarder.

## Comportement
- **iOS only** : Android n'a pas de SDK natif → le bouton est caché (`Platform.OS === 'ios' && appleAvailable`)
- **Premier sign-in** : Apple renvoie `email` + `fullName` → on les passe au backend
- **Logins subsequents** : Apple ne renvoie plus que `identityToken` → le backend lookup par `apple_sub` stable (résolu côté backend dans #518)
- **Dismiss sheet** : `ERR_REQUEST_CANCELED` swallowed silencieusement (UX standard Apple)
- **Look natif** : `AppleAuthenticationButton` officiel Apple HIG (white sur dark, black sur light)

## Dépendances
- **Dépend de #518** (backend `/api/auth/apple/token` + `APPLE_BUNDLE_ID` config)

## Test plan
- [x] `npm test` → 439/439 verts
- [ ] (sur device iOS via dev build) bouton "Sign In with Apple" visible sous Google
- [ ] (iOS device) click bouton → sheet Apple s'ouvre
- [ ] (iOS device) autoriser → app log l'user, redirect (tabs)
- [ ] (iOS device) dismiss sheet → aucun toast d'erreur
- [ ] (sur Android device) bouton Apple non visible
- [ ] (post-deploy) première fois → vérifier que `user.email` est rempli côté DB (premier sign-in only)

## Décisions
- Bundle ID `com.deepsight.app` (existant dans `app.json`) plutôt que créer un nouveau
- Pas de bouton Apple sur Android (Google n'autorise pas un substitut natif, on garde Google + email/password)
- Mock Jest complet de `expo-apple-authentication` plutôt que skip — permet tests E2E synthétiques

🤖 Generated with [Claude Code](https://claude.com/claude-code)