### PR TITLE
feat(discover/search): TikTok engagement score ranking

### DIFF
--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -596,9 +596,7 @@ class TikTokSearcher:
             author = raw.get("author") or {}
             create_time = raw.get("create_time", 0) or 0
             try:
-                published_at = (
-                    datetime.fromtimestamp(int(create_time)) if create_time else datetime.now()
-                )
+                published_at = datetime.fromtimestamp(int(create_time)) if create_time else datetime.now()
             except (ValueError, OSError, OverflowError):
                 published_at = datetime.now()
             title_text = (raw.get("title") or "").strip()
@@ -650,13 +648,7 @@ def tiktok_engagement_score(c: VideoCandidate, now: Optional[datetime] = None) -
     else:
         freshness = 1.0 - (age_days - 7) / 83.0
 
-    return (
-        view_score * 0.30
-        + like_ratio * 0.25
-        + comment_ratio * 0.20
-        + share_ratio * 0.15
-        + freshness * 0.10
-    )
+    return view_score * 0.30 + like_ratio * 0.25 + comment_ratio * 0.20 + share_ratio * 0.15 + freshness * 0.10
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -763,10 +755,6 @@ class RedditSearcher:
             # Skip self-posts (text-only)
             if raw.get("is_self"):
                 return None
-            url = raw.get("url_overridden_by_dest") or raw.get("url") or ""
-            # Build canonical Reddit permalink for analysis
-            permalink = raw.get("permalink") or ""
-            full_url = f"https://www.reddit.com{permalink}" if permalink else url
             thumbnail = raw.get("thumbnail") or ""
             if not thumbnail or thumbnail in ("self", "default", "nsfw", "spoiler", ""):
                 # Try preview image
@@ -1790,12 +1778,8 @@ class IntelligentDiscoveryService:
                     logger.error(f"Scoring error for {cand.video_id}: {e}")
                     return None
 
-        scoring_results = await asyncio.gather(
-            *(_score_with_sem(c) for c in all_candidates.values())
-        )
-        scored_candidates = [
-            s for s in scoring_results if s is not None and s.final_score >= min_quality
-        ]
+        scoring_results = await asyncio.gather(*(_score_with_sem(c) for c in all_candidates.values()))
+        scored_candidates = [s for s in scoring_results if s is not None and s.final_score >= min_quality]
 
         # 4. Tri par score final et diversification
         scored_candidates.sort(key=lambda x: x.final_score, reverse=True)

--- a/backend/src/videos/intelligent_discovery.py
+++ b/backend/src/videos/intelligent_discovery.py
@@ -123,6 +123,8 @@ class VideoCandidate:
     view_count: int
     channel_id: str = ""  # 🔧 Optionnel avec valeur par défaut
     like_count: int = 0
+    comment_count: int = 0
+    share_count: int = 0
     published_at: datetime = field(default_factory=datetime.now)
 
     # Scores calculés
@@ -610,11 +612,51 @@ class TikTokSearcher:
                 duration=int(raw.get("duration") or 0),
                 view_count=int(raw.get("play_count") or 0),
                 like_count=int(raw.get("digg_count") or 0),
+                comment_count=int(raw.get("comment_count") or 0),
+                share_count=int(raw.get("share_count") or 0),
                 published_at=published_at,
             )
         except Exception as e:
             logger.error(f"Error parsing tikwm result: {e}")
             return None
