### PR TITLE
Wave 1 Step 5 — Migrate python-jose -> PyJWT (CVE-2024-33664/33663 remediation)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -60,7 +60,7 @@ async def pro_endpoint(user: User = Depends(require_plan("pro"))):
 |---|---|---|
 | Access token TTL | **60 min** | `ACCESS_TOKEN_TTL_MIN` |
 | Refresh token TTL | **30 jours** | `REFRESH_TOKEN_TTL_DAYS` |
-| Lib JWT | `python-jose[cryptography]` | (pyjwt migration différée V2 — CVE-2024-33664/33663 à surveiller) |
+| Lib JWT | `PyJWT[crypto]` (Wave 1 Step 5, 2026-05-21 — migrée depuis python-jose pour CVE-2024-33664 + CVE-2024-33663) | — |
 | Blocklist | Redis `auth:blocklist:{sha256(token)[:32]}` avec TTL=exp | `REDIS_URL` (fallback in-RAM si absent) |
 
 Avant Sprint C : 7 j / 365 j + blocklist in-RAM (perdue à chaque `docker run`).

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,7 +23,10 @@ greenlet>=3.0.0          # Required for SQLAlchemy async
 # ─────────────────────────────────────────────────────────────────────────────────
 # 🔐 AUTHENTICATION
 # ─────────────────────────────────────────────────────────────────────────────────
-python-jose[cryptography]>=3.4.0
+# Wave 1 Step 5 (2026-05-21) — migrated python-jose → PyJWT[crypto] for
+# CVE-2024-33664 (DoS via decode) and CVE-2024-33663 (algorithm confusion).
+# PyJWT is the actively maintained, audited reference JWT library.
+PyJWT[crypto]>=2.8.0
 passlib>=1.7.4
 bcrypt>=4.0.0            # Secure password hashing
 authlib>=1.3.0           # OAuth (Google)

