### PR TITLE
feat(auth): Sign in with Apple Android via flow OAuth web

### DIFF
--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -6,8 +6,8 @@
 
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
-from fastapi.responses import RedirectResponse
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response
+from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Optional
 
@@ -853,6 +853,131 @@ async def apple_token_login(data: AppleMobileTokenRequest, session: AsyncSession
 async def apple_callback_post(data: AppleMobileTokenRequest, session: AsyncSession = Depends(get_session)):
     """Alias POST de /apple/token pour rester aligne avec /google/callback (web SPA)."""
     return await apple_token_login(data, session)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🍎 SIGN IN WITH APPLE — Native bridge (mobile Android sans SDK natif)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Apple ne fournit PAS de SDK natif pour Android — on doit passer par le flow
+# OAuth web (Service ID `com.deepsightsynthesis.signin`). L'app mobile ouvre
+# `https://appleid.apple.com/auth/authorize?response_mode=form_post&...` via
+# expo-auth-session, Apple POSTe la response form-encoded sur ce endpoint, et
+# on rend une page HTML qui auto-redirige vers le deeplink `deepsight://`.
+#
+# Apple impose `response_mode=form_post` quand on demande les scopes
+# `name` / `email`. Le redirect_uri DOIT etre un HTTPS public, pas un custom
+# scheme — d'ou ce bridge HTTPS → deeplink.
+#
+# Le client mobile (Android principalement, mais fonctionnel iOS aussi en
+# fallback) intercepte le deeplink `deepsight://auth/apple/callback?...` puis
+# envoie l'id_token recu a POST /api/auth/apple/token comme d'habitude.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@router.post("/apple/callback/native")
+async def apple_callback_native(
+    code: Optional[str] = Form(default=None),
+    id_token: Optional[str] = Form(default=None),
+    state: Optional[str] = Form(default=None),
+    user: Optional[str] = Form(default=None),
+    error: Optional[str] = Form(default=None),
+):
+    """
+    Bridge HTTPS → deeplink pour Sign in with Apple cote mobile Android.
+
+    Apple POST form-encoded ici apres l'authentification web. On reflechit les
+    params dans une page HTML qui auto-redirige vers `deepsight://auth/apple/
+    callback?...`. L'app mobile intercepte le deeplink, extrait l'id_token, et
+    appelle POST /api/auth/apple/token pour finaliser la session.
+
+    Ce endpoint NE valide PAS l'id_token cryptographiquement — il fait juste
+    passe-plat. La validation se fait quand le mobile rappelle /apple/token.
+
+    Apple peut envoyer `user` sur le PREMIER sign-in seulement, sous forme de
+    JSON string : `{"name":{"firstName":"Tim","lastName":"Cook"},"email":"..."}`.
+    On le passe verbatim au mobile qui parse et extrait full_name + email.
+
+    Reponse : HTML 200 avec meta-refresh + redirect JS vers deeplink mobile.
+    """
+    from urllib.parse import quote
+    import html as html_lib
+
+    # Si Apple renvoie une erreur ou si rien d'utile n'est present, on
+    # redirige vers le deeplink avec error=... pour que l'app affiche un msg.
+    deeplink_params: list[str] = []
+    if error:
+        deeplink_params.append(f"error={quote(error, safe='')}")
+    if id_token:
+        deeplink_params.append(f"id_token={quote(id_token, safe='')}")
+    if code:
+        deeplink_params.append(f"code={quote(code, safe='')}")
+    if state:
+        deeplink_params.append(f"state={quote(state, safe='')}")
+    if user:
+        # `user` peut etre un JSON string Apple — on l'url-encode tel quel.
+        deeplink_params.append(f"user={quote(user, safe='')}")
+
+    if not deeplink_params:
+        deeplink_params.append("error=missing_params")
+
+    deeplink = f"deepsight://auth/apple/callback?{'&'.join(deeplink_params)}"
+    # On HTML-escape pour le `content` du meta-refresh (mais on garde le
+    # deeplink brut dans le JS — il est deja safe via quote()).
+    deeplink_attr_safe = html_lib.escape(deeplink, quote=True)
+
+    # Page HTML : meta-refresh comme fallback (no-JS browsers) + window.location
+    # immediat en JS. On affiche aussi un lien manuel au cas ou le deeplink ne
+    # se declenche pas (rare — typiquement quand l'app n'est pas installee).
+    html = f"""<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DeepSight — Connexion Apple</title>
+    <meta http-equiv="refresh" content="0; url={deeplink_attr_safe}">
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #0a0a0f;
+            color: #ffffff;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            padding: 20px;
+            text-align: center;
+        }}
+        h1 {{ font-size: 20px; margin: 0 0 12px; }}
+        p {{ color: #a0a0a8; margin: 0 0 24px; font-size: 14px; }}
+        a {{ color: #6366f1; text-decoration: none; font-weight: 600; }}
+    </style>
+</head>
+<body>
+    <h1>Connexion à DeepSight…</h1>
+    <p>Retour à l'application en cours…</p>
+    <p><a href="{deeplink_attr_safe}">Ouvrir DeepSight manuellement</a></p>
+    <script>
+        // Redirect immediat — fonctionne meme si meta-refresh est ignore.
+        window.location.replace({_json_dumps_str(deeplink)});
+    </script>
+</body>
+</html>"""
+
+    return HTMLResponse(content=html, status_code=200)
+
+
+def _json_dumps_str(s: str) -> str:
+    """JSON-safe stringification pour injection JS inline.
+
+    Utilise json.dumps pour escape correctement quotes/backslashes/control chars
+    afin de prevenir une XSS via le param `user` (qui contient deja du JSON
+    Apple) ou tout autre champ controle par l'utilisateur.
+    """
+    import json
+    return json.dumps(s)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/tests/auth/test_apple_oauth.py
+++ b/backend/tests/auth/test_apple_oauth.py
@@ -411,3 +411,145 @@ async def test_apple_token_subsequent_login_no_email(mock_db_session):
     call_kwargs = mock_login.await_args.kwargs
     assert call_kwargs["apple_sub"] == "001234.returning.zzzz"
     assert call_kwargs["email"] is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 8. Native callback bridge (Android web flow) → HTML deeplink redirect
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_callback_native_redirects_to_deeplink():
+    """
+    POST /apple/callback/native avec form-encoded → HTML 200 contenant un
+    deeplink `deepsight://auth/apple/callback?id_token=...&code=...`.
+
+    Sert de bridge HTTPS → deeplink pour Sign in with Apple cote Android (qui
+    n'a pas de SDK natif et passe par le flow web OAuth via expo-auth-session).
+    """
+    from auth.router import apple_callback_native
+
+    response = await apple_callback_native(
+        code="apple-auth-code-xyz",
+        id_token="apple.id.token.signed",
+        state="state-csrf-token",
+        user=None,
+        error=None,
+    )
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    body = response.body.decode("utf-8")
+    # Le deeplink doit etre present et contenir tous les params URL-encodes
+    assert "deepsight://auth/apple/callback?" in body
+    assert "id_token=apple.id.token.signed" in body
+    assert "code=apple-auth-code-xyz" in body
+    assert "state=state-csrf-token" in body
+    # Meta-refresh fallback
+    assert "<meta http-equiv=\"refresh\"" in body
+    # JS redirect immediat
+    assert "window.location.replace" in body
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_callback_native_forwards_user_json_first_login():
+    """
+    Apple envoie `user` (JSON string) UNIQUEMENT au premier sign-in. Le bridge
+    doit le forwarder url-encode dans le deeplink — le mobile parse derriere.
+    """
+    from auth.router import apple_callback_native
+
+    apple_user_json = '{"name":{"firstName":"Tim","lastName":"Cook"},"email":"tim@privaterelay.appleid.com"}'
+
+    response = await apple_callback_native(
+        code="c123",
+        id_token="t123",
+        state="s123",
+        user=apple_user_json,
+        error=None,
+    )
+
+    body = response.body.decode("utf-8")
+    # `user` doit etre present URL-encode (les `:` `{` `}` `"` sont encodes)
+    assert "user=" in body
+    assert "%7B%22name%22" in body  # `{"name"` encoded
+    # Et l'injection JSON Apple ne doit PAS s'echapper du contexte JS
+    # (json.dumps escape correctement les quotes)
+    assert "</script>" not in body.split("window.location.replace")[1].split(";")[0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_callback_native_handles_error_param():
+    """
+    Si Apple renvoie `error=user_cancelled` → le bridge passe l'erreur au
+    deeplink pour que le mobile l'affiche.
+    """
+    from auth.router import apple_callback_native
+
+    response = await apple_callback_native(
+        code=None,
+        id_token=None,
+        state=None,
+        user=None,
+        error="user_cancelled_authorize",
+    )
+
+    body = response.body.decode("utf-8")
+    assert "error=user_cancelled_authorize" in body
+    assert "deepsight://auth/apple/callback?" in body
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_callback_native_missing_params_returns_error_deeplink():
+    """
+    Si Apple POST vide (cas limite) → deeplink avec `error=missing_params`
+    plutot que de crasher ou retourner une page blanche.
+    """
+    from auth.router import apple_callback_native
+
+    response = await apple_callback_native(
+        code=None,
+        id_token=None,
+        state=None,
+        user=None,
+        error=None,
+    )
+
+    body = response.body.decode("utf-8")
+    assert "error=missing_params" in body
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apple_callback_native_html_escapes_attribute_context():
+    """
+    Smoke test XSS : un id_token contenant des caracteres HTML-meta (rare mais
+    possible si Apple devait jamais changer son format) doit etre HTML-escape
+    dans les attributs `href` et `content`.
+    """
+    from auth.router import apple_callback_native
+
+    # Tentative d'injection HTML/JS dans l'id_token (purement defensif —
+    # Apple ne fait jamais ca, mais on defense-in-depth).
+    malicious = 'fake"><script>alert(1)</script>'
+
+    response = await apple_callback_native(
+        code=None,
+        id_token=malicious,
+        state=None,
+        user=None,
+        error=None,
+    )
+
+    body = response.body.decode("utf-8")
+    # Le `<script>` ne doit JAMAIS apparaitre litteralement dans le body — il
+    # doit etre soit url-encode (dans l'href) soit json-escape (dans le JS).
+    # On verifie qu'aucun tag script non echappe ne se baladne dans le body
+    # apres la balise <script> legitime qui contient window.location.
+    legitimate_script_block = body.split("<script>")[1].split("</script>")[0]
+    # Le bloc legitime ne contient PAS le payload en clair
+    assert "alert(1)" not in legitimate_script_block

--- a/mobile/__tests__/hooks/useAppleAuthAndroid.test.ts
+++ b/mobile/__tests__/hooks/useAppleAuthAndroid.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests pour useAppleAuthAndroid (hook flow OAuth web Apple sur Android).
+ *
+ * Couvre :
+ *  - Happy path : openAuthSessionAsync resolve avec deeplink → parse OK.
+ *  - User cancel (Custom Tab ferme).
+ *  - Apple renvoie error=user_cancelled_authorize dans le deeplink.
+ *  - id_token manquant → error.
+ *  - state mismatch (CSRF) → error.
+ *  - User JSON Apple parse correctement (first sign-in).
+ *  - buildAppleAuthorizeUrl assemble les bons params.
+ */
+import { renderHook, act } from "@testing-library/react-native";
+import * as WebBrowser from "expo-web-browser";
+import * as Crypto from "expo-crypto";
+import {
+  useAppleAuthAndroid,
+  buildAppleAuthorizeUrl,
+} from "../../src/hooks/useAppleAuthAndroid";
+
+describe("useAppleAuthAndroid", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset to deterministic random bytes (0xAB → hex "ab" repeated)
+    (Crypto.getRandomBytesAsync as jest.Mock).mockImplementation(
+      (length: number) => Promise.resolve(new Uint8Array(length).fill(0xab)),
+    );
+  });
+
+  describe("signInWithAppleAndroid — happy path", () => {
+    test("returns success with identityToken + state", async () => {
+      // state genere par le hook avec mock crypto = 64 chars 'ab' (32 bytes hex)
+      const expectedState = "ab".repeat(32);
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "success",
+        url: `deepsight://auth/apple/callback?id_token=apple.jwt.token&code=auth_code&state=${expectedState}`,
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("success");
+      expect(status.result.identityToken).toBe("apple.jwt.token");
+      expect(status.result.authorizationCode).toBe("auth_code");
+      expect(status.result.state).toBe(expectedState);
+    });
+
+    test("parses Apple user JSON on first sign-in (email + fullName)", async () => {
+      const expectedState = "ab".repeat(32);
+      const appleUserJson = encodeURIComponent(
+        JSON.stringify({
+          name: { firstName: "Tim", lastName: "Cook" },
+          email: "tim@privaterelay.appleid.com",
+        }),
+      );
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "success",
+        url: `deepsight://auth/apple/callback?id_token=jwt&state=${expectedState}&user=${appleUserJson}`,
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("success");
+      expect(status.result.email).toBe("tim@privaterelay.appleid.com");
+      expect(status.result.fullName).toBe("Tim Cook");
+    });
+
+    test("returns null email/fullName on subsequent sign-in (no user param)", async () => {
+      const expectedState = "ab".repeat(32);
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "success",
+        url: `deepsight://auth/apple/callback?id_token=jwt&state=${expectedState}`,
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("success");
+      expect(status.result.email).toBeNull();
+      expect(status.result.fullName).toBeNull();
+    });
+  });
+
+  describe("signInWithAppleAndroid — cancellation", () => {
+    test("returns cancel when WebBrowser type=cancel", async () => {
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "cancel",
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("cancel");
+    });
+
+    test("returns cancel when WebBrowser type=dismiss", async () => {
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "dismiss",
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("cancel");
+    });
+
+    test("returns cancel when Apple deeplink has error=user_cancelled_authorize", async () => {
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "success",
+        url: "deepsight://auth/apple/callback?error=user_cancelled_authorize",
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("cancel");
+    });
+  });
+
+  describe("signInWithAppleAndroid — errors", () => {
+    test("returns error when id_token missing from deeplink", async () => {
+      const expectedState = "ab".repeat(32);
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "success",
+        url: `deepsight://auth/apple/callback?code=only_code&state=${expectedState}`,
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("error");
+      expect(status.message).toMatch(/id_token/);
+    });
+
+    test("returns error on state mismatch (CSRF protection)", async () => {
+      // Le hook genere state = "ab"*32 mais Apple renvoie un state different
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "success",
+        url: "deepsight://auth/apple/callback?id_token=jwt&state=DIFFERENT_STATE",
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("error");
+      expect(status.message).toMatch(/CSRF|state/i);
+    });
+
+    test("returns error when Apple sends generic error in deeplink", async () => {
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockResolvedValueOnce({
+        type: "success",
+        url: "deepsight://auth/apple/callback?error=server_error",
+      });
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("error");
+      expect(status.message).toMatch(/server_error/);
+    });
+
+    test("returns error when WebBrowser throws", async () => {
+      (WebBrowser.openAuthSessionAsync as jest.Mock).mockRejectedValueOnce(
+        new Error("WebBrowser unavailable"),
+      );
+
+      const { result } = renderHook(() => useAppleAuthAndroid());
+
+      let status: any;
+      await act(async () => {
+        status = await result.current.signInWithAppleAndroid();
+      });
+
+      expect(status.type).toBe("error");
+      expect(status.message).toMatch(/WebBrowser unavailable/);
+    });
+  });
+
+  describe("buildAppleAuthorizeUrl", () => {
+    test("builds URL with all required Apple OAuth params", () => {
+      const url = buildAppleAuthorizeUrl({
+        state: "test_state",
+        nonce: "test_nonce",
+      });
+
+      expect(url).toContain("https://appleid.apple.com/auth/authorize");
+      expect(url).toContain("response_type=code+id_token");
+      expect(url).toContain("response_mode=form_post");
+      expect(url).toContain("client_id=com.deepsightsynthesis.signin");
+      expect(url).toContain(
+        encodeURIComponent(
+          "https://api.deepsightsynthesis.com/api/auth/apple/callback/native",
+        ),
+      );
+      expect(url).toContain("scope=name+email");
+      expect(url).toContain("state=test_state");
+      expect(url).toContain("nonce=test_nonce");
+    });
+  });
+});

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -11,6 +11,7 @@ import {
   Pressable,
   Alert,
   TextInput,
+  ActivityIndicator,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -22,6 +23,7 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useAuth } from "@/contexts/AuthContext";
+import { useAppleAuthAndroid } from "@/hooks/useAppleAuthAndroid";
 import { ApiError } from "@/services/api";
 import { sp, borderRadius } from "@/theme/spacing";
 import { fontFamily, fontSize, textStyles } from "@/theme/typography";
