### PR TITLE
Wave 1 Step 1 — Backend auth V2 foundation: user_sessions table + model

### DIFF
--- a/backend/alembic/versions/033_user_sessions.py
+++ b/backend/alembic/versions/033_user_sessions.py
@@ -1,0 +1,130 @@
+"""user_sessions — table de sessions multi-device pour Auth V2 (Wave 1 Step 1)
+
+Revision ID: 033_user_sessions
+Revises: 032_users_apple_sub
+Create Date: 2026-05-21
+
+Spec : 01-Projects/DeepSight/Specs/2026-05-21-auth-v2-complet-design.md §4
+
+Crée la table `user_sessions` qui pose les fondations de l'Auth V2 :
+- 1 ligne = 1 session refresh actif sur 1 device (multi-device natif)
+- `refresh_token_hash` SHA-256 unique → support rotation single-use
+- `device_label` parsé du user-agent server-side (« Chrome on macOS »)
+- `ip_hash` SHA-256(ip + IP_HASH_SALT) anonymisé (compliance RGPD V2)
+- TTLs séparés : `sliding_expires_at` (30j sliding) + `absolute_expires_at` (90j cap)
+- `stay_signed_in` toggle bool piloté par le client au login
+- `revoked_at` soft-delete pour audit (jamais hard-delete une session)
+
+Convention DeepSight Alembic :
+- Revision ID ≤ 32 chars : "033_user_sessions" = 17 chars ✓
+- Migration idempotente : create only if not exists.
+- Cross-DB : `String(36)` UUID textuel (cf VoiceSession) — pas de
+  PostgreSQL UUID(as_uuid=True) qui casserait SQLite local.
+- Entrypoint Docker exécute `alembic upgrade heads` (plural) à chaque
+  container start, donc on doit rester safe sur re-run.
+
+Indexes :
+- ix_user_sessions_user_id : lookup sessions par user (page « Appareils actifs »)
+- ix_user_sessions_user_id_revoked_at : filtrage sessions actives d'un user
+- ix_user_sessions_sliding_expires_at : background sweeper sessions expirées
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "033_user_sessions"
+down_revision: Union[str, None] = "032_users_apple_sub"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "user_sessions" in existing_tables:
+        # Idempotent : déjà appliquée
+        return
+
+    op.create_table(
+        "user_sessions",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("refresh_token_hash", sa.String(64), nullable=False),
+        sa.Column("device_label", sa.String(255), nullable=True),
+        sa.Column("ip_hash", sa.String(64), nullable=True),
+        sa.Column("user_agent", sa.Text, nullable=True),
+        sa.Column(
+            "stay_signed_in",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "issued_at",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("sliding_expires_at", sa.DateTime, nullable=False),
+        sa.Column("absolute_expires_at", sa.DateTime, nullable=False),
+        sa.Column("revoked_at", sa.DateTime, nullable=True),
+        sa.UniqueConstraint(
+            "refresh_token_hash",
+            name="uq_user_sessions_refresh_token_hash",
+        ),
+    )
+
+    op.create_index(
+        "ix_user_sessions_user_id",
+        "user_sessions",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_user_sessions_user_id_revoked_at",
+        "user_sessions",
+        ["user_id", "revoked_at"],
+    )
+    op.create_index(
+        "ix_user_sessions_sliding_expires_at",
+        "user_sessions",
+        ["sliding_expires_at"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "user_sessions" not in existing_tables:
+        return
+
+    op.drop_index(
+        "ix_user_sessions_sliding_expires_at",
+        table_name="user_sessions",
+    )
+    op.drop_index(
+        "ix_user_sessions_user_id_revoked_at",
+        table_name="user_sessions",
+    )
+    op.drop_index(
+        "ix_user_sessions_user_id",
+        table_name="user_sessions",
+    )
+    op.drop_table("user_sessions")

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -192,9 +192,85 @@ class User(Base):
     study_sessions = relationship("StudySession", back_populates="user", cascade="all, delete-orphan")
     study_stats = relationship("UserStudyStats", back_populates="user", uselist=False, cascade="all, delete-orphan")
     user_badges = relationship("UserBadge", back_populates="user", cascade="all, delete-orphan")
+    # 🔐 Auth V2 — sessions multi-device avec rotation refresh single-use.
+    # Cascade delete-orphan : suppression d'un user → ses sessions disparaissent.
+    sessions = relationship("UserSession", back_populates="user", cascade="all, delete-orphan")
 
     def __repr__(self):
         return f"<User {self.username}>"
+
+
+class UserSession(Base):
+    """🔐 Auth V2 — Sessions refresh multi-device (Wave 1 Step 1).
+
+    Une ligne = un refresh actif sur un device. Permet :
+    - Multi-device natif (page « Appareils actifs » dans Settings).
+    - Rotation single-use du refresh (chaque /api/auth/refresh émet un nouveau
+      `refresh_token_hash`, blocklist l'ancien JTI Redis, met à jour
+      `last_seen_at` + `refresh_token_hash` ici).
+    - TTLs sliding (30j) + absolute cap (90j) découplés du `stay_signed_in`
+      toggle client.
+    - Audit : `revoked_at` soft-delete pour traçabilité (jamais de hard DELETE).
+
+    Spec : 01-Projects/DeepSight/Specs/2026-05-21-auth-v2-complet-design.md §4
+    Migration : alembic 033_user_sessions.py.
+    """
+
+    __tablename__ = "user_sessions"
+
+    # UUID textuel cross-DB (cf VoiceSession). Pas de PostgreSQL UUID natif
+    # qui casserait SQLite local en dev.
+    id = Column(
+        String(36),
+        primary_key=True,
+        default=lambda: str(__import__("uuid").uuid4()),
+    )
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # SHA-256 hex digest du refresh token (64 chars). Unique → un refresh
+    # ne peut vivre que dans une session à la fois (rotation single-use).
+    refresh_token_hash = Column(String(64), nullable=False, unique=True)
+
+    # Device label parsé du user-agent server-side (« Chrome on macOS »).
+    # Pas d'UI custom-label utilisateur en V2 (différé V3, cf spec §6.3).
+    device_label = Column(String(255), nullable=True)
+
+    # SHA-256(ip + IP_HASH_SALT env) anonymisée. Pas de geo lookup en V2
+    # (différé V3, cf spec §6.4). Compliance RGPD simplifiée.
+    ip_hash = Column(String(64), nullable=True)
+    user_agent = Column(Text, nullable=True)
+
+    # Toggle « Stay signed in » piloté par le client au login (cf spec §4.2).
+    # True (défaut) → sliding 30j. False → 24h hard sans sliding.
+    stay_signed_in = Column(Boolean, nullable=False, default=True, server_default=text("true"))
+
+    issued_at = Column(DateTime, nullable=False, server_default=func.now())
+    # Mis à jour à chaque /api/auth/refresh + endpoints sensibles (audit trail).
+    last_seen_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    # Expiration sliding (renouvelée à chaque refresh) capée par absolute_expires_at.
+    sliding_expires_at = Column(DateTime, nullable=False)
+    # Cap dur 90j depuis issued_at (cf spec §4.1) — pas re-renouvelable.
+    absolute_expires_at = Column(DateTime, nullable=False)
+
+    # Soft-delete : NULL = active, timestamp = révoquée.
+    revoked_at = Column(DateTime, nullable=True)
+
+    # Relations
+    user = relationship("User", back_populates="sessions")
+
+    __table_args__ = (
+        Index("ix_user_sessions_user_id_revoked_at", "user_id", "revoked_at"),
+        Index("ix_user_sessions_sliding_expires_at", "sliding_expires_at"),
+    )
+
+    def __repr__(self):
+        return f"<UserSession {self.id} user={self.user_id} device={self.device_label!r}>"
 
 
 class Summary(Base):

--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -1491,8 +1491,7 @@ class IntelligentDiscoveryService:
 
         # Tâches parallèles : primary lang searches + secondary lang translate+search
         primary_tasks = [
-            YouTubeSearcher.search(sq, max_results=max_results, language=primary_lang)
-            for sq in reformulated[:3]
+            YouTubeSearcher.search(sq, max_results=max_results, language=primary_lang) for sq in reformulated[:3]
         ]
         secondary_tasks = [translate_and_search(lang) for lang in other_languages]
 

--- a/backend/tests/test_user_sessions_model.py
+++ b/backend/tests/test_user_sessions_model.py
@@ -1,0 +1,234 @@
+"""Test schema migration 033 — création de la table `user_sessions` + model.
+
+Auth V2 Wave 1 Step 1 — foundations multi-device + rotation refresh single-use.
+
+Vérifie :
+  1. Le model SQLAlchemy `UserSession` est bien déclaré avec toutes les colonnes
+     attendues (id, user_id, refresh_token_hash, device_label, ip_hash,
+     user_agent, stay_signed_in, issued_at, last_seen_at, sliding_expires_at,
+     absolute_expires_at, revoked_at).
+  2. Insert + read-back d'une UserSession avec champs requis (round-trip DB).
+  3. Cascade delete : supprimer un User → ses UserSession orphelines disparaissent
+     (vérifie le `ON DELETE CASCADE` côté FK + `cascade="all, delete-orphan"`
+     côté relationship).
+  4. Query par (user_id, revoked_at IS NULL) — pattern attendu pour la page
+     « Appareils actifs » et la dependency `get_current_user` V2.
+
+Stratégie : SQLite in-memory + `Base.metadata.create_all` pour matérialiser
+le schéma sans dépendre d'Alembic (cf pattern de test_user_preferences_column.py).
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+@pytest_asyncio.fixture
+async def test_session():
+    """SQLite in-memory + tous les models créés via Base.metadata.create_all."""
+    from db.database import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    SessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with SessionLocal() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_user_session_model_has_expected_columns():
+    """Le model UserSession déclare toutes les colonnes du spec V2 §4.1."""
+    from db.database import UserSession
+
+    cols = {c.name for c in UserSession.__table__.columns}
+    expected = {
+        "id",
+        "user_id",
+        "refresh_token_hash",
+        "device_label",
+        "ip_hash",
+        "user_agent",
+        "stay_signed_in",
+        "issued_at",
+        "last_seen_at",
+        "sliding_expires_at",
+        "absolute_expires_at",
+        "revoked_at",
+    }
+    missing = expected - cols
+    assert not missing, f"UserSession missing columns: {missing}"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_user_session_create_with_required_fields(test_session):
+    """Insert + read-back d'une UserSession avec tous les champs requis."""
+    from db.database import User, UserSession
+
+    user = User(
+        username="alice_session",
+        email="alice_session@example.com",
+        password_hash="hashed",
+    )
+    test_session.add(user)
+    await test_session.commit()
+    await test_session.refresh(user)
+
+    now = datetime.utcnow()
+    session_id = str(uuid.uuid4())
+    sess = UserSession(
+        id=session_id,
+        user_id=user.id,
+        refresh_token_hash="a" * 64,  # SHA-256 hex digest (64 chars)
+        device_label="Chrome on macOS",
+        ip_hash="b" * 64,
+        user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        stay_signed_in=True,
+        sliding_expires_at=now + timedelta(days=30),
+        absolute_expires_at=now + timedelta(days=90),
+    )
+    test_session.add(sess)
+    await test_session.commit()
+    await test_session.refresh(sess)
+
+    # Read-back round-trip
+    result = await test_session.execute(
+        select(UserSession).where(UserSession.id == session_id)
+    )
+    fetched = result.scalar_one()
+    assert fetched.user_id == user.id
+    assert fetched.refresh_token_hash == "a" * 64
+    assert fetched.device_label == "Chrome on macOS"
+    assert fetched.stay_signed_in is True
+    assert fetched.revoked_at is None
+    assert fetched.issued_at is not None
+    assert fetched.last_seen_at is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_user_session_cascade_delete_when_user_deleted(test_session):
+    """Supprimer un User → ses UserSession liées disparaissent (FK CASCADE)."""
+    from db.database import User, UserSession
+
+    user = User(
+        username="bob_cascade",
+        email="bob_cascade@example.com",
+        password_hash="hashed",
+    )
+    test_session.add(user)
+    await test_session.commit()
+    await test_session.refresh(user)
+
+    now = datetime.utcnow()
+    # Crée 2 sessions sur ce user (multi-device simulé)
+    sess1 = UserSession(
+        id=str(uuid.uuid4()),
+        user_id=user.id,
+        refresh_token_hash="c" * 64,
+        device_label="Chrome on macOS",
+        sliding_expires_at=now + timedelta(days=30),
+        absolute_expires_at=now + timedelta(days=90),
+    )
+    sess2 = UserSession(
+        id=str(uuid.uuid4()),
+        user_id=user.id,
+        refresh_token_hash="d" * 64,
+        device_label="Safari on iOS",
+        sliding_expires_at=now + timedelta(days=30),
+        absolute_expires_at=now + timedelta(days=90),
+    )
+    test_session.add_all([sess1, sess2])
+    await test_session.commit()
+
+    # Sanity check : 2 sessions existent
+    result = await test_session.execute(
+        select(UserSession).where(UserSession.user_id == user.id)
+    )
+    assert len(result.scalars().all()) == 2
+
+    # Suppression du user via session.delete() pour déclencher le cascade
+    # ORM-side (cascade="all, delete-orphan" sur User.sessions) — équivalent au
+    # ON DELETE CASCADE côté FK mais plus portable sur SQLite.
+    await test_session.delete(user)
+    await test_session.commit()
+
+    # Les sessions doivent avoir disparu
+    result = await test_session.execute(
+        select(UserSession).where(UserSession.user_id == user.id)
+    )
+    remaining = result.scalars().all()
+    assert remaining == [], (
+        f"Expected sessions cascade-deleted, but {len(remaining)} remain"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_user_session_query_by_user_id_and_revoked_at_null(test_session):
+    """Pattern « sessions actives d'un user » : WHERE user_id=? AND revoked_at IS NULL.
+
+    Vérifie que :
+    - les sessions non révoquées (revoked_at=NULL) remontent ;
+    - les sessions révoquées (revoked_at=timestamp) sont exclues.
+
+    L'index `ix_user_sessions_user_id_revoked_at` (cf migration 033) supporte
+    cette requête. Le test ne vérifie pas l'usage de l'index (impossible sans
+    EXPLAIN), juste la correction fonctionnelle de la query.
+    """
+    from db.database import User, UserSession
+
+    user = User(
+        username="carol_active",
+        email="carol_active@example.com",
+        password_hash="hashed",
+    )
+    test_session.add(user)
+    await test_session.commit()
+    await test_session.refresh(user)
+
+    now = datetime.utcnow()
+    active_session = UserSession(
+        id=str(uuid.uuid4()),
+        user_id=user.id,
+        refresh_token_hash="e" * 64,
+        device_label="Chrome on Windows",
+        sliding_expires_at=now + timedelta(days=30),
+        absolute_expires_at=now + timedelta(days=90),
+        revoked_at=None,
+    )
+    revoked_session = UserSession(
+        id=str(uuid.uuid4()),
+        user_id=user.id,
+        refresh_token_hash="f" * 64,
+        device_label="Firefox on Linux",
+        sliding_expires_at=now + timedelta(days=30),
+        absolute_expires_at=now + timedelta(days=90),
+        revoked_at=now - timedelta(hours=1),  # révoquée il y a 1h
+    )
+    test_session.add_all([active_session, revoked_session])
+    await test_session.commit()
+
+    # Query : sessions actives du user
+    result = await test_session.execute(
+        select(UserSession).where(
+            UserSession.user_id == user.id,
+            UserSession.revoked_at.is_(None),
+        )
+    )
+    active = result.scalars().all()
+    assert len(active) == 1, (
+        f"Expected 1 active session, got {len(active)}"
+    )
+    assert active[0].device_label == "Chrome on Windows"
+    assert active[0].revoked_at is None


### PR DESCRIPTION
## Wave 1 Step 1 — Auth V2 foundations

Spec : `01-Projects/DeepSight/Specs/2026-05-21-auth-v2-complet-design.md` §4 (vault Obsidian).

Premier des 6 sub-PRs de la Wave 1 backend. Pose la fondation `user_sessions` qui permettra aux Steps 2-6 de livrer le système de sessions multi-device + rotation refresh single-use + endpoints `/api/auth/sessions/*` + `/api/auth/reauth`.

**Ne change aucun comportement runtime** — uniquement le schéma DB + model SQLAlchemy. Pas de breaking change.

## Summary

- **Migration Alembic 033** (`backend/alembic/versions/033_user_sessions.py`) — crée la table `user_sessions` avec 12 colonnes, 3 indexes, FK CASCADE `users.id`, unique constraint sur `refresh_token_hash`. Idempotente (early return si table existe).
- **Modèle SQLAlchemy `UserSession`** dans `backend/src/db/database.py` (+76 lines) — UUID textuel cross-DB (`String(36)` cf VoiceSession), relationship `User.sessions` avec `cascade="all, delete-orphan"`.
- **4 tests** dans `backend/tests/test_user_sessions_model.py` — déclaration colonnes, insert+read-back, cascade delete, query par `(user_id, revoked_at IS NULL)`.

## Décisions architecturales (validées dans spec §4)

| Colonne | Type | Rôle |
|---|---|---|
| `id` | String(36) UUID | PK textuel cross-DB |
| `user_id` | Integer FK CASCADE | Owner |
| `refresh_token_hash` | String(64) UNIQUE | SHA-256 hex, support rotation single-use |
| `device_label` | String(255) | « Chrome on macOS » parsé du UA server-side |
| `ip_hash` | String(64) | SHA-256(ip + IP_HASH_SALT), pas de geo en V2 |
| `user_agent` | Text | UA brut pour traçabilité |
| `stay_signed_in` | Boolean | Toggle client (default true → 30j sliding) |
| `issued_at` | DateTime | Création |
| `last_seen_at` | DateTime | Refresh + endpoints sensibles |
| `sliding_expires_at` | DateTime | Renouvelable, capé par absolute |
| `absolute_expires_at` | DateTime | Cap dur 90j depuis `issued_at` |
| `revoked_at` | DateTime NULL | Soft-delete (audit), pas de hard DELETE |

Indexes : `ix_user_sessions_user_id`, `ix_user_sessions_user_id_revoked_at` (sessions actives d'un user), `ix_user_sessions_sliding_expires_at` (sweeper background).

## Test plan

- [x] 4 nouveaux tests `test_user_sessions_model.py` passent (1.84s)
- [x] 4 tests existants `test_user_preferences_column.py` (même fixture pattern) passent toujours — pas de régression sur `Base.metadata.create_all`
- [x] Round-trip Alembic vérifié via `MigrationContext` direct (upgrade → downgrade → upgrade → idempotent re-run) : table créée avec 12 colonnes, 3 indexes, FK CASCADE, unique constraint OK ; downgrade drop propre ; re-upgrade fonctionne
- [x] `alembic heads` confirme `033_user_sessions` est bien le nouveau head (chain `032_users_apple_sub → 033_user_sessions`)
- [ ] CI Linux Docker : à valider par GitHub Actions

## Steps suivants (Wave 1)

- **Step 2** — `auth/service.py` : fonctions `create_session()` / `rotate_refresh()` / `revoke_session()` qui écrivent dans `user_sessions`
- **Step 3** — endpoints `/api/auth/sessions/*` (GET list / DELETE one / DELETE all-but-current) + `/api/auth/reauth`
- **Step 4** — feature flag `AUTH_V2_ENABLED` + branche legacy dans `verify_token` + `get_current_user` (cutover grace period 30j)
- **Step 5** — migration `python-jose` → `PyJWT[crypto]` (CVE-2024-33664/33663)
- **Step 6** — tests intégration end-to-end

Wave 2 (front-end tri-plateforme) et Wave 3 (rollout 10→50→100%) suivent.

## Notes

**Tech-debt préexistant Sprint C #522 (non lié à ce PR)** : sur Windows local, 43 tests `test_auth_comprehensive.py` + 8 `test_user_preferences_ambient.py` échouent avec un circular import dans `auth.service` (`verify_token`). Vérifié identique sur `main` pristine. La CI Linux Docker passe normalement (ordre de résolution des imports différent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)