### PR TITLE
fix(discover/search): backstop 25s + parallel yt-dlp + Mistral timeouts

### DIFF
--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -263,6 +263,7 @@ FORMAT DE RÉPONSE (JSON uniquement):
                         "max_tokens": 200,
                         "response_format": {"type": "json_object"},
                     },
+                    timeout=8.0,
                 )
 
                 if response.status_code == 200:
@@ -278,7 +279,7 @@ FORMAT DE RÉPONSE (JSON uniquement):
                     queries = cls._fallback_reformulation(query, language)
 
         except Exception as e:
-            logger.error(f"Mistral reformulation error: {e}")
+            logger.warning(f"Mistral reformulation error (using fallback): {e}")
             queries = cls._fallback_reformulation(query, language)
 
         return queries[:5]  # Max 5 requêtes totales
@@ -383,6 +384,7 @@ FORMAT DE RÉPONSE (JSON uniquement):
                         "temperature": 0.3,
                         "max_tokens": 50,
                     },
+                    timeout=5.0,
                 )
 
                 if response.status_code == 200:
@@ -452,10 +454,10 @@ class YouTubeSearcher:
 
             def run_ytdlp():
                 try:
-                    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+                    result = subprocess.run(cmd, capture_output=True, text=True, timeout=8)
                     return result.stdout, result.stderr
                 except subprocess.TimeoutExpired:
-                    logger.error("yt-dlp timeout after 30s")
+                    logger.warning("yt-dlp timeout after 8s")
                     return "", "timeout"
                 except Exception as e:
                     logger.error(f"yt-dlp subprocess error: {e}")
@@ -1460,35 +1462,48 @@ class IntelligentDiscoveryService:
 
         logger.info(f"🔍 [DISCOVER] Starting search: '{query}' (langs={languages})")
 