@@ -40,6 +42,7 @@ export default function LoginScreen() {
   const { colors, isDark } = useTheme();
   const { login: contextLogin, loginWithGoogleToken, loginWithApple } =
     useAuth();
+  const { signInWithAppleAndroid } = useAppleAuthAndroid();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -198,6 +201,43 @@ export default function LoginScreen() {
       setAppleLoading(false);
     }
   }, [loginWithApple]);
+
+  // Sign in with Apple — Android branch via flow OAuth web.
+  // Apple ne fournit PAS de SDK natif Android — on passe par le Service ID web
+  // configure sur Apple Dev Console (`com.deepsightsynthesis.signin`) qui
+  // redirige vers le bridge backend HTTPS, qui lui-meme redirige via deeplink
+  // `deepsight://auth/apple/callback`. Cf. hooks/useAppleAuthAndroid.ts pour
+  // les details du flow.
+  const handleApplePressAndroid = useCallback(async () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setAppleLoading(true);
+    try {
+      const status = await signInWithAppleAndroid();
+      if (status.type === "cancel") {
+        return; // User a ferme le Custom Tab — silencieux
+      }
+      if (status.type === "error") {
+        Alert.alert("Erreur Apple", status.message);
+        return;
+      }
+      await loginWithApple({
+        identityToken: status.result.identityToken,
+        email: status.result.email,
+        fullName: status.result.fullName,
+      });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        Alert.alert(
+          "Erreur Apple",
+          error.message || "Échec de la connexion Apple",
+        );
+      } else {
+        Alert.alert("Erreur", "Impossible de se connecter avec Apple.");
+      }
+    } finally {
+      setAppleLoading(false);
+    }
+  }, [signInWithAppleAndroid, loginWithApple]);
 
   return (
     <SafeAreaView
@@ -405,6 +445,53 @@ export default function LoginScreen() {
                 )}
               </View>
             )}
