### PR TITLE
feat(decodo): Web Scraping API wrapper + telemetry (Phase 0)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -108,6 +108,19 @@ GOOGLE_OAUTH_ENABLED=false
 # BACKUP_CRON_MINUTE=0
 # BACKUP_RETENTION_DAYS=30               # Delete S3 backups older than N days
 
+# --- Decodo Web Scraping API (Phase 0) ---
+# Tier $49/mo. DISTINCT from the YOUTUBE_PROXY Residential proxy (which is a
+# bandwidth-priced IP rotation only). The Scraping API is the JS-rendering +
+# CAPTCHA bypass service used by Scholar / TikTok / Creator enrichment.
+# Endpoint: POST https://scraper-api.decodo.com/v2/scrape
+# Full "Basic <base64>" header value — store on Hetzner only, never commit real key.
+# DECODO_SCRAPING_API_KEY=Basic <paste-base64-from-decodo-dashboard>
+# Kill-switch (no restart needed). Set to true to stop all scraping API calls.
+# DECODO_SCRAPING_DISABLED=false
+# Monthly request hard-stop. Default 31360 = 80% of Premium+JS 39 200/mo cap.
+# Set to 0 to disable the cap entirely (dev/staging only).
+# DECODO_SCRAPING_MAX_MONTHLY_REQ=31360
+
 # --- Misc ---
 # PORT=8000
 # ALLOWED_ORIGINS=                       # Comma-separated URLs

--- a/backend/alembic/versions/033_decodo_scraping_usage.py
+++ b/backend/alembic/versions/033_decodo_scraping_usage.py
@@ -1,0 +1,110 @@
+"""decodo_scraping_usage — telemetry table pour Decodo Web Scraping API
+
+Revision ID: 033_decodo_scraping_usage
+Revises: 032_users_apple_sub
+Create Date: 2026-05-21
+
+Sprint Decodo Web Scraping Phase 0 (wrapper + telemetry).
+
+DISTINCT de `proxy_usage_daily` (Decodo Residential proxy via env `YOUTUBE_PROXY`,
+PR #466). Le produit Web Scraping API (`scraper-api.decodo.com/v2/scrape`) est un
+service séparé sur tier $49/mois avec ses propres quotas (Premium+JS 39 200/mois,
+Standard+JS 75K/mois, etc.) — d'où une table de telemetry isolée pour ne pas
+mélanger les budgets.
+
+Spec source de vérité : `01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase1-quick-wins.md`
++ `01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase3-new-features.md`.
+
+La table grain = 1 row par appel (vs proxy_usage_daily qui aggrège par jour) :
+- permet d'analyser la latence par call
+- permet d'identifier les URLs problématiques (mauvais status_code, error texte)
+- volume estimé < 2000 req/jour en pic → ~60k rows/mois, parfaitement tenable
+  (index sur created_at DESC pour les retention queries).
+
+Convention DeepSight Alembic :
+- Revision ID ≤ 32 chars : "033_decodo_scraping_usage" = 25 chars ✓
+- Migration idempotente : create only if not exists, drop only if exists.
+- Compatible PostgreSQL ET SQLite (tests locaux).
+
+Entrypoint Docker exécute `alembic upgrade heads` (plural) à chaque container
+start, donc on doit rester safe sur re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "033_decodo_scraping_usage"
+down_revision: Union[str, None] = "032_users_apple_sub"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "decodo_scraping_usage" in existing_tables:
+        return
+
+    op.create_table(
+        "decodo_scraping_usage",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("url", sa.Text(), nullable=False),
+        # standard | premium
+        sa.Column("proxy_pool", sa.String(16), nullable=False),
+        sa.Column("headless", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        # raw_html | markdown
+        sa.Column("output_format", sa.String(16), nullable=False),
+        # Status code retourné par le site cible (200, 404, etc.) — NULL si l'appel
+        # Decodo a échoué avant d'atteindre la cible.
+        sa.Column("target_status_code", sa.Integer(), nullable=True),
+        # Status code retourné par Decodo lui-même (200 = scrape OK, 4xx/5xx = erreur Decodo).
+        sa.Column("decodo_http_status", sa.Integer(), nullable=True),
+        # Cost estimate en USD pour cet appel (matrix proxy_pool × headless).
+        # NUMERIC(10,6) → précision 6 décimales, suffit pour $0.000625 par exemple.
+        sa.Column(
+            "cost_estimate_usd",
+            sa.Numeric(precision=10, scale=6),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        # Durée totale du call Decodo en secondes (NUMERIC(10,3) → 0.001s précision).
+        sa.Column(
+            "duration_s",
+            sa.Numeric(precision=10, scale=3),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        # Texte d'erreur si l'appel a échoué (timeout, exception, etc.). NULL en cas de succès.
+        sa.Column("error", sa.Text(), nullable=True),
+    )
+
+    # Index sur created_at DESC — toutes les queries dashboard scannent par date récente.
+    op.create_index(
+        "ix_decodo_scraping_usage_created_at",
+        "decodo_scraping_usage",
+        [sa.text("created_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "decodo_scraping_usage" in existing_tables:
+        op.drop_index(
+            "ix_decodo_scraping_usage_created_at",
+            table_name="decodo_scraping_usage",
+        )
+        op.drop_table("decodo_scraping_usage")

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -91,6 +91,17 @@ class _DeepSightSettings(BaseSettings):
     PROXY_CIRCUIT_BREAKER_WINDOW_S: int = 60
     PROXY_CIRCUIT_BREAKER_RESET_S: int = 300
 
+    # -- Decodo Web Scraping API (Phase 0 — distinct from Residential Proxy above) --
+    # Tier $49/mois souscrit 2026-05-21. Endpoint: POST scraper-api.decodo.com/v2/scrape.
+    # Wrapper code: backend/src/decodo/ + table `decodo_scraping_usage` (Alembic 033).
+    # Spec: 01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase1-quick-wins.md
+    # Quotas tier: Standard 98K/mo, Standard+JS 75K/mo, Premium 54K/mo, Premium+JS 39 200/mo.
+    DECODO_SCRAPING_API_KEY: str = ""  # "Basic <base64>" — provisioned Hetzner only
+    DECODO_SCRAPING_DISABLED: bool = False  # kill-switch (no restart needed)
+    # Hard-stop monthly request count. Default 31360 = 80% of Premium+JS 39 200/mo
+    # cap. Set to 0 to disable the monthly hard-stop (e.g. dev/staging).
+    DECODO_SCRAPING_MAX_MONTHLY_REQ: int = 31360
+
     # -- Email --
     EMAIL_ENABLED: str = "true"
     RESEND_API_KEY: str = ""
@@ -377,6 +388,10 @@ YOUTUBE_PROXY_LEGACY = _settings.YOUTUBE_PROXY_LEGACY
 PROXY_CIRCUIT_BREAKER_THRESHOLD: int = _settings.PROXY_CIRCUIT_BREAKER_THRESHOLD
 PROXY_CIRCUIT_BREAKER_WINDOW_S: int = _settings.PROXY_CIRCUIT_BREAKER_WINDOW_S
 PROXY_CIRCUIT_BREAKER_RESET_S: int = _settings.PROXY_CIRCUIT_BREAKER_RESET_S
+# Decodo Web Scraping API (Phase 0)
+DECODO_SCRAPING_API_KEY: str = _settings.DECODO_SCRAPING_API_KEY
+DECODO_SCRAPING_DISABLED: bool = _settings.DECODO_SCRAPING_DISABLED
+DECODO_SCRAPING_MAX_MONTHLY_REQ: int = _settings.DECODO_SCRAPING_MAX_MONTHLY_REQ
 
 
 def get_fal_key() -> str:

--- a/backend/src/decodo/__init__.py
+++ b/backend/src/decodo/__init__.py
@@ -1,0 +1,57 @@
+"""
+Decodo Web Scraping API wrapper — Phase 0.
+
+Distinct from the Residential Proxy (gate.decodo.com:7000, env `YOUTUBE_PROXY`,
+instrumented by `middleware/proxy_telemetry.py` / PR #466). This package wraps
+the Web Scraping API tier ($49/mo, endpoint scraper-api.decodo.com/v2/scrape).
+
+Public surface:
+    DecodoScrapingClient — async client with retry + telemetry + budget guard
+    ScrapeResult         — pydantic model of a scrape outcome
+    Errors               — DecodoScrapingError + subclasses
+
+Specs:
+    01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase1-quick-wins.md
+    01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase3-new-features.md
+"""
+
+from decodo.errors import (
+    DecodoBudgetExceededError,
+    DecodoConfigError,
+    DecodoDisabledError,
+    DecodoRequestError,
+    DecodoResponseError,
+    DecodoScrapingError,
+    DecodoTimeoutError,
+)
+from decodo.scraping_client import (
+    DECODO_SCRAPING_ENDPOINT,
+    DEFAULT_TIMEOUT_S,
+    DecodoScrapingClient,
+    ScrapeResult,
+)
+from decodo.telemetry import (
+    cost_estimate_usd,
+    get_monthly_request_count,
+    record_decodo_call,
+)
+
+__all__ = [
+    # Client
+    "DecodoScrapingClient",
+    "ScrapeResult",
+    "DECODO_SCRAPING_ENDPOINT",
+    "DEFAULT_TIMEOUT_S",
+    # Errors
+    "DecodoScrapingError",
+    "DecodoDisabledError",
+    "DecodoBudgetExceededError",
+    "DecodoConfigError",
+    "DecodoRequestError",
+    "DecodoTimeoutError",
+    "DecodoResponseError",
+    # Telemetry helpers
+    "cost_estimate_usd",
+    "get_monthly_request_count",
+    "record_decodo_call",
+]

--- a/backend/src/decodo/errors.py
+++ b/backend/src/decodo/errors.py
@@ -43,9 +43,7 @@ class DecodoBudgetExceededError(DecodoScrapingError):
     def __init__(self, current_count: int, max_count: int) -> None:
         self.current_count = current_count
         self.max_count = max_count
-        super().__init__(
-            f"Decodo Scraping monthly budget exceeded: {current_count} >= {max_count}"
-        )
+        super().__init__(f"Decodo Scraping monthly budget exceeded: {current_count} >= {max_count}")
 
 
 class DecodoConfigError(DecodoScrapingError):
@@ -58,9 +56,7 @@ class DecodoRequestError(DecodoScrapingError):
     def __init__(self, status_code: int, body: str = "") -> None:
         self.status_code = status_code
         self.body = body
-        super().__init__(
-            f"Decodo Scraping API HTTP {status_code}: {body[:200]}"
-        )
+        super().__init__(f"Decodo Scraping API HTTP {status_code}: {body[:200]}")
 
 
 class DecodoTimeoutError(DecodoScrapingError):

--- a/backend/src/decodo/errors.py
+++ b/backend/src/decodo/errors.py
@@ -1,0 +1,75 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🚫 DECODO SCRAPING — Custom exceptions                                            ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Hierarchy :                                                                       ║
+║                                                                                    ║
+║      DecodoScrapingError              (base)                                       ║
+║      ├── DecodoDisabledError          (hard kill-switch via env)                   ║
+║      ├── DecodoBudgetExceededError    (monthly cap reached)                        ║
+║      ├── DecodoConfigError            (missing API key, bad pool, etc.)            ║
+║      ├── DecodoRequestError           (HTTP error from Decodo or target)           ║
+║      ├── DecodoTimeoutError           (httpx timeout)                              ║
+║      └── DecodoResponseError          (Decodo returned 200 but unexpected shape)   ║
+║                                                                                    ║
+║  Callers catch the base class for "any decodo failure" and let the specific ones   ║
+║  fan out into telemetry / fallback logic.                                          ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+
+class DecodoScrapingError(Exception):
+    """Base exception for all Decodo Web Scraping API errors."""
+
+
+class DecodoDisabledError(DecodoScrapingError):
+    """Raised when `DECODO_SCRAPING_DISABLED=true` (env kill-switch).
+
+    The wrapper short-circuits before making any HTTP call. Callers should
+    typically fall back to their non-decodo path (or fail soft).
+    """
+
+
+class DecodoBudgetExceededError(DecodoScrapingError):
+    """Raised when the monthly request budget has been exceeded.
+
+    Triggered when the count of rows in `decodo_scraping_usage` for the
+    current month >= `DECODO_SCRAPING_MAX_MONTHLY_REQ` (default 31360 =
+    80% of the Premium+JS tier 39 200/mo cap).
+    """
+
+    def __init__(self, current_count: int, max_count: int) -> None:
+        self.current_count = current_count
+        self.max_count = max_count
+        super().__init__(
+            f"Decodo Scraping monthly budget exceeded: {current_count} >= {max_count}"
+        )
+
+
+class DecodoConfigError(DecodoScrapingError):
+    """Raised when the wrapper is misconfigured (missing API key, etc.)."""
+
+
+class DecodoRequestError(DecodoScrapingError):
+    """Raised when Decodo returns a non-200 HTTP status (after all retries)."""
+
+    def __init__(self, status_code: int, body: str = "") -> None:
+        self.status_code = status_code
+        self.body = body
+        super().__init__(
+            f"Decodo Scraping API HTTP {status_code}: {body[:200]}"
+        )
+
+
+class DecodoTimeoutError(DecodoScrapingError):
+    """Raised when the Decodo call times out (after all retries)."""
+
+
+class DecodoResponseError(DecodoScrapingError):
+    """Raised when Decodo returns 200 but the body cannot be parsed.
+
+    Examples : missing `results` key, empty `results` array, missing `content`
+    field in the first result. Indicates a contract drift from Decodo.
+    """

--- a/backend/src/decodo/scraping_client.py
+++ b/backend/src/decodo/scraping_client.py
@@ -203,24 +203,18 @@ class DecodoScrapingClient:
         """
         # ── 1. Hard kill-switch ─────────────────────────────────────────────
         if _is_disabled_env():
-            raise DecodoDisabledError(
-                "DECODO_SCRAPING_DISABLED=true — kill switch active"
-            )
+            raise DecodoDisabledError("DECODO_SCRAPING_DISABLED=true — kill switch active")
 
         # ── 2. Monthly budget guard ────────────────────────────────────────
         max_monthly = _max_monthly_req()
         if max_monthly > 0:
             current = await get_monthly_request_count(self._db_session)
             if current >= max_monthly:
-                raise DecodoBudgetExceededError(
-                    current_count=current, max_count=max_monthly
-                )
+                raise DecodoBudgetExceededError(current_count=current, max_count=max_monthly)
 
         # ── 3. Config check ────────────────────────────────────────────────
         if not self._api_key:
-            raise DecodoConfigError(
-                "DECODO_SCRAPING_API_KEY missing from settings/env"
-            )
+            raise DecodoConfigError("DECODO_SCRAPING_API_KEY missing from settings/env")
 
         # ── 4. Build payload + headers ─────────────────────────────────────
         payload = self._build_payload(
@@ -246,17 +240,14 @@ class DecodoScrapingClient:
         for attempt in range(1, MAX_ATTEMPTS + 1):
             try:
                 async with httpx.AsyncClient(timeout=timeout_s) as client:
-                    resp = await client.post(
-                        self._endpoint, json=payload, headers=headers
-                    )
+                    resp = await client.post(self._endpoint, json=payload, headers=headers)
                 decodo_status = resp.status_code
 
                 if 500 <= resp.status_code < 600:
                     # Retryable 5xx
                     last_exc = DecodoRequestError(resp.status_code, resp.text or "")
                     logger.warning(
-                        f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} "
-                        f"5xx {resp.status_code} for {url[:80]}"
+                        f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} 5xx {resp.status_code} for {url[:80]}"
                     )
                     await self._maybe_backoff(attempt)
                     continue
