### PR TITLE
Wave 1 Mobile V2 Step 3 — Page Appareils Activés via FlatList

### DIFF
--- a/mobile/__tests__/screens/DevicesScreen.test.tsx
+++ b/mobile/__tests__/screens/DevicesScreen.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Tests for DevicesScreen — Auth V2 Wave 1 Mobile Step 3.
+ *
+ * Coverage:
+ *  - fetch on mount → renders sessions list
+ *  - empty state when API returns []
+ *  - revoke one session → API called + refetched
+ *  - revoke all others → API called + refetched
+ *  - error path → renders error card with retry
+ */
+import React from "react";
+import {
+  render,
+  fireEvent,
+  screen,
+  waitFor,
+  act,
+} from "@testing-library/react-native";
+import { Alert } from "react-native";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+// Capture Alert.alert calls and auto-trigger the destructive button so we can
+// assert the underlying API call without the native confirmation popup.
+const alertSpy = jest
+  .spyOn(Alert, "alert")
+  .mockImplementation((_title, _msg, buttons) => {
+    const destructive = (buttons ?? []).find(
+      (b) => b.style === "destructive",
+    );
+    destructive?.onPress?.();
+  });
+
+const mockBack = jest.fn();
+jest.mock("expo-router", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Stack: { Screen: () => null },
+    useRouter: () => ({ back: mockBack, push: jest.fn(), replace: jest.fn() }),
+  };
+});
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: "Ionicons",
+}));
+
+jest.mock("@/contexts/ThemeContext", () => ({
+  useTheme: () => ({
+    colors: {
+      bgPrimary: "#0a0a0f",
+      bgSecondary: "#12121a",
+      bgElevated: "#1e1e2a",
+      bgCard: "#15151f",
+      textPrimary: "#fff",
+      textSecondary: "#f1f5f9",
+      textTertiary: "#cbd5e1",
+      accentPrimary: "#C8903A",
+      accentError: "#ef4444",
+      accentWarning: "#f59e0b",
+      border: "rgba(255,255,255,0.1)",
+    },
+  }),
+}));
+
+// Mock authApi + ApiError before importing the screen.
+const mockListSessions = jest.fn();
+const mockRevokeSession = jest.fn();
+const mockRevokeAllOtherSessions = jest.fn();
+jest.mock("@/services/api", () => ({
+  authApi: {
+    listSessions: (...args: unknown[]) => mockListSessions(...args),
+    revokeSession: (...args: unknown[]) => mockRevokeSession(...args),
+    revokeAllOtherSessions: (...args: unknown[]) =>
+      mockRevokeAllOtherSessions(...args),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
+}));
+
+// Import the screen AFTER mocks are set up.
+import DevicesScreen from "../../app/devices";
+
+const SESSIONS_FIXTURE = [
+  {
+    id: "sess_current",
+    device_label: "Chrome on macOS",
+    ip_hash: "abc123def456789",
+    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X)",
+    last_seen_at: new Date(Date.now() - 60_000).toISOString(),
+    created_at: new Date(Date.now() - 86_400_000).toISOString(),
+    current: true,
+  },
+  {
+    id: "sess_other_1",
+    device_label: "iPhone",
+    ip_hash: "xyz987654321abc",
+    user_agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)",
+    last_seen_at: new Date(Date.now() - 3_600_000).toISOString(),
+    created_at: new Date(Date.now() - 7_200_000).toISOString(),
+    current: false,
+  },
+];
+
+describe("DevicesScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    alertSpy.mockClear();
+  });
+
+  it("fetches sessions on mount and renders the list", async () => {
+    mockListSessions.mockResolvedValueOnce(SESSIONS_FIXTURE);
+
+    render(<DevicesScreen />);
+
+    await waitFor(() => {
+      expect(mockListSessions).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("session-card-sess_current")).toBeTruthy();
+      expect(screen.getByTestId("session-card-sess_other_1")).toBeTruthy();
+    });
+    // Banner is rendered because there is 1 non-current session.
+    expect(screen.getByTestId("revoke-all-btn")).toBeTruthy();
+  });
+
+  it("renders empty state when API returns no sessions", async () => {
+    mockListSessions.mockResolvedValueOnce([]);
+
+    render(<DevicesScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("devices-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("revoke-all-btn")).toBeNull();
+  });
+
+  it("revokes one session and refetches the list", async () => {
+    // First fetch — full list. Second fetch (after revoke) — only current.
+    mockListSessions
+      .mockResolvedValueOnce(SESSIONS_FIXTURE)
+      .mockResolvedValueOnce([SESSIONS_FIXTURE[0]]);
+    mockRevokeSession.mockResolvedValueOnce({
+      success: true,
+      message: "OK",
+    });
+
+    render(<DevicesScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("revoke-btn-sess_other_1")).toBeTruthy(),
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("revoke-btn-sess_other_1"));
+    });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+      expect(mockRevokeSession).toHaveBeenCalledWith("sess_other_1");
+      // Initial + post-revoke fetch.
+      expect(mockListSessions).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("revokes all other sessions and refetches", async () => {
+    mockListSessions
+      .mockResolvedValueOnce(SESSIONS_FIXTURE)
+      .mockResolvedValueOnce([SESSIONS_FIXTURE[0]]);
+    mockRevokeAllOtherSessions.mockResolvedValueOnce({
+      success: true,
+      message: "Toutes les autres sessions ont été révoquées.",
+    });
+
+    render(<DevicesScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("revoke-all-btn")).toBeTruthy(),
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("revoke-all-btn"));
+    });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+      expect(mockRevokeAllOtherSessions).toHaveBeenCalledTimes(1);
+      expect(mockListSessions).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("renders error card when the fetch fails", async () => {
+    mockListSessions.mockRejectedValueOnce(new Error("network down"));
+
+    render(<DevicesScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("devices-error")).toBeTruthy();
+      expect(screen.getByTestId("devices-retry-btn")).toBeTruthy();
+    });
+  });
+});

