### PR TITLE
Wave 1 Ext V2 Step 2 — SW resilience mid-refresh (timeout + retry)

### DIFF
--- a/extension/__tests__/utils/swMessage.test.ts
+++ b/extension/__tests__/utils/swMessage.test.ts
@@ -1,0 +1,91 @@
+/**
+ * swMessage — timeout + retry wrapper for chrome.runtime.sendMessage
+ *
+ * Mitigates MV3 service worker death mid-`tryRefreshToken` (Sprint C audit
+ * gap). These tests verify the three documented behaviors :
+ *  1. happy path → resolve immediately, no retry
+ *  2. timeout on first attempt → retry → resolve
+ *  3. timeout on both attempts → reject with `SW_TIMEOUT`
+ */
+
+import { resetChromeMocks, chromeMock } from "../setup/chrome-api-mock";
+import { swMessage, SW_TIMEOUT_ERROR } from "../../src/utils/swMessage";
+
+// Avance les timers internes du wrapper (timeout + retryDelay) sans bloquer
+// les vraies micro-tasks Promises. jest.useFakeTimers() seul ne suffit pas
+// car withTimeout chaîne des `.then()` sur la promise de sendMessage qui
+// utilise des micro-tasks ; on alterne `advanceTimersByTimeAsync` qui flush
+// les deux.
+beforeEach(() => {
+  resetChromeMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("swMessage", () => {
+  it("resolves immediately on happy path without retry", async () => {
+    chromeMock.runtime.sendMessage.mockResolvedValueOnce({
+      success: true,
+      result: { foo: "bar" },
+    });
+
+    const promise = swMessage({ action: "PING" });
+    // Pas besoin d'avancer les timers — sendMessage résout direct.
+    await jest.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result).toEqual({ success: true, result: { foo: "bar" } });
+    expect(chromeMock.runtime.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once and resolves when first attempt times out", async () => {
+    // Premier appel : ne résout jamais → timeout déclenchera retry.
+    // Deuxième appel : résout normalement.
+    chromeMock.runtime.sendMessage
+      .mockReturnValueOnce(new Promise(() => {}))
+      .mockResolvedValueOnce({ success: true });
+
+    const promise = swMessage(
+      { action: "CHECK_AUTH" },
+      { timeout: 100, retryDelay: 50 },
+    );
+
+    // Avance jusqu'au timeout du premier appel.
+    await jest.advanceTimersByTimeAsync(100);
+    // Avance le retryDelay → second appel kick-in.
+    await jest.advanceTimersByTimeAsync(50);
+    // Flush micro-tasks pour récupérer le résolved du second appel.
+    await jest.advanceTimersByTimeAsync(0);
+
+    const result = await promise;
+    expect(result).toEqual({ success: true });
+    expect(chromeMock.runtime.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects with SW_TIMEOUT when both attempts time out", async () => {
+    chromeMock.runtime.sendMessage
+      .mockReturnValueOnce(new Promise(() => {}))
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    const promise = swMessage(
+      { action: "GET_PLAN" },
+      { timeout: 100, retryDelay: 50 },
+    );
+    // Attache un catch IMMÉDIATEMENT pour éviter le warning unhandledRejection
+    // pendant qu'on avance les timers.
+    const rejection = expect(promise).rejects.toThrow(SW_TIMEOUT_ERROR);
+
+    // Premier timeout.
+    await jest.advanceTimersByTimeAsync(100);
+    // Retry delay.
+    await jest.advanceTimersByTimeAsync(50);
+    // Second timeout.
+    await jest.advanceTimersByTimeAsync(100);
+
+    await rejection;
+    expect(chromeMock.runtime.sendMessage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -160,13 +160,75 @@ async function apiRequest<T>(
 
 // ── Auth API ──
 
+// In-memory guard : déduplique les refresh dans la MÊME instance de SW
+// (efficace tant que le SW ne meurt pas entre deux appels concurrents).
 let inflightRefresh: Promise<RefreshResult> | null = null;
+
+// Storage guard : survit au kill du SW MV3. Si Chrome tue le SW à mi-refresh
+// et qu'un nouveau message arrive (ré-instancie le SW), le storage.session
+// signale qu'un refresh est déjà en cours côté backend → on attend la fin
+// au lieu de lancer un second POST /auth/refresh redondant qui pourrait
+// invalider le refresh_token rotaté par le premier (race condition).
+//
+// `chrome.storage.session` est cleared au redémarrage de Chrome (sécurité)
+// mais persiste à travers les morts/respawn du SW. La clé porte un timestamp
+// pour expirer automatiquement les locks orphelins (SW mort sans cleanup).
+const REFRESH_LOCK_KEY = "auth_refresh_in_flight";
+const REFRESH_LOCK_TTL_MS = 15_000; // refresh API timeout 5-10s + marge
+
+interface SessionStorageApi {
+  get?: (key: string) => Promise<Record<string, unknown>>;
+  set?: (data: Record<string, unknown>) => Promise<void>;
+  remove?: (key: string) => Promise<void>;
+}
+
+function getSessionStorage(): SessionStorageApi | undefined {
+  return (
+    chrome as unknown as {
+      storage?: { session?: SessionStorageApi };
+    }
+  ).storage?.session;
+}
+
+async function acquireRefreshLock(): Promise<boolean> {
+  const store = getSessionStorage();
+  if (!store?.get || !store?.set) return true; // pas de session storage → degrade gracefully
+  const existing = await store.get(REFRESH_LOCK_KEY);
+  const lock = existing[REFRESH_LOCK_KEY] as { startedAt?: number } | undefined;
+  if (lock?.startedAt && Date.now() - lock.startedAt < REFRESH_LOCK_TTL_MS) {
+    return false;
+  }
+  await store.set({ [REFRESH_LOCK_KEY]: { startedAt: Date.now() } });
+  return true;
+}
+
+async function releaseRefreshLock(): Promise<void> {
+  const store = getSessionStorage();
+  if (!store?.remove) return;
+  try {
+    await store.remove(REFRESH_LOCK_KEY);
+  } catch {
+    /* ignore — TTL expirera de toute façon */
+  }
+}
 
 async function tryRefreshToken(): Promise<RefreshResult> {
   if (inflightRefresh) return inflightRefresh;
   inflightRefresh = (async () => {
     try {
-      return await doRefreshToken();
+      const acquired = await acquireRefreshLock();
+      if (!acquired) {
+        // Un autre SW (ou ancien instance pre-kill) est déjà sur le coup.
+        // Plutôt que de partir en parallèle, on signale "transient" : le
+        // caller (apiRequest 401 path) gardera les tokens et l'user pourra
+        // retry — d'ici-là, l'autre refresh aura terminé.
+        return "transient";
+      }
+      try {
+        return await doRefreshToken();
+      } finally {
+        await releaseRefreshLock();
+      }
     } finally {
       inflightRefresh = null;
     }

--- a/extension/src/sidepanel/App.tsx
+++ b/extension/src/sidepanel/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import type { User, PlanInfo, MessageResponse } from "../types";
 import Browser from "../utils/browser-polyfill";
+import { swMessage } from "../utils/swMessage";
 import { LoginView } from "./views/LoginView";
 import { MainView } from "./views/MainView";
 import { ConversationView } from "./views/ConversationView";
@@ -197,10 +198,10 @@ export const App: React.FC = () => {
 
   async function checkAuth(): Promise<void> {
     try {
-      const response = await Browser.runtime.sendMessage<
-        unknown,
-        MessageResponse
-      >({
+      // Step 2 SW resilience: swMessage timeout+retry réveille le SW si Chrome
+      // l'a killed (memory pressure / 30s idle). Sans ça, checkAuth pouvait
+      // hanger indéfiniment et bloquer le mount du sidepanel.
+      const response = await swMessage<unknown, MessageResponse>({
         action: "CHECK_AUTH",
       });
       if (response.authenticated && response.user) {
@@ -218,17 +219,14 @@ export const App: React.FC = () => {
 
   async function loadPlanInfo(): Promise<void> {
     try {
-      const response = await Browser.runtime.sendMessage<
-        unknown,
-        MessageResponse
-      >({
+      const response = await swMessage<unknown, MessageResponse>({
         action: "GET_PLAN",
       });
       if (response.success && response.plan) {
         setPlanInfo(response.plan);
       }
     } catch {
-      // Plan info load failed — continue without it
+      // Plan info load failed — continue without it (incl. SW_TIMEOUT).
     }
   }
 

--- a/extension/src/utils/swMessage.ts
+++ b/extension/src/utils/swMessage.ts
@@ -1,0 +1,106 @@
+// extension/src/utils/swMessage.ts
+//
+// Resilient wrapper around `chrome.runtime.sendMessage` for sidepanel → SW
+// communication. Mitigates the Sprint C audit gap: the Manifest V3 service
+// worker can be killed by Chrome at any time (memory pressure, 30s idle).
+// If killed mid-`tryRefreshToken` (or mid-`apiRequest`), the sidepanel hangs
+// indefinitely waiting for a response that will never arrive.
+//
+// Strategy
+// --------
+// 1. Race `sendMessage` against a hard timeout (default 10s).
+// 2. On timeout, retry once after a short delay (default 500ms). Sending a
+//    second message is enough to wake the SW back up (Chrome lazily restarts
+//    it on incoming runtime traffic), and the SW handlers are idempotent for
+//    the actions we care about (CHECK_AUTH, GET_PLAN, etc.).
+// 3. On second timeout → reject with `SW_TIMEOUT` so the caller can surface
+//    a network-style error rather than hang forever.
+//
+// Scope: this helper is opt-in. Existing callers using
+// `Browser.runtime.sendMessage` directly keep working — we migrate only the
+// most critical auth callsites in Step 2 (App.tsx checkAuth + loadPlanInfo).
+// Other sites can be migrated incrementally without breaking anything.
+
+import Browser from "./browser-polyfill";
+
+export interface SwMessageOptions {
+  /** Hard timeout per attempt in milliseconds. Default 10s. */
+  timeout?: number;
+  /** Wait this long before retrying after a timeout. Default 500ms. */
+  retryDelay?: number;
+  /** Retry once on timeout (the retry also wakes the SW). Default true. */
+  retryOnTimeout?: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_RETRY_DELAY_MS = 500;
+
+/**
+ * Error thrown when `sendMessage` times out twice (or once if
+ * `retryOnTimeout: false`). Callers should treat this as a transient network
+ * error (same shape as the existing `"NETWORK_ERROR"` thrown by `apiRequest`
+ * in the SW), not as an auth failure.
+ */
+export const SW_TIMEOUT_ERROR = "SW_TIMEOUT";
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(SW_TIMEOUT_ERROR));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Send a message to the service worker with timeout + automatic retry on
+ * timeout. The retry implicitly wakes the SW if Chrome killed it.
+ *
+ * Use this for sidepanel callsites that previously called
+ * `Browser.runtime.sendMessage` directly when the result is required to
+ * make UI progress (auth checks, plan loads, revoke actions).
+ *
+ * Errors:
+ *  - `SW_TIMEOUT` → SW unreachable after retry (network-style failure).
+ *  - Any other error → propagated as-is from the SW handler.
+ */
+export async function swMessage<TReq = unknown, TRes = unknown>(
+  message: TReq,
+  options: SwMessageOptions = {},
+): Promise<TRes> {
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
+  const retryDelay = options.retryDelay ?? DEFAULT_RETRY_DELAY_MS;
+  const retryOnTimeout = options.retryOnTimeout ?? true;
+
+  const attempt = (): Promise<TRes> =>
+    withTimeout(
+      Browser.runtime.sendMessage<unknown, TRes>(message as unknown),
+      timeout,
+    );
+
+  try {
+    return await attempt();
+  } catch (err) {
+    const isTimeout = (err as Error).message === SW_TIMEOUT_ERROR;
+    if (!isTimeout || !retryOnTimeout) {
+      throw err;
+    }
+    // Brief pause — give Chrome a moment to spin the SW back up before
+    // we hammer it with the second attempt.
+    await sleep(retryDelay);
+    return attempt();
+  }
+}


### PR DESCRIPTION
## Wave 1 Ext V2 Step 2 — SW resilience mid-refresh

Mitiger le gap identifié par audit Sprint C : le Service Worker MV3 peut être killed par Chrome (memory pressure, 30s idle) pendant `tryRefreshToken`. Sans guard, le sidepanel hang indéfiniment au mount et user voit des 401 silencieux sur les requêtes suivantes.

## Stratégie

1. **Côté sidepanel** — nouveau wrapper `swMessage()` qui race `chrome.runtime.sendMessage` contre un timeout (10s par défaut) puis retry once après 500ms en cas de timeout. Le retry réveille implicitement le SW si Chrome l'a killed (Chrome respawn le SW sur incoming runtime traffic). Si les 2 attempts timeout → reject `SW_TIMEOUT`.
2. **Côté SW background.ts** — in-flight guard cross-restart via `chrome.storage.session` (clé `auth_refresh_in_flight`, TTL 15s pour expirer les locks orphelins). Le guard `inflightRefresh` in-memory ne survit pas au kill SW, donc deux sidepanels qui tentent CHECK_AUTH simultanément après respawn auraient pu déclencher 2 refreshes parallèles, dont le second invalidait le refresh_token rotaté par le premier (race condition).
3. **Migration de 2 callsites critiques** au mount (`checkAuth` + `loadPlanInfo` dans `App.tsx`) vers `swMessage()`. Les autres sites peuvent migrer incrémentalement sans casser quoi que ce soit (helper opt-in).

## Fichiers

- `extension/src/utils/swMessage.ts` (nouveau, 106 LOC) — helper timeout + retry.
- `extension/src/background.ts` (+59 LOC) — `acquireRefreshLock` / `releaseRefreshLock` via `chrome.storage.session` + intégration dans `tryRefreshToken`.
- `extension/src/sidepanel/App.tsx` — `checkAuth` et `loadPlanInfo` migrés vers `swMessage()`.
- `extension/__tests__/utils/swMessage.test.ts` (nouveau, 91 LOC) — 3 tests Jest.

## Tests

- Jest `swMessage` : 3/3 verts (happy path / timeout retry resolve / double timeout reject).
- Full Jest suite : 364/392 (baseline pré-Step 2 = 361/389, mêmes 28 fails préexistants, **pas de régression** introduite).
- `npx tsc --noEmit` : clean.
- `webpack --mode production` : OK (que warnings size préexistants).

## Scope respecté

- 4 fichiers touchés (cap = 5).
- ~150 LOC code prod + ~91 LOC tests = 267 lignes total diff.
- PAS de refacto SW complet, PAS de nouvelle UI, PAS de touche frontend/mobile/backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7)