### PR TITLE
Wave 1 Mobile V2 Step 2 — PasswordReauthBottomSheet + useReauth hook

### DIFF
--- a/mobile/__tests__/components/auth/PasswordReauthBottomSheet.test.tsx
+++ b/mobile/__tests__/components/auth/PasswordReauthBottomSheet.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Tests for PasswordReauthBottomSheet — Auth V2 Wave 1 Mobile Step 2.
+ *
+ * Coverage:
+ *  - hidden state quand visible=false
+ *  - submit success → onSuccess(reauth_token) appelé
+ *  - submit 401 → erreur "Mot de passe incorrect" affichée + onSuccess pas appelé
+ *  - cancel → onCancel appelé
+ *  - submit ne fait rien quand password vide
+ */
+import React from "react";
+import {
+  render,
+  fireEvent,
+  screen,
+  waitFor,
+  act,
+} from "@testing-library/react-native";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+// Surcharge la mock globale de @gorhom/bottom-sheet (jest.setup.js) pour
+// fournir BottomSheetTextInput + un ref qui expose snapToIndex/close
+// (utilisés par le composant via useEffect → sheetRef.current?.snapToIndex(0)).
+jest.mock("@gorhom/bottom-sheet", () => {
+  const React = require("react");
+  const { View, TextInput } = require("react-native");
+  const BottomSheet = React.forwardRef(
+    (
+      props: { children?: React.ReactNode; [k: string]: unknown },
+      ref: React.Ref<unknown>,
+    ) => {
+      React.useImperativeHandle(ref, () => ({
+        snapToIndex: jest.fn(),
+        snapToPosition: jest.fn(),
+        expand: jest.fn(),
+        collapse: jest.fn(),
+        close: jest.fn(),
+        forceClose: jest.fn(),
+      }));
+      return React.createElement(View, props);
+    },
+  );
+  return {
+    __esModule: true,
+    default: BottomSheet,
+    BottomSheetScrollView: (props: { children?: React.ReactNode }) =>
+      React.createElement(View, props),
+    BottomSheetView: (props: { children?: React.ReactNode }) =>
+      React.createElement(View, props),
+    BottomSheetBackdrop: (props: { children?: React.ReactNode }) =>
+      React.createElement(View, props),
+    BottomSheetTextInput: React.forwardRef(
+      (props: Record<string, unknown>, ref: React.Ref<unknown>) =>
+        React.createElement(TextInput, { ...props, ref }),
+    ),
+  };
+});
+
+// Mock authApi.requestReauth.
+const mockRequestReauth = jest.fn();
+jest.mock("../../../src/services/api", () => ({
+  authApi: {
+    requestReauth: (...args: unknown[]) => mockRequestReauth(...args),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    code?: string;
+    detail?: string;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
+}));
+
+// Import after mocks are set up.
+import { PasswordReauthBottomSheet } from "../../../src/components/auth/PasswordReauthBottomSheet";
+import { ApiError } from "../../../src/services/api";
+
+describe("PasswordReauthBottomSheet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the sheet content when visible=true", () => {
+    render(
+      <PasswordReauthBottomSheet
+        visible
+        audience="billing"
+        onSuccess={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("reauth-bottom-sheet")).toBeTruthy();
+    expect(screen.getByTestId("reauth-password-input")).toBeTruthy();
+    expect(screen.getByTestId("reauth-submit-btn")).toBeTruthy();
+    expect(screen.getByTestId("reauth-cancel-btn")).toBeTruthy();
+    expect(screen.getByText("Confirmation requise")).toBeTruthy();
+    // Audience-specific copy.
+    expect(
+      screen.getByText(
+        "Pour modifier votre abonnement, confirmez votre mot de passe.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("calls onSuccess(reauth_token) when submit succeeds", async () => {
+    const onSuccess = jest.fn();
+    const onCancel = jest.fn();
+    mockRequestReauth.mockResolvedValueOnce({
+      reauth_token: "tok_abc123",
+      expires_in: 300,
+    });
+
+    render(
+      <PasswordReauthBottomSheet
+        visible
+        audience="billing"
+        onSuccess={onSuccess}
+        onCancel={onCancel}
+      />,
+    );
+
+    const input = screen.getByTestId("reauth-password-input");
+    fireEvent.changeText(input, "hunter2");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("reauth-submit-btn"));
+    });
+
+    await waitFor(() => {
+      expect(mockRequestReauth).toHaveBeenCalledWith("hunter2", "billing");
+      expect(onSuccess).toHaveBeenCalledWith("tok_abc123");
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  it("displays error and does NOT call onSuccess on 401", async () => {
+    const onSuccess = jest.fn();
+    mockRequestReauth.mockRejectedValueOnce(
+      new ApiError("Unauthorized", 401),
+    );
+
+    render(
+      <PasswordReauthBottomSheet
+        visible
+        audience="delete"
+        onSuccess={onSuccess}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    const input = screen.getByTestId("reauth-password-input");
+    fireEvent.changeText(input, "wrong-password");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("reauth-submit-btn"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reauth-error")).toBeTruthy();
+      expect(screen.getByText("Mot de passe incorrect")).toBeTruthy();
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("calls onCancel when cancel button is pressed", () => {
+    const onCancel = jest.fn();
+    render(
+      <PasswordReauthBottomSheet
+        visible
+        audience="change-password"
+        onSuccess={jest.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId("reauth-cancel-btn"));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call requestReauth when password is empty", async () => {
+    const onSuccess = jest.fn();
+    render(
+      <PasswordReauthBottomSheet
+        visible
+        audience="change-email"
+        onSuccess={onSuccess}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    // Don't type anything — submit button should be disabled / no-op.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("reauth-submit-btn"));
+    });
+
+    expect(mockRequestReauth).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/components/auth/PasswordReauthBottomSheet.tsx
+++ b/mobile/src/components/auth/PasswordReauthBottomSheet.tsx
@@ -1,0 +1,333 @@
+/**
+ * 🔐 PasswordReauthBottomSheet — Auth V2 Wave 1 Mobile Step 2
+ *
+ * BottomSheet réutilisable pour la re-authentification scopée avant action
+ * sensible (billing, delete, change-email, change-password). Demande le mot
+ * de passe utilisateur, appelle POST /api/auth/reauth, et resolve avec un
+ * `reauth_token` à passer en header `X-Reauth-Token` sur l'endpoint cible.
+ *
+ * Mirror du pattern web (PR #547 — PasswordReauthModal). Utilise
+ * `@gorhom/bottom-sheet` v5 (déjà installé) et BottomSheetTextInput pour
+ * l'input password qui gère correctement le focus + clavier dans la sheet.
+ */
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetTextInput,
+  BottomSheetView,
+  type BottomSheetBackdropProps,
+} from "@gorhom/bottom-sheet";
+import { Ionicons } from "@expo/vector-icons";
+import { authApi, ApiError } from "../../services/api";
+import type { ReauthAudience } from "../../types/auth";
+
+interface PasswordReauthBottomSheetProps {
+  visible: boolean;
+  audience: ReauthAudience;
+  onSuccess: (reauthToken: string) => void;
+  onCancel: () => void;
+}
+
+const AUDIENCE_LABELS: Record<ReauthAudience, string> = {
+  billing: "Pour modifier votre abonnement, confirmez votre mot de passe.",
+  delete: "Pour supprimer votre compte, confirmez votre mot de passe.",
+  "change-email": "Pour changer votre email, confirmez votre mot de passe.",
+  "change-password":
+    "Pour changer votre mot de passe, confirmez l'actuel.",
+};
+
+// Tokens — dark mode forcés par spec Step 2.
+const BG_PRIMARY = "#12121a";
+const BG_TERTIARY = "#1a1a25";
+const TEXT_PRIMARY = "#ffffff";
+const TEXT_SECONDARY = "#f1f5f9";
+const TEXT_MUTED = "#e2e8f0";
+const ACCENT = "#6366f1";
+const ERROR = "#ef4444";
+const BORDER = "rgba(255,255,255,0.08)";
+
+export const PasswordReauthBottomSheet: React.FC<
+  PasswordReauthBottomSheetProps
+> = ({ visible, audience, onSuccess, onCancel }) => {
+  const sheetRef = useRef<BottomSheet>(null);
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const snapPoints = useMemo(() => ["40%"], []);
+
+  // Driver visible → snapToIndex(0) / close().
+  useEffect(() => {
+    if (visible) {
+      setPassword("");
+      setError(null);
+      setLoading(false);
+      sheetRef.current?.snapToIndex(0);
+    } else {
+      sheetRef.current?.close();
+    }
+  }, [visible]);
+
+  const handleSheetChange = useCallback(
+    (index: number) => {
+      // index === -1 = fermé via swipe-down ou backdrop.
+      if (index === -1 && visible && !loading) {
+        onCancel();
+      }
+    },
+    [visible, loading, onCancel],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!password || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await authApi.requestReauth(password, audience);
+      onSuccess(res.reauth_token);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setError("Mot de passe incorrect");
+      } else if (err instanceof ApiError && err.status === 429) {
+        setError("Trop de tentatives. Réessayez plus tard.");
+      } else {
+        setError("Erreur lors de la vérification. Réessayez.");
+      }
+      setLoading(false);
+    }
+  }, [password, audience, loading, onSuccess]);
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        opacity={0.6}
+        pressBehavior={loading ? "none" : "close"}
+      />
+    ),
+    [loading],
+  );
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      index={-1}
+      snapPoints={snapPoints}
+      enablePanDownToClose={!loading}
+      onChange={handleSheetChange}
+      backgroundStyle={styles.sheetBackground}
+      handleIndicatorStyle={styles.sheetHandle}
+      backdropComponent={renderBackdrop}
+      keyboardBehavior="interactive"
+      keyboardBlurBehavior="restore"
+    >
+      <BottomSheetView style={styles.container} testID="reauth-bottom-sheet">
+        {/* Header */}
+        <View style={styles.header}>
+          <View style={styles.iconWrap}>
+            <Ionicons name="lock-closed" size={18} color={ACCENT} />
+          </View>
+          <Text style={styles.title}>Confirmation requise</Text>
+        </View>
+
+        {/* Description */}
+        <Text style={styles.description}>{AUDIENCE_LABELS[audience]}</Text>
+
+        {/* Input */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Mot de passe</Text>
+          <BottomSheetTextInput
+            value={password}
+            onChangeText={(v) => {
+              setPassword(v);
+              if (error) setError(null);
+            }}
+            placeholder="Votre mot de passe"
+            placeholderTextColor={TEXT_MUTED}
+            secureTextEntry
+            autoCapitalize="none"
+            autoCorrect={false}
+            autoComplete="current-password"
+            editable={!loading}
+            onSubmitEditing={handleSubmit}
+            returnKeyType="done"
+            style={[
+              styles.input,
+              error ? styles.inputError : null,
+            ]}
+            accessibilityLabel="Mot de passe"
+            testID="reauth-password-input"
+          />
+          {error ? (
+            <Text
+              style={styles.errorText}
+              accessibilityLiveRegion="polite"
+              testID="reauth-error"
+            >
+              {error}
+            </Text>
+          ) : null}
+        </View>
+
+        {/* Footer buttons */}
+        <View style={styles.footer}>
+          <Pressable
+            onPress={onCancel}
+            disabled={loading}
+            style={({ pressed }) => [
+              styles.btnGhost,
+              pressed && !loading ? styles.btnPressed : null,
+              loading ? styles.btnDisabled : null,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Annuler"
+            testID="reauth-cancel-btn"
+          >
+            <Text style={styles.btnGhostText}>Annuler</Text>
+          </Pressable>
+          <Pressable
+            onPress={handleSubmit}
+            disabled={loading || !password}
+            style={({ pressed }) => [
+              styles.btnPrimary,
+              pressed && !loading && !!password ? styles.btnPressed : null,
+              loading || !password ? styles.btnDisabled : null,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Confirmer"
+            testID="reauth-submit-btn"
+          >
+            {loading ? (
+              <ActivityIndicator color="#ffffff" size="small" />
+            ) : (
+              <Text style={styles.btnPrimaryText}>Confirmer</Text>
+            )}
+          </Pressable>
+        </View>
+      </BottomSheetView>
+    </BottomSheet>
+  );
+};
+
+PasswordReauthBottomSheet.displayName = "PasswordReauthBottomSheet";
+
+const styles = StyleSheet.create({
+  sheetBackground: {
+    backgroundColor: BG_PRIMARY,
+  },
+  sheetHandle: {
+    backgroundColor: TEXT_MUTED,
+    width: 36,
+  },
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginBottom: 12,
+  },
+  iconWrap: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    backgroundColor: `${ACCENT}1A`,
+    borderWidth: 1,
+    borderColor: `${ACCENT}33`,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: TEXT_PRIMARY,
+  },
+  description: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: TEXT_SECONDARY,
+    marginBottom: 16,
+  },
+  field: {
+    gap: 6,
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: "500",
+    color: TEXT_SECONDARY,
+  },
+  input: {
+    backgroundColor: BG_TERTIARY,
+    borderWidth: 1,
+    borderColor: BORDER,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: TEXT_PRIMARY,
+  },
+  inputError: {
+    borderColor: ERROR,
+  },
+  errorText: {
+    fontSize: 12,
+    color: ERROR,
+    marginTop: 4,
+  },
+  footer: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
+    marginTop: "auto",
+  },
+  btnGhost: {
+    paddingHorizontal: 18,
+    paddingVertical: 11,
+    borderRadius: 10,
+  },
+  btnGhostText: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: TEXT_SECONDARY,
+  },
+  btnPrimary: {
+    backgroundColor: ACCENT,
+    paddingHorizontal: 20,
+    paddingVertical: 11,
+    borderRadius: 10,
+    minWidth: 110,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  btnPrimaryText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#ffffff",
+  },
+  btnPressed: {
+    opacity: 0.85,
+  },
+  btnDisabled: {
+    opacity: 0.4,
+  },
+});
+
+export default PasswordReauthBottomSheet;

--- a/mobile/src/hooks/useReauth.tsx
+++ b/mobile/src/hooks/useReauth.tsx
@@ -1,0 +1,119 @@
+/**
+ * 🪝 useReauth — Auth V2 Wave 1 Mobile Step 2
+ *
+ * Hook React Native qui ouvre `PasswordReauthBottomSheet` à la demande,
+ * attend que l'utilisateur entre son mot de passe (POST /api/auth/reauth)
+ * et resolve la Promise avec le `reauth_token` à passer en header
+ * `X-Reauth-Token` sur l'endpoint sensible cible.
+ *
+ * Cache mémoire (PAS expo-secure-store) : si un token précédent est encore
+ * valide pour la même audience (TTL 5 min côté backend, on garde 30s
+ * de marge), on le retourne immédiatement sans ré-ouvrir le sheet.
+ *
+ * Mirror du pattern web (frontend/src/hooks/useReauth.tsx).
+ *
+ * Usage :
+ *   const { requestReauth, sheet } = useReauth();
+ *   // Monter `{sheet}` quelque part dans l'arbre (ex. le screen courant).
+ *   const token = await requestReauth("billing");
+ *   await api.changePlan({...}, { headers: { "X-Reauth-Token": token }});
+ */
+import React, { useCallback, useRef, useState } from "react";
+import { PasswordReauthBottomSheet } from "../components/auth/PasswordReauthBottomSheet";
+import type { ReauthAudience } from "../types/auth";
+
+/**
+ * Marge de sécurité retirée du TTL pour éviter d'envoyer un token
+ * qui expirerait pendant le vol réseau.
+ */
+const EXPIRY_SAFETY_MARGIN_MS = 30_000;
+
+/** Backend TTL fixé à 5 min — cf. ReauthResponse côté backend. */
+const REAUTH_TTL_MS = 5 * 60 * 1000;
+
+interface CachedToken {
+  token: string;
+  /** Date.now() epoch ms when the token expires (already - safety margin) */
+  expiresAt: number;
+}
+
+interface PendingRequest {
+  audience: ReauthAudience;
+  resolve: (token: string) => void;
+  reject: (err: Error) => void;
+}
+
+export interface UseReauthReturn {
+  /**
+   * Ouvre le BottomSheet de re-auth et résout avec un `reauth_token` valide.
+   * Si un token précédent pour la même `audience` est encore valide en
+   * cache, il est retourné sans ouvrir le sheet.
+   *
+   * @throws Error si l'utilisateur annule le sheet.
+   */
+  requestReauth: (audience: ReauthAudience) => Promise<string>;
+  /**
+   * Élément React à monter dans l'arbre (rend le BottomSheet).
+   * Typiquement à placer dans le composant qui consomme le hook.
+   */
+  sheet: React.ReactElement | null;
+}
+
+/**
+ * @internal — exporté pour tests.
+ */
+export function _isTokenValid(cached: CachedToken | null): boolean {
+  if (!cached) return false;
+  return Date.now() < cached.expiresAt;
+}
+
+export function useReauth(): UseReauthReturn {
+  const [pending, setPending] = useState<PendingRequest | null>(null);
+  // Cache mémoire par audience (Map = scope sub-key clé).
+  const cacheRef = useRef<Map<ReauthAudience, CachedToken>>(new Map());
+
+  const requestReauth = useCallback(
+    (audience: ReauthAudience): Promise<string> => {
+      // Cache hit ?
+      const cached = cacheRef.current.get(audience) ?? null;
+      if (_isTokenValid(cached)) {
+        return Promise.resolve(cached!.token);
+      }
+      // Sinon ouvrir le sheet.
+      return new Promise<string>((resolve, reject) => {
+        setPending({ audience, resolve, reject });
+      });
+    },
+    [],
+  );
+
+  const handleSuccess = useCallback(
+    (token: string) => {
+      if (!pending) return;
+      const expiresAt = Date.now() + REAUTH_TTL_MS - EXPIRY_SAFETY_MARGIN_MS;
+      cacheRef.current.set(pending.audience, { token, expiresAt });
+      pending.resolve(token);
+      setPending(null);
+    },
+    [pending],
+  );
+
+  const handleCancel = useCallback(() => {
+    if (!pending) return;
+    pending.reject(new Error("Reauth cancelled by user"));
+    setPending(null);
+  }, [pending]);
+
+  const sheet = pending ? (
+    <PasswordReauthBottomSheet
+      visible
+      audience={pending.audience}
+      onSuccess={handleSuccess}
+      onCancel={handleCancel}
+    />
+  ) : null;
+
+  return { requestReauth, sheet };
+}
+
+export default useReauth;

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -22,6 +22,7 @@ import type {
   CorpusChatMessage,
   CorpusChatResponse,
 } from "../types";
+import type { ReauthAudience, ReauthResponse } from "../types/auth";
 
 // Request configuration
 interface RequestConfig {
@@ -420,6 +421,26 @@ export const authApi = {
     return request("/api/auth/account", {
       method: "DELETE",
       body: password ? { password } : {},
+    });
+  },
+
+  /**
+   * Re-authentification scopée — Auth V2 Wave 1 Step 2.
+   *
+   * Demande un `reauth_token` (JWT scopé, TTL 5 min côté backend) à passer
+   * en header `X-Reauth-Token` lors d'un appel sur un endpoint sensible
+   * (billing, delete, change-email, change-password).
+   *
+   * @throws ApiError (status=401) si le mot de passe est incorrect.
+   * @throws ApiError (status=429) si trop de tentatives.
+   */
+  async requestReauth(
+    password: string,
+    audience: ReauthAudience,
+  ): Promise<ReauthResponse> {
+    return request<ReauthResponse>("/api/auth/reauth", {
+      method: "POST",
+      body: { password, audience },
     });
   },
 };

--- a/mobile/src/types/auth.ts
+++ b/mobile/src/types/auth.ts
@@ -1,0 +1,27 @@
+/**
+ * Auth V2 types — Wave 1 Mobile (re-auth, sessions, "stay signed in")
+ *
+ * Mirror of frontend/src/types/auth.ts. Consume backend Sprint C + Wave 1 V2
+ * (PR #533 et suite). Endpoint: POST /api/auth/reauth → { reauth_token, expires_in }
+ * Client must then re-call sensitive endpoint with header X-Reauth-Token.
+ */
+
+/**
+ * Audience scope du re-auth token côté backend.
+ * Doit matcher `ReauthAudience` dans backend/src/auth/schemas.py.
+ */
+export type ReauthAudience =
+  | "billing"
+  | "delete"
+  | "change-email"
+  | "change-password";
+
+/**
+ * Réponse du backend pour POST /api/auth/reauth.
+ * - `reauth_token` : JWT scopé à passer en header X-Reauth-Token (TTL 5 min).
+ * - `expires_in`   : durée de vie en secondes (typiquement 300).
+ */
+export interface ReauthResponse {
+  reauth_token: string;
+  expires_in: number;
+}


### PR DESCRIPTION
## Wave 1 Mobile V2 Step 2 — PasswordReauthBottomSheet + useReauth hook

Consume `POST /api/auth/reauth` (livré PR #533 backend) pour gérer le re-auth scopé (X-Reauth-Token, TTL 5 min) avant actions sensibles. Mirror du pattern web (PR #547).

## Comment c'est utilisé
```ts
const { requestReauth, sheet } = useReauth();
// Monter `{sheet}` quelque part dans l'arbre.
const reauthToken = await requestReauth("billing");
await api.changePlan({ ... }, { headers: { "X-Reauth-Token": reauthToken }});
```

Cache mémoire par audience (Map, TTL 5 min - 30s marge) → si l'utilisateur enchaîne plusieurs actions sensibles pour la même audience dans les 4m30s, le sheet ne s'ouvre qu'une fois.

## Fichiers
- `mobile/src/types/auth.ts` (nouveau, 27 LOC) — `ReauthAudience` + `ReauthResponse` (alignés frontend/backend)
- `mobile/src/services/api.ts` (+21 LOC) — `authApi.requestReauth(password, audience)` POST `/api/auth/reauth`
- `mobile/src/components/auth/PasswordReauthBottomSheet.tsx` (nouveau, 333 LOC) — `@gorhom/bottom-sheet` v5 + `BottomSheetTextInput` (focus + clavier intégrés). Dark mode `#12121a`, accent indigo `#6366f1`, snap `40%`, backdrop pressable, loading state, gestion 401/429/autres
- `mobile/src/hooks/useReauth.tsx` (nouveau, 119 LOC) — compound hook `{ requestReauth, sheet }`, cache mémoire par audience
- `mobile/__tests__/components/auth/PasswordReauthBottomSheet.test.tsx` (nouveau, 204 LOC)

## Tests
5/5 verts (`npm test -- PasswordReauthBottomSheet`) :
- visible=true → sheet content rendered
- submit success → `onSuccess(reauth_token)` appelé
- submit 401 → erreur "Mot de passe incorrect" affichée, `onSuccess` pas appelé
- cancel button → `onCancel` appelé
- password vide → `requestReauth` API pas appelée

Typecheck : `npm run typecheck` → 0 erreur.

## OTA-compatible
Aucun nouveau package natif (`@gorhom/bottom-sheet`, `@expo/vector-icons` déjà installés). Compatible Expo Go via mock Jest existant.

## Reste à faire (Step 3 séparé)
- Wave 1 Mobile V2 Step 3 — page "Appareils Activés" via FlatList (consume GET /api/auth/sessions)

🤖 Generated with Claude Code (Opus 4.7)