+
+            {/* Apple button — Android via flow OAuth web (pas de SDK natif).
+               Look noir sur dark theme, noir sur light theme — Apple HIG style.
+               Le bouton iOS natif (AppleAuthenticationButton) fait l'inverse
+               automatiquement, donc on aligne ici sur la convention iOS. */}
+            {Platform.OS === "android" && (
+              <Pressable
+                onPress={handleApplePressAndroid}
+                disabled={loading || googleLoading || appleLoading}
+                style={({ pressed }) => [
+                  styles.appleButtonAndroid,
+                  {
+                    backgroundColor: isDark ? "#ffffff" : "#000000",
+                    opacity: pressed ? 0.85 : 1,
+                  },
+                  (loading || googleLoading || appleLoading) && {
+                    opacity: 0.6,
+                  },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel="Continuer avec Apple"
+              >
+                {appleLoading ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={isDark ? "#000000" : "#ffffff"}
+                  />
+                ) : (
+                  <>
+                    <Ionicons
+                      name="logo-apple"
+                      size={20}
+                      color={isDark ? "#000000" : "#ffffff"}
+                      style={styles.appleButtonAndroidIcon}
+                    />
+                    <Text
+                      style={[
+                        styles.appleButtonAndroidText,
+                        { color: isDark ? "#000000" : "#ffffff" },
+                      ]}
+                    >
+                      Continuer avec Apple
+                    </Text>
+                  </>
+                )}
+              </Pressable>
+            )}
           </View>
 
           {/* Register link */}
@@ -565,5 +652,21 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 0,
     borderRadius: borderRadius.md,
+  },
+  appleButtonAndroid: {
+    marginTop: sp.md,
+    height: 48,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: borderRadius.md,
+    paddingHorizontal: sp.lg,
+  },
+  appleButtonAndroidIcon: {
+    marginRight: sp.sm,
+  },
+  appleButtonAndroidText: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
   },
 });

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -71,6 +71,26 @@ jest.mock("expo-apple-authentication", () => ({
   AppleAuthenticationButtonType: { SIGN_IN: 0, CONTINUE: 1, SIGN_UP: 2 },
 }));
 
