### PR TITLE
fix(auth): migrate residual jose imports to PyJWT (router.py + dependencies.py)

### DIFF
--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -16,7 +16,8 @@ from typing import Callable, Optional
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer, HTTPBearer, HTTPAuthorizationCredentials
-from jose import ExpiredSignatureError, JWTError, jwt
+import jwt  # PyJWT (Wave 1 Step 5 migration from python-jose, CVE-2024-33664/33663)
+from jwt.exceptions import ExpiredSignatureError, PyJWTError as JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import core.config as _core_config

--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
-from jose import jwt
+import jwt  # PyJWT (Wave 1 Step 5 migration from python-jose, CVE-2024-33664/33663)
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Optional
 


### PR DESCRIPTION
## Summary

🚨 **Hotfix prod** : Wave 1 Step 3 + Step 5 deploy a crashé au boot.

`ModuleNotFoundError: No module named 'jose'` — Step 5 PR #529 a migré `auth/service.py` mais Step 3 PR #533 (mergée juste après) avait introduit 2 nouveaux imports jose dans :
- `auth/router.py:11` (endpoints sessions/reauth)
- `auth/dependencies.py:19` (require_recent_reauth + get_current_token_payload)

Ces imports n'ont pas été migrés en même temps car les 2 branches étaient stackées en parallèle. Step 5 a checké jose au moment où Step 3 n'avait pas encore ajouté les nouveaux usages.

## Impact

- Prod container `repo-backend-1` tournait avec **ancienne image Sprint C** (rollback CI smoke test fail).
- `/api/auth/sessions` + `/api/auth/reauth` → 404 (pas déployés).
- Pas d'incident user-facing (backend healthy avec ancien code).

## Fix

```diff
# auth/router.py:11
- from jose import jwt
+ import jwt  # PyJWT

# auth/dependencies.py:19
- from jose import ExpiredSignatureError, JWTError, jwt
+ import jwt
+ from jwt.exceptions import ExpiredSignatureError, PyJWTError as JWTError
```

API compat PyJWT vs jose : wire-compatible (encode/decode kwargs identiques), exception aliasée pour préserver `except JWTError`.

## Test plan

- [x] Boot test local : `python -c "from auth import router, dependencies"` OK
- [ ] CI Lint vert
- [ ] CI Backend Pytest vert (les pre-existing fails proxy/scholar pas liés, déjà skippés #531/#532)
- [ ] Auto-merge + Hetzner re-deploy → smoke test green
- [ ] `curl /api/auth/sessions` retourne 401 (pas 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)