### PR TITLE
feat(youtube): decodo scraping fallback pour ytdlp info (Phase 1.3)

### DIFF
--- a/backend/src/videos/youtube_storyboard.py
+++ b/backend/src/videos/youtube_storyboard.py
@@ -45,6 +45,9 @@ from .frame_extractor import (
     compute_frame_budget,
 )
 
+# Decodo Scraping fallback — Feature 1.3 Phase 1 (2026-05-21). Lazy import the
+# client inside the helper so unrelated callers don't pull httpx/pydantic in.
+
 logger = logging.getLogger(__name__)
 
 
@@ -254,6 +257,224 @@ async def _download_sheet(client: httpx.AsyncClient, url: str, log_tag: str) -> 
         if attempt < HTTPX_RETRIES_PER_SHEET:
             await asyncio.sleep(0.5 * (attempt + 1))
     return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 🛰️ DECODO SCRAPING FALLBACK — Feature 1.3 Phase 1 (2026-05-21)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# yt-dlp depuis Hetzner reçoit régulièrement un bot challenge YouTube. Avant
+# Phase 1 le pipeline restait coincé sur `_ytdlp_info_sync` → None et tous les
+# fallbacks downstream (duration_hint inclus, PR #470) ne tombaient pas car
+# `extract_storyboard_frames` n'avait pas d'`info` à parser.
+#
+# Cette section ajoute un 6e fallback : si yt-dlp KO, scraper la watch page via
+# Decodo Premium+JS (Cloudflare/anti-bot bypass), extraire
+# `ytInitialPlayerResponse` JSON, et reconstruire un dict info compatible
+# yt-dlp (duration + title + storyboards reconstruits depuis
+# `playerStoryboardSpecRenderer.spec`).
+#
+# Le test cURL pré-flight a été validé au smoke J0 (2026-05-21) — HTTP 200,
+# 2.2 MB rendered HTML, ytInitialPlayerResponse présent, lengthSeconds OK.
+# Fixture capturée dans `backend/tests/fixtures/youtube/watch_decodo_player_response.json`.
+
+# Regex YouTube-compatible. `ytInitialPlayerResponse` est assigné via
+# `var ytInitialPlayerResponse = {...};` dans le bundle inline. yt-dlp upstream
+# utilise une regex non-greedy équivalente (cf. `extractor/youtube.py`).
+_YT_PLAYER_RESPONSE_REGEX = re.compile(r"ytInitialPlayerResponse\s*=\s*({.+?});", re.DOTALL)
+
+# Storyboard CDN base : YouTube serve les sheets via `i.ytimg.com/sb/<vid>/storyboard3_L$L/$N.jpg`
+# où `$L` = level (résolution storyboard) et `$N` = index du sheet.
+_YT_STORYBOARD_BASE = "https://i.ytimg.com"
+
+# Hard cap on Decodo scrape duration. 45s gives the wrapper room for one retry
+# at 15s + one at 30s without blowing the user-facing analyse timeout.
+_DECODO_YT_TIMEOUT_S = 45.0
+
+
+def _parse_youtube_storyboards(player_response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Convert ``playerStoryboardSpecRenderer.spec`` → yt-dlp-compatible formats list.
+
+    MVP duration-only acceptable: yt-dlp dedicates ~300 LOC to the full
+    storyboard spec parser. We implement the canonical "level | duration_ms |
+    rows | cols | count" pipe-delimited base format with a best-effort URL
+    template. This is sufficient to feed `select_storyboard_format` and the
+    downstream sheet download loop. If parsing yields nothing usable, the
+    function returns ``[]`` and ``extract_storyboard_frames`` will exit at the
+    "No storyboard format available" guard — but `duration` and `title` will
+    still have been recovered, so the 5e fallback (duration_hint PR #470) can
+    still be exercised by upstream callers in v6/v2.1.
+
+    Spec format observed on dQw4w9WgXcQ::
+
+        https://i.ytimg.com/sb/dQw4w9WgXcQ/storyboard3_L$L/$N.jpg?sqp=...|
+        48#27#100#10#10#0#default#rs$AOn4CL...|
+        80#45#108#10#10#2000#M$M#rs$AOn4CL...|
+        160#90#108#5#5#2000#M$M#rs$AOn4CL...|
+        320#180#56#5#5#2000#M$M#rs$AOn4CL...
+
+    First token is the URL template (with ``$L`` and ``$N`` placeholders),
+    each subsequent token describes one level. Returns a list with one
+    yt-dlp-style format dict per level (format_id="sb0"|"sb1"|...).
+    """
+    if not isinstance(player_response, dict):
+        return []
+    storyboards = player_response.get("storyboards") or {}
+    if not isinstance(storyboards, dict):
+        return []
+    renderer = storyboards.get("playerStoryboardSpecRenderer") or {}
+    spec_str = renderer.get("spec")
+    if not isinstance(spec_str, str) or "|" not in spec_str:
+        return []
+
+    parts = spec_str.split("|")
+    url_template = parts[0]
+    if "$L" not in url_template or "$N" not in url_template:
+        return []
+
+    formats: List[Dict[str, Any]] = []
+    for level_idx, level_str in enumerate(parts[1:]):
+        fields = level_str.split("#")
+        if len(fields) < 5:
+            continue
+        try:
+            width = int(fields[0])
+            height = int(fields[1])
+            total_count = int(fields[2])  # total frames across all sheets
+            cols = int(fields[3])
+            rows = int(fields[4])
+        except ValueError:
+            continue
+        if width <= 0 or height <= 0 or total_count <= 0 or cols <= 0 or rows <= 0:
+            continue
+
+        per_sheet = max(1, cols * rows)
+        sheet_count = max(1, -(-total_count // per_sheet))  # ceil div
+
+        # Sheet URL: substitute $L with level index, $N with sheet number.
+        # YouTube serves these from i.ytimg.com (CDN sffe) which doesn't
+        # bot-guard from Hetzner (validated 2026-05-05).
+        url_tpl = url_template.replace("$L", str(level_idx))
+        fragments = [
+            {
+                "url": url_tpl.replace("$N", str(n)),
+                # We don't know per-fragment duration here; the downstream
+                # code accepts duration=0 and uses cumulative_t = 0 then
+                # walks frames evenly. The duration_s passed separately to
+                # extract_storyboard_frames is what truly drives clipping.
+                "duration": 0.0,
+            }
+            for n in range(sheet_count)
+        ]
+        formats.append(
+            {
+                "format_id": f"sb{level_idx}",
+                "ext": "mhtml",
+                "width": width,
+                "height": height,
+                "columns": cols,
+                "rows": rows,
+                "fragments": fragments,
+            }
+        )
+
+    return formats
+
+
+async def _decodo_scrape_youtube_info(video_id: str, log_tag: str) -> Optional[Dict[str, Any]]:
+    """6e fallback : scrape YouTube watch page via Decodo Premium+JS.
+
+    Active uniquement après échec de ``_ytdlp_info_sync`` (bot challenge
+    Hetzner). Parse ``ytInitialPlayerResponse`` qui contient ``videoDetails``
+    (duration, title) et ``storyboards.playerStoryboardSpecRenderer.spec``.
+
+    Reconstruit un dict compatible avec le format yt-dlp downstream :
+      - id, title, duration (s)
+      - formats: list of storyboard dicts (sb0, sb1, ...)
+      - _source: "decodo_scrape" pour traçabilité
+
+    Returns None si Decodo retourne KO, HTML trop court, regex no-match ou
+    JSON parse fail. Tous les cas font un warning log et fall-through ; la
+    fonction NE LÈVE JAMAIS — caller fait son propre `if not info`.
+
+    Spec § 6.3, Phase 1.3 Decodo Web Scraping rollout.
+    """
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    try:
+        # Lazy import: keep decodo client out of the hot path when unused.
+        from decodo import DecodoScrapingClient
+
+        client = DecodoScrapingClient()
+        result = await client.scrape(
+            url,
+            proxy_pool="premium",
+            headless=True,
+            output_format="raw_html",
+            timeout_s=_DECODO_YT_TIMEOUT_S,
+        )
+    except Exception as e:
+        # DecodoDisabledError / DecodoBudgetExceededError / DecodoConfigError /
+        # DecodoRequestError / DecodoTimeoutError / DecodoResponseError all
+        # inherit from DecodoScrapingError. Anything else is unexpected but
+        # must not break the analyse pipeline.
+        logger.warning(
+            "[%s] decodo_youtube_watch: client.scrape raised %s: %s",
+            log_tag,
+            type(e).__name__,
+            str(e)[:200],
+        )
+        return None
+
+    html = result.content or ""
+    if len(html) < 50_000:
+        logger.warning(
+            "[%s] decodo_youtube_watch: html too short (%d bytes)",
+            log_tag,
+            len(html),
+        )
+        return None
+
+    m = _YT_PLAYER_RESPONSE_REGEX.search(html)
+    if not m:
+        logger.warning(
+            "[%s] decodo_youtube_watch: ytInitialPlayerResponse not found in %d byte HTML",
+            log_tag,
+            len(html),
+        )
+        return None
+
+    try:
+        player = json.loads(m.group(1))
+    except json.JSONDecodeError as e:
+        logger.warning(
+            "[%s] decodo_youtube_watch: JSON parse error at offset %d: %s",
+            log_tag,
+            getattr(e, "pos", -1),
+            str(e)[:200],
+        )
+        return None
+
+    video_details = player.get("videoDetails") or {}
+    try:
+        duration = int(video_details.get("lengthSeconds", 0) or 0)
+    except (TypeError, ValueError):
+        duration = 0
+    title = video_details.get("title") or ""
+
+    formats = _parse_youtube_storyboards(player)
+    logger.info(
+        "[%s] decodo_youtube_watch: recovered info (duration=%ds, storyboards=%d)",
+        log_tag,
+        duration,
+        len(formats),
+    )
+    return {
+        "id": video_id,
+        "title": title,
+        "duration": duration,
+        "formats": formats,
+        "_source": "decodo_scrape",
+    }
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/src/videos/youtube_storyboard.py
+++ b/backend/src/videos/youtube_storyboard.py
@@ -477,6 +477,51 @@ async def _decodo_scrape_youtube_info(video_id: str, log_tag: str) -> Optional[D
     }
 
 
+async def get_youtube_info_with_fallback(video_id: str, log_tag: str) -> Optional[Dict[str, Any]]:
+    """Async cascade : yt-dlp first, Decodo Scraping fallback on KO.
+
+    This is the single entry-point that `extract_storyboard_frames` uses to
+    obtain video info. The yt-dlp path is kept intact (still ran through the
+    Decodo Residential proxy) — when it fails (bot challenge from Hetzner,
+    timeout, malformed JSON, etc.) we fall through to the Web Scraping API
+    which has Premium+JS Cloudflare/anti-bot bypass.
+
+    Returns the same dict shape `_ytdlp_info_sync` would have returned on
+    success, with an optional `_source` key indicating which path produced
+    it ("ytdlp" or "decodo_scrape"). Callers should treat absent `_source`
+    as legacy yt-dlp behavior.
+
+    NEVER raises — both legs return None on failure. The caller decides what
+    to do when nothing comes back (today: `extract_storyboard_frames` exits
+    at L308 and the visual analyse becomes a no-op).
+
+    Bail-early audit (Phase 1.3, anti-PR #468-trap):
+      * `videos/router.py:1507` v6 → `enrich_and_capture_visual` ✓
+      * `videos/router.py:2444` v2.1 → `enrich_and_capture_visual` ✓
+      * `videos/visual_integration.py:303` `enrich_and_capture_visual` →
+        `extract_storyboard_frames` (no `_extract_youtube_visual_frames`
+        intermediate in current code) ✓
+      * `videos/youtube_storyboard.py:extract_storyboard_frames` calls this
+        wrapper — yt-dlp KO no longer short-circuits, Decodo gets its turn.
+    """
+    loop = asyncio.get_event_loop()
+
+    # 1. yt-dlp (current path, unchanged) — runs in the executor since it
+    # spawns a subprocess.
+    info = await loop.run_in_executor(executor, _ytdlp_info_sync, video_id, log_tag)
+    if info:
+        return info
+
+    # 2. Decodo Web Scraping API fallback — Premium+JS, ~3-12s typical.
+    logger.info("[%s] yt-dlp returned None, attempting Decodo Scraping", log_tag)
+    info = await _decodo_scrape_youtube_info(video_id, log_tag)
+    if info:
+        logger.info("[%s] Decodo Scraping recovered YouTube info", log_tag)
+        return info
+
+    return None
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # 🚀 API PUBLIQUE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -523,13 +568,24 @@ async def extract_storyboard_frames(
     loop = asyncio.get_event_loop()
 
     try:
-        # ── 1. yt-dlp -j ──
+        # ── 1. yt-dlp -j (+ 6e fallback Decodo Scraping on KO) ──
+        # Phase 1.3 (2026-05-21) : `get_youtube_info_with_fallback` chains
+        # yt-dlp → Decodo Premium+JS so a Hetzner bot challenge no longer
+        # short-circuits the visual pipeline. The `_source` key inside info
+        # tracks which leg produced the dict (for telemetry & debugging).
         t0 = time.time()
-        info = await loop.run_in_executor(executor, _ytdlp_info_sync, video_id, log_tag)
+        info = await get_youtube_info_with_fallback(video_id, log_tag)
         if not info:
             shutil.rmtree(workdir, ignore_errors=True)
             return None
-        logger.info("[%s] yt-dlp info OK in %.1fs (video_id=%s)", log_tag, time.time() - t0, video_id)
+        info_source = info.get("_source", "ytdlp")
+        logger.info(
+            "[%s] info OK in %.1fs (video_id=%s, source=%s)",
+            log_tag,
+            time.time() - t0,
+            video_id,
+            info_source,
+        )
 
         duration_s = float(info.get("duration") or 0)
 

--- a/backend/tests/fixtures/youtube/_extract_player_response.py
+++ b/backend/tests/fixtures/youtube/_extract_player_response.py
@@ -1,0 +1,57 @@
+"""Helper to extract ytInitialPlayerResponse from a Decodo raw response.
+
+Reads ``_decodo_raw_response.json`` (the Decodo envelope) and writes the
+inner ``ytInitialPlayerResponse`` object as ``watch_decodo_player_response.json``.
+
+Run once to capture the fixture. Then this helper itself can stay alongside the
+fixture as documentation of how it was generated.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+RAW = HERE / "_decodo_raw_response.json"
+OUT = HERE / "watch_decodo_player_response.json"
+
+PLAYER_RE = re.compile(r"ytInitialPlayerResponse\s*=\s*({.+?});", re.DOTALL)
+
+
+def main() -> int:
+    if not RAW.exists():
+        print(f"Missing raw response at {RAW}", file=sys.stderr)
+        return 1
+    envelope = json.loads(RAW.read_text(encoding="utf-8"))
+    results = envelope.get("results") or []
+    if not results:
+        print("envelope has no 'results' array", file=sys.stderr)
+        return 1
+    html = results[0].get("content") or ""
+    if len(html) < 50_000:
+        print(f"content too short ({len(html)} bytes)", file=sys.stderr)
+        return 1
+    m = PLAYER_RE.search(html)
+    if not m:
+        print("ytInitialPlayerResponse not found in HTML", file=sys.stderr)
+        return 1
+    try:
+        player = json.loads(m.group(1))
+    except json.JSONDecodeError as e:
+        print(f"player_response JSON parse error: {e}", file=sys.stderr)
+        return 1
+    OUT.write_text(json.dumps(player, indent=2), encoding="utf-8")
+    vd = player.get("videoDetails", {})
+    print(
+        f"OK: wrote {OUT.name} ({OUT.stat().st_size:,} bytes); "
+        f"videoId={vd.get('videoId')} title={vd.get('title')!r} "
+        f"lengthSeconds={vd.get('lengthSeconds')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/fixtures/youtube/watch_decodo_player_response.json
+++ b/backend/tests/fixtures/youtube/watch_decodo_player_response.json
@@ -1,0 +1,3478 @@
+{
+  "responseContext": {
+    "serviceTrackingParams": [
+      {
+        "service": "GFEEDBACK",
+        "params": [
+          {
+            "key": "is_alc_surface",
+            "value": "false"
+          },
+          {
+            "key": "ipcc",
+            "value": "0"
+          },
+          {
+            "key": "is_viewed_live",
+            "value": "False"
+          },
+          {
+            "key": "logged_in",
+            "value": "0"
+          },
+          {
+            "key": "visitor_data",
+            "value": "CgtJUEgyMXQwc0lFbyiFu7zQBjIKCgJVUxIEGgAgZ2LfAgrcAjE4LllUPVpGcEFURVA2aW9lTTBQUDcwVEkwOVYzNlJreHhRbnU5Rlp3d0dsZGE0d3lhNl9aN2pmWDQ0MGVqaW1NcE55RFF1UDBKb01EZzM2Y1BxcGg2ZGdBX2RmbkhmdUY5dFVVenRRNXBBdWdvbTRNSXczODkxX3RJVmw0QnVMRHVFR2JuU0N1S2ZWSDBiUVhERHR2UGhycExMOEttTDRjakxUVVNrUkxqQzNZZlNKS3FfcTEzTVZTc2VXbHJmMXNYTEdPWTJWbDNTT18xR3FjdHRxa3VONHN5WUNPYi1SODFrMlVyZFVwZHVvYVRRVWhxOW9hTTIzOHl1cG54cTRBd2VTdTg1c2xoNFR5NjNaYmd4ZnhfZ3d3M0loQTNldHFMbXdrMmtnVnRBMXl6TkZrNGZXOHdBWFh2dzdwaldFOTJkaGt3OVFjclhYNWhxOVB0Si02VXF1WTB0Zw%3D%3D"
+          }
+        ]
+      },
+      {
+        "service": "CSI",
+        "params": [
+          {
+            "key": "yt_ad",
+            "value": "1"
+          },
+          {
+            "key": "c",
+            "value": "WEB"
+          },
+          {
+            "key": "cver",
+            "value": "2.20260519.10.00"
+          },
+          {
+            "key": "yt_li",
+            "value": "0"
+          },
+          {
+            "key": "GetPlayer_rid",
+            "value": "0x0f977e98def17444"
+          }
+        ]
+      },
+      {
+        "service": "GUIDED_HELP",
+        "params": [
+          {
+            "key": "logged_in",
+            "value": "0"
+          }
+        ]
+      },
+      {
+        "service": "ECATCHER",
+        "params": [
+          {
+            "key": "client.version",
+            "value": "2.20260519"
+          },
+          {
+            "key": "client.name",
+            "value": "WEB"
+          }
+        ]
+      }
+    ],
+    "maxAgeSeconds": 0,
+    "mainAppWebResponseContext": {
+      "loggedOut": true,
+      "trackingParam": "k5_fmPxhoXZRODxEPDaEcYrg4BLUA8r4TFBELN-IVsC8ohIkAUhUJ4-0qzRMkuMYNLBwOcCw59TLtslLKPQGSS"
+    },
+    "responseId": "IhMI0qLjodLKlAMVp35MCB2BFiYD",
+    "webResponseContextExtensionData": {
+      "webResponseContextPreloadData": {
+        "preloadMessageNames": [
+          "miniplayerRenderer",
+          "adPlacementRenderer",
+          "clientForecastingAdRenderer",
+          "playerCaptionsTracklistRenderer",
+          "playerAnnotationsExpandedRenderer",
+          "subscribeButtonRenderer",
+          "confirmDialogRenderer",
+          "buttonRenderer",
+          "playerStoryboardSpecRenderer",
+          "playerMicroformatRenderer",
+          "cardCollectionRenderer",
+          "cardRenderer",
+          "simpleCardTeaserRenderer",
+          "infoCardIconRenderer",
+          "mealbarPromoRenderer",
+          "endscreenRenderer",
+          "endscreenElementRenderer",
+          "thumbnailOverlayTimeStatusRenderer",
+          "toggleButtonViewModel",
+          "buttonViewModel"
+        ]
+      },
+      "hasDecorated": true
+    }
+  },
+  "playabilityStatus": {
+    "status": "OK",
+    "playableInEmbed": true,
+    "miniplayer": {
+      "miniplayerRenderer": {
+        "playbackMode": "PLAYBACK_MODE_ALLOW"
+      }
+    },
+    "contextParams": "Q0FFU0FnZ0I="
+  },
+  "streamingData": {
+    "expiresInSeconds": "21540",
+    "formats": [
+      {
+        "itag": 18,
+        "mimeType": "video/mp4; codecs=\"avc1.42001E, mp4a.40.2\"",
+        "bitrate": 444226,
+        "width": 640,
+        "height": 360,
+        "lastModified": "1766960953317159",
+        "quality": "medium",
+        "fps": 25,
+        "qualityLabel": "360p",
+        "projectionType": "RECTANGULAR",
+        "audioQuality": "AUDIO_QUALITY_LOW",
+        "approxDurationMs": "213089",
+        "audioSampleRate": "44100",
+        "audioChannels": 2,
+        "signatureCipher": "s=MHHEAAEqNM4wRQIgRoLvI6jAugMjRprAE1zVM36wDjU1HCnHxEGK9v5U2q8CIQDLaPofm9FCAOTohH-cgG5bsRXNMJW82tyyN5wEF-SiFw%3D%3Dw%3D%3D&sp=sig&url=https://rr6---sn-bvvbaxivnuxqjvhj5nu-nx5z.googlevideo.com/videoplayback%3Fexpire%3D1779397093%26ei%3DhR0PapLMKKf9sfIPga2YGQ%26ip%3D2601%253A600%253A9000%253A3e20%253A1310%253A6860%253A455a%253A1e1f%26id%3Do-AP-cIBcGTARqgEN9Znjkz_XthTubN13RHhi8BaVsd2G-%26itag%3D18%26source%3Dyoutube%26requiressl%3Dyes%26xpc%3DEgVo2aDSNQ%253D%253D%26met%3D1779375493%252C%26mh%3D7c%26mm%3D18%252C29%26mn%3Dsn-bvvbaxivnuxqjvhj5nu-nx5z%252Csn-nx57ynsk%26ms%3Daub%252Crdu%26mv%3Dm%26mvi%3D6%26pl%3D34%26rms%3Daub%252Caub%26initcwndbps%3D3925000%26bui%3DAbKmrwoKS-yRjb5GDBzPW6mfDuTTiYWcsEwLSfmcfb6wUlq_82c_HD8HEKjAvbV-TEZxPILx4znYaOgz%26spc%3D96Xrvw0u8g7J7jhynw9DfsAaEdeGIJkzwZ0VdnJ9d9GUgrYLWmG40dq-XRH0sNDOuN77gHSdTEvIAw%26vprv%3D1%26svpuc%3D1%26mime%3Dvideo%252Fmp4%26ns%3DNyANxxXH27yZnZyL7vQG-PkV%26rqh%3D1%26cnr%3D14%26ratebypass%3Dyes%26dur%3D213.089%26lmt%3D1766960953317159%26mt%3D1779375138%26fvip%3D4%26fexp%3D51565116%252C51565681%26c%3DWEB%26sefc%3D1%26txp%3D5538534%26n%3DSHWVIGiYZa3GZuikgv4%26sparams%3Dexpire%252Cei%252Cip%252Cid%252Citag%252Csource%252Crequiressl%252Cxpc%252Cbui%252Cspc%252Cvprv%252Csvpuc%252Cmime%252Cns%252Crqh%252Ccnr%252Cratebypass%252Cdur%252Clmt%26lsparams%3Dmet%252Cmh%252Cmm%252Cmn%252Cms%252Cmv%252Cmvi%252Cpl%252Crms%252Cinitcwndbps%26lsig%3DAPaTxxMwRAIgJH6POxvar3eVKN0dmPcGRILEkB6NX-8yyWaqJzDIeWsCIAf7KkLI6C0J6FIoZoHrWq1_telDxoP7FUasWdGMepzF",
+        "qualityOrdinal": "QUALITY_ORDINAL_360P"
+      }
+    ],
+    "adaptiveFormats": [
+      {
+        "itag": 313,
+        "mimeType": "video/webm; codecs=\"vp9\"",
+        "bitrate": 18076636,
+        "width": 3840,
+        "height": 2160,
+        "initRange": {
+          "start": "0",
+          "end": "220"
+        },
+        "indexRange": {
+          "start": "221",
+          "end": "893"
+        },
+        "lastModified": "1766963492248817",
+        "contentLength": "358608461",
+        "quality": "hd2160",
+        "fps": 25,
+        "qualityLabel": "2160p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 13466333,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_2160P"
+      },
+      {
+        "itag": 401,
+        "mimeType": "video/mp4; codecs=\"av01.0.12M.08\"",
+        "bitrate": 17400774,
+        "width": 3840,
+        "height": 2160,
+        "initRange": {
+          "start": "0",
+          "end": "700"
+        },
+        "indexRange": {
+          "start": "701",
+          "end": "1188"
+        },
+        "lastModified": "1766961226342025",
+        "contentLength": "240334643",
+        "quality": "hd2160",
+        "fps": 25,
+        "qualityLabel": "2160p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 9024958,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_2160P"
+      },
+      {
+        "itag": 271,
+        "mimeType": "video/webm; codecs=\"vp9\"",
+        "bitrate": 8978328,
+        "width": 2560,
+        "height": 1440,
+        "initRange": {
+          "start": "0",
+          "end": "219"
+        },
+        "indexRange": {
+          "start": "220",
+          "end": "889"
+        },
+        "lastModified": "1766962756705951",
+        "contentLength": "151103346",
+        "quality": "hd1440",
+        "fps": 25,
+        "qualityLabel": "1440p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 5674177,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_1440P"
+      },
+      {
+        "itag": 400,
+        "mimeType": "video/mp4; codecs=\"av01.0.12M.08\"",
+        "bitrate": 7755221,
+        "width": 2560,
+        "height": 1440,
+        "initRange": {
+          "start": "0",
+          "end": "700"
+        },
+        "indexRange": {
+          "start": "701",
+          "end": "1188"
+        },
+        "lastModified": "1766961246255689",
+        "contentLength": "122168277",
+        "quality": "hd1440",
+        "fps": 25,
+        "qualityLabel": "1440p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 4587618,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_1440P"
+      },
+      {
+        "itag": 137,
+        "mimeType": "video/mp4; codecs=\"avc1.640028\"",
+        "bitrate": 4334157,
+        "width": 1920,
+        "height": 1080,
+        "initRange": {
+          "start": "0",
+          "end": "741"
+        },
+        "indexRange": {
+          "start": "742",
+          "end": "1229"
+        },
+        "lastModified": "1766957926174250",
+        "contentLength": "80911999",
+        "quality": "hd1080",
+        "fps": 25,
+        "qualityLabel": "1080p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 3038377,
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+      },
+      {
+        "itag": 248,
+        "mimeType": "video/webm; codecs=\"vp9\"",
+        "bitrate": 1549172,
+        "width": 1920,
+        "height": 1080,
+        "initRange": {
+          "start": "0",
+          "end": "219"
+        },
+        "indexRange": {
+          "start": "220",
+          "end": "874"
+        },
+        "lastModified": "1766963494258902",
+        "contentLength": "30846580",
+        "quality": "hd1080",
+        "fps": 25,
+        "qualityLabel": "1080p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 1158339,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+      },
+      {
+        "itag": 399,
+        "mimeType": "video/mp4; codecs=\"av01.0.08M.08\"",
+        "bitrate": 1594543,
+        "width": 1920,
+        "height": 1080,
+        "initRange": {
+          "start": "0",
+          "end": "699"
+        },
+        "indexRange": {
+          "start": "700",
+          "end": "1187"
+        },
+        "lastModified": "1766970905427393",
+        "contentLength": "30415996",
+        "quality": "hd1080",
+        "fps": 25,
+        "qualityLabel": "1080p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 1142170,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+      },
+      {
+        "itag": 136,
+        "mimeType": "video/mp4; codecs=\"avc1.4d401f\"",
+        "bitrate": 1058310,
+        "width": 1280,
+        "height": 720,
+        "initRange": {
+          "start": "0",
+          "end": "739"
+        },
+        "indexRange": {
+          "start": "740",
+          "end": "1227"
+        },
+        "lastModified": "1766958204135500",
+        "contentLength": "26455880",
+        "quality": "hd720",
+        "fps": 25,
+        "qualityLabel": "720p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 993461,
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_720P"
+      },
+      {
+        "itag": 247,
+        "mimeType": "video/webm; codecs=\"vp9\"",
+        "bitrate": 867871,
+        "width": 1280,
+        "height": 720,
+        "initRange": {
+          "start": "0",
+          "end": "219"
+        },
+        "indexRange": {
+          "start": "220",
+          "end": "860"
+        },
+        "lastModified": "1766962272813700",
+        "contentLength": "17686717",
+        "quality": "hd720",
+        "fps": 25,
+        "qualityLabel": "720p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 664165,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_720P"
+      },
+      {
+        "itag": 398,
+        "mimeType": "video/mp4; codecs=\"av01.0.05M.08\"",
+        "bitrate": 1012348,
+        "width": 1280,
+        "height": 720,
+        "initRange": {
+          "start": "0",
+          "end": "699"
+        },
+        "indexRange": {
+          "start": "700",
+          "end": "1187"
+        },
+        "lastModified": "1766960928964543",
+        "contentLength": "17593076",
+        "quality": "hd720",
+        "fps": 25,
+        "qualityLabel": "720p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 660648,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_720P"
+      },
+      {
+        "itag": 135,
+        "mimeType": "video/mp4; codecs=\"avc1.4d401e\"",
+        "bitrate": 690764,
+        "width": 854,
+        "height": 480,
+        "initRange": {
+          "start": "0",
+          "end": "740"
+        },
+        "indexRange": {
+          "start": "741",
+          "end": "1228"
+        },
+        "lastModified": "1766958212394312",
+        "contentLength": "14103519",
+        "quality": "large",
+        "fps": 25,
+        "qualityLabel": "480p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 529610,
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_480P"
+      },
+      {
+        "itag": 244,
+        "mimeType": "video/webm; codecs=\"vp9\"",
+        "bitrate": 466632,
+        "width": 854,
+        "height": 480,
+        "initRange": {
+          "start": "0",
+          "end": "219"
+        },
+        "indexRange": {
+          "start": "220",
+          "end": "857"
+        },
+        "lastModified": "1766961781254744",
+        "contentLength": "9381481",
+        "quality": "large",
+        "fps": 25,
+        "qualityLabel": "480p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 352289,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_480P"
+      },
+      {
+        "itag": 397,
+        "mimeType": "video/mp4; codecs=\"av01.0.04M.08\"",
+        "bitrate": 525728,
+        "width": 854,
+        "height": 480,
+        "initRange": {
+          "start": "0",
+          "end": "699"
+        },
+        "indexRange": {
+          "start": "700",
+          "end": "1187"
+        },
+        "lastModified": "1766961026797508",
+        "contentLength": "9874826",
+        "quality": "large",
+        "fps": 25,
+        "qualityLabel": "480p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 370815,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_480P"
+      },
+      {
+        "itag": 134,
+        "mimeType": "video/mp4; codecs=\"avc1.4d401e\"",
+        "bitrate": 450863,
+        "width": 640,
+        "height": 360,
+        "initRange": {
+          "start": "0",
+          "end": "740"
+        },
+        "indexRange": {
+          "start": "741",
+          "end": "1228"
+        },
+        "lastModified": "1766960771651324",
+        "contentLength": "8390921",
+        "quality": "medium",
+        "fps": 25,
+        "qualityLabel": "360p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 315092,
+        "highReplication": true,
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_360P"
+      },
+      {
+        "itag": 243,
+        "mimeType": "video/webm; codecs=\"vp9\"",
+        "bitrate": 288453,
+        "width": 640,
+        "height": 360,
+        "initRange": {
+          "start": "0",
+          "end": "219"
+        },
+        "indexRange": {
+          "start": "220",
+          "end": "857"
+        },
+        "lastModified": "1766962597390784",
+        "contentLength": "6014765",
+        "quality": "medium",
+        "fps": 25,
+        "qualityLabel": "360p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 225864,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_360P"
+      },
+      {
+        "itag": 396,
+        "mimeType": "video/mp4; codecs=\"av01.0.01M.08\"",
+        "bitrate": 304466,
+        "width": 640,
+        "height": 360,
+        "initRange": {
+          "start": "0",
+          "end": "699"
+        },
+        "indexRange": {
+          "start": "700",
+          "end": "1187"
+        },
+        "lastModified": "1766958935473272",
+        "contentLength": "5685561",
+        "quality": "medium",
+        "fps": 25,
+        "qualityLabel": "360p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 213502,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_360P"
+      },
+      {
+        "itag": 133,
+        "mimeType": "video/mp4; codecs=\"avc1.4d4015\"",
+        "bitrate": 236224,
+        "width": 426,
+        "height": 240,
+        "initRange": {
+          "start": "0",
+          "end": "739"
+        },
+        "indexRange": {
+          "start": "740",
+          "end": "1227"
+        },
+        "lastModified": "1766961065074107",
+        "contentLength": "4310122",
+        "quality": "small",
+        "fps": 25,
+        "qualityLabel": "240p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 161852,
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_240P"
+      },
+      {
+        "itag": 242,
+        "mimeType": "video/webm; codecs=\"vp9\"",
+        "bitrate": 131647,
+        "width": 426,
+        "height": 240,
+        "initRange": {
+          "start": "0",
+          "end": "218"
+        },
+        "indexRange": {
+          "start": "219",
+          "end": "856"
+        },
+        "lastModified": "1766963772564266",
+        "contentLength": "2706929",
+        "quality": "small",
+        "fps": 25,
+        "qualityLabel": "240p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 101649,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_240P"
+      },
+      {
+        "itag": 395,
+        "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+        "bitrate": 159709,
+        "width": 426,
+        "height": 240,
+        "initRange": {
+          "start": "0",
+          "end": "699"
+        },
+        "indexRange": {
+          "start": "700",
+          "end": "1187"
+        },
+        "lastModified": "1766960927930211",
+        "contentLength": "3095447",
+        "quality": "small",
+        "fps": 25,
+        "qualityLabel": "240p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 116239,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_240P"
+      },
+      {
+        "itag": 160,
+        "mimeType": "video/mp4; codecs=\"avc1.4d400c\"",
+        "bitrate": 109973,
+        "width": 256,
+        "height": 144,
+        "initRange": {
+          "start": "0",
+          "end": "738"
+        },
+        "indexRange": {
+          "start": "739",
+          "end": "1226"
+        },
+        "lastModified": "1766961162303498",
+        "contentLength": "2058142",
+        "quality": "tiny",
+        "fps": 25,
+        "qualityLabel": "144p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 77286,
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_144P"
+      },
+      {
+        "itag": 278,
+        "mimeType": "video/webm; codecs=\"vp9\"",
+        "bitrate": 68500,
+        "width": 256,
+        "height": 144,
+        "initRange": {
+          "start": "0",
+          "end": "217"
+        },
+        "indexRange": {
+          "start": "218",
+          "end": "854"
+        },
+        "lastModified": "1766962598503008",
+        "contentLength": "1540844",
+        "quality": "tiny",
+        "fps": 25,
+        "qualityLabel": "144p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 57861,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_144P"
+      },
+      {
+        "itag": 394,
+        "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+        "bitrate": 83289,
+        "width": 256,
+        "height": 144,
+        "initRange": {
+          "start": "0",
+          "end": "699"
+        },
+        "indexRange": {
+          "start": "700",
+          "end": "1187"
+        },
+        "lastModified": "1766961689433204",
+        "contentLength": "1505504",
+        "quality": "tiny",
+        "fps": 25,
+        "qualityLabel": "144p",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 56534,
+        "colorInfo": {
+          "primaries": "COLOR_PRIMARIES_BT709",
+          "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+          "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+        },
+        "approxDurationMs": "213040",
+        "qualityOrdinal": "QUALITY_ORDINAL_144P"
+      },
+      {
+        "itag": 140,
+        "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+        "bitrate": 130677,
+        "initRange": {
+          "start": "0",
+          "end": "722"
+        },
+        "indexRange": {
+          "start": "723",
+          "end": "1018"
+        },
+        "lastModified": "1766955925572207",
+        "contentLength": "3449447",
+        "quality": "tiny",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 129502,
+        "highReplication": true,
+        "audioQuality": "AUDIO_QUALITY_MEDIUM",
+        "approxDurationMs": "213089",
+        "audioSampleRate": "44100",
+        "audioChannels": 2,
+        "loudnessDb": 0.98999977,
+        "trackAbsoluteLoudnessLkfs": -13.01,
+        "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+      },
+      {
+        "itag": 249,
+        "mimeType": "audio/webm; codecs=\"opus\"",
+        "bitrate": 49496,
+        "initRange": {
+          "start": "0",
+          "end": "258"
+        },
+        "indexRange": {
+          "start": "259",
+          "end": "628"
+        },
+        "lastModified": "1766955883595299",
+        "contentLength": "1231355",
+        "quality": "tiny",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 46234,
+        "audioQuality": "AUDIO_QUALITY_LOW",
+        "approxDurationMs": "213061",
+        "audioSampleRate": "48000",
+        "audioChannels": 2,
+        "loudnessDb": 0.97999954,
+        "trackAbsoluteLoudnessLkfs": -13.02,
+        "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+      },
+      {
+        "itag": 250,
+        "mimeType": "audio/webm; codecs=\"opus\"",
+        "bitrate": 65508,
+        "initRange": {
+          "start": "0",
+          "end": "258"
+        },
+        "indexRange": {
+          "start": "259",
+          "end": "629"
+        },
+        "lastModified": "1766955884018742",
+        "contentLength": "1628559",
+        "quality": "tiny",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 61149,
+        "audioQuality": "AUDIO_QUALITY_LOW",
+        "approxDurationMs": "213061",
+        "audioSampleRate": "48000",
+        "audioChannels": 2,
+        "loudnessDb": 0.97999954,
+        "trackAbsoluteLoudnessLkfs": -13.02,
+        "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+      },
+      {
+        "itag": 251,
+        "mimeType": "audio/webm; codecs=\"opus\"",
+        "bitrate": 136544,
+        "initRange": {
+          "start": "0",
+          "end": "258"
+        },
+        "indexRange": {
+          "start": "259",
+          "end": "629"
+        },
+        "lastModified": "1766955883819090",
+        "contentLength": "3433755",
+        "quality": "tiny",
+        "projectionType": "RECTANGULAR",
+        "averageBitrate": 128930,
+        "audioQuality": "AUDIO_QUALITY_MEDIUM",
+        "approxDurationMs": "213061",
+        "audioSampleRate": "48000",
+        "audioChannels": 2,
+        "loudnessDb": 0.97999954,
+        "trackAbsoluteLoudnessLkfs": -13.02,
+        "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+      }
+    ],
+    "serverAbrStreamingUrl": "https://rr6---sn-bvvbaxivnuxqjvhj5nu-nx5z.googlevideo.com/videoplayback?expire=1779397093&ei=hR0PapLMKKf9sfIPga2YGQ&ip=2601%3A600%3A9000%3A3e20%3A1310%3A6860%3A455a%3A1e1f&id=o-AP-cIBcGTARqgEN9Znjkz_XthTubN13RHhi8BaVsd2G-&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&met=1779375493%2C&mh=7c&mm=18%2C29&mn=sn-bvvbaxivnuxqjvhj5nu-nx5z%2Csn-nx57ynsk&ms=aub%2Crdu&mv=m&mvi=6&pl=34&rms=aub%2Caub&initcwndbps=3925000&spc=96Xrvw0t8g7J7jhynw9DfsAaEdeGIJkzwZ0VdnJ9d9GUgrYLWmG40dq-XRH0sND0vqz4-HR1TNM&svpuc=1&ns=6jlPXfEz0IjWvcL7HXf-EvkV&sabr=1&rqh=1&mt=1779375138&fvip=4&keepalive=yes&fexp=51565116%2C51565681&c=WEB&n=zFag2m5u9-_Bedj8kRl&sparams=expire%2Cei%2Cip%2Cid%2Csource%2Crequiressl%2Cxpc%2Cspc%2Csvpuc%2Cns%2Csabr%2Crqh&sig=AHEqNM4wRgIhAJP0FYGn5BzImmaHhumQzyNx__c9GFz8yg-hw-uxd9LfAiEAhZJh0a9u54N8VnScS2hNYPUv2qpv0yYfEuzHp8Li7hA%3D&lsparams=met%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgJH6POxvar3eVKN0dmPcGRILEkB6NX-8yyWaqJzDIeWsCIAf7KkLI6C0J6FIoZoHrWq1_telDxoP7FUasWdGMepzF"
+  },
+  "playbackTracking": {
+    "videostatsPlaybackUrl": {
+      "baseUrl": "https://s.youtube.com/api/stats/playback?cl=916919049&docid=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&fexp=&ns=yt&plid=AAZSVSQ5QFuFdjS6&el=detailpage&len=214&of=JkNmGsq-klhuzbqUlFz4fg&vm=CAMQARgBOjJBSHFpSlRLUkZwZG1pWHhwamJIYU9QYWNNZWtPYi1Ha2gyLWlZZE9QcDN3cTFXamNoQWJfQUxkcUFQSmNILU5yU2xzbFJvMHJWMms5ajRNaE9LdERHM3NmN2YtLU9mZ0lRXzcyQTFjUEFRbXhfRG5FMEVxcHgtdVBsRW5HM3lzVkpySWlrdTNzZGkxLThhbjFvSWu4AQE"
+    },
+    "videostatsDelayplayUrl": {
+      "baseUrl": "https://s.youtube.com/api/stats/delayplay?cl=916919049&docid=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&fexp=&ns=yt&plid=AAZSVSQ5QFuFdjS6&el=detailpage&len=214&of=JkNmGsq-klhuzbqUlFz4fg&vm=CAMQARgBOjJBSHFpSlRLUkZwZG1pWHhwamJIYU9QYWNNZWtPYi1Ha2gyLWlZZE9QcDN3cTFXamNoQWJfQUxkcUFQSmNILU5yU2xzbFJvMHJWMms5ajRNaE9LdERHM3NmN2YtLU9mZ0lRXzcyQTFjUEFRbXhfRG5FMEVxcHgtdVBsRW5HM3lzVkpySWlrdTNzZGkxLThhbjFvSWu4AQE"
+    },
+    "videostatsWatchtimeUrl": {
+      "baseUrl": "https://s.youtube.com/api/stats/watchtime?cl=916919049&docid=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&fexp=&ns=yt&plid=AAZSVSQ5QFuFdjS6&el=detailpage&len=214&of=JkNmGsq-klhuzbqUlFz4fg&vm=CAMQARgBOjJBSHFpSlRLUkZwZG1pWHhwamJIYU9QYWNNZWtPYi1Ha2gyLWlZZE9QcDN3cTFXamNoQWJfQUxkcUFQSmNILU5yU2xzbFJvMHJWMms5ajRNaE9LdERHM3NmN2YtLU9mZ0lRXzcyQTFjUEFRbXhfRG5FMEVxcHgtdVBsRW5HM3lzVkpySWlrdTNzZGkxLThhbjFvSWu4AQE"
+    },
+    "ptrackingUrl": {
+      "baseUrl": "https://www.youtube.com/ptracking?ei=hR0PapLMKKf9sfIPga2YGQ&m=A9EOxnBgsEZmTsO1TOkRJOTDgXhj69x8X90NIFyxPu9Wp_asyUn09wiiZXBaTazRJxAVMbkYzE276IzGrImH7K-o&oid=QuEoptyF_C_7jHTEUMsRjA&plid=AAZSVSQ5QFuFdjS6&pltype=content&ptchn=uAXFkgsw1L7xaCfnd5JJOw&ptk=youtube_single&video_id=dQw4w9WgXcQ"
+    },
+    "qoeUrl": {
+      "baseUrl": "https://s.youtube.com/api/stats/qoe?cl=916919049&docid=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&el=detailpage&event=streamingstats&fexp=&ns=yt&plid=AAZSVSQ5QFuFdjS6"
+    },
+    "atrUrl": {
+      "baseUrl": "https://s.youtube.com/api/stats/atr?c=WEB&docid=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&len=214&ns=yt&plid=AAZSVSQ5QFuFdjS6&ver=2&vm=CAMQARgBOjJBSHFpSlRLUkZwZG1pWHhwamJIYU9QYWNNZWtPYi1Ha2gyLWlZZE9QcDN3cTFXamNoQWJfQUxkcUFQSmNILU5yU2xzbFJvMHJWMms5ajRNaE9LdERHM3NmN2YtLU9mZ0lRXzcyQTFjUEFRbXhfRG5FMEVxcHgtdVBsRW5HM3lzVkpySWlrdTNzZGkxLThhbjFvSWu4AQE",
+      "elapsedMediaTimeSeconds": 5
+    },
+    "videostatsScheduledFlushWalltimeSeconds": [
+      10,
+      20,
+      30
+    ],
+    "videostatsDefaultFlushIntervalSeconds": 40,
+    "youtubeRemarketingUrl": {
+      "baseUrl": "https://www.youtube.com/pagead/viewthroughconversion/962985656/?backend=innertube&cname=1&cver=2_20260519&data=backend%3Dinnertube%3Bcname%3D1%3Bcver%3D2_20260519%3Bm%3D1%3Bptype%3Df_view%3Btype%3Dview%3Butuid%3DuAXFkgsw1L7xaCfnd5JJOw%3Butvid%3DdQw4w9WgXcQ%3Bw%3D1&foc_id=uAXFkgsw1L7xaCfnd5JJOw&label=followon_view&ptype=f_view&random=104959669&utuid=uAXFkgsw1L7xaCfnd5JJOw",
+      "elapsedMediaTimeSeconds": 0
+    },
+    "googleRemarketingUrl": {
+      "baseUrl": "https://www.google.com/pagead/1p-user-list/962985656/?backend=innertube&cname=1&cver=2_20260519&data=backend%3Dinnertube%3Bcname%3D1%3Bcver%3D2_20260519%3Bm%3D1%3Bptype%3Df_view%3Btype%3Dview%3Butuid%3DuAXFkgsw1L7xaCfnd5JJOw%3Butvid%3DdQw4w9WgXcQ%3Bw%3D1&is_vtc=0&ptype=f_view&random=1001635636&utuid=uAXFkgsw1L7xaCfnd5JJOw",
+      "elapsedMediaTimeSeconds": 0
+    }
+  },
+  "captions": {
+    "playerCaptionsTracklistRenderer": {
+      "captionTracks": [
+        {
+          "baseUrl": "https://www.youtube.com/api/timedtext?v=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&caps=asr&opi=112496729&exp=xpe&xoaf=5&xowf=1&hl=en&ip=0.0.0.0&ipbits=0&expire=1779400693&sparams=ip,ipbits,expire,v,ei,caps,opi,exp,xoaf&signature=AD96D9AE9E877C98BBF232CCD72568BB9576DD13.31A9D468EECA3BDD1C8038D1962801AED3098AB6&key=yt8&lang=en",
+          "name": {
+            "simpleText": "English"
+          },
+          "vssId": ".en",
+          "languageCode": "en",
+          "isTranslatable": true,
+          "trackName": ""
+        },
+        {
+          "baseUrl": "https://www.youtube.com/api/timedtext?v=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&caps=asr&opi=112496729&exp=xpe&xoaf=5&xowf=1&hl=en&ip=0.0.0.0&ipbits=0&expire=1779400693&sparams=ip,ipbits,expire,v,ei,caps,opi,exp,xoaf&signature=AD96D9AE9E877C98BBF232CCD72568BB9576DD13.31A9D468EECA3BDD1C8038D1962801AED3098AB6&key=yt8&kind=asr&lang=en",
+          "name": {
+            "simpleText": "English (auto-generated)"
+          },
+          "vssId": "a.en",
+          "languageCode": "en",
+          "kind": "asr",
+          "isTranslatable": true,
+          "trackName": ""
+        },
+        {
+          "baseUrl": "https://www.youtube.com/api/timedtext?v=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&caps=asr&opi=112496729&exp=xpe&xoaf=5&xowf=1&hl=en&ip=0.0.0.0&ipbits=0&expire=1779400693&sparams=ip,ipbits,expire,v,ei,caps,opi,exp,xoaf&signature=AD96D9AE9E877C98BBF232CCD72568BB9576DD13.31A9D468EECA3BDD1C8038D1962801AED3098AB6&key=yt8&lang=de-DE",
+          "name": {
+            "simpleText": "German (Germany)"
+          },
+          "vssId": ".de-DE",
+          "languageCode": "de-DE",
+          "isTranslatable": true,
+          "trackName": ""
+        },
+        {
+          "baseUrl": "https://www.youtube.com/api/timedtext?v=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&caps=asr&opi=112496729&exp=xpe&xoaf=5&xowf=1&hl=en&ip=0.0.0.0&ipbits=0&expire=1779400693&sparams=ip,ipbits,expire,v,ei,caps,opi,exp,xoaf&signature=AD96D9AE9E877C98BBF232CCD72568BB9576DD13.31A9D468EECA3BDD1C8038D1962801AED3098AB6&key=yt8&lang=ja",
+          "name": {
+            "simpleText": "Japanese"
+          },
+          "vssId": ".ja",
+          "languageCode": "ja",
+          "isTranslatable": true,
+          "trackName": ""
+        },
+        {
+          "baseUrl": "https://www.youtube.com/api/timedtext?v=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&caps=asr&opi=112496729&exp=xpe&xoaf=5&xowf=1&hl=en&ip=0.0.0.0&ipbits=0&expire=1779400693&sparams=ip,ipbits,expire,v,ei,caps,opi,exp,xoaf&signature=AD96D9AE9E877C98BBF232CCD72568BB9576DD13.31A9D468EECA3BDD1C8038D1962801AED3098AB6&key=yt8&lang=pt-BR",
+          "name": {
+            "simpleText": "Portuguese (Brazil)"
+          },
+          "vssId": ".pt-BR",
+          "languageCode": "pt-BR",
+          "isTranslatable": true,
+          "trackName": ""
+        },
+        {
+          "baseUrl": "https://www.youtube.com/api/timedtext?v=dQw4w9WgXcQ&ei=hR0PapLMKKf9sfIPga2YGQ&caps=asr&opi=112496729&exp=xpe&xoaf=5&xowf=1&hl=en&ip=0.0.0.0&ipbits=0&expire=1779400693&sparams=ip,ipbits,expire,v,ei,caps,opi,exp,xoaf&signature=AD96D9AE9E877C98BBF232CCD72568BB9576DD13.31A9D468EECA3BDD1C8038D1962801AED3098AB6&key=yt8&lang=es-419",
+          "name": {
+            "simpleText": "Spanish (Latin America)"
+          },
+          "vssId": ".es-419",
+          "languageCode": "es-419",
+          "isTranslatable": true,
+          "trackName": ""
+        }
+      ],
+      "audioTracks": [
+        {
+          "captionTrackIndices": [
+            0,
+            2,
+            3,
+            4,
+            5,
+            1
+          ],
+          "defaultCaptionTrackIndex": 0,
+          "hasDefaultTrack": true,
+          "captionsInitialState": "CAPTIONS_INITIAL_STATE_OFF_RECOMMENDED"
+        }
+      ],
+      "translationLanguages": [
+        {
+          "languageCode": "ab",
+          "languageName": {
+            "simpleText": "Abkhazian"
+          }
+        },
+        {
+          "languageCode": "aa",
+          "languageName": {
+            "simpleText": "Afar"
+          }
+        },
+        {
+          "languageCode": "af",
+          "languageName": {
+            "simpleText": "Afrikaans"
+          }
+        },
+        {
+          "languageCode": "ak",
+          "languageName": {
+            "simpleText": "Akan"
+          }
+        },
+        {
+          "languageCode": "sq",
+          "languageName": {
+            "simpleText": "Albanian"
+          }
+        },
+        {
+          "languageCode": "am",
+          "languageName": {
+            "simpleText": "Amharic"
+          }
+        },
+        {
+          "languageCode": "ar",
+          "languageName": {
+            "simpleText": "Arabic"
+          }
+        },
+        {
+          "languageCode": "hy",
+          "languageName": {
+            "simpleText": "Armenian"
+          }
+        },
+        {
+          "languageCode": "as",
+          "languageName": {
+            "simpleText": "Assamese"
+          }
+        },
+        {
+          "languageCode": "ay",
+          "languageName": {
+            "simpleText": "Aymara"
+          }
+        },
+        {
+          "languageCode": "az",
+          "languageName": {
+            "simpleText": "Azerbaijani"
+          }
+        },
+        {
+          "languageCode": "bn",
+          "languageName": {
+            "simpleText": "Bangla"
+          }
+        },
+        {
+          "languageCode": "ba",
+          "languageName": {
+            "simpleText": "Bashkir"
+          }
+        },
+        {
+          "languageCode": "eu",
+          "languageName": {
+            "simpleText": "Basque"
+          }
+        },
+        {
+          "languageCode": "be",
+          "languageName": {
+            "simpleText": "Belarusian"
+          }
+        },
+        {
+          "languageCode": "bho",
+          "languageName": {
+            "simpleText": "Bhojpuri"
+          }
+        },
+        {
+          "languageCode": "bs",
+          "languageName": {
+            "simpleText": "Bosnian"
+          }
+        },
+        {
+          "languageCode": "br",
+          "languageName": {
+            "simpleText": "Breton"
+          }
+        },
+        {
+          "languageCode": "bg",
+          "languageName": {
+            "simpleText": "Bulgarian"
+          }
+        },
+        {
+          "languageCode": "my",
+          "languageName": {
+            "simpleText": "Burmese"
+          }
+        },
+        {
+          "languageCode": "ca",
+          "languageName": {
+            "simpleText": "Catalan"
+          }
+        },
+        {
+          "languageCode": "ceb",
+          "languageName": {
+            "simpleText": "Cebuano"
+          }
+        },
+        {
+          "languageCode": "zh-Hans",
+          "languageName": {
+            "simpleText": "Chinese (Simplified)"
+          }
+        },
+        {
+          "languageCode": "zh-Hant",
+          "languageName": {
+            "simpleText": "Chinese (Traditional)"
+          }
+        },
+        {
+          "languageCode": "co",
+          "languageName": {
+            "simpleText": "Corsican"
+          }
+        },
+        {
+          "languageCode": "hr",
+          "languageName": {
+            "simpleText": "Croatian"
+          }
+        },
+        {
+          "languageCode": "cs",
+          "languageName": {
+            "simpleText": "Czech"
+          }
+        },
+        {
+          "languageCode": "da",
+          "languageName": {
+            "simpleText": "Danish"
+          }
+        },
+        {
+          "languageCode": "dv",
+          "languageName": {
+            "simpleText": "Divehi"
+          }
+        },
+        {
+          "languageCode": "nl",
+          "languageName": {
+            "simpleText": "Dutch"
+          }
+        },
+        {
+          "languageCode": "dz",
+          "languageName": {
+            "simpleText": "Dzongkha"
+          }
+        },
+        {
+          "languageCode": "en",
+          "languageName": {
+            "simpleText": "English"
+          }
+        },
+        {
+          "languageCode": "eo",
+          "languageName": {
+            "simpleText": "Esperanto"
+          }
+        },
+        {
+          "languageCode": "et",
+          "languageName": {
+            "simpleText": "Estonian"
+          }
+        },
+        {
+          "languageCode": "ee",
+          "languageName": {
+            "simpleText": "Ewe"
+          }
+        },
+        {
+          "languageCode": "fo",
+          "languageName": {
+            "simpleText": "Faroese"
+          }
+        },
+        {
+          "languageCode": "fj",
+          "languageName": {
+            "simpleText": "Fijian"
+          }
+        },
+        {
+          "languageCode": "fil",
+          "languageName": {
+            "simpleText": "Filipino"
+          }
+        },
+        {
+          "languageCode": "fi",
+          "languageName": {
+            "simpleText": "Finnish"
+          }
+        },
+        {
+          "languageCode": "fr",
+          "languageName": {
+            "simpleText": "French"
+          }
+        },
+        {
+          "languageCode": "gaa",
+          "languageName": {
+            "simpleText": "Ga"
+          }
+        },
+        {
+          "languageCode": "gl",
+          "languageName": {
+            "simpleText": "Galician"
+          }
+        },
+        {
+          "languageCode": "lg",
+          "languageName": {
+            "simpleText": "Ganda"
+          }
+        },
+        {
+          "languageCode": "ka",
+          "languageName": {
+            "simpleText": "Georgian"
+          }
+        },
+        {
+          "languageCode": "de",
+          "languageName": {
+            "simpleText": "German"
+          }
+        },
+        {
+          "languageCode": "el",
+          "languageName": {
+            "simpleText": "Greek"
+          }
+        },
+        {
+          "languageCode": "gn",
+          "languageName": {
+            "simpleText": "Guarani"
+          }
+        },
+        {
+          "languageCode": "gu",
+          "languageName": {
+            "simpleText": "Gujarati"
+          }
+        },
+        {
+          "languageCode": "ht",
+          "languageName": {
+            "simpleText": "Haitian Creole"
+          }
+        },
+        {
+          "languageCode": "ha",
+          "languageName": {
+            "simpleText": "Hausa"
+          }
+        },
+        {
+          "languageCode": "haw",
+          "languageName": {
+            "simpleText": "Hawaiian"
+          }
+        },
+        {
+          "languageCode": "iw",
+          "languageName": {
+            "simpleText": "Hebrew"
+          }
+        },
+        {
+          "languageCode": "hi",
+          "languageName": {
+            "simpleText": "Hindi"
+          }
+        },
+        {
+          "languageCode": "hmn",
+          "languageName": {
+            "simpleText": "Hmong"
+          }
+        },
+        {
+          "languageCode": "hu",
+          "languageName": {
+            "simpleText": "Hungarian"
+          }
+        },
+        {
+          "languageCode": "is",
+          "languageName": {
+            "simpleText": "Icelandic"
+          }
+        },
+        {
+          "languageCode": "ig",
+          "languageName": {
+            "simpleText": "Igbo"
+          }
+        },
+        {
+          "languageCode": "id",
+          "languageName": {
+            "simpleText": "Indonesian"
+          }
+        },
+        {
+          "languageCode": "iu",
+          "languageName": {
+            "simpleText": "Inuktitut"
+          }
+        },
+        {
+          "languageCode": "ga",
+          "languageName": {
+            "simpleText": "Irish"
+          }
+        },
+        {
+          "languageCode": "it",
+          "languageName": {
+            "simpleText": "Italian"
+          }
+        },
+        {
+          "languageCode": "ja",
+          "languageName": {
+            "simpleText": "Japanese"
+          }
+        },
+        {
+          "languageCode": "jv",
+          "languageName": {
+            "simpleText": "Javanese"
+          }
+        },
+        {
+          "languageCode": "kl",
+          "languageName": {
+            "simpleText": "Kalaallisut"
+          }
+        },
+        {
+          "languageCode": "kn",
+          "languageName": {
+            "simpleText": "Kannada"
+          }
+        },
+        {
+          "languageCode": "kk",
+          "languageName": {
+            "simpleText": "Kazakh"
+          }
+        },
+        {
+          "languageCode": "kha",
+          "languageName": {
+            "simpleText": "Khasi"
+          }
+        },
+        {
+          "languageCode": "km",
+          "languageName": {
+            "simpleText": "Khmer"
+          }
+        },
+        {
+          "languageCode": "rw",
+          "languageName": {
+            "simpleText": "Kinyarwanda"
+          }
+        },
+        {
+          "languageCode": "ko",
+          "languageName": {
+            "simpleText": "Korean"
+          }
+        },
+        {
+          "languageCode": "kri",
+          "languageName": {
+            "simpleText": "Krio"
+          }
+        },
+        {
+          "languageCode": "ku",
+          "languageName": {
+            "simpleText": "Kurdish"
+          }
+        },
+        {
+          "languageCode": "ky",
+          "languageName": {
+            "simpleText": "Kyrgyz"
+          }
+        },
+        {
+          "languageCode": "lo",
+          "languageName": {
+            "simpleText": "Lao"
+          }
+        },
+        {
+          "languageCode": "la",
+          "languageName": {
+            "simpleText": "Latin"
+          }
+        },
+        {
+          "languageCode": "lv",
+          "languageName": {
+            "simpleText": "Latvian"
+          }
+        },
+        {
+          "languageCode": "ln",
+          "languageName": {
+            "simpleText": "Lingala"
+          }
+        },
+        {
+          "languageCode": "lt",
+          "languageName": {
+            "simpleText": "Lithuanian"
+          }
+        },
+        {
+          "languageCode": "lua",
+          "languageName": {
+            "simpleText": "Luba-Lulua"
+          }
+        },
+        {
+          "languageCode": "luo",
+          "languageName": {
+            "simpleText": "Luo"
+          }
+        },
+        {
+          "languageCode": "lb",
+          "languageName": {
+            "simpleText": "Luxembourgish"
+          }
+        },
+        {
+          "languageCode": "mk",
+          "languageName": {
+            "simpleText": "Macedonian"
+          }
+        },
+        {
+          "languageCode": "mg",
+          "languageName": {
+            "simpleText": "Malagasy"
+          }
+        },
+        {
+          "languageCode": "ms",
+          "languageName": {
+            "simpleText": "Malay"
+          }
+        },
+        {
+          "languageCode": "ml",
+          "languageName": {
+            "simpleText": "Malayalam"
+          }
+        },
+        {
+          "languageCode": "mt",
+          "languageName": {
+            "simpleText": "Maltese"
+          }
+        },
+        {
+          "languageCode": "gv",
+          "languageName": {
+            "simpleText": "Manx"
+          }
+        },
+        {
+          "languageCode": "mi",
+          "languageName": {
+            "simpleText": "M\u0101ori"
+          }
+        },
+        {
+          "languageCode": "mr",
+          "languageName": {
+            "simpleText": "Marathi"
+          }
+        },
+        {
+          "languageCode": "mn",
+          "languageName": {
+            "simpleText": "Mongolian"
+          }
+        },
+        {
+          "languageCode": "mfe",
+          "languageName": {
+            "simpleText": "Morisyen"
+          }
+        },
+        {
+          "languageCode": "ne",
+          "languageName": {
+            "simpleText": "Nepali"
+          }
+        },
+        {
+          "languageCode": "new",
+          "languageName": {
+            "simpleText": "Newari"
+          }
+        },
+        {
+          "languageCode": "nso",
+          "languageName": {
+            "simpleText": "Northern Sotho"
+          }
+        },
+        {
+          "languageCode": "no",
+          "languageName": {
+            "simpleText": "Norwegian"
+          }
+        },
+        {
+          "languageCode": "ny",
+          "languageName": {
+            "simpleText": "Nyanja"
+          }
+        },
+        {
+          "languageCode": "oc",
+          "languageName": {
+            "simpleText": "Occitan"
+          }
+        },
+        {
+          "languageCode": "or",
+          "languageName": {
+            "simpleText": "Odia"
+          }
+        },
+        {
+          "languageCode": "om",
+          "languageName": {
+            "simpleText": "Oromo"
+          }
+        },
+        {
+          "languageCode": "os",
+          "languageName": {
+            "simpleText": "Ossetic"
+          }
+        },
+        {
+          "languageCode": "pam",
+          "languageName": {
+            "simpleText": "Pampanga"
+          }
+        },
+        {
+          "languageCode": "ps",
+          "languageName": {
+            "simpleText": "Pashto"
+          }
+        },
+        {
+          "languageCode": "fa",
+          "languageName": {
+            "simpleText": "Persian"
+          }
+        },
+        {
+          "languageCode": "pl",
+          "languageName": {
+            "simpleText": "Polish"
+          }
+        },
+        {
+          "languageCode": "pt",
+          "languageName": {
+            "simpleText": "Portuguese"
+          }
+        },
+        {
+          "languageCode": "pt-PT",
+          "languageName": {
+            "simpleText": "Portuguese (Portugal)"
+          }
+        },
+        {
+          "languageCode": "pa",
+          "languageName": {
+            "simpleText": "Punjabi"
+          }
+        },
+        {
+          "languageCode": "qu",
+          "languageName": {
+            "simpleText": "Quechua"
+          }
+        },
+        {
+          "languageCode": "ro",
+          "languageName": {
+            "simpleText": "Romanian"
+          }
+        },
+        {
+          "languageCode": "rn",
+          "languageName": {
+            "simpleText": "Rundi"
+          }
+        },
+        {
+          "languageCode": "ru",
+          "languageName": {
+            "simpleText": "Russian"
+          }
+        },
+        {
+          "languageCode": "sm",
+          "languageName": {
+            "simpleText": "Samoan"
+          }
+        },
+        {
+          "languageCode": "sg",
+          "languageName": {
+            "simpleText": "Sango"
+          }
+        },
+        {
+          "languageCode": "sa",
+          "languageName": {
+            "simpleText": "Sanskrit"
+          }
+        },
+        {
+          "languageCode": "gd",
+          "languageName": {
+            "simpleText": "Scottish Gaelic"
+          }
+        },
+        {
+          "languageCode": "sr",
+          "languageName": {
+            "simpleText": "Serbian"
+          }
+        },
+        {
+          "languageCode": "crs",
+          "languageName": {
+            "simpleText": "Seselwa Creole French"
+          }
+        },
+        {
+          "languageCode": "sn",
+          "languageName": {
+            "simpleText": "Shona"
+          }
+        },
+        {
+          "languageCode": "sd",
+          "languageName": {
+            "simpleText": "Sindhi"
+          }
+        },
+        {
+          "languageCode": "si",
+          "languageName": {
+            "simpleText": "Sinhala"
+          }
+        },
+        {
+          "languageCode": "sk",
+          "languageName": {
+            "simpleText": "Slovak"
+          }
+        },
+        {
+          "languageCode": "sl",
+          "languageName": {
+            "simpleText": "Slovenian"
+          }
+        },
+        {
+          "languageCode": "so",
+          "languageName": {
+            "simpleText": "Somali"
+          }
+        },
+        {
+          "languageCode": "st",
+          "languageName": {
+            "simpleText": "Southern Sotho"
+          }
+        },
+        {
+          "languageCode": "es",
+          "languageName": {
+            "simpleText": "Spanish"
+          }
+        },
+        {
+          "languageCode": "su",
+          "languageName": {
+            "simpleText": "Sundanese"
+          }
+        },
+        {
+          "languageCode": "sw",
+          "languageName": {
+            "simpleText": "Swahili"
+          }
+        },
+        {
+          "languageCode": "ss",
+          "languageName": {
+            "simpleText": "Swati"
+          }
+        },
+        {
+          "languageCode": "sv",
+          "languageName": {
+            "simpleText": "Swedish"
+          }
+        },
+        {
+          "languageCode": "tg",
+          "languageName": {
+            "simpleText": "Tajik"
+          }
+        },
+        {
+          "languageCode": "ta",
+          "languageName": {
+            "simpleText": "Tamil"
+          }
+        },
+        {
+          "languageCode": "tt",
+          "languageName": {
+            "simpleText": "Tatar"
+          }
+        },
+        {
+          "languageCode": "te",
+          "languageName": {
+            "simpleText": "Telugu"
+          }
+        },
+        {
+          "languageCode": "th",
+          "languageName": {
+            "simpleText": "Thai"
+          }
+        },
+        {
+          "languageCode": "bo",
+          "languageName": {
+            "simpleText": "Tibetan"
+          }
+        },
+        {
+          "languageCode": "ti",
+          "languageName": {
+            "simpleText": "Tigrinya"
+          }
+        },
+        {
+          "languageCode": "to",
+          "languageName": {
+            "simpleText": "Tongan"
+          }
+        },
+        {
+          "languageCode": "ts",
+          "languageName": {
+            "simpleText": "Tsonga"
+          }
+        },
+        {
+          "languageCode": "tn",
+          "languageName": {
+            "simpleText": "Tswana"
+          }
+        },
+        {
+          "languageCode": "tum",
+          "languageName": {
+            "simpleText": "Tumbuka"
+          }
+        },
+        {
+          "languageCode": "tr",
+          "languageName": {
+            "simpleText": "Turkish"
+          }
+        },
+        {
+          "languageCode": "tk",
+          "languageName": {
+            "simpleText": "Turkmen"
+          }
+        },
+        {
+          "languageCode": "uk",
+          "languageName": {
+            "simpleText": "Ukrainian"
+          }
+        },
+        {
+          "languageCode": "ur",
+          "languageName": {
+            "simpleText": "Urdu"
+          }
+        },
+        {
+          "languageCode": "ug",
+          "languageName": {
+            "simpleText": "Uyghur"
+          }
+        },
+        {
+          "languageCode": "uz",
+          "languageName": {
+            "simpleText": "Uzbek"
+          }
+        },
+        {
+          "languageCode": "ve",
+          "languageName": {
+            "simpleText": "Venda"
+          }
+        },
+        {
+          "languageCode": "vi",
+          "languageName": {
+            "simpleText": "Vietnamese"
+          }
+        },
+        {
+          "languageCode": "war",
+          "languageName": {
+            "simpleText": "Waray"
+          }
+        },
+        {
+          "languageCode": "cy",
+          "languageName": {
+            "simpleText": "Welsh"
+          }
+        },
+        {
+          "languageCode": "fy",
+          "languageName": {
+            "simpleText": "Western Frisian"
+          }
+        },
+        {
+          "languageCode": "wo",
+          "languageName": {
+            "simpleText": "Wolof"
+          }
+        },
+        {
+          "languageCode": "xh",
+          "languageName": {
+            "simpleText": "Xhosa"
+          }
+        },
+        {
+          "languageCode": "yi",
+          "languageName": {
+            "simpleText": "Yiddish"
+          }
+        },
+        {
+          "languageCode": "yo",
+          "languageName": {
+            "simpleText": "Yoruba"
+          }
+        },
+        {
+          "languageCode": "zu",
+          "languageName": {
+            "simpleText": "Zulu"
+          }
+        }
+      ],
+      "defaultAudioTrackIndex": 0
+    }
+  },
+  "videoDetails": {
+    "videoId": "dQw4w9WgXcQ",
+    "title": "Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)",
+    "lengthSeconds": "213",
+    "keywords": [
+      "rick astley",
+      "Never Gonna Give You Up",
+      "nggyu",
+      "never gonna give you up lyrics",
+      "rick rolled",
+      "Rick Roll",
+      "rick astley official",
+      "rickrolled",
+      "Fortnite song",
+      "Fortnite event",
+      "Fortnite dance",
+      "fortnite never gonna give you up",
+      "rick roll",
+      "rickrolling",
+      "rick rolling",
+      "never gonna give you up",
+      "80s music",
+      "rick astley new",
+      "animated video",
+      "rickroll",
+      "meme songs",
+      "never gonna give u up lyrics",
+      "Rick Astley 2022",
+      "never gonna let you down",
+      "animated",
+      "rick rolls 2022",
+      "never gonna give you up karaoke"
+    ],
+    "channelId": "UCuAXFkgsw1L7xaCfnd5JJOw",
+    "isOwnerViewing": false,
+    "shortDescription": "The official video for \u201cNever Gonna Give You Up\u201d by Rick Astley. \n\nNever: The Autobiography \ud83d\udcda OUT NOW! \nFollow this link to get your copy and listen to Rick\u2019s \u2018Never\u2019 playlist \u2764\ufe0f #RickAstleyNever\nhttps://linktr.ee/rickastleynever\n\n\u201cNever Gonna Give You Up\u201d was a global smash on its release in July 1987, topping the charts in 25 countries including Rick\u2019s native UK and the US Billboard Hot 100.  It also won the Brit Award for Best single in 1988. Stock Aitken and Waterman wrote and produced the track which was the lead-off single and lead track from Rick\u2019s debut LP \u201cWhenever You Need Somebody\u201d.  The album was itself a UK number one and would go on to sell over 15 million copies worldwide.\n\nThe legendary video was directed by Simon West \u2013 who later went on to make Hollywood blockbusters such as Con Air, Lara Croft \u2013 Tomb Raider and The Expendables 2.  The video passed the 1bn YouTube views milestone on 28 July 2021.\n\nSubscribe to the official Rick Astley YouTube channel: https://RickAstley.lnk.to/YTSubID\n\nFollow Rick Astley:\nFacebook: https://RickAstley.lnk.to/FBFollowID \nTwitter: https://RickAstley.lnk.to/TwitterID \nInstagram: https://RickAstley.lnk.to/InstagramID \nWebsite: https://RickAstley.lnk.to/storeID \nTikTok: https://RickAstley.lnk.to/TikTokID\n\nListen to Rick Astley:\nSpotify: https://RickAstley.lnk.to/SpotifyID \nApple Music: https://RickAstley.lnk.to/AppleMusicID \nAmazon Music: https://RickAstley.lnk.to/AmazonMusicID \nDeezer: https://RickAstley.lnk.to/DeezerID \n\nLyrics:\nWe\u2019re no strangers to love\nYou know the rules and so do I\nA full commitment\u2019s what I\u2019m thinking of\nYou wouldn\u2019t get this from any other guy\n\nI just wanna tell you how I\u2019m feeling\nGotta make you understand\n\nNever gonna give you up\nNever gonna let you down\nNever gonna run around and desert you\nNever gonna make you cry\nNever gonna say goodbye\nNever gonna tell a lie and hurt you\n\nWe\u2019ve known each other for so long\nYour heart\u2019s been aching but you\u2019re too shy to say it\nInside we both know what\u2019s been going on\nWe know the game and we\u2019re gonna play it\n\nAnd if you ask me how I\u2019m feeling\nDon\u2019t tell me you\u2019re too blind to see\n\nNever gonna give you up\nNever gonna let you down\nNever gonna run around and desert you\nNever gonna make you cry\nNever gonna say goodbye\nNever gonna tell a lie and hurt you\n\n#RickAstley #NeverGonnaGiveYouUp #WheneverYouNeedSomebody #OfficialMusicVideo",
+    "isCrawlable": true,
+    "thumbnail": {
+      "thumbnails": [
+        {
+          "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg?sqp=-oaymwEmCKgBEF5IWvKriqkDGQgBFQAAiEIYAdgBAeIBCggYEAIYBjgBQAE=&rs=AOn4CLBnMMOHLLLps0tlvAfAK0OZIjH0ag",
+          "width": 168,
+          "height": 94
+        },
+        {
+          "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg?sqp=-oaymwEmCMQBEG5IWvKriqkDGQgBFQAAiEIYAdgBAeIBCggYEAIYBjgBQAE=&rs=AOn4CLAUiD0XY5TvJ1WbvTR4qqR4YbczDA",
+          "width": 196,
+          "height": 110
+        },
+        {
+          "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg?sqp=-oaymwEnCPYBEIoBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLCRUSG-V-rRLr-poV94Wno2jn4e5w",
+          "width": 246,
+          "height": 138
+        },
+        {
+          "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg?sqp=-oaymwEnCNACELwBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLDv2Q0yAnW19SsfDxlWNZc2MfRnvQ",
+          "width": 336,
+          "height": 188
+        },
+        {
+          "url": "https://i.ytimg.com/vi_webp/dQw4w9WgXcQ/maxresdefault.webp",
+          "width": 1920,
+          "height": 1080
+        }
+      ]
+    },
+    "allowRatings": true,
+    "viewCount": "1774606375",
+    "author": "Rick Astley",
+    "isPrivate": false,
+    "isUnpluggedCorpus": false,
+    "isLiveContent": false,
+    "isTvfilmVideo": false
+  },
+  "annotations": [
+    {
+      "playerAnnotationsExpandedRenderer": {
+        "featuredChannel": {
+          "startTimeMs": "0",
+          "endTimeMs": "193000",
+          "watermark": {
+            "thumbnails": [
+              {
+                "url": "https://i.ytimg.com/an/uAXFkgsw1L7xaCfnd5JJOw/featured_channel.jpg?v=6101641a",
+                "width": 40,
+                "height": 40
+              }
+            ]
+          },
+          "trackingParams": "CBUQ8zciEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+          "navigationEndpoint": {
+            "clickTrackingParams": "CBUQ8zciEwjSouOh0sqUAxWnfkwIHYEWJgMyAml2ygEEj0TqbQ==",
+            "commandMetadata": {
+              "webCommandMetadata": {
+                "url": "/channel/UCuAXFkgsw1L7xaCfnd5JJOw",
+                "webPageType": "WEB_PAGE_TYPE_CHANNEL",
+                "rootVe": 3611,
+                "apiUrl": "/youtubei/v1/browse"
+              }
+            },
+            "browseEndpoint": {
+              "browseId": "UCuAXFkgsw1L7xaCfnd5JJOw"
+            }
+          },
+          "channelName": "Rick Astley",
+          "subscribeButton": {
+            "subscribeButtonRenderer": {
+              "buttonText": {
+                "runs": [
+                  {
+                    "text": "SUBSCRIBE"
+                  }
+                ]
+              },
+              "subscribed": false,
+              "enabled": true,
+              "type": "FREE",
+              "channelId": "UCuAXFkgsw1L7xaCfnd5JJOw",
+              "showPreferences": false,
+              "subscribedButtonText": {
+                "runs": [
+                  {
+                    "text": "SUBSCRIBED"
+                  }
+                ]
+              },
+              "unsubscribedButtonText": {
+                "runs": [
+                  {
+                    "text": "SUBSCRIBE"
+                  }
+                ]
+              },
+              "trackingParams": "CBYQmysiEwjSouOh0sqUAxWnfkwIHYEWJgMyAml2",
+              "unsubscribeButtonText": {
+                "runs": [
+                  {
+                    "text": "UNSUBSCRIBE"
+                  }
+                ]
+              },
+              "serviceEndpoints": [
+                {
+                  "clickTrackingParams": "CBYQmysiEwjSouOh0sqUAxWnfkwIHYEWJgMyAml2ygEEj0TqbQ==",
+                  "commandMetadata": {
+                    "webCommandMetadata": {
+                      "sendPost": true,
+                      "apiUrl": "/youtubei/v1/subscription/subscribe"
+                    }
+                  },
+                  "subscribeEndpoint": {
+                    "channelIds": [
+                      "UCuAXFkgsw1L7xaCfnd5JJOw"
+                    ],
+                    "params": "EgIIBBgA"
+                  }
+                },
+                {
+                  "clickTrackingParams": "CBYQmysiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                  "commandMetadata": {
+                    "webCommandMetadata": {
+                      "sendPost": true
+                    }
+                  },
+                  "signalServiceEndpoint": {
+                    "signal": "CLIENT_SIGNAL",
+                    "actions": [
+                      {
+                        "clickTrackingParams": "CBYQmysiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                        "openPopupAction": {
+                          "popup": {
+                            "confirmDialogRenderer": {
+                              "trackingParams": "CBcQxjgiEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+                              "dialogMessages": [
+                                {
+                                  "runs": [
+                                    {
+                                      "text": "Unsubscribe from "
+                                    },
+                                    {
+                                      "text": "Rick Astley"
+                                    },
+                                    {
+                                      "text": "?"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "confirmButton": {
+                                "buttonRenderer": {
+                                  "style": "STYLE_BLUE_TEXT",
+                                  "size": "SIZE_DEFAULT",
+                                  "isDisabled": false,
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Unsubscribe"
+                                      }
+                                    ]
+                                  },
+                                  "serviceEndpoint": {
+                                    "clickTrackingParams": "CBkQ8FsiEwjSouOh0sqUAxWnfkwIHYEWJgMyAml2ygEEj0TqbQ==",
+                                    "commandMetadata": {
+                                      "webCommandMetadata": {
+                                        "sendPost": true,
+                                        "apiUrl": "/youtubei/v1/subscription/unsubscribe"
+                                      }
+                                    },
+                                    "unsubscribeEndpoint": {
+                                      "channelIds": [
+                                        "UCuAXFkgsw1L7xaCfnd5JJOw"
+                                      ],
+                                      "params": "CgIIBBgA"
+                                    }
+                                  },
+                                  "accessibility": {
+                                    "label": "Unsubscribe"
+                                  },
+                                  "trackingParams": "CBkQ8FsiEwjSouOh0sqUAxWnfkwIHYEWJgM="
+                                }
+                              },
+                              "cancelButton": {
+                                "buttonRenderer": {
+                                  "style": "STYLE_TEXT",
+                                  "size": "SIZE_DEFAULT",
+                                  "isDisabled": false,
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Cancel"
+                                      }
+                                    ]
+                                  },
+                                  "accessibility": {
+                                    "label": "Cancel"
+                                  },
+                                  "trackingParams": "CBgQ8FsiEwjSouOh0sqUAxWnfkwIHYEWJgM="
+                                }
+                              },
+                              "primaryIsCancel": false
+                            }
+                          },
+                          "popupType": "DIALOG"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "subscribeAccessibility": {
+                "accessibilityData": {
+                  "label": "Subscribe to Rick Astley."
+                }
+              },
+              "unsubscribeAccessibility": {
+                "accessibilityData": {
+                  "label": "Unsubscribe from Rick Astley."
+                }
+              },
+              "signInEndpoint": {
+                "clickTrackingParams": "CBYQmysiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                "commandMetadata": {
+                  "webCommandMetadata": {
+                    "url": "https://accounts.google.com/ServiceLogin?service=youtube&uilel=3&passive=true&continue=http%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26app%3Ddesktop%26hl%3Den%26next%3Dhttps%253A%252F%252Fwww.youtube.com%252Fchannel%252FUCuAXFkgsw1L7xaCfnd5JJOw%26feature%3Div%26continue_action%3DQUFFLUhqa1N0MDRVdjFvSnlVdmItbHpKNTlUcmRwc091UXxBQ3Jtc0tsQ2t2VlVpX2plQ0cyQ0hReEhlNjIyVVVQTWVIR3RsLU1aVUJsa3NCVjZOZC1PRS1Ka1VQR3BJVTBhdEEwUmVYWlp1RGMtR0VsbElHa0ZRYURfUGhLai0wMGVpUXZQbHJkZUc0MTIxdWc4bV9yZzRtdThhSmV0ZnlOTnFtZVpDb0hJSXVjLVMtTks0b0ZIMjZBWVhqYjZ4WUx3NDFlVlJ4OHJyZk1IMXNYaGpNc2xjazgyY3Y1ODF3al9JeDczcUxYUUZhMks%253D&hl=en"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allowSwipeDismiss": true,
+        "annotationId": "5dad8f5d-0000-20c2-8451-883d24f8e7cc"
+      }
+    }
+  ],
+  "playerConfig": {
+    "granularVariableSpeedConfig": {
+      "minimumPlaybackRate": 25,
+      "maximumPlaybackRate": 200,
+      "stepSize": 5,
+      "defaultPlaybackRateOptions": [
+        {
+          "label": "1.0",
+          "value": 100,
+          "isPremiumUpsell": false,
+          "priority": 5
+        },
+        {
+          "label": "1.25",
+          "value": 125,
+          "isPremiumUpsell": false,
+          "priority": 2
+        },
+        {
+          "label": "1.5",
+          "value": 150,
+          "isPremiumUpsell": false,
+          "priority": 3
+        },
+        {
+          "label": "1.75",
+          "value": 175,
+          "isPremiumUpsell": false,
+          "priority": 0
+        },
+        {
+          "label": "2.0",
+          "value": 200,
+          "isPremiumUpsell": false,
+          "priority": 4
+        },
+        {
+          "label": "3.0",
+          "value": 300,
+          "isPremiumUpsell": true,
+          "priority": 1
+        }
+      ]
+    },
+    "vssClientConfig": {
+      "vssUsePostRequest": true
+    },
+    "audioConfig": {
+      "loudnessDb": 0.98999977,
+      "perceptualLoudnessDb": -13.01,
+      "enablePerFormatLoudness": true,
+      "trackAbsoluteLoudnessLkfs": -13.01,
+      "loudnessTargetLkfs": -14,
+      "loudnessNormalizationConfig": {
+        "applyStatefulNormalization": false,
+        "preserveStatefulLoudnessTarget": true,
+        "maxStatefulTimeThresholdSec": 300,
+        "minimumLoudnessTargetLkfs": -24
+      }
+    },
+    "streamSelectionConfig": {
+      "maxBitrate": "31400000"
+    },
+    "daiConfig": {
+      "sendSsdaiMissingAdBreakReasons": true
+    },
+    "mediaCommonConfig": {
+      "dynamicReadaheadConfig": {
+        "maxReadAheadMediaTimeMs": 120000,
+        "minReadAheadMediaTimeMs": 15000,
+        "readAheadGrowthRateMs": 1000
+      },
+      "mediaUstreamerRequestConfig": {
+        "videoPlaybackUstreamerConfig": "CuoICq0FCAAlAACAPy0zM3M_NT0Klz9yGgoWbWZzMl9jbWZzX3dlYl92M18yXzAwMxgAoAEBqAEAuAIA2gKAARCw6gEYgN3bASCgnAEooJwBcIgngAH0A-ABAZgCDNACAugCBIADAogDiCeoAwPAAwHIAwGABAHQBAHYBAH4BAeABX3ABQHIBQHgBdAP6AUB-AXQD5AGAdAGAfAGAYAH0A-ACAGICAGdCM3MTD6gCOgH4AgB6Aj___________8B-gJFqAHQhgOFApqZGT-NAgAAgD_AAt8D_QLNzMw9kAMBnQMK1yM91QQAACBBtQa9N4Y1vQYzM4NAyAcB5QcAgAlE8AcBgAgBqAMBsAMD0AMB2AMBygQcChMIwKkHEJh1GOgHJQAAAAAoADAAEODUAxjQD9IEDwoICLAJELAJIAEgiCcoAdoEDQoGCPAuEPAuIPAuKAHwBQGYBgGoBoCAAtIGFAjoBxBkGg0IiCcVAAAAPx3NzEw_2AYBuAcBoAgB0ggGCAEQARgBqQkAAAAAAADwv7EJAAAAAAAA8L_QCQHaCSQwMlpxV3VxKytBNkw2RVRxVkEyTGFoZERGTTdYTldybzZEdGeYCuSx2xiiCgzisdsY47HbGOSx2xioCuKx2xjqCwSLBowGgAwBqAyQAeANAcgPAdAPAegQAZARAaARAbIRKENBTVNHUlVRdUxiSkRKVUNuQTc1RlhKRDZRUFFDaXpyMVFfYUh3UT3QEgHgEgGAEwGwEwHYEwDoEwGIFACRFAAAAAAAAPC_mRQAAAAAAADwv8oUEXYyMDI1MDkyMl8xMjI2LjAw2BSIJ-IULAoAEihDQU1TR1JVUXVMYkpESlVDbkE3NUZYSkQ2UVBRQ2l6cjFRX2FId1E9gRUAAAAAAADwv6gVAcAVAYinocoLATIMCLkCEPG5pfqz4ZEDMgwIkQMQib3pwavhkQMyDAiPAhCfvcebseGRAzIMCJADEMn0qMur4ZEDMgwIiQEQqpyXnJ_hkQMyDAj4ARDWkaD7s-GRAzIMCI8DEMH7lcnP4ZEDMgwIiAEQzNDcoKDhkQMyDAj3ARCEhem0r-GRAzIMCI4DEL__grSq4ZEDMgwIhwEQyNrUpKDhkQMyDAj0ARDY1LbKreGRAzIMCI0DEMSf1uKq4ZEDMgwIhgEQ_K2B6anhkQMyDAjzARDA08vPsOGRAzIMCIwDEPj4uf2i4ZEDMgwIhQEQu7v29KrhkQMyDAjyARCqxvr_tOGRAzIMCIsDEOPuw7Oq4ZEDMgwIoAEQivCko6vhkQMyDAiWAhDgxI_QsOGRAzIMCIoDEPSo0p6t4ZEDMgwIjAEQ75Sc4pfhkQMyDAj5ARCjjJrOl-GRAzIMCPoBELb4s86X4ZEDMgwI-wEQ0uCnzpfhkQM6AFItGgJlbigAMhhVQ3VBWEZrZ3N3MUw3eGFDZm5kNUpKT3c4AEAAWABgAHgAiAEBoAEBsAEFugEDBAUxwgEIAQIDBAUIKjDQAQCAAgASSwAgZg7IMEQCICJoUWXVZneHvbeM2Ab5VB-eEKBSuoiEe1_kRAPV6yT2AiANGDrYOY2Hof5DhrYA5ztq3wgaucT11v6eH_iN6O9RzhoCZWk="
+      },
+      "useServerDrivenAbr": true,
+      "serverPlaybackStartConfig": {
+        "enable": true,
+        "playbackStartPolicy": {
+          "startMinReadaheadPolicy": [
+            {
+              "minReadaheadMs": 1200
+            }
+          ]
+        }
+      },
+      "platypusUseEnvoyNetFetch": false,
+      "fixLivePlaybackModelDefaultPosition": false
+    },
+    "webPlayerConfig": {
+      "useCobaltTvosDash": true,
+      "webPlayerActionsPorting": {
+        "getSharePanelCommand": {
+          "clickTrackingParams": "CAAQu2kiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+          "commandMetadata": {
+            "webCommandMetadata": {
+              "sendPost": true,
+              "apiUrl": "/youtubei/v1/share/get_web_player_share_panel"
+            }
+          },
+          "webPlayerShareEntityServiceEndpoint": {
+            "serializedShareEntity": "CgtkUXc0dzlXZ1hjUQ%3D%3D"
+          }
+        },
+        "subscribeCommand": {
+          "clickTrackingParams": "CAAQu2kiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+          "commandMetadata": {
+            "webCommandMetadata": {
+              "sendPost": true,
+              "apiUrl": "/youtubei/v1/subscription/subscribe"
+            }
+          },
+          "subscribeEndpoint": {
+            "channelIds": [
+              "UCuAXFkgsw1L7xaCfnd5JJOw"
+            ],
+            "params": "EgIIBxgA"
+          }
+        },
+        "unsubscribeCommand": {
+          "clickTrackingParams": "CAAQu2kiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+          "commandMetadata": {
+            "webCommandMetadata": {
+              "sendPost": true,
+              "apiUrl": "/youtubei/v1/subscription/unsubscribe"
+            }
+          },
+          "unsubscribeEndpoint": {
+            "channelIds": [
+              "UCuAXFkgsw1L7xaCfnd5JJOw"
+            ],
+            "params": "CgIIBxgA"
+          }
+        },
+        "addToWatchLaterCommand": {
+          "clickTrackingParams": "CAAQu2kiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+          "commandMetadata": {
+            "webCommandMetadata": {
+              "sendPost": true,
+              "apiUrl": "/youtubei/v1/browse/edit_playlist"
+            }
+          },
+          "playlistEditEndpoint": {
+            "playlistId": "WL",
+            "actions": [
+              {
+                "addedVideoId": "dQw4w9WgXcQ",
+                "action": "ACTION_ADD_VIDEO"
+              }
+            ]
+          }
+        },
+        "removeFromWatchLaterCommand": {
+          "clickTrackingParams": "CAAQu2kiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+          "commandMetadata": {
+            "webCommandMetadata": {
+              "sendPost": true,
+              "apiUrl": "/youtubei/v1/browse/edit_playlist"
+            }
+          },
+          "playlistEditEndpoint": {
+            "playlistId": "WL",
+            "actions": [
+              {
+                "action": "ACTION_REMOVE_VIDEO_BY_VIDEO_ID",
+                "removedVideoId": "dQw4w9WgXcQ"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "storyboards": {
+    "playerStoryboardSpecRenderer": {
+      "spec": "https://i.ytimg.com/sb/dQw4w9WgXcQ/storyboard3_L$L/$N.jpg?sqp=-oaymwENSDfyq4qpAwVwAcABBqLzl_8DBgjXxPfBBg==|48#27#100#10#10#0#default#rs$AOn4CLDgtWGAnaqZZSEHsiFathAqjUlfLQ|80#45#108#10#10#2000#M$M#rs$AOn4CLBf8GkpJjLT0oNOXNqGg2XsF5MCMg|160#90#108#5#5#2000#M$M#rs$AOn4CLClA1jTU48sHENDTij_c2ZcE493TQ|320#180#108#3#3#2000#M$M#rs$AOn4CLCHZGerbRu0IiBb-AIyubx5_-E4oQ",
+      "recommendedLevel": 3,
+      "fineScrubbingRecommendedLevel": 2,
+      "highResolutionRecommendedLevel": 3
+    }
+  },
+  "microformat": {
+    "playerMicroformatRenderer": {
+      "thumbnail": {
+        "thumbnails": [
+          {
+            "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
+            "width": 1280,
+            "height": 720
+          }
+        ]
+      },
+      "embed": {
+        "iframeUrl": "https://www.youtube.com/embed/dQw4w9WgXcQ",
+        "width": 1280,
+        "height": 720
+      },
+      "title": {
+        "simpleText": "Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)"
+      },
+      "description": {
+        "simpleText": "The official video for \u201cNever Gonna Give You Up\u201d by Rick Astley. \n\nNever: The Autobiography \ud83d\udcda OUT NOW! \nFollow this link to get your copy and listen to Rick\u2019s \u2018Never\u2019 playlist \u2764\ufe0f #RickAstleyNever\nhttps://linktr.ee/rickastleynever\n\n\u201cNever Gonna Give You Up\u201d was a global smash on its release in July 1987, topping the charts in 25 countries including Rick\u2019s native UK and the US Billboard Hot 100.  It also won the Brit Award for Best single in 1988. Stock Aitken and Waterman wrote and produced the track which was the lead-off single and lead track from Rick\u2019s debut LP \u201cWhenever You Need Somebody\u201d.  The album was itself a UK number one and would go on to sell over 15 million copies worldwide.\n\nThe legendary video was directed by Simon West \u2013 who later went on to make Hollywood blockbusters such as Con Air, Lara Croft \u2013 Tomb Raider and The Expendables 2.  The video passed the 1bn YouTube views milestone on 28 July 2021.\n\nSubscribe to the official Rick Astley YouTube channel: https://RickAstley.lnk.to/YTSubID\n\nFollow Rick Astley:\nFacebook: https://RickAstley.lnk.to/FBFollowID \nTwitter: https://RickAstley.lnk.to/TwitterID \nInstagram: https://RickAstley.lnk.to/InstagramID \nWebsite: https://RickAstley.lnk.to/storeID \nTikTok: https://RickAstley.lnk.to/TikTokID\n\nListen to Rick Astley:\nSpotify: https://RickAstley.lnk.to/SpotifyID \nApple Music: https://RickAstley.lnk.to/AppleMusicID \nAmazon Music: https://RickAstley.lnk.to/AmazonMusicID \nDeezer: https://RickAstley.lnk.to/DeezerID \n\nLyrics:\nWe\u2019re no strangers to love\nYou know the rules and so do I\nA full commitment\u2019s what I\u2019m thinking of\nYou wouldn\u2019t get this from any other guy\n\nI just wanna tell you how I\u2019m feeling\nGotta make you understand\n\nNever gonna give you up\nNever gonna let you down\nNever gonna run around and desert you\nNever gonna make you cry\nNever gonna say goodbye\nNever gonna tell a lie and hurt you\n\nWe\u2019ve known each other for so long\nYour heart\u2019s been aching but you\u2019re too shy to say it\nInside we both know what\u2019s been going on\nWe know the game and we\u2019re gonna play it\n\nAnd if you ask me how I\u2019m feeling\nDon\u2019t tell me you\u2019re too blind to see\n\nNever gonna give you up\nNever gonna let you down\nNever gonna run around and desert you\nNever gonna make you cry\nNever gonna say goodbye\nNever gonna tell a lie and hurt you\n\n#RickAstley #NeverGonnaGiveYouUp #WheneverYouNeedSomebody #OfficialMusicVideo"
+      },
+      "lengthSeconds": "214",
+      "ownerProfileUrl": "http://www.youtube.com/@RickAstleyYT",
+      "externalChannelId": "UCuAXFkgsw1L7xaCfnd5JJOw",
+      "isFamilySafe": true,
+      "availableCountries": [
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AO",
+        "AQ",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BV",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GS",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HM",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NU",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PN",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TC",
+        "TD",
+        "TF",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "UM",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW"
+      ],
+      "isUnlisted": false,
+      "hasYpcMetadata": false,
+      "viewCount": "1774606375",
+      "category": "Music",
+      "publishDate": "2009-10-24T23:57:33-07:00",
+      "ownerChannelName": "Rick Astley",
+      "uploadDate": "2009-10-24T23:57:33-07:00",
+      "isShortsEligible": false,
+      "externalVideoId": "dQw4w9WgXcQ",
+      "likeCount": "19108106",
+      "canonicalUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    }
+  },
+  "cards": {
+    "cardCollectionRenderer": {
+      "cards": [
+        {
+          "cardRenderer": {
+            "teaser": {
+              "simpleCardTeaserRenderer": {
+                "message": {
+                  "simpleText": "View corrections"
+                },
+                "trackingParams": "CBQQ0DYiEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+                "prominent": true,
+                "logVisibilityUpdates": true,
+                "onTapCommand": {
+                  "clickTrackingParams": "CBQQ0DYiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                  "changeEngagementPanelVisibilityAction": {
+                    "targetId": "engagement-panel-error-corrections",
+                    "visibility": "ENGAGEMENT_PANEL_VISIBILITY_EXPANDED"
+                  }
+                }
+              }
+            },
+            "cueRanges": [
+              {
+                "startCardActiveMs": "0",
+                "endCardActiveMs": "5000",
+                "teaserDurationMs": "6000",
+                "iconAfterTeaserMs": "5000"
+              }
+            ],
+            "trackingParams": "CBMQtZcBGAAiEwjSouOh0sqUAxWnfkwIHYEWJgM="
+          }
+        }
+      ],
+      "headerText": {
+        "simpleText": "From Rick Astley"
+      },
+      "icon": {
+        "infoCardIconRenderer": {
+          "trackingParams": "CBIQsJcBIhMI0qLjodLKlAMVp35MCB2BFiYD"
+        }
+      },
+      "closeButton": {
+        "infoCardIconRenderer": {
+          "trackingParams": "CBEQsZcBIhMI0qLjodLKlAMVp35MCB2BFiYD"
+        }
+      },
+      "trackingParams": "CBAQwjciEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+      "allowTeaserDismiss": true,
+      "logIconVisibilityUpdates": true
+    }
+  },
+  "trackingParams": "CAAQu2kiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+  "messages": [
+    {
+      "mealbarPromoRenderer": {
+        "icon": {
+          "thumbnails": [
+            {
+              "url": "https://www.gstatic.com/youtube/img/promos/growth/32565a681f5420b051f863e20a723490d94d07306de7b379862f0ec4a0d6676c_384x384.png",
+              "width": 384,
+              "height": 384
+            }
+          ]
+        },
+        "messageTexts": [
+          {
+            "runs": [
+              {
+                "text": "Music lovers, we dedicate this to you \u2013 the YouTube Music web player"
+              }
+            ]
+          }
+        ],
+        "actionButton": {
+          "buttonRenderer": {
+            "style": "STYLE_MONO_FILLED",
+            "size": "SIZE_DEFAULT",
+            "text": {
+              "runs": [
+                {
+                  "text": "Check it out"
+                }
+              ]
+            },
+            "trackingParams": "CA8Q7G8iEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+            "command": {
+              "clickTrackingParams": "CA8Q7G8iEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+              "commandExecutorCommand": {
+                "commands": [
+                  {
+                    "clickTrackingParams": "CA8Q7G8iEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                    "commandMetadata": {
+                      "webCommandMetadata": {
+                        "url": "https://music.youtube.com/",
+                        "webPageType": "WEB_PAGE_TYPE_UNKNOWN",
+                        "rootVe": 83769
+                      }
+                    },
+                    "urlEndpoint": {
+                      "url": "https://music.youtube.com",
+                      "target": "TARGET_NEW_WINDOW"
+                    }
+                  },
+                  {
+                    "commandMetadata": {
+                      "webCommandMetadata": {
+                        "sendPost": true,
+                        "apiUrl": "/youtubei/v1/feedback"
+                      }
+                    },
+                    "feedbackEndpoint": {
+                      "feedbackToken": "AB9zfpIvWMpgeNTlmkCsfEGZ0INrmInCEnPS_68VepjMgL2IuzDHq_wAzBZF2kDmIpx0p5M2CxKHwNcrtPXM24_HVEgYCXTBxzHw09ZIpO5dCkpVSkDvogWi0NkJywgh7_cHTvF85NUnuMOkB7rL8lSPsnsbu3EhCM3Qcr2olKXsbsnEN7Usog4",
+                      "uiActions": {
+                        "hideEnclosingContainer": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "dismissButton": {
+          "buttonRenderer": {
+            "style": "STYLE_MONO_TONAL",
+            "size": "SIZE_DEFAULT",
+            "text": {
+              "runs": [
+                {
+                  "text": "No thanks"
+                }
+              ]
+            },
+            "trackingParams": "CA4Q7W8iEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+            "command": {
+              "clickTrackingParams": "CA4Q7W8iEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+              "commandExecutorCommand": {
+                "commands": [
+                  {
+                    "clickTrackingParams": "CA4Q7W8iEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                    "commandMetadata": {
+                      "webCommandMetadata": {
+                        "sendPost": true,
+                        "apiUrl": "/youtubei/v1/feedback"
+                      }
+                    },
+                    "feedbackEndpoint": {
+                      "feedbackToken": "AB9zfpJ8nDp2pwiQJMPHaJCpr0lgxV8vcx38kmF6Iz75L4rN3ENKn3aFCHkreDIJVFt82abhQG0teh8QetTzvIskb_ZzCnZ289ZSdoUOfuPH_1QANaKnozRRydy90oc0QEU-auTn8HpWjA8KkQFbRcuIEw954nJj6dIOzrulLWWmtF-egZZ2mJI",
+                      "uiActions": {
+                        "hideEnclosingContainer": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "triggerCondition": "TRIGGER_CONDITION_POST_AD",
+        "style": "STYLE_MODERN",
+        "trackingParams": "CA0Q42kYASITCNKi46HSypQDFad-TAgdgRYmAw==",
+        "impressionEndpoints": [
+          {
+            "clickTrackingParams": "CA0Q42kYASITCNKi46HSypQDFad-TAgdgRYmA8oBBI9E6m0=",
+            "commandMetadata": {
+              "webCommandMetadata": {
+                "sendPost": true,
+                "apiUrl": "/youtubei/v1/feedback"
+              }
+            },
+            "feedbackEndpoint": {
+              "feedbackToken": "AB9zfpJ-butclp3XN6pQExh4SedwzfSXVLW1pnE9BeynsLY0OUgufwmppgoGdmZIGvNb2hdKSm6EuaID4lNzljdyT81rV5Y2h9eRE4RqgIs61dp9BKY1jE72ozCDujs49yZpwbJAVd_H9QSM8vSqUGLa8zvLAhdhNhbm1x7UmtUmRTkCyN0lWiU",
+              "uiActions": {
+                "hideEnclosingContainer": false
+              }
+            }
+          }
+        ],
+        "isVisible": true,
+        "messageTitle": {
+          "runs": [
+            {
+              "text": "Into music? We are too."
+            }
+          ]
+        },
+        "iconDark": {
+          "thumbnails": [
+            {
+              "url": "https://www.gstatic.com/youtube/img/promos/growth/32565a681f5420b051f863e20a723490d94d07306de7b379862f0ec4a0d6676c_384x384.png",
+              "width": 384,
+              "height": 384
+            }
+          ]
+        },
+        "supplementalText": {
+          "runs": [
+            {
+              "text": "Terms apply. Cancel anytime"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "endscreen": {
+    "endscreenRenderer": {
+      "elements": [
+        {
+          "endscreenElementRenderer": {
+            "style": "CHANNEL",
+            "image": {
+              "thumbnails": [
+                {
+                  "url": "https://yt3.ggpht.com/MOWpaiGJdgN4aKMI-NGQLL4jMVP3aDORlQpOBWooi0GSE2TGt4_9ncyepk1pCh-yWQ795AhPbw=s250-c-k-c0x00ffffff-no-rj",
+                  "width": 250,
+                  "height": 250
+                },
+                {
+                  "url": "https://yt3.ggpht.com/MOWpaiGJdgN4aKMI-NGQLL4jMVP3aDORlQpOBWooi0GSE2TGt4_9ncyepk1pCh-yWQ795AhPbw=s400-c-k-c0x00ffffff-no-rj",
+                  "width": 400,
+                  "height": 400
+                }
+              ]
+            },
+            "icon": {
+              "thumbnails": [
+                {
+                  "url": "https://www.gstatic.com/youtube/img/annotations/youtube.png"
+                }
+              ]
+            },
+            "left": 0.035802968,
+            "width": 0.15438597,
+            "top": 0.14801845,
+            "aspectRatio": 1,
+            "startMs": "201451",
+            "endMs": "212040",
+            "title": {
+              "accessibility": {
+                "accessibilityData": {
+                  "label": "Rick Astley, channel"
+                }
+              },
+              "simpleText": "Rick Astley"
+            },
+            "metadata": {
+              "simpleText": "New single \u2018Raindrops\u2019 out now. \nhttps://rickastley.lnk.to/Raindrops\n\nTickets for summer shows 2026 on sale now.\nhttps://rickastley.co.uk/\n"
+            },
+            "callToAction": {
+              "simpleText": "VISIT CHANNEL"
+            },
+            "dismiss": {
+              "simpleText": "CANCEL"
+            },
+            "endpoint": {
+              "clickTrackingParams": "CAgQ-N4BGAAiEwjSouOh0sqUAxWnfkwIHYEWJgMyDGl2LWVuZHNjcmVlbkjEu4GtvZiOhnXKAQSPROpt",
+              "commandMetadata": {
+                "webCommandMetadata": {
+                  "url": "/channel/UCuAXFkgsw1L7xaCfnd5JJOw",
+                  "webPageType": "WEB_PAGE_TYPE_CHANNEL",
+                  "rootVe": 3611,
+                  "apiUrl": "/youtubei/v1/browse"
+                }
+              },
+              "browseEndpoint": {
+                "browseId": "UCuAXFkgsw1L7xaCfnd5JJOw"
+              }
+            },
+            "hovercardButton": {
+              "subscribeButtonRenderer": {
+                "buttonText": {
+                  "runs": [
+                    {
+                      "text": "SUBSCRIBE"
+                    }
+                  ]
+                },
+                "subscribed": false,
+                "enabled": true,
+                "type": "FREE",
+                "channelId": "UCuAXFkgsw1L7xaCfnd5JJOw",
+                "showPreferences": false,
+                "subscribedButtonText": {
+                  "runs": [
+                    {
+                      "text": "SUBSCRIBED"
+                    }
+                  ]
+                },
+                "unsubscribedButtonText": {
+                  "runs": [
+                    {
+                      "text": "SUBSCRIBE"
+                    }
+                  ]
+                },
+                "trackingParams": "CAkQmysiEwjSouOh0sqUAxWnfkwIHYEWJgMyDGl2LWVuZHNjcmVlbg==",
+                "unsubscribeButtonText": {
+                  "runs": [
+                    {
+                      "text": "UNSUBSCRIBE"
+                    }
+                  ]
+                },
+                "serviceEndpoints": [
+                  {
+                    "clickTrackingParams": "CAkQmysiEwjSouOh0sqUAxWnfkwIHYEWJgMyDGl2LWVuZHNjcmVlbsoBBI9E6m0=",
+                    "commandMetadata": {
+                      "webCommandMetadata": {
+                        "sendPost": true,
+                        "apiUrl": "/youtubei/v1/subscription/subscribe"
+                      }
+                    },
+                    "subscribeEndpoint": {
+                      "channelIds": [
+                        "UCuAXFkgsw1L7xaCfnd5JJOw"
+                      ],
+                      "params": "EgIIBBgA"
+                    }
+                  },
+                  {
+                    "clickTrackingParams": "CAkQmysiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                    "commandMetadata": {
+                      "webCommandMetadata": {
+                        "sendPost": true
+                      }
+                    },
+                    "signalServiceEndpoint": {
+                      "signal": "CLIENT_SIGNAL",
+                      "actions": [
+                        {
+                          "clickTrackingParams": "CAkQmysiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                          "openPopupAction": {
+                            "popup": {
+                              "confirmDialogRenderer": {
+                                "trackingParams": "CAoQxjgiEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+                                "dialogMessages": [
+                                  {
+                                    "runs": [
+                                      {
+                                        "text": "Unsubscribe from "
+                                      },
+                                      {
+                                        "text": "Rick Astley"
+                                      },
+                                      {
+                                        "text": "?"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "confirmButton": {
+                                  "buttonRenderer": {
+                                    "style": "STYLE_BLUE_TEXT",
+                                    "size": "SIZE_DEFAULT",
+                                    "isDisabled": false,
+                                    "text": {
+                                      "runs": [
+                                        {
+                                          "text": "Unsubscribe"
+                                        }
+                                      ]
+                                    },
+                                    "serviceEndpoint": {
+                                      "clickTrackingParams": "CAwQ8FsiEwjSouOh0sqUAxWnfkwIHYEWJgMyDGl2LWVuZHNjcmVlbsoBBI9E6m0=",
+                                      "commandMetadata": {
+                                        "webCommandMetadata": {
+                                          "sendPost": true,
+                                          "apiUrl": "/youtubei/v1/subscription/unsubscribe"
+                                        }
+                                      },
+                                      "unsubscribeEndpoint": {
+                                        "channelIds": [
+                                          "UCuAXFkgsw1L7xaCfnd5JJOw"
+                                        ],
+                                        "params": "CgIIBBgA"
+                                      }
+                                    },
+                                    "accessibility": {
+                                      "label": "Unsubscribe"
+                                    },
+                                    "trackingParams": "CAwQ8FsiEwjSouOh0sqUAxWnfkwIHYEWJgM="
+                                  }
+                                },
+                                "cancelButton": {
+                                  "buttonRenderer": {
+                                    "style": "STYLE_TEXT",
+                                    "size": "SIZE_DEFAULT",
+                                    "isDisabled": false,
+                                    "text": {
+                                      "runs": [
+                                        {
+                                          "text": "Cancel"
+                                        }
+                                      ]
+                                    },
+                                    "accessibility": {
+                                      "label": "Cancel"
+                                    },
+                                    "trackingParams": "CAsQ8FsiEwjSouOh0sqUAxWnfkwIHYEWJgM="
+                                  }
+                                },
+                                "primaryIsCancel": false
+                              }
+                            },
+                            "popupType": "DIALOG"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "subscribeAccessibility": {
+                  "accessibilityData": {
+                    "label": "Subscribe to Rick Astley."
+                  }
+                },
+                "unsubscribeAccessibility": {
+                  "accessibilityData": {
+                    "label": "Unsubscribe from Rick Astley."
+                  }
+                },
+                "signInEndpoint": {
+                  "clickTrackingParams": "CAkQmysiEwjSouOh0sqUAxWnfkwIHYEWJgPKAQSPROpt",
+                  "commandMetadata": {
+                    "webCommandMetadata": {
+                      "url": "https://accounts.google.com/ServiceLogin?service=youtube&uilel=3&passive=true&continue=http%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26app%3Ddesktop%26hl%3Den%26next%3Dhttps%253A%252F%252Fwww.youtube.com%252Fchannel%252FUCuAXFkgsw1L7xaCfnd5JJOw%26feature%3Div-endscreen%26continue_action%3DQUFFLUhqbktVRXVmYmtvdm1lelhSS2FfVUVWU1lTcVRpd3xBQ3Jtc0ttV3hYb0VjY1h4YloyMHJpUFh5eXpWY2oxUjZvempyUWtQblUzYUlTRHdCZlhTaFBFRnRUS0dDVTBQb2FDalBGeGlFYjViS1FCcmU1Y1NQOGt3QVJEMTFzTTV0VlBKb2ZiczBHUGZjU213TjI1Tm90a2ZfcmtGeng4UW83c01Ba1UzUTRTeEp4aWxGYV9SazJwVVBYRklIWlUwQmx2bjhaR3BSYW1FdVFaZC1sUzVEMk5HN1FEbk9HWXRDVmVrZ2lSZGlmNE8%253D&hl=en"
+                    }
+                  }
+                }
+              }
+            },
+            "trackingParams": "CAgQ-N4BGAAiEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+            "isSubscribe": true,
+            "id": "720b1b77-5167-4d00-a42e-b8e715efaef1"
+          }
+        },
+        {
+          "endscreenElementRenderer": {
+            "style": "VIDEO",
+            "image": {
+              "thumbnails": [
+                {
+                  "url": "https://i.ytimg.com/vi/qQDrqV5Hw4c/hqdefault.jpg?sqp=-oaymwFACKgBEF5IWvKriqkDMwgBFQAAiEIYAdgBAeIBCggYEAIYBjgBQAHwAQH4Af4JgALQBYoCDAgAEAEYWCBfKGUwDw==&rs=AOn4CLCzj6_DcqR21HsLJj7aEx-HD164Sw",
+                  "width": 168,
+                  "height": 94
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/qQDrqV5Hw4c/hqdefault.jpg?sqp=-oaymwFACMQBEG5IWvKriqkDMwgBFQAAiEIYAdgBAeIBCggYEAIYBjgBQAHwAQH4Af4JgALQBYoCDAgAEAEYWCBfKGUwDw==&rs=AOn4CLCgj2QM99y82SV-zdL3zm3WcTYjtw",
+                  "width": 196,
+                  "height": 110
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/qQDrqV5Hw4c/hqdefault.jpg?sqp=-oaymwFBCPYBEIoBSFryq4qpAzMIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB8AEB-AH-CYAC0AWKAgwIABABGFggXyhlMA8=&rs=AOn4CLBDyyrDLCfbRlIYgQRjDDw3aKgqLA",
+                  "width": 246,
+                  "height": 138
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/qQDrqV5Hw4c/hqdefault.jpg?sqp=-oaymwFBCNACELwBSFryq4qpAzMIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB8AEB-AH-CYAC0AWKAgwIABABGFggXyhlMA8=&rs=AOn4CLCVs3J9KRWVx3C-ULdqMBgDQrHqQA",
+                  "width": 336,
+                  "height": 188
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/qQDrqV5Hw4c/maxresdefault.jpg?sqp=-oaymwEmCIAKENAF8quKqQMa8AEB-AH-CYAC0AWKAgwIABABGFggXyhlMA8=&rs=AOn4CLBDFgN-ehq0DU9qYo5qdDhC4mg_sw",
+                  "width": 1920,
+                  "height": 1080
+                }
+              ]
+            },
+            "left": 0.65438598,
+            "width": 0.32280701,
+            "top": 0.52454501,
+            "aspectRatio": 1.7777778,
+            "startMs": "201451",
+            "endMs": "212040",
+            "title": {
+              "accessibility": {
+                "accessibilityData": {
+                  "label": "Rick Astley - Never : The Autobiography - Listen to the introduction of the Audiobook, video"
+                }
+              },
+              "simpleText": "Rick Astley - Never : The Autobiography - Listen to the introduction of the Audiobook"
+            },
+            "metadata": {
+              "simpleText": "97,417 views"
+            },
+            "endpoint": {
+              "clickTrackingParams": "CAcQ8N4BGAEiEwjSouOh0sqUAxWnfkwIHYEWJgMyDGl2LWVuZHNjcmVlbkjEu4GtvZiOhnWaAQMQu2nKAQSPROpt",
+              "commandMetadata": {
+                "webCommandMetadata": {
+                  "url": "/watch?v=qQDrqV5Hw4c",
+                  "webPageType": "WEB_PAGE_TYPE_WATCH",
+                  "rootVe": 3832
+                },
+                "interactionLoggingCommandMetadata": {
+                  "loggingExpectations": {
+                    "screenCreatedLoggingExpectations": {
+                      "expectedParentScreens": [
+                        {
+                          "screenVeType": 3832
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "watchEndpoint": {
+                "videoId": "qQDrqV5Hw4c",
+                "watchEndpointSupportedOnesieConfig": {
+                  "html5PlaybackOnesieConfig": {
+                    "commonConfig": {
+                      "url": "https://rr3---sn-bvvbaxivnuxqjvhj5nu-nx5r.googlevideo.com/initplayback?source=youtube&oeis=1&c=WEB&oad=3200&ovd=3200&oaad=11000&oavd=11000&ocs=700&oewis=1&oputc=1&ofpcc=1&msp=1&odepv=1&oreouc=1&id=a900eba95e47c387&ip=2601%3A600%3A9000%3A3e20%3A1310%3A6860%3A455a%3A1e1f&initcwndbps=4037500&mt=1779375207&oweuc=&pxtags=Cg4KAnR4Egg1MTgyODk2NA&rxtags=Cg4KAnR4Egg1MTgyODk2Mg%2CCg4KAnR4Egg1MTgyODk2Mw%2CCg4KAnR4Egg1MTgyODk2NA"
+                    }
+                  }
+                }
+              }
+            },
+            "trackingParams": "CAcQ8N4BGAEiEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+            "id": "2267387294768269328",
+            "thumbnailOverlays": [
+              {
+                "thumbnailOverlayTimeStatusRenderer": {
+                  "text": {
+                    "accessibility": {
+                      "accessibilityData": {
+                        "label": "12 minutes"
+                      }
+                    },
+                    "simpleText": "12:00"
+                  },
+                  "style": "DEFAULT"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "endscreenElementRenderer": {
+            "style": "VIDEO",
+            "image": {
+              "thumbnails": [
+                {
+                  "url": "https://i.ytimg.com/vi/yi6fWPV6qXg/hqdefault.jpg?sqp=-oaymwEmCKgBEF5IWvKriqkDGQgBFQAAiEIYAdgBAeIBCggYEAIYBjgBQAE=&rs=AOn4CLDfel1eqM8JfJ_b1cSYDEKuK7w-UQ",
+                  "width": 168,
+                  "height": 94
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/yi6fWPV6qXg/hqdefault.jpg?sqp=-oaymwEmCMQBEG5IWvKriqkDGQgBFQAAiEIYAdgBAeIBCggYEAIYBjgBQAE=&rs=AOn4CLDsHfHeUnT-h_nSxIx9HiHSH9ibfQ",
+                  "width": 196,
+                  "height": 110
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/yi6fWPV6qXg/hqdefault.jpg?sqp=-oaymwEnCPYBEIoBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLCNISWhemmUehEUtNHoUhuJnHq1SA",
+                  "width": 246,
+                  "height": 138
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/yi6fWPV6qXg/hqdefault.jpg?sqp=-oaymwEnCNACELwBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLCrrxLeokkAPpcG_9S6agr4Mu0bSg",
+                  "width": 336,
+                  "height": 188
+                },
+                {
+                  "url": "https://i.ytimg.com/vi_webp/yi6fWPV6qXg/maxresdefault.webp",
+                  "width": 1920,
+                  "height": 1080
+                }
+              ]
+            },
+            "left": 0.65438598,
+            "width": 0.32280701,
+            "top": 0.13084112,
+            "aspectRatio": 1.7777778,
+            "startMs": "201451",
+            "endMs": "212040",
+            "title": {
+              "accessibility": {
+                "accessibilityData": {
+                  "label": "Rick Astley - The Reflection Tour 2026 - Trailer, video"
+                }
+              },
+              "simpleText": "Rick Astley - The Reflection Tour 2026 - Trailer"
+            },
+            "metadata": {
+              "simpleText": "105,256 views"
+            },
+            "endpoint": {
+              "clickTrackingParams": "CAYQ8N4BGAIiEwjSouOh0sqUAxWnfkwIHYEWJgMyDGl2LWVuZHNjcmVlbkjEu4GtvZiOhnWaAQMQu2nKAQSPROpt",
+              "commandMetadata": {
+                "webCommandMetadata": {
+                  "url": "/watch?v=yi6fWPV6qXg",
+                  "webPageType": "WEB_PAGE_TYPE_WATCH",
+                  "rootVe": 3832
+                },
+                "interactionLoggingCommandMetadata": {
+                  "loggingExpectations": {
+                    "screenCreatedLoggingExpectations": {
+                      "expectedParentScreens": [
+                        {
+                          "screenVeType": 3832
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "watchEndpoint": {
+                "videoId": "yi6fWPV6qXg",
+                "watchEndpointSupportedOnesieConfig": {
+                  "html5PlaybackOnesieConfig": {
+                    "commonConfig": {
+                      "url": "https://rr6---sn-bvvbaxivnuxqjvhj5nu-nx5l.googlevideo.com/initplayback?source=youtube&oeis=1&c=WEB&oad=3200&ovd=3200&oaad=11000&oavd=11000&ocs=700&oewis=1&oputc=1&ofpcc=1&msp=1&odepv=1&oreouc=1&id=ca2e9f58f57aa978&ip=2601%3A600%3A9000%3A3e20%3A1310%3A6860%3A455a%3A1e1f&initcwndbps=4041250&mt=1779375207&oweuc=&pxtags=Cg4KAnR4Egg1MTgyODk2NA&rxtags=Cg4KAnR4Egg1MTgyODk2Mg%2CCg4KAnR4Egg1MTgyODk2Mw%2CCg4KAnR4Egg1MTgyODk2NA"
+                    }
+                  }
+                }
+              }
+            },
+            "trackingParams": "CAYQ8N4BGAIiEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+            "id": "6974177256580774925",
+            "thumbnailOverlays": [
+              {
+                "thumbnailOverlayTimeStatusRenderer": {
+                  "text": {
+                    "accessibility": {
+                      "accessibilityData": {
+                        "label": "40 seconds"
+                      }
+                    },
+                    "simpleText": "0:40"
+                  },
+                  "style": "DEFAULT"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "endscreenElementRenderer": {
+            "style": "PLAYLIST",
+            "image": {
+              "thumbnails": [
+                {
+                  "url": "https://i.ytimg.com/vi/zRVjZ2DJ9Cg/hqdefault.jpg?sqp=-oaymwEmCKgBEF5IWvKriqkDGQgBFQAAiEIYAdgBAeIBCggYEAIYBjgBQAE=&rs=AOn4CLCXqdP0dmd8IeaT4KtLeT9fgQMupQ",
+                  "width": 168,
+                  "height": 94
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/zRVjZ2DJ9Cg/hqdefault.jpg?sqp=-oaymwEmCMQBEG5IWvKriqkDGQgBFQAAiEIYAdgBAeIBCggYEAIYBjgBQAE=&rs=AOn4CLDBhPIyzktAGCtUIFScNUpgXqlDFw",
+                  "width": 196,
+                  "height": 110
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/zRVjZ2DJ9Cg/hqdefault.jpg?sqp=-oaymwEnCPYBEIoBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLABfvmg2oINAKICUb_x-97wd6_FoQ",
+                  "width": 246,
+                  "height": 138
+                },
+                {
+                  "url": "https://i.ytimg.com/vi/zRVjZ2DJ9Cg/hqdefault.jpg?sqp=-oaymwEnCNACELwBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLDHmau8FJP0IdTt6zJ7KPp-792fvQ",
+                  "width": 336,
+                  "height": 188
+                },
+                {
+                  "url": "https://i.ytimg.com/vi_webp/zRVjZ2DJ9Cg/maxresdefault.webp",
+                  "width": 1920,
+                  "height": 1080
+                }
+              ]
+            },
+            "playlistLength": {
+              "simpleText": "41 videos"
+            },
+            "left": 0.035802968,
+            "width": 0.32280701,
+            "top": 0.50776422,
+            "aspectRatio": 1.7777778,
+            "startMs": "201451",
+            "endMs": "212040",
+            "title": {
+              "accessibility": {
+                "accessibilityData": {
+                  "label": "41 videos, Rick Astley: Official Music Videos"
+                }
+              },
+              "simpleText": "Rick Astley: Official Music Videos"
+            },
+            "metadata": {
+              "simpleText": "by Rick Astley"
+            },
+            "endpoint": {
+              "clickTrackingParams": "CAUQ894BGAMiEwjSouOh0sqUAxWnfkwIHYEWJgMyDGl2LWVuZHNjcmVlbkjEu4GtvZiOhnWaAQMQu2nKAQSPROpt",
+              "commandMetadata": {
+                "webCommandMetadata": {
+                  "url": "/watch?v=zRVjZ2DJ9Cg&list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc",
+                  "webPageType": "WEB_PAGE_TYPE_WATCH",
+                  "rootVe": 3832
+                }
+              },
+              "watchEndpoint": {
+                "videoId": "zRVjZ2DJ9Cg",
+                "playlistId": "PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc",
+                "loggingContext": {
+                  "vssLoggingContext": {
+                    "serializedContextData": "GiJQTGxhTjg4YTd5Ml9wbGVjWW9KeHZSRlRMSFZiSVZBT29j"
+                  }
+                },
+                "watchEndpointSupportedOnesieConfig": {
+                  "html5PlaybackOnesieConfig": {
+                    "commonConfig": {
+                      "url": "https://rr9---sn-bvvbaxivnuxqjvhj5nu-nx5l.googlevideo.com/initplayback?source=youtube&oeis=1&c=WEB&oad=3200&ovd=3200&oaad=11000&oavd=11000&ocs=700&oewis=1&oputc=1&ofpcc=1&msp=1&odepv=1&oreouc=1&id=cd15636760c9f428&ip=2601%3A600%3A9000%3A3e20%3A1310%3A6860%3A455a%3A1e1f&initcwndbps=4041250&mt=1779375207&oweuc=&pxtags=Cg4KAnR4Egg1MTgyODk2NA&rxtags=Cg4KAnR4Egg1MTgyODk2Mg%2CCg4KAnR4Egg1MTgyODk2Mw%2CCg4KAnR4Egg1MTgyODk2NA"
+                    }
+                  }
+                }
+              }
+            },
+            "trackingParams": "CAUQ894BGAMiEwjSouOh0sqUAxWnfkwIHYEWJgM=",
+            "id": "277763988111692989"
+          }
+        }
+      ],
+      "startMs": "201451",
+      "trackingParams": "CAEQ794BIhMI0qLjodLKlAMVp35MCB2BFiYD",
+      "hideButton": {
+        "toggleButtonViewModel": {
+          "defaultButtonViewModel": {
+            "buttonViewModel": {
+              "iconName": "VISIBILITY_OFF",
+              "title": "Hide",
+              "onTap": {
+                "innertubeCommand": {
+                  "clickTrackingParams": "CAQQ088OIhMI0qLjodLKlAMVp35MCB2BFiYDygEEj0TqbQ==",
+                  "changeCreatorEndscreenVisibilityCommand": {
+                    "hide": true
+                  }
+                }
+              },
+              "accessibilityText": "Hide endscreen cards",
+              "style": "BUTTON_VIEW_MODEL_STYLE_OVERLAY",
+              "trackingParams": "CAQQ088OIhMI0qLjodLKlAMVp35MCB2BFiYD",
+              "type": "BUTTON_VIEW_MODEL_TYPE_FILLED",
+              "buttonSize": "BUTTON_VIEW_MODEL_SIZE_XSMALL"
+            }
+          },
+          "toggledButtonViewModel": {
+            "buttonViewModel": {
+              "iconName": "VISIBILITY",
+              "title": "Show",
+              "onTap": {
+                "innertubeCommand": {
+                  "clickTrackingParams": "CAMQ1M8OIhMI0qLjodLKlAMVp35MCB2BFiYDygEEj0TqbQ==",
+                  "changeCreatorEndscreenVisibilityCommand": {
+                    "hide": false
+                  }
+                }
+              },
+              "accessibilityText": "Show endscreen cards",
+              "style": "BUTTON_VIEW_MODEL_STYLE_OVERLAY",
+              "trackingParams": "CAMQ1M8OIhMI0qLjodLKlAMVp35MCB2BFiYD",
+              "type": "BUTTON_VIEW_MODEL_TYPE_FILLED",
+              "buttonSize": "BUTTON_VIEW_MODEL_SIZE_XSMALL"
+            }
+          },
+          "rendererContext": {
+            "loggingContext": {
+              "loggingDirectives": {
+                "trackingParams": "CAIQ_O4OIhMI0qLjodLKlAMVp35MCB2BFiYD",
+                "visibility": {
+                  "types": "12"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "adPlacements": [
+    {
+      "adPlacementRenderer": {
+        "config": {
+          "adPlacementConfig": {
+            "kind": "AD_PLACEMENT_KIND_START",
+            "adTimeOffset": {
+              "offsetStartMilliseconds": "0",
+              "offsetEndMilliseconds": "-1"
+            },
+            "hideCueRangeMarker": true
+          }
+        },
+        "renderer": {
+          "clientForecastingAdRenderer": {}
+        },
+        "adSlotLoggingData": {
+          "serializedSlotAdServingDataEntry": "ChMIs4DkodLKlAMV7f3nAx07EjwfGhJiEElLb2V5Mk9ocWZ2T0N5NEw="
+        }
+      }
+    }
+  ],
+  "adBreakHeartbeatParams": "Q0FBJTNE",
+  "frameworkUpdates": {
+    "entityBatchUpdate": {
+      "mutations": [
+        {
+          "entityKey": "Eg0KC2RRdzR3OVdnWGNRIPYBKAE%3D",
+          "type": "ENTITY_MUTATION_TYPE_REPLACE",
+          "payload": {
+            "offlineabilityEntity": {
+              "key": "Eg0KC2RRdzR3OVdnWGNRIPYBKAE%3D",
+              "addToOfflineButtonState": "ADD_TO_OFFLINE_BUTTON_STATE_UNKNOWN"
+            }
+          }
+        }
+      ],
+      "timestamp": {
+        "seconds": "1779375493",
+        "nanos": 756765979
+      }
+    }
+  }
+}

--- a/backend/tests/test_decodo_scraping_youtube.py
+++ b/backend/tests/test_decodo_scraping_youtube.py
@@ -1,0 +1,243 @@
+"""
+╔════════════════════════════════════════════════════════════════════════════════════╗
+║  🧪 TESTS — Decodo Scraping fallback for YouTube info (Feature 1.3 Phase 1)        ║
+╠════════════════════════════════════════════════════════════════════════════════════╣
+║  Coverage:                                                                         ║
+║  • _parse_youtube_storyboards on captured fixture                                  ║
+║  • _decodo_scrape_youtube_info: happy path (mock DecodoScrapingClient)             ║
+║  • _decodo_scrape_youtube_info: empty html                                         ║
+║  • _decodo_scrape_youtube_info: missing ytInitialPlayerResponse                    ║
+║  • _decodo_scrape_youtube_info: malformed JSON inside the script tag               ║
+║  • _decodo_scrape_youtube_info: Decodo client raises (returns None, no leak)       ║
+║  • get_youtube_info_with_fallback: yt-dlp KO + Decodo OK                           ║
+║  • get_youtube_info_with_fallback: yt-dlp OK → Decodo never called                 ║
+║  • get_youtube_info_with_fallback: both KO → None                                  ║
+╚════════════════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Add src to path (mirror conftest pattern for direct imports).
+_src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+# Bootstrap the import graph by loading the main FastAPI module first. The
+# `videos/__init__.py` pulls in routers that have a known circular import with
+# auth.service/auth.dependencies (pre-existing CI issue, not introduced by
+# this PR). Pre-loading `main` resolves the chain before any submodule import.
+import main  # noqa: E402,F401  (side-effect import)
+
+from videos import youtube_storyboard as ys  # noqa: E402
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "youtube" / "watch_decodo_player_response.json"
+
+
+@pytest.fixture(scope="module")
+def player_response_fixture() -> Dict[str, Any]:
+    """Load the captured ytInitialPlayerResponse JSON.
+
+    Captured 2026-05-21 via Decodo Premium+JS on Rick Astley watch page.
+    """
+    assert FIXTURE_PATH.exists(), f"Missing fixture: {FIXTURE_PATH}"
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def watch_html_with_player_response(player_response_fixture) -> str:
+    """Build a minimal watch.html that contains the assignment line.
+
+    yt-dlp / our regex look for ``ytInitialPlayerResponse = {...};`` exactly.
+    We surround the JSON with enough filler bytes to clear the 50KB guard.
+    """
+    player_json = json.dumps(player_response_fixture)
+    # Pad to >50000 bytes (the guard inside _decodo_scrape_youtube_info).
+    padding = "<!-- pad -->" * 4500  # ~54 KB on its own
+    return (
+        "<html><head><script>"
+        f"var ytInitialPlayerResponse = {player_json};"
+        "var foo = 1;</script></head><body>"
+        f"{padding}"
+        "</body></html>"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _parse_youtube_storyboards
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestParseStoryboards:
+    def test_parses_fixture_into_at_least_one_format(self, player_response_fixture):
+        formats = ys._parse_youtube_storyboards(player_response_fixture)
+        # MVP acceptance: the fixture has spec="L0|L1|L2|L3", so ≥1 format.
+        assert len(formats) >= 1, "expected at least one storyboard format"
+        for fmt in formats:
+            assert fmt["format_id"].startswith("sb")
+            assert fmt["ext"] == "mhtml"
+            assert fmt["width"] > 0
+            assert fmt["height"] > 0
+            assert fmt["columns"] > 0
+            assert fmt["rows"] > 0
+            assert isinstance(fmt["fragments"], list)
+            assert len(fmt["fragments"]) >= 1
+            for frag in fmt["fragments"]:
+                # Every sheet URL must be a YouTube CDN URL with $L/$N expanded.
+                assert frag["url"].startswith("https://i.ytimg.com/sb/")
+                assert "$L" not in frag["url"]
+                assert "$N" not in frag["url"]
+
+    def test_returns_empty_on_missing_storyboards_key(self):
+        assert ys._parse_youtube_storyboards({"videoDetails": {}}) == []
+
+    def test_returns_empty_on_non_dict_input(self):
+        assert ys._parse_youtube_storyboards(None) == []  # type: ignore[arg-type]
+        assert ys._parse_youtube_storyboards("not a dict") == []  # type: ignore[arg-type]
+
+    def test_returns_empty_on_malformed_spec(self):
+        # Spec missing the URL template placeholders.
+        player = {
+            "storyboards": {
+                "playerStoryboardSpecRenderer": {
+                    "spec": "no-pipes-here-just-a-bare-string",
+                }
+            }
+        }
+        assert ys._parse_youtube_storyboards(player) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _decodo_scrape_youtube_info — happy + error paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeScrapeResult:
+    """Minimal stand-in for ScrapeResult that only needs .content."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class TestDecodoScrapeYoutubeInfo:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_compatible_info_dict(
+        self, watch_html_with_player_response, player_response_fixture
+    ):
+        fake_client = MagicMock()
+        fake_client.scrape = AsyncMock(return_value=_FakeScrapeResult(watch_html_with_player_response))
+        with patch("decodo.DecodoScrapingClient", return_value=fake_client):
+            info = await ys._decodo_scrape_youtube_info("dQw4w9WgXcQ", "TEST")
+        assert info is not None
+        assert info["id"] == "dQw4w9WgXcQ"
+        assert info["duration"] == int(player_response_fixture["videoDetails"]["lengthSeconds"])
+        assert info["title"] == player_response_fixture["videoDetails"]["title"]
+        # MVP acceptance: storyboards either reconstructed or empty list, never
+        # missing.
+        assert isinstance(info["formats"], list)
+        assert info["_source"] == "decodo_scrape"
+        # Confirm the client was invoked with Premium+JS on the right URL.
+        fake_client.scrape.assert_awaited_once()
+        call_kwargs = fake_client.scrape.call_args.kwargs
+        assert call_kwargs.get("proxy_pool") == "premium"
+        assert call_kwargs.get("headless") is True
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_html_too_short(self):
+        fake_client = MagicMock()
+        fake_client.scrape = AsyncMock(return_value=_FakeScrapeResult("<html></html>"))
+        with patch("decodo.DecodoScrapingClient", return_value=fake_client):
+            info = await ys._decodo_scrape_youtube_info("abc12345xyz", "TEST")
+        assert info is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_player_response_absent(self):
+        # 60KB of HTML but no ytInitialPlayerResponse assignment.
+        bogus_html = "<html>" + ("noise " * 12_000) + "</html>"
+        fake_client = MagicMock()
+        fake_client.scrape = AsyncMock(return_value=_FakeScrapeResult(bogus_html))
+        with patch("decodo.DecodoScrapingClient", return_value=fake_client):
+            info = await ys._decodo_scrape_youtube_info("abc12345xyz", "TEST")
+        assert info is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_invalid_json(self):
+        # Assignment present but JSON is malformed (unbalanced braces).
+        broken_html = (
+            "<html><script>var ytInitialPlayerResponse = {not-valid-json};</script>" + ("pad " * 15_000) + "</html>"
+        )
+        fake_client = MagicMock()
+        fake_client.scrape = AsyncMock(return_value=_FakeScrapeResult(broken_html))
+        with patch("decodo.DecodoScrapingClient", return_value=fake_client):
+            info = await ys._decodo_scrape_youtube_info("abc12345xyz", "TEST")
+        assert info is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_client_raises(self):
+        fake_client = MagicMock()
+        fake_client.scrape = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch("decodo.DecodoScrapingClient", return_value=fake_client):
+            info = await ys._decodo_scrape_youtube_info("abc12345xyz", "TEST")
+        # Must swallow the exception and return None so the caller can fall
+        # through to its own fallbacks (duration_hint etc.).
+        assert info is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_youtube_info_with_fallback — cascade integration (Checkpoint 4)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGetYoutubeInfoWithFallback:
+    """Integration tests for the cascade wrapper. Added at CP4 once the wrapper
+    is wired into ``extract_storyboard_frames``."""
+
+    @pytest.mark.asyncio
+    async def test_ytdlp_ok_skips_decodo(self):
+        fake_info = {"id": "x", "duration": 100, "title": "y", "formats": []}
+        if not hasattr(ys, "get_youtube_info_with_fallback"):
+            pytest.skip("wrapper added in CP4")
+        with (
+            patch.object(ys, "_ytdlp_info_sync", return_value=fake_info),
+            patch.object(ys, "_decodo_scrape_youtube_info", new=AsyncMock()) as dec,
+        ):
+            info = await ys.get_youtube_info_with_fallback("abcdefghijk", "TEST")
+        assert info is fake_info
+        dec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ytdlp_ko_falls_back_to_decodo(self):
+        fake_info = {"id": "x", "duration": 213, "title": "y", "formats": []}
+        if not hasattr(ys, "get_youtube_info_with_fallback"):
+            pytest.skip("wrapper added in CP4")
+        with (
+            patch.object(ys, "_ytdlp_info_sync", return_value=None),
+            patch.object(
+                ys,
+                "_decodo_scrape_youtube_info",
+                new=AsyncMock(return_value=fake_info),
+            ) as dec,
+        ):
+            info = await ys.get_youtube_info_with_fallback("abcdefghijk", "TEST")
+        assert info is fake_info
+        dec.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_both_ko_returns_none(self):
+        if not hasattr(ys, "get_youtube_info_with_fallback"):
+            pytest.skip("wrapper added in CP4")
+        with (
+            patch.object(ys, "_ytdlp_info_sync", return_value=None),
+            patch.object(ys, "_decodo_scrape_youtube_info", new=AsyncMock(return_value=None)),
+        ):
+            info = await ys.get_youtube_info_with_fallback("abcdefghijk", "TEST")
+        assert info is None

--- a/backend/tests/test_decodo_scraping_youtube.py
+++ b/backend/tests/test_decodo_scraping_youtube.py
@@ -241,3 +241,43 @@ class TestGetYoutubeInfoWithFallback:
         ):
             info = await ys.get_youtube_info_with_fallback("abcdefghijk", "TEST")
         assert info is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# extract_storyboard_frames — cascade is wired in
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractStoryboardFramesUsesFallback:
+    """One integration test confirming that `extract_storyboard_frames` reaches
+    the Decodo fallback when yt-dlp returns None. We don't drive the full
+    pipeline (sheet download / PIL slicing happens against a real CDN); we
+    only assert that the wrapper is called and yields enough to exit cleanly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ytdlp_ko_routes_through_decodo(self, player_response_fixture):
+        # yt-dlp KO → Decodo returns info with duration > 0 but storyboards=[]
+        # (a realistic MVP outcome). The function should NOT raise, and it
+        # should detect "No storyboard format available" then exit None.
+        fake_info = {
+            "id": "dQw4w9WgXcQ",
+            "title": "test",
+            "duration": int(player_response_fixture["videoDetails"]["lengthSeconds"]),
+            "formats": [],
+            "_source": "decodo_scrape",
+        }
+        with (
+            patch.object(ys, "_ytdlp_info_sync", return_value=None),
+            patch.object(ys, "_decodo_scrape_youtube_info", new=AsyncMock(return_value=fake_info)) as dec_mock,
+        ):
+            result = await ys.extract_storyboard_frames(
+                "dQw4w9WgXcQ",
+                log_tag="TEST",
+            )
+        # Decodo was reached (no bail-early before it).
+        dec_mock.assert_awaited_once()
+        # storyboards=[] → select_storyboard_format returns None → function
+        # cleans up workdir and returns None. The non-bail-early goal is the
+        # asserting condition: the AsyncMock above being awaited.
+        assert result is None


### PR DESCRIPTION
## Summary

Phase 1.3 du rollout Decodo Web Scraping API (spec § 6, vault `01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase1-quick-wins.md`). Ajoute un 6e fallback dans le pipeline storyboard YouTube : quand yt-dlp est bot-challenged depuis l'IP Hetzner (`reference_youtube-download-hetzner-blocked` 2026-05-05), on scrape la watch page via Decodo Premium+JS et on reconstruit un dict info yt-dlp-compatible.

**Motivation** : avant ce PR, `_ytdlp_info_sync` retournait None → `extract_storyboard_frames` exit L308 → 4 fallbacks duration + le 5e fallback `duration_hint` (PR #470) jamais consultés. Le visual_analysis devenait `null` silencieusement.

Phase 0 (wrapper `core.decodo_scraping` + table `decodo_scraping_usage`) déjà mergée prod (PR #526 commit `65c7b734`). Migration `033_decodo_scraping_usage` appliquée Hetzner. Smoke test J0 GO confirmé (HTTP 200, 2.2 MB content, `ytInitialPlayerResponse` 71 KB extractable, `lengthSeconds` présent).

## Changements

| Fichier | Nature |
|---|---|
| `backend/src/videos/youtube_storyboard.py` | +320 LOC : `_decodo_scrape_youtube_info`, `_parse_youtube_storyboards`, `get_youtube_info_with_fallback`, rewire L307 (`extract_storyboard_frames` → wrapper async) |
| `backend/tests/test_decodo_scraping_youtube.py` | NEW, 13 tests passants |
| `backend/tests/fixtures/youtube/watch_decodo_player_response.json` | NEW, 119 KB — `ytInitialPlayerResponse` capturé Decodo Premium+JS sur dQw4w9WgXcQ |
| `backend/tests/fixtures/youtube/_extract_player_response.py` | NEW, helper de capture pour reproductibilité |

## Storyboards : full parser (non MVP duration-only)

Brief autorisait MVP duration-only mais le spec format observé sur la fixture est suffisamment simple (URL template + tokens pipe-delimited `w#h#count#cols#rows#...`) pour parser tous les levels (sb0/sb1/sb2/sb3). Implémentation 65 LOC dans `_parse_youtube_storyboards`. Reconstruit fragments URLs avec `$L`/`$N` substitution (CDN `i.ytimg.com`, validé pas de bot guard 2026-05-05).

Si parse échoue, returns `[]` → `select_storyboard_format` retourne None → `extract_storyboard_frames` exit "No storyboard format available" mais le 5e fallback `duration_hint` upstream peut toujours rattraper la durée. Pas de régression vs avant PR.

## Bail-early audit (anti-PR #468 trap)

Memo `feedback_fallback-bail-early-trap` — case study PR #468 dead-code 14h. Audit fait :

```
router.py:1507 v6        → enrich_and_capture_visual ✓ (pas de bail)
router.py:2444 v2.1      → enrich_and_capture_visual ✓ (pas de bail)
visual_integration.py:303 → extract_storyboard_frames (no intermediate)
youtube_storyboard.py:extract_storyboard_frames
                          → get_youtube_info_with_fallback (NEW)
                              ├─ _ytdlp_info_sync (current path, unchanged)
                              └─ _decodo_scrape_youtube_info (NEW)
```

Confirmé en test runtime (`test_ytdlp_ko_routes_through_decodo`) : `_ytdlp_info_sync` mocked None → `_decodo_scrape_youtube_info` IS awaited (`.assert_awaited_once()`). Le code path atteint Decodo en cas yt-dlp KO. Logs temporaires `[BAIL_AUDIT]` utilisés en dev, retirés avant ce commit per brief.

## Tests

```
tests/test_decodo_scraping_youtube.py  →  13 passed (2.7s)
```

Coverage :
- `_parse_youtube_storyboards` : fixture happy, missing storyboards, non-dict, malformed spec
- `_decodo_scrape_youtube_info` : happy path (mock + fixture HTML), html trop court, no player_response, JSON invalid, client raises
- `get_youtube_info_with_fallback` : yt-dlp OK (skip Decodo), yt-dlp KO + Decodo OK, both KO
- `extract_storyboard_frames` integration : yt-dlp KO + Decodo OK avec storyboards=[] → cascade reachable + return None propre

E2E live laissé en TODO comment (5 vidéos staging post-deploy).

**Note CI** : un test `test_proxy_injected_when_set` failure pré-existe sur main (circular import `auth.service`/`auth.dependencies`, pas introduit par ce PR). Mes tests le contournent via `import main` bootstrap (même pattern que `tests/videos/test_visual_integration.py`).

## Décisions techniques

- Lazy import de `decodo.DecodoScrapingClient` dans `_decodo_scrape_youtube_info` (évite que `videos/__init__.py` pulle pydantic/httpx pour les call-sites non-visuels).
- Timeout Decodo = 45s (couvre 2 retries internes du wrapper avec backoff 0.5s+1s).
- Errors swallowed → None (callers fall through aux fallbacks duration_hint existants).
- `_source` clé dans info dict (`"ytdlp"` ou `"decodo_scrape"`) pour telemetry et debug.
- Pas de wiring direct v6/v2.1 dans `router.py` — l'effet se propage via `visual_integration.py:303` (pattern identique à TikTok visual fallbacks).

## Quota Decodo prévu

Estimation steady-state : ~150 analyses YouTube/jour × 10% fallback (cas bot challenge réel) = ~15 req Premium+JS/jour = ~450/mois. ~1% du quota 39 200 Premium+JS du tier $49/mois. Hard-stop `DECODO_SCRAPING_DISABLED=true` env (kill switch sans deploy).

## Refs

- Spec : `01-Projects/DeepSight/Ideas/2026-05-21-decodo-scraping-phase1-quick-wins.md` § 6
- Phase 0 wrapper : PR #526 commit `65c7b734`
- Smoke test J0 : GO (vault `00-Inbox/2026-05-21-decodo-scraping-smoke-j0.md`)
- Bail-early memo : `feedback_fallback-bail-early-trap`
- Hetzner block : `reference_youtube-download-hetzner-blocked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)