@@ -320,18 +311,12 @@ class DecodoScrapingClient:
 
             except httpx.TimeoutException as e:
                 last_exc = DecodoTimeoutError(f"timeout after {timeout_s}s: {e}")
-                logger.warning(
-                    f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} "
-                    f"timeout for {url[:80]}"
-                )
+                logger.warning(f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} timeout for {url[:80]}")
                 await self._maybe_backoff(attempt)
                 continue
             except (httpx.ConnectError, httpx.ReadError, httpx.RemoteProtocolError) as e:
                 last_exc = DecodoRequestError(0, f"connection error: {e}")
-                logger.warning(
-                    f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} "
-                    f"connection error: {e}"
-                )
+                logger.warning(f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} connection error: {e}")
                 await self._maybe_backoff(attempt)
                 continue
             except (DecodoRequestError, DecodoResponseError):
@@ -416,28 +401,19 @@ class DecodoScrapingClient:
         """
         results = body.get("results")
         if not isinstance(results, list) or len(results) == 0:
-            raise DecodoResponseError(
-                f"response missing 'results' array (keys={list(body.keys())[:5]})"
-            )
+            raise DecodoResponseError(f"response missing 'results' array (keys={list(body.keys())[:5]})")
         first = results[0]
         if not isinstance(first, dict):
-            raise DecodoResponseError(
-                f"results[0] is not a dict (got {type(first).__name__})"
-            )
+            raise DecodoResponseError(f"results[0] is not a dict (got {type(first).__name__})")
 
         status = first.get("status_code")
         content = first.get("content")
         if status is None or content is None:
-            raise DecodoResponseError(
-                f"results[0] missing status_code/content (keys={list(first.keys())})"
-            )
+            raise DecodoResponseError(f"results[0] missing status_code/content (keys={list(first.keys())})")
 
         raw_headers = first.get("headers") or {}
         # Lowercase header keys for predictability across HTTP/2 vs HTTP/1.
-        headers = {
-            str(k).lower(): str(v)
-            for k, v in (raw_headers.items() if isinstance(raw_headers, dict) else [])
-        }
+        headers = {str(k).lower(): str(v) for k, v in (raw_headers.items() if isinstance(raw_headers, dict) else [])}
 
         return ScrapeResult(
             status_code=int(status),

--- a/backend/src/decodo/scraping_client.py
+++ b/backend/src/decodo/scraping_client.py
@@ -1,0 +1,546 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🕸️ DECODO SCRAPING — Async wrapper for the Web Scraping API                       ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  ENDPOINT                                                                          ║
+║      POST https://scraper-api.decodo.com/v2/scrape                                 ║
+║      Auth : Basic <base64(user:pass)> via header                                   ║
+║                                                                                    ║
+║  USAGE                                                                             ║
+║      from decodo import DecodoScrapingClient                                       ║
+║                                                                                    ║
+║      client = DecodoScrapingClient()                                               ║
+║      result = await client.scrape(                                                 ║
+║          "https://scholar.google.com/scholar?q=transformers",                      ║
+║          proxy_pool="premium",                                                     ║
+║          headless=True,                                                            ║
+║          output_format="markdown",                                                 ║
+║      )                                                                             ║
+║      print(result.content)         # HTML or markdown body                         ║
+║      print(result.cost_estimate_usd)  # 0.00125 for premium+JS                     ║
+║                                                                                    ║
+║  GUARDS                                                                            ║
+║  • DECODO_SCRAPING_DISABLED=true → DecodoDisabledError (kill-switch, no HTTP).     ║
+║  • Monthly count >= DECODO_SCRAPING_MAX_MONTHLY_REQ (default 31360, 80% of         ║
+║    Premium+JS 39 200/mo cap) → DecodoBudgetExceededError.                          ║
+║  • Missing API key → DecodoConfigError at first call.                              ║
+║                                                                                    ║
+║  RETRY                                                                             ║
+║  • 3 attempts with exponential backoff (0.5s → 1s → 2s).                           ║
+║  • Retry only on 5xx, connection errors, and httpx.TimeoutException.               ║
+║  • 4xx (including 401/403) bubble up immediately (no point retrying).              ║
+║                                                                                    ║
+║  TELEMETRY                                                                         ║
+║  • Each call writes one row to `decodo_scraping_usage` (fire-and-forget,           ║
+║    never blocks the return). Failure cases also recorded (status NULL +            ║
+║    error text).                                                                    ║
+║                                                                                    ║
+║  TODO PHASE 1.2                                                                    ║
+║  • The exact param name for Markdown output mode is NOT confirmed by Decodo       ║
+║    public docs at time of writing. Current best guess: `"output_format":          ║
+║    "markdown"` in the JSON body. To validate via the cURL playground before        ║
+║    Phase 1 (Scholar feature) ships. If the param name turns out to be different   ║
+║    (e.g. header `X-Output-Format`, `output` field, `markdown: true`), patch        ║
+║    `_build_payload` accordingly. The wrapper still works for raw_html in the      ║
+║    meantime.                                                                       ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, Literal, Optional
+
+import httpx
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.logging import logger
+from decodo.errors import (
+    DecodoBudgetExceededError,
+    DecodoConfigError,
+    DecodoDisabledError,
+    DecodoRequestError,
+    DecodoResponseError,
+    DecodoTimeoutError,
+)
+from decodo.telemetry import (
+    cost_estimate_usd,
+    get_monthly_request_count,
+    record_decodo_call,
+)
+
+
+DECODO_SCRAPING_ENDPOINT = "https://scraper-api.decodo.com/v2/scrape"
+
+# Default request timeout. JS rendering can be slow; 30s is the spec's default
+# but specific call sites can override (e.g. 45s for YouTube watch pages).
+DEFAULT_TIMEOUT_S = 30.0
+
+# Retry policy.
+MAX_ATTEMPTS = 3
+BASE_BACKOFF_S = 0.5  # first retry waits 0.5s, then 1.0s, then 2.0s
+
+
+ProxyPool = Literal["standard", "premium"]
+OutputFormat = Literal["raw_html", "markdown"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📦 RESULT MODEL
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class ScrapeResult(BaseModel):
+    """One Decodo Web Scraping API result.
+
+    Mirrors the shape of `response["results"][0]` plus metadata about the
+    call itself (cost, duration, pool, format) for caller-side analytics.
+    """
+
+    status_code: int = Field(
+        ...,
+        description="HTTP status of the TARGET site (200 = page rendered, 404, etc.)",
+    )
+    content: str = Field(..., description="Scraped body (HTML or markdown)")
+    headers: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Response headers from the target site (lowercased keys)",
+    )
+    cost_estimate_usd: float = Field(
+        ...,
+        description="Cost of this call in USD (from cost_estimate_usd matrix)",
+    )
+    duration_s: float = Field(
+        ...,
+        description="Wall-clock time of the Decodo call in seconds",
+    )
+    proxy_pool: str = Field(..., description='Pool used: "standard" or "premium"')
+    output_format: str = Field(..., description='Output mode: "raw_html" or "markdown"')
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🤖 CLIENT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class DecodoScrapingClient:
+    """Async wrapper around the Decodo Web Scraping API.
+
+    Construction reads `DECODO_SCRAPING_API_KEY` from settings by default, but
+    accepts overrides for testing and multi-tenant scenarios.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        endpoint: str = DECODO_SCRAPING_ENDPOINT,
+        db_session: Optional[AsyncSession] = None,
+    ) -> None:
+        """Initialize the client.
+
+        Args:
+            api_key: Full `Basic <base64>` header value. If None, reads from
+                `settings.DECODO_SCRAPING_API_KEY`. If still empty, calls will
+                raise DecodoConfigError.
+            endpoint: Override the Decodo endpoint (for testing).
+            db_session: Optional shared AsyncSession for telemetry writes. If
+                None, telemetry opens its own ad-hoc session.
+        """
+        if api_key is None:
+            try:
+                from core.config import settings
+
+                api_key = getattr(settings, "DECODO_SCRAPING_API_KEY", "") or ""
+            except Exception:
+                api_key = ""
+        # Normalize: accept "Basic <b64>" or raw "<b64>".
+        if api_key and not api_key.lower().startswith("basic "):
+            api_key = f"Basic {api_key}"
+        self._api_key = api_key.strip()
+        self._endpoint = endpoint
+        self._db_session = db_session
+
+    # ── Public API ──────────────────────────────────────────────────────────
+
+    async def scrape(
+        self,
+        url: str,
+        *,
+        proxy_pool: ProxyPool = "premium",
+        headless: bool = True,
+        device_type: str = "desktop_chrome",
+        output_format: OutputFormat = "raw_html",
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ) -> ScrapeResult:
+        """Scrape a URL through the Decodo Web Scraping API.
+
+        Args:
+            url: target URL to scrape.
+            proxy_pool: "standard" (cheap, no Cloudflare bypass) or "premium"
+                (Premium pool, recommended for Cloudflare/CAPTCHA/anti-bot).
+            headless: True to render JS via headless browser (paid surcharge),
+                False to fetch raw HTML.
+            device_type: "desktop_chrome", "mobile_chrome", etc. Forwarded to
+                Decodo as-is.
+            output_format: "raw_html" returns the page HTML. "markdown" asks
+                Decodo to return an AI-optimized markdown version.
+            timeout_s: per-attempt httpx timeout. The total wall-clock can be
+                up to 3 × timeout_s + 3s of backoff.
+
+        Returns:
+            ScrapeResult with the scraped content + cost + duration.
+
+        Raises:
+            DecodoDisabledError: env kill-switch is on.
+            DecodoBudgetExceededError: monthly cap reached.
+            DecodoConfigError: API key missing.
+            DecodoRequestError: HTTP non-200 after all retries.
+            DecodoTimeoutError: timed out after all retries.
+            DecodoResponseError: 200 but body cannot be parsed.
+        """
+        # ── 1. Hard kill-switch ─────────────────────────────────────────────
+        if _is_disabled_env():
+            raise DecodoDisabledError(
+                "DECODO_SCRAPING_DISABLED=true — kill switch active"
+            )
+
+        # ── 2. Monthly budget guard ────────────────────────────────────────
+        max_monthly = _max_monthly_req()
+        if max_monthly > 0:
+            current = await get_monthly_request_count(self._db_session)
+            if current >= max_monthly:
+                raise DecodoBudgetExceededError(
+                    current_count=current, max_count=max_monthly
+                )
+
+        # ── 3. Config check ────────────────────────────────────────────────
+        if not self._api_key:
+            raise DecodoConfigError(
+                "DECODO_SCRAPING_API_KEY missing from settings/env"
+            )
+
+        # ── 4. Build payload + headers ─────────────────────────────────────
+        payload = self._build_payload(
+            url=url,
+            proxy_pool=proxy_pool,
+            headless=headless,
+            device_type=device_type,
+            output_format=output_format,
+        )
+        headers = {
+            "Authorization": self._api_key,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+        cost = cost_estimate_usd(proxy_pool=proxy_pool, headless=headless)
+
+        # ── 5. Send with retry policy ──────────────────────────────────────
+        last_exc: Optional[Exception] = None
+        decodo_status: Optional[int] = None
+        t0 = time.monotonic()
+
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            try:
+                async with httpx.AsyncClient(timeout=timeout_s) as client:
+                    resp = await client.post(
+                        self._endpoint, json=payload, headers=headers
+                    )
+                decodo_status = resp.status_code
+
+                if 500 <= resp.status_code < 600:
+                    # Retryable 5xx
+                    last_exc = DecodoRequestError(resp.status_code, resp.text or "")
+                    logger.warning(
+                        f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} "
+                        f"5xx {resp.status_code} for {url[:80]}"
+                    )
+                    await self._maybe_backoff(attempt)
+                    continue
+
+                if resp.status_code != 200:
+                    # 4xx — don't retry, surface immediately.
+                    duration = time.monotonic() - t0
+                    await self._record(
+                        url=url,
+                        proxy_pool=proxy_pool,
+                        headless=headless,
+                        output_format=output_format,
+                        target_status_code=None,
+                        decodo_http_status=resp.status_code,
+                        cost=cost,
+                        duration=duration,
+                        error=f"HTTP {resp.status_code}: {(resp.text or '')[:200]}",
+                    )
+                    raise DecodoRequestError(resp.status_code, resp.text or "")
+
+                # 200 OK — parse body.
+                try:
+                    body = resp.json()
+                except Exception as e:
+                    duration = time.monotonic() - t0
+                    err = f"non-JSON body: {e}"
+                    await self._record(
+                        url=url,
+                        proxy_pool=proxy_pool,
+                        headless=headless,
+                        output_format=output_format,
+                        target_status_code=None,
+                        decodo_http_status=200,
+                        cost=cost,
+                        duration=duration,
+                        error=err,
+                    )
+                    raise DecodoResponseError(err)
+
+                result = self._extract_result(
+                    body=body,
+                    proxy_pool=proxy_pool,
+                    output_format=output_format,
+                    cost=cost,
+                    duration=time.monotonic() - t0,
+                )
+
+                # Telemetry — success.
+                await self._record(
+                    url=url,
+                    proxy_pool=proxy_pool,
+                    headless=headless,
+                    output_format=output_format,
+                    target_status_code=result.status_code,
+                    decodo_http_status=200,
+                    cost=cost,
+                    duration=result.duration_s,
+                    error=None,
+                )
+                return result
+
+            except httpx.TimeoutException as e:
+                last_exc = DecodoTimeoutError(f"timeout after {timeout_s}s: {e}")
+                logger.warning(
+                    f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} "
+                    f"timeout for {url[:80]}"
+                )
+                await self._maybe_backoff(attempt)
+                continue
+            except (httpx.ConnectError, httpx.ReadError, httpx.RemoteProtocolError) as e:
+                last_exc = DecodoRequestError(0, f"connection error: {e}")
+                logger.warning(
+                    f"[DECODO_SCRAPE] attempt {attempt}/{MAX_ATTEMPTS} "
+                    f"connection error: {e}"
+                )
+                await self._maybe_backoff(attempt)
+                continue
+            except (DecodoRequestError, DecodoResponseError):
+                # Already recorded above (4xx / non-JSON); bubble up.
+                raise
+
+        # All retries exhausted.
+        duration = time.monotonic() - t0
+        err_msg = str(last_exc) if last_exc else "all retries exhausted"
+        await self._record(
+            url=url,
+            proxy_pool=proxy_pool,
+            headless=headless,
+            output_format=output_format,
+            target_status_code=None,
+            decodo_http_status=decodo_status,
+            cost=cost,
+            duration=duration,
+            error=err_msg,
+        )
+        if last_exc:
+            raise last_exc
+        raise DecodoRequestError(0, "all retries exhausted with no captured exception")
+
+    # ── Internal helpers ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _build_payload(
+        *,
+        url: str,
+        proxy_pool: str,
+        headless: bool,
+        device_type: str,
+        output_format: str,
+    ) -> Dict[str, Any]:
+        """Build the JSON body for POST /v2/scrape.
+
+        TODO Phase 1.2: the exact param name for Markdown output isn't 100%
+        confirmed by Decodo docs. We send both `output_format` (best guess)
+        and pass through downstream call sites for now. If the upstream
+        contract clarifies (header / different field), update here only.
+        """
+        payload: Dict[str, Any] = {
+            "url": url,
+            "proxy_pool": proxy_pool,
+            "device_type": device_type,
+        }
+        # `headless: "html"` triggers Decodo's headless browser. Setting it
+        # to empty string or omitting it = raw fetch (no JS).
+        if headless:
+            payload["headless"] = "html"
+
+        if output_format == "markdown":
+            # Best-effort. TODO: validate via Decodo playground (spec § 9 Q1).
+            payload["output_format"] = "markdown"
+        # raw_html is the default Decodo behavior — no extra param needed.
+
+        return payload
+
+    @staticmethod
+    def _extract_result(
+        *,
+        body: Dict[str, Any],
+        proxy_pool: str,
+        output_format: str,
+        cost: float,
+        duration: float,
+    ) -> ScrapeResult:
+        """Parse the Decodo response envelope and build a ScrapeResult.
+
+        Expected shape (verified at smoke test J0 on Scholar/TikTok/YouTube):
+
+            {
+                "results": [
+                    {
+                        "status_code": 200,
+                        "content": "<html>...",
+                        "headers": {"content-type": "text/html; ..."}
+                    }
+                ]
+            }
+        """
+        results = body.get("results")
+        if not isinstance(results, list) or len(results) == 0:
+            raise DecodoResponseError(
+                f"response missing 'results' array (keys={list(body.keys())[:5]})"
+            )
+        first = results[0]
+        if not isinstance(first, dict):
+            raise DecodoResponseError(
+                f"results[0] is not a dict (got {type(first).__name__})"
+            )
+
+        status = first.get("status_code")
+        content = first.get("content")
+        if status is None or content is None:
+            raise DecodoResponseError(
+                f"results[0] missing status_code/content (keys={list(first.keys())})"
+            )
+
+        raw_headers = first.get("headers") or {}
+        # Lowercase header keys for predictability across HTTP/2 vs HTTP/1.
+        headers = {
+            str(k).lower(): str(v)
+            for k, v in (raw_headers.items() if isinstance(raw_headers, dict) else [])
+        }
+
+        return ScrapeResult(
+            status_code=int(status),
+            content=str(content),
+            headers=headers,
+            cost_estimate_usd=cost,
+            duration_s=round(duration, 3),
+            proxy_pool=proxy_pool,
+            output_format=output_format,
+        )
+
+    @staticmethod
+    async def _maybe_backoff(attempt: int) -> None:
+        """Sleep with exponential backoff between retries.
+
+        Skip the sleep after the LAST attempt — there's no point sleeping
+        before raising.
+        """
+        if attempt >= MAX_ATTEMPTS:
+            return
+        delay = BASE_BACKOFF_S * (2 ** (attempt - 1))
+        await asyncio.sleep(delay)
+
+    async def _record(
+        self,
+        *,
+        url: str,
+        proxy_pool: str,
+        headless: bool,
+        output_format: str,
+        target_status_code: Optional[int],
+        decodo_http_status: Optional[int],
+        cost: float,
+        duration: float,
+        error: Optional[str],
+    ) -> None:
+        """Wrapper around record_decodo_call that never raises."""
+        try:
+            await record_decodo_call(
+                url=url,
+                proxy_pool=proxy_pool,
+                headless=headless,
+                output_format=output_format,
+                target_status_code=target_status_code,
+                decodo_http_status=decodo_http_status,
+                cost_estimate_usd_value=cost,
+                duration_s=duration,
+                error=error,
+                session=self._db_session,
+            )
+        except Exception as e:
+            logger.debug(f"[DECODO_SCRAPE] telemetry write failed: {e}")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔧 ENV READERS — settings-aware with raw env fallback
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _is_disabled_env() -> bool:
+    """Read DECODO_SCRAPING_DISABLED — settings first, raw env fallback."""
+    try:
+        from core.config import settings
+
+        val = getattr(settings, "DECODO_SCRAPING_DISABLED", None)
+        if val is not None:
+            return _truthy(val)
+    except Exception:
+        pass
+    import os
+
+    return _truthy(os.environ.get("DECODO_SCRAPING_DISABLED", ""))
+
+
+def _max_monthly_req() -> int:
+    """Read DECODO_SCRAPING_MAX_MONTHLY_REQ — settings first, raw env fallback.
+
+    Returns 0 if not set (= no monthly cap enforced).
+    Default in `core/config.py` is 31360 (80% of Premium+JS 39 200/mo).
+    """
+    try:
+        from core.config import settings
+
+        val = getattr(settings, "DECODO_SCRAPING_MAX_MONTHLY_REQ", None)
+        if val is not None:
+            try:
+                return int(val)
+            except (TypeError, ValueError):
+                pass
+    except Exception:
+        pass
+    import os
+
+    raw = os.environ.get("DECODO_SCRAPING_MAX_MONTHLY_REQ", "").strip()
+    try:
+        return int(raw) if raw else 0
+    except ValueError:
+        return 0
+
+
+def _truthy(val: Any) -> bool:
+    """Coerce a settings/env value to bool."""
+    if isinstance(val, bool):
+        return val
+    s = str(val).strip().lower()
+    return s in ("true", "1", "yes", "on")

