### PR TITLE
Wave 1 Web V2 Step 3 — Toggle 'Stay signed in' au login (24h vs 30j)

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -19,6 +19,7 @@ import {
   getAccessToken,
   getRefreshToken,
   setTokens,
+  isSessionExpired,
   ApiError,
   User,
 } from "../services/api";
@@ -149,6 +150,13 @@ export function useAuth(): UseAuthReturn {
   const initialUser = useMemo(() => {
     const token = getAccessToken();
     if (!token) return null;
+    // Auth V2 Step 3 — hard cap 24h côté client si l'user a décoché
+    // "Rester connecté" au login. Override le sliding refresh JWT.
+    if (isSessionExpired()) {
+      clearTokens();
+      setCachedUser(null);
+      return null;
+    }
     // Ne pas utiliser un token expiré
     if (isTokenExpired(token)) {
       // Essayer le refresh token
@@ -599,6 +607,16 @@ export function useAuth(): UseAuthReturn {
   useEffect(() => {
     if (state.isAuthenticated && !sessionCheckIntervalRef.current) {
       sessionCheckIntervalRef.current = setInterval(async () => {
+        // Auth V2 Step 3 — hard cap 24h dépassé (toggle "Rester connecté"
+        // décoché au login) → force logout client-side même si tokens
+        // sont encore valides côté serveur.
+        if (isSessionExpired()) {
+          clearTokens();
+          setCachedUser(null);
+          window.dispatchEvent(new CustomEvent("auth:logout"));
+          return;
+        }
+
         const token = getAccessToken();
         if (!token) return;
 
@@ -705,6 +723,12 @@ export function useAuth(): UseAuthReturn {
     // 🆕 Écouter la visibilité de la page (refresh au retour)
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible" && state.isAuthenticated) {
+        // Auth V2 Step 3 — re-check hard cap 24h au retour de tab background.
+        if (isSessionExpired()) {
+          handleLogout();
+          window.dispatchEvent(new CustomEvent("auth:logout"));
+          return;
+        }
         const token = getAccessToken();
         if (token && isTokenExpiringSoon(token)) {
           refreshTokens();

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -137,7 +137,9 @@
     "featureAnalysis": "AI Analysis",
     "featureFactCheck": "Fact-checking",
     "featureStudyTools": "Study Tools",
-    "featureChat": "Contextual Chat"
+    "featureChat": "Contextual Chat",
+    "staySignedIn": "Stay signed in",
+    "staySignedInHint": "Uncheck to sign out after 24h of inactivity"
   },
   "dashboard": {
     "title": "Video Analysis",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -137,7 +137,9 @@
     "featureAnalysis": "Analyse IA",
     "featureFactCheck": "Vérification des faits",
     "featureStudyTools": "Outils d'étude",
-    "featureChat": "Chat contextuel"
+    "featureChat": "Chat contextuel",
+    "staySignedIn": "Rester connecté",
+    "staySignedInHint": "Décocher pour vous déconnecter après 24h d'inactivité"
   },
   "dashboard": {
     "title": "Analyse vidéo",

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -16,8 +16,17 @@ import { useAnalytics } from "../hooks/useAnalytics";
 import { useTranslation } from "../hooks/useTranslation";
 import { SEO } from "../components/SEO";
 import DoodleBackground from "../components/DoodleBackground";
+import { applyStaySignedIn } from "../services/api";
 
-import { Mail, Lock, AlertCircle, Eye, EyeOff, ArrowLeft } from "lucide-react";
+import {
+  Mail,
+  Lock,
+  AlertCircle,
+  Eye,
+  EyeOff,
+  ArrowLeft,
+  Info,
+} from "lucide-react";
 import { DeepSightSpinnerMicro } from "../components/ui/DeepSightSpinner";
 
 // === Google Icon ===
@@ -94,6 +103,11 @@ export const Login: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  // Auth V2 Step 3 — Toggle "Rester connecté" au login. Coché par défaut
+  // (30j refresh sliding côté backend). Si décoché → hard cap 24h côté
+  // client appliqué via applyStaySignedIn(false) → localStorage
+  // `auth_session_expiry`. Le hook useAuth force logout dès la deadline.
+  const [staySignedIn, setStaySignedIn] = useState(true);
 
   // Support ?tab=register from landing page CTA
   useEffect(() => {
@@ -183,6 +197,11 @@ export const Login: React.FC = () => {
         );
       } else {
         await login(email, password);
+        // Auth V2 Step 3 — Applique le toggle "Rester connecté" APRÈS le
+        // succès du login (sinon clearTokens du flow d'erreur effacerait
+        // la clé qu'on vient de poser). staySignedIn=true → clear la clé,
+        // staySignedIn=false → set deadline 24h dans localStorage.
+        applyStaySignedIn(staySignedIn);
         // `trackLogin` ne peut pas accéder au user qui vient d'être chargé
         // dans le state useAuth — useEffect ci-dessus gère la redirection ;
         // l'identify se fait au prochain mount via trackLogin si appelé,
@@ -241,6 +260,10 @@ export const Login: React.FC = () => {
   const handleGoogleLogin = async () => {
     setError(null);
     setLoading(true);
+    // Auth V2 Step 3 — OAuth redirige hors-page : on persiste le choix
+    // "Rester connecté" AVANT le redirect. AuthCallback ne réinitialise
+    // pas cette clé, donc la deadline 24h (si décochée) survit au flow.
+    applyStaySignedIn(staySignedIn);
     try {
       await loginWithGoogle();
     } catch (err: unknown) {
@@ -253,6 +276,8 @@ export const Login: React.FC = () => {
   const handleAppleLogin = async () => {
     setError(null);
     setLoading(true);
+    // Auth V2 Step 3 — idem Google : poser le hard cap avant redirect.
+    applyStaySignedIn(staySignedIn);
     try {
       await loginWithApple();
     } catch (err: unknown) {
@@ -657,6 +682,30 @@ export const Login: React.FC = () => {
                       </button>
                     </div>
                   </div>
+
+                  {/* Auth V2 Step 3 — "Rester connecté" toggle (login only) */}
+                  {!isRegister && (
+                    <label className="flex items-center gap-2 cursor-pointer select-none group pt-0.5">
+                      <input
+                        type="checkbox"
+                        checked={staySignedIn}
+                        onChange={(e) => setStaySignedIn(e.target.checked)}
+                        disabled={loading}
+                        className="w-4 h-4 rounded border-border-default bg-bg-secondary text-accent-primary focus:ring-2 focus:ring-accent-primary focus:ring-offset-0 cursor-pointer accent-indigo-500"
+                        aria-label={t.auth.staySignedIn}
+                      />
+                      <span className="text-xs text-text-secondary group-hover:text-text-primary transition-colors">
+                        {t.auth.staySignedIn}
+                      </span>
+                      <span
+                        className="text-text-muted hover:text-text-secondary transition-colors"
+                        title={t.auth.staySignedInHint}
+                        aria-label={t.auth.staySignedInHint}
+                      >
+                        <Info className="w-3.5 h-3.5" />
+                      </span>
+                    </label>
+                  )}
 
                   {/* Confirm Password (register) */}
                   <AnimatePresence>

--- a/frontend/src/pages/__tests__/Login.test.tsx
+++ b/frontend/src/pages/__tests__/Login.test.tsx
@@ -412,6 +412,115 @@ describe("Login Page - Navigation", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// 💾 STAY SIGNED IN TOGGLE (Auth V2 Step 3)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("Login Page - Stay signed in toggle", () => {
+  it("should render checkbox visible and checked by default", () => {
+    renderWithProviders(<Login />);
+    // FR: "Rester connecté"
+    const checkbox = screen.getByRole("checkbox", { name: /Rester connecté/i });
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toBeChecked();
+  });
+
+  it("should clear auth_session_expiry on successful login when checked", async () => {
+    // Pré-remplir une vieille deadline pour vérifier qu'elle est purgée
+    localStorage.setItem("auth_session_expiry", String(Date.now() - 1000));
+
+    const user = userEvent.setup();
+    const mockLogin = vi.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ ...defaultAuthState, login: mockLogin });
+
+    renderWithProviders(<Login />);
+
+    await user.type(
+      screen.getByPlaceholderText("you@example.com"),
+      "test@example.com",
+    );
+    await user.type(screen.getByPlaceholderText("••••••••"), "password123");
+    await user.click(screen.getByRole("button", { name: /Se connecter/ }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalled();
+    });
+    // Checkbox laissée cochée (défaut) → la clé doit avoir disparu
+    expect(localStorage.getItem("auth_session_expiry")).toBeNull();
+  });
+
+  it("should set auth_session_expiry ~24h ahead on successful login when unchecked", async () => {
+    const user = userEvent.setup();
+    const mockLogin = vi.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ ...defaultAuthState, login: mockLogin });
+
+    renderWithProviders(<Login />);
+
+    // Décocher avant submit
+    const checkbox = screen.getByRole("checkbox", { name: /Rester connecté/i });
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+
+    await user.type(
+      screen.getByPlaceholderText("you@example.com"),
+      "test@example.com",
+    );
+    await user.type(screen.getByPlaceholderText("••••••••"), "password123");
+
+    const beforeMs = Date.now();
+    await user.click(screen.getByRole("button", { name: /Se connecter/ }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalled();
+    });
+
+    const raw = localStorage.getItem("auth_session_expiry");
+    expect(raw).not.toBeNull();
+    const deadline = Number(raw);
+    const TWENTY_FOUR_H_MS = 24 * 60 * 60 * 1000;
+    // Tolère 10 s d'écart pour CI lente
+    expect(deadline).toBeGreaterThanOrEqual(beforeMs + TWENTY_FOUR_H_MS - 10_000);
+    expect(deadline).toBeLessThanOrEqual(Date.now() + TWENTY_FOUR_H_MS + 10_000);
+  });
+
+  it("should not show checkbox in register mode", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Login />);
+
+    // Toggle into register mode via "Créer un compte" button
+    const registerToggle = screen.getAllByText(/Créer un compte/)[0];
+    await user.click(registerToggle);
+
+    expect(
+      screen.queryByRole("checkbox", { name: /Rester connecté/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should apply Stay signed in choice before Google OAuth redirect", async () => {
+    const user = userEvent.setup();
+    const mockLoginWithGoogle = vi.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({
+      ...defaultAuthState,
+      loginWithGoogle: mockLoginWithGoogle,
+    });
+
+    renderWithProviders(<Login />);
+
+    // Décocher
+    await user.click(screen.getByRole("checkbox", { name: /Rester connecté/i }));
+
+    // Click Google login
+    await user.click(
+      screen.getByRole("button", { name: /Continuer avec Google/i }),
+    );
+
+    expect(mockLoginWithGoogle).toHaveBeenCalled();
+    // La deadline 24h doit être posée AVANT le redirect (le mock résout
+    // immédiatement, on peut donc lire la clé juste après).
+    expect(localStorage.getItem("auth_session_expiry")).not.toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // 🎯 EDGE CASES
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -29,6 +29,10 @@ import {
   API_URL,
   authApi,
   videoApi,
+  applyStaySignedIn,
+  isSessionExpired,
+  getSessionExpiry,
+  AUTH_SESSION_EXPIRY_KEY,
 } from "../api";
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -57,6 +61,55 @@ describe("Token Storage", () => {
     localStorage.setItem("cached_user", JSON.stringify({ user: { id: 1 } }));
     clearTokens();
     expect(localStorage.getItem("cached_user")).toBeNull();
+  });
+
+  it("should clear auth_session_expiry on clearTokens", () => {
+    localStorage.setItem(AUTH_SESSION_EXPIRY_KEY, String(Date.now() + 1000));
+    clearTokens();
+    expect(localStorage.getItem(AUTH_SESSION_EXPIRY_KEY)).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Stay signed in helpers (Auth V2 Step 3)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Stay signed in helpers", () => {
+  it("applyStaySignedIn(true) clears the expiry key", () => {
+    localStorage.setItem(AUTH_SESSION_EXPIRY_KEY, "12345");
+    applyStaySignedIn(true);
+    expect(localStorage.getItem(AUTH_SESSION_EXPIRY_KEY)).toBeNull();
+  });
+
+  it("applyStaySignedIn(false) sets a deadline ~24h ahead", () => {
+    vi.useRealTimers();
+    const before = Date.now();
+    applyStaySignedIn(false);
+    const raw = localStorage.getItem(AUTH_SESSION_EXPIRY_KEY);
+    expect(raw).not.toBeNull();
+    const deadline = Number(raw);
+    const TWENTY_FOUR_H_MS = 24 * 60 * 60 * 1000;
+    expect(deadline).toBeGreaterThanOrEqual(before + TWENTY_FOUR_H_MS - 1000);
+    expect(deadline).toBeLessThanOrEqual(Date.now() + TWENTY_FOUR_H_MS + 1000);
+  });
+
+  it("isSessionExpired returns false when key is absent", () => {
+    expect(isSessionExpired()).toBe(false);
+  });
+
+  it("isSessionExpired returns true when deadline is in the past", () => {
+    localStorage.setItem(AUTH_SESSION_EXPIRY_KEY, String(Date.now() - 1000));
+    expect(isSessionExpired()).toBe(true);
+  });
+
+  it("isSessionExpired returns false when deadline is in the future", () => {
+    localStorage.setItem(AUTH_SESSION_EXPIRY_KEY, String(Date.now() + 60_000));
+    expect(isSessionExpired()).toBe(false);
+  });
+
+  it("getSessionExpiry returns null for malformed value", () => {
+    localStorage.setItem(AUTH_SESSION_EXPIRY_KEY, "not-a-number");
+    expect(getSessionExpiry()).toBeNull();
   });
 });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -43,6 +43,61 @@ const TOKEN_KEYS = {
   REFRESH: "refresh_token",
 } as const;
 
+// ─── Auth V2 — "Stay signed in" toggle (Wave 1 Web V2 Step 3) ────────────────
+// Quand l'user décoche "Rester connecté" au login, on stocke un hard cap
+// 24h dans cette clé. Au mount d'AuthContext / sur chaque request, si
+// `Date.now() >= AUTH_SESSION_EXPIRY` → force logout client-side même si le
+// refresh token JWT est encore valide. Quand coché (défaut), la clé est
+// supprimée → comportement standard (refresh sliding ~30j côté backend).
+export const AUTH_SESSION_EXPIRY_KEY = "auth_session_expiry";
+const STAY_SIGNED_IN_HARD_CAP_MS = 24 * 60 * 60 * 1000; // 24h
+
+/**
+ * Auth V2 Step 3 — Lit le timestamp d'expiration côté client (ms epoch).
+ * Retourne `null` si la clé est absente (user a coché "Rester connecté").
+ */
+export function getSessionExpiry(): number | null {
+  try {
+    const raw = localStorage.getItem(AUTH_SESSION_EXPIRY_KEY);
+    if (!raw) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Auth V2 Step 3 — Vrai si l'user a décoché "Rester connecté" ET la deadline
+ * 24h est dépassée. Faux dans tous les autres cas (clé absente OU encore
+ * dans la fenêtre 24h).
+ */
+export function isSessionExpired(now: number = Date.now()): boolean {
+  const deadline = getSessionExpiry();
+  if (deadline === null) return false;
+  return now >= deadline;
+}
+
+/**
+ * Auth V2 Step 3 — Applique le choix "Rester connecté" au moment du login.
+ * `staySignedIn=true` (défaut) → supprime la clé (sliding refresh ~30j).
+ * `staySignedIn=false` → set deadline now + 24h (hard cap client).
+ */
+export function applyStaySignedIn(staySignedIn: boolean): void {
+  try {
+    if (staySignedIn) {
+      localStorage.removeItem(AUTH_SESSION_EXPIRY_KEY);
+    } else {
+      localStorage.setItem(
+        AUTH_SESSION_EXPIRY_KEY,
+        String(Date.now() + STAY_SIGNED_IN_HARD_CAP_MS),
+      );
+    }
+  } catch {
+    /* Safari private mode */
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // 📊 TYPES
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -646,6 +701,9 @@ export function clearTokens(): void {
     localStorage.removeItem(TOKEN_KEYS.ACCESS);
     localStorage.removeItem(TOKEN_KEYS.REFRESH);
     localStorage.removeItem("cached_user");
+    // Auth V2 Step 3 — purge le hard cap "Rester connecté" pour repartir
+    // propre au prochain login (sinon une deadline périmée se réactiverait).
+    localStorage.removeItem(AUTH_SESSION_EXPIRY_KEY);
   } catch {
     /* Safari private mode */
   }


### PR DESCRIPTION
## Wave 1 Web V2 Step 3 — Toggle "Stay signed in" au login

DERNIER step Web V2. Coché par défaut (refresh sliding ~30j côté backend) / décoché → hard cap 24h côté client via `localStorage.auth_session_expiry`.

## Stratégie

**Option 1 retenue (côté client uniquement)** — pas de patch backend.
Le param `stay_signed_in` n'est pas envoyé à `/login` ; à la place :

- Au submit avec checkbox cochée → `localStorage.removeItem("auth_session_expiry")` (sliding refresh ~30j inchangé).
- Au submit avec checkbox décochée → `localStorage.setItem("auth_session_expiry", String(Date.now() + 24h))`.
- `useAuth` check `isSessionExpired()` au mount, dans le heartbeat 60s, et au retour de tab background (`visibilitychange`). Si expiré → `clearTokens()` + `auth:logout` event → flow logout existant.
- L'interceptor 401 dans `services/api.ts` (request fn, lignes 816-822) gère déjà le retry refresh + dispatch `auth:logout` — pas de modif nécessaire ici.

OAuth Google/Apple : `applyStaySignedIn(staySignedIn)` est appelé AVANT le redirect, donc la deadline 24h survit au flow `AuthCallback`.

## Fichiers (5 prod + 2 tests)

- `frontend/src/services/api.ts` — helpers `applyStaySignedIn` / `isSessionExpired` / `getSessionExpiry` + extension `clearTokens` pour purger la clé.
- `frontend/src/hooks/useAuth.ts` — check `isSessionExpired()` au mount (initialUser memo), dans le heartbeat 60s, et sur visibilitychange.
- `frontend/src/pages/Login.tsx` — checkbox "Rester connecté" cochée par défaut, hide en mode register, applique le choix sur les 3 flows (email / Google / Apple).
- `frontend/src/i18n/fr.json` + `en.json` — `auth.staySignedIn` + `auth.staySignedInHint`.
- `frontend/src/pages/__tests__/Login.test.tsx` — 5 tests (checkbox visible+default checked, clear/set localStorage selon état, hide register, applied before Google redirect).
- `frontend/src/services/__tests__/api.test.ts` — 7 tests pour helpers + clearTokens étendu.

## Tests

61/61 verts (33 Login + 28 api). Lint clean sur fichiers touchés, typecheck clean.

## Reste à faire

- Activer feature flag `AUTH_V2_ENABLED=true` + `AUTH_V2_BUCKET_PERCENT=10` sur Hetzner pour démarrer rollout.

🤖 Generated with Claude Code (Opus 4.7)