### PR TITLE
feat(auth): mode privé admin-only + désactivation du backup CI cassé

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,9 +1,16 @@
 name: Daily Database Backup
 
+# ⚠️ DÉSACTIVÉ (2026-06-10) — déclencheur planifié retiré.
+# Le backup quotidien réel est assuré par l'APScheduler du backend
+# (backend/src/main.py → run_backup(upload=True) vers R2/S3, via .env.production).
+# Ce workflow échouait tous les jours faute de secrets GitHub configurés
+# (DATABASE_URL / AWS_* vides). Conservé en exécution MANUELLE uniquement :
+# pour le réactiver en cron, restaurer le bloc `schedule` ci-dessous ET
+# renseigner les secrets repo (DATABASE_URL, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).
 on:
-  schedule:
-    # Every day at 03:00 UTC
-    - cron: "0 3 * * *"
+  # schedule:
+  #   # Every day at 03:00 UTC
+  #   - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
       upload:

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -42,6 +42,46 @@ def _jwt_config() -> dict:
 
 logger = logging.getLogger(__name__)
 
+
+def is_admin_user(user: Optional[User]) -> bool:
+    """True si l'utilisateur est admin (flag DB is_admin OU email == ADMIN_EMAIL)."""
+    if user is None:
+        return False
+    admin_email = (_core_config.ADMIN_CONFIG.get("ADMIN_EMAIL") or "").lower()
+    return bool(user.is_admin or ((user.email or "").lower() == admin_email))
+
+
+def is_private_mode_allowed(user: Optional[User]) -> bool:
+    """True si l'utilisateur peut accéder pendant le mode privé.
+
+    Admin (is_admin / ADMIN_EMAIL) OU email dans l'allowlist de sécurité
+    (cf core.config.private_mode_allowed_emails — garantit l'accès du fondateur).
+    """
+    if is_admin_user(user):
+        return True
+    email = ((getattr(user, "email", "") or "")).lower() if user is not None else ""
+    return bool(email and email in _core_config.private_mode_allowed_emails())
+
+
+def enforce_private_mode(user: Optional[User]) -> None:
+    """🔒 Mode privé : bloque tout sauf l'admin/allowlist quand PRIVATE_MODE est actif.
+
+    Lève une 403 explicite pour les non-autorisés. No-op si le mode est inactif
+    (cas par défaut en dev/test) ou si l'utilisateur est autorisé.
+    """
+    if _core_config.is_private_mode() and not is_private_mode_allowed(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "private_mode",
+                "message": (
+                    "DeepSight est temporairement en accès privé (maintenance). "
+                    "L'accès est réservé à l'administrateur."
+                ),
+            },
+        )
+
+
 # Import du service de sécurité
 try:
     from core.security import is_token_blacklisted, check_rate_limit
@@ -187,6 +227,9 @@ async def get_current_user(
                     "wait_seconds": rate_info.get("wait_seconds", 60),
                 },
             )
+
+    # 🔒 Mode privé — coupe l'accès aux non-admins (y compris sessions déjà ouvertes)
+    enforce_private_mode(user)
 
     return user
 

--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -68,7 +68,7 @@ from .service import (
     revoke_session_v2,
 )
 from services.audit_log import log_audit
-from .dependencies import get_current_user, get_current_token_payload
+from .dependencies import get_current_user, get_current_token_payload, enforce_private_mode, is_private_mode_allowed
 from .email import send_verification_email, send_password_reset_email, send_welcome_email
 
 router = APIRouter()
