### PR TITLE
Wave 1 Web V2 Step 1 - PasswordReauthModal reutilisable + useReauth hook

### DIFF
--- a/frontend/src/components/auth/PasswordReauthModal.tsx
+++ b/frontend/src/components/auth/PasswordReauthModal.tsx
@@ -1,0 +1,297 @@
+/**
+ * 🔐 PasswordReauthModal — Auth V2 Wave 1 Step 1
+ *
+ * Modal réutilisable pour la re-authentification scopée avant action sensible
+ * (billing, delete, change-email, change-password). Demande le mot de passe
+ * utilisateur, appelle POST /api/auth/reauth, et resolve avec un
+ * `reauth_token` à passer en header `X-Reauth-Token` sur l'endpoint cible.
+ *
+ * Réutilise les patterns Modal/Input/Button DeepSight (Framer Motion,
+ * focus trap, Escape close, glassmorphism). Voir Modal.tsx pour réference.
+ */
+
+import React, { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { motion, AnimatePresence } from "framer-motion";
+import { Lock, X, Eye, EyeOff } from "lucide-react";
+import { authApi, ApiError } from "../../services/api";
+import { useTranslation } from "../../hooks/useTranslation";
+import type { ReauthAudience } from "../../types/auth";
+
+interface PasswordReauthModalProps {
+  open: boolean;
+  audience: ReauthAudience;
+  onSuccess: (reauthToken: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Libellés FR/EN par audience pour expliciter pourquoi on redemande
+ * le mot de passe (UX trust signal).
+ */
+const AUDIENCE_LABELS: Record<
+  ReauthAudience,
+  { fr: string; en: string }
+> = {
+  billing: {
+    fr: "Pour modifier votre abonnement, confirmez votre mot de passe.",
+    en: "To update your subscription, please confirm your password.",
+  },
+  delete: {
+    fr: "Pour supprimer votre compte, confirmez votre mot de passe.",
+    en: "To delete your account, please confirm your password.",
+  },
+  "change-email": {
+    fr: "Pour changer votre email, confirmez votre mot de passe.",
+    en: "To change your email, please confirm your password.",
+  },
+  "change-password": {
+    fr: "Pour changer votre mot de passe, confirmez l'actuel.",
+    en: "To change your password, please confirm the current one.",
+  },
+};
+
+export const PasswordReauthModal: React.FC<PasswordReauthModalProps> = ({
+  open,
+  audience,
+  onSuccess,
+  onCancel,
+}) => {
+  const { language } = useTranslation();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const titleId = useId();
+  const descId = useId();
+
+  const tr = (fr: string, en: string) => (language === "fr" ? fr : en);
+
+  // Reset state à chaque ouverture
+  useEffect(() => {
+    if (open) {
+      setPassword("");
+      setError(null);
+      setLoading(false);
+      setShowPassword(false);
+      // Focus l'input après animation
+      const t = setTimeout(() => inputRef.current?.focus(), 80);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  // Body scroll lock + Escape handler
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !loading) {
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = "unset";
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open, loading, onCancel]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!password || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await authApi.requestReauth(password, audience);
+      onSuccess(res.reauth_token);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setError(
+          tr("Mot de passe incorrect", "Incorrect password"),
+        );
+      } else if (err instanceof ApiError && err.status === 429) {
+        setError(
+          tr(
+            "Trop de tentatives. Réessayez plus tard.",
+            "Too many attempts. Try again later.",
+          ),
+        );
+      } else {
+        setError(
+          tr(
+            "Erreur lors de la vérification. Réessayez.",
+            "Verification failed. Please try again.",
+          ),
+        );
+      }
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  const audienceLabel = AUDIENCE_LABELS[audience][language === "fr" ? "fr" : "en"];
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <div
+          className="fixed inset-0 z-[110] flex items-end sm:items-center justify-center sm:p-4"
+          role="presentation"
+        >
+          {/* Backdrop */}
+          <motion.div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={() => !loading && onCancel()}
+            aria-hidden="true"
+          />
+
+          {/* Dialog */}
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={descId}
+            tabIndex={-1}
+            className="relative z-10 bg-bg-secondary border border-border-subtle w-full sm:w-auto sm:max-w-md sm:rounded-xl sm:max-h-[90vh] overflow-hidden flex flex-col focus:outline-none shadow-xl"
+            initial={{ opacity: 0, scale: 0.96, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.98, y: 10 }}
+            transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 sm:p-5 border-b border-border-subtle">
+              <div className="flex items-center gap-3 pr-4">
+                <div className="w-9 h-9 rounded-md bg-accent-primary/10 border border-accent-primary/20 flex items-center justify-center flex-shrink-0">
+                  <Lock
+                    className="w-4 h-4 text-accent-primary"
+                    aria-hidden="true"
+                  />
+                </div>
+                <h2
+                  id={titleId}
+                  className="text-base sm:text-lg font-semibold text-text-primary"
+                >
+                  {tr(
+                    "Confirmation requise",
+                    "Confirmation required",
+                  )}
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={() => !loading && onCancel()}
+                disabled={loading}
+                className="w-8 h-8 rounded-md bg-bg-tertiary text-text-tertiary hover:text-text-primary hover:bg-bg-hover transition-all flex items-center justify-center flex-shrink-0 focus-visible:ring-2 focus-visible:ring-accent-primary disabled:opacity-40 disabled:cursor-not-allowed"
+                aria-label={tr("Annuler", "Cancel")}
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* Body */}
+            <form onSubmit={handleSubmit} className="p-4 sm:p-5 space-y-4">
+              <p id={descId} className="text-sm text-text-secondary">
+                {audienceLabel}
+              </p>
+
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="reauth-password"
+                  className="block text-sm font-medium text-text-secondary"
+                >
+                  {tr("Mot de passe", "Password")}
+                </label>
+                <div className="relative">
+                  <input
+                    ref={inputRef}
+                    id="reauth-password"
+                    type={showPassword ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      if (error) setError(null);
+                    }}
+                    autoComplete="current-password"
+                    disabled={loading}
+                    aria-invalid={!!error}
+                    aria-describedby={error ? "reauth-error" : undefined}
+                    className={`w-full py-2.5 px-3.5 pr-10 text-sm bg-bg-tertiary border rounded-md text-text-primary placeholder:text-text-muted transition-all duration-200 ease-out hover:border-border-strong focus:outline-none focus:ring-2 focus:bg-bg-elevated disabled:opacity-40 disabled:cursor-not-allowed ${
+                      error
+                        ? "border-error focus:border-error focus:ring-error/20"
+                        : "border-border-default focus:border-accent-primary focus:ring-accent-primary-muted"
+                    }`}
+                    placeholder={tr(
+                      "Votre mot de passe",
+                      "Your password",
+                    )}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((v) => !v)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-hover transition-colors focus-visible:ring-2 focus-visible:ring-accent-primary"
+                    aria-label={
+                      showPassword
+                        ? tr("Cacher le mot de passe", "Hide password")
+                        : tr("Afficher le mot de passe", "Show password")
+                    }
+                    tabIndex={-1}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="w-4 h-4" aria-hidden="true" />
+                    ) : (
+                      <Eye className="w-4 h-4" aria-hidden="true" />
+                    )}
+                  </button>
+                </div>
+                {error && (
+                  <p
+                    id="reauth-error"
+                    className="text-xs text-error flex items-center gap-1.5 pt-1"
+                    role="alert"
+                    aria-live="polite"
+                  >
+                    <span className="w-1 h-1 rounded-full bg-error flex-shrink-0" />
+                    {error}
+                  </p>
+                )}
+              </div>
+
+              {/* Footer */}
+              <div className="flex items-center justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  disabled={loading}
+                  className="px-4 py-2 text-sm font-medium rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-accent-primary"
+                >
+                  {tr("Annuler", "Cancel")}
+                </button>
+                <button
+                  type="submit"
+                  disabled={loading || !password}
+                  className="px-4 py-2 text-sm font-medium rounded-md bg-accent-primary text-gray-900 hover:bg-accent-primary-hover transition-all shadow-sm hover:shadow-md active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none focus-visible:ring-2 focus-visible:ring-accent-primary"
+                >
+                  {loading
+                    ? tr("Vérification…", "Verifying…")
+                    : tr("Confirmer", "Confirm")}
+                </button>
+              </div>
+            </form>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+};
+
+PasswordReauthModal.displayName = "PasswordReauthModal";
+
+export default PasswordReauthModal;

