### PR TITLE
feat(discover/search): TikTok platform via tikwm + toggle YT/TT mobile

### DIFF
--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -540,6 +540,84 @@ class YouTubeSearcher:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# 🎵 TIKTOK SEARCH VIA TIKWM
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TikTokSearcher:
+    """Recherche TikTok via l'API publique tikwm.com (no API key, no auth).
+
+    Empiriquement (2026-05-21) : depuis l'IP Hetzner sans proxy, le call
+    /api/feed/search retourne ~20 vidéos en 1.6s. Le proxy résidentiel
+    Decodo bloque cet endpoint — on appelle direct.
+    """
+
+    SEARCH_URL = "https://www.tikwm.com/api/feed/search"
+    SEARCH_TIMEOUT = 10.0
+
+    @classmethod
+    async def search(cls, query: str, max_results: int = 20):
+        if not query or not query.strip():
+            return []
+        try:
+            async with shared_http_client() as client:
+                response = await client.get(
+                    cls.SEARCH_URL,
+                    params={
+                        "keywords": query,
+                        "count": min(max_results, 30),
+                        "cursor": 0,
+                        "HD": 0,
+                    },
+                    timeout=cls.SEARCH_TIMEOUT,
+                )
+            if response.status_code != 200:
+                logger.warning(f"tikwm search HTTP {response.status_code}")
+                return []
+            payload = response.json()
+            if payload.get("code") != 0:
+                logger.warning(f"tikwm search error: {payload.get('msg')}")
+                return []
+            raw_videos = payload.get("data", {}).get("videos", []) or []
+            logger.info(f"🎵 tikwm found {len(raw_videos)} TikTok videos for '{query}'")
+            return [c for c in (cls._parse_video(v) for v in raw_videos) if c is not None]
+        except Exception as e:
+            logger.error(f"TikTok search error: {e}")
+            return []
+
+    @staticmethod
+    def _parse_video(raw):
+        try:
+            video_id = raw.get("video_id") or raw.get("aweme_id") or raw.get("id")
+            if not video_id:
+                return None
+            author = raw.get("author") or {}
+            create_time = raw.get("create_time", 0) or 0
+            try:
+                published_at = (
+                    datetime.fromtimestamp(int(create_time)) if create_time else datetime.now()
+                )
+            except (ValueError, OSError, OverflowError):
+                published_at = datetime.now()
+            title_text = (raw.get("title") or "").strip()
+            return VideoCandidate(
+                video_id=str(video_id),
+                title=title_text[:200] or "TikTok video",
+                channel=(author.get("nickname") or author.get("unique_id") or "TikTok").strip(),
+                channel_id=str(author.get("unique_id") or ""),
+                description=title_text[:500],
+                thumbnail_url=raw.get("cover") or raw.get("origin_cover") or "",
+                duration=int(raw.get("duration") or 0),
+                view_count=int(raw.get("play_count") or 0),
+                like_count=int(raw.get("digg_count") or 0),
+                published_at=published_at,
+            )
+        except Exception as e:
+            logger.error(f"Error parsing tikwm result: {e}")
+            return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # 📊 QUALITY SCORER
 # ═══════════════════════════════════════════════════════════════════════════════
 

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -4615,7 +4615,12 @@ async def create_all_study_materials(
 # 🔍 INTELLIGENT DISCOVERY — Recherche intelligente de vidéos
 # ═══════════════════════════════════════════════════════════════════════════════
 
-from .intelligent_discovery import IntelligentDiscoveryService, generate_text_video_id, validate_raw_text
+from .intelligent_discovery import (
+    IntelligentDiscoveryService,
+    TikTokSearcher,
+    generate_text_video_id,
+    validate_raw_text,
+)
 from .schemas import (
     SmartDiscoveryRequest,
     DiscoveryResponse,
@@ -4716,12 +4721,23 @@ async def discover_best_video(
         raise HTTPException(status_code=500, detail=f"Erreur: {str(e)}")
 
 
+def _build_youtube_url(video_id: str) -> str:
+    return f"https://www.youtube.com/watch?v={video_id}"
+
+
+def _build_tiktok_url(video_id: str, channel_id: str) -> str:
+    if channel_id:
+        return f"https://www.tiktok.com/@{channel_id}/video/{video_id}"
+    return f"https://www.tiktok.com/video/{video_id}"
+
+
 @router.post("/discover/search")
 async def discover_search_videos(
     query: str = Query(..., description="Requête de recherche"),
     languages: str = Query("fr,en", description="Langues séparées par virgule"),
     limit: int = Query(15, ge=1, le=50, description="Nombre max de résultats"),
     sort_by: str = Query("quality", description="Tri: quality, views, date, academic"),
+    platform: str = Query("youtube", regex="^(youtube|tiktok)$", description="youtube | tiktok"),
     current_user: User = Depends(get_current_user),
 ):
     """
@@ -4730,14 +4746,49 @@ async def discover_search_videos(
     GRATUIT - Ne consomme pas de crédits.
     Retourne toujours { videos: [...], total: N, query: str }, jamais de 404.
     """
-    logger.info(f"🔍 [DISCOVER/SEARCH] User {current_user.email} query='{query}' sort={sort_by} limit={limit}")
-
-    lang_list = [l.strip() for l in languages.split(",")]
+    logger.info(
+        f"🔍 [DISCOVER/SEARCH] User {current_user.email} query='{query}' "
+        f"platform={platform} sort={sort_by} limit={limit}"
+    )
 
     try:
-        # 🛡️ Backstop 25s : si discover() hang sur Mistral/yt-dlp, on coupe net
-        # et on renvoie une liste vide plutôt que de laisser le mobile attendre
-        # son propre timeout 30s. Évite "ça charge à l'infini" côté UI.
+        if platform == "tiktok":
+            candidates = await asyncio.wait_for(
+                TikTokSearcher.search(query, max_results=limit),
+                timeout=15.0,
+            )
+            videos = [
+                {
+                    "video_id": c.video_id,
+                    "title": c.title,
+                    "channel": c.channel,
+                    "thumbnail_url": c.thumbnail_url,
+                    "duration": c.duration,
+                    "view_count": c.view_count,
+                    "quality_score": 0,
+                    "tournesol_score": 0,
+                    "published_at": c.published_at.isoformat() if c.published_at else None,
+                    "is_tournesol_pick": False,
+                    "platform": "tiktok",
+                    "video_url": _build_tiktok_url(c.video_id, c.channel_id),
+                }
+                for c in candidates
+            ]
+            if sort_by == "date":
+                videos.sort(key=lambda v: v["published_at"] or "", reverse=True)
+            else:
+                videos.sort(key=lambda v: v["view_count"], reverse=True)
+            videos = videos[:limit]
+            logger.info(f"✅ [DISCOVER/SEARCH] Returning {len(videos)} TikTok videos")
+            return {
+                "videos": videos,
+                "total": len(videos),
+                "query": query,
+                "platform": "tiktok",
+            }
+
+        lang_list = [l.strip() for l in languages.split(",")]
+
         result = await asyncio.wait_for(
             IntelligentDiscoveryService.discover(
                 query=query,
@@ -4748,7 +4799,6 @@ async def discover_search_videos(
             timeout=25.0,
         )
 
-        # Convert candidates to dicts
         videos = []
         for c in result.candidates:
             d = c.to_dict()
@@ -4764,6 +4814,8 @@ async def discover_search_videos(
                     "tournesol_score": d.get("tournesol_score", 0),
                     "published_at": d.get("published_at"),
                     "is_tournesol_pick": d.get("is_tournesol_pick", False),
+                    "platform": "youtube",
+                    "video_url": _build_youtube_url(d.get("video_id", "")),
                 }
             )
 

--- a/mobile/src/components/home/YouTubeSearch.tsx
+++ b/mobile/src/components/home/YouTubeSearch.tsx
@@ -31,7 +31,11 @@ interface VideoResult {
   tournesol_score: number;
   published_at: string | null;
   is_tournesol_pick: boolean;
+  platform?: "youtube" | "tiktok";
+  video_url?: string;
 }
+
+type SearchPlatform = "youtube" | "tiktok";
 
 interface YouTubeSearchProps {
   onOptionsPress: () => void;
@@ -66,6 +70,7 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
   const [analyzingId, setAnalyzingId] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [platform, setPlatform] = useState<SearchPlatform>("youtube");
 
   const handleSearch = useCallback(async () => {
     const trimmed = query.trim();
@@ -77,14 +82,17 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
     setError(null);
     setHasSearched(true);
 
+    const platformLabel = platform === "tiktok" ? "TikTok" : "YouTube";
+
     try {
       const response = await videoApi.discoverSearch(trimmed, {
         limit: 20,
         language: options.language || "fr,en",
         sort_by: "quality",
+        platform,
       });
       if (response.timeout) {
-        setError("Recherche YouTube indisponible — réessaie dans un instant.");
+        setError(`Recherche ${platformLabel} indisponible — réessaie dans un instant.`);
         setResults([]);
       } else {
         setResults(response.videos || []);
@@ -96,7 +104,7 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
           err.message.toLowerCase().includes("timeout") ||
           err.message.toLowerCase().includes("abort")
         ) {
-          message = "Recherche trop lente — réessaie dans un instant.";
+          message = `Recherche ${platformLabel} trop lente — réessaie dans un instant.`;
         } else {
           message = err.message;
         }
@@ -106,7 +114,18 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
     } finally {
       setIsSearching(false);
     }
-  }, [query, isSearching, options.language]);
+  }, [query, isSearching, options.language, platform]);
+
+  const handleSwitchPlatform = useCallback((next: SearchPlatform) => {
+    setPlatform((current) => {
+      if (current === next) return current;
+      Haptics.selectionAsync();
+      setResults([]);
+      setHasSearched(false);
+      setError(null);
+      return next;
+    });
+  }, []);
 
   const handleAnalyze = useCallback(
     async (video: VideoResult) => {
@@ -117,7 +136,9 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
       setError(null);
 
       try {
-        const videoUrl = `https://www.youtube.com/watch?v=${video.video_id}`;
+        const videoUrl =
+          video.video_url ||
+          `https://www.youtube.com/watch?v=${video.video_id}`;
         const response = await videoApi.analyze({
           url: videoUrl,
           mode: options.mode,
@@ -250,6 +271,64 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
 
   return (
     <View style={styles.wrapper}>
+      {/* Platform toggle */}
+      <View
+        style={[
+          styles.platformToggle,
+          { backgroundColor: colors.glassBg, borderColor: colors.glassBorder },
+        ]}
+        accessibilityRole="tablist"
+      >
+        <Pressable
+          onPress={() => handleSwitchPlatform("youtube")}
+          style={[
+            styles.platformOption,
+            platform === "youtube" && { backgroundColor: palette.indigo },
+          ]}
+          accessibilityRole="tab"
+          accessibilityState={{ selected: platform === "youtube" }}
+          accessibilityLabel="Rechercher sur YouTube"
+        >
+          <Ionicons
+            name="logo-youtube"
+            size={16}
+            color={platform === "youtube" ? "#ffffff" : colors.textSecondary}
+          />
+          <Text
+            style={[
+              styles.platformLabel,
+              { color: platform === "youtube" ? "#ffffff" : colors.textSecondary },
+            ]}
+          >
+            YouTube
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={() => handleSwitchPlatform("tiktok")}
+          style={[
+            styles.platformOption,
+            platform === "tiktok" && { backgroundColor: palette.indigo },
+          ]}
+          accessibilityRole="tab"
+          accessibilityState={{ selected: platform === "tiktok" }}
+          accessibilityLabel="Rechercher sur TikTok"
+        >
+          <Ionicons
+            name="musical-notes"
+            size={16}
+            color={platform === "tiktok" ? "#ffffff" : colors.textSecondary}
+          />
+          <Text
+            style={[
+              styles.platformLabel,
+              { color: platform === "tiktok" ? "#ffffff" : colors.textSecondary },
+            ]}
+          >
+            TikTok
+          </Text>
+        </Pressable>
+      </View>
+
       {/* Search bar */}
       <View
         style={[
@@ -269,7 +348,11 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
         <TextInput
           ref={inputRef}
           style={[styles.searchInput, { color: colors.textPrimary }]}
-          placeholder="Rechercher une vidéo YouTube / TikTok..."
+          placeholder={
+            platform === "tiktok"
+              ? "Rechercher une vidéo TikTok..."
+              : "Rechercher une vidéo YouTube..."
+          }
           placeholderTextColor={colors.textMuted}
           value={query}
           onChangeText={(text) => {
@@ -394,6 +477,27 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
 const styles = StyleSheet.create({
   wrapper: {
     marginBottom: sp.md,
+  },
+  platformToggle: {
+    flexDirection: "row",
+    alignSelf: "flex-start",
+    padding: 4,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    marginBottom: sp.sm,
+    gap: 4,
+  },
+  platformOption: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: sp.md,
+    paddingVertical: sp.xs,
+    borderRadius: borderRadius.full,
+  },
+  platformLabel: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
   },
   searchContainer: {
     flexDirection: "row",

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -903,6 +903,7 @@ export const videoApi = {
       limit?: number;
       language?: string;
       sort_by?: "quality" | "views" | "date" | "academic";
+      platform?: "youtube" | "tiktok";
     },
   ): Promise<{
     videos: Array<{
@@ -916,9 +917,12 @@ export const videoApi = {
       tournesol_score: number;
       published_at: string | null;
       is_tournesol_pick: boolean;
+      platform?: "youtube" | "tiktok";
+      video_url?: string;
     }>;
     total: number;
     query: string;
+    platform?: "youtube" | "tiktok";
     timeout?: boolean;
   }> {
     const langs = options?.language || "fr,en";
@@ -927,6 +931,7 @@ export const videoApi = {
       languages: langs,
       limit: String(options?.limit || 20),
       sort_by: options?.sort_by || "quality",
+      platform: options?.platform || "youtube",
     });
     // Backend has a 25s backstop (returns 200 with timeout:true). We keep a 30s
     // client timeout for headroom + network latency, then surface the timeout


### PR DESCRIPTION
## UX

Toggle au-dessus de la barre de recherche sur la page d'accueil mobile :
- **YouTube** (par défaut, comportement existant)
- **TikTok** (nouveau)

Pas de feed mixte — un toggle, un type de résultats. Switcher reset les résultats.

## Backend

- **`TikTokSearcher`** dans `intelligent_discovery.py` — appelle l'API publique `tikwm.com/api/feed/search` depuis l'IP Hetzner (sans le proxy résidentiel Decodo qui bloque cet endpoint). Empiriquement 1.6s pour ~20 résultats.
- **Param `platform`** sur `POST /api/videos/discover/search` (`youtube` | `tiktok`). TikTok skip tout le pipeline Mistral/yt-dlp/scoring multi-critère — juste tikwm + tri par play_count. Backstop 15s.
- Chaque résultat retourne maintenant **`platform`** + **`video_url`** (`https://www.tiktok.com/@author/video/{id}` pour TT).

## Mobile

- **`discoverSearch`** accepte `platform`, type le retour avec `platform` + `video_url?`.
- **Toggle pill YT|TT** au-dessus de la barre de recherche (`YouTubeSearch.tsx`).
- **`handleAnalyze`** utilise `video.video_url` (fallback YT pour rétro-compat) au lieu de construire en dur l'URL YouTube. Permet d'analyser les vidéos TikTok via le pipeline visual_analysis déjà en place.
- Message d'erreur dynamique selon la plateforme.

## Note sur le diff

Le diff énorme (+11k/-11k) vient d'une normalisation line-endings (CRLF → LF) appliquée par le patch script. Les changements fonctionnels sont localisés :
- `intelligent_discovery.py` : ajout classe `TikTokSearcher` (~85 lignes)
- `router.py` : ajout helpers `_build_*_url`, param `platform`, branche `if platform == "tiktok"` (~60 lignes)
- `api.ts` : ajout `platform?` dans options + response type (~5 lignes)
- `YouTubeSearch.tsx` : toggle UI + state + handleSwitchPlatform + dynamic placeholder/error (~130 lignes)

## Test plan

- [ ] Auto-deploy Hetzner
- [ ] EAS OTA mobile
- [ ] App mobile : toggle YouTube → recherche, toggle TikTok → recherche, vérifier que les 2 plateformes retournent des résultats et que tap sur une vidéo lance l'analyse

Pas de migration DB. Pas de changement de scoring multi-critère YouTube.

🤖 Generated with [Claude Code](https://claude.com/claude-code)