--- a/mobile/app/devices.tsx
+++ b/mobile/app/devices.tsx
@@ -1,0 +1,721 @@
+/**
+ * DevicesScreen — Auth V2 Wave 1 Mobile Step 3.
+ *
+ * Mirror du DevicesPage web (frontend/src/pages/DevicesPage.tsx — PR #551)
+ * en React Native. Consomme :
+ *   GET    /api/auth/sessions       → list[UserSession]
+ *   DELETE /api/auth/sessions/{id}  → MessageResponse
+ *   DELETE /api/auth/sessions       → MessageResponse (révoque tout sauf current)
+ *
+ * UX :
+ *  - FlatList des sessions, pull-to-refresh (RefreshControl)
+ *  - Card par session : device_label / ip_hash / last_seen_at / badge "Cette session"
+ *  - Bouton "Révoquer" (Alert confirmation) sur chaque session non-current
+ *  - Bouton header "Déconnecter tous les autres" si >1 session active
+ *  - Empty state si aucune session
+ *  - Pas de re-auth modal (endpoints non protégés par require_recent_reauth)
+ */
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  Alert,
+  ActivityIndicator,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import { useTheme } from "@/contexts/ThemeContext";
+import { authApi, ApiError } from "@/services/api";
+import type { UserSession } from "@/types/auth";
+import { GlassCard } from "@/components/ui/GlassCard";
+import { sp, borderRadius } from "@/theme/spacing";
+import { fontFamily, fontSize } from "@/theme/typography";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+function formatRelativeTime(iso: string): string {
+  try {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return iso;
+    const seconds = Math.max(
+      0,
+      Math.floor((Date.now() - date.getTime()) / 1000),
+    );
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+    if (seconds < 60) return "à l'instant";
+    if (minutes < 60) return `il y a ${minutes} min`;
+    if (hours < 24) return `il y a ${hours} h`;
+    if (days < 30) return `il y a ${days} j`;
+    return date.toLocaleDateString("fr-FR");
+  } catch {
+    return iso;
+  }
+}
+
+function shortHash(value?: string | null): string {
+  if (!value) return "—";
+  return value.length > 12 ? `${value.slice(0, 12)}…` : value;
+}
+
+function pickDeviceIcon(
+  session: UserSession,
+): keyof typeof Ionicons.glyphMap {
+  const haystack = `${session.device_label || ""} ${session.user_agent || ""}`
+    .toLowerCase();
+  if (/iphone|android|mobile|ipad|tablet/.test(haystack)) {
+    return "phone-portrait-outline";
+  }
+  if (/chrome|firefox|safari|edge|windows|mac|linux/.test(haystack)) {
+    return "desktop-outline";
+  }
+  return "globe-outline";
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Component
+// ───────────────────────────────────────────────────────────────────────────
+
+export default function DevicesScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { colors } = useTheme();
+
+  const [sessions, setSessions] = useState<UserSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [revokingAll, setRevokingAll] = useState(false);
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      setError(null);
+      const list = await authApi.listSessions();
+      setSessions(list);
+    } catch (err) {
+      const message =
+        err instanceof ApiError ? err.message : "Erreur de chargement";
+      setError(message);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    fetchSessions();
+  }, [fetchSessions]);
+
+  const handleRevokeOne = useCallback(
+    (session: UserSession) => {
+      const label = session.device_label || "cet appareil";
+      Alert.alert(
+        "Révoquer la session",
+        `Révoquer la session sur « ${label} » ? L'appareil devra se reconnecter.`,
+        [
+          { text: "Annuler", style: "cancel" },
+          {
+            text: "Révoquer",
+            style: "destructive",
+            onPress: async () => {
+              setRevokingId(session.id);
+              try {
+                await authApi.revokeSession(session.id);
+                Haptics.notificationAsync(
+                  Haptics.NotificationFeedbackType.Success,
+                );
+                await fetchSessions();
+              } catch (err) {
+                const message =
+                  err instanceof ApiError
+                    ? err.message
+                    : "Échec de la révocation";
+                Alert.alert("Erreur", message);
+              } finally {
+                setRevokingId(null);
+              }
+            },
+          },
+        ],
+      );
+    },
+    [fetchSessions],
+  );
+
+  const handleRevokeAll = useCallback(() => {
+    Alert.alert(
+      "Déconnecter tous les autres",
+      "Déconnecter TOUS les autres appareils ? Ta session courante restera active.",
+      [
+        { text: "Annuler", style: "cancel" },
+        {
+          text: "Déconnecter tout",
+          style: "destructive",
+          onPress: async () => {
+            setRevokingAll(true);
+            try {
+              await authApi.revokeAllOtherSessions();
+              Haptics.notificationAsync(
+                Haptics.NotificationFeedbackType.Success,
+              );
+              await fetchSessions();
+            } catch (err) {
+              const message =
+                err instanceof ApiError
+                  ? err.message
+                  : "Échec de la révocation";
+              Alert.alert("Erreur", message);
+            } finally {
+              setRevokingAll(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [fetchSessions]);
+
+  const otherSessionsCount = sessions.filter((s) => !s.current).length;
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Renderers
+  // ───────────────────────────────────────────────────────────────────────────
+
+  const renderItem = useCallback(
+    ({ item }: { item: UserSession }) => {
+      const isCurrent = item.current;
+      const isRevoking = revokingId === item.id;
+      const iconName = pickDeviceIcon(item);
+      return (
+        <GlassCard
+          style={[
+            styles.card,
+            isCurrent && {
+              borderColor: colors.accentPrimary,
+              borderWidth: 1.5,
+            },
+          ]}
+        >
+          <View
+            style={styles.cardRow}
+            testID={`session-card-${item.id}`}
+          >
+            <View
+              style={[
+                styles.iconWrap,
+                {
+                  backgroundColor: isCurrent
+                    ? `${colors.accentPrimary}26`
+                    : colors.bgElevated,
+                },
+              ]}
+            >
+              <Ionicons
+                name={iconName}
+                size={20}
+                color={
+                  isCurrent ? colors.accentPrimary : colors.textSecondary
+                }
+              />
+            </View>
+
+            <View style={styles.cardBody}>
+              <View style={styles.titleRow}>
+                <Text
+                  style={[styles.deviceLabel, { color: colors.textPrimary }]}
+                  numberOfLines={1}
+                >
+                  {item.device_label || "Appareil inconnu"}
+                </Text>
+                {isCurrent && (
+                  <View
+                    style={[
+                      styles.currentBadge,
+                      { backgroundColor: `${colors.accentPrimary}26` },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.currentBadgeText,
+                        { color: colors.accentPrimary },
+                      ]}
+                    >
+                      Cette session
+                    </Text>
+                  </View>
+                )}
+              </View>
+
+              <View style={styles.metaRow}>
+                <View style={styles.metaItem}>
+                  <Ionicons
+                    name="time-outline"
+                    size={12}
+                    color={colors.textTertiary}
+                  />
+                  <Text
+                    style={[styles.metaText, { color: colors.textTertiary }]}
+                  >
+                    Vu {formatRelativeTime(item.last_seen_at)}
+                  </Text>
+                </View>
+                <View style={styles.metaItem}>
+                  <Ionicons
+                    name="globe-outline"
+                    size={12}
+                    color={colors.textTertiary}
+                  />
+                  <Text
+                    style={[
+                      styles.metaText,
+                      styles.mono,
+                      { color: colors.textTertiary },
+                    ]}
+                  >
+                    {shortHash(item.ip_hash)}
+                  </Text>
+                </View>
+              </View>
+
+              {item.user_agent ? (
+                <Text
+                  style={[
+                    styles.userAgent,
+                    { color: colors.textTertiary },
+                  ]}
+                  numberOfLines={1}
+                >
+                  {item.user_agent}
+                </Text>
+              ) : null}
+            </View>
+
+            {!isCurrent && (
+              <Pressable
+                onPress={() => handleRevokeOne(item)}
+                disabled={isRevoking}
+                accessibilityRole="button"
+                accessibilityLabel="Révoquer cette session"
+                testID={`revoke-btn-${item.id}`}
+                style={({ pressed }) => [
+                  styles.revokeBtn,
+                  {
+                    backgroundColor: `${colors.accentError}1a`,
+                    borderColor: `${colors.accentError}4d`,
+                    opacity: pressed || isRevoking ? 0.6 : 1,
+                  },
+                ]}
+              >
+                {isRevoking ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={colors.accentError}
+                  />
+                ) : (
+                  <Ionicons
+                    name="trash-outline"
+                    size={16}
+                    color={colors.accentError}
+                  />
+                )}
+              </Pressable>
+            )}
+          </View>
+        </GlassCard>
+      );
+    },
+    [colors, handleRevokeOne, revokingId],
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bgPrimary }]}>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: "Mes appareils",
+          headerStyle: { backgroundColor: colors.bgPrimary },
+          headerTitleStyle: {
+            color: colors.textPrimary,
+            fontFamily: fontFamily.bodySemiBold,
+          },
+          headerTintColor: colors.accentPrimary,
+          headerLeft: () => (
+            <Pressable
+              onPress={() => router.back()}
+              accessibilityRole="button"
+              accessibilityLabel="Retour"
+              testID="devices-back-btn"
+              style={({ pressed }) => [
+                styles.headerBtn,
+                { opacity: pressed ? 0.6 : 1 },
+              ]}
+            >
+              <Ionicons
+                name="chevron-back"
+                size={26}
+                color={colors.accentPrimary}
+              />
+            </Pressable>
+          ),
+        }}
+      />
+
+      <FlatList
+        data={sessions}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        testID="devices-list"
+        contentContainerStyle={[
+          styles.listContent,
+          { paddingBottom: insets.bottom + sp.xl },
+        ]}
+        ItemSeparatorComponent={() => <View style={{ height: sp.md }} />}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={colors.accentPrimary}
+            colors={[colors.accentPrimary]}
+          />
+        }
+        ListHeaderComponent={
+          <View style={styles.headerBlock}>
+            <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+              Liste des appareils connectés à ton compte. Révoque une session si
+              tu ne la reconnais pas.
+            </Text>
+
+            {!loading && otherSessionsCount > 0 && (
+              <GlassCard style={styles.bannerCard}>
+                <View style={styles.bannerRow}>
+                  <Ionicons
+                    name="shield-outline"
+                    size={20}
+                    color={colors.accentWarning}
+                  />
+                  <View style={styles.bannerBody}>
+                    <Text
+                      style={[
+                        styles.bannerTitle,
+                        { color: colors.textPrimary },
+                      ]}
+                    >
+                      {otherSessionsCount} autre
+                      {otherSessionsCount > 1 ? "s" : ""} session
+                      {otherSessionsCount > 1 ? "s" : ""} active
+                      {otherSessionsCount > 1 ? "s" : ""}
+                    </Text>
+                    <Text
+                      style={[
+                        styles.bannerSub,
+                        { color: colors.textTertiary },
+                      ]}
+                    >
+                      Si tu suspectes une connexion non autorisée,
+                      déconnecte-les toutes maintenant.
+                    </Text>
+                  </View>
+                </View>
+                <Pressable
+                  onPress={handleRevokeAll}
+                  disabled={revokingAll}
+                  accessibilityRole="button"
+                  accessibilityLabel="Déconnecter tous les autres appareils"
+                  testID="revoke-all-btn"
+                  style={({ pressed }) => [
+                    styles.revokeAllBtn,
+                    {
+                      backgroundColor: `${colors.accentWarning}1a`,
+                      borderColor: `${colors.accentWarning}4d`,
+                      opacity: pressed || revokingAll ? 0.6 : 1,
+                    },
+                  ]}
+                >
+                  {revokingAll ? (
+                    <ActivityIndicator
+                      size="small"
+                      color={colors.accentWarning}
+                    />
+                  ) : (
+                    <Ionicons
+                      name="shield-checkmark-outline"
+                      size={16}
+                      color={colors.accentWarning}
+                    />
+                  )}
+                  <Text
+                    style={[
+                      styles.revokeAllText,
+                      { color: colors.accentWarning },
+                    ]}
+                  >
+                    Déconnecter tous les autres
+                  </Text>
+                </Pressable>
+              </GlassCard>
+            )}
+          </View>
+        }
+        ListEmptyComponent={
+          loading ? (
+            <View style={styles.centered} testID="devices-loading">
+              <ActivityIndicator
+                size="large"
+                color={colors.accentPrimary}
+              />
+              <Text
+                style={[styles.centeredText, { color: colors.textSecondary }]}
+              >
+                Chargement…
+              </Text>
+            </View>
+          ) : error ? (
+            <View testID="devices-error">
+            <GlassCard style={styles.errorCard}>
+              <Ionicons
+                name="alert-circle-outline"
+                size={22}
+                color={colors.accentError}
+              />
+              <Text
+                style={[styles.errorTitle, { color: colors.accentError }]}
+              >
+                Erreur
+              </Text>
+              <Text
+                style={[styles.errorText, { color: colors.textSecondary }]}
+              >
+                {error}
+              </Text>
+              <Pressable
+                onPress={() => {
+                  setLoading(true);
+                  fetchSessions();
+                }}
+                accessibilityRole="button"
+                accessibilityLabel="Réessayer"
+                testID="devices-retry-btn"
+                style={({ pressed }) => [
+                  styles.retryBtn,
+                  {
+                    borderColor: colors.accentError,
+                    opacity: pressed ? 0.6 : 1,
+                  },
+                ]}
+              >
+                <Text
+                  style={[styles.retryText, { color: colors.accentError }]}
+                >
+                  Réessayer
+                </Text>
+              </Pressable>
+            </GlassCard>
+            </View>
+          ) : (
+            <View testID="devices-empty">
+              <GlassCard style={styles.emptyCard}>
+                <Text
+                  style={[styles.emptyText, { color: colors.textSecondary }]}
+                >
+                  Aucune session active trouvée.
+                </Text>
+              </GlassCard>
+            </View>
+          )
+        }
+      />
+    </View>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Styles
+// ───────────────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  headerBtn: {
+    paddingHorizontal: sp.sm,
+    paddingVertical: sp.xs,
+  },
+  listContent: {
+    paddingHorizontal: sp.lg,
+    paddingTop: sp.lg,
+    flexGrow: 1,
+  },
+  headerBlock: {
+    marginBottom: sp.lg,
+    gap: sp.md,
+  },
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    lineHeight: 20,
+  },
+  bannerCard: {
+    gap: sp.md,
+  },
+  bannerRow: {
+    flexDirection: "row",
+    gap: sp.md,
+    alignItems: "flex-start",
+  },
+  bannerBody: {
+    flex: 1,
+    gap: sp.xs,
+  },
+  bannerTitle: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
+  },
+  bannerSub: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+    lineHeight: 16,
+  },
+  revokeAllBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: sp.sm,
+    paddingVertical: sp.md,
+    paddingHorizontal: sp.lg,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+  },
+  revokeAllText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.sm,
+  },
+  card: {
+    padding: sp.md,
+  },
+  cardRow: {
+    flexDirection: "row",
+    gap: sp.md,
+    alignItems: "flex-start",
+  },
+  iconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.lg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cardBody: {
+    flex: 1,
+    gap: sp.xs,
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: sp.sm,
+    flexWrap: "wrap",
+  },
+  deviceLabel: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.sm,
+    flexShrink: 1,
+  },
+  currentBadge: {
+    paddingHorizontal: sp.sm,
+    paddingVertical: 2,
+    borderRadius: borderRadius.full,
+  },
+  currentBadgeText: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: 10,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  metaRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: sp.md,
+    marginTop: 2,
+  },
+  metaItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  metaText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.xs,
+  },
+  mono: {
+    fontFamily: fontFamily.body,
+  },
+  userAgent: {
+    fontFamily: fontFamily.body,
+    fontSize: 10,
+    marginTop: 2,
+  },
+  revokeBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  centered: {
+    paddingVertical: sp["3xl"],
+    alignItems: "center",
+    gap: sp.md,
+  },
+  centeredText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+  },
+  errorCard: {
+    alignItems: "center",
+    gap: sp.sm,
+    padding: sp.lg,
+  },
+  errorTitle: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.base,
+  },
+  errorText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    textAlign: "center",
+  },
+  retryBtn: {
+    marginTop: sp.sm,
+    paddingVertical: sp.sm,
+    paddingHorizontal: sp.lg,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+  },
+  retryText: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.sm,
+  },
+  emptyCard: {
+    alignItems: "center",
+    padding: sp.xl,
+  },
+  emptyText: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.sm,
+    textAlign: "center",
+  },
+});

