### PR TITLE
Wave 1 Mobile V2 Step 1 — AppState resume → ping /me + force logout si 401

### DIFF
--- a/mobile/__tests__/hooks/useAuthResumeHandler.test.ts
+++ b/mobile/__tests__/hooks/useAuthResumeHandler.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for useAuthResumeHandler hook
+ *
+ * Covers: AppState transitions, /api/auth/me ping, force logout on 401,
+ * retry on 5xx, no-op when not authenticated.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import { AppState, AppStateStatus } from "react-native";
+
+// Capture AppState listener so we can fire transitions manually.
+let appStateListener: ((state: AppStateStatus) => void) | null = null;
+const mockRemove = jest.fn();
+jest.spyOn(AppState, "addEventListener").mockImplementation(
+  (_event: string, callback: (state: AppStateStatus) => void) => {
+    appStateListener = callback;
+    return { remove: mockRemove } as { remove: () => void };
+  },
+);
+
+const mockGetMe = jest.fn();
+const mockCaptureException = jest.fn();
+const mockCaptureMessage = jest.fn();
+
+jest.mock("../../src/services/api", () => ({
+  authApi: {
+    getMe: (...args: unknown[]) => mockGetMe(...args),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    code?: string;
+    detail?: string;
+    constructor(
+      message: string,
+      status: number,
+      code?: string,
+      detail?: string,
+    ) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+      this.code = code;
+      this.detail = detail;
+    }
+  },
+}));
+
+jest.mock("../../src/services/CrashReporting", () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+}));
+
+// Import after mocks are set up.
+import { useAuthResumeHandler } from "../../src/hooks/useAuthResumeHandler";
+import { ApiError } from "../../src/services/api";
+
+// Use a microtask-based flush that works with fake timers.
+const flushPromises = () =>
+  new Promise<void>((resolve) => {
+    Promise.resolve().then(() => Promise.resolve().then(() => resolve()));
+  });
+
+describe("useAuthResumeHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateListener = null;
+  });
+
+  it("does not ping /me on mount (no-op until AppState change)", async () => {
+    const forceLogout = jest.fn();
+    renderHook(() =>
+      useAuthResumeHandler({ isAuthenticated: true, forceLogout }),
+    );
+
+    expect(appStateListener).not.toBeNull();
+    expect(mockGetMe).not.toHaveBeenCalled();
+    expect(forceLogout).not.toHaveBeenCalled();
+  });
+
+  it("pings /me on background → active transition (200 → no-op)", async () => {
+    const forceLogout = jest.fn();
+    mockGetMe.mockResolvedValueOnce({ id: 1, email: "test@example.com" });
+
+    renderHook(() =>
+      useAuthResumeHandler({ isAuthenticated: true, forceLogout }),
+    );
+
+    act(() => {
+      // Simulate: background → active.
+      appStateListener?.("background");
+      appStateListener?.("active");
+    });
+
+    await flushPromises();
+
+    expect(mockGetMe).toHaveBeenCalledTimes(1);
+    expect(forceLogout).not.toHaveBeenCalled();
+  });
+
+  it("calls forceLogout when /me returns 401 on resume", async () => {
+    const forceLogout = jest.fn().mockResolvedValue(undefined);
+    mockGetMe.mockRejectedValueOnce(new ApiError("Unauthorized", 401));
+
+    renderHook(() =>
+      useAuthResumeHandler({ isAuthenticated: true, forceLogout }),
+    );
+
+    act(() => {
+      appStateListener?.("background");
+      appStateListener?.("active");
+    });
+
+    await waitFor(() => {
+      expect(forceLogout).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGetMe).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once after 2s on 5xx, then logs Sentry if still 5xx", async () => {
+    jest.useFakeTimers();
+    const forceLogout = jest.fn();
+    mockGetMe
+      .mockRejectedValueOnce(new ApiError("Server error", 503))
+      .mockRejectedValueOnce(new ApiError("Server error", 503));
+
+    renderHook(() =>
+      useAuthResumeHandler({ isAuthenticated: true, forceLogout }),
+    );
+
+    act(() => {
+      appStateListener?.("background");
+      appStateListener?.("active");
+    });
+
+    // First call fires immediately — flush microtasks for the rejected promise.
+    await flushPromises();
+    expect(mockGetMe).toHaveBeenCalledTimes(1);
+    expect(forceLogout).not.toHaveBeenCalled();
+
+    // Retry scheduled for +2s.
+    act(() => {
+      jest.advanceTimersByTime(RETRY_DELAY_MS);
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(mockGetMe).toHaveBeenCalledTimes(2);
+    expect(forceLogout).not.toHaveBeenCalled();
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("/me returned 5xx after retry"),
+      "warning",
+      expect.any(Object),
+    );
+    jest.useRealTimers();
+  });
+
+  it("does not ping /me when isAuthenticated is false", async () => {
+    const forceLogout = jest.fn();
+    renderHook(() =>
+      useAuthResumeHandler({ isAuthenticated: false, forceLogout }),
+    );
+
+    act(() => {
+      appStateListener?.("background");
+      appStateListener?.("active");
+    });
+
+    await flushPromises();
+
+    expect(mockGetMe).not.toHaveBeenCalled();
+    expect(forceLogout).not.toHaveBeenCalled();
+  });
+});
+
+// Mirror constant from implementation — exposed only via behavior.
+const RETRY_DELAY_MS = 2000;

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -26,6 +26,7 @@ import {
   useShareIntent,
   PENDING_SHARE_URL_KEY,
 } from "../src/hooks/useShareIntent";