+
+
+def tiktok_engagement_score(c: VideoCandidate, now: Optional[datetime] = None) -> float:
+    """Score [0..1] mimicking TikTok's relevance ranking.
+
+    Pondération : vues (log normalisé) + ratios likes/comments/shares + fraîcheur.
+    Les ratios pénalisent les vidéos virales en vues mais sans interaction réelle,
+    et favorisent les vidéos avec un engagement profond (comments, shares).
+    """
+    now = now or datetime.now()
+    views = max(c.view_count, 0)
+    if views == 0:
+        return 0.0
+
+    # Vues normalisées en log10 (cap à 1M vues = 1.0)
+    view_score = min(math.log10(views + 1) / 6.0, 1.0)
+
+    # Ratios d'engagement (cap à 1.0)
+    like_ratio = min((c.like_count / views) * 10, 1.0) if c.like_count else 0.0
+    comment_ratio = min((c.comment_count / views) * 100, 1.0) if c.comment_count else 0.0
+    share_ratio = min((c.share_count / views) * 50, 1.0) if c.share_count else 0.0
+
+    # Fraîcheur : 1.0 si <7j, decay linéaire jusqu'à 0 à 90j
+    age_days = max((now - c.published_at).days, 0) if c.published_at else 90
+    if age_days <= 7:
+        freshness = 1.0
+    elif age_days >= 90:
+        freshness = 0.0
+    else:
+        freshness = 1.0 - (age_days - 7) / 83.0
+
+    return (
+        view_score * 0.30
+        + like_ratio * 0.25
+        + comment_ratio * 0.20
+        + share_ratio * 0.15
+        + freshness * 0.10
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -4620,6 +4620,7 @@ from .intelligent_discovery import (
     RedditSearcher,
     TikTokSearcher,
     generate_text_video_id,
+    tiktok_engagement_score,
     validate_raw_text,
 )
 from .schemas import (
@@ -4764,6 +4765,15 @@ async def discover_search_videos(
                 TikTokSearcher.search(query, max_results=limit),
                 timeout=15.0,
             )
+            scored = [(c, tiktok_engagement_score(c)) for c in candidates]
+            if sort_by == "date":
+                scored.sort(
+                    key=lambda x: x[0].published_at or datetime.min, reverse=True
+                )
+            elif sort_by == "views":
+                scored.sort(key=lambda x: x[0].view_count, reverse=True)
+            else:
+                scored.sort(key=lambda x: x[1], reverse=True)
             videos = [
                 {
                     "video_id": c.video_id,
@@ -4772,19 +4782,18 @@ async def discover_search_videos(
                     "thumbnail_url": c.thumbnail_url,
                     "duration": c.duration,
                     "view_count": c.view_count,
-                    "quality_score": 0,
+                    "like_count": c.like_count,
+                    "comment_count": c.comment_count,
+                    "share_count": c.share_count,
+                    "quality_score": round(score * 100),
                     "tournesol_score": 0,
                     "published_at": c.published_at.isoformat() if c.published_at else None,
                     "is_tournesol_pick": False,
                     "platform": "tiktok",
                     "video_url": _build_tiktok_url(c.video_id, c.channel_id),
                 }
-                for c in candidates
+                for c, score in scored
             ]
-            if sort_by == "date":
-                videos.sort(key=lambda v: v["published_at"] or "", reverse=True)
-            else:
-                videos.sort(key=lambda v: v["view_count"], reverse=True)
             videos = videos[:limit]
             logger.info(f"✅ [DISCOVER/SEARCH] Returning {len(videos)} TikTok videos")
             return {

--- a/backend/src/videos/router.py
+++ b/backend/src/videos/router.py
@@ -4767,9 +4767,7 @@ async def discover_search_videos(
             )
             scored = [(c, tiktok_engagement_score(c)) for c in candidates]
             if sort_by == "date":
-                scored.sort(
-                    key=lambda x: x[0].published_at or datetime.min, reverse=True
-                )
+                scored.sort(key=lambda x: x[0].published_at or datetime.min, reverse=True)
             elif sort_by == "views":
                 scored.sort(key=lambda x: x[0].view_count, reverse=True)
             else:

--- a/backend/tests/videos/test_tiktok_engagement_score.py
+++ b/backend/tests/videos/test_tiktok_engagement_score.py
@@ -1,0 +1,82 @@
+"""Tests for tiktok_engagement_score helper.
+
+Verifies that the scoring function gives sensible relative ordering:
+- High views + high engagement → higher score than high views alone
+- Recent content gets a small freshness bonus
+- Empty/zero-view candidates score 0
+"""
+
+from datetime import datetime, timedelta
+
+from videos.intelligent_discovery import VideoCandidate, tiktok_engagement_score
+
+
+def _make(
+    *,
+    views: int = 0,
+    likes: int = 0,
+    comments: int = 0,
+    shares: int = 0,
+    age_days: int = 30,
+    now: datetime | None = None,
+) -> VideoCandidate:
+    now = now or datetime(2026, 5, 21, 12, 0, 0)
+    return VideoCandidate(
+        video_id="x",
+        title="x",
+        channel="x",
+        description="x",
+        thumbnail_url="x",
+        duration=30,
+        view_count=views,
+        like_count=likes,
+        comment_count=comments,
+        share_count=shares,
+        published_at=now - timedelta(days=age_days),
+    )
+
+
+def test_zero_views_returns_zero():
+    assert tiktok_engagement_score(_make()) == 0.0
+
+
+def test_engagement_beats_pure_views():
+    now = datetime(2026, 5, 21, 12, 0, 0)
+    # Vidéo très virale, peu d'interaction (clickbait)
+    viral_dull = _make(views=10_000_000, likes=100, comments=10, shares=5, age_days=60, now=now)
+    # Vidéo moins virale mais engagement profond
+    moderate_engaged = _make(
+        views=500_000, likes=80_000, comments=4_000, shares=2_000, age_days=10, now=now
+    )
+    assert tiktok_engagement_score(moderate_engaged, now=now) > tiktok_engagement_score(
+        viral_dull, now=now
+    )
+
+
+def test_freshness_breaks_tie():
+    now = datetime(2026, 5, 21, 12, 0, 0)
+    stats = dict(views=100_000, likes=10_000, comments=500, shares=200)
+    fresh = _make(**stats, age_days=3, now=now)
+    stale = _make(**stats, age_days=120, now=now)
+    assert tiktok_engagement_score(fresh, now=now) > tiktok_engagement_score(stale, now=now)
+
+
+def test_score_bounded_zero_one():
+    now = datetime(2026, 5, 21, 12, 0, 0)
+    extreme = _make(
+        views=1_000_000_000,
+        likes=500_000_000,
+        comments=100_000_000,
+        shares=50_000_000,
+        age_days=0,
+        now=now,
+    )
+    score = tiktok_engagement_score(extreme, now=now)
+    assert 0.0 <= score <= 1.0
+
+
+def test_views_only_still_scores():
+    """Une vidéo avec uniquement des vues (engagement non capturé) doit quand même scorer > 0."""
+    now = datetime(2026, 5, 21, 12, 0, 0)
+    c = _make(views=10_000, age_days=2, now=now)
+    assert tiktok_engagement_score(c, now=now) > 0.0


### PR DESCRIPTION
## Contexte

Suite de #530. L'utilisateur a signalé que la recherche TikTok ne renvoie pas les "vidéos les plus évidentes en premier" — actuellement on trie par `view_count` brut, ce qui privilégie les vidéos très anciennes et virales mais avec peu d'interaction (clickbait) face à des vidéos plus récentes avec un engagement profond.

## Changements

### Backend `intelligent_discovery.py`
- **`VideoCandidate`** : ajout de `comment_count` et `share_count` (auparavant droppés du payload tikwm)
- **`TikTokSearcher._parse_video`** : capture `raw.get("comment_count")` + `raw.get("share_count")`
- **Nouveau helper `tiktok_engagement_score(c, now=None) -> float`** : score [0..1] pondéré
  - `view_score` log10(views)/6 — pondération 30%
  - `like_ratio` capped à 1.0 — 25%
  - `comment_ratio` capped à 1.0 — 20%
  - `share_ratio` capped à 1.0 — 15%
  - `freshness` linéaire decay 7j→90j — 10%

### Backend `router.py` (`discover_search_videos`)
- Branche TikTok : remplace le `sort(view_count)` par le tri sur `tiktok_engagement_score`
- Conserve `sort_by=date` (récence) et expose `sort_by=views` (raw views) pour ceux qui le préfèrent
- Le défaut `quality` déclenche désormais le score engagement
- Le payload réponse expose maintenant `like_count`, `comment_count`, `share_count` et `quality_score = round(score * 100)` pour debug/UI

## Tests

5 tests sur le helper :
1. `views == 0` → score 0
2. Vidéo "moins virale mais engagée" bat la "virale clickbait" (0.821 > 0.336)
3. À engagement identique, vidéo fraîche bat vidéo ancienne (0.715 > 0.615)
4. Score borné [0, 1] sur valeurs extrêmes
5. Vidéo avec uniquement des vues score quand même > 0

Tests pytest committés sous `backend/tests/videos/test_tiktok_engagement_score.py`. Validation locale via test inline pure (le conftest backend a un circular import non lié dans cet env).

## Test plan

- [ ] CI Backend Pytest vert
- [ ] Auto-deploy Hetzner (`git pull` + rebuild backend container)
- [ ] Test mobile : recherche TikTok "cuisine rapide" → ordre des résultats plus pertinent qu'avant (les top n'sont plus juste les plus vues mais aussi les plus engageantes)
- [ ] Sanity check : `sort_by=date` et `sort_by=views` répondent encore correctement

https://claude.ai/code/session_0111YYk7kQNSX9vZHzLCzmiq

---
_Generated by [Claude Code](https://claude.ai/code/session_0111YYk7kQNSX9vZHzLCzmiq)_