### PR TITLE
Wave 1 Web V2 Step 2 — Page Appareils (/settings/devices) liste + révocation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -340,6 +340,7 @@ const PlaylistDetailPage = lazyWithRetry(
 const SearchPage = lazyWithRetry(() => import("./pages/SearchPage"));
 const UpgradePage = lazyWithRetry(() => import("./pages/UpgradePage"));
 const Settings = lazyWithRetry(() => import("./pages/Settings"));
+const DevicesPage = lazyWithRetry(() => import("./pages/DevicesPage"));
 const MyAccount = lazyWithRetry(() => import("./pages/MyAccount"));
 const AdminPage = lazyWithRetry(() => import("./pages/AdminPage"));
 const UsageDashboard = lazyWithRetry(() => import("./pages/UsageDashboard"));
@@ -976,6 +977,22 @@ const AppRoutes = () => {
                                 fallback={<PageSkeleton variant="form" />}
                               >
                                 <Settings />
+                              </Suspense>
+                            </RouteErrorBoundary>
+                          }
+                        />
+
+                        <Route
+                          path="/settings/devices"
+                          element={
+                            <RouteErrorBoundary
+                              variant="full"
+                              componentName="DevicesPage"
+                            >
+                              <Suspense
+                                fallback={<PageSkeleton variant="form" />}
+                              >
+                                <DevicesPage />
                               </Suspense>
                             </RouteErrorBoundary>
                           }

--- a/frontend/src/pages/DevicesPage.tsx
+++ b/frontend/src/pages/DevicesPage.tsx
@@ -1,0 +1,440 @@
+/**
+ * ╔══════════════════════════════════════════════════════════════════════════════╗
+ * ║  DEEP SIGHT — Devices Page (Auth V2 Wave 1 Step 2)                            ║
+ * ║  Liste des sessions actives + révocation (individuelle ou toutes les autres). ║
+ * ║  Consomme :                                                                   ║
+ * ║    GET    /api/auth/sessions                                                  ║
+ * ║    DELETE /api/auth/sessions/{id}                                             ║
+ * ║    DELETE /api/auth/sessions                                                  ║
+ * ║  (Backend PR #533 — Wave 1 V2 multi-device sessions)                          ║
+ * ╚══════════════════════════════════════════════════════════════════════════════╝
+ */
+
+import React, { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "../hooks/useTranslation";
+import { authApi } from "../services/api";
+import { Sidebar } from "../components/layout/Sidebar";
+import { useToast } from "../components/Toast";
+import { SEO } from "../components/SEO";
+import DoodleBackground from "../components/DoodleBackground";
+import {
+  Smartphone,
+  Monitor,
+  Globe,
+  Trash2,
+  ShieldOff,
+  Clock,
+  AlertCircle,
+  RefreshCw,
+} from "lucide-react";
+import type { UserSession } from "../types/auth";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🛠️ Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Format ISO timestamp → "il y a X temps" (fr) ou "X ago" (en).
+ * Gardé volontairement simple, pas de dépendance dayjs/date-fns ici pour
+ * limiter la surface du sprint Step 2.
+ */
+function formatRelativeTime(iso: string, lang: "fr" | "en"): string {
+  try {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return iso;
+    const seconds = Math.max(
+      0,
+      Math.floor((Date.now() - date.getTime()) / 1000),
+    );
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (lang === "fr") {
+      if (seconds < 60) return "à l'instant";
+      if (minutes < 60) return `il y a ${minutes} min`;
+      if (hours < 24) return `il y a ${hours} h`;
+      if (days < 30) return `il y a ${days} j`;
+      return date.toLocaleDateString("fr-FR");
+    }
+    if (seconds < 60) return "just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    if (hours < 24) return `${hours}h ago`;
+    if (days < 30) return `${days}d ago`;
+    return date.toLocaleDateString("en-US");
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Tronque ip_hash pour l'affichage (les 12 premiers chars suffisent
+ * pour distinguer deux sessions différentes).
+ */
+function shortHash(value?: string | null): string {
+  if (!value) return "—";
+  return value.length > 12 ? `${value.slice(0, 12)}…` : value;
+}
+
+/**
+ * Choisit une icône d'appareil depuis le device_label / user_agent.
+ */
+function pickDeviceIcon(session: UserSession) {
+  const haystack = `${session.device_label || ""} ${session.user_agent || ""}`
+    .toLowerCase();
+  if (/iphone|android|mobile|ipad|tablet/.test(haystack)) return Smartphone;
+  if (/chrome|firefox|safari|edge|windows|mac|linux/.test(haystack)) {
+    return Monitor;
+  }
+  return Globe;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 🎨 Component
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const DevicesPage: React.FC = () => {
+  const { language } = useTranslation();
+  const { showToast, ToastComponent } = useToast();
+  const tr = useCallback(
+    (fr: string, en: string) => (language === "fr" ? fr : en),
+    [language],
+  );
+
+  const [sessions, setSessions] = useState<UserSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [revokingAll, setRevokingAll] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 📡 Fetch
+  // ───────────────────────────────────────────────────────────────────────────
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      setError(null);
+      const list = await authApi.listSessions();
+      setSessions(list);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : tr("Erreur de chargement", "Loading error");
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [tr]);
+
+  useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🗑️ Actions
+  // ───────────────────────────────────────────────────────────────────────────
+
+  const handleRevokeOne = useCallback(
+    async (session: UserSession) => {
+      const label = session.device_label || tr("cet appareil", "this device");
+      const confirmMsg = tr(
+        `Révoquer la session sur "${label}" ? L'appareil devra se reconnecter.`,
+        `Revoke the session on "${label}"? The device will need to sign in again.`,
+      );
+      if (!window.confirm(confirmMsg)) return;
+
+      setRevokingId(session.id);
+      try {
+        const res = await authApi.revokeSession(session.id);
+        showToast(
+          res.message || tr("Session révoquée", "Session revoked"),
+          "success",
+        );
+        await fetchSessions();
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : tr("Échec de la révocation", "Revocation failed");
+        showToast(message, "error");
+      } finally {
+        setRevokingId(null);
+      }
+    },
+    [fetchSessions, showToast, tr],
+  );
+
+  const handleRevokeAll = useCallback(async () => {
+    const confirmMsg = tr(
+      "Déconnecter TOUS les autres appareils ? Ta session courante restera active.",
+      "Sign out ALL other devices? Your current session will stay active.",
+    );
+    if (!window.confirm(confirmMsg)) return;
+
+    setRevokingAll(true);
+    try {
+      const res = await authApi.revokeAllOtherSessions();
+      showToast(
+        res.message ||
+          tr("Sessions révoquées", "Other sessions revoked"),
+        "success",
+      );
+      await fetchSessions();
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : tr("Échec de la révocation", "Revocation failed");
+      showToast(message, "error");
+    } finally {
+      setRevokingAll(false);
+    }
+  }, [fetchSessions, showToast, tr]);
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🖼️ Render
+  // ───────────────────────────────────────────────────────────────────────────
+
+  const otherSessionsCount = sessions.filter((s) => !s.current).length;
+
+  return (
+    <div className="min-h-screen bg-bg-primary relative">
+      <SEO title={tr("Mes appareils", "My devices")} path="/settings/devices" />
+      <DoodleBackground variant="tech" />
+
+      <Sidebar
+        collapsed={sidebarCollapsed}
+        onToggle={() => setSidebarCollapsed(!sidebarCollapsed)}
+        mobileOpen={mobileMenuOpen}
+        onMobileClose={() => setMobileMenuOpen(false)}
+      />
+
+      <main
+        id="main-content"
+        className={`transition-all duration-200 ease-out relative z-10 ${
+          sidebarCollapsed ? "lg:ml-[60px]" : "lg:ml-[240px]"
+        }`}
+      >
+        <div className="min-h-screen pt-16 lg:pt-0 p-3 sm:p-6 lg:p-8 pb-8">
+          <div className="max-w-2xl mx-auto space-y-4 sm:space-y-6">
+            {/* Header */}
+            <header className="mb-6 sm:mb-8 ml-12 sm:ml-0 lg:ml-0">
+              <h1 className="text-lg sm:text-2xl font-semibold mb-2 flex items-center gap-2 sm:gap-3 text-text-primary">
+                <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl bg-indigo-500/10 flex items-center justify-center flex-shrink-0">
+                  <Monitor className="w-4 h-4 sm:w-5 sm:h-5 text-indigo-400" />
+                </div>
+                <span className="truncate">
+                  {tr("Mes appareils", "My devices")}
+                </span>
+              </h1>
+              <p className="text-text-secondary text-xs sm:text-sm sm:ml-[52px]">
+                {tr(
+                  "Liste des appareils actuellement connectés à ton compte. Tu peux révoquer une session si tu ne la reconnais pas.",
+                  "Devices currently signed into your account. Revoke a session if you don't recognize it.",
+                )}
+              </p>
+            </header>
+
+            {/* Action globale — visible seulement si >1 session */}
+            {!loading && otherSessionsCount > 0 && (
+              <section className="rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-4 sm:p-5">
+                <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 justify-between">
+                  <div className="flex items-start gap-3">
+                    <ShieldOff className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5" />
+                    <div>
+                      <p className="font-medium text-text-primary text-sm">
+                        {tr(
+                          `${otherSessionsCount} autre${otherSessionsCount > 1 ? "s" : ""} session${otherSessionsCount > 1 ? "s" : ""} active${otherSessionsCount > 1 ? "s" : ""}`,
+                          `${otherSessionsCount} other active session${otherSessionsCount > 1 ? "s" : ""}`,
+                        )}
+                      </p>
+                      <p className="text-xs text-text-tertiary mt-0.5">
+                        {tr(
+                          "Si tu suspectes une connexion non autorisée, déconnecte tout maintenant.",
+                          "If you suspect unauthorized access, sign everything out now.",
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={handleRevokeAll}
+                    disabled={revokingAll}
+                    aria-label={tr(
+                      "Déconnecter tous les autres appareils",
+                      "Sign out all other devices",
+                    )}
+                    className="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-xl bg-amber-500/10 hover:bg-amber-500/20 border border-amber-500/30 text-amber-300 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {revokingAll ? (
+                      <RefreshCw className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <ShieldOff className="w-4 h-4" />
+                    )}
+                    {tr(
+                      "Déconnecter tous les autres",
+                      "Sign out all others",
+                    )}
+                  </button>
+                </div>
+              </section>
+            )}
+
+            {/* Liste sessions */}
+            <section
+              aria-label={tr("Sessions actives", "Active sessions")}
+              className="space-y-3"
+            >
+              {loading && (
+                <div
+                  className="rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-6 flex items-center justify-center gap-2 text-text-secondary text-sm"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <RefreshCw className="w-4 h-4 animate-spin" />
+                  {tr("Chargement…", "Loading…")}
+                </div>
+              )}
+
+              {!loading && error && (
+                <div
+                  className="rounded-2xl border border-red-500/30 bg-red-500/5 p-4 flex items-start gap-3"
+                  role="alert"
+                >
+                  <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
+                  <div className="flex-1">
+                    <p className="font-medium text-red-300 text-sm">
+                      {tr("Erreur", "Error")}
+                    </p>
+                    <p className="text-xs text-red-300/80 mt-1">{error}</p>
+                    <button
+                      onClick={() => {
+                        setLoading(true);
+                        fetchSessions();
+                      }}
+                      className="mt-3 inline-flex items-center gap-2 text-xs text-red-200 hover:text-white underline"
+                    >
+                      <RefreshCw className="w-3 h-3" />
+                      {tr("Réessayer", "Retry")}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {!loading && !error && sessions.length === 0 && (
+                <div className="rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-6 text-center text-sm text-text-secondary">
+                  {tr(
+                    "Aucune session active trouvée.",
+                    "No active session found.",
+                  )}
+                </div>
+              )}
+
+              {!loading &&
+                !error &&
+                sessions.map((session) => {
+                  const Icon = pickDeviceIcon(session);
+                  const isCurrent = session.current;
+                  const isRevoking = revokingId === session.id;
+                  return (
+                    <article
+                      key={session.id}
+                      data-testid={`session-card-${session.id}`}
+                      className={`rounded-2xl backdrop-blur-xl bg-white/5 border p-4 sm:p-5 transition-colors ${
+                        isCurrent
+                          ? "border-indigo-500/40 ring-1 ring-indigo-500/20"
+                          : "border-white/10 hover:border-white/20"
+                      }`}
+                    >
+                      <div className="flex items-start gap-3 sm:gap-4">
+                        <div
+                          className={`w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 ${
+                            isCurrent
+                              ? "bg-indigo-500/15 text-indigo-300"
+                              : "bg-white/5 text-text-secondary"
+                          }`}
+                        >
+                          <Icon className="w-5 h-5" />
+                        </div>
+
+                        <div className="flex-1 min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="font-medium text-text-primary text-sm truncate">
+                              {session.device_label ||
+                                tr("Appareil inconnu", "Unknown device")}
+                            </p>
+                            {isCurrent && (
+                              <span
+                                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-indigo-500/15 text-indigo-300 text-[10px] font-medium uppercase tracking-wide"
+                                aria-label={tr(
+                                  "Cette session",
+                                  "Current session",
+                                )}
+                              >
+                                {tr("Cette session", "Current session")}
+                              </span>
+                            )}
+                          </div>
+
+                          <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-tertiary">
+                            <span
+                              className="inline-flex items-center gap-1"
+                              title={session.last_seen_at}
+                            >
+                              <Clock className="w-3 h-3" />
+                              {tr("Vu", "Seen")}{" "}
+                              {formatRelativeTime(
+                                session.last_seen_at,
+                                language as "fr" | "en",
+                              )}
+                            </span>
+                            <span className="inline-flex items-center gap-1 font-mono">
+                              <Globe className="w-3 h-3" />
+                              {shortHash(session.ip_hash)}
+                            </span>
+                          </div>
+
+                          {session.user_agent && (
+                            <p className="mt-1.5 text-[11px] text-text-tertiary/70 truncate font-mono">
+                              {session.user_agent}
+                            </p>
+                          )}
+                        </div>
+
+                        {!isCurrent && (
+                          <button
+                            onClick={() => handleRevokeOne(session)}
+                            disabled={isRevoking}
+                            aria-label={tr(
+                              "Révoquer cette session",
+                              "Revoke this session",
+                            )}
+                            className="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-xl bg-red-500/10 hover:bg-red-500/20 border border-red-500/30 text-red-300 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {isRevoking ? (
+                              <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+                            ) : (
+                              <Trash2 className="w-3.5 h-3.5" />
+                            )}
+                            <span className="hidden sm:inline">
+                              {tr("Révoquer", "Revoke")}
+                            </span>
+                          </button>
+                        )}
+                      </div>
+                    </article>
+                  );
+                })}
+            </section>
+          </div>
+        </div>
+      </main>
+
+      {ToastComponent}
+    </div>
+  );
+};
+
+export default DevicesPage;

--- a/frontend/src/pages/MyAccount.tsx
+++ b/frontend/src/pages/MyAccount.tsx
@@ -52,6 +52,7 @@ import {
   GraduationCap,
   Brain,
   BookOpen,
+  Monitor,
 } from "lucide-react";
 import { DeepSightSpinnerMicro } from "../components/ui";
 import { Link, useNavigate } from "react-router-dom";
@@ -1338,6 +1339,27 @@ export const MyAccount: React.FC = () => {
                     <Lock className="w-4 h-4" />
                   </div>
                 </div>
+
+                <Link
+                  to="/settings/devices"
+                  className="w-full flex items-center justify-between p-4 rounded-lg bg-bg-tertiary border border-border-subtle hover:bg-bg-hover transition-colors text-left"
+                >
+                  <div className="flex items-center gap-3">
+                    <Monitor className="w-5 h-5 text-text-tertiary" />
+                    <div>
+                      <p className="font-medium text-text-primary">
+                        {tr("Mes appareils", "My devices")}
+                      </p>
+                      <p className="text-sm text-text-tertiary">
+                        {tr(
+                          "Voir et révoquer les sessions actives",
+                          "View and revoke active sessions",
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-text-tertiary" />
+                </Link>
 
                 <button
                   onClick={handleLogout}

--- a/frontend/src/pages/__tests__/DevicesPage.test.tsx
+++ b/frontend/src/pages/__tests__/DevicesPage.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * 🧪 Tests — DevicesPage (Auth V2 Wave 1 Step 2)
+ *
+ * Couvre :
+ *   1. fetch listSessions au mount → API appelée
+ *   2. render des cards avec device_label + badge "Cette session" si current
+ *   3. clic "Révoquer" sur non-current → confirm + revokeSession + refresh
+ *   4. clic "Déconnecter tous les autres" → confirm + revokeAllOtherSessions + refresh
+ *   5. erreur fetch → message d'erreur affiché
+ *
+ * Pattern emprunté à SearchPage.test.tsx (mock Sidebar/DoodleBackground/SEO).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { LanguageProvider } from "../../contexts/LanguageContext";
+import { ThemeProvider } from "../../contexts/ThemeContext";
+import DevicesPage from "../DevicesPage";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const listSessionsMock = vi.fn();
+const revokeSessionMock = vi.fn();
+const revokeAllOtherSessionsMock = vi.fn();
+
+vi.mock("../../services/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../services/api")>(
+      "../../services/api",
+    );
+  return {
+    ...actual,
+    authApi: {
+      ...actual.authApi,
+      listSessions: (...args: unknown[]) => listSessionsMock(...args),
+      revokeSession: (...args: unknown[]) => revokeSessionMock(...args),
+      revokeAllOtherSessions: (...args: unknown[]) =>
+        revokeAllOtherSessionsMock(...args),
+    },
+  };
+});
+
+vi.mock("../../components/layout/Sidebar", () => ({ Sidebar: () => null }));
+vi.mock("../../components/DoodleBackground", () => ({ default: () => null }));
+vi.mock("../../components/SEO", () => ({ SEO: () => null }));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/settings/devices"]}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <DevicesPage />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const SESSION_CURRENT = {
+  id: "00000000-0000-4000-8000-000000000001",
+  device_label: "Chrome on macOS",
+  ip_hash: "abcd1234ef5678",
+  user_agent: "Mozilla/5.0 Chrome/Mac",
+  last_seen_at: new Date(Date.now() - 60_000).toISOString(),
+  created_at: new Date(Date.now() - 3_600_000).toISOString(),
+  current: true,
+};
+
+const SESSION_OTHER = {
+  id: "00000000-0000-4000-8000-000000000002",
+  device_label: "Safari on iPhone",
+  ip_hash: "ffff9999aaaa11",
+  user_agent: "Mozilla/5.0 iPhone Safari",
+  last_seen_at: new Date(Date.now() - 7_200_000).toISOString(),
+  created_at: new Date(Date.now() - 86_400_000).toISOString(),
+  current: false,
+};
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  listSessionsMock.mockReset();
+  revokeSessionMock.mockReset();
+  revokeAllOtherSessionsMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("DevicesPage - Fetch on mount", () => {
+  it("calls authApi.listSessions on mount and renders sessions", async () => {
+    listSessionsMock.mockResolvedValueOnce([SESSION_CURRENT, SESSION_OTHER]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(listSessionsMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByText("Chrome on macOS")).toBeInTheDocument();
+    expect(await screen.findByText("Safari on iPhone")).toBeInTheDocument();
+    // Badge "Cette session" sur la session courante
+    expect(screen.getByText(/Cette session/i)).toBeInTheDocument();
+  });
+});
+
+describe("DevicesPage - Revoke single session", () => {
+  it("calls revokeSession and refetches when confirming revoke", async () => {
+    listSessionsMock
+      .mockResolvedValueOnce([SESSION_CURRENT, SESSION_OTHER])
+      .mockResolvedValueOnce([SESSION_CURRENT]);
+    revokeSessionMock.mockResolvedValueOnce({
+      success: true,
+      message: "Session révoquée",
+    });
+
+    // window.confirm → accepter
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockImplementation(() => true);
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText("Safari on iPhone");
+
+    // Click sur le bouton "Révoquer" du non-current (aria-label)
+    const revokeBtn = screen.getByRole("button", {
+      name: /Révoquer cette session/i,
+    });
+    await user.click(revokeBtn);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(revokeSessionMock).toHaveBeenCalledWith(SESSION_OTHER.id);
+    });
+    // Refetch
+    await waitFor(() => {
+      expect(listSessionsMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does NOT call revokeSession when user cancels confirm", async () => {
+    listSessionsMock.mockResolvedValueOnce([SESSION_CURRENT, SESSION_OTHER]);
+    vi.spyOn(window, "confirm").mockImplementation(() => false);
+
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText("Safari on iPhone");
+
+    const revokeBtn = screen.getByRole("button", {
+      name: /Révoquer cette session/i,
+    });
+    await user.click(revokeBtn);
+
+    expect(revokeSessionMock).not.toHaveBeenCalled();
+    // Only the initial fetch
+    expect(listSessionsMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DevicesPage - Revoke all other sessions", () => {
+  it("calls revokeAllOtherSessions and refetches", async () => {
+    listSessionsMock
+      .mockResolvedValueOnce([SESSION_CURRENT, SESSION_OTHER])
+      .mockResolvedValueOnce([SESSION_CURRENT]);
+    revokeAllOtherSessionsMock.mockResolvedValueOnce({
+      success: true,
+      message: "✅ 1 sessions révoquées",
+    });
+
+    vi.spyOn(window, "confirm").mockImplementation(() => true);
+
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText("Safari on iPhone");
+
+    const allBtn = screen.getByRole("button", {
+      name: /Déconnecter tous les autres appareils/i,
+    });
+    await user.click(allBtn);
+
+    await waitFor(() => {
+      expect(revokeAllOtherSessionsMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(listSessionsMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("DevicesPage - Error state", () => {
+  it("shows error message when fetch fails", async () => {
+    listSessionsMock.mockRejectedValueOnce(new Error("Network down"));
+    renderPage();
+
+    expect(await screen.findByText(/Network down/i)).toBeInTheDocument();
+    // Retry button visible
+    expect(
+      screen.getByRole("button", { name: /Réessayer/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1144,6 +1144,62 @@ export const authApi = {
   },
 
   /**
+   * Auth V2 — Liste les sessions actives de l'utilisateur courant
+   * (Wave 1 backend PR #533).
+   *
+   * GET /api/auth/sessions
+   * → list[UserSession{id, device_label, ip_hash, user_agent,
+   *    last_seen_at, created_at, current}]
+   *
+   * `current=true` est posé sur la session associée au JWT courant.
+   * Affiché sur `/settings/devices` (Step 2).
+   */
+  async listSessions(): Promise<
+    Array<{
+      id: string;
+      device_label?: string | null;
+      ip_hash?: string | null;
+      user_agent?: string | null;
+      last_seen_at: string;
+      created_at: string;
+      current: boolean;
+    }>
+  > {
+    return request("/api/auth/sessions");
+  },
+
+  /**
+   * Auth V2 — Révoque UNE session ciblée par son id.
+   *
+   * DELETE /api/auth/sessions/{id}
+   * → { success: boolean, message: string }
+   *
+   * Backend Wave 1 ne protège PAS cet endpoint par require_recent_reauth.
+   */
+  async revokeSession(
+    id: string,
+  ): Promise<{ success: boolean; message: string }> {
+    return request(`/api/auth/sessions/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+  },
+
+  /**
+   * Auth V2 — Révoque TOUTES les autres sessions (garde la session courante).
+   *
+   * DELETE /api/auth/sessions
+   * → { success: boolean, message: "✅ N sessions révoquées" }
+   *
+   * Backend Wave 1 ne protège PAS cet endpoint par require_recent_reauth.
+   */
+  async revokeAllOtherSessions(): Promise<{
+    success: boolean;
+    message: string;
+  }> {
+    return request("/api/auth/sessions", { method: "DELETE" });
+  },
+
+  /**
    * RGPD Article 20 — Right to data portability.
    * Downloads a ZIP archive with the user's personal data.
    * Triggers a browser file download (no return value).

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -25,3 +25,26 @@ export interface ReauthResponse {
   reauth_token: string;
   expires_in: number;
 }
+
+/**
+ * Représentation publique d'une session utilisateur exposée via
+ * `GET /api/auth/sessions`. Doit matcher `UserSessionResponse` dans
+ * `backend/src/auth/schemas.py`.
+ *
+ * - `id`            : UUID String(36) — utilisé pour `DELETE /sessions/{id}`.
+ * - `device_label`  : label parsé du user-agent (ex: "Chrome on macOS").
+ * - `ip_hash`       : SHA-256(ip + salt) tronqué — pas l'IP brute.
+ * - `user_agent`    : User-Agent brut (debug uniquement).
+ * - `last_seen_at`  : ISO timestamp de la dernière activité observée.
+ * - `created_at`    : ISO timestamp d'émission initiale.
+ * - `current`       : true si c'est la session associée au JWT courant.
+ */
+export interface UserSession {
+  id: string;
+  device_label?: string | null;
+  ip_hash?: string | null;
+  user_agent?: string | null;
+  last_seen_at: string;
+  created_at: string;
+  current: boolean;
+}


### PR DESCRIPTION
## Wave 1 Web V2 Step 2 — Page Appareils

Consume `GET /api/auth/sessions` + `DELETE /api/auth/sessions/{id}` + `DELETE /api/auth/sessions` (livrés PR #533 backend) pour permettre à l'utilisateur de voir et révoquer ses sessions actives depuis `/settings/devices`.

Backend Wave 1 ne protège PAS ces endpoints par `require_recent_reauth` → pas de modal de re-auth pour les révocations ici. Le modal Step 1 (PR #547) reste destiné à billing / delete / change-email / change-password.

## UX

- Route protégée `/settings/devices` (lazy-loadée sous `ProtectedLayout`).
- Header glassmorphism + paragraphe d'intro.
- Si ≥1 autre session : bannière jaune avec compteur (`N autres sessions actives`) + bouton "Déconnecter tous les autres".
- Liste verticale de cards 1 par session :
  - Icône appareil détectée du user-agent (Smartphone / Monitor / Globe).
  - `device_label`, badge "Cette session" (ring indigo) si `current`.
  - Relative time pour `last_seen_at` ("il y a 5 min", "il y a 2 h", …) + `ip_hash` tronqué 12 chars en mono.
  - User-agent brut en `text-[11px] truncate font-mono` (debug visuel).
  - Bouton "Révoquer" (rouge, icône `Trash2`) sur les non-current.
- Confirmations via `window.confirm` simple — pas de modal custom (scope Step 2).
- Refetch automatique après chaque révocation.
- États couverts : loading (spinner), error (card rouge + bouton "Réessayer"), empty.
- Lien d'entrée ajouté dans `MyAccount.tsx` section "Sécurité" (au-dessus de "Déconnexion").

## Fichiers (5 touchés, +562 LOC nettes)

- `frontend/src/types/auth.ts` — interface `UserSession` (+25 LOC).
- `frontend/src/services/api.ts` — `authApi.listSessions / revokeSession / revokeAllOtherSessions` (+54 LOC).
- `frontend/src/pages/DevicesPage.tsx` — page complète (+345 LOC, nouveau fichier).
- `frontend/src/App.tsx` — route lazy `/settings/devices` (+18 LOC).
- `frontend/src/pages/MyAccount.tsx` — lien "Mes appareils" dans section Sécurité (+22 LOC).
- `frontend/src/pages/__tests__/DevicesPage.test.tsx` — 5 tests Vitest (+216 LOC, nouveau fichier).

## Tests

- `npm run test -- DevicesPage` → **5/5 tests verts** en 727ms :
  1. fetch on mount + render + badge "Cette session" sur current
  2. revoke single → confirm + API appelée + refetch
  3. revoke single + confirm cancel → API NON appelée
  4. revoke all others → API appelée + refetch
  5. fetch error → message d'erreur + bouton "Réessayer"
- `npm run test -- PasswordReauthModal` → 6/6 verts (non-régression Step 1).
- `npm run typecheck` → clean.
- `npm run lint` → 0 errors (warnings préexistants seulement).

## Reste à faire (Step 3 séparé)

- Wave 1 Web V2 Step 3 — toggle "Stay signed in" au login + interceptor 401.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with Claude Code (Opus 4.7)