### PR TITLE
Wave 1 Step 3 — Sessions endpoints + Re-auth scopé

### DIFF
--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -12,14 +12,32 @@
 
 import os
 import logging
+from typing import Callable, Optional
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer, HTTPBearer, HTTPAuthorizationCredentials
+from jose import ExpiredSignatureError, JWTError, jwt
 from sqlalchemy.ext.asyncio import AsyncSession
-from typing import Optional
 
+import core.config as _core_config
 from db.database import get_session, User
 from .service import verify_token, get_user_by_id, validate_session_token
+
+
+def _jwt_config() -> dict:
+    """Lookup JWT_CONFIG at call time, not import time.
+
+    Workaround pour le test suite qui reload `core.config` via
+    `importlib.reload` (cf `tests/billing/test_pricing_v2.py`). Un import
+    `from core.config import JWT_CONFIG` au top du module fige une
+    référence vers l'ancien dict, qui ne correspond plus au dict actif
+    après reload — d'où des `JWSSignatureError` quand un token signé avec
+    le nouveau dict est décodé avec l'ancienne référence. La résolution
+    dynamique via `_core_config.JWT_CONFIG` à chaque call garantit la
+    cohérence.
+    """
+    return _core_config.JWT_CONFIG
+
 
 logger = logging.getLogger(__name__)
 
@@ -368,3 +386,151 @@ def require_feature(feature: str):
         return current_user
 
     return check_feature
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔐 AUTH V2 — Token payload + Re-auth scopé (Wave 1 Step 3, 2026-05-21)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def get_current_token_payload(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(http_bearer),
+    token: Optional[str] = Depends(oauth2_scheme),
+) -> dict:
+    """Decode le JWT courant et retourne le payload brut (sans re-valider la session).
+
+    La validation complète (blocklist, session, user) est déjà faite par
+    `get_current_user` — cette dépendance ne sert qu'à exposer le payload pour
+    les endpoints qui ont besoin du `jti` (= session_id V2) pour marquer la
+    session courante.
+
+    Doit toujours être déclarée APRÈS `get_current_user` dans l'endpoint (FastAPI
+    résout les Depends dans l'ordre de la signature, mais comme on ne re-valide
+    pas ici, l'ordre importe peu en pratique).
+
+    Returns:
+        Le payload décodé du JWT (dict avec sub, exp, iat, type, jti, ...).
+
+    Raises:
+        HTTPException 401 si aucun token n'est fourni ou si le decode échoue
+        (ne devrait pas arriver si get_current_user a précédemment validé).
+    """
+    # Priorité au Bearer token dans les headers (même règle que get_current_user)
+    actual_token: Optional[str] = None
+    if credentials:
+        actual_token = credentials.credentials
+    elif token:
+        actual_token = token
+
+    if not actual_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "not_authenticated", "message": "Authentication required."},
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        return jwt.decode(
+            actual_token,
+            _jwt_config()["SECRET_KEY"],
+            algorithms=[_jwt_config()["ALGORITHM"]],
+        )
+    except JWTError:
+        # Ne devrait pas arriver si get_current_user a déjà validé, mais defensive.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "token_invalid", "message": "Invalid or expired token."},
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def require_recent_reauth(audience: str) -> Callable:
+    """Factory de dépendance qui valide la présence d'un `X-Reauth-Token` valide.
+
+    Utilisée pour scoper les endpoints sensibles (billing, account deletion,
+    change-email, change-password). Le client doit d'abord appeler
+    POST /api/auth/reauth pour obtenir un reauth_token (JWT 5 min, scope=reauth,
+    aud=<audience>) puis le re-fournir dans le header `X-Reauth-Token`.
+
+    Spec : `2026-05-21-auth-v2-complet-design.md` §4.6.
+
+    Args:
+        audience: scope cible (ex: "billing", "delete", "change-email",
+            "change-password"). Doit matcher `ReauthAudience` Literal côté
+            schemas.
+
+    Usage:
+        @router.delete("/account")
+        async def delete_account(
+            _: None = Depends(require_recent_reauth("delete")),
+            current_user: User = Depends(get_current_user),
+            ...
+        ):
+            ...
+
+    Returns:
+        Une dépendance FastAPI qui retourne None si OK, raise HTTPException 401
+        sinon (avec un code détaillé : REAUTH_REQUIRED / REAUTH_EXPIRED /
+        REAUTH_INVALID / REAUTH_WRONG_SCOPE / REAUTH_WRONG_AUDIENCE /
+        REAUTH_USER_MISMATCH).
+    """
+
+    async def dep(
+        request: Request,
+        current_user: User = Depends(get_current_user),
+    ) -> None:
+        reauth_token = request.headers.get("X-Reauth-Token")
+        if not reauth_token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={"code": "REAUTH_REQUIRED", "message": "Re-authentication required for this action."},
+            )
+
+        try:
+            payload = jwt.decode(
+                reauth_token,
+                _jwt_config()["SECRET_KEY"],
+                algorithms=[_jwt_config()["ALGORITHM"]],
+                audience=audience,
+            )
+        except ExpiredSignatureError:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={
+                    "code": "REAUTH_EXPIRED",
+                    "message": "Re-authentication expired. Please re-enter your password.",
+                },
+            )
+        except JWTError as e:
+            # jose lève JWTClaimsError (sous-classe de JWTError) si l'audience
+            # ne match pas — on remap en REAUTH_WRONG_AUDIENCE pour signaler
+            # clairement la cause côté frontend.
+            msg = str(e).lower()
+            if "audience" in msg:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail={"code": "REAUTH_WRONG_AUDIENCE", "message": "Re-auth token scoped for another action."},
+                )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={"code": "REAUTH_INVALID", "message": "Re-authentication token invalid."},
+            )
+
+        if payload.get("scope") != "reauth":
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={"code": "REAUTH_WRONG_SCOPE", "message": "Token is not a re-auth token."},
+            )
+
+        if str(payload.get("sub")) != str(current_user.id):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={
+                    "code": "REAUTH_USER_MISMATCH",
+                    "message": "Re-auth token does not belong to the current user.",
+                },
+            )
+
+        return None
+
+    return dep