@@ -90,6 +90,9 @@ async def register(data: UserRegister, session: AsyncSession = Depends(get_sessi
     breakdown les cohorts et funnels par canal d'acquisition (PH, Twitter,
     Karim B2B, etc.). Aucune nouvelle migration requise.
     """
+    # 🔒 Mode privé — aucune nouvelle inscription tant que l'accès est restreint.
+    enforce_private_mode(None)
+
     success, user, message = await create_user(
         session, username=data.username, email=data.email, password=data.password
     )
@@ -141,6 +144,9 @@ async def login(data: UserLogin, session: AsyncSession = Depends(get_session)):
                 status_code=403, detail="EMAIL_NOT_VERIFIED", headers={"X-Email": user.email if user else ""}
             )
         raise HTTPException(status_code=401, detail=message)
+
+    # 🔒 Mode privé — seul l'admin peut obtenir des tokens.
+    enforce_private_mode(user)
 
     # Générer les tokens avec session_token intégré
     access_token = create_access_token(user.id, user.is_admin, session_token)
@@ -628,6 +634,10 @@ async def google_callback(
     if not success or not user:
         return RedirectResponse(url=f"{FRONTEND_URL}/login?error=auth_failed", status_code=302)
 
+    # 🔒 Mode privé — seul l'admin/allowlist peut se connecter (redirection, pas de token).
+    if _core_config.is_private_mode() and not is_private_mode_allowed(user):
+        return RedirectResponse(url=f"{FRONTEND_URL}/login?error=private_mode", status_code=302)
+
     # Générer les tokens JWT avec session_token
     access_token = create_access_token(user.id, user.is_admin, session_token)
     refresh_token = create_refresh_token(user.id, session_token)
@@ -668,6 +678,9 @@ async def google_callback_post(data: GoogleCallbackRequest, session: AsyncSessio
 
     if not success or not user:
         raise HTTPException(status_code=400, detail=message)
+
+    # 🔒 Mode privé — seul l'admin peut obtenir des tokens.
+    enforce_private_mode(user)
 
     # Tokens JWT avec session_token
     access_token = create_access_token(user.id, user.is_admin, session_token)
@@ -753,6 +766,9 @@ async def google_token_login(data: GoogleMobileTokenRequest, session: AsyncSessi
     if not success or not user:
         log.warning(f"Google mobile login failed for {email}: {message}")
         raise HTTPException(status_code=400, detail=message)
+
+    # 🔒 Mode privé — seul l'admin peut obtenir des tokens.
+    enforce_private_mode(user)
 
     # 5. Générer nos JWT (device_name transmis pour traçabilité future)
     access_token = create_access_token(user.id, user.is_admin, session_token)

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -364,6 +364,58 @@ ADMIN_CONFIG = {
 }
 
 # =============================================================================
+# PRIVATE MODE — verrouillage admin-only
+# =============================================================================
+# Quand actif, seul l'admin (User.is_admin ou email == ADMIN_EMAIL) peut
+# s'authentifier et utiliser l'API. Les endpoints publics inoffensifs
+# (/health, /api/billing/plans, webhook Stripe...) restent accessibles.
+#
+# Mis en place le 2026-06-10 : garder DeepSight accessible au seul fondateur
+# pendant une période d'indisponibilité, sans couper l'infra.
+#
+# Résolution de l'état (dans l'ordre) :
+#   1. Variable d'env PRIVATE_MODE définie → elle gagne (true/1/yes/on => actif).
+#   2. Sinon → verrouillé en PRODUCTION uniquement (PRIVATE_MODE_LOCKDOWN),
+#      ouvert en dev/test pour ne pas casser la suite de tests.
+#
+# Pour ROUVRIR au public, deux options :
+#   - passer PRIVATE_MODE_LOCKDOWN à False ci-dessous puis redéployer, OU
+#   - définir PRIVATE_MODE=false dans .env.production sur le VPS.
+PRIVATE_MODE_LOCKDOWN = True
+
+# Filet de sécurité : emails TOUJOURS autorisés en mode privé, même si
+# ADMIN_EMAIL n'est pas réglé côté VPS. Garantit que le fondateur ne peut jamais
+# se verrouiller dehors (il n'a pas d'accès SSH pour corriger un lockout).
+# Override/extension possible via env PRIVATE_MODE_ALLOWED_EMAILS (CSV).
+PRIVATE_MODE_ALLOWED_EMAILS = {"maximeleparc3@gmail.com"}
+
+
+def is_private_mode() -> bool:
+    """Retourne True si l'accès à DeepSight est restreint à l'admin uniquement."""
+    raw = os.getenv("PRIVATE_MODE")
+    if raw is not None:
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+    return PRIVATE_MODE_LOCKDOWN and _settings.is_production
+
+
+def private_mode_allowed_emails() -> set:
+    """Emails autorisés à accéder pendant le mode privé.
+
+    Union de : allowlist hardcodée (fondateur) + env PRIVATE_MODE_ALLOWED_EMAILS
+    (CSV) + ADMIN_EMAIL courant. Tout en minuscules.
+    """
+    emails = {e.lower() for e in PRIVATE_MODE_ALLOWED_EMAILS}
+    raw = os.getenv("PRIVATE_MODE_ALLOWED_EMAILS", "")
+    for e in raw.split(","):
+        e = e.strip().lower()
+        if e:
+            emails.add(e)
+    admin_email = (ADMIN_CONFIG.get("ADMIN_EMAIL") or "").lower()
+    if admin_email:
+        emails.add(admin_email)
+    return emails
+
+# =============================================================================
 # API KEYS
 # =============================================================================
 

--- a/backend/tests/test_private_mode.py
+++ b/backend/tests/test_private_mode.py
@@ -1,0 +1,127 @@
+"""Tests du mode privé (verrouillage admin-only) — 2026-06-10.
+
+Couvre :
+- core.config.is_private_mode() : résolution env > défaut prod-only.
+- auth.dependencies.is_admin_user() : détection admin (flag DB ou email).
+- auth.dependencies.enforce_private_mode() : 403 pour non-admin, no-op sinon.
+
+Aucune dépendance DB : on monkeypatch les globals et on utilise des doubles.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+import core.config as config
+from auth import dependencies as deps
+
+
+class _FakeSettings:
+    def __init__(self, is_production: bool):
+        self.is_production = is_production
+
+
+class _FakeUser:
+    def __init__(self, is_admin: bool = False, email: str = ""):
+        self.is_admin = is_admin
+        self.email = email
+
+
+@pytest.fixture(autouse=True)
+def _clean_private_mode_env(monkeypatch):
+    # Garantit un état déterministe quel que soit l'environnement d'exécution.
+    monkeypatch.delenv("PRIVATE_MODE", raising=False)
+    monkeypatch.delenv("PRIVATE_MODE_ALLOWED_EMAILS", raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# is_private_mode — résolution de l'état
+# --------------------------------------------------------------------------- #
+def test_env_override_true_wins_over_dev(monkeypatch):
+    monkeypatch.setenv("PRIVATE_MODE", "true")
+    monkeypatch.setattr(config, "_settings", _FakeSettings(is_production=False))
+    assert config.is_private_mode() is True
+
+
+def test_env_override_false_wins_over_prod(monkeypatch):
+    monkeypatch.setenv("PRIVATE_MODE", "false")
+    monkeypatch.setattr(config, "_settings", _FakeSettings(is_production=True))
+    assert config.is_private_mode() is False
+
+
+def test_lockdown_active_in_production_by_default(monkeypatch):
+    monkeypatch.setattr(config, "PRIVATE_MODE_LOCKDOWN", True)
+    monkeypatch.setattr(config, "_settings", _FakeSettings(is_production=True))
+    assert config.is_private_mode() is True
+
+
+def test_open_in_dev_even_with_lockdown(monkeypatch):
+    # Protège la suite de tests : jamais verrouillé hors production.
+    monkeypatch.setattr(config, "PRIVATE_MODE_LOCKDOWN", True)
+    monkeypatch.setattr(config, "_settings", _FakeSettings(is_production=False))
+    assert config.is_private_mode() is False
+
+
+# --------------------------------------------------------------------------- #
+# is_admin_user
+# --------------------------------------------------------------------------- #
+def test_is_admin_user_detection(monkeypatch):
+    monkeypatch.setitem(config.ADMIN_CONFIG, "ADMIN_EMAIL", "boss@deepsight.com")
+    assert deps.is_admin_user(_FakeUser(is_admin=True)) is True
+    assert deps.is_admin_user(_FakeUser(email="BOSS@deepsight.com")) is True  # case-insensitive
+    assert deps.is_admin_user(_FakeUser(email="rando@example.com")) is False
+    assert deps.is_admin_user(None) is False
+
+
+# --------------------------------------------------------------------------- #
+# enforce_private_mode
+# --------------------------------------------------------------------------- #
+def test_enforce_blocks_non_admin_when_active(monkeypatch):
+    monkeypatch.setattr(config, "is_private_mode", lambda: True)
+    monkeypatch.setitem(config.ADMIN_CONFIG, "ADMIN_EMAIL", "boss@deepsight.com")
+
+    with pytest.raises(HTTPException) as exc:
+        deps.enforce_private_mode(_FakeUser(email="rando@example.com"))
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "private_mode"
+
+    with pytest.raises(HTTPException):
+        deps.enforce_private_mode(None)
+
+
+def test_enforce_allows_admin_when_active(monkeypatch):
+    monkeypatch.setattr(config, "is_private_mode", lambda: True)
+    monkeypatch.setitem(config.ADMIN_CONFIG, "ADMIN_EMAIL", "boss@deepsight.com")
+    # Ne lève pas pour l'admin (par email ou par flag).
+    deps.enforce_private_mode(_FakeUser(email="boss@deepsight.com"))
+    deps.enforce_private_mode(_FakeUser(is_admin=True))
+
+
+def test_enforce_noop_when_inactive(monkeypatch):
+    monkeypatch.setattr(config, "is_private_mode", lambda: False)
+    # Aucun blocage même pour un non-admin quand le mode est désactivé.
+    deps.enforce_private_mode(_FakeUser(email="rando@example.com"))
+    deps.enforce_private_mode(None)
+
+
+# --------------------------------------------------------------------------- #
+# Allowlist de sécurité (filet anti-lockout fondateur)
+# --------------------------------------------------------------------------- #
+def test_founder_email_always_in_allowlist():
+    # Le fondateur est toujours autorisé, indépendamment d'ADMIN_EMAIL/env.
+    assert "maximeleparc3@gmail.com" in config.private_mode_allowed_emails()
+
+
+def test_allowlist_extendable_via_env(monkeypatch):
+    monkeypatch.setenv("PRIVATE_MODE_ALLOWED_EMAILS", "tester@x.com, Other@X.com")
+    allowed = config.private_mode_allowed_emails()
+    assert "tester@x.com" in allowed
+    assert "other@x.com" in allowed  # normalisé en minuscules
+
+
+def test_founder_passes_private_mode_even_if_not_admin(monkeypatch):
+    monkeypatch.setattr(config, "is_private_mode", lambda: True)
+    monkeypatch.setitem(config.ADMIN_CONFIG, "ADMIN_EMAIL", "someone-else@deepsight.com")
+    founder = _FakeUser(is_admin=False, email="maximeleparc3@gmail.com")
+    assert deps.is_private_mode_allowed(founder) is True
+    # Ne lève pas.
+    deps.enforce_private_mode(founder)


### PR DESCRIPTION
## Contexte

Demande du fondateur (indisponible, accès limité au seul téléphone + Claude) : rendre DeepSight accessible **à lui seul** (`maximeleparc3@gmail.com`, admin) pendant sa période d'absence, et nettoyer les workflows CI cassés. Production saine par ailleurs (cf. diagnostic du 10/06).

Cette PR contient **deux changements** (même branche imposée).

---

## 1. 🔒 Mode privé — verrouillage admin-only (changement principal)

Quand actif, **seul l'admin** (`is_admin` / `ADMIN_EMAIL`) ou un email de l'allowlist de sécurité peut s'authentifier et utiliser l'API. Les endpoints publics inoffensifs (`/health`, `/api/billing/plans`, webhook Stripe) restent ouverts pour ne pas casser l'infra ni le smoke-test de déploiement.

**Implémentation**
- `core/config.py` : flag `PRIVATE_MODE` résolu ainsi → (1) env `PRIVATE_MODE` si définie, sinon (2) `PRIVATE_MODE_LOCKDOWN and is_production`. **Inactif en dev/test** (ENV != production) → la suite de tests n'est pas affectée.
- **Filet anti-lockout** : `PRIVATE_MODE_ALLOWED_EMAILS` inclut toujours `maximeleparc3@gmail.com`, même si `ADMIN_EMAIL` n'est pas réglé côté VPS → le fondateur ne peut jamais se verrouiller dehors.
- `auth/dependencies.py` : helpers `is_admin_user` / `is_private_mode_allowed` / `enforce_private_mode` + **gate central dans `get_current_user`** (coupe aussi les sessions déjà ouvertes).
- `auth/router.py` : blocage `login`, `register` (zéro nouvelle inscription) et les 3 flux Google (POST callback, mobile token, GET callback → redirect `/login?error=private_mode`).
- Tests unitaires dédiés : `backend/tests/test_private_mode.py`.

**Activation / désactivation (sans SSH, sans PC)**
- Le merge sur `main` déclenche `deploy-backend.yml` (SSH Hetzner, rebuild, smoke-test, rollback auto) → le mode s'active en prod.
- **Pour rouvrir au public** : passer `PRIVATE_MODE_LOCKDOWN = False` (1 ligne) puis re-merge, OU `PRIVATE_MODE=false` dans `.env.production`.

**Suivi possible (hors scope ici)** : message d'UI dédié côté frontend pour `error=private_mode` / code `private_mode` (cosmétique — le verrou fonctionne sans).

---

## 2. ci(backup) — désactivation du workflow de backup GitHub

`Daily Database Backup` échouait chaque jour (`DATABASE_URL not set` — secrets repo absents). Le backup réel est l'APScheduler du backend (`run_backup → R2/S3`). Cron retiré, `workflow_dispatch` conservé.

https://claude.ai/code/session_01MdXHy3BnBMeM7FCNx7i8cj