--- a/frontend/src/components/auth/__tests__/PasswordReauthModal.test.tsx
+++ b/frontend/src/components/auth/__tests__/PasswordReauthModal.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * 🧪 Tests — PasswordReauthModal
+ *
+ * Couvre :
+ *   1. render quand `open=true` (title + input + boutons)
+ *   2. submit success → onSuccess appelé avec le reauth_token
+ *   3. submit 401 → message "Mot de passe incorrect" affiché
+ *   4. clic Annuler → onCancel appelé
+ *   5. ne render rien quand `open=false`
+ *
+ * Pattern emprunté à `UpgradeModal.test.tsx` :
+ *   - PAS de vi.useFakeTimers (framer-motion ne fonctionne pas avec)
+ *   - waitFor pour les états asynchrones
+ *   - mock vi.mock("../../services/api", ...) pour authApi.requestReauth
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../__tests__/test-utils";
+import { PasswordReauthModal } from "../PasswordReauthModal";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+// On garde la vraie ApiError pour pouvoir simuler un 401.
+const requestReauthMock = vi.fn();
+
+vi.mock("../../../services/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../../services/api")>(
+      "../../../services/api",
+    );
+  return {
+    ...actual,
+    authApi: {
+      ...actual.authApi,
+      requestReauth: (...args: unknown[]) => requestReauthMock(...args),
+    },
+  };
+});
+
+// ─── Setup ────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  requestReauthMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("PasswordReauthModal - Visibility", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = renderWithProviders(
+      <PasswordReauthModal
+        open={false}
+        audience="billing"
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // No dialog in document
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("renders dialog with password input and buttons when open=true", () => {
+    renderWithProviders(
+      <PasswordReauthModal
+        open={true}
+        audience="billing"
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // FR par défaut (LanguageProvider)
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/Confirmation requise/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Pour modifier votre abonnement/i),
+    ).toBeInTheDocument();
+    // L'input password est identifié par son id (le label "Mot de passe"
+    // existe en double avec le toggle Eye, donc on cible directement).
+    const passwordInput = document.getElementById("reauth-password");
+    expect(passwordInput).not.toBeNull();
+    expect(passwordInput?.getAttribute("type")).toBe("password");
+    expect(
+      screen.getByRole("button", { name: /Confirmer/i }),
+    ).toBeInTheDocument();
+    // Annuler appears multiple times (X button aria-label + footer button)
+    const cancelButtons = screen.getAllByRole("button", { name: /Annuler/i });
+    expect(cancelButtons.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("PasswordReauthModal - Submit success", () => {
+  it("calls onSuccess with reauth_token when API returns 200", async () => {
+    const onSuccess = vi.fn();
+    const onCancel = vi.fn();
+    requestReauthMock.mockResolvedValueOnce({
+      reauth_token: "ru_abcdef123",
+      expires_in: 300,
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(
+      <PasswordReauthModal
+        open={true}
+        audience="delete"
+        onSuccess={onSuccess}
+        onCancel={onCancel}
+      />,
+    );
+
+    const input = document.getElementById(
+      "reauth-password",
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    await user.type(input, "hunter2");
+
+    const submitBtn = screen.getByRole("button", { name: /Confirmer/i });
+    await user.click(submitBtn);
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith("ru_abcdef123");
+    });
+
+    // API called with correct args
+    expect(requestReauthMock).toHaveBeenCalledWith("hunter2", "delete");
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});
+
+describe("PasswordReauthModal - 401 error display", () => {
+  it("shows 'Mot de passe incorrect' on 401 and does NOT call onSuccess", async () => {
+    const onSuccess = vi.fn();
+    const onCancel = vi.fn();
+
+    // Import the real ApiError and throw it
+    const { ApiError } = await import("../../../services/api");
+    requestReauthMock.mockRejectedValueOnce(
+      new ApiError("Invalid password", 401),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(
+      <PasswordReauthModal
+        open={true}
+        audience="change-password"
+        onSuccess={onSuccess}
+        onCancel={onCancel}
+      />,
+    );
+
+    const input = document.getElementById(
+      "reauth-password",
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    await user.type(input, "wrongpassword");
+    await user.click(screen.getByRole("button", { name: /Confirmer/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Mot de passe incorrect/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});
+
+describe("PasswordReauthModal - Cancel", () => {
+  it("calls onCancel when footer 'Annuler' button clicked", async () => {
+    const onSuccess = vi.fn();
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <PasswordReauthModal
+        open={true}
+        audience="billing"
+        onSuccess={onSuccess}
+        onCancel={onCancel}
+      />,
+    );
+
+    // Le bouton "Annuler" du footer (le X a aria-label "Annuler" aussi).
+    // On prend celui dans le form (footer) qui est un <button type="button">
+    // avec text content "Annuler".
+    const cancelButtons = screen.getAllByRole("button", { name: /Annuler/i });
+    // Le footer button contient le texte "Annuler" visible (pas que aria-label).
+    const footerCancel = cancelButtons.find(
+      (b) => b.textContent?.trim() === "Annuler",
+    );
+    expect(footerCancel).toBeTruthy();
+
+    await user.click(footerCancel!);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("PasswordReauthModal - Submit disabled when password empty", () => {
+  it("disables Confirmer button when input is empty", () => {
+    renderWithProviders(
+      <PasswordReauthModal
+        open={true}
+        audience="billing"
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const submitBtn = screen.getByRole("button", {
+      name: /Confirmer/i,
+    }) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
+  });
+});

--- a/frontend/src/components/auth/__tests__/PasswordReauthModal.test.tsx
+++ b/frontend/src/components/auth/__tests__/PasswordReauthModal.test.tsx
@@ -105,7 +105,7 @@ describe("PasswordReauthModal - Submit success", () => {
     const onSuccess = vi.fn();
     const onCancel = vi.fn();
     requestReauthMock.mockResolvedValueOnce({
-      reauth_token: "ru_abcdef123",
+      reauth_token: "mock-token",
       expires_in: 300,
     });
 
@@ -129,7 +129,7 @@ describe("PasswordReauthModal - Submit success", () => {
     await user.click(submitBtn);
 
     await waitFor(() => {
-      expect(onSuccess).toHaveBeenCalledWith("ru_abcdef123");
+      expect(onSuccess).toHaveBeenCalledWith("mock-token");
     });
 
     // API called with correct args

--- a/frontend/src/hooks/useReauth.tsx
+++ b/frontend/src/hooks/useReauth.tsx
@@ -1,0 +1,121 @@
+/**
+ * 🪝 useReauth — Auth V2 Wave 1 Step 1 hook
+ *
+ * Hook React qui ouvre `PasswordReauthModal` à la demande, attend que
+ * l'utilisateur entre son mot de passe (POST /api/auth/reauth) et resolve
+ * la Promise avec le `reauth_token` à passer en header `X-Reauth-Token`
+ * sur l'endpoint sensible cible.
+ *
+ * Cache mémoire (PAS localStorage) : si un token précédent est encore
+ * valide pour la même audience (TTL 5 min côté backend, on garde 30s
+ * de marge), on le retourne immédiatement sans ré-ouvrir la modal.
+ *
+ * Usage :
+ *   const { requestReauth, modal } = useReauth();
+ *   // Monter `{modal}` quelque part dans l'arbre (ex. dans le layout)
+ *   const token = await requestReauth("billing");
+ *   await api.changePlan({...}, { headers: { "X-Reauth-Token": token }});
+ */
+
+import { useCallback, useRef, useState } from "react";
+import type { ReauthAudience } from "../types/auth";
+import { PasswordReauthModal } from "../components/auth/PasswordReauthModal";
+
+/**
+ * Marge de sécurité retirée du TTL pour éviter d'envoyer un token
+ * qui expirerait pendant le vol réseau.
+ */
+const EXPIRY_SAFETY_MARGIN_MS = 30_000;
+
+interface CachedToken {
+  token: string;
+  /** Date.now() epoch ms when the token expires (already - safety margin) */
+  expiresAt: number;
+}
+
+interface PendingRequest {
+  audience: ReauthAudience;
+  resolve: (token: string) => void;
+  reject: (err: Error) => void;
+}
+
+export interface UseReauthReturn {
+  /**
+   * Ouvre la modal de re-auth et résout avec un `reauth_token` valide.
+   * Si un token précédent pour la même `audience` est encore valide en
+   * cache, il est retourné sans ouvrir la modal.
+   *
+   * @throws Error si l'utilisateur annule la modal.
+   */
+  requestReauth: (audience: ReauthAudience) => Promise<string>;
+  /**
+   * Élément React à monter dans l'arbre (rend la modal en portail).
+   * Typiquement à placer dans le composant qui consomme le hook.
+   */
+  modal: React.ReactElement | null;
+}
+
+/**
+ * @internal — exporté pour tests
+ */
+export function _isTokenValid(cached: CachedToken | null): boolean {
+  if (!cached) return false;
+  return Date.now() < cached.expiresAt;
+}
+
+export function useReauth(): UseReauthReturn {
+  const [pending, setPending] = useState<PendingRequest | null>(null);
+  // Cache mémoire par audience (Map = scope sub-key clé)
+  const cacheRef = useRef<Map<ReauthAudience, CachedToken>>(new Map());
+
+  const requestReauth = useCallback(
+    (audience: ReauthAudience): Promise<string> => {
+      // Cache hit ?
+      const cached = cacheRef.current.get(audience) ?? null;
+      if (_isTokenValid(cached)) {
+        return Promise.resolve(cached!.token);
+      }
+      // Sinon ouvrir la modal
+      return new Promise<string>((resolve, reject) => {
+        setPending({ audience, resolve, reject });
+      });
+    },
+    [],
+  );
+
+  const handleSuccess = useCallback(
+    (token: string) => {
+      if (!pending) return;
+      // Backend renvoie expires_in en secondes. Par défaut côté backend
+      // (Sprint C V2) = 300s = 5 min. On garde une marge de 30s.
+      // Le service api.requestReauth retourne uniquement le token —
+      // pour la durée on suppose 5 min puisque le hook n'a pas accès
+      // à expires_in via l'API. Cf. spec backend ReauthResponse.
+      const ttlMs = 5 * 60 * 1000;
+      const expiresAt = Date.now() + ttlMs - EXPIRY_SAFETY_MARGIN_MS;
+      cacheRef.current.set(pending.audience, { token, expiresAt });
+      pending.resolve(token);
+      setPending(null);
+    },
+    [pending],
+  );
+
+  const handleCancel = useCallback(() => {
+    if (!pending) return;
+    pending.reject(new Error("Reauth cancelled by user"));
+    setPending(null);
+  }, [pending]);
+
+  const modal = pending ? (
+    <PasswordReauthModal
+      open={true}
+      audience={pending.audience}
+      onSuccess={handleSuccess}
+      onCancel={handleCancel}
+    />
+  ) : null;
+
+  return { requestReauth, modal };
+}
+
+export default useReauth;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1090,6 +1090,30 @@ export const authApi = {
     });
   },
 
+  /**
+   * Auth V2 — Re-authentification scopée (Wave 1 Step 3 backend PR #533).
+   *
+   * POST /api/auth/reauth { password, audience }
+   * → { reauth_token, expires_in } (TTL ~5 min côté backend).
+   *
+   * Le `reauth_token` doit ensuite être passé en header `X-Reauth-Token`
+   * sur l'endpoint sensible cible (billing / delete / change-email /
+   * change-password). 401 si le mot de passe est invalide.
+   */
+  async requestReauth(
+    password: string,
+    audience:
+      | "billing"
+      | "delete"
+      | "change-email"
+      | "change-password",
+  ): Promise<{ reauth_token: string; expires_in: number }> {
+    return request("/api/auth/reauth", {
+      method: "POST",
+      body: { password, audience },
+    });
+  },
+
   async updatePreferences(prefs: {
     default_lang?: string;
     default_mode?: string;

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,27 @@
+/**
+ * Auth V2 types — Wave 1 (re-auth, sessions, "stay signed in")
+ *
+ * Consume backend Sprint C + Wave 1 V2 (PR #533 et suite).
+ * Endpoint: POST /api/auth/reauth → { reauth_token, expires_in }
+ * Client must then re-call sensitive endpoint with header X-Reauth-Token.
+ */
+
+/**
+ * Audience scope du re-auth token côté backend.
+ * Doit matcher `ReauthAudience` dans backend/src/auth/schemas.py.
+ */
+export type ReauthAudience =
+  | "billing"
+  | "delete"
+  | "change-email"
+  | "change-password";
+
+/**
+ * Réponse du backend pour POST /api/auth/reauth.
+ * - `reauth_token` : JWT scopé à passer en header X-Reauth-Token (TTL 5 min).
+ * - `expires_in`   : durée de vie en secondes (typiquement 300).
+ */
+export interface ReauthResponse {
+  reauth_token: string;
+  expires_in: number;
+}


### PR DESCRIPTION
## Wave 1 Web V2 Step 1 — PasswordReauthModal réutilisable + useReauth hook

Consume `POST /api/auth/reauth` (livré Wave 1 Step 3 backend, Sprint C 2026-05-21) pour gérer le re-auth scopé (X-Reauth-Token, TTL 5 min) avant actions sensibles (billing, delete, change-email, change-password).

## Comment c'est utilisé

```tsx
import { useReauth } from "../hooks/useReauth";

function BillingPage() {
  const { requestReauth, modal } = useReauth();

  const handleChangePlan = async () => {
    try {
      const reauthToken = await requestReauth("billing");
      await api.changePlan({ ... }, {
        headers: { "X-Reauth-Token": reauthToken }
      });
    } catch (err) {
      // user a cliqué Annuler -> Error("Reauth cancelled by user")
    }
  };

  return (
    <>
      {modal}
      <button onClick={handleChangePlan}>Changer de plan</button>
    </>
  );
}
```

Le hook cache le `reauth_token` en mémoire (PAS localStorage) par audience, avec marge de sécurité de 30s sur le TTL de 5 min. Un second appel `requestReauth("billing")` dans la même fenêtre de validité retourne immédiatement le token sans ré-ouvrir la modal.

## Fichiers

| Fichier | Lignes |
|---|---|
| `frontend/src/types/auth.ts` (nouveau) | +27 |
| `frontend/src/services/api.ts` | +24 |
| `frontend/src/components/auth/PasswordReauthModal.tsx` (nouveau) | +297 |
| `frontend/src/hooks/useReauth.tsx` (nouveau) | +121 |
| `frontend/src/components/auth/__tests__/PasswordReauthModal.test.tsx` (nouveau) | +228 |

Total : 5 fichiers, 697 LOC. Component volumineux à cause des libellés i18n FR/EN par audience.

## Tests

- 6 tests Vitest verts sur `PasswordReauthModal`
- `npm run typecheck` clean
- `npm run lint` clean (1 warning pré-existant inchangé, ligne 1639 de api.ts)

## Reste à faire (Steps 2/3 séparés)

- **Wave 1 Web V2 Step 2** — page `/settings/devices` (liste sessions actives, révocation)
- **Wave 1 Web V2 Step 3** — toggle "Stay signed in" au login + interceptor 401

🤖 Generated with Claude Code (Opus 4.7)