### PR TITLE
fix(scholar): remove 2 unused imports after Decodo migration (F401)

### DIFF
--- a/backend/src/academic/scholar.py
+++ b/backend/src/academic/scholar.py
@@ -46,8 +46,7 @@ from typing import List, Optional
 from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field
 
-from core.http_client import get_proxied_client
-from middleware.proxy_telemetry import record_proxy_usage, should_bypass_proxy_async
+from middleware.proxy_telemetry import record_proxy_usage
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Quick lint fix after Phase 1.2 Scholar merge (PR #535) — ruff check found 2 F401 unused imports in `scholar.py` left from the BS4→Decodo refactor:

- `core.http_client.get_proxied_client` (used pre-Decodo for direct HTTP)
- `middleware.proxy_telemetry.should_bypass_proxy_async` (idem)

Auto-fixed via `ruff check --fix`.

Branch name says 'f841' but the actual issue was F401 — branch was created prophylactically before re-checking, then repurposed.

## Tests
- `ruff check src/` → All checks passed ✓
- `ruff format src/ --check` → 322 files already formatted ✓
- No behavior change (only unused import removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)