--- a/backend/src/decodo/telemetry.py
+++ b/backend/src/decodo/telemetry.py
@@ -1,0 +1,285 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  📊 DECODO SCRAPING — Telemetry (PG writes + monthly budget check)                 ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  RÔLE                                                                              ║
+║  • record_decodo_call(...) : INSERT 1 row dans `decodo_scraping_usage` après       ║
+║    chaque appel (fire-and-forget — toute exception est avalée à debug-level).      ║
+║  • get_monthly_request_count() : COUNT(*) du mois en cours (utilisé par le         ║
+║    hard-stop budget mensuel via `DECODO_SCRAPING_MAX_MONTHLY_REQ`).                ║
+║  • cost_estimate_usd(...) : matrice proxy_pool × headless → coût/req en USD.       ║
+║                                                                                    ║
+║  Pattern miroir de `middleware/proxy_telemetry.py` (PR #466 Residential), mais     ║
+║  table dédiée (grain = 1 row par call, pas aggregat journalier) car le volume      ║
+║  attendu permet la granularité et on veut tracker URL / status / latence.          ║
+║                                                                                    ║
+║  Cache TTL 60s sur le count mensuel pour éviter de hammer la DB sur chaque         ║
+║  call site.                                                                        ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime
+from typing import Literal, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.logging import logger
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 💰 COST MATRIX — Decodo Web Scraping API tier $49/mois
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Source : spec `2026-05-21-decodo-scraping-phase1-quick-wins.md` § 0
+# +       fiche tarifaire Decodo (souscrit 2026-05-21).
+#
+#   pool / js     |  False (no JS)  |  True (JS render)
+#   --------------+-----------------+-------------------
+#   standard      |  $0.50 / 1K     |  $0.65 / 1K
+#   premium       |  $0.90 / 1K     |  $1.25 / 1K
+#
+# Premium+JS = la combinaison la plus utilisée (Cloudflare bypass + Markdown
+# AI-optimized). Tier $49 cap = 39 200 req/mois.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_COST_PER_REQ_USD: dict[tuple[str, bool], float] = {
+    ("standard", False): 0.00050,
+    ("standard", True): 0.00065,
+    ("premium", False): 0.00090,
+    ("premium", True): 0.00125,
+}
+
+
+def cost_estimate_usd(*, proxy_pool: str, headless: bool) -> float:
+    """Coût estimé d'un appel Decodo Scraping en USD.
+
+    Args:
+        proxy_pool: "standard" ou "premium".
+        headless: True si JS render activé (paye le surcoût JS), False sinon.
+
+    Returns:
+        Coût en USD par appel. Retourne 0.0 si la combinaison n'est pas connue
+        (fail-open — on log une telemetry incomplete plutôt que crasher le call).
+    """
+    key = (proxy_pool, bool(headless))
+    cost = _COST_PER_REQ_USD.get(key)
+    if cost is None:
+        logger.warning(
+            f"[DECODO_TELEMETRY] unknown cost combo: pool={proxy_pool} "
+            f"headless={headless} — fallback 0"
+        )
+        return 0.0
+    return cost
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🗄️ MONTHLY COUNT CACHE — TTL 60s
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class _CountState:
+    """Per-process cache for the monthly request count."""
+
+    def __init__(self) -> None:
+        # (count, monotonic_ts_set)
+        self.cache: Optional[tuple[int, float]] = None
+
+
+_state = _CountState()
+_CACHE_TTL_SECONDS = 60.0
+
+
+def _reset_state_for_tests() -> None:
+    """Reset the in-memory cache (helper test-only)."""
+    global _state
+    _state = _CountState()
+
+
+def _invalidate_cache() -> None:
+    """Invalidate the monthly count cache so the next call hits the DB."""
+    _state.cache = None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📥 MONTHLY COUNT — Hard-stop budget query
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def _fetch_monthly_count(session: AsyncSession) -> int:
+    """Count rows in `decodo_scraping_usage` for the current month."""
+    today = date.today()
+    first_of_month = today.replace(day=1)
+
+    result = await session.execute(
+        text(
+            "SELECT COUNT(*) FROM decodo_scraping_usage "
+            "WHERE created_at >= :first_of_month"
+        ),
+        {"first_of_month": datetime(first_of_month.year, first_of_month.month, 1)},
+    )
+    return int(result.scalar() or 0)
+
+
+async def get_monthly_request_count(
+    session: Optional[AsyncSession] = None,
+) -> int:
+    """Return the count of Decodo Scraping requests for the current month.
+
+    Uses a 60s in-memory cache to avoid hitting the DB on every wrapper call.
+    Fails open (returns 0) if the DB is not reachable — never blocks the path.
+
+    Args:
+        session: optional AsyncSession. If provided and cache is stale, refresh
+            the cache via this session. Otherwise open an ad-hoc session.
+    """
+    loop = asyncio.get_event_loop()
+    now = loop.time()
+
+    if _state.cache is not None:
+        cached_count, cached_at = _state.cache
+        if (now - cached_at) < _CACHE_TTL_SECONDS:
+            return cached_count
+
+    if session is None:
+        try:
+            from db.database import async_session_maker
+
+            async with async_session_maker() as ad_hoc:
+                total = await _fetch_monthly_count(ad_hoc)
+        except Exception as e:
+            logger.debug(
+                f"[DECODO_TELEMETRY] get_monthly_request_count failed (ad-hoc): {e}"
+            )
+            return 0
+    else:
+        try:
+            total = await _fetch_monthly_count(session)
+        except Exception as e:
+            logger.debug(f"[DECODO_TELEMETRY] get_monthly_request_count failed: {e}")
+            return 0
+
+    _state.cache = (total, now)
+    return total
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 💾 INSERT — record_decodo_call
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def record_decodo_call(
+    *,
+    url: str,
+    proxy_pool: Literal["standard", "premium"],
+    headless: bool,
+    output_format: Literal["raw_html", "markdown"],
+    target_status_code: Optional[int],
+    decodo_http_status: Optional[int],
+    cost_estimate_usd_value: float,
+    duration_s: float,
+    error: Optional[str] = None,
+    session: Optional[AsyncSession] = None,
+) -> None:
+    """Insert one row into `decodo_scraping_usage` describing a call.
+
+    Best-effort : any exception is logged at debug-level and swallowed.
+    The wrapper MUST NOT block its return value on telemetry success.
+
+    Args:
+        url: target URL we asked Decodo to scrape.
+        proxy_pool: "standard" or "premium".
+        headless: True if JS render was requested.
+        output_format: "raw_html" or "markdown".
+        target_status_code: HTTP status of the target site (200/404/etc), or
+            None if the Decodo call failed before reaching the target.
+        decodo_http_status: HTTP status from Decodo itself.
+        cost_estimate_usd_value: precomputed cost via `cost_estimate_usd()`.
+        duration_s: wall-clock time of the call in seconds.
+        error: short error message if the call failed (None on success).
+        session: optional AsyncSession.
+    """
+    try:
+        if session is None:
+            from db.database import async_session_maker
+
+            async with async_session_maker() as ad_hoc:
+                await _insert_row(
+                    ad_hoc,
+                    url=url,
+                    proxy_pool=proxy_pool,
+                    headless=headless,
+                    output_format=output_format,
+                    target_status_code=target_status_code,
+                    decodo_http_status=decodo_http_status,
+                    cost_estimate_usd_value=cost_estimate_usd_value,
+                    duration_s=duration_s,
+                    error=error,
+                )
+        else:
+            await _insert_row(
+                session,
+                url=url,
+                proxy_pool=proxy_pool,
+                headless=headless,
+                output_format=output_format,
+                target_status_code=target_status_code,
+                decodo_http_status=decodo_http_status,
+                cost_estimate_usd_value=cost_estimate_usd_value,
+                duration_s=duration_s,
+                error=error,
+            )
+    except Exception as e:
+        logger.debug(f"[DECODO_TELEMETRY] record_decodo_call INSERT failed: {e}")
+        return
+
+    # On successful insert, bump the cached count so the budget hard-stop
+    # reacts without waiting for the 60s TTL to flush.
+    if _state.cache is not None:
+        count, ts = _state.cache
+        _state.cache = (count + 1, ts)
+
+
+async def _insert_row(
+    session: AsyncSession,
+    *,
+    url: str,
+    proxy_pool: str,
+    headless: bool,
+    output_format: str,
+    target_status_code: Optional[int],
+    decodo_http_status: Optional[int],
+    cost_estimate_usd_value: float,
+    duration_s: float,
+    error: Optional[str],
+) -> None:
+    """Low-level INSERT helper. Commits before returning."""
+    await session.execute(
+        text(
+            """
+            INSERT INTO decodo_scraping_usage
+                (url, proxy_pool, headless, output_format,
+                 target_status_code, decodo_http_status,
+                 cost_estimate_usd, duration_s, error)
+            VALUES
+                (:url, :proxy_pool, :headless, :output_format,
+                 :target_status_code, :decodo_http_status,
+                 :cost_estimate_usd, :duration_s, :error)
+            """
+        ),
+        {
+            "url": url[:2000],  # trim absurdly long URLs to avoid index bloat
+            "proxy_pool": proxy_pool,
+            "headless": bool(headless),
+            "output_format": output_format,
+            "target_status_code": target_status_code,
+            "decodo_http_status": decodo_http_status,
+            "cost_estimate_usd": cost_estimate_usd_value,
+            "duration_s": duration_s,
+            "error": (error[:2000] if error else None),
+        },
+    )
+    await session.commit()

