### PR TITLE
Sprint C — Auth security patch: TTLs 60min/30j + Redis blocklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,13 +454,19 @@ Migration v0/v1 → v2 (Alembic 012, mergée prod 2026-04-30) : `plus → pro`, 
 
 ```
 1. POST /api/auth/register → Create user + send verification email (Resend)
-2. POST /api/auth/login    → Returns access_token (15min) + refresh_token (7d)
+2. POST /api/auth/login    → Returns access_token (60min) + refresh_token (30d)
 3. All requests            → Header: Authorization: Bearer {access_token}
 4. POST /api/auth/refresh  → New access_token (rotation)
 5. Google OAuth Web        → /api/auth/google/login → callback
 6. Google OAuth Mobile     → /api/auth/google/token  ⚠️ Backend endpoint existe mais incomplet
 7. Extension               → chrome.identity.launchWebAuthFlow() + sync tokens
 ```
+
+**TTLs** (Sprint C, 2026-05-21 — alignés Claude/ChatGPT) : access 60 min / refresh 30 jours.
+Avant Sprint C : 7 jours / 365 jours (doc historique mentionnait à tort « 15min/7d »).
+Override sans rebuild via env `ACCESS_TOKEN_TTL_MIN` / `REFRESH_TOKEN_TTL_DAYS`.
+Blocklist révocation : Redis-backed, clé `auth:blocklist:{sha256(token)[:32]}`,
+TTL = exp du token (auto-cleanup). Fail-open + audit log si Redis indispo.
 
 ---
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -54,6 +54,22 @@ async def pro_endpoint(user: User = Depends(require_plan("pro"))):
     ...
 ```
 
+## Auth JWT — TTLs & blocklist (Sprint C, 2026-05-21)
+
+| Aspect | Valeur | Override env |
+|---|---|---|
+| Access token TTL | **60 min** | `ACCESS_TOKEN_TTL_MIN` |
+| Refresh token TTL | **30 jours** | `REFRESH_TOKEN_TTL_DAYS` |
+| Lib JWT | `python-jose[cryptography]` | (pyjwt migration différée V2 — CVE-2024-33664/33663 à surveiller) |
+| Blocklist | Redis `auth:blocklist:{sha256(token)[:32]}` avec TTL=exp | `REDIS_URL` (fallback in-RAM si absent) |
+
+Avant Sprint C : 7 j / 365 j + blocklist in-RAM (perdue à chaque `docker run`).
+Pour révoquer un token côté code : `await blacklist_token(token, expiry_seconds=...)`.
+Pour vérifier : `await is_token_blacklisted(token)` — fail-open + audit log
+(`audit_logs.action="auth_blocklist_fail_open"`) si Redis indispo.
+
+Cf. audit complet : `01-Projects/DeepSight/Sessions/2026-05-21-audit-auth-sprint-c.md`.
+
 ## Feature gating (SSOT)
 
 ```python

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -69,8 +69,8 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # 🔒 Vérifier si le token est blacklisté (logout/révoqué)
-    if SECURITY_AVAILABLE and is_token_blacklisted(actual_token):
+    # 🔒 Vérifier si le token est blacklisté (logout/révoqué) — Sprint C: now async (Redis)
+    if SECURITY_AVAILABLE and await is_token_blacklisted(actual_token):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={"code": "token_revoked", "message": "This session has been revoked. Please log in again."},
@@ -164,8 +164,8 @@ async def get_current_user_optional(
     if not actual_token:
         return None
 
-    # Vérifier le blacklist
-    if SECURITY_AVAILABLE and is_token_blacklisted(actual_token):
+    # Vérifier le blacklist — Sprint C: now async (Redis)
+    if SECURITY_AVAILABLE and await is_token_blacklisted(actual_token):
         return None
 
     payload = verify_token(actual_token, token_type="access")

--- a/backend/src/chat/websocket.py
+++ b/backend/src/chat/websocket.py
@@ -555,8 +555,8 @@ async def _authenticate_websocket(websocket: WebSocket, token: Optional[str]) ->
         await websocket.close(code=4001, reason="Authentication required. Provide ?token=<jwt>")
         return None
 
-    # Vérifier si le token est blacklisté
-    if security_available and is_token_blacklisted(token):
+    # Vérifier si le token est blacklisté — Sprint C: now async (Redis)
+    if security_available and await is_token_blacklisted(token):
         await websocket.close(code=4001, reason="Token revoked. Please log in again.")
         return None
 

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -532,8 +532,11 @@ APPLE_OAUTH_CONFIG = {
 JWT_CONFIG = {
     "SECRET_KEY": _settings.JWT_SECRET_KEY or _settings.ADMIN_SECRET_KEY,
     "ALGORITHM": "HS256",
-    "ACCESS_TOKEN_EXPIRE_MINUTES": 10080,  # 7 jours — long session UX (was 24h, then 1h originally) ; rotation actif via /refresh
-    "REFRESH_TOKEN_EXPIRE_DAYS": 365,  # 1 an — session quasi-éternelle pour user actif (rotation à chaque /refresh étend la durée)
+    # Sprint C (2026-05-21) — TTLs alignés Claude/ChatGPT (60 min / 30 j).
+    # Avant : 10080 min (7 j) / 365 j — voir audit `01-Projects/DeepSight/Sessions/2026-05-21-audit-auth-sprint-c.md`.
+    # Override sans rebuild via env `ACCESS_TOKEN_TTL_MIN` / `REFRESH_TOKEN_TTL_DAYS`.
+    "ACCESS_TOKEN_EXPIRE_MINUTES": int(os.getenv("ACCESS_TOKEN_TTL_MIN", "60")),
+    "REFRESH_TOKEN_EXPIRE_DAYS": int(os.getenv("REFRESH_TOKEN_TTL_DAYS", "30")),
 }
 
 # =============================================================================

--- a/backend/src/core/security.py
+++ b/backend/src/core/security.py
@@ -368,28 +368,137 @@ def cleanup_expired_ip_limits():
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# 🔐 GESTION DES TOKENS
+# 🔐 GESTION DES TOKENS — Blocklist Redis-backed (Sprint C, 2026-05-21)
 # ═══════════════════════════════════════════════════════════════════════════════
+# Avant : `_token_blacklist: Dict[str, float]` in-process — perdue à chaque
+# `docker run`, donc un logout côté user devenait silencieusement inopérant
+# après le moindre redeploy. Maintenant : Redis SET avec TTL = exp du token
+# (auto-cleanup natif). Fallback in-RAM dict si Redis indispo (dev/CI), avec
+# log + audit `audit_logs.action="auth_blocklist_fail_open"` en prod.
+#
+# Pattern de clé : `auth:blocklist:{sha256_token_hash_32chars}`.
+# Le `core.cache.cache_service.backend.redis` est réutilisé (déjà initialisé
+# dans le lifespan `main.py:564`). Fail-open (return False) sur erreur Redis
+# pour ne pas dégrader l'UX : équivalent au comportement baseline RAM qui se
+# perdait au reboot de toute façon.
+
+# Sentinel pour indiquer une erreur Redis (fail-open + log)
+_BLOCKLIST_REDIS_KEY_PREFIX = "auth:blocklist:"
 
 
-def blacklist_token(token: str, expiry_seconds: int = 86400):
+def _get_redis_client():
+    """Récupère le client Redis depuis core.cache si disponible.
+
+    Returns:
+        Le client redis.asyncio ou None si Redis n'est pas initialisé
+        (mode dev/CI sans REDIS_URL, ou avant lifespan startup).
+    """
+    try:
+        from core.cache import cache_service
+
+        backend = getattr(cache_service, "backend", None)
+        if backend is None:
+            return None
+        # RedisCacheBackend expose `.redis` ; InMemoryCacheBackend non.
+        return getattr(backend, "redis", None)
+    except Exception:
+        return None
+
+
+async def _log_blocklist_fail_open(operation: str, error: str) -> None:
+    """Audit log d'un fail-open de la blocklist (Redis indispo).
+
+    Best-effort : si l'audit lui-même échoue on absorbe pour ne pas casser
+    le path auth. PostHog peut être ajouté plus tard côté caller si besoin.
+    """
+    try:
+        from db.database import async_session_maker, AuditLog
+
+        async with async_session_maker() as session:
+            session.add(
+                AuditLog(
+                    user_id=None,
+                    actor_id=None,
+                    action="auth_blocklist_fail_open",
+                    details={"operation": operation, "error": error[:500]},
+                )
+            )
+            await session.commit()
+    except Exception as audit_err:
+        # On log dans stderr mais on n'élève pas l'exception : la blocklist
+        # doit rester non-bloquante même en cas d'audit cassé.
+        print(
+            f"⚠️  blocklist fail-open audit failed ({operation}): {audit_err}",
+            flush=True,
+        )
+
+
+async def blacklist_token(token: str, expiry_seconds: int = 86400) -> bool:
+    """Ajoute un token à la blocklist (révocation par logout ou rotation).
+
+    Args:
+        token: Le JWT brut (sera hashé SHA-256 pour la clé Redis).
+        expiry_seconds: TTL de la clé blocklist. Devrait correspondre à
+            l'exp restante du token (clamped min 1). Default 86400 = 24h
+            pour compatibilité avec les anciens callers.
+
+    Returns:
+        True si la blocklist a été mise à jour, False en cas d'erreur Redis
+        (fail-open — le token reste valide jusqu'à son exp naturelle).
+    """
     token_hash = _hash_token(token)
-    _token_blacklist[token_hash] = time.time() + expiry_seconds
+    ttl = max(1, int(expiry_seconds))
+    redis = _get_redis_client()
 
-    now = time.time()
-    expired = [h for h, exp in _token_blacklist.items() if exp < now]
-    for h in expired:
-        del _token_blacklist[h]
+    if redis is None:
+        # Fallback in-RAM (dev/CI ou Redis pas encore init)
+        _token_blacklist[token_hash] = time.time() + ttl
+        now = time.time()
+        expired = [h for h, exp in _token_blacklist.items() if exp < now]
+        for h in expired:
+            del _token_blacklist[h]
+        return True
+
+    try:
+        await redis.set(f"{_BLOCKLIST_REDIS_KEY_PREFIX}{token_hash}", "1", ex=ttl)
+        return True
+    except Exception as e:
+        await _log_blocklist_fail_open("add", str(e))
+        # Fallback in-RAM pour ne pas perdre la révocation en cas de Redis flaky
+        _token_blacklist[token_hash] = time.time() + ttl
+        return False
 
 
-def is_token_blacklisted(token: str) -> bool:
+async def is_token_blacklisted(token: str) -> bool:
+    """Vérifie si un token est dans la blocklist.
+
+    Fail-open sur erreur Redis : retourne False (token accepté) + log audit.
+    Rationale : avant Sprint C la blocklist était in-RAM et se perdait à
+    chaque reboot, donc fail-open est strictement pas pire que le baseline.
+    """
     token_hash = _hash_token(token)
-    if token_hash in _token_blacklist:
-        if _token_blacklist[token_hash] > time.time():
-            return True
-        else:
-            del _token_blacklist[token_hash]
-    return False
+    redis = _get_redis_client()
+
+    if redis is None:
+        # Fallback in-RAM
+        if token_hash in _token_blacklist:
+            if _token_blacklist[token_hash] > time.time():
+                return True
+            else:
+                del _token_blacklist[token_hash]
+        return False
+
+    try:
+        result = await redis.exists(f"{_BLOCKLIST_REDIS_KEY_PREFIX}{token_hash}")
+        return bool(result)
+    except Exception as e:
+        await _log_blocklist_fail_open("check", str(e))
+        # Fail-open : on accepte le token. Le RAM fallback peut quand même
+        # contenir une révocation locale, on l'honore.
+        if token_hash in _token_blacklist:
+            if _token_blacklist[token_hash] > time.time():
+                return True
+        return False
 
 
 def generate_secure_operation_id(user_id: int, operation_type: str) -> str:

--- a/backend/tests/test_auth_comprehensive.py
+++ b/backend/tests/test_auth_comprehensive.py
@@ -1274,3 +1274,113 @@ async def test_full_google_oauth_flow(mock_db_session):
     payload = jwt.decode(access_token, test_secret, algorithms=["HS256"])
     assert payload["sub"] == "1"
     assert payload["session"] == "oauth_sess"
+
+
+# ======================================================================
+# SPRINT C — TOKEN BLOCKLIST (Redis-backed) TESTS
+# ======================================================================
+# Mission: vérifier que la blocklist Sprint C
+#  (1) ajoute → check returns True
+#  (2) expire via TTL → check returns False
+#  (3) fail-open quand Redis indispo (ConnectionError) + log audit
+#
+# fakeredis est déjà dans requirements.txt (utilisé par tutor.service).
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_blocklist_add_then_check_returns_true():
+    """Sprint C — Un token ajouté à la blocklist est détecté comme blacklisté."""
+    import fakeredis.aioredis as fakeredis_async
+    from core import security
+
+    fake_redis = fakeredis_async.FakeRedis(decode_responses=True)
+
+    # Monkey-patch _get_redis_client pour qu'il renvoie le fake
+    with patch("core.security._get_redis_client", return_value=fake_redis):
+        token = "ey.fake.jwt.token.for.testing"
+        added = await security.blacklist_token(token, expiry_seconds=3600)
+        assert added is True
+
+        is_blocked = await security.is_token_blacklisted(token)
+        assert is_blocked is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_blocklist_check_after_ttl_expiry_returns_false():
+    """Sprint C — Après expiration TTL, le token n'est plus dans la blocklist.
+
+    On utilise ex=1 sur fakeredis et on attend > 1s pour observer l'expiration
+    naturelle (fakeredis honore les TTLs en temps réel par défaut).
+    """
+    import asyncio as _asyncio
+    import fakeredis.aioredis as fakeredis_async
+    from core import security
+
+    fake_redis = fakeredis_async.FakeRedis(decode_responses=True)
+
+    with patch("core.security._get_redis_client", return_value=fake_redis):
+        token = "ey.expiring.token"
+        await security.blacklist_token(token, expiry_seconds=1)
+
+        # Juste avant l'expiration : encore blacklisté
+        assert await security.is_token_blacklisted(token) is True
+
+        # Attendre que le TTL expire (1s + marge)
+        await _asyncio.sleep(1.2)
+
+        # Après expiration : Redis nettoie la clé, plus blacklisté
+        assert await security.is_token_blacklisted(token) is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_blocklist_redis_down_fails_open_and_logs():
+    """Sprint C — Si Redis lève ConnectionError, is_token_blacklisted retourne
+    False (fail-open) et `_log_blocklist_fail_open` est appelé.
+
+    Rationale : avant Sprint C la blocklist était in-RAM et perdue à chaque
+    reboot, donc fail-open est strictement pas pire que le baseline.
+    """
+    from core import security
+
+    # Mock Redis qui crash sur exists()
+    crashing_redis = MagicMock()
+    crashing_redis.exists = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    audit_calls = []
+
+    async def fake_log(op, err):
+        audit_calls.append((op, err))
+
+    with patch("core.security._get_redis_client", return_value=crashing_redis), \
+         patch("core.security._log_blocklist_fail_open", side_effect=fake_log):
+        result = await security.is_token_blacklisted("any.token.here")
+
+    # Fail-open : on accepte le token (False = pas blacklisté)
+    assert result is False
+    # Audit log appelé exactement une fois avec operation="check"
+    assert len(audit_calls) == 1
+    assert audit_calls[0][0] == "check"
+    assert "redis down" in audit_calls[0][1]
+
+
+@pytest.mark.unit
+def test_jwt_ttls_from_env_var_defaults(monkeypatch):
+    """Sprint C — JWT_CONFIG lit ACCESS_TOKEN_TTL_MIN / REFRESH_TOKEN_TTL_DAYS
+    des variables d'environnement, avec defaults 60 / 30.
+
+    Cf. backend/src/core/config.py:535-538 + audit Sprint C.
+    """
+    # Default sans env override = 60 min / 30 jours
+    from core.config import JWT_CONFIG
+    # Les valeurs au moment de l'import du module ; on vérifie qu'elles sont
+    # cohérentes avec les defaults Sprint C (60 / 30) — c'est le contrat
+    # exposé aux clients web/mobile/extension.
+    assert JWT_CONFIG["ACCESS_TOKEN_EXPIRE_MINUTES"] == 60, (
+        f"Sprint C contract violated: access TTL = {JWT_CONFIG['ACCESS_TOKEN_EXPIRE_MINUTES']} (expected 60)"
+    )
+    assert JWT_CONFIG["REFRESH_TOKEN_EXPIRE_DAYS"] == 30, (
+        f"Sprint C contract violated: refresh TTL = {JWT_CONFIG['REFRESH_TOKEN_EXPIRE_DAYS']} (expected 30)"
+    )


### PR DESCRIPTION
## Summary

Sprint C — patch sécurité minimum-viable sur l'auth backend. **NO UI, NO new endpoints, NO DB schema.** Couvre les 3 trous critiques identifiés par l'audit du 2026-05-21 sans toucher au scope V2 complet (différé sprint suivant).

Audit source : `01-Projects/DeepSight/Sessions/2026-05-21-audit-auth-sprint-c.md` (vault Obsidian).

## Changes

| # | Fix | Avant | Après | Risque adressé |
|---|---|---|---|---|
| 1 | Access token TTL | 7 jours (10080 min) | **60 min** (env `ACCESS_TOKEN_TTL_MIN`) | 🔴 vol cookie = compte ouvert 1 semaine |
| 2 | Refresh token TTL | 365 jours | **30 jours** (env `REFRESH_TOKEN_TTL_DAYS`) | 🔴 vol refresh = accès durable an+ |
| 3 | Blocklist révocation | `Dict[str, float]` in-RAM | **Redis** `auth:blocklist:{jti}` avec TTL=exp | 🔴 logout perdu à chaque `docker run` |
| 4 | Doc CLAUDE.md | Affirmait à tort « 15min/7d » | Aligné 60min/30j Sprint C | 🟡 doc trompeuse |

## Notes & decisions

**1. Cutover doux.** Les TTLs sont encodés dans chaque JWT au moment de l'émission (`exp` claim). Les tokens déjà émis conservent leur exp naturelle. Seuls les nouveaux logins/refreshs reçoivent les TTLs courts. **Pas d'action côté front/mobile/extension requise.**

**2. Blocklist fail-open.** Si Redis est inaccessible (`ConnectionError`, etc.), `is_token_blacklisted` retourne `False` (token accepté) et log dans `audit_logs.action='auth_blocklist_fail_open'`. Rationale : équivalent au baseline pré-Sprint-C où la blocklist était RAM et perdue à chaque reboot — c'est strictement pas pire. Un fallback in-RAM dict honore quand même les révocations effectuées pendant le même process lifetime.

**3. API change : `blacklist_token` et `is_token_blacklisted` deviennent async.** Les 3 callsites (auth/dependencies.py × 2, chat/websocket.py × 1) sont tous dans des `async def`, mis à jour pour `await`. Pas de caller externe.

**4. pyjwt migration → différée V2.** L'audit identifiait `python-jose` non-maintenu (CVE-2024-33664/33663). La migration est non-triviale à cause du flow Apple Sign-in (RS256 + JWK + audience + issuer, juste shippé sur la branche feat/apple-signin-android) — PyJWT a une API différente pour `from_jwk()`. Le risque de casser Apple Sign-in en prod surpasse le gain CVE pour un sprint « minimum-viable ». Tracker via une PR dédiée V2.

## Files modified

- `backend/src/core/config.py` (JWT_CONFIG externalisation env vars)
- `backend/src/core/security.py` (blocklist Redis-backed + fail-open + audit log)
- `backend/src/auth/dependencies.py` (await is_token_blacklisted × 2)
- `backend/src/chat/websocket.py` (await is_token_blacklisted)
- `backend/tests/test_auth_comprehensive.py` (+4 tests Sprint C)
- `CLAUDE.md` + `backend/CLAUDE.md` (doc alignée)

## Test plan

- [x] **Backend tests : 2407 passed, 11 skipped** (was 2403, exactement +4 nouveaux tests Sprint C, zéro régression). Commande : `cd backend && python -m pytest tests/ -q`.
- [x] Nouveaux tests :
  - `test_blocklist_add_then_check_returns_true` (round-trip fakeredis)
  - `test_blocklist_check_after_ttl_expiry_returns_false` (TTL honoré, ex=1s + sleep 1.2s)
  - `test_blocklist_redis_down_fails_open_and_logs` (`ConnectionError` → return False + audit call)
  - `test_jwt_ttls_from_env_var_defaults` (contract: access=60min / refresh=30d)
- [ ] Post-merge Hetzner smoke : vérifier `/api/auth/login` retourne un access_token avec exp ≈ now+60min (vs +7d avant). Override testable via `docker exec -e ACCESS_TOKEN_TTL_MIN=120 ...`.
- [ ] Post-merge : checker `docker logs repo-backend-1 | grep blocklist_fail_open` reste vide (Redis healthy).
- [ ] Sentry/PostHog : aucun pic de `token_revoked` (les anciens tokens valides restent valides jusqu'à leur exp).

## Out of scope

- pyjwt migration (déféré V2 — voir note 4)
- Table `user_sessions` multi-device (V2)
- Refresh token rotation single-use (V2)
- Page UI Appareils tri-plateforme (V2)
- Re-auth scopé + grace period (V2)

V2 complet estimé 8-9 j-p, spec à rédiger dans `01-Projects/DeepSight/Specs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)