--- a/backend/src/auth/service.py
+++ b/backend/src/auth/service.py
@@ -19,6 +19,7 @@
 """
 
 import hashlib
+import json
 import os
 import re
 import secrets
@@ -26,7 +27,21 @@ import uuid
 import httpx
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
-from jose import jwt, JWTError
+
+# Wave 1 Step 5 (2026-05-21) — Migration python-jose → PyJWT[crypto].
+# Motivation : CVE-2024-33664 (DoS via decode) + CVE-2024-33663 (algorithm
+# confusion) sur python-jose, non-patched upstream. PyJWT est la lib JWT
+# Python de référence, activement maintenue + audit régulier.
+#
+# Compat layer : `JWTError` est aliasé sur `PyJWTError` pour garder les
+# `except JWTError as e` existants. PyJWT.encode/decode ont une API
+# quasi-identique (mêmes kwargs `algorithm`/`algorithms`/`audience`/`issuer`).
+# Différence notable côté Apple Sign-in : pas de `jwk.construct(dict)` —
+# on utilise `jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(dict))` qui
+# retourne directement une RSAPublicKey passable comme `key` à `jwt.decode`.
+import jwt
+from jwt.exceptions import PyJWTError as JWTError
+from jwt.algorithms import RSAAlgorithm
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -887,20 +902,32 @@ async def verify_apple_id_token(id_token_str: str, client_platform: str = "web")
         log.warning("Apple id_token header missing 'kid'")
         return None
 
-    matching_key = next((k for k in jwks["keys"] if k.get("kid") == kid), None)
-    if not matching_key:
+    matching_jwk = next((k for k in jwks["keys"] if k.get("kid") == kid), None)
+    if not matching_jwk:
         log.warning(f"Apple id_token: no JWK matches kid={kid}")
         # Force-refresh cache au cas ou Apple a tourne ses cles
         _APPLE_JWKS_CACHE.pop("jwks", None)
         return None
 
-    # Try each allowed audience (jose.decode prend une seule audience a la fois)
+    # Wave 1 Step 5 — Migration jose → PyJWT.
+    # jose acceptait un dict JWK direct comme `key`. PyJWT veut une clé
+    # cryptographic object → on construit la RSAPublicKey explicitement
+    # via `RSAAlgorithm.from_jwk(json_str)`. Échec ici = JWK Apple corrompu
+    # ou format inattendu → on log + return None (équivalent au comportement
+    # jose qui levait JWTError plus bas dans le decode).
+    try:
+        public_key = RSAAlgorithm.from_jwk(json.dumps(matching_jwk))
+    except (ValueError, TypeError, JWTError) as e:
+        log.warning(f"Apple id_token: cannot construct RSA key from JWK: {e}")
+        return None
+
+    # Try each allowed audience (jwt.decode prend une seule audience a la fois)
     last_error: Optional[Exception] = None
     for audience in allowed_audiences:
         try:
             claims = jwt.decode(
                 id_token_str,
-                matching_key,
+                public_key,
                 algorithms=["RS256"],
                 audience=audience,
                 issuer=APPLE_ISSUER,

--- a/backend/tests/conftest_enhanced.py
+++ b/backend/tests/conftest_enhanced.py
@@ -12,7 +12,9 @@ import json
 from typing import AsyncGenerator, Dict, Any, Optional
 from unittest.mock import MagicMock, AsyncMock, patch
 from datetime import datetime, timedelta
-from jose import jwt
+
+# Wave 1 Step 5 (2026-05-21) — Migration python-jose → PyJWT[crypto].
+import jwt
 
 # Importer depuis conftest existant
 from conftest import (

--- a/backend/tests/test_auth_comprehensive.py
+++ b/backend/tests/test_auth_comprehensive.py
@@ -19,7 +19,10 @@ Total: 45 tests
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime, timedelta
-from jose import jwt, JWTError
+
+# Wave 1 Step 5 (2026-05-21) — Migration python-jose → PyJWT[crypto].
+import jwt
+from jwt.exceptions import PyJWTError as JWTError
 from fastapi import HTTPException
 
 from conftest_enhanced import (

--- a/backend/tests/test_pyjwt_apple_compat.py
+++ b/backend/tests/test_pyjwt_apple_compat.py
@@ -1,0 +1,259 @@
+"""PyJWT Apple Sign-in compat tests.
+
+Wave 1 Step 5 (2026-05-21) — Migration python-jose → PyJWT[crypto].
+Couvre spécifiquement le chemin critique Apple Sign-in qui utilisait
+`jose.jwk.construct(dict)` et qui est désormais migré vers
+`jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(dict))`.
+
+Approche : on génère une RSA keypair localement, on construit un JWT signé
+RS256 avec les claims Apple typiques (sub, email, aud, iss, exp), on expose
+la clé publique sous forme JWK, et on vérifie que :
+
+  1. Le decode PyJWT avec une RSAPublicKey construite via
+     `RSAAlgorithm.from_jwk(json.dumps(jwk))` accepte le JWT et renvoie
+     les claims attendus.
+  2. Le decode avec audience mismatch lève une JWTError (= PyJWTError) —
+     compatibilité du except clause existant dans `verify_apple_id_token`.
+  3. Le decode avec issuer mismatch lève aussi une JWTError.
+  4. Le decode d'un JWT expiré lève `ExpiredSignatureError` (sous-classe de
+     PyJWTError → catché par `except JWTError`).
+  5. `get_unverified_header()` extrait `kid` correctement avant verification.
+
+Pourquoi pas test E2E `verify_apple_id_token` : la fonction fetch un JWKS
+distant via httpx — mocker tout le httpx + asyncio est lourd, et le bug
+le plus probable de la migration est exactement le from_jwk → decode
+chemin, qui est ce que ce test exerce directement.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+from jwt.exceptions import PyJWTError as JWTError, ExpiredSignatureError, InvalidAudienceError, InvalidIssuerError
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Fixtures — RSA keypair + JWK + signed JWT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def rsa_keypair():
+    """Génère une paire RSA-2048 fraîche (équivalent format Apple JWKS)."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend(),
+    )
+    public_key = private_key.public_key()
+    return private_key, public_key
+
+
+@pytest.fixture
+def rsa_jwk(rsa_keypair):
+    """Convertit la clé publique en JWK dict (format identique à Apple JWKS)."""
+    _, public_key = rsa_keypair
+    # PyJWT a une méthode utilitaire pour générer le JWK depuis la clé publique
+    jwk_json = RSAAlgorithm.to_jwk(public_key)
+    jwk_dict = json.loads(jwk_json)
+    # Apple JWKS ajoute toujours kid, alg, use, kty — on simule ce shape
+    jwk_dict.setdefault("kid", "test-kid-2026-05-21")
+    jwk_dict.setdefault("alg", "RS256")
+    jwk_dict.setdefault("use", "sig")
+    return jwk_dict
+
+
+@pytest.fixture
+def apple_audience():
+    return "com.deepsight.app"
+
+
+@pytest.fixture
+def apple_issuer():
+    return "https://appleid.apple.com"
+
+
+@pytest.fixture
+def signed_apple_jwt(rsa_keypair, apple_audience, apple_issuer):
+    """Génère un JWT RS256 signé avec les claims Apple typiques."""
+    private_key, _ = rsa_keypair
+    now = datetime.now(timezone.utc)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    payload = {
+        "sub": "001234.abcdef.5678",
+        "email": "user@privaterelay.appleid.com",
+        "email_verified": "true",
+        "is_private_email": "true",
+        "aud": apple_audience,
+        "iss": apple_issuer,
+        "exp": int((now + timedelta(hours=1)).timestamp()),
+        "iat": int(now.timestamp()),
+    }
+    headers = {"kid": "test-kid-2026-05-21", "alg": "RS256"}
+    return jwt.encode(payload, private_pem, algorithm="RS256", headers=headers)
+
+
+@pytest.fixture
+def expired_apple_jwt(rsa_keypair, apple_audience, apple_issuer):
+    """JWT déjà expiré (exp -1h)."""
+    private_key, _ = rsa_keypair
+    now = datetime.now(timezone.utc)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    payload = {
+        "sub": "001234.abcdef.5678",
+        "aud": apple_audience,
+        "iss": apple_issuer,
+        "exp": int((now - timedelta(hours=1)).timestamp()),
+        "iat": int((now - timedelta(hours=2)).timestamp()),
+    }
+    headers = {"kid": "test-kid-2026-05-21", "alg": "RS256"}
+    return jwt.encode(payload, private_pem, algorithm="RS256", headers=headers)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_from_jwk_constructs_rsa_public_key(rsa_jwk):
+    """`RSAAlgorithm.from_jwk(json.dumps(jwk))` retourne une clé exploitable."""
+    public_key = RSAAlgorithm.from_jwk(json.dumps(rsa_jwk))
+    # Doit être une RSAPublicKey de cryptography, pas un dict ou None
+    assert hasattr(public_key, "public_numbers"), (
+        "RSAAlgorithm.from_jwk doit retourner une RSAPublicKey, pas un wrapper opaque"
+    )
+
+
+def test_decode_with_jwk_key_returns_claims(signed_apple_jwt, rsa_jwk, apple_audience, apple_issuer):
+    """Le decode PyJWT avec key construite via from_jwk renvoie les claims Apple."""
+    public_key = RSAAlgorithm.from_jwk(json.dumps(rsa_jwk))
+    claims = jwt.decode(
+        signed_apple_jwt,
+        public_key,
+        algorithms=["RS256"],
+        audience=apple_audience,
+        issuer=apple_issuer,
+    )
+    assert claims["sub"] == "001234.abcdef.5678"
+    assert claims["email"] == "user@privaterelay.appleid.com"
+    assert claims["aud"] == apple_audience
+    assert claims["iss"] == apple_issuer
+
+
+def test_decode_with_audience_mismatch_raises_jwterror(signed_apple_jwt, rsa_jwk, apple_issuer):
+    """Audience mismatch → InvalidAudienceError (sous-classe de PyJWTError = JWTError alias)."""
+    public_key = RSAAlgorithm.from_jwk(json.dumps(rsa_jwk))
+    with pytest.raises(JWTError):
+        jwt.decode(
+            signed_apple_jwt,
+            public_key,
+            algorithms=["RS256"],
+            audience="com.wrong.audience",
+            issuer=apple_issuer,
+        )
+    # Vérification supplémentaire : la sous-classe précise est InvalidAudienceError
+    with pytest.raises(InvalidAudienceError):
+        jwt.decode(
+            signed_apple_jwt,
+            public_key,
+            algorithms=["RS256"],
+            audience="com.wrong.audience",
+            issuer=apple_issuer,
+        )
+
+
+def test_decode_with_issuer_mismatch_raises_jwterror(signed_apple_jwt, rsa_jwk, apple_audience):
+    """Issuer mismatch → InvalidIssuerError (sous-classe de PyJWTError)."""
+    public_key = RSAAlgorithm.from_jwk(json.dumps(rsa_jwk))
+    with pytest.raises(JWTError):
+        jwt.decode(
+            signed_apple_jwt,
+            public_key,
+            algorithms=["RS256"],
+            audience=apple_audience,
+            issuer="https://wrong.issuer.example",
+        )
+    with pytest.raises(InvalidIssuerError):
+        jwt.decode(
+            signed_apple_jwt,
+            public_key,
+            algorithms=["RS256"],
+            audience=apple_audience,
+            issuer="https://wrong.issuer.example",
+        )
+
+
+def test_decode_expired_jwt_raises_jwterror(expired_apple_jwt, rsa_jwk, apple_audience, apple_issuer):
+    """JWT expiré → ExpiredSignatureError (sous-classe d'InvalidTokenError → PyJWTError)."""
+    public_key = RSAAlgorithm.from_jwk(json.dumps(rsa_jwk))
+    with pytest.raises(JWTError):
+        jwt.decode(
+            expired_apple_jwt,
+            public_key,
+            algorithms=["RS256"],
+            audience=apple_audience,
+            issuer=apple_issuer,
+        )
+    with pytest.raises(ExpiredSignatureError):
+        jwt.decode(
+            expired_apple_jwt,
+            public_key,
+            algorithms=["RS256"],
+            audience=apple_audience,
+            issuer=apple_issuer,
+        )
+
+
+def test_get_unverified_header_extracts_kid(signed_apple_jwt):
+    """`jwt.get_unverified_header()` extrait `kid` sans valider la signature.
+
+    C'est l'étape #1 du flow Apple : on a besoin de `kid` pour sélectionner
+    la bonne clé JWK dans la JWKS, AVANT de pouvoir vérifier la signature.
+    """
+    header = jwt.get_unverified_header(signed_apple_jwt)
+    assert header["kid"] == "test-kid-2026-05-21"
+    assert header["alg"] == "RS256"
+
+
+def test_get_unverified_header_malformed_jwt_raises_jwterror():
+    """Un JWT mal formé → JWTError (catché dans verify_apple_id_token)."""
+    with pytest.raises(JWTError):
+        jwt.get_unverified_header("not.a.jwt")
+
+
+def test_apple_jwk_dict_with_extra_fields_still_constructs(rsa_jwk):
+    """Apple ajoute parfois des champs au JWK (`use`, `alg`, `kid`) — from_jwk doit les tolérer."""
+    # On enrichit le JWK comme le ferait Apple
+    enriched = {**rsa_jwk, "extra_field_apple_may_add": "ignored"}
+    # Doit toujours construire la clé sans erreur (champs non-reconnus ignorés)
+    public_key = RSAAlgorithm.from_jwk(json.dumps(enriched))
+    assert hasattr(public_key, "public_numbers")
+
+
+def test_pyjwt_error_alias_is_pyjwt_exception_base():
+    """Sanity check : `JWTError` alias = `jwt.PyJWTError` (= base de TOUTES exceptions PyJWT).
+
+    Garantit que les `except JWTError` existants dans auth.service catchent
+    bien TOUS les cas d'erreur PyJWT, identique au comportement legacy avec
+    `from jose import JWTError`.
+    """
+    assert JWTError is jwt.PyJWTError
+    # Toutes les exceptions PyJWT héritent de PyJWTError
+    assert issubclass(jwt.ExpiredSignatureError, JWTError)
+    assert issubclass(jwt.InvalidTokenError, JWTError)
+    assert issubclass(jwt.InvalidSignatureError, JWTError)
+    assert issubclass(InvalidAudienceError, JWTError)
+    assert issubclass(InvalidIssuerError, JWTError)


### PR DESCRIPTION
## Summary

Migrate the DeepSight backend auth surface from `python-jose[cryptography]` to `PyJWT[crypto]>=2.8.0`.

**Why now**: `python-jose` has two unpatched vulnerabilities upstream:
- **CVE-2024-33664** — DoS via `decode()`
- **CVE-2024-33663** — algorithm confusion

`PyJWT[crypto]` is the actively maintained reference JWT library for Python, audited regularly. Sprint C deferred this migration because of the Apple Sign-in flow (RS256 + JWK + audience + issuer) where the jose vs PyJWT APIs diverge. This PR resolves that.

## Behavior changes

### Wire-compatible (zero-effort)
- `jwt.encode(payload, key, algorithm=...)` — same signature, same return (str)
- `jwt.decode(token, key, algorithms=[...], audience=..., issuer=..., options=...)` — same signature, same return (dict)
- `jwt.get_unverified_header(token)` — same signature, same return

All v1/v2 token helpers (`create_access_token`, `create_refresh_token`, `verify_token`, `get_token_session`, `create_refresh_token_v2`, `create_access_token_v2`) require zero behavior changes.

### Aliased (compat layer)
- `from jwt.exceptions import PyJWTError as JWTError` — `PyJWTError` is the base class of all PyJWT exceptions, so `except JWTError as e` clauses catch the same surface as before. Validated by `test_pyjwt_error_alias_is_pyjwt_exception_base`.

### Breaking (one localized fix)
**Apple Sign-in JWK loading** (`verify_apple_id_token`):
- `jose` accepted a raw JWK dict as `key` argument of `decode()`.
- `PyJWT` requires a proper cryptographic key object.
- Fix: build the `RSAPublicKey` explicitly via `RSAAlgorithm.from_jwk(json.dumps(jwk_dict))` BEFORE the audience loop, then pass the result as `key` to `jwt.decode`.
- Error during JWK→key construction (corrupted JWK from Apple) is logged and returns `None` — same observable behavior as the legacy code which would have raised `JWTError` inside `decode()`.

## Apple Sign-in regression coverage

NEW `backend/tests/test_pyjwt_apple_compat.py` — 9 tests that exercise the exact code path that was at risk. Generates a real RSA-2048 keypair, signs a JWT with Apple-shaped claims (`sub`/`email`/`aud`/`iss`/`exp`), exposes the public key as a JWKS-shaped dict, and verifies:

1. `RSAAlgorithm.from_jwk(json.dumps(jwk))` returns a usable `RSAPublicKey`.
2. `jwt.decode(token, public_key, algorithms=["RS256"], audience=..., issuer=...)` returns the expected claims.
3. Audience mismatch → `JWTError` (and specifically `InvalidAudienceError`).
4. Issuer mismatch → `JWTError` (`InvalidIssuerError`).
5. Expired JWT → `JWTError` (`ExpiredSignatureError`).
6. `jwt.get_unverified_header()` extracts `kid` correctly (step 1 of the Apple flow, runs BEFORE signature verification).
7. Malformed JWT → `JWTError` on `get_unverified_header`.
8. JWK with extra fields Apple may add → still constructs successfully.
9. `JWTError` alias = `jwt.PyJWTError` (= base of all PyJWT exceptions).

## Test plan

- [x] Existing test suite passes — `backend/tests/test_auth_comprehensive.py` (52 tests) + `backend/tests/test_auth_service_v2.py` (32 tests) — **84/84 PASSING**
- [x] New Apple JWK compat tests — `backend/tests/test_pyjwt_apple_compat.py` — **9/9 PASSING**
- [x] Total: **93/93 PASSING** on the auth surface
- [x] `ruff check` on all 5 modified files — clean
- [x] Import smoke test on `auth.service` confirms PyJWT bindings resolve (`JWTError is jwt.PyJWTError`, `RSAAlgorithm.from_jwk` callable)
- [ ] CI run on the PR (Linux + Python 3.11) — expected green
- [ ] Manual smoke on staging Apple Sign-in flow before merge — recommended

## Files changed

| File | Change |
|------|--------|
| `backend/requirements.txt` | swap `python-jose[cryptography]>=3.4.0` for `PyJWT[crypto]>=2.8.0` |
| `backend/CLAUDE.md` | doc the migration in the JWT/TTL section |
| `backend/src/auth/service.py` | import migration + Apple JWK loading via `RSAAlgorithm.from_jwk` |
| `backend/tests/conftest_enhanced.py` | replace `from jose import jwt` with `import jwt` |
| `backend/tests/test_auth_comprehensive.py` | replace `from jose import jwt, JWTError` with PyJWT equivalent |
| `backend/tests/test_pyjwt_apple_compat.py` | **NEW** — 9 Apple JWK compat tests |

Note: `backend/tests/test_auth_flow.py` has a pre-existing circular-import collection error on Windows local — unrelated to this PR (same error on `feat/auth-v2-wave1-step2-service-refactor`).

## Stacked PR

Based on `feat/auth-v2-wave1-step2-service-refactor` (Wave 1 Step 2). Will auto-rebase to `main` once #527 merges.

## DO NOT MERGE

Per task spec — leave open for review.