-        # 1. Reformulation via Mistral AI (multilingue)
-        reformulated = await MistralReprompt.reformulate(query, primary_lang)
+        # 1. Reformulation via Mistral AI (multilingue) — timeout-protected
+        try:
+            reformulated = await asyncio.wait_for(
+                MistralReprompt.reformulate(query, primary_lang),
+                timeout=10.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("⏱️ Mistral reformulate timeout — using fallback")
+            reformulated = MistralReprompt._fallback_reformulation(query, primary_lang)
         logger.info(f"🧠 Reformulated queries: {reformulated}")
 
-        # 2. Recherche YouTube multilingue pour trouver les meilleures infos
+        # 2. 🚀 Préparer les traductions et les recherches en PARALLÈLE
+        # Avant: 3 yt-dlp + 2 (translate + yt-dlp) en séquentiel → 5×8s = 40s worst case
+        # Après: tout en gather() → ~8s worst case
+        other_languages = [l for l in ["en", "fr", "de", "es"] if l not in languages[:1]][:2]
+
+        async def translate_and_search(lang: str) -> List[Dict]:
+            """Translate query + run yt-dlp search for a secondary language."""
+            try:
+                translated = await asyncio.wait_for(
+                    MistralReprompt.translate_query(query, primary_lang, lang),
+                    timeout=6.0,
+                )
+            except asyncio.TimeoutError:
+                translated = query
+            return await YouTubeSearcher.search(translated, max_results=max_results // 2, language=lang)
+
+        # Tâches parallèles : primary lang searches + secondary lang translate+search
+        primary_tasks = [
+            YouTubeSearcher.search(sq, max_results=max_results, language=primary_lang)
+            for sq in reformulated[:3]
+        ]
+        secondary_tasks = [translate_and_search(lang) for lang in other_languages]
+
+        all_search_results = await asyncio.gather(*primary_tasks, *secondary_tasks, return_exceptions=True)
+
+        # 3. Aggregate candidates from all parallel searches
         all_candidates: Dict[str, VideoCandidate] = {}
-
-        # Recherche dans la langue principale
-        for search_query in reformulated[:3]:
-            results = await YouTubeSearcher.search(search_query, max_results=max_results, language=primary_lang)
-
-            for raw in results:
-                candidate = YouTubeSearcher.parse_video_result(raw)
-                if candidate and candidate.video_id not in all_candidates:
-                    all_candidates[candidate.video_id] = candidate
-
-        # 🌍 Recherche dans d'autres langues pour compléter avec du contenu de qualité
-        other_languages = [l for l in ["en", "fr", "de", "es"] if l not in languages[:1]]
-
-        for other_lang in other_languages[:2]:  # Max 2 langues supplémentaires
-            # Traduire la requête pour cette langue
-            translated_query = await MistralReprompt.translate_query(query, primary_lang, other_lang)
-
-            results = await YouTubeSearcher.search(
-                translated_query,
-                max_results=max_results // 2,  # Moins de résultats pour les autres langues
-                language=other_lang,
-            )
-
+        for results in all_search_results:
+            if isinstance(results, Exception):
+                logger.warning(f"Search task error (skipped): {results}")
+                continue
             for raw in results:
                 candidate = YouTubeSearcher.parse_video_result(raw)
                 if candidate and candidate.video_id not in all_candidates:

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -4735,11 +4735,17 @@ async def discover_search_videos(
     lang_list = [l.strip() for l in languages.split(",")]
 
     try:
-        result = await IntelligentDiscoveryService.discover(
-            query=query,
-            languages=lang_list,
-            max_results=limit,
-            min_quality=15.0,
+        # 🛡️ Backstop 25s : si discover() hang sur Mistral/yt-dlp, on coupe net
+        # et on renvoie une liste vide plutôt que de laisser le mobile attendre
+        # son propre timeout 30s. Évite "ça charge à l'infini" côté UI.
+        result = await asyncio.wait_for(
+            IntelligentDiscoveryService.discover(
+                query=query,
+                languages=lang_list,
+                max_results=limit,
+                min_quality=15.0,
+            ),
+            timeout=25.0,
         )
 
         # Convert candidates to dicts
@@ -4782,6 +4788,14 @@ async def discover_search_videos(
             "query": query,
         }
 
+    except asyncio.TimeoutError:
+        logger.warning(f"⏱️ [DISCOVER/SEARCH] Backstop 25s hit for query='{query}' — returning empty")
+        return {
+            "videos": [],
+            "total": 0,
+            "query": query,
+            "timeout": True,
+        }
     except Exception as e:
         logger.error(f"❌ [DISCOVER/SEARCH] Error: {e}")
         # Always return valid JSON, never 404

--- a/mobile/src/components/home/YouTubeSearch.tsx
+++ b/mobile/src/components/home/YouTubeSearch.tsx
@@ -83,10 +83,24 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
         language: options.language || "fr,en",
         sort_by: "quality",
       });
-      setResults(response.videos || []);
+      if (response.timeout) {
+        setError("Recherche YouTube indisponible — réessaie dans un instant.");
+        setResults([]);
+      } else {
+        setResults(response.videos || []);
+      }
     } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : "Erreur de recherche";
+      let message = "Erreur de recherche";
+      if (err instanceof Error) {
+        if (
+          err.message.toLowerCase().includes("timeout") ||
+          err.message.toLowerCase().includes("abort")
+        ) {
+          message = "Recherche trop lente — réessaie dans un instant.";
+        } else {
+          message = err.message;
+        }
+      }
       setError(message);
       setResults([]);
     } finally {

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -919,6 +919,7 @@ export const videoApi = {
     }>;
     total: number;
     query: string;
+    timeout?: boolean;
   }> {
     const langs = options?.language || "fr,en";
     const params = new URLSearchParams({
@@ -927,9 +928,13 @@ export const videoApi = {
       limit: String(options?.limit || 20),
       sort_by: options?.sort_by || "quality",
     });
-    return requestPatient(`/api/videos/discover/search?${params.toString()}`, {
+    // Backend has a 25s backstop (returns 200 with timeout:true). We keep a 30s
+    // client timeout for headroom + network latency, then surface the timeout
+    // signal to the UI for a clear error message rather than the legacy
+    // 120s "loads forever" experience.
+    return request(`/api/videos/discover/search?${params.toString()}`, {
       method: "POST",
-      timeout: 120000,
+      timeout: 30000,
     });
   },
 


### PR DESCRIPTION
## Bug

Recherche YouTube mobile chargeait à l'infini sur la page d'accueil (bouton **Recherche**).

Logs prod (`api.deepsightsynthesis.com`, container `repo-backend-1`) :

```
09:51:54.933  🔍 [DISCOVER/SEARCH] query='grenouille'
09:54:04.288  ✅ [DISCOVER/SEARCH] Returning 0 videos
              → duration_ms: 129416  (status 200)
```

Cause :
- `MistralReprompt.reformulate/translate_query` sans timeout HTTP explicite
- Boucle séquentielle de 5 `yt-dlp ytsearch` (3 primary + 2 translated)
- Subprocess timeout réglé à 30s par appel (5×30s worst case = 150s)
- Hang silencieux : aucun log interne de `discover()` n'apparaissait dans la fenêtre 09:51:54 → 09:54:04

Côté client mobile : timeout 120s + `requestPatient` (4 retries) → user voit "ça charge à l'infini" parce que 130s c'est trop long pour qu'il attende l'erreur.

## Fix

### Backend (`intelligent_discovery.py`, `router.py`)
- **Backstop 25s** : `asyncio.wait_for(discover(...), timeout=25)` dans le router. Si timeout → renvoie `{videos: [], total: 0, timeout: true}` au lieu de laisser le hang propager.
- **Mistral timeouts** : `reformulate` 8s, `translate_query` 5s. En cas de timeout → fallback non-IA (variantes simples).
- **Parallélisation yt-dlp** : remplace les 2 boucles `for ... await ...` par un seul `asyncio.gather()` sur les 5 search tasks (3 primary + 2 translate-and-search). Bornes : 5×8s séquentiel = 40s → ~8s parallèle.
- **yt-dlp subprocess** : timeout 30s → 8s (matche le profil observé de 1.4s pour une recherche saine).

### Mobile (`api.ts`, `YouTubeSearch.tsx`)
- `discoverSearch` : timeout client 120s → 30s, preset `request` (no retry) au lieu de `requestPatient` (4 retries inutiles puisque le backend renvoie 200 dans tous les cas).
- UX : message dédié si `response.timeout === true` ou si le client abort/timeout → "Recherche YouTube indisponible — réessaie dans un instant."

## Test plan

- [ ] Auto-deploy Hetzner (push main → SSH webhook → docker rebuild)
- [ ] Tail logs `repo-backend-1` pendant une recherche depuis l'app mobile : vérifier que `🧠 Reformulated queries:` et `📊 Found N unique candidates` apparaissent et que `duration_ms < 25000`
- [ ] Test fail-path : provoquer un timeout côté backend → vérifier que mobile affiche "Recherche YouTube indisponible" et NON le spinner infini
- [ ] EAS OTA mobile (runtime 1.2.0) — vérifier que la nouvelle version est servie sur device

## Risque

- ⚠️ Le backstop coupe une recherche légitime à 25s — mais à partir de 25s on a déjà perdu l'utilisateur. Mieux vaut un échec rapide qu'une attente sans fin.
- Aucune migration DB. Aucun changement de schema API (ajout `timeout?: boolean` optionnel rétrocompat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)