--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -4,14 +4,17 @@
 ╚════════════════════════════════════════════════════════════════════════════════════╝
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
+from jose import jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Optional
 
-from db.database import get_session
+import core.config as _core_config  # runtime lookup pour JWT_CONFIG (cf reload edge case dépendances)
+
+from db.database import get_session, verify_password
 from core.analytics import track_event
 from core.config import FRONTEND_URL, EMAIL_CONFIG, GOOGLE_OAUTH_CONFIG, APPLE_OAUTH_CONFIG
 from .schemas import (
@@ -33,6 +36,9 @@ from .schemas import (
     AuthUrlResponse,
     MessageResponse,
     QuotaResponse,
+    ReauthRequest,
+    ReauthResponse,
+    UserSessionResponse,
 )
 from .service import (
     create_user,
@@ -58,9 +64,11 @@ from .service import (
     verify_google_id_token,
     verify_apple_id_token,
     login_or_register_apple_user,
+    list_user_sessions,
+    revoke_session_v2,
 )
 from services.audit_log import log_audit
-from .dependencies import get_current_user
+from .dependencies import get_current_user, get_current_token_payload
 from .email import send_verification_email, send_password_reset_email, send_welcome_email
 
 router = APIRouter()
@@ -198,6 +206,7 @@ async def logout(current_user=Depends(get_current_user), session: AsyncSession =
     return MessageResponse(success=True, message="✅ Déconnecté")
 
 
+# TODO Wave 1 Step 3 : add Depends(require_recent_reauth("delete")) when frontend wires the X-Reauth-Token header
 @router.delete("/account", response_model=MessageResponse)
 async def delete_account(
     data: DeleteAccountRequest, current_user=Depends(get_current_user), session: AsyncSession = Depends(get_session)
@@ -397,6 +406,7 @@ async def reset_password_endpoint(data: ResetPasswordRequest, session: AsyncSess
     return MessageResponse(success=True, message=message)
 
 
+# TODO Wave 1 Step 3 : add Depends(require_recent_reauth("change-password")) when frontend wires the X-Reauth-Token header
 @router.post("/change-password", response_model=MessageResponse)
 async def change_password_endpoint(
     data: ChangePasswordRequest, current_user=Depends(get_current_user), session: AsyncSession = Depends(get_session)
@@ -853,6 +863,157 @@ async def apple_token_login(data: AppleMobileTokenRequest, session: AsyncSession
 async def apple_callback_post(data: AppleMobileTokenRequest, session: AsyncSession = Depends(get_session)):
     """Alias POST de /apple/token pour rester aligne avec /google/callback (web SPA)."""
     return await apple_token_login(data, session)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔐 AUTH V2 — Sessions multi-device + Re-auth scopé (Wave 1 Step 3, 2026-05-21)
+# ═══════════════════════════════════════════════════════════════════════════════
+# Spec : 01-Projects/DeepSight/Specs/2026-05-21-auth-v2-complet-design.md §4.4 + §4.6.
+#
+# Endpoints :
+#   GET    /api/auth/sessions       → liste les sessions actives (page Settings)
+#   DELETE /api/auth/sessions/{id}  → révoque une session spécifique
+#   DELETE /api/auth/sessions       → révoque toutes les autres sessions
+#   POST   /api/auth/reauth         → émet un reauth_token scopé (5 min)
+
+
+@router.get("/sessions", response_model=list[UserSessionResponse])
+async def list_active_sessions(
+    current_user=Depends(get_current_user),
+    current_token_payload: dict = Depends(get_current_token_payload),
+    session: AsyncSession = Depends(get_session),
+):
+    """Liste les sessions actives de l'utilisateur (non révoquées, non expirées).
+
+    La session associée au JWT courant est marquée `current=True` via comparaison
+    avec le `jti` du token V2. Pour les tokens legacy (V1, sans `jti`), aucune
+    session n'est marquée current (false par défaut).
+    """
+    sessions = await list_user_sessions(session, current_user.id)
+    current_jti = current_token_payload.get("jti")  # None pour les tokens legacy V1
+    return [
+        UserSessionResponse(
+            id=s.id,
+            device_label=s.device_label,
+            ip_hash=s.ip_hash,
+            user_agent=s.user_agent,
+            last_seen_at=s.last_seen_at,
+            created_at=s.issued_at,
+            current=(s.id == current_jti),
+        )
+        for s in sessions
+    ]
+
+
+@router.delete("/sessions/{session_id}", response_model=MessageResponse)
+async def revoke_session_by_id(
+    session_id: str,
+    current_user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Révoque une session spécifique par UUID.
+
+    Security : `revoke_session_v2` vérifie déjà que la session appartient au
+    user qui demande la révocation — empêche un user A de révoquer une session
+    d'un user B par énumération d'UUIDs.
+    """
+    ok = await revoke_session_v2(session, session_id, current_user.id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Session not found or already revoked")
+    await log_audit(
+        session,
+        action="session.revoked",
+        user_id=current_user.id,
+        details={"session_id": session_id, "scope": "single"},
+    )
+    await session.commit()
+    return MessageResponse(success=True, message="✅ Session révoquée")
+
+
+@router.delete("/sessions", response_model=MessageResponse)
+async def revoke_all_other_sessions(
+    current_user=Depends(get_current_user),
+    current_token_payload: dict = Depends(get_current_token_payload),
+    session: AsyncSession = Depends(get_session),
+):
+    """Révoque toutes les sessions de l'utilisateur SAUF celle du JWT courant.
+
+    Comportement « Sign out everywhere else » de la page Settings. Pour les
+    tokens legacy V1 (sans `jti`), toutes les sessions V2 sont révoquées.
+    """
+    current_jti = current_token_payload.get("jti")
+    sessions = await list_user_sessions(session, current_user.id)
+    revoked_count = 0
+    for s in sessions:
+        if s.id == current_jti:
+            continue
+        if await revoke_session_v2(session, s.id, current_user.id):
+            revoked_count += 1
+    await log_audit(
+        session,
+        action="session.revoked",
+        user_id=current_user.id,
+        details={"scope": "all_other", "revoked_count": revoked_count},
+    )
+    await session.commit()
+    return MessageResponse(success=True, message=f"✅ {revoked_count} sessions révoquées")
+
+
+@router.post("/reauth", response_model=ReauthResponse)
+async def reauth(
+    data: ReauthRequest,
+    request: Request,
+    current_user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Re-vérifie le mot de passe et émet un reauth_token scopé pour une action sensible.
+
+    Spec : §4.6 — JWT 5 min, scope=reauth, aud=<audience>. Le client doit
+    re-fournir ce token dans `X-Reauth-Token: <jwt>` lors de l'appel à
+    l'endpoint sensible (via `Depends(require_recent_reauth(audience))`).
+    """
+    # Verify password (réutilise verify_password de db.database — supporte
+    # bcrypt et legacy SHA256 cf migration auto au login).
+    if not current_user.password_hash or not verify_password(data.password, current_user.password_hash):
+        # Audit log "reauth_failed_wrong_password" pour détection de brute-force
+        # (Article 30 RGPD — traçabilité des tentatives de re-authentification).
+        await log_audit(
+            session,
+            action="auth.reauth_failed",
+            user_id=current_user.id,
+            request=request,
+            details={"reason": "wrong_password", "audience": data.audience},
+        )
+        await session.commit()
+        raise HTTPException(status_code=401, detail="REAUTH_WRONG_PASSWORD")
+
+    # Émet JWT 5 min — scope=reauth + aud=audience (validé par require_recent_reauth)
+    expires_in = 5 * 60  # 300s
+    now = datetime.now(timezone.utc)
+    expire_at = now + timedelta(seconds=expires_in)
+    payload = {
+        "sub": str(current_user.id),
+        "scope": "reauth",
+        "aud": data.audience,
+        "iat": now,
+        "exp": expire_at,
+    }
+    reauth_token = jwt.encode(
+        payload,
+        _core_config.JWT_CONFIG["SECRET_KEY"],
+        algorithm=_core_config.JWT_CONFIG["ALGORITHM"],
+    )
+
+    await log_audit(
+        session,
+        action="auth.reauth_success",
+        user_id=current_user.id,
+        request=request,
+        details={"audience": data.audience, "expires_in": expires_in},
+    )
+    await session.commit()
+
+    return ReauthResponse(reauth_token=reauth_token, expires_in=expires_in)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/src/auth/schemas.py
+++ b/backend/src/auth/schemas.py
@@ -226,6 +226,69 @@ class DeleteAccountRequest(BaseModel):
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# 🔐 AUTH V2 — Sessions multi-device + Re-auth scopé (Wave 1 Step 3, 2026-05-21)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Audiences supportées pour le re-auth scopé. Une audience par action sensible :
+# - billing  → POST /api/billing/* (write paths : checkout, change-plan, cancel…)
+# - delete   → DELETE /api/auth/account
+# - change-email → POST /api/auth/change-email (futur)
+# - change-password → POST /api/auth/change-password
+ReauthAudience = Literal["billing", "delete", "change-email", "change-password"]
+
+
+class ReauthRequest(BaseModel):
+    """Schéma pour demander un reauth_token scopé.
+
+    Le client envoie son mot de passe + l'audience cible (la prochaine action
+    sensible qu'il veut faire). Le serveur vérifie le mot de passe puis émet
+    un JWT court (5 min, scope=reauth, aud=audience) qui débloque l'endpoint
+    correspondant via `Depends(require_recent_reauth(audience))`.
+
+    Spec : 2026-05-21-auth-v2-complet-design.md §4.6.
+    """
+
+    password: str = Field(..., min_length=1, description="Mot de passe actuel de l'utilisateur")
+    audience: ReauthAudience = Field(..., description="Endpoint cible scopé (billing, delete, change-email, change-password)")
+
+
+class ReauthResponse(BaseModel):
+    """Réponse à POST /api/auth/reauth.
+
+    Le client doit re-fournir le `reauth_token` dans le header
+    `X-Reauth-Token: <jwt>` lors de l'appel à l'endpoint sensible. TTL court
+    (5 min) — pas de refresh sur ce token (re-saisir le mot de passe si
+    expiré).
+    """
+
+    reauth_token: str = Field(..., description="JWT court (5 min) avec scope=reauth + aud=audience")
+    expires_in: int = Field(..., description="TTL restant en secondes (typiquement 300)")
+
+
+class UserSessionResponse(BaseModel):
+    """Représentation publique d'une UserSession pour la page « Appareils actifs ».
+
+    Toutes les valeurs sensibles (refresh_token_hash, ip_hash brut, etc.) sont
+    omises ou anonymisées avant exposition. Le frontend affiche `device_label`
+    + `last_seen_at` + `current` pour permettre à l'utilisateur de révoquer un
+    appareil suspect.
+
+    Spec : 2026-05-21-auth-v2-complet-design.md §4.4.
+    """
+
+    id: str = Field(..., description="UUID String(36) de la session — utilisé pour DELETE /sessions/{id}")
+    device_label: Optional[str] = Field(None, description="Label parsé du user-agent (ex: 'Chrome on macOS')")
+    ip_hash: Optional[str] = Field(None, description="SHA-256(ip + salt) tronqué 16 chars — pas l'IP brute")
+    user_agent: Optional[str] = Field(None, description="User-Agent brut (debug uniquement, peut être très long)")
+    last_seen_at: datetime = Field(..., description="Dernière activité observée sur cette session")
+    created_at: datetime = Field(..., description="Date d'émission initiale (alias de issued_at)")
+    current: bool = Field(False, description="True si c'est la session associée au JWT courant")
+
+    class Config:
+        from_attributes = True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # 📤 RÉPONSES (Output)
 # ═══════════════════════════════════════════════════════════════════════════════
 

--- a/backend/src/auth/schemas.py
+++ b/backend/src/auth/schemas.py
@@ -249,7 +249,9 @@ class ReauthRequest(BaseModel):
     """
 
     password: str = Field(..., min_length=1, description="Mot de passe actuel de l'utilisateur")
-    audience: ReauthAudience = Field(..., description="Endpoint cible scopé (billing, delete, change-email, change-password)")
+    audience: ReauthAudience = Field(
+        ..., description="Endpoint cible scopé (billing, delete, change-email, change-password)"
+    )
 
 
 class ReauthResponse(BaseModel):

--- a/backend/src/billing/router.py
+++ b/backend/src/billing/router.py
@@ -707,6 +707,7 @@ async def get_billing_info(
     )
 
 
+# TODO Wave 1 Step 3 : add Depends(require_recent_reauth("billing")) when frontend wires the X-Reauth-Token header
 @router.post("/checkout")
 async def create_checkout_session(
     request: CreateCheckoutRequest,
@@ -814,6 +815,7 @@ class CreateCheckoutByPlanId(BaseModel):
     acquisition_channel: Optional[str] = None
 
 
+# TODO Wave 1 Step 3 : add Depends(require_recent_reauth("billing")) when frontend wires the X-Reauth-Token header
 @router.post("/create-checkout")
 async def create_checkout_by_plan_id(
     request: CreateCheckoutByPlanId,
@@ -955,6 +957,7 @@ class ChangePlanResponse(BaseModel):
     effective_date: Optional[str] = None
 
 
+# TODO Wave 1 Step 3 : add Depends(require_recent_reauth("billing")) when frontend wires the X-Reauth-Token header
 @router.post("/change-plan", response_model=ChangePlanResponse)
 async def change_subscription_plan(
     request: ChangePlanRequest,
@@ -1452,6 +1455,7 @@ async def confirm_checkout(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+# TODO Wave 1 Step 3 : add Depends(require_recent_reauth("billing")) when frontend wires the X-Reauth-Token header
 @router.post("/cancel")
 async def cancel_subscription(
     request: CancelRequest = CancelRequest(),

--- a/backend/tests/test_auth_reauth.py
+++ b/backend/tests/test_auth_reauth.py
@@ -1,0 +1,315 @@
+"""Tests Auth V2 — POST /api/auth/reauth + dependency `require_recent_reauth`.
+
+Wave 1 Step 3 (2026-05-21) — couvre :
+- POST /api/auth/reauth : password verification + émission JWT scopé 5 min.
+- `require_recent_reauth(audience)` : accepte un token valide, rejette
+  expired / wrong audience / wrong scope / missing header.
+
+Spec : 01-Projects/DeepSight/Specs/2026-05-21-auth-v2-complet-design.md §4.6.
+
+Pattern : SQLite in-memory + override deps + appel direct de la dependency
+factory pour les tests unitaires (pas besoin d'un endpoint wiré).
+"""
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+from jose import jwt
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+
+# ⚠️ Workaround circular import (pattern test_auth_service_v2.py).
+import db.database as _db_database  # noqa: F401, E402
+import importlib.util as _ilu  # noqa: E402
+import sys as _sys  # noqa: E402
+from pathlib import Path as _Path  # noqa: E402
+
+if "billing.plan_config" not in _sys.modules:
+    _spec = _ilu.spec_from_file_location(
+        "billing.plan_config",
+        str(_Path(__file__).parent.parent / "src" / "billing" / "plan_config.py"),
+    )
+    if _spec is not None and _spec.loader is not None:
+        _mod = _ilu.module_from_spec(_spec)
+        if "billing" not in _sys.modules:
+            import types as _types
+
+            _billing_pkg = _types.ModuleType("billing")
+            _billing_pkg.__path__ = [str(_Path(__file__).parent.parent / "src" / "billing")]
+            _sys.modules["billing"] = _billing_pkg
+        _sys.modules["billing.plan_config"] = _mod
+        try:
+            _spec.loader.exec_module(_mod)
+        except Exception:  # noqa: BLE001
+            _sys.modules.pop("billing.plan_config", None)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧰 FIXTURES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest_asyncio.fixture
+async def test_engine():
+    from db.database import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def test_session(test_engine):
+    SessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with SessionLocal() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def test_user(test_session):
+    from db.database import User, hash_password
+
+    user = User(
+        username=f"alice_{uuid.uuid4().hex[:8]}",
+        email=f"alice_{uuid.uuid4().hex[:8]}@example.com",
+        password_hash=hash_password("correctpassword"),
+        email_verified=True,
+        plan="free",
+        credits=10,
+    )
+    test_session.add(user)
+    await test_session.commit()
+    await test_session.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def app(test_engine, test_user):
+    from main import app as fastapi_app
+    from db.database import get_session
+    from auth.dependencies import get_current_user
+
+    SessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_session():
+        async with SessionLocal() as s:
+            yield s
+
+    async def override_user():
+        return test_user
+
+    fastapi_app.dependency_overrides[get_session] = override_session
+    fastapi_app.dependency_overrides[get_current_user] = override_user
+
+    yield fastapi_app
+    fastapi_app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+def _make_request_mock(headers: dict | None = None):
+    """Mock minimal d'un Request pour tester `require_recent_reauth` direct."""
+    req = MagicMock()
+    h = MagicMock()
+    headers = headers or {}
+    h.get = lambda key, default=None: headers.get(key, default)
+    req.headers = h
+    return req
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📨 POST /api/auth/reauth
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_POST_reauth_wrong_password_returns_401_REAUTH_WRONG_PASSWORD(client):
+    """Mot de passe incorrect → 401 REAUTH_WRONG_PASSWORD."""
+    resp = await client.post(
+        "/api/auth/reauth",
+        json={"password": "wrongpassword", "audience": "billing"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "REAUTH_WRONG_PASSWORD"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_POST_reauth_emits_5min_jwt_with_correct_claims(client):
+    """Mot de passe correct → JWT 5 min avec scope=reauth + aud=audience."""
+    import core.config as _cc  # runtime lookup (cf importlib.reload edge case)
+
+    resp = await client.post(
+        "/api/auth/reauth",
+        json={"password": "correctpassword", "audience": "billing"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["expires_in"] == 300  # 5 min
+    token = body["reauth_token"]
+    assert token
+
+    # Decode + check claims
+    payload = jwt.decode(
+        token,
+        _cc.JWT_CONFIG["SECRET_KEY"],
+        algorithms=[_cc.JWT_CONFIG["ALGORITHM"]],
+        audience="billing",
+    )
+    assert payload["scope"] == "reauth"
+    assert payload["aud"] == "billing"
+
+    # exp doit être ~ 5min dans le futur
+    now = datetime.now(timezone.utc).timestamp()
+    assert 290 < (payload["exp"] - now) < 305
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_POST_reauth_rejects_invalid_audience_schema(client):
+    """Audience hors Literal → 422 (validation Pydantic)."""
+    resp = await client.post(
+        "/api/auth/reauth",
+        json={"password": "correctpassword", "audience": "not-a-valid-audience"},
+    )
+    assert resp.status_code == 422
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🔒 require_recent_reauth(audience) — dependency unitaire
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _emit_reauth_token(user_id: int, audience: str, ttl_seconds: int = 300, scope: str = "reauth") -> str:
+    """Helper : émet un JWT reauth (ou variant pour tests négatifs).
+
+    Runtime lookup de JWT_CONFIG (et non `from core.config import`) parce que
+    `tests/billing/test_pricing_v2.py` reload `core.config` via importlib —
+    un import figé donnerait un secret différent de celui utilisé par
+    `auth.dependencies` après le reload.
+    """
+    import core.config as _cc
+
+    now = datetime.now(timezone.utc)
+    return jwt.encode(
+        {
+            "sub": str(user_id),
+            "scope": scope,
+            "aud": audience,
+            "iat": now,
+            "exp": now + timedelta(seconds=ttl_seconds),
+        },
+        _cc.JWT_CONFIG["SECRET_KEY"],
+        algorithm=_cc.JWT_CONFIG["ALGORITHM"],
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_require_recent_reauth_accepts_valid_token(test_user):
+    """Token valide → la dépendance retourne None sans exception."""
+    from auth.dependencies import require_recent_reauth
+
+    token = _emit_reauth_token(test_user.id, "billing")
+    dep = require_recent_reauth("billing")
+    request = _make_request_mock({"X-Reauth-Token": token})
+
+    result = await dep(request=request, current_user=test_user)
+    assert result is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_require_recent_reauth_rejects_missing_header(test_user):
+    """Pas de X-Reauth-Token → 401 REAUTH_REQUIRED."""
+    from auth.dependencies import require_recent_reauth
+
+    dep = require_recent_reauth("billing")
+    request = _make_request_mock(headers={})  # no X-Reauth-Token
+
+    with pytest.raises(HTTPException) as exc:
+        await dep(request=request, current_user=test_user)
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "REAUTH_REQUIRED"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_require_recent_reauth_rejects_expired_token(test_user):
+    """Token avec exp dans le passé → 401 REAUTH_EXPIRED."""
+    from auth.dependencies import require_recent_reauth
+
+    token = _emit_reauth_token(test_user.id, "billing", ttl_seconds=-10)  # déjà expiré
+    dep = require_recent_reauth("billing")
+    request = _make_request_mock({"X-Reauth-Token": token})
+
+    with pytest.raises(HTTPException) as exc:
+        await dep(request=request, current_user=test_user)
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "REAUTH_EXPIRED"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_require_recent_reauth_rejects_wrong_audience(test_user):
+    """Token aud="delete" appelé avec audience="billing" → 401 REAUTH_WRONG_AUDIENCE."""
+    from auth.dependencies import require_recent_reauth
+
+    token = _emit_reauth_token(test_user.id, "delete")  # aud=delete
+    dep = require_recent_reauth("billing")  # mais on attend billing
+    request = _make_request_mock({"X-Reauth-Token": token})
+
+    with pytest.raises(HTTPException) as exc:
+        await dep(request=request, current_user=test_user)
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "REAUTH_WRONG_AUDIENCE"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_require_recent_reauth_rejects_wrong_scope(test_user):
+    """Token avec scope=access (pas reauth) → 401 REAUTH_WRONG_SCOPE."""
+    from auth.dependencies import require_recent_reauth
+
+    token = _emit_reauth_token(test_user.id, "billing", scope="access")
+    dep = require_recent_reauth("billing")
+    request = _make_request_mock({"X-Reauth-Token": token})
+
+    with pytest.raises(HTTPException) as exc:
+        await dep(request=request, current_user=test_user)
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "REAUTH_WRONG_SCOPE"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_require_recent_reauth_rejects_user_mismatch(test_user):
+    """Token sub=other_user_id → 401 REAUTH_USER_MISMATCH."""
+    from auth.dependencies import require_recent_reauth
+
+    other_user_id = test_user.id + 9999
+    token = _emit_reauth_token(other_user_id, "billing")
+    dep = require_recent_reauth("billing")
+    request = _make_request_mock({"X-Reauth-Token": token})
+
+    with pytest.raises(HTTPException) as exc:
+        await dep(request=request, current_user=test_user)
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "REAUTH_USER_MISMATCH"

--- a/backend/tests/test_auth_sessions_endpoint.py
+++ b/backend/tests/test_auth_sessions_endpoint.py
@@ -1,0 +1,348 @@
+"""Tests Auth V2 — endpoints sessions (`/api/auth/sessions`).
+
+Wave 1 Step 3 (2026-05-21) — couvre :
+- GET /api/auth/sessions : liste les sessions actives uniquement, marque
+  `current` via `jti`, isolement strict par user.
+- DELETE /api/auth/sessions/{id} : révoque une session, 404 sur ID inconnu
+  OU appartenant à un autre user.
+- DELETE /api/auth/sessions : révoque toutes les autres sessions, préserve
+  la courante.
+
+Spec : 01-Projects/DeepSight/Specs/2026-05-21-auth-v2-complet-design.md §4.4.
+
+Stratégie test : SQLite in-memory + override `get_session` + `get_current_user`
++ `get_current_token_payload`. Pattern identique à `test_auth_service_v2.py`
+pour la fixture DB + le workaround circular import sur Windows local.
+"""
+
+import os
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+# Env defaults pour import safety
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-minimum-32-characters-long!")
+os.environ.setdefault("MISTRAL_API_KEY", "test-key")
+
+
+# ⚠️ Workaround circular import (pattern identique à test_auth_service_v2.py).
+import db.database as _db_database  # noqa: F401, E402
+import importlib.util as _ilu  # noqa: E402
+import sys as _sys  # noqa: E402
+from pathlib import Path as _Path  # noqa: E402
+
+if "billing.plan_config" not in _sys.modules:
+    _spec = _ilu.spec_from_file_location(
+        "billing.plan_config",
+        str(_Path(__file__).parent.parent / "src" / "billing" / "plan_config.py"),
+    )
+    if _spec is not None and _spec.loader is not None:
+        _mod = _ilu.module_from_spec(_spec)
+        if "billing" not in _sys.modules:
+            import types as _types
+
+            _billing_pkg = _types.ModuleType("billing")
+            _billing_pkg.__path__ = [str(_Path(__file__).parent.parent / "src" / "billing")]
+            _sys.modules["billing"] = _billing_pkg
+        _sys.modules["billing.plan_config"] = _mod
+        try:
+            _spec.loader.exec_module(_mod)
+        except Exception:  # noqa: BLE001
+            _sys.modules.pop("billing.plan_config", None)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🧰 FIXTURES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest_asyncio.fixture
+async def test_engine():
+    """SQLite in-memory engine partagé entre app + tests."""
+    from db.database import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def test_session(test_engine):
+    """Session SQLAlchemy partagée (commit dans les tests visible côté app)."""
+    SessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with SessionLocal() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def test_user(test_session):
+    """User réel en DB."""
+    from db.database import User, hash_password
+
+    user = User(
+        username=f"alice_{uuid.uuid4().hex[:8]}",
+        email=f"alice_{uuid.uuid4().hex[:8]}@example.com",
+        password_hash=hash_password("correctpassword"),
+        email_verified=True,
+        plan="free",
+        credits=10,
+    )
+    test_session.add(user)
+    await test_session.commit()
+    await test_session.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def other_user(test_session):
+    """Second user pour les tests d'isolement."""
+    from db.database import User, hash_password
+
+    user = User(
+        username=f"bob_{uuid.uuid4().hex[:8]}",
+        email=f"bob_{uuid.uuid4().hex[:8]}@example.com",
+        password_hash=hash_password("otherpw"),
+        email_verified=True,
+        plan="free",
+        credits=10,
+    )
+    test_session.add(user)
+    await test_session.commit()
+    await test_session.refresh(user)
+    return user
+
+
+async def _create_session(test_session, user_id: int, ua: str = "Mozilla/5.0", host: str = "1.2.3.4"):
+    """Helper : crée une UserSession V2 + sync hash. Retourne la session ORM."""
+    from unittest.mock import MagicMock
+
+    from auth.service import create_session_v2, create_refresh_token_v2, update_session_refresh_hash
+
+    request = MagicMock()
+    headers = MagicMock()
+    headers.get = lambda key, default=None: ua if key.lower() == "user-agent" else default
+    request.headers = headers
+    client = MagicMock()
+    client.host = host
+    request.client = client
+
+    user_session = await create_session_v2(
+        session=test_session,
+        user_id=user_id,
+        stay_signed_in=True,
+        request=request,
+    )
+    ttl = int((user_session.sliding_expires_at - datetime.utcnow()).total_seconds())
+    refresh_jwt = create_refresh_token_v2(user_id=user_id, jti=user_session.id, ttl_seconds=ttl)
+    await update_session_refresh_hash(test_session, user_session.id, refresh_jwt)
+    await test_session.commit()
+    await test_session.refresh(user_session)
+    return user_session
+
+
+@pytest_asyncio.fixture
+async def app(test_engine, test_session, test_user):
+    """App FastAPI avec get_session + get_current_user overridés."""
+    from main import app as fastapi_app
+    from db.database import get_session
+    from auth.dependencies import get_current_user, get_current_token_payload
+
+    # Override get_session pour utiliser notre engine SQLite in-memory.
+    SessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_session():
+        async with SessionLocal() as s:
+            yield s
+
+    async def override_user():
+        return test_user
+
+    fastapi_app.dependency_overrides[get_session] = override_session
+    fastapi_app.dependency_overrides[get_current_user] = override_user
+
+    # Par défaut : pas de jti (token legacy V1). Les tests qui ont besoin
+    # d'un jti spécifique le surchargent eux-mêmes dans le test.
+    async def override_payload():
+        return {"sub": str(test_user.id)}
+
+    fastapi_app.dependency_overrides[get_current_token_payload] = override_payload
+
+    yield fastapi_app
+    fastapi_app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 📋 GET /api/auth/sessions
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_GET_sessions_returns_only_active_for_user(client, test_session, test_user):
+    """GET /sessions retourne seulement les sessions actives (non révoquées, non expirées)."""
+    # 2 sessions actives + 1 révoquée + 1 expirée
+    s1 = await _create_session(test_session, test_user.id)
+    s2 = await _create_session(test_session, test_user.id)
+    s_revoked = await _create_session(test_session, test_user.id)
+    s_expired = await _create_session(test_session, test_user.id)
+
+    # Marquer une session comme révoquée
+    s_revoked.revoked_at = datetime.utcnow()
+    # Marquer une autre comme expirée (sliding dans le passé)
+    s_expired.sliding_expires_at = datetime.utcnow() - timedelta(hours=1)
+    await test_session.commit()
+
+    resp = await client.get("/api/auth/sessions")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert isinstance(data, list)
+
+    ids = [s["id"] for s in data]
+    assert s1.id in ids
+    assert s2.id in ids
+    assert s_revoked.id not in ids
+    assert s_expired.id not in ids
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_GET_sessions_marks_current_via_jti(app, test_session, test_user):
+    """La session dont l'id == jti du JWT courant a `current=True`."""
+    from auth.dependencies import get_current_token_payload
+
+    s1 = await _create_session(test_session, test_user.id)
+    s2 = await _create_session(test_session, test_user.id)
+
+    # Override le payload pour pointer vers s1
+    async def override_payload():
+        return {"sub": str(test_user.id), "jti": s1.id}
+
+    app.dependency_overrides[get_current_token_payload] = override_payload
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/auth/sessions")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    by_id = {s["id"]: s for s in data}
+    assert by_id[s1.id]["current"] is True
+    assert by_id[s2.id]["current"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_GET_sessions_other_user_isolation(client, test_session, test_user, other_user):
+    """Les sessions d'autres users ne sont pas retournées."""
+    s_mine = await _create_session(test_session, test_user.id)
+    s_other = await _create_session(test_session, other_user.id)
+
+    resp = await client.get("/api/auth/sessions")
+    assert resp.status_code == 200
+    ids = [s["id"] for s in resp.json()]
+    assert s_mine.id in ids
+    assert s_other.id not in ids
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🗑️ DELETE /api/auth/sessions/{id}
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_DELETE_session_by_id_marks_revoked(client, test_engine, test_session, test_user):
+    """DELETE /sessions/{id} marque revoked_at."""
+    from db.database import UserSession
+    from sqlalchemy import select
+
+    s = await _create_session(test_session, test_user.id)
+    session_id = s.id
+    assert s.revoked_at is None
+
+    resp = await client.delete(f"/api/auth/sessions/{session_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+
+    # Re-lookup avec session fraîche (l'endpoint commit dans une SessionLocal
+    # distincte → test_session a une identity-map cache qu'on doit éviter).
+    SessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with SessionLocal() as fresh:
+        result = await fresh.execute(select(UserSession).where(UserSession.id == session_id))
+        refreshed = result.scalar_one()
+        assert refreshed.revoked_at is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_DELETE_session_other_user_returns_404(client, test_session, test_user, other_user):
+    """Tenter de révoquer une session d'un autre user → 404 (sécurité par énumération)."""
+    s_other = await _create_session(test_session, other_user.id)
+
+    resp = await client.delete(f"/api/auth/sessions/{s_other.id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_DELETE_session_unknown_id_returns_404(client):
+    """DELETE /sessions/{id} avec UUID inconnu → 404."""
+    fake_id = str(uuid.uuid4())
+    resp = await client.delete(f"/api/auth/sessions/{fake_id}")
+    assert resp.status_code == 404
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🗑️ DELETE /api/auth/sessions (révoque les autres)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_DELETE_all_sessions_keeps_current_one(app, test_engine, test_session, test_user):
+    """DELETE /sessions révoque toutes SAUF celle du jti courant."""
+    from db.database import UserSession
+    from sqlalchemy import select
+    from auth.dependencies import get_current_token_payload
+
+    s_current = await _create_session(test_session, test_user.id)
+    s_other_1 = await _create_session(test_session, test_user.id)
+    s_other_2 = await _create_session(test_session, test_user.id)
+    current_id, other_1_id, other_2_id = s_current.id, s_other_1.id, s_other_2.id
+
+    async def override_payload():
+        return {"sub": str(test_user.id), "jti": current_id}
+
+    app.dependency_overrides[get_current_token_payload] = override_payload
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.delete("/api/auth/sessions")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert "2" in body["message"]  # 2 sessions révoquées
+
+    # Verify en DB via session fraîche (cf commentaire dans test_DELETE_session_by_id_marks_revoked)
+    SessionLocal = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with SessionLocal() as fresh:
+        result = await fresh.execute(select(UserSession).where(UserSession.user_id == test_user.id))
+        all_sessions = list(result.scalars().all())
+        by_id = {s.id: s for s in all_sessions}
+        assert by_id[current_id].revoked_at is None  # current preserved
+        assert by_id[other_1_id].revoked_at is not None
+        assert by_id[other_2_id].revoked_at is not None


### PR DESCRIPTION
## Summary

Wave 1 Step 3 (2026-05-21) — endpoints `/api/auth/sessions/*` + `POST /api/auth/reauth` + dependency `require_recent_reauth(audience)`.

**Reprise après crash du premier sub-agent** : le 1er sub-agent avait écrit les schemas (`UserSessionResponse`, `ReauthRequest/Response`, `ReauthAudience`) avant de crasher. Ce PR finit le reste (router + dependency + tests).

Spec : `01-Projects/DeepSight/Specs/2026-05-21-auth-v2-complet-design.md` §4.4 + §4.6.

## Endpoints ajoutés

- `GET    /api/auth/sessions`       → liste des sessions actives (page Settings « Appareils »). Marque `current=True` pour celle dont id == jti du token V2 ; `false` pour tokens legacy V1 sans jti.
- `DELETE /api/auth/sessions/{id}`  → révoque une session par UUID. Sécurité owner enforcée dans `revoke_session_v2` (anti-énumération cross-user).
- `DELETE /api/auth/sessions`       → « Sign out everywhere else » — révoque toutes sauf la courante (jti).
- `POST   /api/auth/reauth`         → vérifie password + émet JWT 5 min `scope=reauth` `aud=<audience>`. Audit log sur success/failure.

## Dependency ajoutée

- `require_recent_reauth(audience)` (factory) : valide la présence d'un header `X-Reauth-Token` JWT correct (signature + non expiré + scope=reauth + aud matche + sub = current_user.id). Codes d'erreur détaillés : `REAUTH_REQUIRED` / `REAUTH_EXPIRED` / `REAUTH_INVALID` / `REAUTH_WRONG_SCOPE` / `REAUTH_WRONG_AUDIENCE` / `REAUTH_USER_MISMATCH`.
- `get_current_token_payload` : utility dependency pour récupérer le `jti` du JWT courant dans les endpoints `/sessions`.

## TODO comments laissés (à wirer après frontend re-auth flow)

- `backend/src/auth/router.py:201` → DELETE `/account` (audience="delete")
- `backend/src/auth/router.py:401` → POST `/change-password` (audience="change-password")
- `backend/src/billing/router.py:710`  → POST `/checkout`
- `backend/src/billing/router.py:818`  → POST `/create-checkout`
- `backend/src/billing/router.py:960`  → POST `/change-plan`
- `backend/src/billing/router.py:1458` → POST `/cancel`

## Tests (16 nouveaux)

`backend/tests/test_auth_sessions_endpoint.py` (7 tests) :
- GET active only + isolement par user + current via jti
- DELETE par id : OK + 404 cross-user + 404 unknown
- DELETE all : preserve current via jti

`backend/tests/test_auth_reauth.py` (9 tests) :
- POST /reauth wrong password / happy path / audience invalide
- require_recent_reauth : 6 cases (valid + missing header + expired + wrong audience + wrong scope + user mismatch)

## Décisions techniques non-évidentes

1. **Runtime lookup `_jwt_config()` au lieu de `from core.config import JWT_CONFIG`** :
   `tests/billing/test_pricing_v2.py` appelle `importlib.reload(core.config)`, qui crée un nouveau dict `JWT_CONFIG` en mémoire. Un import statique au top de `dependencies.py` figerait la référence sur l'ancien dict → `JWSSignatureError` au décode après reload. Le runtime lookup via `_core_config.JWT_CONFIG` résout le problème pour la suite ordonnée alphabétique.

2. **Audit logs sur `/reauth`** : tracé séparément en `auth.reauth_success` / `auth.reauth_failed` (RGPD Article 30 — détection brute-force).

3. **Tests : SQLite in-memory + override `get_session` + `get_current_user` + `get_current_token_payload`** : pattern identique à `test_auth_service_v2.py`. Workaround circular import `billing/__init__` recopié.

4. **Session fraîche pour assertions DB** : dans les tests DELETE, l'endpoint commit via une `SessionLocal` distincte de la fixture `test_session` (identity-map cache). On re-lookup avec une session fraîche pour voir `revoked_at` populated.

## Test results

- 16/16 nouveaux tests verts.
- Broader suite : 2475/2477 (les 2 fails dans `test_intelligent_discovery_proxy.py` sont **pré-existants** — circular import `auth.service` confirmé via `git stash`).
- `ruff format --check src/` : ✅
- `ruff check src/` : ✅

## Files modified

- `backend/src/auth/dependencies.py` (+170 lignes)
- `backend/src/auth/router.py` (+167 lignes)
- `backend/src/auth/schemas.py` (1 line ruff drive-by)
- `backend/src/billing/router.py` (+4 lignes TODO comments)
- `backend/tests/test_auth_reauth.py` (NEW, 320 lignes)
- `backend/tests/test_auth_sessions_endpoint.py` (NEW, 343 lignes)

## DO NOT MERGE — Maxime review

Reprise post-crash. Vérifier en particulier :
- Le wrapping `_jwt_config()` (runtime lookup) — est-ce qu'on veut le propager au reste de `dependencies.py` (defensive) ou laisser le reste utiliser `verify_token` via `auth.service` (qui a son propre lookup) ?
- L'ordre des TODO comments à wirer (priorité billing > delete > change-password ?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)