+// expo-web-browser — utilise pour le flow Apple OAuth web Android
+// (useAppleAuthAndroid). Mock par defaut retourne un success avec URL
+// deeplink contenant id_token + state. Les tests peuvent override via
+// mockResolvedValueOnce.
+jest.mock("expo-web-browser", () => ({
+  openAuthSessionAsync: jest.fn().mockResolvedValue({
+    type: "success",
+    url: "deepsight://auth/apple/callback?id_token=mock.apple.token&code=mock_code&state=MOCK_STATE",
+  }),
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+// expo-crypto — utilise pour generer state + nonce CSRF dans le flow Apple
+// OAuth web Android. Le mock retourne des bytes deterministes pour les tests.
+jest.mock("expo-crypto", () => ({
+  getRandomBytesAsync: jest.fn((length) =>
+    Promise.resolve(new Uint8Array(length).fill(0xab)),
+  ),
+}));
+
 jest.mock("@react-native-google-signin/google-signin", () => ({
   GoogleSignin: {
     configure: jest.fn(),

--- a/mobile/src/hooks/useAppleAuthAndroid.ts
+++ b/mobile/src/hooks/useAppleAuthAndroid.ts
@@ -1,0 +1,245 @@
+/**
+ * useAppleAuthAndroid — Sign in with Apple via web OAuth flow (Android-specific).
+ *
+ * Pourquoi ce hook existe :
+ * Apple ne fournit PAS de SDK natif Android. Sur iOS, on utilise
+ * `expo-apple-authentication` (PR #520) qui ouvre la sheet systeme native. Sur
+ * Android, on doit passer par le flow OAuth web standard, identique au flow web
+ * AppleID.auth.js — mais adapte au contexte mobile.
+ *
+ * Flow technique :
+ *   1. Generation d'un `state` random (CSRF) + nonce (replay protection).
+ *   2. Ouverture de `https://appleid.apple.com/auth/authorize` dans un Custom
+ *      Tab Android (via `expo-web-browser` openAuthSessionAsync).
+ *   3. Apple authentifie l'utilisateur puis fait un `form_post` vers le redirect
+ *      URI HTTPS configure cote Apple Dev Console :
+ *      https://api.deepsightsynthesis.com/api/auth/apple/callback/native
+ *   4. Le backend (cf. backend/src/auth/router.py::apple_callback_native) recoit
+ *      le POST form-encoded, et retourne une page HTML qui auto-redirige vers
+ *      `deepsight://auth/apple/callback?id_token=...&code=...&state=...`.
+ *   5. `openAuthSessionAsync` detecte le deeplink `deepsight://` et resolve
+ *      avec l'URL — on parse les query params et on retourne le payload.
+ *
+ * Pourquoi pas `expo-auth-session` AuthRequest :
+ * AuthRequest est concu pour le flow OAuth standard `response_mode=query` ou
+ * `fragment`, mais Apple impose `response_mode=form_post` quand on demande les
+ * scopes `name` ou `email`. C'est pourquoi on assemble l'URL d'autorisation a
+ * la main et on relie sur le bridge backend pour la conversion form_post →
+ * deeplink.
+ *
+ * Notes Apple :
+ * - L'`identityToken` (`id_token`) est un JWT signe RS256 par Apple, audience
+ *   = APPLE_CLIENT_ID (Service ID = `com.deepsightsynthesis.signin`).
+ * - `user` n'est envoye QU'AU PREMIER sign-in, sous forme de JSON Apple :
+ *   `{"name":{"firstName":"X","lastName":"Y"},"email":"..."}`.
+ * - L'`email` peut etre un alias prive `@privaterelay.appleid.com` si l'user
+ *   a active Hide My Email.
+ */
+
+import { useCallback } from "react";
+import * as Crypto from "expo-crypto";
+import * as WebBrowser from "expo-web-browser";
+
+// Service ID web Apple — utilise comme `client_id` dans le flow OAuth web.
+// MUST match `APPLE_CLIENT_ID` backend (config Hetzner) + `Service ID` config
+// dans Apple Dev Console. Si on doit changer ca un jour il faudra coordonner
+// les 3 endroits.
+const APPLE_SERVICE_ID = "com.deepsightsynthesis.signin";
+
+// Endpoint Apple OAuth authorize. Constant, ne change jamais.
+const APPLE_AUTHORIZE_ENDPOINT = "https://appleid.apple.com/auth/authorize";
+
+// Bridge backend : Apple POST form-encoded → HTML deeplink mobile.
+// MUST etre configure comme Return URL dans Apple Dev Console pour ce
+// Service ID. Pour les builds dev pointant sur backend local, ca ne marchera
+// PAS — Apple n'accepte que des URLs HTTPS publiques dans la Service ID
+// config. Solution : utiliser un tunnel ngrok ou pointer sur prod.
+const APPLE_CALLBACK_BRIDGE =
+  "https://api.deepsightsynthesis.com/api/auth/apple/callback/native";
+
+// Custom scheme intercepte par l'app via expo-linking. Doit matcher le
+// `scheme` du app.json + l'intent filter Android.
+const DEEPLINK_RETURN_URL = "deepsight://auth/apple/callback";
+
+export interface AppleAuthAndroidResult {
+  identityToken: string;
+  authorizationCode?: string;
+  state: string;
+  email?: string | null;
+  fullName?: string | null;
+}
+
+export type AppleAuthAndroidStatus =
+  | { type: "success"; result: AppleAuthAndroidResult }
+  | { type: "cancel" }
+  | { type: "error"; message: string };
+
+/**
+ * Genere un random hex URL-safe via expo-crypto.
+ * Sert pour `state` (CSRF) et `nonce` (replay protection cote serveur).
+ *
+ * On utilise hex plutot que base64url parce que `btoa`/`atob` ne sont pas
+ * disponibles sur tous les runtimes React Native (cf. TokenManager.ts qui
+ * fait son propre fallback). Hex est universel et toujours URL-safe — un peu
+ * plus verbeux (2x) mais on s'en moque pour un random de 32 bytes.
+ */
+async function generateRandomString(length: number = 32): Promise<string> {
+  const bytes = await Crypto.getRandomBytesAsync(length);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Parse Apple's `user` JSON string (envoye sur first sign-in seulement) en
+ * { email, fullName }. Tolere les formats partiels et les erreurs JSON sans
+ * crasher le flow d'auth.
+ */
+function parseAppleUserJson(
+  raw: string | null,
+): { email: string | null; fullName: string | null } {
+  if (!raw) return { email: null, fullName: null };
+  try {
+    const parsed = JSON.parse(raw);
+    const firstName = parsed?.name?.firstName ?? "";
+    const lastName = parsed?.name?.lastName ?? "";
+    const fullName = `${firstName} ${lastName}`.trim() || null;
+    const email = parsed?.email ?? null;
+    return { email, fullName };
+  } catch {
+    return { email: null, fullName: null };
+  }
+}
+
+/**
+ * Parse l'URL deeplink retournee par `openAuthSessionAsync` apres le bridge
+ * backend. Format :
+ *   deepsight://auth/apple/callback?id_token=...&code=...&state=...&user=<urlencoded JSON>
+ *   ou (erreur) :
+ *   deepsight://auth/apple/callback?error=...
+ */
+function parseCallbackUrl(url: string): AppleAuthAndroidStatus {
+  // expo-linking `Linking.parse` casserait sur un scheme custom dans certains
+  // builds — on parse les query params manuellement via URL.
+  const queryIndex = url.indexOf("?");
+  if (queryIndex === -1) {
+    return { type: "error", message: "URL deeplink sans parametres" };
+  }
+  const query = url.slice(queryIndex + 1);
+  const params = new URLSearchParams(query);
+
+  const error = params.get("error");
+  if (error) {
+    if (error === "user_cancelled_authorize") {
+      return { type: "cancel" };
+    }
+    return { type: "error", message: `Apple: ${error}` };
+  }
+
+  const identityToken = params.get("id_token");
+  const state = params.get("state");
+  if (!identityToken) {
+    return { type: "error", message: "Aucun id_token recu d'Apple" };
+  }
+  if (!state) {
+    return { type: "error", message: "Aucun state recu d'Apple" };
+  }
+
+  const { email, fullName } = parseAppleUserJson(params.get("user"));
+
+  return {
+    type: "success",
+    result: {
+      identityToken,
+      authorizationCode: params.get("code") ?? undefined,
+      state,
+      email,
+      fullName,
+    },
+  };
+}
+
+/**
+ * Construit l'URL d'autorisation Apple avec tous les params requis.
+ * Exporte pour testabilite + reusability future (extension Chrome?).
+ */
+export function buildAppleAuthorizeUrl(params: {
+  state: string;
+  nonce: string;
+}): string {
+  const searchParams = new URLSearchParams({
+    response_type: "code id_token",
+    response_mode: "form_post", // OBLIGATOIRE avec scope name/email
+    client_id: APPLE_SERVICE_ID,
+    redirect_uri: APPLE_CALLBACK_BRIDGE,
+    scope: "name email",
+    state: params.state,
+    nonce: params.nonce,
+  });
+  return `${APPLE_AUTHORIZE_ENDPOINT}?${searchParams.toString()}`;
+}
+
+/**
+ * Hook React qui expose `signInWithAppleAndroid()` — lance le flow OAuth web
+ * Apple et resolve avec l'identityToken (id_token) + claims optionnels.
+ *
+ * Usage cote ecran login :
+ *
+ *   const { signInWithAppleAndroid } = useAppleAuthAndroid();
+ *   const status = await signInWithAppleAndroid();
+ *   if (status.type === "success") {
+ *     await loginWithApple({
+ *       identityToken: status.result.identityToken,
+ *       email: status.result.email,
+ *       fullName: status.result.fullName,
+ *     });
+ *   }
+ */
+export function useAppleAuthAndroid(): {
+  signInWithAppleAndroid: () => Promise<AppleAuthAndroidStatus>;
+} {
+  const signInWithAppleAndroid =
+    useCallback(async (): Promise<AppleAuthAndroidStatus> => {
+      try {
+        const state = await generateRandomString(32);
+        const nonce = await generateRandomString(32);
+        const authorizeUrl = buildAppleAuthorizeUrl({ state, nonce });
+
+        // openAuthSessionAsync ouvre un Custom Tab Android (ou ASWebAuthenticationSession iOS)
+        // et resolve quand l'URL atteint le `returnUrl` (custom scheme).
+        const result = await WebBrowser.openAuthSessionAsync(
+          authorizeUrl,
+          DEEPLINK_RETURN_URL,
+        );
+
+        if (result.type === "cancel" || result.type === "dismiss") {
+          return { type: "cancel" };
+        }
+
+        if (result.type !== "success" || !result.url) {
+          return {
+            type: "error",
+            message: "Connexion Apple interrompue",
+          };
+        }
+
+        const parsed = parseCallbackUrl(result.url);
+
+        // CSRF check : le `state` retourne doit matcher celui qu'on a envoye.
+        if (parsed.type === "success" && parsed.result.state !== state) {
+          return {
+            type: "error",
+            message: "Mismatch state OAuth (CSRF protection)",
+          };
+        }
+
+        return parsed;
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Erreur connexion Apple";
+        return { type: "error", message };
+      }
+    }, []);
+
+  return { signInWithAppleAndroid };
+}


### PR DESCRIPTION
## Pourquoi

Suite de PR #520 (Sign in with Apple iOS via `expo-apple-authentication` natif). Apple ne fournit **pas de SDK natif Android** — on doit passer par le flow OAuth web standard.

Sans cette PR, le bouton "Continuer avec Apple" est invisible sur Android, ce qui exclut une grande partie de la base utilisateur mobile.

## Comment (architecture)

```
Android app
  │
  │ openAuthSessionAsync (expo-web-browser, Custom Tab)
  ▼
https://appleid.apple.com/auth/authorize?response_mode=form_post&client_id=com.deepsightsynthesis.signin&redirect_uri=https://api.deepsightsynthesis.com/api/auth/apple/callback/native&scope=name+email&state=...&nonce=...
  │
  │ User authentifie + autorise → Apple POSTe form-encoded
  ▼
POST /api/auth/apple/callback/native  (NOUVEAU endpoint backend)
  │
  │ Retourne HTML avec meta-refresh + JS window.location.replace
  ▼
deepsight://auth/apple/callback?id_token=...&code=...&state=...&user=<urlencoded JSON>
  │
  │ openAuthSessionAsync detecte le returnUrl, resolve avec l'URL
  ▼
Hook useAppleAuthAndroid parse les params → AppleAuthAndroidResult
  │
  │ loginWithApple({ identityToken, email, fullName }) (AuthContext)
  ▼
POST /api/auth/apple/token  (endpoint existant PR #518 — verification RS256)
  │
  ▼
Session DeepSight créée
```

### Pourquoi pas `expo-auth-session` AuthRequest

Apple impose `response_mode=form_post` quand on demande les scopes `name` ou `email`. AuthRequest est conçu pour `query`/`fragment` — il ne marche pas avec `form_post`. D'où l'assemblage manuel de l'URL + le bridge backend HTTPS → deeplink.

### Pourquoi un endpoint backend bridge

Apple n'accepte que des **HTTPS publics** dans la Service ID config (pas de `deepsight://` direct). Le bridge `/api/auth/apple/callback/native` reçoit le form_post et fait la conversion form_post → deeplink. Il ne valide pas le token (la vérification RS256 + audience + issuer reste dans `/apple/token`).

## Fichiers

**Créés** :
- `mobile/src/hooks/useAppleAuthAndroid.ts` — hook React + helper `buildAppleAuthorizeUrl`
- `mobile/__tests__/hooks/useAppleAuthAndroid.test.ts` — 11 tests

**Modifiés** :
- `backend/src/auth/router.py` — `POST /apple/callback/native` (74 lignes nettes)
- `backend/tests/auth/test_apple_oauth.py` — 5 tests pour le nouveau endpoint
- `mobile/app/(auth)/login.tsx` — bouton Android + handler, branche `Platform.OS === 'android'`
- `mobile/jest.setup.js` — mocks `expo-web-browser` + `expo-crypto`

## Sécurité

- `state` CSRF + `nonce` replay-protection générés via `expo-crypto.getRandomBytesAsync` (32 bytes → hex 64 chars, URL-safe natif)
- État CSRF vérifié au retour : si Apple renvoie un `state` différent de celui envoyé → erreur
- Backend ne fait pas confiance au bridge : l'id_token est revérifié RS256 + audience + issuer dans `/apple/token`
- XSS defense-in-depth : les params Apple URL-encodés via `quote()`, HTML-escapés via `html.escape(quote=True)` pour les attributs HTML, et `json.dumps()` pour l'injection JS — smoke test inclus

## Tests

**Backend** : 12/12 verts sur `tests/auth/test_apple_oauth.py` (7 existants PR #518 + 5 nouveaux pour le bridge)
- ⚠️ Comme PR #518, doit être lancé via la suite complète (`pytest tests/`) à cause d'un bug circulaire pré-existant `auth/billing/dependencies` — c'est documenté dans la PR #518 et c'est OK.

**Mobile** : 450/450 verts (439 avant + 11 nouveaux pour `useAppleAuthAndroid`). Le test existant `loginWithApple` (PR #520) passe toujours.

**Typecheck mobile** : propre sur les fichiers touchés (1 erreur pré-existante `HubAnalysisSheet.tsx` hors scope, confirmé memory).

## Comment tester en local

### Backend

```bash
cd backend
python -m pytest tests/ -k apple -v
# Doit passer 12 tests
```

### Mobile

```bash
cd mobile
npm test -- __tests__/hooks/useAppleAuthAndroid.test.ts
# 11/11 verts

npx tsc --noEmit
# 1 erreur pre-existante HubAnalysisSheet hors scope, sinon clean
```

### Test E2E manuel (apres merge + EAS build)

1. **Apple Dev Console** : confirmer que la Return URL `https://api.deepsightsynthesis.com/api/auth/apple/callback/native` est bien ajoutée dans la config du Service ID `com.deepsightsynthesis.signin`. Le brief indique que c'est déjà configuré.
2. EAS build Android (nouveau natif requis — cf. section Deploiement).
3. Sur device Android, ouvrir l'app → écran login → bouton "Continuer avec Apple" doit apparaître (en dessous de Google).
4. Tap → Custom Tab Chrome s'ouvre → flow Apple ID classique web.
5. Après auth → retour automatique dans l'app via deeplink, session créée.

## Déploiement

| Cible | Type | Détails |
|-------|------|---------|
| Backend | Auto-deploy Hetzner | Après merge sur `main`, le webhook `junglefarmz-deploy.service` rebuild le container. Pas de migration DB. |
| Mobile | **EAS build natif requis** | Le hook utilise `expo-web-browser` et `expo-crypto` qui sont déjà dans `package.json` (versions `~15.0.10` et `~15.0.8`), donc en théorie OTA possible. **MAIS** un build natif est recommandé pour valider le flow Custom Tab Android sur device réel et les intent filters `deepsight://` existants (cf. `mobile/app.json` ligne 96). À confirmer en test EAS update sur staging avant production. |
| Apple Dev Console | Aucune action | Service ID + Return URL déjà configurés selon le brief |

## Liens

- PR #520 (iOS) — https://github.com/Fonira/DeepSight-Main/pull/520
- PR #519 (Web frontend) — https://github.com/Fonira/DeepSight-Main/pull/519
- PR #518 (Backend) — https://github.com/Fonira/DeepSight-Main/pull/518

## NE FAIS PAS (rappel review)

- Ne pas merger sans vérifier que la Return URL bridge est bien dans Apple Dev Console (sinon Apple rejette le flow avec `invalid_redirect_uri`)
- Ne pas changer le `APPLE_SERVICE_ID` constant dans `useAppleAuthAndroid.ts` sans mettre à jour aussi `APPLE_CLIENT_ID` backend + Apple Dev Console (3 endroits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)