--- a/mobile/src/components/profile/AccountSection.tsx
+++ b/mobile/src/components/profile/AccountSection.tsx
@@ -202,6 +202,9 @@ export const AccountSection: React.FC = () => {
         {renderRow("Changer le mot de passe", () => openSheet("password"), {
           icon: "lock-closed-outline",
         })}
+        {renderRow("Mes appareils", () => router.push("/devices"), {
+          icon: "phone-portrait-outline",
+        })}
         {renderRow(
           "Conditions d'utilisation",
           () => Linking.openURL("https://www.deepsightsynthesis.com/legal"),

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -22,7 +22,12 @@ import type {
   CorpusChatMessage,
   CorpusChatResponse,
 } from "../types";
-import type { ReauthAudience, ReauthResponse } from "../types/auth";
+import type {
+  ReauthAudience,
+  ReauthResponse,
+  UserSession,
+  MessageResponse,
+} from "../types/auth";
 
 // Request configuration
 interface RequestConfig {
@@ -442,6 +447,40 @@ export const authApi = {
       method: "POST",
       body: { password, audience },
     });
+  },
+
+  /**
+   * Liste les sessions actives du user — Auth V2 Wave 1 Step 3 (multi-device).
+   *
+   * Backend : GET /api/auth/sessions → list[UserSession].
+   * La session courante est marquée via `current: true` (par défaut non
+   * révocable côté UI pour éviter le suicide de session).
+   */
+  async listSessions(): Promise<UserSession[]> {
+    return request<UserSession[]>("/api/auth/sessions");
+  },
+
+  /**
+   * Révoque une session précise (un appareil) — Auth V2 Wave 1 Step 3.
+   *
+   * Backend : DELETE /api/auth/sessions/{id}. Le refresh token associé est
+   * blocklisté Redis, l'appareil doit se reconnecter à son prochain refresh.
+   */
+  async revokeSession(sessionId: string): Promise<MessageResponse> {
+    return request<MessageResponse>(
+      `/api/auth/sessions/${encodeURIComponent(sessionId)}`,
+      { method: "DELETE" },
+    );
+  },
+
+  /**
+   * Révoque toutes les sessions sauf la session courante — Wave 1 V2 Step 3.
+   *
+   * Backend : DELETE /api/auth/sessions. Utilisé pour "Déconnecter tous les
+   * autres appareils" — la session de l'appel reste active.
+   */
+  async revokeAllOtherSessions(): Promise<MessageResponse> {
+    return request<MessageResponse>("/api/auth/sessions", { method: "DELETE" });
   },
 };
 

--- a/mobile/src/types/auth.ts
+++ b/mobile/src/types/auth.ts
@@ -25,3 +25,42 @@ export interface ReauthResponse {
   reauth_token: string;
   expires_in: number;
 }
+
+/**
+ * Représentation d'une session active multi-appareils — Wave 1 V2 (Step 3).
+ *
+ * Mirror du schema backend `UserSession` (PR #533) et frontend
+ * `frontend/src/types/auth.ts`. Consommé par la page « Mes appareils »
+ * (GET /api/auth/sessions, DELETE /api/auth/sessions/{id},
+ *  DELETE /api/auth/sessions) pour permettre la révocation individuelle
+ * ou globale (sauf session courante).
+ *
+ * - `id`              : identifiant opaque de la session (UUID côté backend).
+ * - `device_label`    : libellé lisible (ex. "Chrome on macOS", "iPhone").
+ *                       Optionnel — peut être null/absent si non détecté.
+ * - `ip_hash`         : hash SHA-256 tronqué de l'IP (jamais l'IP en clair).
+ *                       Optionnel.
+ * - `user_agent`      : User-Agent brut de la requête login.
+ *                       Optionnel, principalement debug.
+ * - `last_seen_at`    : ISO 8601 — dernière requête vue avec ce refresh token.
+ * - `created_at`      : ISO 8601 — création de la session (login initial).
+ * - `current`         : true si c'est la session de l'appel en cours
+ *                       (le bouton "Révoquer" est masqué pour cette session).
+ */
+export interface UserSession {
+  id: string;
+  device_label?: string | null;
+  ip_hash?: string | null;
+  user_agent?: string | null;
+  last_seen_at: string;
+  created_at: string;
+  current: boolean;
+}
+
+/**
+ * Réponse générique des endpoints DELETE /api/auth/sessions{/{id}}.
+ */
+export interface MessageResponse {
+  success: boolean;
+  message: string;
+}


### PR DESCRIPTION
## Wave 1 Mobile V2 Step 3 — Page Appareils Activés

DERNIER step Mobile V2. Mirror du DevicesPage web (PR #551) en React Native. Consomme `GET/DELETE /api/auth/sessions` (backend Wave 1 V2 multi-device sessions, PR #533).

## UX

- Tab profil → row **"Mes appareils"** (AccountSection) → naviguation vers `/devices`
- `FlatList` de sessions actives avec `RefreshControl` pull-to-refresh
- Card par session : icône appareil adaptive (phone/desktop/globe), `device_label`, `ip_hash` tronqué 12 chars, `last_seen_at` relatif fr ("il y a X min"), `user_agent` raw discret
- Badge **"Cette session"** indigo (`#C8903A`) ring sur la session courante (bouton révoquer masqué — anti-suicide-de-session)
- Bouton **révoque** (icône trash, accentError) via `Alert.alert` confirmation destructive (annuler / révoquer)
- Banner **"Déconnecter tous les autres"** (accentWarning, shield icon) affiché si ≥1 session non-current
- Empty state, loading spinner, error card avec bouton retry
- Pas de re-auth modal (endpoints non protégés par `require_recent_reauth`)
- Haptics succès sur révocation

## Fichiers (5)

- `mobile/src/types/auth.ts` — `UserSession` + `MessageResponse` interfaces
- `mobile/src/services/api.ts` — `authApi.listSessions / revokeSession / revokeAllOtherSessions`
- `mobile/app/devices.tsx` — DevicesScreen (route hors tabs, pattern `upgrade.tsx`)
- `mobile/src/components/profile/AccountSection.tsx` — row "Mes appareils" → `router.push("/devices")`
- `mobile/__tests__/screens/DevicesScreen.test.tsx` — 5 tests Jest + RN Testing Library

## Tests

5/5 verts (`npm test -- DevicesScreen`) :
- fetch on mount → renders list
- empty state (API renvoie [])
- revoke one session → `revokeSession(id)` appelée + refetch
- revoke all others → `revokeAllOtherSessions()` appelée + refetch
- error path → renders error card avec retry button

Typecheck OK (`npx tsc --noEmit` clean au-delà du `HubAnalysisSheet.tsx` préexistant).

## OTA-compatible

Aucun nouveau package natif ajouté. `@expo/vector-icons` (Ionicons), `expo-haptics`, `expo-router` déjà présents.

## Reste à faire

- EAS Update prod pour livrer Steps 1+2+3 aux users : `eas update --channel production`
- Activer feature flag `AUTH_V2` côté backend prod
- Chrome Web Store upload (Step 3 extension a sa propre PR)

Generated with Claude Code (Opus 4.7).