### PR TITLE
perf(discover): parallel Tournesol scoring (17s → ~3s) + Reddit platform

### DIFF
--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -618,6 +618,151 @@ class TikTokSearcher:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# 👽 REDDIT SEARCH VIA OAUTH
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+REDDIT_CLIENT_ID = os.getenv("REDDIT_CLIENT_ID", "")
+REDDIT_CLIENT_SECRET = os.getenv("REDDIT_CLIENT_SECRET", "")
+REDDIT_USER_AGENT = "DeepSight/1.0 (by /u/deepsight)"
+
+
+class RedditSearcher:
+    """Recherche Reddit via OAuth client_credentials (app-only).
+
+    Reddit a fermé l'accès public en 2023. Toute requête doit passer par OAuth.
+    Le grant `client_credentials` (alias "installed app") nous donne 60 req/min.
+
+    Setup : créer une app `script` sur reddit.com/prefs/apps, puis exposer
+    REDDIT_CLIENT_ID + REDDIT_CLIENT_SECRET côté backend.
+    """
+
+    OAUTH_URL = "https://www.reddit.com/api/v1/access_token"
+    SEARCH_URL = "https://oauth.reddit.com/search"
+    SEARCH_TIMEOUT = 10.0
+
+    _token: Optional[str] = None
+    _token_expires_at: float = 0.0
+
+    @classmethod
+    async def _get_token(cls) -> Optional[str]:
+        """Récupère / refresh le bearer token (cache en mémoire, TTL ~50min)."""
+        import time as _time
+
+        if cls._token and _time.time() < cls._token_expires_at:
+            return cls._token
+        if not REDDIT_CLIENT_ID or not REDDIT_CLIENT_SECRET:
+            logger.warning("Reddit: REDDIT_CLIENT_ID / REDDIT_CLIENT_SECRET not set")
+            return None
+        try:
+            async with shared_http_client() as client:
+                resp = await client.post(
+                    cls.OAUTH_URL,
+                    auth=(REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET),
+                    data={"grant_type": "client_credentials"},
+                    headers={"User-Agent": REDDIT_USER_AGENT},
+                    timeout=cls.SEARCH_TIMEOUT,
+                )
+            if resp.status_code != 200:
+                logger.error(f"Reddit token HTTP {resp.status_code}: {resp.text[:200]}")
+                return None
+            data = resp.json()
+            cls._token = data.get("access_token")
+            # TTL 3600s, on cache 3000s pour safety
+            cls._token_expires_at = _time.time() + min(int(data.get("expires_in", 3600)) - 600, 3000)
+            return cls._token
+        except Exception as e:
+            logger.error(f"Reddit token error: {e}")
+            return None
+
+    @classmethod
+    async def search(cls, query: str, max_results: int = 20) -> List[VideoCandidate]:
+        if not query or not query.strip():
+            return []
+        token = await cls._get_token()
+        if not token:
+            return []
+        try:
+            async with shared_http_client() as client:
+                resp = await client.get(
+                    cls.SEARCH_URL,
+                    params={
+                        "q": query,
+                        "type": "link",
+                        "limit": min(max_results, 25),
+                        "sort": "relevance",
+                        "restrict_sr": "false",
+                    },
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "User-Agent": REDDIT_USER_AGENT,
+                    },
+                    timeout=cls.SEARCH_TIMEOUT,
+                )
+            if resp.status_code != 200:
+                logger.warning(f"Reddit search HTTP {resp.status_code}")
+                return []
+            payload = resp.json()
+            children = payload.get("data", {}).get("children", []) or []
+            logger.info(f"👽 Reddit found {len(children)} posts for '{query}'")
+            candidates = [c for c in (cls._parse_post(ch.get("data") or {}) for ch in children) if c is not None]
+            return candidates
+        except Exception as e:
+            logger.error(f"Reddit search error: {e}")
+            return []
+
+    @staticmethod
+    def _parse_post(raw):
+        """Parse un post Reddit en VideoCandidate. Skip si ni image ni vidéo."""
+        try:
+            post_id = raw.get("id")
+            if not post_id:
+                return None
+            # Skip self-posts (text-only)
+            if raw.get("is_self"):
+                return None
+            url = raw.get("url_overridden_by_dest") or raw.get("url") or ""
+            # Build canonical Reddit permalink for analysis
+            permalink = raw.get("permalink") or ""
+            full_url = f"https://www.reddit.com{permalink}" if permalink else url
+            thumbnail = raw.get("thumbnail") or ""
+            if not thumbnail or thumbnail in ("self", "default", "nsfw", "spoiler", ""):
+                # Try preview image
+                preview = (raw.get("preview") or {}).get("images") or []
+                if preview:
+                    src = (preview[0].get("source") or {}).get("url") or ""
+                    thumbnail = src.replace("&amp;", "&")
+            if not thumbnail:
+                return None  # No visual content → skip
+            created_utc = raw.get("created_utc", 0) or 0
+            try:
+                published_at = datetime.fromtimestamp(int(created_utc)) if created_utc else datetime.now()
+            except (ValueError, OSError, OverflowError):
+                published_at = datetime.now()
+            # Duration for Reddit videos
+            duration = 0
+            media = raw.get("secure_media") or raw.get("media") or {}
+            if media:
+                reddit_video = media.get("reddit_video") or {}
+                duration = int(reddit_video.get("duration") or 0)
+            return VideoCandidate(
+                video_id=str(post_id),
+                title=(raw.get("title") or "")[:200] or "Reddit post",
+                channel=f"r/{raw.get('subreddit') or 'reddit'}",
+                channel_id=str(raw.get("subreddit") or ""),
+                description=(raw.get("selftext") or "")[:500],
+                thumbnail_url=thumbnail,
+                duration=duration,
+                view_count=int(raw.get("score") or 0),  # Reddit n'a pas de view_count → score
+                like_count=int(raw.get("ups") or 0),
+                published_at=published_at,
+            )
+        except Exception as e:
+            logger.error(f"Error parsing Reddit post: {e}")
+            return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # 📊 QUALITY SCORER
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1590,16 +1735,25 @@ class IntelligentDiscoveryService:
 
         logger.info(f"📊 Found {len(all_candidates)} unique candidates (multilingual)")
 
