### PR TITLE
test(discover): skip TestSourceLevelLock class (obsolete after PR #525)

### DIFF
--- a/backend/tests/videos/test_intelligent_discovery_proxy.py
+++ b/backend/tests/videos/test_intelligent_discovery_proxy.py
@@ -142,9 +142,19 @@ class TestYouTubeSearcherProxy:
         assert "foo bar" in cmd[-1]
 
 
+@pytest.mark.skip(
+    reason="Obsolete after PR #525 — ytsearch path no longer uses --proxy nor "
+    "*_yt_dlp_extra_args() splat (perf fix : 25.5s/0 → 1.5s/20 results from "
+    "Hetzner IP). Source-level locks pointaient l'ancienne implémentation. "
+    "Tracking : follow-up task « Rewrite proxy test for post-#525 behavior »."
+)
 class TestSourceLevelLock:
     """Source-level smoke : ensure the proxy helper import + injection
-    don't accidentally regress."""
+    don't accidentally regress.
+
+    NOTE 2026-05-21 : entire class skipped — PR #525 retire ces patterns
+    intentionnellement. Rewrite TODO en follow-up task.
+    """
 
     def test_imports_yt_dlp_extra_args(self):
         """The fix relies on `_yt_dlp_extra_args` being callable from this module.


### PR DESCRIPTION
## Summary

Suite de PR #531 (skip `test_proxy_injected_when_set`). Le CI sur PR #527 / #529 a révélé un second test obsolète du même fichier : `TestSourceLevelLock::test_ytsearch_cmd_includes_extra_args_splat` assert que `*_yt_dlp_extra_args()` apparaît dans le source de `intelligent_discovery.py`. Mais PR #525 a retiré ce splat (perf : 25.5s/0 → 1.5s/20 results).

## Fix

Class-level `@pytest.mark.skip` sur `TestSourceLevelLock` (couvre les 2 tests de la classe).

## Test plan

- [ ] CI Lint vert
- [ ] CI Backend Pytest vert (3 tests SKIPPED désormais — 1 du #531, 2 du #532)
- [ ] Cascade : Wave 1 PRs auto-unlocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)