+import { useAuthResumeHandler } from "../src/hooks/useAuthResumeHandler";
 import { DismissKeyboardView } from "../src/components/ui/DismissKeyboardView";
 
 // Prevent splash screen from auto-hiding
@@ -184,12 +185,17 @@ export default function RootLayout() {
 }
 
 function RootNavigator() {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, forceLogout } = useAuth();
   const segments = useSegments();
   const router = useRouter();
 
   // Handle incoming shared URLs from TikTok, YouTube, etc.
   useShareIntent();
+
+  // Wave 1 Mobile V2 Step 1 — sur AppState resume (background|inactive → active),
+  // ping /api/auth/me pour valider la session JWT. Si 401, forceLogout() clear
+  // les tokens et RootNavigator redirige automatiquement vers /(auth).
+  useAuthResumeHandler({ isAuthenticated, forceLogout });
 
   useEffect(() => {
     if (isLoading) return;

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -71,6 +71,13 @@ interface AuthContextType {
   ) => Promise<{ requiresVerification: boolean }>;
   verifyEmail: (email: string, code: string) => Promise<void>;
   logout: () => Promise<void>;
+  /**
+   * Local cleanup uniquement (clear tokens + user state). N'appelle PAS
+   * `/api/auth/logout` côté serveur — utilisé quand le serveur a déjà
+   * invalidé la session (401 sur /me au resume, refresh expiré, etc.).
+   * La redirection vers /(auth) se fait automatiquement via RootNavigator.
+   */
+  forceLogout: () => Promise<void>;
   forgotPassword: (email: string) => Promise<void>;
   refreshUser: (force?: boolean) => Promise<void>;
   clearError: () => void;
@@ -458,6 +465,26 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
     }
   }, []);
 