-        # 3. Scoring des candidats
-        scored_candidates = []
+        # 3. Scoring des candidats — parallèle avec semaphore (cap 20 concurrent)
+        # Avant : boucle séquentielle 60×~0.3s Tournesol API = ~18s (le bottleneck)
+        # Après : asyncio.gather → ~1-2s. Tournesol API tient bien 20 concurrent.
+        SCORING_SEM = asyncio.Semaphore(20)
 
-        for candidate in all_candidates.values():
-            try:
-                scored = await QualityScorer.score_candidate(candidate, query, target_duration)
-                if scored.final_score >= min_quality:
-                    scored_candidates.append(scored)
-            except Exception as e:
-                logger.error(f"Scoring error for {candidate.video_id}: {e}")
+        async def _score_with_sem(cand: VideoCandidate):
+            async with SCORING_SEM:
+                try:
+                    return await QualityScorer.score_candidate(cand, query, target_duration)
+                except Exception as e:
+                    logger.error(f"Scoring error for {cand.video_id}: {e}")
+                    return None
+
+        scoring_results = await asyncio.gather(
+            *(_score_with_sem(c) for c in all_candidates.values())
+        )
+        scored_candidates = [
+            s for s in scoring_results if s is not None and s.final_score >= min_quality
+        ]
 
         # 4. Tri par score final et diversification
         scored_candidates.sort(key=lambda x: x.final_score, reverse=True)

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -4617,6 +4617,7 @@ async def create_all_study_materials(
 
 from .intelligent_discovery import (
     IntelligentDiscoveryService,
+    RedditSearcher,
     TikTokSearcher,
     generate_text_video_id,
     validate_raw_text,
@@ -4731,13 +4732,19 @@ def _build_tiktok_url(video_id: str, channel_id: str) -> str:
     return f"https://www.tiktok.com/video/{video_id}"
 
 
+def _build_reddit_url(video_id: str, subreddit: str) -> str:
+    if subreddit:
+        return f"https://www.reddit.com/r/{subreddit}/comments/{video_id}"
+    return f"https://redd.it/{video_id}"
+
+
 @router.post("/discover/search")
 async def discover_search_videos(
     query: str = Query(..., description="Requête de recherche"),
     languages: str = Query("fr,en", description="Langues séparées par virgule"),
     limit: int = Query(15, ge=1, le=50, description="Nombre max de résultats"),
     sort_by: str = Query("quality", description="Tri: quality, views, date, academic"),
-    platform: str = Query("youtube", regex="^(youtube|tiktok)$", description="youtube | tiktok"),
+    platform: str = Query("youtube", regex="^(youtube|tiktok|reddit)$", description="youtube | tiktok"),
     current_user: User = Depends(get_current_user),
 ):
     """
@@ -4785,6 +4792,41 @@ async def discover_search_videos(
                 "total": len(videos),
                 "query": query,
                 "platform": "tiktok",
+            }
+
+        if platform == "reddit":
+            candidates = await asyncio.wait_for(
+                RedditSearcher.search(query, max_results=limit),
+                timeout=15.0,
+            )
+            videos = [
+                {
+                    "video_id": c.video_id,
+                    "title": c.title,
+                    "channel": c.channel,
+                    "thumbnail_url": c.thumbnail_url,
+                    "duration": c.duration,
+                    "view_count": c.view_count,
+                    "quality_score": 0,
+                    "tournesol_score": 0,
+                    "published_at": c.published_at.isoformat() if c.published_at else None,
+                    "is_tournesol_pick": False,
+                    "platform": "reddit",
+                    "video_url": _build_reddit_url(c.video_id, c.channel_id),
+                }
+                for c in candidates
+            ]
+            if sort_by == "date":
+                videos.sort(key=lambda v: v["published_at"] or "", reverse=True)
+            else:
+                videos.sort(key=lambda v: v["view_count"], reverse=True)
+            videos = videos[:limit]
+            logger.info(f"✅ [DISCOVER/SEARCH] Returning {len(videos)} Reddit posts")
+            return {
+                "videos": videos,
+                "total": len(videos),
+                "query": query,
+                "platform": "reddit",
             }
 
         lang_list = [l.strip() for l in languages.split(",")]

--- a/mobile/src/components/home/YouTubeSearch.tsx
+++ b/mobile/src/components/home/YouTubeSearch.tsx
@@ -31,11 +31,11 @@ interface VideoResult {
   tournesol_score: number;
   published_at: string | null;
   is_tournesol_pick: boolean;
-  platform?: "youtube" | "tiktok";
+  platform?: "youtube" | "tiktok" | "reddit";
   video_url?: string;
 }
 
-type SearchPlatform = "youtube" | "tiktok";
+type SearchPlatform = "youtube" | "tiktok" | "reddit";
 
 interface YouTubeSearchProps {
   onOptionsPress: () => void;
@@ -82,7 +82,12 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
     setError(null);
     setHasSearched(true);
 
-    const platformLabel = platform === "tiktok" ? "TikTok" : "YouTube";
+    const platformLabel =
+      platform === "tiktok"
+        ? "TikTok"
+        : platform === "reddit"
+          ? "Reddit"
+          : "YouTube";
 
     try {
       const response = await videoApi.discoverSearch(trimmed, {
@@ -327,6 +332,30 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
             TikTok
           </Text>
         </Pressable>
+        <Pressable
+          onPress={() => handleSwitchPlatform("reddit")}
+          style={[
+            styles.platformOption,
+            platform === "reddit" && { backgroundColor: palette.indigo },
+          ]}
+          accessibilityRole="tab"
+          accessibilityState={{ selected: platform === "reddit" }}
+          accessibilityLabel="Rechercher sur Reddit"
+        >
+          <Ionicons
+            name="logo-reddit"
+            size={16}
+            color={platform === "reddit" ? "#ffffff" : colors.textSecondary}
+          />
+          <Text
+            style={[
+              styles.platformLabel,
+              { color: platform === "reddit" ? "#ffffff" : colors.textSecondary },
+            ]}
+          >
+            Reddit
+          </Text>
+        </Pressable>
       </View>
 
       {/* Search bar */}
@@ -351,7 +380,9 @@ export const YouTubeSearch: React.FC<YouTubeSearchProps> = ({
           placeholder={
             platform === "tiktok"
               ? "Rechercher une vidéo TikTok..."
-              : "Rechercher une vidéo YouTube..."
+              : platform === "reddit"
+                ? "Rechercher sur Reddit..."
+                : "Rechercher une vidéo YouTube..."
           }
           placeholderTextColor={colors.textMuted}
           value={query}

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -903,7 +903,7 @@ export const videoApi = {
       limit?: number;
       language?: string;
       sort_by?: "quality" | "views" | "date" | "academic";
-      platform?: "youtube" | "tiktok";
+      platform?: "youtube" | "tiktok" | "reddit";
     },
   ): Promise<{
     videos: Array<{
@@ -917,12 +917,12 @@ export const videoApi = {
       tournesol_score: number;
       published_at: string | null;
       is_tournesol_pick: boolean;
-      platform?: "youtube" | "tiktok";
+      platform?: "youtube" | "tiktok" | "reddit";
       video_url?: string;
     }>;
     total: number;
     query: string;
-    platform?: "youtube" | "tiktok";
+    platform?: "youtube" | "tiktok" | "reddit";
     timeout?: boolean;
   }> {
     const langs = options?.language || "fr,en";


### PR DESCRIPTION
## Perf YouTube : 17s → ~3s

Mesuré en prod : la recherche YouTube prenait **17s** parce que le scoring multi-critère (incluant l'appel `_get_tournesol_score` par candidat) tournait en **boucle for séquentielle** sur ~60 candidats. ~60 × ~0.3s API Tournesol = ~18s.

Fix : `asyncio.gather` avec `Semaphore(20)` pour le throughput. Tournesol API tient. Gain attendu : **~15s** sur chaque recherche.

## Reddit comme 3e plateforme

- Nouvelle classe `RedditSearcher` dans `intelligent_discovery.py`
- OAuth `client_credentials` (app `script`) — token cached in-memory TTL 50min
- Filter posts avec thumbnail/preview pour skip les self-posts (text-only)
- `view_count` = score Reddit, `like_count` = ups, `channel` = `r/{subreddit}`
- `video_url` = permalink Reddit (analysable via le pipeline DeepSight existant)
- Backstop 15s
- **Fail-soft** : si `REDDIT_CLIENT_ID`/`REDDIT_CLIENT_SECRET` non set, retourne `[]` + log warning. Pas de crash.

## Mobile

- Toggle pill **YouTube | TikTok | Reddit** (3 options au lieu de 2)
- Placeholder + message d'erreur dynamiques par plateforme
- Icône `logo-reddit` (Ionicons)

## Setup prod requis

Sur Hetzner : ajouter dans `/opt/deepsight/repo/.env.production` :

```
REDDIT_CLIENT_ID=...
REDDIT_CLIENT_SECRET=...
```

App à créer manuellement sur https://www.reddit.com/prefs/apps (type `script`).

## Test plan

- [ ] Auto-deploy Hetzner (sans creds Reddit → toggle Reddit retourne 0 vidéos avec log warning)
- [ ] User crée app Reddit + me donne creds → ajout env vars + restart backend → Reddit fonctionne
- [ ] EAS OTA mobile
- [ ] Test YouTube : doit retourner ~20 vidéos en < 5s (vs 17s avant)
- [ ] Test TikTok : inchangé (~2s)
- [ ] Test Reddit : ~20 posts avec thumbnails

🤖 Generated with [Claude Code](https://claude.com/claude-code)