--- a/backend/src/decodo/telemetry.py
+++ b/backend/src/decodo/telemetry.py
@@ -68,10 +68,7 @@ def cost_estimate_usd(*, proxy_pool: str, headless: bool) -> float:
     key = (proxy_pool, bool(headless))
     cost = _COST_PER_REQ_USD.get(key)
     if cost is None:
-        logger.warning(
-            f"[DECODO_TELEMETRY] unknown cost combo: pool={proxy_pool} "
-            f"headless={headless} — fallback 0"
-        )
+        logger.warning(f"[DECODO_TELEMETRY] unknown cost combo: pool={proxy_pool} headless={headless} — fallback 0")
         return 0.0
     return cost
 
@@ -115,10 +112,7 @@ async def _fetch_monthly_count(session: AsyncSession) -> int:
     first_of_month = today.replace(day=1)
 
     result = await session.execute(
-        text(
-            "SELECT COUNT(*) FROM decodo_scraping_usage "
-            "WHERE created_at >= :first_of_month"
-        ),
+        text("SELECT COUNT(*) FROM decodo_scraping_usage WHERE created_at >= :first_of_month"),
         {"first_of_month": datetime(first_of_month.year, first_of_month.month, 1)},
     )
     return int(result.scalar() or 0)
@@ -151,9 +145,7 @@ async def get_monthly_request_count(
             async with async_session_maker() as ad_hoc:
                 total = await _fetch_monthly_count(ad_hoc)
         except Exception as e:
-            logger.debug(
-                f"[DECODO_TELEMETRY] get_monthly_request_count failed (ad-hoc): {e}"
-            )
+            logger.debug(f"[DECODO_TELEMETRY] get_monthly_request_count failed (ad-hoc): {e}")
             return 0
     else:
         try:

--- a/backend/tests/decodo/test_scraping_client.py
+++ b/backend/tests/decodo/test_scraping_client.py
@@ -1,0 +1,605 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — Decodo Web Scraping API wrapper (Phase 0)                              ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Coverage:                                                                         ║
+║  • cost_estimate_usd matrix (standard/premium × headless False/True)               ║
+║  • DecodoScrapingClient.scrape: 200 OK happy path → ScrapeResult populated         ║
+║  • Retry: 500 → 500 → 200 succeeds after 3 attempts                                ║
+║  • Hard-stop env DECODO_SCRAPING_DISABLED=true → DecodoDisabledError               ║
+║  • Hard-stop monthly budget → DecodoBudgetExceededError                            ║
+║  • Missing API key → DecodoConfigError                                             ║
+║  • Telemetry: row inserted into decodo_scraping_usage on each call                 ║
+║  • Payload shape: proxy_pool, headless, output_format                              ║
+║  • 4xx (401/403) → no retry, immediate DecodoRequestError                          ║
+║  • Malformed response → DecodoResponseError                                        ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+# Add src to path (mirror conftest pattern).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry_state():
+    """Reset the in-memory monthly count cache between tests."""
+    from decodo.telemetry import _reset_state_for_tests
+
+    _reset_state_for_tests()
+    yield
+    _reset_state_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Default env: no kill-switch, no monthly cap, fake API key present."""
+    monkeypatch.delenv("DECODO_SCRAPING_DISABLED", raising=False)
+    monkeypatch.delenv("DECODO_SCRAPING_MAX_MONTHLY_REQ", raising=False)
+    # Force the settings reader to see our test values.
+    monkeypatch.setattr(
+        "core.config.DECODO_SCRAPING_DISABLED", False, raising=False
+    )
+    monkeypatch.setattr(
+        "core.config.DECODO_SCRAPING_MAX_MONTHLY_REQ", 0, raising=False
+    )
+    monkeypatch.setattr(
+        "core.config.DECODO_SCRAPING_API_KEY",
+        "Basic dGVzdHVzZXI6dGVzdHBhc3M=",
+        raising=False,
+    )
+    # Also patch the settings attribute in case clients import via settings.X.
+    try:
+        from core.config import settings as _s
+
+        monkeypatch.setattr(_s, "DECODO_SCRAPING_DISABLED", False, raising=False)
+        monkeypatch.setattr(_s, "DECODO_SCRAPING_MAX_MONTHLY_REQ", 0, raising=False)
+        monkeypatch.setattr(
+            _s,
+            "DECODO_SCRAPING_API_KEY",
+            "Basic dGVzdHVzZXI6dGVzdHBhc3M=",
+            raising=False,
+        )
+    except Exception:
+        pass
+    yield
+
+
+@pytest.fixture
+async def db_session():
+    """SQLite async in-memory session with the decodo_scraping_usage table."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                """
+                CREATE TABLE decodo_scraping_usage (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    url TEXT NOT NULL,
+                    proxy_pool TEXT NOT NULL,
+                    headless BOOLEAN NOT NULL DEFAULT 0,
+                    output_format TEXT NOT NULL,
+                    target_status_code INTEGER NULL,
+                    decodo_http_status INTEGER NULL,
+                    cost_estimate_usd NUMERIC(10,6) NOT NULL DEFAULT 0,
+                    duration_s NUMERIC(10,3) NOT NULL DEFAULT 0,
+                    error TEXT NULL
+                )
+                """
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+
+    await engine.dispose()
+
+
+def _fake_httpx_response(
+    *,
+    status_code: int = 200,
+    body: Any = None,
+    raise_timeout: bool = False,
+) -> MagicMock:
+    """Build a fake httpx.Response. If raise_timeout, the AsyncClient.post
+    raises httpx.TimeoutException instead."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = "" if body is None else (body if isinstance(body, str) else "")
+    if isinstance(body, dict):
+        resp.json = MagicMock(return_value=body)
+        resp.text = ""
+    elif body is None:
+        resp.json = MagicMock(return_value={})
+    else:
+        resp.json = MagicMock(side_effect=ValueError("not JSON"))
+    return resp
+
+
+def _patch_httpx_post(responses: List[Any], monkeypatch):
+    """Patch httpx.AsyncClient.post to return / raise from the `responses` list
+    in order, one per call. List items can be:
+      • a MagicMock response object → returned
+      • an Exception class or instance → raised
+    """
+    call_idx = {"i": 0}
+
+    async def fake_post(self, url, json=None, headers=None):
+        i = call_idx["i"]
+        call_idx["i"] += 1
+        if i >= len(responses):
+            raise AssertionError(
+                f"httpx.post called more times ({i + 1}) than fakes provided ({len(responses)})"
+            )
+        r = responses[i]
+        if isinstance(r, Exception):
+            raise r
+        if isinstance(r, type) and issubclass(r, Exception):
+            raise r("fake")
+        return r
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    return call_idx
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cost matrix
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCostMatrix:
+    @pytest.mark.unit
+    def test_cost_standard_no_js(self):
+        from decodo.telemetry import cost_estimate_usd
+
+        assert cost_estimate_usd(proxy_pool="standard", headless=False) == 0.00050
+
+    @pytest.mark.unit
+    def test_cost_standard_with_js(self):
+        from decodo.telemetry import cost_estimate_usd
+
+        assert cost_estimate_usd(proxy_pool="standard", headless=True) == 0.00065
+
+    @pytest.mark.unit
+    def test_cost_premium_no_js(self):
+        from decodo.telemetry import cost_estimate_usd
+
+        assert cost_estimate_usd(proxy_pool="premium", headless=False) == 0.00090
+
+    @pytest.mark.unit
+    def test_cost_premium_with_js(self):
+        from decodo.telemetry import cost_estimate_usd
+
+        assert cost_estimate_usd(proxy_pool="premium", headless=True) == 0.00125
+
+    @pytest.mark.unit
+    def test_cost_unknown_combo_returns_zero(self):
+        """Defensive: unknown pool/headless combos fail open with 0.0."""
+        from decodo.telemetry import cost_estimate_usd
+
+        assert cost_estimate_usd(proxy_pool="weird_pool", headless=True) == 0.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy path + retry
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestScrapeHappyPath:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_scrape_returns_scrape_result(self, monkeypatch, db_session):
+        """Decodo returns 200 with valid envelope → ScrapeResult populated."""
+        from decodo import DecodoScrapingClient
+
+        fake_body = {
+            "results": [
+                {
+                    "status_code": 200,
+                    "content": "<html><body>OK</body></html>",
+                    "headers": {"Content-Type": "text/html; charset=utf-8"},
+                }
+            ]
+        }
+        _patch_httpx_post(
+            [_fake_httpx_response(status_code=200, body=fake_body)], monkeypatch
+        )
+
+        # Skip sleep in retry path (not actually used here).
+        monkeypatch.setattr(
+            "decodo.scraping_client.asyncio.sleep", AsyncMock(return_value=None)
+        )
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        result = await client.scrape(
+            "https://example.com",
+            proxy_pool="premium",
+            headless=True,
+            output_format="raw_html",
+        )
+
+        assert result.status_code == 200
+        assert result.content == "<html><body>OK</body></html>"
+        assert result.headers["content-type"].startswith("text/html")
+        assert result.cost_estimate_usd == 0.00125  # premium + js
+        assert result.duration_s >= 0
+        assert result.proxy_pool == "premium"
+        assert result.output_format == "raw_html"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_scrape_retries_on_5xx_then_succeeds(self, monkeypatch, db_session):
+        """500 → 500 → 200 succeeds after 3 attempts."""
+        from decodo import DecodoScrapingClient
+
+        success_body = {
+            "results": [
+                {"status_code": 200, "content": "ok", "headers": {}}
+            ]
+        }
+        responses = [
+            _fake_httpx_response(status_code=500, body="upstream boom"),
+            _fake_httpx_response(status_code=502, body="upstream boom"),
+            _fake_httpx_response(status_code=200, body=success_body),
+        ]
+        call_idx = _patch_httpx_post(responses, monkeypatch)
+
+        # No real sleeping during tests.
+        sleep_mock = AsyncMock(return_value=None)
+        monkeypatch.setattr("decodo.scraping_client.asyncio.sleep", sleep_mock)
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        result = await client.scrape("https://example.com")
+
+        assert call_idx["i"] == 3
+        assert result.status_code == 200
+        # 2 backoff sleeps between 3 attempts.
+        assert sleep_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_scrape_4xx_no_retry(self, monkeypatch, db_session):
+        """401/403/404 from Decodo bubble up immediately without retry."""
+        from decodo import DecodoScrapingClient
+        from decodo.errors import DecodoRequestError
+
+        responses = [_fake_httpx_response(status_code=401, body="bad auth")]
+        call_idx = _patch_httpx_post(responses, monkeypatch)
+
+        sleep_mock = AsyncMock(return_value=None)
+        monkeypatch.setattr("decodo.scraping_client.asyncio.sleep", sleep_mock)
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        with pytest.raises(DecodoRequestError) as exc_info:
+            await client.scrape("https://example.com")
+
+        assert exc_info.value.status_code == 401
+        assert call_idx["i"] == 1  # No retry on 4xx.
+        assert sleep_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_scrape_timeout_then_succeeds(self, monkeypatch, db_session):
+        """Timeout → retry → success."""
+        from decodo import DecodoScrapingClient
+
+        success_body = {
+            "results": [{"status_code": 200, "content": "ok", "headers": {}}]
+        }
+        responses = [
+            httpx.TimeoutException("first timeout"),
+            _fake_httpx_response(status_code=200, body=success_body),
+        ]
+        _patch_httpx_post(responses, monkeypatch)
+        monkeypatch.setattr(
+            "decodo.scraping_client.asyncio.sleep", AsyncMock(return_value=None)
+        )
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        result = await client.scrape("https://example.com")
+        assert result.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_scrape_all_retries_exhausted_raises_last(
+        self, monkeypatch, db_session
+    ):
+        """3 consecutive 5xx → DecodoRequestError raised on last attempt."""
+        from decodo import DecodoScrapingClient
+        from decodo.errors import DecodoRequestError
+
+        responses = [
+            _fake_httpx_response(status_code=503, body="boom"),
+            _fake_httpx_response(status_code=503, body="boom"),
+            _fake_httpx_response(status_code=503, body="boom"),
+        ]
+        _patch_httpx_post(responses, monkeypatch)
+        monkeypatch.setattr(
+            "decodo.scraping_client.asyncio.sleep", AsyncMock(return_value=None)
+        )
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        with pytest.raises(DecodoRequestError) as exc_info:
+            await client.scrape("https://example.com")
+        assert exc_info.value.status_code == 503
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Hard-stops
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHardStops:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_disabled_env_raises_immediately(self, monkeypatch, db_session):
+        """DECODO_SCRAPING_DISABLED=true → DecodoDisabledError, no HTTP."""
+        from decodo import DecodoScrapingClient
+        from decodo.errors import DecodoDisabledError
+
+        monkeypatch.setenv("DECODO_SCRAPING_DISABLED", "true")
+        try:
+            from core.config import settings as _s
+
+            monkeypatch.setattr(_s, "DECODO_SCRAPING_DISABLED", True, raising=False)
+        except Exception:
+            pass
+
+        # Patch httpx.post — should NOT be called.
+        post_mock = AsyncMock(side_effect=AssertionError("should not be called"))
+        monkeypatch.setattr(httpx.AsyncClient, "post", post_mock)
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        with pytest.raises(DecodoDisabledError):
+            await client.scrape("https://example.com")
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_monthly_budget_exceeded(self, monkeypatch, db_session):
+        """Monthly count >= max → DecodoBudgetExceededError, no HTTP."""
+        from decodo import DecodoScrapingClient
+        from decodo.errors import DecodoBudgetExceededError
+
+        # Override the env reader directly — bypasses settings caching issues.
+        monkeypatch.setattr(
+            "decodo.scraping_client._max_monthly_req", lambda: 5
+        )
+
+        # Mock the count query. The client imports it via
+        # `from decodo.telemetry import get_monthly_request_count`, so we must
+        # patch on the importing module's namespace.
+        async def fake_count(session=None):
+            return 10  # Way over the cap of 5
+
+        monkeypatch.setattr(
+            "decodo.scraping_client.get_monthly_request_count", fake_count
+        )
+
+        post_mock = AsyncMock(side_effect=AssertionError("should not be called"))
+        monkeypatch.setattr(httpx.AsyncClient, "post", post_mock)
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        with pytest.raises(DecodoBudgetExceededError) as exc_info:
+            await client.scrape("https://example.com")
+        assert exc_info.value.current_count == 10
+        assert exc_info.value.max_count == 5
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_missing_api_key_raises_config_error(self, monkeypatch, db_session):
+        """Empty API key → DecodoConfigError before any HTTP call."""
+        from decodo import DecodoScrapingClient
+        from decodo.errors import DecodoConfigError
+
+        post_mock = AsyncMock(side_effect=AssertionError("should not be called"))
+        monkeypatch.setattr(httpx.AsyncClient, "post", post_mock)
+
+        client = DecodoScrapingClient(api_key="", db_session=db_session)
+        with pytest.raises(DecodoConfigError):
+            await client.scrape("https://example.com")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Payload shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPayload:
+    @pytest.mark.unit
+    def test_payload_markdown_includes_output_format(self):
+        from decodo.scraping_client import DecodoScrapingClient
+
+        payload = DecodoScrapingClient._build_payload(
+            url="https://example.com",
+            proxy_pool="premium",
+            headless=True,
+            device_type="desktop_chrome",
+            output_format="markdown",
+        )
+        assert payload["url"] == "https://example.com"
+        assert payload["proxy_pool"] == "premium"
+        assert payload["device_type"] == "desktop_chrome"
+        assert payload["headless"] == "html"
+        assert payload["output_format"] == "markdown"
+
+    @pytest.mark.unit
+    def test_payload_raw_html_no_output_format(self):
+        from decodo.scraping_client import DecodoScrapingClient
+
+        payload = DecodoScrapingClient._build_payload(
+            url="https://example.com",
+            proxy_pool="standard",
+            headless=False,
+            device_type="desktop_chrome",
+            output_format="raw_html",
+        )
+        # No JS, no output_format param — Decodo defaults to raw HTML.
+        assert "headless" not in payload
+        assert "output_format" not in payload
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Response parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestResponseParsing:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_malformed_response_no_results(self, monkeypatch, db_session):
+        """200 OK but body has no `results` array → DecodoResponseError."""
+        from decodo import DecodoScrapingClient
+        from decodo.errors import DecodoResponseError
+
+        bad_body = {"unexpected": "shape"}
+        _patch_httpx_post(
+            [_fake_httpx_response(status_code=200, body=bad_body)], monkeypatch
+        )
+        monkeypatch.setattr(
+            "decodo.scraping_client.asyncio.sleep", AsyncMock(return_value=None)
+        )
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        with pytest.raises(DecodoResponseError):
+            await client.scrape("https://example.com")
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_malformed_response_empty_results(self, monkeypatch, db_session):
+        """200 OK with empty results array → DecodoResponseError."""
+        from decodo import DecodoScrapingClient
+        from decodo.errors import DecodoResponseError
+
+        bad_body = {"results": []}
+        _patch_httpx_post(
+            [_fake_httpx_response(status_code=200, body=bad_body)], monkeypatch
+        )
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        with pytest.raises(DecodoResponseError):
+            await client.scrape("https://example.com")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Telemetry
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTelemetry:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_success_writes_telemetry_row(self, monkeypatch, db_session):
+        """On 200 OK, one row is inserted into decodo_scraping_usage."""
+        from decodo import DecodoScrapingClient
+
+        success_body = {
+            "results": [
+                {
+                    "status_code": 200,
+                    "content": "ok",
+                    "headers": {"x-foo": "bar"},
+                }
+            ]
+        }
+        _patch_httpx_post(
+            [_fake_httpx_response(status_code=200, body=success_body)], monkeypatch
+        )
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        await client.scrape(
+            "https://example.com/path",
+            proxy_pool="premium",
+            headless=True,
+            output_format="markdown",
+        )
+
+        result = await db_session.execute(
+            text(
+                "SELECT url, proxy_pool, headless, output_format, "
+                "target_status_code, decodo_http_status, "
+                "cost_estimate_usd, error FROM decodo_scraping_usage"
+            )
+        )
+        rows = result.fetchall()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row[0] == "https://example.com/path"
+        assert row[1] == "premium"
+        assert bool(row[2]) is True
+        assert row[3] == "markdown"
+        assert row[4] == 200  # target_status_code
+        assert row[5] == 200  # decodo_http_status
+        assert float(row[6]) == 0.00125  # premium + js cost
+        assert row[7] is None  # no error
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_failure_writes_telemetry_with_error(self, monkeypatch, db_session):
+        """On 4xx, a row is still written with the error text."""
+        from decodo import DecodoScrapingClient
+        from decodo.errors import DecodoRequestError
+
+        _patch_httpx_post(
+            [_fake_httpx_response(status_code=403, body="forbidden")],
+            monkeypatch,
+        )
+        monkeypatch.setattr(
+            "decodo.scraping_client.asyncio.sleep", AsyncMock(return_value=None)
+        )
+
+        client = DecodoScrapingClient(
+            api_key="Basic dGVzdA==", db_session=db_session
+        )
+        with pytest.raises(DecodoRequestError):
+            await client.scrape("https://example.com")
+
+        result = await db_session.execute(
+            text(
+                "SELECT decodo_http_status, target_status_code, error "
+                "FROM decodo_scraping_usage"
+            )
+        )
+        rows = result.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == 403
+        assert rows[0][1] is None
+        assert "403" in (rows[0][2] or "")


### PR DESCRIPTION
## Summary

Préalable bloquant Phase 1 (TikTok visual fallback, Scholar deep_search, YouTube unblock) + Phase 3 (Creator cross-platform, Brand monitor, Topic research). Cette PR provisionne le wrapper backend + table telemetry + env vars qui seront ensuite consommés par les features Phase 1/3.

**DISTINCT du proxy Residential** (`gate.decodo.com:7000`, env `YOUTUBE_PROXY`, instrumenté par #466). Ici c'est l'API Web Scraping (tier `$49/mois`, endpoint `scraper-api.decodo.com/v2/scrape`) qui fait JS render + Cloudflare bypass + Markdown AI-optimized output.

## Specs source (vault Obsidian)

- `01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase1-quick-wins.md` — Phase 1 (sub-agent A)
- `01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase3-new-features.md` — Phase 3 (sub-agent C)

Les deux specs convergent sur la même interface wrapper. Aucune divergence à résoudre.

## Fichiers créés

| Fichier | Rôle | LOC |
|---|---|---|
| `backend/src/decodo/__init__.py` | Public exports | 57 |
| `backend/src/decodo/errors.py` | `DecodoScrapingError` hierarchy (7 exceptions) | 75 |
| `backend/src/decodo/scraping_client.py` | `DecodoScrapingClient` async + retry + payload + parsing | 546 |
| `backend/src/decodo/telemetry.py` | Cost matrix + PG INSERT + monthly cap query | 285 |
| `backend/alembic/versions/033_decodo_scraping_usage.py` | Table telemetry | 110 |
| `backend/tests/decodo/test_scraping_client.py` | 19 unit tests | 605 |
| `backend/src/core/config.py` | +3 settings | +15 |
| `backend/.env.example` | +13 lignes docs/placeholder | +13 |

Total : 1706 insertions, 9 fichiers.

## Features wrapper

- **Retry policy** : 3 attempts avec exponential backoff (0.5s → 1s → 2s). Retry sur 5xx / timeout / connection error. PAS de retry sur 4xx (bubble up immédiat).
- **Kill-switch** : `DECODO_SCRAPING_DISABLED=true` → `DecodoDisabledError` raise, aucun HTTP. Pas de restart nécessaire.
- **Hard-stop budget mensuel** : `DECODO_SCRAPING_MAX_MONTHLY_REQ` (défaut 31360 = 80% de Premium+JS 39 200/mo cap). Compte les rows dans `decodo_scraping_usage` du mois en cours (cache TTL 60s).
- **Cost matrix** :
  | pool / js | False | True |
  |---|---|---|
  | standard | $0.50/1K | $0.65/1K |
  | premium | $0.90/1K | $1.25/1K |
- **Telemetry fire-and-forget** : 1 row par call dans `decodo_scraping_usage` (jamais bloquant). Capture url / pool / headless / format / status target / status decodo / cost / duration / error.
- **Output modes** : `raw_html` (défaut Decodo) ou `markdown` (AI-optimized, payload `output_format: "markdown"` — TODO Phase 1.2 confirmer le param exact via playground).

## Migration alembic

- Revision ID : `033_decodo_scraping_usage` (25 chars ≤ 32 ✓)
- down_revision : `032_users_apple_sub`
- Table `decodo_scraping_usage` (BIGSERIAL PK, index sur `created_at DESC`)
- Idempotente (create only if not exists)
- Compatible PostgreSQL + SQLite (tests locaux SQLite)

⚠️ **NE PAS appliquer la migration sur Hetzner depuis cette PR.** Étape post-merge Maxime :

```bash
ssh -i ~/.ssh/id_hetzner root@89.167.23.214 \
  "docker exec repo-backend-1 alembic upgrade heads"
```

## Tests

19/19 passent en local :

```bash
cd backend && python -m pytest tests/decodo/ -v
```

Couverture :
- Cost matrix (4 combos × 1 fallback) : 5 tests
- Happy path / retry / 4xx / timeout / exhaustion : 5 tests
- Hard-stops (disabled / budget / missing key) : 3 tests
- Payload shape (markdown / raw_html) : 2 tests
- Response parsing (malformed / empty results) : 2 tests
- Telemetry (success row / failure row) : 2 tests

Aucune régression sur `test_proxy_telemetry.py` (20/20 + 1 skip — vérifié).

## Env vars (placeholder, vraie clé Hetzner only)

```
DECODO_SCRAPING_API_KEY=Basic <paste-base64-from-decodo-dashboard>
DECODO_SCRAPING_DISABLED=false
DECODO_SCRAPING_MAX_MONTHLY_REQ=31360
```

## Pattern repris de PR #466

- Cache TTL 60s sur le compteur DB pour éviter de hammer
- Settings + raw-env fallback pour lire les flags
- Fire-and-forget telemetry (debug log si fail, jamais raise)
- Migration idempotente avec inspector check

## TODO post-merge

- [ ] Maxime : SSH Hetzner et `alembic upgrade heads`
- [ ] Maxime : ajouter `DECODO_SCRAPING_API_KEY` dans `/opt/deepsight/repo/.env.production`
- [ ] Maxime : `docker restart repo-backend-1`
- [ ] Phase 1.1 : intégrer dans `videos/visual_integration.py:_extract_tiktok_visual_frames` (3e fallback)
- [ ] Phase 1.2 : intégrer dans `academic/scholar.py:search_scholar()` (output_format=markdown + Mistral extract)
- [ ] Phase 1.3 : test cURL YouTube watch page avant intégration (cf spec § 6.2)
- [ ] Phase 1.2 follow-up : confirmer le nom exact du param Markdown via Decodo playground

## Refs vault internes

- `[[reference_decodo-residential-proxy]]` — Residential actif depuis 2026-05-12
- `[[project_sprint-decodo-wave1-2026-05-12]]` — sprint Decodo wave 1+2
- `[[reference_alembic-deepsight-conventions]]` — ≤32 chars + heads plural
- `[[reference_deepsight-hetzner-auto-deploy]]` — pas d'entrypoint.sh, migrations manuelles
- `[[feedback_fallback-bail-early-trap]]` — case study PR #468 dead-code 14h

🤖 Generated with [Claude Code](https://claude.com/claude-code)