+  // Force logout local-only — utilisé par useAuthResumeHandler quand /me
+  // renvoie 401 au resume. Skip l'appel `/api/auth/logout` (le serveur a
+  // déjà invalidé) et nettoie tokens + state. La redirection vers /(auth)
+  // est gérée par RootNavigator via le `useEffect` segments-based.
+  const forceLogout = useCallback(async () => {
+    pushTokenRef.current = null;
+    try {
+      setUser(null);
+      await tokenStorage.clearTokens();
+      await userStorage.clearUser();
+      analytics.track("logout");
+      analytics.reset();
+    } catch (cleanupError) {
+      if (__DEV__) {
+        console.warn("[Auth] Force logout cleanup error:", cleanupError);
+      }
+      setUser(null);
+    }
+  }, []);
+
   const forgotPassword = useCallback(async (email: string) => {
     setIsLoading(true);
     setError(null);
@@ -526,6 +553,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         register,
         verifyEmail,
         logout,
+        forceLogout,
         forgotPassword,
         refreshUser,
         clearError,

--- a/mobile/src/hooks/useAuthResumeHandler.ts
+++ b/mobile/src/hooks/useAuthResumeHandler.ts
@@ -1,0 +1,130 @@
+/**
+ * useAuthResumeHandler — auth V2 step 1
+ *
+ * Quand l'app revient au foreground (transition `background|inactive → active`),
+ * ping `GET /api/auth/me` pour valider la session JWT en cours :
+ *   - 200      → no-op (token encore valide)
+ *   - 401      → forceLogout() (clear tokens + redirect /(auth))
+ *   - 5xx      → retry 1× après 2s puis log Sentry et no-op
+ *   - autre    → log Sentry et no-op
+ *
+ * Sans ce hook, l'utilisateur tombait sur des 401 silencieux jusqu'à un refresh
+ * réflexe car l'access token (60min, Sprint C 2026-05-21) peut expirer pendant
+ * que l'app est en arrière-plan.
+ *
+ * Early-return si non authentifié — le hook ne fait rien tant qu'aucune session
+ * n'est active.
+ */
+import { useEffect, useRef } from "react";
+import { AppState, AppStateStatus } from "react-native";
+import { authApi, ApiError } from "../services/api";
+import { captureException, captureMessage } from "../services/CrashReporting";
+
+interface UseAuthResumeHandlerOptions {
+  /** Indique si une session utilisateur est active. Le hook no-op si false. */
+  isAuthenticated: boolean;
+  /** Callback appelé sur 401 — doit clear tokens + rediriger /(auth). */
+  forceLogout: () => Promise<void> | void;
+}
+
+const RETRY_DELAY_MS = 2000;
+
+export function useAuthResumeHandler({
+  isAuthenticated,
+  forceLogout,
+}: UseAuthResumeHandlerOptions): void {
+  // Refs pour éviter de re-binder le listener AppState sur chaque render.
+  const isAuthenticatedRef = useRef(isAuthenticated);
+  const forceLogoutRef = useRef(forceLogout);
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+
+  useEffect(() => {
+    isAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    forceLogoutRef.current = forceLogout;
+  }, [forceLogout]);
+
+  useEffect(() => {
+    const pingMe = async (isRetry = false): Promise<void> => {
+      try {
+        await authApi.getMe();
+        // 200 → no-op, token encore valide.
+      } catch (err) {
+        if (err instanceof ApiError) {
+          if (err.status === 401) {
+            // Session révoquée ou expirée côté serveur → force logout.
+            try {
+              await forceLogoutRef.current();
+            } catch (logoutErr) {
+              captureException(logoutErr, {
+                tags: { source: "useAuthResumeHandler", reason: "logout_failed" },
+              });
+            }
+            return;
+          }
+
+          if (err.status >= 500 && !isRetry) {
+            // 5xx → retry 1× après 2s.
+            setTimeout(() => {
+              if (isAuthenticatedRef.current) {
+                void pingMe(true);
+              }
+            }, RETRY_DELAY_MS);
+            return;
+          }
+
+          if (err.status >= 500) {
+            // Retry échoué → log Sentry et no-op (pas de logout sur infra).
+            captureMessage(
+              "[useAuthResumeHandler] /me returned 5xx after retry",
+              "warning",
+              { tags: { source: "useAuthResumeHandler", status: String(err.status) } },
+            );
+            return;
+          }
+
+          // Autre status code (4xx hors 401) → log et no-op.
+          captureMessage(
+            `[useAuthResumeHandler] /me returned ${err.status}`,
+            "info",
+            { tags: { source: "useAuthResumeHandler", status: String(err.status) } },
+          );
+          return;
+        }
+
+        // Erreur non-API (réseau, parse, etc.) → log et no-op.
+        captureException(err, {
+          tags: { source: "useAuthResumeHandler", reason: "unknown_error" },
+        });
+      }
+    };
+
+    const handleAppStateChange = (nextState: AppStateStatus): void => {
+      const prevState = appStateRef.current;
+      appStateRef.current = nextState;
+
+      // Transition background|inactive → active.
+      const cameToForeground =
+        (prevState === "background" || prevState === "inactive") &&
+        nextState === "active";
+
+      if (!cameToForeground) return;
+      if (!isAuthenticatedRef.current) return;
+
+      void pingMe();
+    };
+
+    const subscription = AppState.addEventListener(
+      "change",
+      handleAppStateChange,
+    );
+
+    return () => {
+      subscription?.remove();
+    };
+  }, []);
+}
+
+export default useAuthResumeHandler;


### PR DESCRIPTION
## Wave 1 Mobile V2 Step 1 — AppState resume handler

Fix du **gap majeur** identifié par l'audit Sprint C : l'app mobile ne pingait pas `/api/auth/me` quand elle revenait au foreground → 401 silencieux sur les premières requêtes user après retour d'arrière-plan. Avec les TTLs Sprint C (access 60min / refresh 30j sliding), un access token peut très facilement expirer pendant que l'app est en background.

## Comportement

- Mount du hook au root layout (`RootNavigator`, sous `AuthProvider`).
- Sur `AppState change → active` (background/inactive → active), ping `GET /api/auth/me`.
- **200** → no-op (token encore valide).
- **401** → `forceLogout()` (SecureStore deleteItemAsync + RootNavigator redirige automatiquement vers `/(auth)`).
- **5xx** → retry 1× après 2s, puis `captureMessage` Sentry et no-op (pas de logout sur erreur infra).
- **Autre status** → `captureMessage` info Sentry et no-op.
- Early-return si `!isAuthenticated` — le hook ne fait rien tant qu'aucune session n'est active.

## Fichiers

- `mobile/src/hooks/useAuthResumeHandler.ts` (+129 LOC) — nouveau hook RN.
- `mobile/src/contexts/AuthContext.tsx` (+27 LOC) — nouvelle fonction `forceLogout()` local-only (skip `/api/auth/logout` car serveur a déjà invalidé sur 401).
- `mobile/app/_layout.tsx` (+6 LOC) — intégration du hook dans `RootNavigator`.
- `mobile/__tests__/hooks/useAuthResumeHandler.test.ts` (+175 LOC) — 5 tests Jest + RN Testing Library.

**Total : 4 fichiers touchés, ~337 LOC nettes.**

## Tests

```
PASS __tests__/hooks/useAuthResumeHandler.test.ts
  useAuthResumeHandler
    √ does not ping /me on mount (no-op until AppState change)
    √ pings /me on background → active transition (200 → no-op)
    √ calls forceLogout when /me returns 401 on resume
    √ retries once after 2s on 5xx, then logs Sentry if still 5xx
    √ does not ping /me when isAuthenticated is false

Tests:       5 passed, 5 total
```

`AuthContext` existant : 17/17 toujours verts (pas de régression).
`npm run typecheck` : 0 erreur.

## OTA-compatible

Aucun nouveau package natif. Uniquement RN core `AppState` + Expo Router + SecureStore déjà installé (via `tokenStorage`). Déploiement via `eas update` (pas de build natif requis).

## Reste à faire (Steps 2/3 séparés)

- **Step 2** — modal re-auth (PasswordReauthModal mobile via SimpleBottomSheet) sur opérations sensibles (delete account, change password, change email).
- **Step 3** — page "Appareils Activés" via FlatList listant les sessions actives + bouton "Révoquer toutes les autres sessions".

🤖 Generated with Claude Code (Opus 4.7)